### PR TITLE
fix: make tsconfig.json optional in Docker COPY to prevent build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM oven/bun:1 AS build
 
 WORKDIR /app
-COPY package.json bun.lock* tsconfig.json ./
+COPY package.json bun.lock* tsconfig.json* ./
 COPY bin/ ./bin/
 COPY src/ ./src/
 


### PR DESCRIPTION
Fixes #70

The Dockerfile `COPY` on line 5 lists `tsconfig.json` as a required file, but it's not needed by `bun build`. Users without it get:

```
failed to calculate checksum ... "/tsconfig.json": not found
```

**Fix:** `tsconfig.json` → `tsconfig.json*` (glob makes it optional, same pattern as `bun.lock*`).

**Tested:** Reproduced the exact error without `tsconfig.json`, confirmed the fix builds successfully.