### PR TITLE
fix: include mcpTools.ts in published package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "bin/",
     "src/proxy/",
     "src/logger.ts",
+    "src/mcpTools.ts",
     "README.md"
   ],
   "keywords": [


### PR DESCRIPTION
## Summary

- Adds `src/mcpTools.ts` to the `files` array in `package.json` so it is included in the published npm package.
- Fixes `Cannot find module '../mcpTools'` error that occurs when running the package after installing from npm/bun, because `src/proxy/server.ts` imports `../mcpTools` but the file was missing from the published tarball.

## Test plan

- [x] Verified with `npm pack --dry-run` that `src/mcpTools.ts` is now listed in the tarball contents
- [x] Ran `npm pack` → installed the tarball in a clean temp directory → confirmed the file exists at the expected relative path from `server.ts`

Made with [Cursor](https://cursor.com)