### PR TITLE
fix: resolve UID mismatch between claude user and docker-compose init volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:22 AS build
 
 RUN npm install -g bun \
     && npm cache clean --force \
-    && useradd -m -s /bin/bash claude \
+    && userdel -r node \
+    && useradd -m -s /bin/bash -u 1000 claude \
     && mkdir -p /home/claude/.claude \
     && chown -R claude:claude /home/claude
 
@@ -21,7 +22,8 @@ FROM node:22-slim
 
 COPY --from=build /usr/local/bin/bun /usr/local/bin/
 
-RUN useradd -m -s /bin/bash claude \
+RUN userdel -r node \
+    && useradd -m -s /bin/bash -u 1000 claude \
     && mkdir -p /home/claude/.claude \
     && chown -R claude:claude /home/claude
 


### PR DESCRIPTION
## Problem

PR #63 switched the docker-compose init service from the built image to `busybox` with `chown -R 1000:1000`. However, `node:22` and `node:22-slim` both ship a `node` user at **UID 1000**:

```
$ docker run --rm node:22-slim id node
uid=1000(node) gid=1000(node) groups=1000(node)
```

So `useradd claude` gets **UID 1001**, not 1000. The proxy runs as claude (1001) but the volume is owned by 1000 → **permission denied** on `/home/claude/.claude`.

## Fix

Remove the `node` user in both build and runtime stages, then explicitly create `claude` with `-u 1000`:

```dockerfile
RUN userdel -r node \
    && useradd -m -s /bin/bash -u 1000 claude ...
```

This ensures the claude user is UID 1000, matching the `chown -R 1000:1000` in the busybox init service.