### PR TITLE
fix: resolve connection reset issues with configurable maxTurns and permissionMode

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,5 @@
-const shouldLog = () => process.env["OPENCODE_CLAUDE_PROVIDER_DEBUG"]
+const shouldLog = () =>
+  process.env["OPENCODE_CLAUDE_PROVIDER_DEBUG"] || process.env["CLAUDE_PROXY_DEBUG"]
 
 export const claudeLog = (message: string, extra?: Record<string, unknown>) => {
   if (!shouldLog()) return

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -12,6 +12,22 @@ function mapModelToClaudeModel(model: string): "sonnet" | "opus" | "haiku" {
   return "sonnet"
 }
 
+function extractTextFromSystem(system: unknown): string {
+  if (!system) return ""
+  if (typeof system === "string") return system
+  if (!Array.isArray(system)) return ""
+  return system
+    .map((block) => {
+      if (!block || typeof block !== "object") return ""
+      const maybeType = (block as { type?: unknown }).type
+      if (maybeType !== "text") return ""
+      const maybeText = (block as { text?: unknown }).text
+      return typeof maybeText === "string" ? maybeText : ""
+    })
+    .filter(Boolean)
+    .join("\n")
+}
+
 export function createProxyServer(config: Partial<ProxyConfig> = {}) {
   const finalConfig = { ...DEFAULT_PROXY_CONFIG, ...config }
   const app = new Hono()
@@ -31,10 +47,48 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
   const handleMessages = async (c: Context) => {
     try {
       const body = await c.req.json()
-      const model = mapModelToClaudeModel(body.model || "sonnet")
+      const requestId = `${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+      const startedAt = Date.now()
+
+      const rawModel = body.model || "sonnet"
+      const model = mapModelToClaudeModel(rawModel)
       const stream = body.stream ?? true
 
-      claudeLog("proxy.anthropic.request", { model, stream, messageCount: body.messages?.length })
+      const systemText = extractTextFromSystem(body.system)
+      const queryOptions = {
+        maxTurns: finalConfig.maxTurns,
+        model,
+        permissionMode: finalConfig.permissionMode,
+        allowDangerouslySkipPermissions: finalConfig.allowDangerouslySkipPermissions,
+        ...(systemText
+          ? {
+              systemPrompt: {
+                type: "preset" as const,
+                preset: "claude_code" as const,
+                append: systemText
+              }
+            }
+          : {})
+      }
+
+      const bodyKeys = body && typeof body === "object" ? Object.keys(body) : []
+      claudeLog("proxy.anthropic.request", {
+        requestId,
+        path: c.req.path,
+        rawModel,
+        model,
+        stream,
+        messageCount: body.messages?.length,
+        bodyKeys,
+        idleTimeout: finalConfig.idleTimeout,
+        sseHeartbeatMs: finalConfig.sseHeartbeatMs,
+        maxTurns: finalConfig.maxTurns,
+        permissionMode: finalConfig.permissionMode,
+        allowDangerouslySkipPermissions: finalConfig.allowDangerouslySkipPermissions,
+        systemChars: systemText.length
+      })
+
+      claudeLog("proxy.anthropic.request.body", { requestId, body })
 
       const prompt = body.messages
         ?.map((m: { role: string; content: string | Array<{ type: string; text?: string }> }) => {
@@ -54,14 +108,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
         })
         .join("\n\n") || ""
 
+      claudeLog("proxy.anthropic.prompt", {
+        requestId,
+        chars: prompt.length,
+        startedMsAgo: Date.now() - startedAt
+      })
+
       if (!stream) {
         let fullContent = ""
+
+        claudeLog("proxy.sdk.query.start", { requestId, stream: false })
         const response = query({
           prompt,
-          options: { maxTurns: 1, model }
+          options: queryOptions
         })
 
         for await (const message of response) {
+          claudeLog("proxy.sdk.message", { requestId, type: message.type })
           if (message.type === "assistant") {
             for (const block of message.message.content) {
               if (block.type === "text") {
@@ -70,6 +133,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
             }
           }
         }
+
+        claudeLog("proxy.sdk.query.end", {
+          requestId,
+          stream: false,
+          durationMs: Date.now() - startedAt,
+          outputChars: fullContent.length
+        })
 
         return c.json({
           id: `msg_${Date.now()}`,
@@ -85,8 +155,34 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
       const encoder = new TextEncoder()
       const readable = new ReadableStream({
         async start(controller) {
+          const safeEnqueue = (label: string, chunk: string) => {
+            try {
+              controller.enqueue(encoder.encode(chunk))
+              claudeLog("proxy.sse.send", {
+                requestId,
+                label,
+                bytes: chunk.length,
+                chunk,
+                msSinceStart: Date.now() - startedAt
+              })
+              return true
+            } catch (error) {
+              claudeLog("proxy.sse.enqueue_error", {
+                requestId,
+                label,
+                error: error instanceof Error ? error.message : String(error)
+              })
+              return false
+            }
+          }
+
+          const sendEvent = (event: string, data: unknown) =>
+            safeEnqueue(event, `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+
+          const sendComment = (comment: string) => safeEnqueue(`comment:${comment}`, `: ${comment}\n\n`)
+
           try {
-            controller.enqueue(encoder.encode(`event: message_start\ndata: ${JSON.stringify({
+            sendEvent("message_start", {
               type: "message_start",
               message: {
                 id: `msg_${Date.now()}`,
@@ -97,67 +193,151 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                 stop_reason: null,
                 usage: { input_tokens: 0, output_tokens: 0 }
               }
-            })}\n\n`))
+            })
 
-            controller.enqueue(encoder.encode(`event: content_block_start\ndata: ${JSON.stringify({
+            sendEvent("content_block_start", {
               type: "content_block_start",
               index: 0,
               content_block: { type: "text", text: "" }
-            })}\n\n`))
-
-            const response = query({
-              prompt,
-              options: { maxTurns: 1, model }
             })
 
-            const heartbeat = setInterval(() => {
-              try {
-                controller.enqueue(encoder.encode(`: ping\n\n`))
-              } catch {
-                clearInterval(heartbeat)
-              }
-            }, 15_000)
+            claudeLog("proxy.sdk.query.start", { requestId, stream: true })
+            const response = query({
+              prompt,
+              options: queryOptions
+            })
+
+            let heartbeat: ReturnType<typeof setInterval> | undefined
+            if (finalConfig.sseHeartbeatMs > 0) {
+              heartbeat = setInterval(() => {
+                const ok = sendComment("ping")
+                if (!ok && heartbeat) {
+                  clearInterval(heartbeat)
+                  heartbeat = undefined
+                }
+              }, finalConfig.sseHeartbeatMs)
+            }
 
             try {
+              let sentText = false
+              let successResultText: string | undefined
+              let resultError: { subtype: string; errors?: string[] } | undefined
+
               for await (const message of response) {
+                const subtype = (message as { subtype?: string }).subtype
+
+                if (message.type === "assistant") {
+                  const blockTypes = Array.isArray(message.message?.content)
+                    ? message.message.content.map((b: { type?: unknown }) => b?.type).filter(Boolean)
+                    : []
+                  claudeLog("proxy.sdk.message", {
+                    requestId,
+                    type: message.type,
+                    blockTypes,
+                    msSinceStart: Date.now() - startedAt
+                  })
+                } else if (message.type === "result") {
+                  claudeLog("proxy.sdk.message", {
+                    requestId,
+                    type: message.type,
+                    subtype,
+                    is_error: (message as { is_error?: boolean }).is_error,
+                    errors: (message as { errors?: string[] }).errors,
+                    msSinceStart: Date.now() - startedAt
+                  })
+                } else {
+                  claudeLog("proxy.sdk.message", {
+                    requestId,
+                    type: message.type,
+                    subtype,
+                    msSinceStart: Date.now() - startedAt
+                  })
+                }
+
+                if (message.type === "result") {
+                  if (subtype === "success") {
+                    successResultText = (message as { result?: string }).result
+                  } else if (typeof subtype === "string") {
+                    resultError = {
+                      subtype,
+                      errors: (message as { errors?: string[] }).errors
+                    }
+                  }
+                }
+
                 if (message.type === "assistant") {
                   for (const block of message.message.content) {
                     if (block.type === "text") {
-                      controller.enqueue(encoder.encode(`event: content_block_delta\ndata: ${JSON.stringify({
+                      sendEvent("content_block_delta", {
                         type: "content_block_delta",
                         index: 0,
                         delta: { type: "text_delta", text: block.text }
-                      })}\n\n`))
+                      })
+                      sentText = true
                     }
                   }
                 }
               }
+
+              if (!sentText && successResultText && successResultText.trim().length > 0) {
+                sendEvent("content_block_delta", {
+                  type: "content_block_delta",
+                  index: 0,
+                  delta: { type: "text_delta", text: successResultText }
+                })
+                sentText = true
+              }
+
+              if (resultError) {
+                sendEvent("error", {
+                  type: "error",
+                  error: {
+                    type: "api_error",
+                    message: `Claude Agent SDK ended with ${resultError.subtype}${
+                      resultError.errors?.length ? `: ${resultError.errors.join("; ")}` : ""
+                    }`
+                  }
+                })
+                controller.close()
+                return
+              }
             } finally {
-              clearInterval(heartbeat)
+              if (heartbeat) clearInterval(heartbeat)
             }
 
-            controller.enqueue(encoder.encode(`event: content_block_stop\ndata: ${JSON.stringify({
+            claudeLog("proxy.sdk.query.end", {
+              requestId,
+              stream: true,
+              durationMs: Date.now() - startedAt
+            })
+
+            sendEvent("content_block_stop", {
               type: "content_block_stop",
               index: 0
-            })}\n\n`))
+            })
 
-            controller.enqueue(encoder.encode(`event: message_delta\ndata: ${JSON.stringify({
+            sendEvent("message_delta", {
               type: "message_delta",
               delta: { stop_reason: "end_turn" },
               usage: { output_tokens: 0 }
-            })}\n\n`))
+            })
 
-            controller.enqueue(encoder.encode(`event: message_stop\ndata: ${JSON.stringify({
+            sendEvent("message_stop", {
               type: "message_stop"
-            })}\n\n`))
+            })
 
             controller.close()
           } catch (error) {
-            claudeLog("proxy.anthropic.error", { error: error instanceof Error ? error.message : String(error) })
-            controller.enqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
+            claudeLog("proxy.anthropic.error", {
+              requestId,
+              error: error instanceof Error ? error.message : String(error)
+            })
+
+            sendEvent("error", {
               type: "error",
               error: { type: "api_error", message: error instanceof Error ? error.message : "Unknown error" }
-            })}\n\n`))
+            })
+
             controller.close()
           }
         }
@@ -167,6 +347,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
         headers: {
           "Content-Type": "text/event-stream",
           "Cache-Control": "no-cache",
+          "X-Accel-Buffering": "no",
           Connection: "keep-alive"
         }
       })
@@ -194,6 +375,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}) {
   const server = Bun.serve({
     port: finalConfig.port,
     hostname: finalConfig.host,
+    idleTimeout: finalConfig.idleTimeout,
     fetch: app.fetch
   })
 

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -2,10 +2,50 @@ export interface ProxyConfig {
   port: number
   host: string
   debug: boolean
+  idleTimeout: number
+  sseHeartbeatMs: number
+  maxTurns: number
+  permissionMode: "default" | "acceptEdits" | "bypassPermissions" | "plan" | "delegate" | "dontAsk"
+  allowDangerouslySkipPermissions: boolean
+}
+
+const intEnv = (name: string, fallback: number) => {
+  const raw = process.env[name]
+  const parsed = raw ? Number.parseInt(raw, 10) : fallback
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const boolEnv = (name: string, fallback: boolean) => {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  return raw === "1" || raw.toLowerCase() === "true"
+}
+
+const permissionModeEnv = (): ProxyConfig["permissionMode"] => {
+  const raw = process.env.CLAUDE_PROXY_PERMISSION_MODE
+  if (
+    raw === "default" ||
+    raw === "acceptEdits" ||
+    raw === "bypassPermissions" ||
+    raw === "plan" ||
+    raw === "delegate" ||
+    raw === "dontAsk"
+  ) {
+    return raw
+  }
+  return "bypassPermissions"
 }
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
+  permissionMode: permissionModeEnv(),
   port: 3456,
   host: "127.0.0.1",
-  debug: process.env.CLAUDE_PROXY_DEBUG === "1"
+  debug: process.env.CLAUDE_PROXY_DEBUG === "1",
+  idleTimeout: intEnv("CLAUDE_PROXY_IDLE_TIMEOUT", 0),
+  sseHeartbeatMs: intEnv("CLAUDE_PROXY_SSE_HEARTBEAT_MS", 5000),
+  maxTurns: intEnv("CLAUDE_PROXY_MAX_TURNS", 50),
+  allowDangerouslySkipPermissions: boolEnv(
+    "CLAUDE_PROXY_ALLOW_DANGEROUSLY_SKIP_PERMISSIONS",
+    permissionModeEnv() === "bypassPermissions"
+  )
 }


### PR DESCRIPTION
## Summary
- Add `CLAUDE_PROXY_MAX_TURNS` env var (default 50) to prevent `error_max_turns` when SDK uses tools
- Add `CLAUDE_PROXY_PERMISSION_MODE` for SDK permission behavior (default `bypassPermissions`)
- Pass system prompt from Anthropic API to SDK `systemPrompt.append`
- Add verbose debug logging with request IDs for easier troubleshooting
- Add `CLAUDE_PROXY_DEBUG` as alias for `OPENCODE_CLAUDE_PROVIDER_DEBUG`

## Test plan
- [ ] Start proxy with `CLAUDE_PROXY_DEBUG=1` and verify request IDs appear in logs
- [ ] Send a prompt that triggers tool usage and verify it completes without `error_max_turns`
- [ ] Test with custom `CLAUDE_PROXY_MAX_TURNS` value
- [ ] Verify system prompt passthrough works

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)