### PR TITLE
feat: fuzzy match agent names for reliable subagent delegation

### DIFF
--- a/src/__tests__/proxy-agent-fuzzy-match.test.ts
+++ b/src/__tests__/proxy-agent-fuzzy-match.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Agent Name Fuzzy Matching Tests
+ *
+ * When Claude sends an invalid agent type (e.g., "general-purpose"),
+ * the proxy should rewrite it to the closest valid agent name extracted
+ * from the Task tool definition in the request.
+ *
+ * This is deterministic string matching, not LLM guessing.
+ */
+
+import { describe, it, expect } from "bun:test"
+
+// Import the matching function directly
+import { fuzzyMatchAgentName } from "../proxy/agentMatch"
+
+describe("fuzzyMatchAgentName", () => {
+  const validAgents = [
+    "build", "plan", "general", "explore",
+    "sisyphus-junior", "oracle", "librarian",
+    "multimodal-looker", "metis", "momus"
+  ]
+
+  // --- Exact matches (already correct) ---
+  it("should return exact match unchanged", () => {
+    expect(fuzzyMatchAgentName("explore", validAgents)).toBe("explore")
+    expect(fuzzyMatchAgentName("oracle", validAgents)).toBe("oracle")
+    expect(fuzzyMatchAgentName("build", validAgents)).toBe("build")
+  })
+
+  // --- Capitalization ---
+  it("should lowercase and match", () => {
+    expect(fuzzyMatchAgentName("Explore", validAgents)).toBe("explore")
+    expect(fuzzyMatchAgentName("Oracle", validAgents)).toBe("oracle")
+    expect(fuzzyMatchAgentName("LIBRARIAN", validAgents)).toBe("librarian")
+    expect(fuzzyMatchAgentName("Sisyphus-Junior", validAgents)).toBe("sisyphus-junior")
+  })
+
+  // --- Common SDK mistakes ---
+  it("should map 'general-purpose' to 'general'", () => {
+    expect(fuzzyMatchAgentName("general-purpose", validAgents)).toBe("general")
+    expect(fuzzyMatchAgentName("General-Purpose", validAgents)).toBe("general")
+  })
+
+  it("should map 'code-reviewer' or 'reviewer' to 'oracle'", () => {
+    // Oracle's description says "Read-only consultation agent"
+    // Claude might guess "code-reviewer" for a review task
+    expect(fuzzyMatchAgentName("code-reviewer", validAgents)).toBe("oracle")
+    expect(fuzzyMatchAgentName("reviewer", validAgents)).toBe("oracle")
+  })
+
+  // --- Prefix/substring matching ---
+  it("should match by prefix", () => {
+    expect(fuzzyMatchAgentName("lib", validAgents)).toBe("librarian")
+    expect(fuzzyMatchAgentName("multi", validAgents)).toBe("multimodal-looker")
+    expect(fuzzyMatchAgentName("sisyphus", validAgents)).toBe("sisyphus-junior")
+  })
+
+  it("should match by substring", () => {
+    expect(fuzzyMatchAgentName("looker", validAgents)).toBe("multimodal-looker")
+    expect(fuzzyMatchAgentName("junior", validAgents)).toBe("sisyphus-junior")
+  })
+
+  // --- Suffix stripping ---
+  it("should strip common suffixes and match", () => {
+    expect(fuzzyMatchAgentName("explore-agent", validAgents)).toBe("explore")
+    expect(fuzzyMatchAgentName("oracle-agent", validAgents)).toBe("oracle")
+    expect(fuzzyMatchAgentName("build-agent", validAgents)).toBe("build")
+  })
+
+  // --- No match → return original lowercased ---
+  it("should return lowercased original when no match found", () => {
+    expect(fuzzyMatchAgentName("nonexistent", validAgents)).toBe("nonexistent")
+    expect(fuzzyMatchAgentName("FooBar", validAgents)).toBe("foobar")
+  })
+
+  // --- Edge cases ---
+  it("should handle empty input", () => {
+    expect(fuzzyMatchAgentName("", validAgents)).toBe("")
+  })
+
+  it("should handle empty valid agents list", () => {
+    expect(fuzzyMatchAgentName("explore", [])).toBe("explore")
+  })
+
+  // --- Common oh-my-opencode agent aliases ---
+  it("should match common aliases", () => {
+    expect(fuzzyMatchAgentName("search", validAgents)).toBe("explore")
+    expect(fuzzyMatchAgentName("research", validAgents)).toBe("librarian")
+    expect(fuzzyMatchAgentName("consult", validAgents)).toBe("oracle")
+  })
+})

--- a/src/proxy/agentMatch.ts
+++ b/src/proxy/agentMatch.ts
@@ -1,0 +1,93 @@
+/**
+ * Fuzzy matching for agent names.
+ *
+ * When Claude sends an invalid subagent_type, this tries to map it
+ * to the closest valid agent name. This is deterministic string matching,
+ * not LLM guessing.
+ *
+ * Matching priority:
+ * 1. Exact match (case-insensitive)
+ * 2. Known aliases (e.g., "general-purpose" → "general")
+ * 3. Prefix match (e.g., "lib" → "librarian")
+ * 4. Substring match (e.g., "junior" → "sisyphus-junior")
+ * 5. Suffix-stripped match (e.g., "explore-agent" → "explore")
+ * 6. Semantic aliases (e.g., "search" → "explore")
+ * 7. Fallback: return lowercased original
+ */
+
+// Known aliases for common SDK mistakes
+const KNOWN_ALIASES: Record<string, string> = {
+  "general-purpose": "general",
+  "default": "general",
+  "code-reviewer": "oracle",
+  "reviewer": "oracle",
+  "code-review": "oracle",
+  "review": "oracle",
+  "consultation": "oracle",
+  "analyzer": "oracle",
+  "debugger": "oracle",
+  "search": "explore",
+  "grep": "explore",
+  "find": "explore",
+  "codebase-search": "explore",
+  "research": "librarian",
+  "docs": "librarian",
+  "documentation": "librarian",
+  "lookup": "librarian",
+  "reference": "librarian",
+  "consult": "oracle",
+  "architect": "oracle",
+  "image-analyzer": "multimodal-looker",
+  "image": "multimodal-looker",
+  "pdf": "multimodal-looker",
+  "visual": "multimodal-looker",
+  "planner": "plan",
+  "planning": "plan",
+  "builder": "build",
+  "coder": "build",
+  "developer": "build",
+  "writer": "build",
+  "executor": "build",
+}
+
+// Common suffixes to strip
+const STRIP_SUFFIXES = ["-agent", "-tool", "-worker", "-task", " agent", " tool"]
+
+export function fuzzyMatchAgentName(input: string, validAgents: string[]): string {
+  if (!input) return input
+  if (validAgents.length === 0) return input.toLowerCase()
+
+  const lowered = input.toLowerCase()
+
+  // 1. Exact match (case-insensitive)
+  const exact = validAgents.find(a => a.toLowerCase() === lowered)
+  if (exact) return exact
+
+  // 2. Known aliases
+  const alias = KNOWN_ALIASES[lowered]
+  if (alias && validAgents.includes(alias)) return alias
+
+  // 3. Prefix match
+  const prefixMatch = validAgents.find(a => a.toLowerCase().startsWith(lowered))
+  if (prefixMatch) return prefixMatch
+
+  // 4. Substring match
+  const substringMatch = validAgents.find(a => a.toLowerCase().includes(lowered))
+  if (substringMatch) return substringMatch
+
+  // 5. Suffix-stripped match
+  for (const suffix of STRIP_SUFFIXES) {
+    if (lowered.endsWith(suffix)) {
+      const stripped = lowered.slice(0, -suffix.length)
+      const strippedMatch = validAgents.find(a => a.toLowerCase() === stripped)
+      if (strippedMatch) return strippedMatch
+    }
+  }
+
+  // 6. Reverse substring (input contains a valid agent name)
+  const reverseMatch = validAgents.find(a => lowered.includes(a.toLowerCase()))
+  if (reverseMatch) return reverseMatch
+
+  // 7. Fallback
+  return lowered
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -12,6 +12,7 @@ import { join, dirname } from "path"
 import { opencodeMcpServer } from "../mcpTools"
 import { randomUUID, createHash } from "crypto"
 import { withClaudeLogContext } from "../logger"
+import { fuzzyMatchAgentName } from "./agentMatch"
 
 // --- Session Tracking ---
 // Maps OpenCode session ID (or fingerprint) → Claude SDK session ID
@@ -204,16 +205,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
         }
       }
 
-      // Extract available agent types from the Task tool definition and inject as a hint.
-      // This prevents Claude from guessing wrong agent names (e.g., "Explore" instead of "explore").
+      // Extract available agent types from the Task tool definition.
+      // Used for: 1) prompt hint injection, 2) fuzzy matching in tool_use normalization
+      let validAgentNames: string[] = []
       if (Array.isArray(body.tools)) {
         const taskTool = body.tools.find((t: any) => t.name === "task" || t.name === "Task")
         if (taskTool?.description) {
           const agentMatch = taskTool.description.match(/Available agent types.*?:\n((?:- \w[\w-]*:.*\n?)+)/s)
           if (agentMatch) {
-            const agentNames = [...agentMatch[1].matchAll(/^- (\w[\w-]*):/gm)].map(m => m[1])
-            if (agentNames.length > 0) {
-              systemContext += `\n\nIMPORTANT: When using the task/Task tool, the subagent_type parameter must be one of these exact values (case-sensitive, lowercase): ${agentNames.join(", ")}. Do NOT capitalize or modify these names.`
+            validAgentNames = [...agentMatch[1].matchAll(/^- (\w[\w-]*):/gm)].map(m => m[1])
+            if (validAgentNames.length > 0) {
+              systemContext += `\n\nIMPORTANT: When using the task/Task tool, the subagent_type parameter must be one of these exact values (case-sensitive, lowercase): ${validAgentNames.join(", ")}. Do NOT capitalize or modify these names.`
             }
           }
         }
@@ -311,11 +313,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                 // Preserve ALL content blocks (text, tool_use, thinking, etc.)
                 for (const block of message.message.content) {
                   const b = block as Record<string, unknown>
-                  // Normalize task tool_use: lowercase subagent_type
+                  // Normalize task tool_use: fuzzy match subagent_type to valid agent names
                   if (b.type === "tool_use" && typeof b.name === "string" &&
                       (b.name === "task" || b.name === "Task") &&
                       b.input && typeof (b.input as any).subagent_type === "string") {
-                    (b.input as any).subagent_type = (b.input as any).subagent_type.toLowerCase()
+                    (b.input as any).subagent_type = fuzzyMatchAgentName(
+                      (b.input as any).subagent_type, validAgentNames
+                    )
                   }
                   contentBlocks.push(b)
                 }
@@ -553,10 +557,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                         taskBlockIndices.has(eventIndex)) {
                       const delta = (event as any).delta
                       if (delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
-                        // Replace capitalized subagent_type values with lowercase
+                        // Fuzzy match subagent_type to valid agent names
                         const normalized = delta.partial_json.replace(
                           /("subagent_type"\s*:\s*")([^"]+)(")/g,
-                          (_: string, pre: string, name: string, post: string) => `${pre}${name.toLowerCase()}${post}`
+                          (_: string, pre: string, name: string, post: string) =>
+                            `${pre}${fuzzyMatchAgentName(name, validAgentNames)}${post}`
                         )
                         if (normalized !== delta.partial_json) {
                           eventToForward = {


### PR DESCRIPTION
When Claude sends an invalid subagent_type, the proxy now fuzzy-matches it to the closest valid agent name. This fixes cases like:

- `general-purpose` → `general`
- `code-reviewer` → `oracle`
- `Explore-Agent` → `explore`
- `search` → `explore`
- `research` → `librarian`

Matching is deterministic (not LLM guessing) with 6 priority levels: exact → alias → prefix → substring → suffix-strip → semantic.

Valid agent names are extracted from the Task tool description that OpenCode sends in every request, so this works with any agent framework (oh-my-opencode, custom agents, etc.).

64 tests (11 new), all passing.
Verified: oracle agent delegation succeeded via OpenCode.

Part of #21