### PR TITLE
feat: Docker support and README install options

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:24.04
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system deps + Node.js
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    git \
+    ca-certificates \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user (SDK refuses --dangerously-skip-permissions as root)
+RUN useradd -m -s /bin/bash claude
+USER claude
+
+# Install Bun
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/home/claude/.bun/bin:$PATH"
+
+# Install Claude CLI via Bun (npm global doesn't work for non-root)
+RUN bun install -g @anthropic-ai/claude-code
+
+# Set up working directory
+WORKDIR /app
+
+# Copy package files first (better layer caching)
+COPY --chown=claude:claude package.json bun.lock* ./
+RUN bun install --frozen-lockfile || bun install
+
+# Copy source
+COPY --chown=claude:claude . .
+
+# Expose proxy port
+EXPOSE 3456
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD curl -sf http://127.0.0.1:3456/health || exit 1
+
+# Default: passthrough mode with supervisor
+ENV CLAUDE_PROXY_PASSTHROUGH=1
+ENV CLAUDE_PROXY_HOST=0.0.0.0
+CMD ["./bin/claude-proxy-supervisor.sh"]

--- a/README.md
+++ b/README.md
@@ -59,9 +59,17 @@ No monkey-patching. No forked SDKs. No fragile stream rewriting. Just a hook and
 
 1. **Claude Max subscription** — [Subscribe here](https://claude.ai/settings/subscription)
 2. **Claude CLI** authenticated: `npm install -g @anthropic-ai/claude-code && claude login`
-3. **Bun** runtime: `curl -fsSL https://bun.sh/install | bash`
 
-### Install & Run
+### Option A: npm Install
+
+```bash
+npm install -g opencode-claude-max-proxy
+
+# Start in passthrough mode (recommended)
+CLAUDE_PROXY_PASSTHROUGH=1 claude-max-proxy
+```
+
+### Option B: From Source
 
 ```bash
 git clone https://github.com/rynfar/opencode-claude-max-proxy
@@ -71,6 +79,26 @@ bun install
 # Start in passthrough mode (recommended)
 CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy
 ```
+
+> **Note:** Running from source requires [Bun](https://bun.sh): `curl -fsSL https://bun.sh/install | bash`
+
+### Option C: Docker
+
+```bash
+git clone https://github.com/rynfar/opencode-claude-max-proxy
+cd opencode-claude-max-proxy
+
+# Start the container
+docker compose up -d
+
+# Login to Claude inside the container (one-time)
+docker compose exec proxy claude login
+
+# Verify
+curl http://127.0.0.1:3456/health
+```
+
+> **Note:** On macOS, `claude login` must be run inside the container (keychain credentials can't be mounted). On Linux, volume-mounting `~/.claude` may work without re-login.
 
 ### Connect OpenCode
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  proxy:
+    build: .
+    user: "claude"
+    ports:
+      - "3456:3456"
+    volumes:
+      - ~/.claude:/home/claude/.claude
+      - ~/.claude/.claude.json:/home/claude/.claude.json
+    environment:
+      - CLAUDE_PROXY_PASSTHROUGH=1
+      - CLAUDE_PROXY_HOST=0.0.0.0
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:3456/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds Docker support and updates README with three install methods.

### Docker
- Ubuntu 24.04 base with Bun + Claude CLI
- Non-root `claude` user (SDK refuses `--dangerously-skip-permissions` as root)
- `docker-compose.yml` with health check and auto-restart
- Volume mounts for `~/.claude` auth persistence
- Passthrough mode enabled by default

### README
Three install options documented:
- **npm**: `npm install -g opencode-claude-max-proxy`
- **Source**: `git clone` + `bun install`
- **Docker**: `docker compose up -d`

### Tested
End-to-end on macOS with Docker Desktop:
- ✅ Health endpoint: healthy
- ✅ Claude query: responds correctly
- ✅ OpenCode passthrough: full tool loop working

Closes #15