### PR TITLE
fix: deduplicate tool_use blocks in streaming passthrough mode

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -837,6 +837,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
               }, 15_000)
 
               const skipBlockIndices = new Set<number>()
+              const streamedToolUseIds = new Set<string>() // Track tool_use IDs already forwarded in stream
               let messageStartEmitted = false // Track if we've sent a message_start to the client
 
               try {
@@ -890,6 +891,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                         if (passthrough && block.name.startsWith(PASSTHROUGH_MCP_PREFIX)) {
                           // Passthrough mode: strip prefix and forward to OpenCode
                           block.name = stripMcpPrefix(block.name)
+                          // Track this tool_use ID so we don't emit it again from capturedToolUses
+                          if (block.id) streamedToolUseIds.add(block.id)
                         } else if (block.name.startsWith("mcp__")) {
                           // Internal mode: skip all MCP tool blocks (internal execution)
                           if (eventIndex !== undefined) skipBlockIndices.add(eventIndex)
@@ -948,9 +951,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
 
               if (!streamClosed) {
                 // In passthrough mode, emit captured tool_use blocks as stream events
-                if (passthrough && capturedToolUses.length > 0 && messageStartEmitted) {
-                  for (let i = 0; i < capturedToolUses.length; i++) {
-                    const tu = capturedToolUses[i]!
+                // Skip any that were already forwarded during the stream (dedup by ID)
+                const unseenToolUses = capturedToolUses.filter(tu => !streamedToolUseIds.has(tu.id))
+                if (passthrough && unseenToolUses.length > 0 && messageStartEmitted) {
+                  for (let i = 0; i < unseenToolUses.length; i++) {
+                    const tu = unseenToolUses[i]!
                     const blockIndex = eventsForwarded + i
 
                     // content_block_start


### PR DESCRIPTION
Fixes #69

**Problem:** In streaming passthrough mode, tool_use blocks are emitted twice — once from the SDK stream events and again from `capturedToolUses` after the loop. This causes OpenCode to execute every tool call twice (duplicate TODO lists, syntax errors from double edits).

**Root cause:** The non-streaming path (line 696) already deduplicates by ID:
```ts
if (!contentBlocks.some(b => b.type === "tool_use" && b.id === tu.id))
```
The streaming path had no equivalent guard.

**Fix:** Track tool_use IDs forwarded during the stream in a `Set`, then filter `capturedToolUses` before the post-loop emission.

All 126 tests pass. Credit to @stefanpartheym for the detailed analysis and patch in #69.