### PR TITLE
fix: remove bun install from publish job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,13 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: oven-sh/setup-bun@v2
-
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-
-      - run: bun install --frozen-lockfile
 
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- Removes `bun install --frozen-lockfile` and `setup-bun` from the publish job
- No build step exists — `npm publish` just packages the source files listed in `package.json#files`

## Problem

`bun install --frozen-lockfile` failed due to lockfile version mismatch between local and CI bun versions. Since there's no build step, install is unnecessary.