### PR TITLE
feat: per-terminal proxy launcher and shared session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,28 +102,41 @@ curl http://127.0.0.1:3456/health
 
 ### Connect OpenCode
 
-#### Environment Variables
+#### Per-Terminal Launcher (recommended)
 
 ```bash
+./bin/oc.sh
+```
+
+Each terminal gets its own proxy on a random port. No port conflicts, no concurrency crashes. The proxy starts automatically, connects OpenCode, and cleans up when you exit. Sessions resume across terminals via a shared session file.
+
+Add to your shell config for easy access:
+
+```bash
+# ~/.zshrc or ~/.bashrc
+alias oc='/path/to/opencode-claude-max-proxy/bin/oc.sh'
+```
+
+#### Shared Proxy
+
+If you prefer a single long-running proxy:
+
+```bash
+# Terminal 1: start the proxy
+CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy
+
+# Terminal 2+: connect OpenCode
 ANTHROPIC_API_KEY=dummy ANTHROPIC_BASE_URL=http://127.0.0.1:3456 opencode
 ```
 
 The `ANTHROPIC_API_KEY` can be any non-empty string — the proxy doesn't use it. Authentication is handled by your `claude login` session.
 
-#### Shell Alias
+#### OpenCode Desktop / Config File
 
-```bash
-# Add to ~/.zshrc or ~/.bashrc or ~/.config/fish/config.fish
-alias oc='ANTHROPIC_API_KEY=dummy ANTHROPIC_BASE_URL=http://127.0.0.1:3456 opencode'
-```
-
-#### OpenCode Config File
-
-Alternatively, the proxy URL and API key can be set globally in `~/.config/opencode/opencode.json`. This has the benefit of working in OpenCode Desktop as well.
+For OpenCode Desktop (or to avoid env vars), add the proxy to `~/.config/opencode/opencode.json`. Start the shared proxy in the background and Desktop connects automatically.
 
 ```json
 {
-  ...
   "provider": {
     "anthropic": {
       "options": {
@@ -132,9 +145,10 @@ Alternatively, the proxy URL and API key can be set globally in `~/.config/openc
       }
     }
   }
-  ...
 }
 ```
+
+> **Tip:** Use the shared proxy with the supervisor for Desktop: `CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy`. Both Desktop and terminal instances share sessions via the file store.
 
 ## Modes
 
@@ -182,6 +196,7 @@ The proxy tracks SDK session IDs and resumes conversations on follow-up requests
 
 - **Faster responses** — no re-processing of conversation history
 - **Better context** — the SDK remembers tool results from previous turns
+- **Works across terminals** — sessions are shared via a file store at `~/.cache/opencode-claude-max-proxy/sessions.json`
 
 Session tracking works two ways:
 
@@ -192,7 +207,7 @@ Session tracking works two ways:
 
 2. **Fingerprint-based** (automatic fallback) — hashes the first user message to identify returning conversations
 
-Sessions are cached for 24 hours.
+Sessions are cached for 24 hours. When using per-terminal proxies (`oc.sh`), the shared file store ensures a session started in one terminal can be resumed from another.
 
 ## Configuration
 
@@ -207,26 +222,19 @@ Sessions are cached for 24 hours.
 
 ## Concurrency
 
-The proxy supports multiple simultaneous OpenCode instances. Each request spawns its own independent SDK subprocess — run as many terminals as you want. All concurrent responses are delivered correctly.
+**Per-terminal proxies (`oc.sh`)** are the recommended approach for multiple terminals. Each OpenCode instance gets its own proxy — no concurrency issues at all.
 
-**Use the auto-restart supervisor** (recommended):
-
-```bash
-CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy
-# or directly:
-CLAUDE_PROXY_PASSTHROUGH=1 ./bin/claude-proxy-supervisor.sh
-```
+**Shared proxy** supports concurrent requests but has a known limitation:
 
 > **⚠️ Known Issue: Bun SSE Crash ([oven-sh/bun#17947](https://github.com/oven-sh/bun/issues/17947))**
 >
-> The Claude Agent SDK's `cli.js` subprocess is compiled with Bun, which has a known segfault in `structuredCloneForStream` during cleanup of concurrent streaming responses. This affects all runtimes (Bun, Node.js via tsx) because the crash originates in the SDK's child process, not in the proxy itself.
+> The Claude Agent SDK's `cli.js` subprocess (compiled with Bun) has a known segfault during cleanup of concurrent streaming responses.
 >
-> **What this means in practice:**
-> - **Sequential requests (1 terminal):** No impact. Never crashes.
-> - **Concurrent requests (2+ terminals):** All responses are delivered correctly. The crash occurs *after* responses complete, during stream cleanup. No work is lost.
-> - **After a crash:** The supervisor restarts the proxy in ~1-3 seconds. If a new request arrives during this window, OpenCode shows "Unable to connect" — just retry.
+> - **All responses are delivered correctly** — the crash only occurs after responses complete
+> - **The supervisor auto-restarts** in ~1-3 seconds
+> - **Per-terminal proxies avoid this entirely** — no concurrency, no crash
 >
-> We are monitoring the upstream Bun issue for a fix. Once patched, the supervisor becomes optional.
+> We are monitoring the upstream Bun issue for a fix.
 
 ## Model Mapping
 

--- a/bin/oc.sh
+++ b/bin/oc.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Per-terminal proxy launcher for OpenCode.
+#
+# Starts a dedicated proxy on a random port, launches OpenCode pointed at it,
+# and cleans up when OpenCode exits. Each terminal gets its own proxy — no
+# concurrent request issues, no shared port conflicts.
+#
+# Session resume works across terminals via the shared session file store.
+#
+# Usage: ./bin/oc.sh [opencode args...]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROXY_SCRIPT="$SCRIPT_DIR/claude-proxy.ts"
+
+if [ ! -f "$PROXY_SCRIPT" ]; then
+  echo "❌ Proxy script not found: $PROXY_SCRIPT" >&2
+  exit 1
+fi
+
+# Pick a random free port
+PORT=$(python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()' 2>/dev/null \
+  || ruby -e 'require "socket"; s = TCPServer.new("127.0.0.1", 0); puts s.addr[1]; s.close' 2>/dev/null \
+  || echo $((RANDOM + 10000)))
+
+# Start proxy in background
+CLAUDE_PROXY_PORT=$PORT \
+CLAUDE_PROXY_WORKDIR="$PWD" \
+CLAUDE_PROXY_PASSTHROUGH="${CLAUDE_PROXY_PASSTHROUGH:-1}" \
+  bun run "$PROXY_SCRIPT" > /dev/null 2>&1 &
+PROXY_PID=$!
+
+# Ensure proxy is cleaned up on exit
+cleanup() {
+  kill $PROXY_PID 2>/dev/null
+  wait $PROXY_PID 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+
+# Wait for proxy to be ready (up to 10 seconds)
+for i in $(seq 1 100); do
+  if curl -sf "http://127.0.0.1:$PORT/health" > /dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 $PROXY_PID 2>/dev/null; then
+    echo "❌ Proxy failed to start" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+
+# Verify proxy is healthy
+if ! curl -sf "http://127.0.0.1:$PORT/health" > /dev/null 2>&1; then
+  echo "❌ Proxy didn't become healthy within 10 seconds" >&2
+  exit 1
+fi
+
+# Launch OpenCode
+ANTHROPIC_API_KEY=dummy \
+ANTHROPIC_BASE_URL="http://127.0.0.1:$PORT" \
+  opencode "$@"

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared Session Store Tests
+ *
+ * Tests the file-based session store that enables cross-proxy
+ * session resume when running per-terminal proxies.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test"
+import { lookupSharedSession, storeSharedSession, clearSharedSessions } from "../proxy/sessionStore"
+import { join } from "path"
+import { mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
+
+describe("Shared session store", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "session-store-test-"))
+    process.env.CLAUDE_PROXY_SESSION_DIR = tmpDir
+    clearSharedSessions()
+  })
+
+  it("should store and retrieve a session", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    const result = lookupSharedSession("session-123")
+    expect(result).toBeDefined()
+    expect(result!.claudeSessionId).toBe("claude-sess-abc")
+  })
+
+  it("should return undefined for unknown session", () => {
+    const result = lookupSharedSession("nonexistent")
+    expect(result).toBeUndefined()
+  })
+
+  it("should update lastUsedAt on store", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    const first = lookupSharedSession("session-123")!.lastUsedAt
+
+    // Small delay
+    const start = Date.now()
+    while (Date.now() - start < 10) {} // busy wait 10ms
+
+    storeSharedSession("session-123", "claude-sess-abc")
+    const second = lookupSharedSession("session-123")!.lastUsedAt
+    expect(second).toBeGreaterThanOrEqual(first)
+  })
+
+  it("should preserve createdAt on update", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    const created = lookupSharedSession("session-123")!.createdAt
+
+    storeSharedSession("session-123", "claude-sess-def")
+    const result = lookupSharedSession("session-123")!
+    expect(result.createdAt).toBe(created)
+    expect(result.claudeSessionId).toBe("claude-sess-def")
+  })
+
+  it("should handle multiple sessions", () => {
+    storeSharedSession("sess-1", "claude-1")
+    storeSharedSession("sess-2", "claude-2")
+    storeSharedSession("sess-3", "claude-3")
+
+    expect(lookupSharedSession("sess-1")!.claudeSessionId).toBe("claude-1")
+    expect(lookupSharedSession("sess-2")!.claudeSessionId).toBe("claude-2")
+    expect(lookupSharedSession("sess-3")!.claudeSessionId).toBe("claude-3")
+  })
+
+  it("should clear all sessions", () => {
+    storeSharedSession("sess-1", "claude-1")
+    storeSharedSession("sess-2", "claude-2")
+    clearSharedSessions()
+    expect(lookupSharedSession("sess-1")).toBeUndefined()
+    expect(lookupSharedSession("sess-2")).toBeUndefined()
+  })
+
+  it("should handle concurrent writes safely", async () => {
+    // Simulate two proxies writing at the same time
+    const writes = Array.from({ length: 10 }, (_, i) =>
+      Promise.resolve().then(() => storeSharedSession(`sess-${i}`, `claude-${i}`))
+    )
+    await Promise.all(writes)
+
+    // All should be readable
+    for (let i = 0; i < 10; i++) {
+      const session = lookupSharedSession(`sess-${i}`)
+      expect(session).toBeDefined()
+      expect(session!.claudeSessionId).toBe(`claude-${i}`)
+    }
+  })
+
+  it("should handle corrupted file gracefully", () => {
+    const { writeFileSync } = require("fs")
+    writeFileSync(join(tmpDir, "sessions.json"), "not json{{{")
+    const result = lookupSharedSession("anything")
+    expect(result).toBeUndefined()
+    // Should still be able to write after corruption
+    storeSharedSession("new-sess", "claude-new")
+    expect(lookupSharedSession("new-sess")!.claudeSessionId).toBe("claude-new")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -15,6 +15,7 @@ import { withClaudeLogContext } from "../logger"
 import { fuzzyMatchAgentName } from "./agentMatch"
 import { buildAgentDefinitions } from "./agentDefs"
 import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { lookupSharedSession, storeSharedSession, clearSharedSessions } from "./sessionStore"
 
 // --- Session Tracking ---
 // Maps OpenCode session ID (or fingerprint) → Claude SDK session ID
@@ -31,6 +32,8 @@ const fingerprintCache = new Map<string, SessionState>()
 export function clearSessionCache() {
   sessionCache.clear()
   fingerprintCache.clear()
+  // Also clear shared file store
+  try { clearSharedSessions() } catch {}
 }
 
 // Clean stale sessions every hour — sessions survive a full workday
@@ -63,13 +66,41 @@ function lookupSession(
   opencodeSessionId: string | undefined,
   messages: Array<{ role: string; content: any }>
 ): SessionState | undefined {
-  // Primary: use x-opencode-session header
+  // When a session ID is provided, only match by that ID — don't fall through
+  // to fingerprint. A different session ID means a different session.
   if (opencodeSessionId) {
-    return sessionCache.get(opencodeSessionId)
+    const cached = sessionCache.get(opencodeSessionId)
+    if (cached) return cached
+    // Check shared file store
+    const shared = lookupSharedSession(opencodeSessionId)
+    if (shared) {
+      const state: SessionState = {
+        claudeSessionId: shared.claudeSessionId,
+        lastAccess: shared.lastUsedAt,
+        messageCount: 0,
+      }
+      sessionCache.set(opencodeSessionId, state)
+      return state
+    }
+    return undefined
   }
-  // Fallback: fingerprint (only when no header is present)
+
+  // No session ID — use fingerprint fallback
   const fp = getConversationFingerprint(messages)
-  if (fp) return fingerprintCache.get(fp)
+  if (fp) {
+    const cached = fingerprintCache.get(fp)
+    if (cached) return cached
+    const shared = lookupSharedSession(fp)
+    if (shared) {
+      const state: SessionState = {
+        claudeSessionId: shared.claudeSessionId,
+        lastAccess: shared.lastUsedAt,
+        messageCount: 0,
+      }
+      fingerprintCache.set(fp, state)
+      return state
+    }
+  }
   return undefined
 }
 
@@ -81,9 +112,13 @@ function storeSession(
 ) {
   if (!claudeSessionId) return
   const state: SessionState = { claudeSessionId, lastAccess: Date.now(), messageCount: messages?.length || 0 }
+  // In-memory cache
   if (opencodeSessionId) sessionCache.set(opencodeSessionId, state)
   const fp = getConversationFingerprint(messages)
   if (fp) fingerprintCache.set(fp, state)
+  // Shared file store (cross-proxy resume)
+  const key = opencodeSessionId || fp
+  if (key) storeSharedSession(key, claudeSessionId)
 }
 
 /** Extract only the last user message (for resume — SDK already has history) */

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -1,0 +1,92 @@
+/**
+ * File-based session store for cross-proxy session resume.
+ *
+ * When running per-terminal proxies (each on a different port),
+ * sessions need to be shared so you can resume a conversation
+ * started in one terminal from another. This stores session
+ * mappings in a JSON file that all proxy instances read/write.
+ *
+ * Format: { [key]: { claudeSessionId, createdAt, lastUsedAt } }
+ * Keys are either OpenCode session IDs or conversation fingerprints.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "fs"
+import { join, dirname } from "path"
+import { homedir } from "os"
+
+export interface StoredSession {
+  claudeSessionId: string
+  createdAt: number
+  lastUsedAt: number
+}
+
+const SESSION_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+function getStorePath(): string {
+  const dir = process.env.CLAUDE_PROXY_SESSION_DIR
+    || join(homedir(), ".cache", "opencode-claude-max-proxy")
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  return join(dir, "sessions.json")
+}
+
+function readStore(): Record<string, StoredSession> {
+  const path = getStorePath()
+  if (!existsSync(path)) return {}
+  try {
+    const data = readFileSync(path, "utf-8")
+    const store = JSON.parse(data) as Record<string, StoredSession>
+    // Prune expired entries
+    const now = Date.now()
+    const pruned: Record<string, StoredSession> = {}
+    for (const [key, session] of Object.entries(store)) {
+      if (now - session.lastUsedAt < SESSION_TTL_MS) {
+        pruned[key] = session
+      }
+    }
+    return pruned
+  } catch {
+    return {}
+  }
+}
+
+function writeStore(store: Record<string, StoredSession>): void {
+  const path = getStorePath()
+  const tmp = path + ".tmp"
+  try {
+    writeFileSync(tmp, JSON.stringify(store, null, 2))
+    renameSync(tmp, path) // atomic write
+  } catch {
+    // If rename fails, try direct write
+    try {
+      writeFileSync(path, JSON.stringify(store, null, 2))
+    } catch {}
+  }
+}
+
+export function lookupSharedSession(key: string): StoredSession | undefined {
+  const store = readStore()
+  const session = store[key]
+  if (!session) return undefined
+  if (Date.now() - session.lastUsedAt >= SESSION_TTL_MS) return undefined
+  return session
+}
+
+export function storeSharedSession(key: string, claudeSessionId: string): void {
+  const store = readStore()
+  const existing = store[key]
+  store[key] = {
+    claudeSessionId,
+    createdAt: existing?.createdAt || Date.now(),
+    lastUsedAt: Date.now(),
+  }
+  writeStore(store)
+}
+
+export function clearSharedSessions(): void {
+  const path = getStorePath()
+  try {
+    writeFileSync(path, "{}")
+  } catch {}
+}


### PR DESCRIPTION
## Summary

Two features that work together to solve concurrency and session resume:

### Per-Terminal Launcher (`bin/oc.sh`)
Each terminal gets its own proxy on a random port. No shared port, no concurrent crashes, no supervisor needed.

```bash
./bin/oc.sh        # starts proxy, launches OpenCode, cleans up on exit
```

### Shared Session File Store
Sessions persist to `~/.cache/opencode-claude-max-proxy/sessions.json` so they can be resumed across terminals — even when each terminal has its own proxy.

- Atomic writes for safety
- 24-hour TTL with auto-pruning
- In-memory cache as fast path, file as fallback
- `clearSessionCache()` also clears file store (no test leaks)

### Who Uses What

| Use Case | Approach | Concurrency | Session Resume |
|---|---|---|---|
| **CLI (multiple terminals)** | `oc.sh` per-terminal | ✅ No crashes | ✅ Shared file store |
| **OpenCode Desktop** | Shared proxy + config file | ⚠️ Use supervisor | ✅ Same file store |
| **Single terminal** | Either | ✅ No issue | ✅ Both work |

### Verified
- Two proxies on different ports: Proxy A creates session → Proxy B resumes it ✅
- Launcher starts proxy, connects OpenCode, cleans up on exit ✅
- 114 tests (8 new for session store), all passing ✅

Credit to @calebdw (#46) for the per-terminal proxy idea.