### PR TITLE
fix: run MCP tools in the caller project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Now just run `oc` to start OpenCode with Claude Max.
 |---------------------|---------|-------------|
 | `CLAUDE_PROXY_PORT` | 3456 | Proxy server port |
 | `CLAUDE_PROXY_HOST` | 127.0.0.1 | Proxy server host |
+| `CLAUDE_PROXY_WORKDIR` | (process cwd) | Base working directory used by MCP file/shell tools |
 
 ## How It Works
 

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -8,7 +8,7 @@ import { glob as globLib } from "glob"
 
 const execAsync = promisify(exec)
 
-const getCwd = () => process.cwd()
+const getCwd = () => process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
 
 export const opencodeMcpServer = createSdkMcpServer({
   name: "opencode",


### PR DESCRIPTION
## Why
When the proxy was started from its own repository, MCP tools (read/write/edit/bash/glob/grep) inherited the proxy process cwd. OpenCode sessions launched from a different project were then operating on the wrong directory, causing confusion and incorrect file/tool behavior.

## What changed
- MCP tools now resolve relative paths from `CLAUDE_PROXY_WORKDIR` when set
- fallback remains `process.cwd()` for backward compatibility
- README updated to document `CLAUDE_PROXY_WORKDIR`

## Result
- proxy can run from one location while tools correctly target the intended project
- predictable per-project behavior without relocating the proxy checkout