### PR TITLE
fix(session-store): add file locking for concurrent access safety

### DIFF
--- a/src/__tests__/proxy-session-store-locking.test.ts
+++ b/src/__tests__/proxy-session-store-locking.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { clearSharedSessions, lookupSharedSession, storeSharedSession } from "../proxy/sessionStore"
+
+describe("Shared session store locking", () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "session-store-locking-test-"))
+    process.env.CLAUDE_PROXY_SESSION_DIR = tmpDir
+    clearSharedSessions()
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+    delete process.env.CLAUDE_PROXY_SESSION_DIR
+  })
+
+  it("preserves all entries during concurrent writes", async () => {
+    const writes = Array.from({ length: 25 }, (_, i) =>
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          storeSharedSession(`sess-${i}`, `claude-${i}`, i)
+          resolve()
+        }, Math.floor(Math.random() * 6))
+      })
+    )
+
+    await Promise.all(writes)
+
+    for (let i = 0; i < 25; i++) {
+      const stored = lookupSharedSession(`sess-${i}`)
+      expect(stored).toBeDefined()
+      if (!stored) {
+        throw new Error(`expected sess-${i} to be stored`)
+      }
+      expect(stored.claudeSessionId).toBe(`claude-${i}`)
+      expect(stored.messageCount).toBe(i)
+    }
+  })
+
+  it("recovers from stale lock files", () => {
+    const sessionsPath = join(tmpDir, "sessions.json")
+    const lockPath = `${sessionsPath}.lock`
+
+    writeFileSync(lockPath, "")
+    const staleTime = (Date.now() - 31_000) / 1000
+    utimesSync(lockPath, staleTime, staleTime)
+
+    storeSharedSession("stale-lock-session", "claude-stale")
+
+    expect(lookupSharedSession("stale-lock-session")?.claudeSessionId).toBe("claude-stale")
+    expect(existsSync(lockPath)).toBe(false)
+  })
+
+  it("logs errors instead of silently swallowing failures", () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {})
+
+    writeFileSync(join(tmpDir, "sessions.json"), "{invalid-json")
+    expect(lookupSharedSession("broken")).toBeUndefined()
+
+    const badDirPath = join(tmpDir, "not-a-dir")
+    writeFileSync(badDirPath, "file")
+    process.env.CLAUDE_PROXY_SESSION_DIR = badDirPath
+    storeSharedSession("write-failure", "claude-write")
+    clearSharedSessions()
+
+    const messages = errorSpy.mock.calls.map((call) => call[0])
+    expect(messages).toContain("[sessionStore] read failed:")
+    expect(messages).toContain("[sessionStore] write failed:")
+    expect(messages).toContain("[sessionStore] clear failed:")
+
+    errorSpy.mockRestore()
+  })
+
+  it("warns and degrades gracefully when lock cannot be acquired", () => {
+    const sessionsPath = join(tmpDir, "sessions.json")
+    const lockPath = `${sessionsPath}.lock`
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
+
+    writeFileSync(lockPath, "")
+    storeSharedSession("lock-contention", "claude-fallback")
+
+    expect(lookupSharedSession("lock-contention")?.claudeSessionId).toBe("claude-fallback")
+    expect(warnSpy).toHaveBeenCalledWith("[sessionStore] could not acquire lock, proceeding without")
+
+    warnSpy.mockRestore()
+  })
+})

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -10,9 +10,19 @@
  * Keys are either OpenCode session IDs or conversation fingerprints.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "fs"
-import { join, dirname } from "path"
-import { homedir } from "os"
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
 
 export interface StoredSession {
   claudeSessionId: string
@@ -22,6 +32,41 @@ export interface StoredSession {
 }
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+const STALE_LOCK_THRESHOLD_MS = 30_000
+
+function acquireLock(lockPath: string): boolean {
+  try {
+    const fd = openSync(lockPath, "wx")
+    closeSync(fd)
+    return true
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException
+    if (err.code !== "EEXIST") {
+      console.error("[sessionStore] lock acquire failed:", err.message)
+      return false
+    }
+    try {
+      const stat = statSync(lockPath)
+      if (Date.now() - stat.mtimeMs > STALE_LOCK_THRESHOLD_MS) {
+        unlinkSync(lockPath)
+        const fd = openSync(lockPath, "wx")
+        closeSync(fd)
+        return true
+      }
+    } catch (staleError) {
+      console.error("[sessionStore] stale lock recovery failed:", (staleError as Error).message)
+    }
+    return false
+  }
+}
+
+function releaseLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath)
+  } catch (e) {
+    console.error("[sessionStore] lock release failed:", (e as Error).message)
+  }
+}
 
 function getStorePath(): string {
   const dir = process.env.CLAUDE_PROXY_SESSION_DIR
@@ -47,22 +92,26 @@ function readStore(): Record<string, StoredSession> {
       }
     }
     return pruned
-  } catch {
+  } catch (e) {
+    console.error("[sessionStore] read failed:", (e as Error).message)
     return {}
   }
 }
 
 function writeStore(store: Record<string, StoredSession>): void {
   const path = getStorePath()
-  const tmp = path + ".tmp"
+  const tmp = `${path}.tmp`
   try {
     writeFileSync(tmp, JSON.stringify(store, null, 2))
     renameSync(tmp, path) // atomic write
-  } catch {
+  } catch (e) {
+    console.error("[sessionStore] write failed:", (e as Error).message)
     // If rename fails, try direct write
     try {
       writeFileSync(path, JSON.stringify(store, null, 2))
-    } catch {}
+    } catch (directWriteError) {
+      console.error("[sessionStore] write failed:", (directWriteError as Error).message)
+    }
   }
 }
 
@@ -75,20 +124,34 @@ export function lookupSharedSession(key: string): StoredSession | undefined {
 }
 
 export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number): void {
-  const store = readStore()
-  const existing = store[key]
-  store[key] = {
-    claudeSessionId,
-    createdAt: existing?.createdAt || Date.now(),
-    lastUsedAt: Date.now(),
-    messageCount: messageCount ?? existing?.messageCount ?? 0,
+  const path = getStorePath()
+  const lockPath = `${path}.lock`
+  const hasLock = acquireLock(lockPath)
+  if (!hasLock) {
+    console.warn("[sessionStore] could not acquire lock, proceeding without")
   }
-  writeStore(store)
+  try {
+    const store = readStore()
+    const existing = store[key]
+    store[key] = {
+      claudeSessionId,
+      createdAt: existing?.createdAt || Date.now(),
+      lastUsedAt: Date.now(),
+      messageCount: messageCount ?? existing?.messageCount ?? 0,
+    }
+    writeStore(store)
+  } finally {
+    if (hasLock) {
+      releaseLock(lockPath)
+    }
+  }
 }
 
 export function clearSharedSessions(): void {
   const path = getStorePath()
   try {
     writeFileSync(path, "{}")
-  } catch {}
+  } catch (e) {
+    console.error("[sessionStore] clear failed:", (e as Error).message)
+  }
 }


### PR DESCRIPTION
## Problem
Multiple proxy instances (via \`oc.sh\`) share \`sessions.json\` with no file locking. Concurrent writes can corrupt data.

## Fix
- Add file locking around read-modify-write in \`storeSharedSession()\`
- Stale lock recovery (30s timeout)
- Replace empty catch blocks with \`console.error\` logging

## Test
\`bun test\` — all existing + new \`proxy-session-store-locking.test.ts\`