### PR TITLE
feat: add multimodal content support (images, documents, files)

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -423,11 +423,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
       let structuredMessages: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null; session_id: string }> | undefined
       if (hasMultimodalContent) {
         const sessionId = randomUUID()
+        // Strip cache_control from content blocks — the SDK manages its own caching
+        // and OpenCode's ttl='1h' blocks conflict with the SDK's ttl='5m' blocks
+        const stripCacheControl = (content: any) => {
+          if (typeof content === "string") return content
+          if (!Array.isArray(content)) return content
+          return content.map((block: any) => {
+            if (block.cache_control) {
+              const { cache_control, ...rest } = block
+              return rest
+            }
+            return block
+          })
+        }
         structuredMessages = messagesToConvert
           ?.filter((m: any) => m.role === "user")
           .map((m: any) => ({
             type: "user" as const,
-            message: { role: m.role, content: m.content },
+            message: { role: m.role, content: stripCacheControl(m.content) },
             parent_tool_use_id: null,
             session_id: sessionId,
           }))
@@ -1007,6 +1020,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
         mode: process.env.CLAUDE_PROXY_PASSTHROUGH ? "passthrough" : "internal",
       })
     }
+  })
+
+  // Catch-all: log any unhandled requests (helps debug missing endpoints like /v1/files)
+  app.all("*", (c) => {
+    console.error(`[PROXY] UNHANDLED ${c.req.method} ${c.req.url}`)
+    return c.json({ error: { type: "not_found", message: `Endpoint not supported: ${c.req.method} ${new URL(c.req.url).pathname}` } }, 404)
   })
 
   return { app, config: finalConfig }


### PR DESCRIPTION
## Summary

- **Multimodal passthrough**: When incoming messages contain `image`, `document`, or `file` content blocks, the proxy now uses the SDK's `AsyncIterable<SDKUserMessage>` interface with native `MessageParam` instead of converting everything to a text string. This preserves attachments end-to-end.
- **Cache control fix**: Strips `cache_control` from incoming content blocks before passing to the SDK, preventing TTL ordering conflicts (`1h` from OpenCode vs `5m` from the SDK).
- **System prompt via SDK option**: When structured messages are used, the system prompt is passed via `options.systemPrompt` instead of being prepended to the text prompt.
- **DRY refactor**: Extracted duplicated SDK options between stream and non-stream paths into a shared `sdkOptions` object.
- **Catch-all route**: Logs unhandled requests for easier debugging of missing endpoints.

## Problem

Previously, all non-text content blocks were silently stripped during the message-to-prompt conversion. Image, document, and file blocks returned an empty string and were discarded, making the proxy text-only.

Additionally, when multimodal content was forwarded, OpenCode's `cache_control` blocks with `ttl='1h'` conflicted with the SDK's internal `ttl='5m'` blocks, causing `invalid_request_error` due to the API requiring TTLs in descending order.

## Solution

1. **Detection**: Check if any message contains multimodal block types (`image`, `document`, `file`)
2. **Structured messages**: When detected, build `SDKUserMessage[]` objects preserving the original `MessageParam` content (including binary/base64 blocks)
3. **Cache control stripping**: Remove `cache_control` from incoming content blocks — the SDK manages its own caching strategy
4. **AsyncIterable prompt**: Pass the structured messages as an async generator to `query()`, which the SDK accepts via `prompt: string | AsyncIterable<SDKUserMessage>`
5. **Fallback**: Text-only messages continue using the existing string prompt path — zero impact on current behavior

## Test plan

- [x] All 106 existing tests pass (0 failures)
- [x] Manual test: images work correctly through the proxy
- [x] Manual test: PDF documents work correctly through the proxy
- [x] Manual test: text-only messages work identically (no regression)
- [x] Cache control TTL ordering error resolved