### PR TITLE
fix(proxy): add LRU eviction to bound session cache growth

### DIFF
--- a/src/__tests__/proxy-cache-eviction.test.ts
+++ b/src/__tests__/proxy-cache-eviction.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+const originalMaxSessions = process.env.CLAUDE_PROXY_MAX_SESSIONS
+process.env.CLAUDE_PROXY_MAX_SESSIONS = "2"
+
+type MockSdkMessage = Record<string, unknown>
+type TestApp = { fetch: (req: Request) => Promise<Response> }
+
+let mockMessages: MockSdkMessage[] = []
+let capturedQueryParams: { options?: { resume?: string } } | null = null
+let queuedSessionIds: string[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: unknown) => {
+    capturedQueryParams = params as { options?: { resume?: string } }
+    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    return (async function* () {
+      for (const msg of mockMessages) {
+        yield { ...msg, session_id: sessionId }
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+}))
+
+mock.module("../proxy/sessionStore", () => ({
+  lookupSharedSession: () => undefined,
+  storeSharedSession: () => {},
+  clearSharedSessions: () => {},
+}))
+
+const { createProxyServer, clearSessionCache, getMaxSessionsLimit } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app as TestApp
+}
+
+async function post(app: TestApp, body: Record<string, unknown>, headers: Record<string, string> = {}) {
+  const req = new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  })
+  return app.fetch(req)
+}
+
+async function send(app: TestApp, session: string | undefined, firstMessage: string, sessionId: string) {
+  queuedSessionIds.push(sessionId)
+  const headers = session ? { "x-opencode-session": session } : {}
+  const response = await post(app, {
+    model: "claude-sonnet-4-5",
+    max_tokens: 128,
+    stream: false,
+    messages: [{ role: "user", content: firstMessage }],
+  }, headers)
+  await response.json()
+}
+
+beforeEach(() => {
+  mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+  capturedQueryParams = null
+  queuedSessionIds = []
+  clearSessionCache()
+})
+
+afterAll(() => {
+  if (originalMaxSessions === undefined) delete process.env.CLAUDE_PROXY_MAX_SESSIONS
+  else process.env.CLAUDE_PROXY_MAX_SESSIONS = originalMaxSessions
+})
+
+describe("Session cache LRU eviction", () => {
+  it("evicts the least-recently-used session entry", async () => {
+    const app = createTestApp()
+
+    await send(app, "oc-A", "first-A", "sdk-A")
+    await send(app, "oc-B", "first-B", "sdk-B")
+    await send(app, "oc-C", "first-C", "sdk-C")
+
+    await send(app, "oc-A", "first-A", "sdk-A-new")
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+
+  it("refreshes recency when a key is accessed", async () => {
+    const app = createTestApp()
+
+    await send(app, "oc-A", "first-A", "sdk-A")
+    await send(app, "oc-B", "first-B", "sdk-B")
+
+    await send(app, "oc-A", "first-A", "sdk-A")
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+
+    await send(app, "oc-C", "first-C", "sdk-C")
+
+    await send(app, "oc-B", "first-B", "sdk-B-new")
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+
+  it("coordinates eviction across session and fingerprint caches", async () => {
+    const app = createTestApp()
+
+    await send(app, "oc-A", "alpha", "sdk-A")
+    await send(app, "oc-B", "beta", "sdk-B")
+    await send(app, "oc-C", "gamma", "sdk-C")
+
+    await send(app, undefined, "alpha", "sdk-alpha-new")
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+
+    clearSessionCache()
+
+    await send(app, "oc-A", "alpha", "sdk-A2")
+    await send(app, undefined, "fp-X", "sdk-X")
+    await send(app, undefined, "fp-Y", "sdk-Y")
+
+    await send(app, "oc-A", "alpha", "sdk-A3")
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+})
+
+describe("Max session env parsing", () => {
+  it("falls back to default and logs warning for invalid values", () => {
+    const original = process.env.CLAUDE_PROXY_MAX_SESSIONS
+    const originalWarn = console.warn
+    const warnings: string[] = []
+
+    process.env.CLAUDE_PROXY_MAX_SESSIONS = "not-a-number"
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((arg) => String(arg)).join(" "))
+    }
+
+    try {
+      expect(getMaxSessionsLimit()).toBe(1000)
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]).toContain("CLAUDE_PROXY_MAX_SESSIONS")
+      expect(warnings[0]).toContain("using default 1000")
+    } finally {
+      console.warn = originalWarn
+      if (original === undefined) delete process.env.CLAUDE_PROXY_MAX_SESSIONS
+      else process.env.CLAUDE_PROXY_MAX_SESSIONS = original
+    }
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -27,11 +27,134 @@ interface SessionState {
   messageCount: number
 }
 
-const sessionCache = new Map<string, SessionState>()
-const fingerprintCache = new Map<string, SessionState>()
+class LRUMap<K, V> implements Iterable<[K, V]> {
+  private readonly map = new Map<K, V>()
+
+  constructor(
+    private readonly maxSize: number,
+    private readonly onEvict?: (key: K, value: V) => void
+  ) {}
+
+  get size(): number {
+    return this.map.size
+  }
+
+  get(key: K): V | undefined {
+    const value = this.map.get(key)
+    if (value === undefined) return undefined
+    this.map.delete(key)
+    this.map.set(key, value)
+    return value
+  }
+
+  set(key: K, value: V): this {
+    if (this.map.has(key)) {
+      this.map.delete(key)
+    } else if (this.map.size >= this.maxSize) {
+      this.evictOldest()
+    }
+
+    this.map.set(key, value)
+    return this
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key)
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.map.entries()
+  }
+
+  keys(): MapIterator<K> {
+    return this.map.keys()
+  }
+
+  values(): MapIterator<V> {
+    return this.map.values()
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.map[Symbol.iterator]()
+  }
+
+  private evictOldest(): void {
+    const oldestKey = this.map.keys().next().value as K | undefined
+    if (oldestKey === undefined) return
+
+    const oldestValue = this.map.get(oldestKey)
+    if (oldestValue === undefined) return
+
+    this.map.delete(oldestKey)
+    this.onEvict?.(oldestKey, oldestValue)
+  }
+}
+
+const DEFAULT_MAX_SESSIONS = 1000
+
+export function getMaxSessionsLimit(): number {
+  const raw = process.env.CLAUDE_PROXY_MAX_SESSIONS
+  if (!raw) return DEFAULT_MAX_SESSIONS
+
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(`[PROXY] Invalid CLAUDE_PROXY_MAX_SESSIONS value "${raw}"; using default ${DEFAULT_MAX_SESSIONS}`)
+    return DEFAULT_MAX_SESSIONS
+  }
+
+  return parsed
+}
+
+let sessionCache: LRUMap<string, SessionState>
+let fingerprintCache: LRUMap<string, SessionState>
+let activeSessionCacheSize = 0
+
+function removeFingerprintEntriesByClaudeSessionId(claudeSessionId: string): void {
+  for (const [key, state] of fingerprintCache.entries()) {
+    if (state.claudeSessionId === claudeSessionId) {
+      fingerprintCache.delete(key)
+    }
+  }
+}
+
+function removeSessionEntriesByClaudeSessionId(claudeSessionId: string): void {
+  for (const [key, state] of sessionCache.entries()) {
+    if (state.claudeSessionId === claudeSessionId) {
+      sessionCache.delete(key)
+    }
+  }
+}
+
+function initializeSessionCaches(maxSize: number): void {
+  activeSessionCacheSize = maxSize
+  sessionCache = new LRUMap<string, SessionState>(maxSize, (_key, evictedState) => {
+    removeFingerprintEntriesByClaudeSessionId(evictedState.claudeSessionId)
+  })
+  fingerprintCache = new LRUMap<string, SessionState>(maxSize, (_key, evictedState) => {
+    removeSessionEntriesByClaudeSessionId(evictedState.claudeSessionId)
+  })
+}
+
+function ensureSessionCacheLimit(): void {
+  const configuredLimit = getMaxSessionsLimit()
+  if (configuredLimit !== activeSessionCacheSize) {
+    initializeSessionCaches(configuredLimit)
+  }
+}
+
+initializeSessionCaches(getMaxSessionsLimit())
 
 /** Clear all session caches (used in tests) */
 export function clearSessionCache() {
+  ensureSessionCacheLimit()
   sessionCache.clear()
   fingerprintCache.clear()
   // Also clear shared file store
@@ -299,6 +422,7 @@ function isClosedControllerError(error: unknown): boolean {
 }
 
 export function createProxyServer(config: Partial<ProxyConfig> = {}) {
+  ensureSessionCacheLimit()
   const finalConfig = { ...DEFAULT_PROXY_CONFIG, ...config }
   const app = new Hono()
 


### PR DESCRIPTION
## Problem
\`sessionCache\` and \`fingerprintCache\` grow indefinitely — only pruned by TTL every 60 min.

## Fix
- Add \`LRUMap\` wrapper with size-based eviction using Map insertion order
- Coordinated eviction across both maps (no orphaned entries)
- Configurable via \`CLAUDE_PROXY_MAX_SESSIONS\` env var (default: 1000)

## Test
\`bun test\` — all existing + new \`proxy-cache-eviction.test.ts\`