### PR TITLE
fix: only send new messages on resume, not full history

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -118,7 +118,7 @@ function storeSession(
   if (fp) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = opencodeSessionId || fp
-  if (key) storeSharedSession(key, claudeSessionId)
+  if (key) storeSharedSession(key, claudeSessionId, state.messageCount)
 }
 
 /** Extract only the last user message (for resume — SDK already has history) */

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -18,6 +18,7 @@ export interface StoredSession {
   claudeSessionId: string
   createdAt: number
   lastUsedAt: number
+  messageCount: number
 }
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
@@ -73,13 +74,14 @@ export function lookupSharedSession(key: string): StoredSession | undefined {
   return session
 }
 
-export function storeSharedSession(key: string, claudeSessionId: string): void {
+export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number): void {
   const store = readStore()
   const existing = store[key]
   store[key] = {
     claudeSessionId,
     createdAt: existing?.createdAt || Date.now(),
     lastUsedAt: Date.now(),
+    messageCount: messageCount ?? existing?.messageCount ?? 0,
   }
   writeStore(store)
 }


### PR DESCRIPTION
On resume, the SDK already has the prior conversation. Instead of re-sending the entire message history (which grows to 700K+ tokens on long sessions), we now send only the delta.

### Before
Every follow-up request converted the full conversation to text and sent it to the SDK. At 80+ tool rounds, this exceeded the context limit and crashed.

### After
We track how many messages the SDK has seen (`messageCount`). On resume, we slice from that point — the SDK gets only the new tool_result + follow-up.

| Turn | OpenCode sends | We forward |
|------|---------------|------------|
| 1 | 1 message | 1 message (no resume) |
| 10 | 10 messages | 2 messages (delta) |
| 80 | 80 messages | 2 messages (delta) |

### Verified
- Cross-proxy resume with delta (Proxy A creates, Proxy B sends delta only)
- messageCount persists in shared session file store
- 114 tests, all passing

Fixes #49