### PR TITLE
feat: multimodal content support (images, documents, files)

### DIFF
--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Multimodal Content Tests
+ *
+ * Verifies that image, document, and file content blocks are
+ * preserved and passed to the SDK as structured messages.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let capturedQueryParams: any = null
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParams = params
+    return (async function* () {
+      yield {
+        type: "assistant",
+        message: {
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "I see the image" }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: "sess-1",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }))
+}
+
+describe("Multimodal content", () => {
+  beforeEach(() => {
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  it("should use text prompt for text-only messages", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })).json()
+
+    expect(typeof capturedQueryParams.prompt).toBe("string")
+  })
+
+  it("should use structured prompt for image content", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "what is this?" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBOR..." } },
+        ],
+      }],
+    })).json()
+
+    // Should be an AsyncIterable, not a string
+    expect(typeof capturedQueryParams.prompt).not.toBe("string")
+    expect(capturedQueryParams.prompt[Symbol.asyncIterator]).toBeDefined()
+  })
+
+  it("should use structured prompt for document content", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "summarize this" },
+          { type: "document", source: { type: "base64", media_type: "application/pdf", data: "JVBER..." } },
+        ],
+      }],
+    })).json()
+
+    expect(typeof capturedQueryParams.prompt).not.toBe("string")
+  })
+
+  it("should use structured prompt for file content", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "review this" },
+          { type: "file", source: { type: "base64", data: "..." } },
+        ],
+      }],
+    })).json()
+
+    expect(typeof capturedQueryParams.prompt).not.toBe("string")
+  })
+
+  it("should include all message roles in structured messages", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "look at this" }, { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } }] },
+        { role: "assistant", content: [{ type: "text", text: "I see it" }] },
+        { role: "user", content: "what color is it?" },
+      ],
+    })).json()
+
+    // Collect all messages from the async iterable
+    const messages: any[] = []
+    for await (const msg of capturedQueryParams.prompt) {
+      messages.push(msg)
+    }
+
+    // Should have system context + all 3 messages
+    expect(messages.length).toBeGreaterThanOrEqual(3)
+    // All should have the user type wrapper (SDK requirement)
+    for (const msg of messages) {
+      expect(msg.type).toBe("user")
+      expect(msg.message).toBeDefined()
+    }
+  })
+
+  it("should strip cache_control from content blocks", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "hello", cache_control: { type: "ephemeral", ttl: "1h" } },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" }, cache_control: { type: "ephemeral" } },
+        ],
+      }],
+    })).json()
+
+    const messages: any[] = []
+    for await (const msg of capturedQueryParams.prompt) {
+      messages.push(msg)
+    }
+
+    // Find the message with image content (skip system context)
+    const imageMsg = messages.find((m: any) =>
+      Array.isArray(m.message.content) &&
+      m.message.content.some((b: any) => b.type === "image")
+    )
+    expect(imageMsg).toBeDefined()
+    for (const block of imageMsg.message.content) {
+      expect(block.cache_control).toBeUndefined()
+    }
+  })
+
+  it("should include system context in structured messages", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      system: "You are a helpful assistant.",
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "what is this?" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+        ],
+      }],
+    })).json()
+
+    const messages: any[] = []
+    for await (const msg of capturedQueryParams.prompt) {
+      messages.push(msg)
+    }
+
+    // First message should be the system context
+    expect(messages[0]!.message.content).toContain("You are a helpful assistant.")
+  })
+
+  it("should fall back to text prompt with image placeholder when no multimodal", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+    })).json()
+
+    expect(typeof capturedQueryParams.prompt).toBe("string")
+    expect(capturedQueryParams.prompt).toContain("hello")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -415,34 +415,118 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
 
 
 
-      // When resuming, only send the last user message (SDK already has history)
-      const messagesToConvert = isResume
-        ? getLastUserMessage(body.messages || [])
-        : body.messages
+      // When resuming, only send new messages the SDK doesn't have.
+      const allMessages = body.messages || []
+      let messagesToConvert: typeof allMessages
 
-      // Convert messages to a text prompt, preserving all content types
-      const conversationParts = messagesToConvert
-        ?.map((m: { role: string; content: string | Array<{ type: string; text?: string; content?: string; tool_use_id?: string; name?: string; input?: unknown; id?: string }> }) => {
-          const role = m.role === "assistant" ? "Assistant" : "Human"
-          let content: string
-          if (typeof m.content === "string") {
-            content = m.content
-          } else if (Array.isArray(m.content)) {
-            content = m.content
-              .map((block: any) => {
-                if (block.type === "text" && block.text) return block.text
-                if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
-                if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
-                return ""
-              })
-              .filter(Boolean)
-              .join("\n")
-          } else {
-            content = String(m.content)
+      if (isResume && cachedSession) {
+        const knownCount = cachedSession.messageCount || 0
+        if (knownCount > 0 && knownCount < allMessages.length) {
+          messagesToConvert = allMessages.slice(knownCount)
+        } else {
+          messagesToConvert = getLastUserMessage(allMessages)
+        }
+      } else {
+        messagesToConvert = allMessages
+      }
+
+      // Check if any messages contain multimodal content (images, documents, files)
+      const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
+      const hasMultimodal = messagesToConvert?.some((m: any) =>
+        Array.isArray(m.content) && m.content.some((b: any) => MULTIMODAL_TYPES.has(b.type))
+      )
+
+      // Strip cache_control from content blocks — the SDK manages its own caching
+      // and OpenCode's ttl='1h' blocks conflict with the SDK's ttl='5m' blocks
+      function stripCacheControl(content: any): any {
+        if (!Array.isArray(content)) return content
+        return content.map((block: any) => {
+          if (block.cache_control) {
+            const { cache_control, ...rest } = block
+            return rest
           }
-          return `${role}: ${content}`
+          return block
         })
-        .join("\n\n") || ""
+      }
+
+      // Build the prompt — either structured (multimodal) or text
+      let prompt: string | AsyncIterable<any>
+
+      if (hasMultimodal) {
+        // Structured messages preserve image/document/file blocks for Claude to see.
+        // The SDK only accepts role:"user" in SDKUserMessage, so assistant messages
+        // are converted to text summaries wrapped as user messages.
+        const structured = messagesToConvert.map((m: any) => {
+          if (m.role === "user") {
+            return {
+              type: "user" as const,
+              message: { role: "user" as const, content: stripCacheControl(m.content) },
+              parent_tool_use_id: null,
+            }
+          }
+          // Convert assistant/tool messages to text summary
+          let text: string
+          if (typeof m.content === "string") {
+            text = `[Assistant: ${m.content}]`
+          } else if (Array.isArray(m.content)) {
+            text = m.content.map((b: any) => {
+              if (b.type === "text" && b.text) return `[Assistant: ${b.text}]`
+              if (b.type === "tool_use") return `[Tool Use: ${b.name}(${JSON.stringify(b.input)})]`
+              if (b.type === "tool_result") return `[Tool Result: ${typeof b.content === "string" ? b.content : JSON.stringify(b.content)}]`
+              return ""
+            }).filter(Boolean).join("\n")
+          } else {
+            text = `[Assistant: ${String(m.content)}]`
+          }
+          return {
+            type: "user" as const,
+            message: { role: "user" as const, content: text },
+            parent_tool_use_id: null,
+          }
+        })
+
+        // Prepend system context as a text message
+        if (systemContext) {
+          structured.unshift({
+            type: "user" as const,
+            message: { role: "user", content: systemContext },
+            parent_tool_use_id: null,
+          })
+        }
+
+        prompt = (async function* () { for (const msg of structured) yield msg })()
+      } else {
+        // Text prompt — convert messages to string
+        const conversationParts = messagesToConvert
+          ?.map((m: { role: string; content: string | Array<{ type: string; text?: string; content?: string; tool_use_id?: string; name?: string; input?: unknown; id?: string }> }) => {
+            const role = m.role === "assistant" ? "Assistant" : "Human"
+            let content: string
+            if (typeof m.content === "string") {
+              content = m.content
+            } else if (Array.isArray(m.content)) {
+              content = m.content
+                .map((block: any) => {
+                  if (block.type === "text" && block.text) return block.text
+                  if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
+                  if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
+                  if (block.type === "image") return "[Image attached]"
+                  if (block.type === "document") return "[Document attached]"
+                  if (block.type === "file") return "[File attached]"
+                  return ""
+                })
+                .filter(Boolean)
+                .join("\n")
+            } else {
+              content = String(m.content)
+            }
+            return `${role}: ${content}`
+          })
+          .join("\n\n") || ""
+
+        prompt = systemContext
+          ? `${systemContext}\n\n${conversationParts}`
+          : conversationParts
+      }
 
       // --- Passthrough mode ---
       // When enabled, ALL tool execution is forwarded to OpenCode instead of
@@ -499,10 +583,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
             }
           : undefined
 
-      // Combine system context with conversation
-      const prompt = systemContext
-        ? `${systemContext}\n\n${conversationParts}`
-        : conversationParts
+
 
         if (!stream) {
           const contentBlocks: Array<Record<string, unknown>> = []
@@ -1032,6 +1113,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
         mode: process.env.CLAUDE_PROXY_PASSTHROUGH ? "passthrough" : "internal",
       })
     }
+  })
+
+  // Catch-all: log unhandled requests
+  app.all("*", (c) => {
+    console.error(`[PROXY] UNHANDLED ${c.req.method} ${c.req.url}`)
+    return c.json({ error: { type: "not_found", message: `Endpoint not supported: ${c.req.method} ${new URL(c.req.url).pathname}` } }, 404)
   })
 
   return { app, config: finalConfig }


### PR DESCRIPTION
Images, documents, and files are now passed to Claude instead of being silently dropped.

When a message contains multimodal content, the proxy builds structured `SDKUserMessage` objects that preserve the binary data. Claude sees the actual image and can describe it, analyze it, etc.

### How it works
- Text-only messages → text prompt (unchanged)
- Messages with image/document/file blocks → `AsyncIterable<SDKUserMessage>` prompt
- Assistant messages in the delta are converted to text summaries (SDK only accepts `role: user`)
- Cache control stripped from content blocks (OpenCode's TTL conflicts with SDK's)
- System context prepended as a text message, not via `systemPrompt` option
- Works with delta resume — only new messages sent on follow-ups

### Also includes
- Delta resume fix (was missing from #57) — `messagesToConvert` now slices from `messageCount`
- Catch-all 404 route for unhandled endpoints

### Tested
- Text session → resume with image → Claude correctly says 'red' ✅
- All message roles handled (user preserved, assistant summarized) ✅
- Cache control stripping ✅
- 122 tests (8 new), all passing ✅

Credit to @juanferreiramorel (#42) for identifying the problem and the `AsyncIterable` approach. We reworked the implementation to avoid `systemPrompt` override, include all message roles, and integrate with delta resume.