### PR TITLE
fix(proxy): convert blocking execSync calls to async

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
 import { startProxyServer } from "../src/proxy/server"
-import { execSync } from "child_process"
+import { exec as execCallback } from "child_process"
+import { promisify } from "util"
+
+const exec = promisify(execCallback)
 
 // Prevent SDK subprocess crashes from killing the proxy
 process.on("uncaughtException", (err) => {
@@ -15,19 +18,28 @@ const port = parseInt(process.env.CLAUDE_PROXY_PORT || "3456", 10)
 const host = process.env.CLAUDE_PROXY_HOST || "127.0.0.1"
 const idleTimeoutSeconds = parseInt(process.env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS || "120", 10)
 
-// Pre-flight auth check
-try {
-  const authJson = execSync("claude auth status", { encoding: "utf-8", timeout: 5000 })
-  const auth = JSON.parse(authJson)
-  if (!auth.loggedIn) {
-    console.error("\x1b[31m✗ Not logged in to Claude.\x1b[0m Run: claude login")
-    process.exit(1)
+export async function runCli(
+  start = startProxyServer,
+  runExec: typeof exec = exec
+) {
+  // Pre-flight auth check
+  try {
+    const { stdout } = await runExec("claude auth status", { timeout: 5000 })
+    const auth = JSON.parse(stdout)
+    if (!auth.loggedIn) {
+      console.error("\x1b[31m✗ Not logged in to Claude.\x1b[0m Run: claude login")
+      process.exit(1)
+    }
+    if (auth.subscriptionType !== "max") {
+      console.error(`\x1b[33m⚠ Claude subscription: ${auth.subscriptionType || "unknown"} (Max recommended)\x1b[0m`)
+    }
+  } catch {
+    console.error("\x1b[33m⚠ Could not verify Claude auth status. If requests fail, run: claude login\x1b[0m")
   }
-  if (auth.subscriptionType !== "max") {
-    console.error(`\x1b[33m⚠ Claude subscription: ${auth.subscriptionType || "unknown"} (Max recommended)\x1b[0m`)
-  }
-} catch {
-  console.error("\x1b[33m⚠ Could not verify Claude auth status. If requests fail, run: claude login\x1b[0m")
+
+  await start({ port, host, idleTimeoutSeconds })
 }
 
-await startProxyServer({ port, host, idleTimeoutSeconds })
+if (import.meta.main) {
+  await runCli()
+}

--- a/src/__tests__/proxy-async-ops.test.ts
+++ b/src/__tests__/proxy-async-ops.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test"
+
+const { createProxyServer, startProxyServer } = await import("../proxy/server")
+const { runCli } = await import("../../bin/cli")
+
+describe("proxy async ops", () => {
+  it("starts server with async executable resolution", async () => {
+    const serverA = await startProxyServer({ port: 0, host: "127.0.0.1" })
+    const serverB = await startProxyServer({ port: 0, host: "127.0.0.1" })
+
+    serverA.close()
+    serverB.close()
+
+    expect(typeof serverA.keepAliveTimeout).toBe("number")
+    expect(typeof serverB.keepAliveTimeout).toBe("number")
+  })
+
+  it("serves async health endpoint with unchanged response schema", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const response = await app.fetch(new Request("http://localhost/health"))
+    const body = await response.json() as any
+
+    expect(typeof body.status).toBe("string")
+    expect(typeof body.mode).toBe("string")
+    expect(["healthy", "degraded", "unhealthy"]).toContain(body.status)
+
+    if (body.status === "healthy") {
+      expect(typeof body.auth.loggedIn).toBe("boolean")
+      expect(body.auth.loggedIn).toBe(true)
+      expect(Object.keys(body).sort()).toEqual(["auth", "mode", "status"])
+    }
+
+    if (body.status === "unhealthy") {
+      expect(typeof body.error).toBe("string")
+      expect(body.auth.loggedIn).toBe(false)
+      expect(Object.keys(body).sort()).toEqual(["auth", "error", "status"])
+    }
+
+    if (body.status === "degraded") {
+      expect(typeof body.error).toBe("string")
+      expect(Object.keys(body).sort()).toEqual(["error", "mode", "status"])
+    }
+
+    expect(response.status).toBe(body.status === "unhealthy" ? 503 : 200)
+  })
+
+  it("returns degraded health when auth status command times out", async () => {
+    const originalPath = process.env.PATH
+    process.env.PATH = ""
+
+    try {
+      const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+      const response = await app.fetch(new Request("http://localhost/health"))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({
+        status: "degraded",
+        error: "Could not verify auth status",
+        mode: "internal",
+      })
+    } finally {
+      process.env.PATH = originalPath
+    }
+  })
+
+  it("keeps CLI missing-binary warning behavior", async () => {
+    const errors: string[] = []
+    const originalError = console.error
+    console.error = (...args: any[]) => {
+      errors.push(args.join(" "))
+    }
+
+    let startCalled = 0
+    try {
+      await runCli(
+        async () => {
+          startCalled += 1
+          return {} as any
+        },
+        (() => {
+          throw new Error("spawn ENOENT")
+        }) as any
+      )
+    } finally {
+      console.error = originalError
+    }
+
+    expect(startCalled).toBe(1)
+    expect(errors.some((line) => line.includes("Could not verify Claude auth status"))).toBe(true)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -7,10 +7,11 @@ import type { Context } from "hono"
 import type { ProxyConfig } from "./types"
 import { DEFAULT_PROXY_CONFIG } from "./types"
 import { claudeLog } from "../logger"
-import { execSync } from "child_process"
+import { exec as execCallback } from "child_process"
 import { existsSync } from "fs"
 import { fileURLToPath } from "url"
 import { join, dirname } from "path"
+import { promisify } from "util"
 import { opencodeMcpServer } from "../mcpTools"
 import { randomUUID, createHash } from "crypto"
 import { withClaudeLogContext } from "../logger"
@@ -268,24 +269,46 @@ const ALLOWED_MCP_TOOLS = [
   `mcp__${MCP_SERVER_NAME}__grep`
 ]
 
-function resolveClaudeExecutable(): string {
-  // 1. Try the SDK's bundled cli.js (same dir as this module's SDK)
-  try {
-    const sdkPath = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-agent-sdk"))
-    const sdkCliJs = join(dirname(sdkPath), "cli.js")
-    if (existsSync(sdkCliJs)) return sdkCliJs
-  } catch {}
+const exec = promisify(execCallback)
 
-  // 2. Try the system-installed claude binary
-  try {
-    const claudePath = execSync("which claude", { encoding: "utf-8" }).trim()
-    if (claudePath && existsSync(claudePath)) return claudePath
-  } catch {}
+let cachedClaudePath: string | null = null
+let cachedClaudePathPromise: Promise<string> | null = null
+let claudeExecutable = ""
 
-  throw new Error("Could not find Claude Code executable. Install via: npm install -g @anthropic-ai/claude-code")
+async function resolveClaudeExecutableAsync(): Promise<string> {
+  if (cachedClaudePath) return cachedClaudePath
+  if (cachedClaudePathPromise) return cachedClaudePathPromise
+
+  cachedClaudePathPromise = (async () => {
+    // 1. Try the SDK's bundled cli.js (same dir as this module's SDK)
+    try {
+      const sdkPath = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-agent-sdk"))
+      const sdkCliJs = join(dirname(sdkPath), "cli.js")
+      if (existsSync(sdkCliJs)) {
+        cachedClaudePath = sdkCliJs
+        return sdkCliJs
+      }
+    } catch {}
+
+    // 2. Try the system-installed claude binary
+    try {
+      const { stdout } = await exec("which claude")
+      const claudePath = stdout.trim()
+      if (claudePath && existsSync(claudePath)) {
+        cachedClaudePath = claudePath
+        return claudePath
+      }
+    } catch {}
+
+    throw new Error("Could not find Claude Code executable. Install via: npm install -g @anthropic-ai/claude-code")
+  })()
+
+  try {
+    return await cachedClaudePathPromise
+  } finally {
+    cachedClaudePathPromise = null
+  }
 }
-
-const claudeExecutable = resolveClaudeExecutable()
 
 function mapModelToClaudeModel(model: string): "sonnet" | "opus" | "haiku" {
   if (model.includes("opus")) return "opus"
@@ -1110,10 +1133,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
   app.post("/messages", (c) => handleWithQueue(c, "/messages"))
 
   // Health check endpoint — verifies auth status
-  app.get("/health", (c) => {
+  app.get("/health", async (c) => {
     try {
-      const authJson = execSync("claude auth status", { encoding: "utf-8", timeout: 5000 })
-      const auth = JSON.parse(authJson)
+      const { stdout } = await exec("claude auth status", { timeout: 5000 })
+      const auth = JSON.parse(stdout)
       if (!auth.loggedIn) {
         return c.json({
           status: "unhealthy",
@@ -1149,6 +1172,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
 }
 
 export async function startProxyServer(config: Partial<ProxyConfig> = {}) {
+  claudeExecutable = await resolveClaudeExecutableAsync()
   const { app, config: finalConfig } = createProxyServer(config)
 
   const server = serve({


### PR DESCRIPTION
## Problem
\`execSync\` calls block the event loop — \`which claude\` at startup, \`claude auth status\` on every health check (up to 5s).

## Fix
- Convert to async \`exec\` with \`util.promisify\`
- Lazy-init + cache for claude path resolution
- Health endpoint now async with preserved timeout

## Test
\`bun test\` — all existing + new \`proxy-async-ops.test.ts\`