### PR TITLE
refactor: extract LRUMap, harden executable resolution, add TOCTOU docs

### DIFF
--- a/src/__tests__/lru-map.test.ts
+++ b/src/__tests__/lru-map.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test"
+import { LRUMap } from "../utils/lruMap"
+
+describe("LRUMap", () => {
+  it("stores and retrieves values", () => {
+    const map = new LRUMap<string, number>(3)
+    map.set("a", 1)
+    map.set("b", 2)
+    expect(map.get("a")).toBe(1)
+    expect(map.get("b")).toBe(2)
+    expect(map.get("c")).toBeUndefined()
+    expect(map.size).toBe(2)
+  })
+
+  it("evicts the oldest entry when maxSize is exceeded", () => {
+    const map = new LRUMap<string, number>(2)
+    map.set("a", 1)
+    map.set("b", 2)
+    map.set("c", 3) // evicts "a"
+
+    expect(map.get("a")).toBeUndefined()
+    expect(map.get("b")).toBe(2)
+    expect(map.get("c")).toBe(3)
+    expect(map.size).toBe(2)
+  })
+
+  it("refreshes recency on get()", () => {
+    const map = new LRUMap<string, number>(2)
+    map.set("a", 1)
+    map.set("b", 2)
+    map.get("a") // refreshes "a", "b" is now oldest
+    map.set("c", 3) // evicts "b"
+
+    expect(map.get("a")).toBe(1)
+    expect(map.get("b")).toBeUndefined()
+    expect(map.get("c")).toBe(3)
+  })
+
+  it("refreshes recency on set() update", () => {
+    const map = new LRUMap<string, number>(2)
+    map.set("a", 1)
+    map.set("b", 2)
+    map.set("a", 10) // update refreshes "a"
+    map.set("c", 3) // evicts "b"
+
+    expect(map.get("a")).toBe(10)
+    expect(map.get("b")).toBeUndefined()
+    expect(map.get("c")).toBe(3)
+  })
+
+  it("fires onEvict callback with evicted key and value", () => {
+    const evicted: [string, number][] = []
+    const map = new LRUMap<string, number>(2, (k, v) => evicted.push([k, v]))
+
+    map.set("a", 1)
+    map.set("b", 2)
+    map.set("c", 3)
+
+    expect(evicted).toEqual([["a", 1]])
+  })
+
+  it("does NOT fire onEvict on manual delete()", () => {
+    const evicted: string[] = []
+    const map = new LRUMap<string, number>(3, (k) => evicted.push(k))
+
+    map.set("a", 1)
+    map.delete("a")
+
+    expect(evicted).toEqual([])
+    expect(map.has("a")).toBe(false)
+  })
+
+  it("does NOT fire onEvict on clear()", () => {
+    const evicted: string[] = []
+    const map = new LRUMap<string, number>(3, (k) => evicted.push(k))
+
+    map.set("a", 1)
+    map.set("b", 2)
+    map.clear()
+
+    expect(evicted).toEqual([])
+    expect(map.size).toBe(0)
+  })
+
+  it("supports has(), delete(), and iteration", () => {
+    const map = new LRUMap<string, number>(5)
+    map.set("x", 10)
+    map.set("y", 20)
+
+    expect(map.has("x")).toBe(true)
+    expect(map.has("z")).toBe(false)
+
+    map.delete("x")
+    expect(map.has("x")).toBe(false)
+    expect(map.size).toBe(1)
+
+    const entries: [string, number][] = []
+    for (const [k, v] of map) {
+      entries.push([k, v])
+    }
+    expect(entries).toEqual([["y", 20]])
+  })
+
+  it("supports forEach()", () => {
+    const map = new LRUMap<string, number>(5)
+    map.set("a", 1)
+    map.set("b", 2)
+
+    const collected: [string, number][] = []
+    map.forEach((v, k) => collected.push([k, v]))
+    expect(collected).toEqual([["a", 1], ["b", 2]])
+  })
+
+  it("handles maxSize of 1", () => {
+    const map = new LRUMap<string, number>(1)
+    map.set("a", 1)
+    map.set("b", 2)
+
+    expect(map.get("a")).toBeUndefined()
+    expect(map.get("b")).toBe(2)
+    expect(map.size).toBe(1)
+  })
+
+  it("chains multiple evictions correctly", () => {
+    const evicted: string[] = []
+    const map = new LRUMap<string, number>(2, (k) => evicted.push(k))
+
+    map.set("a", 1)
+    map.set("b", 2)
+    map.set("c", 3) // evicts a
+    map.set("d", 4) // evicts b
+
+    expect(evicted).toEqual(["a", "b"])
+    expect(map.size).toBe(2)
+    expect(map.get("c")).toBe(3)
+    expect(map.get("d")).toBe(4)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -19,6 +19,7 @@ import { fuzzyMatchAgentName } from "./agentMatch"
 import { buildAgentDefinitions } from "./agentDefs"
 import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { lookupSharedSession, storeSharedSession, clearSharedSessions } from "./sessionStore"
+import { LRUMap } from "../utils/lruMap"
 
 // --- Session Tracking ---
 // Maps OpenCode session ID (or fingerprint) → Claude SDK session ID
@@ -26,77 +27,6 @@ interface SessionState {
   claudeSessionId: string
   lastAccess: number
   messageCount: number
-}
-
-class LRUMap<K, V> implements Iterable<[K, V]> {
-  private readonly map = new Map<K, V>()
-
-  constructor(
-    private readonly maxSize: number,
-    private readonly onEvict?: (key: K, value: V) => void
-  ) {}
-
-  get size(): number {
-    return this.map.size
-  }
-
-  get(key: K): V | undefined {
-    const value = this.map.get(key)
-    if (value === undefined) return undefined
-    this.map.delete(key)
-    this.map.set(key, value)
-    return value
-  }
-
-  set(key: K, value: V): this {
-    if (this.map.has(key)) {
-      this.map.delete(key)
-    } else if (this.map.size >= this.maxSize) {
-      this.evictOldest()
-    }
-
-    this.map.set(key, value)
-    return this
-  }
-
-  has(key: K): boolean {
-    return this.map.has(key)
-  }
-
-  delete(key: K): boolean {
-    return this.map.delete(key)
-  }
-
-  clear(): void {
-    this.map.clear()
-  }
-
-  entries(): MapIterator<[K, V]> {
-    return this.map.entries()
-  }
-
-  keys(): MapIterator<K> {
-    return this.map.keys()
-  }
-
-  values(): MapIterator<V> {
-    return this.map.values()
-  }
-
-  [Symbol.iterator](): MapIterator<[K, V]> {
-    return this.map[Symbol.iterator]()
-  }
-
-  private evictOldest(): void {
-    const oldestKey = this.map.keys().next().value as K | undefined
-    if (oldestKey === undefined) return
-
-    const oldestValue = this.map.get(oldestKey)
-    if (oldestValue === undefined) return
-
-    this.map.delete(oldestKey)
-    this.onEvict?.(oldestKey, oldestValue)
-  }
 }
 
 const DEFAULT_MAX_SESSIONS = 1000
@@ -114,10 +44,6 @@ export function getMaxSessionsLimit(): number {
   return parsed
 }
 
-let sessionCache: LRUMap<string, SessionState>
-let fingerprintCache: LRUMap<string, SessionState>
-let activeSessionCacheSize = 0
-
 function removeFingerprintEntriesByClaudeSessionId(claudeSessionId: string): void {
   for (const [key, state] of fingerprintCache.entries()) {
     if (state.claudeSessionId === claudeSessionId) {
@@ -134,30 +60,37 @@ function removeSessionEntriesByClaudeSessionId(claudeSessionId: string): void {
   }
 }
 
-function initializeSessionCaches(maxSize: number): void {
-  activeSessionCacheSize = maxSize
-  sessionCache = new LRUMap<string, SessionState>(maxSize, (_key, evictedState) => {
+function createSessionCache(maxSize: number) {
+  return new LRUMap<string, SessionState>(maxSize, (_key, evictedState) => {
     removeFingerprintEntriesByClaudeSessionId(evictedState.claudeSessionId)
   })
-  fingerprintCache = new LRUMap<string, SessionState>(maxSize, (_key, evictedState) => {
+}
+
+function createFingerprintCache(maxSize: number) {
+  return new LRUMap<string, SessionState>(maxSize, (_key, evictedState) => {
     removeSessionEntriesByClaudeSessionId(evictedState.claudeSessionId)
   })
 }
 
-function ensureSessionCacheLimit(): void {
-  const configuredLimit = getMaxSessionsLimit()
-  if (configuredLimit !== activeSessionCacheSize) {
-    initializeSessionCaches(configuredLimit)
-  }
-}
+// Read limit once at module load — no hot-reload in createProxyServer to avoid
+// silently dropping all sessions mid-operation. clearSessionCache() re-reads the
+// env var so tests can override the limit.
+let activeMaxSessions = getMaxSessionsLimit()
+let sessionCache = createSessionCache(activeMaxSessions)
+let fingerprintCache = createFingerprintCache(activeMaxSessions)
 
-initializeSessionCaches(getMaxSessionsLimit())
-
-/** Clear all session caches (used in tests) */
+/** Clear all session caches (used in tests).
+ *  Re-reads CLAUDE_PROXY_MAX_SESSIONS so tests can override the limit. */
 export function clearSessionCache() {
-  ensureSessionCacheLimit()
-  sessionCache.clear()
-  fingerprintCache.clear()
+  const configuredLimit = getMaxSessionsLimit()
+  if (configuredLimit !== activeMaxSessions) {
+    activeMaxSessions = configuredLimit
+    sessionCache = createSessionCache(activeMaxSessions)
+    fingerprintCache = createFingerprintCache(activeMaxSessions)
+  } else {
+    sessionCache.clear()
+    fingerprintCache.clear()
+  }
   // Also clear shared file store
   try { clearSharedSessions() } catch {}
 }
@@ -398,6 +331,17 @@ let cachedClaudePath: string | null = null
 let cachedClaudePathPromise: Promise<string> | null = null
 let claudeExecutable = ""
 
+/**
+ * Resolve the Claude executable path asynchronously (non-blocking).
+ *
+ * Uses a three-tier cache:
+ * 1. cachedClaudePath — resolved path, returned immediately on subsequent calls
+ * 2. cachedClaudePathPromise — deduplicates concurrent calls during resolution
+ * 3. Falls through to resolution logic (SDK cli.js → system `which claude`)
+ *
+ * The promise is cleared in `finally` to allow retry on failure while
+ * cachedClaudePath prevents re-resolution on success.
+ */
 async function resolveClaudeExecutableAsync(): Promise<string> {
   if (cachedClaudePath) return cachedClaudePath
   if (cachedClaudePathPromise) return cachedClaudePathPromise
@@ -445,7 +389,6 @@ function isClosedControllerError(error: unknown): boolean {
 }
 
 export function createProxyServer(config: Partial<ProxyConfig> = {}) {
-  ensureSessionCacheLimit()
   const finalConfig = { ...DEFAULT_PROXY_CONFIG, ...config }
   const app = new Hono()
 
@@ -759,6 +702,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
           claudeLog("upstream.start", { mode: "non_stream", model })
 
           try {
+            // Lazy-resolve executable if not already set (e.g. when using createProxyServer directly)
+            if (!claudeExecutable) {
+              claudeExecutable = await resolveClaudeExecutableAsync()
+            }
+
             const response = query({
               prompt,
               options: {

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -48,6 +48,9 @@ function acquireLock(lockPath: string): boolean {
     try {
       const stat = statSync(lockPath)
       if (Date.now() - stat.mtimeMs > STALE_LOCK_THRESHOLD_MS) {
+        // TOCTOU: another process could grab the lock between unlink and open.
+        // The second openSync("wx") will throw EEXIST in that case, caught below.
+        // This is acceptable — one process wins, the other proceeds without lock.
         unlinkSync(lockPath)
         const fd = openSync(lockPath, "wx")
         closeSync(fd)

--- a/src/utils/lruMap.ts
+++ b/src/utils/lruMap.ts
@@ -1,0 +1,84 @@
+/**
+ * A Map with LRU (Least Recently Used) eviction.
+ *
+ * Entries are evicted oldest-first when the map exceeds maxSize.
+ * Both get() and set() refresh an entry's recency.
+ * An optional onEvict callback fires when entries are automatically evicted.
+ *
+ * Note: delete() does NOT fire onEvict — only automatic eviction from set() does.
+ */
+export class LRUMap<K, V> implements Iterable<[K, V]> {
+  private readonly map = new Map<K, V>()
+
+  constructor(
+    private readonly maxSize: number,
+    private readonly onEvict?: (key: K, value: V) => void
+  ) {}
+
+  get size(): number {
+    return this.map.size
+  }
+
+  get(key: K): V | undefined {
+    const value = this.map.get(key)
+    if (value === undefined) return undefined
+    // Move to end (most recent) by re-inserting
+    this.map.delete(key)
+    this.map.set(key, value)
+    return value
+  }
+
+  set(key: K, value: V): this {
+    if (this.map.has(key)) {
+      this.map.delete(key)
+    } else if (this.map.size >= this.maxSize) {
+      this.evictOldest()
+    }
+
+    this.map.set(key, value)
+    return this
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key)
+  }
+
+  delete(key: K): boolean {
+    return this.map.delete(key)
+  }
+
+  clear(): void {
+    this.map.clear()
+  }
+
+  entries(): MapIterator<[K, V]> {
+    return this.map.entries()
+  }
+
+  keys(): MapIterator<K> {
+    return this.map.keys()
+  }
+
+  values(): MapIterator<V> {
+    return this.map.values()
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: LRUMap<K, V>) => void): void {
+    this.map.forEach((value, key) => callbackfn(value, key, this))
+  }
+
+  [Symbol.iterator](): MapIterator<[K, V]> {
+    return this.map[Symbol.iterator]()
+  }
+
+  private evictOldest(): void {
+    const oldestKey = this.map.keys().next().value as K | undefined
+    if (oldestKey === undefined) return
+
+    const oldestValue = this.map.get(oldestKey)
+    if (oldestValue === undefined) return
+
+    this.map.delete(oldestKey)
+    this.onEvict?.(oldestKey, oldestValue)
+  }
+}


### PR DESCRIPTION
Follow-up improvements to PRs #75, #76, #77:

- **LRUMap extracted** to `src/utils/lruMap.ts` with 11 dedicated unit tests — removes 92 lines of inline data structure code from server.ts
- **Session cache hot-reload removed** from `createProxyServer` — env var read once at init, `clearSessionCache()` re-reads for test flexibility only
- **Lazy executable resolution** — `claudeExecutable` resolved in request handler if not pre-set by `startProxyServer()`, preventing empty-string footgun
- **TOCTOU comment** added to sessionStore stale lock recovery
- **JSDoc** added to `resolveClaudeExecutableAsync` explaining three-tier cache

149/150 tests pass (1 pre-existing untracked test for unimplemented feature).