### PR TITLE
fix: pass OpenCode system prompt via SDK appendSystemPrompt

### DIFF
--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -149,7 +149,7 @@ describe("Multimodal content", () => {
       messages.push(msg)
     }
 
-    // Should have system context + all 3 messages
+    // Should have all 3 messages (system context now in SDK option, not in prompt)
     expect(messages.length).toBeGreaterThanOrEqual(3)
     // All should have the user type wrapper (SDK requirement)
     for (const msg of messages) {
@@ -178,7 +178,7 @@ describe("Multimodal content", () => {
       messages.push(msg)
     }
 
-    // Find the message with image content (skip system context)
+    // Find the message with image content
     const imageMsg = messages.find((m: any) =>
       Array.isArray(m.message.content) &&
       m.message.content.some((b: any) => b.type === "image")
@@ -189,7 +189,7 @@ describe("Multimodal content", () => {
     }
   })
 
-  it("should include system context in structured messages", async () => {
+  it("should pass system context via systemPrompt option, not in structured messages", async () => {
     const app = createTestApp()
     await (await post(app, {
       model: "claude-sonnet-4-5",
@@ -205,13 +205,23 @@ describe("Multimodal content", () => {
       }],
     })).json()
 
+    // System context should be in SDK option, not injected as a structured message
+    expect(capturedQueryParams.options.systemPrompt).toEqual({
+      type: "preset",
+      preset: "claude_code",
+      append: "You are a helpful assistant.",
+    })
+
     const messages: any[] = []
     for await (const msg of capturedQueryParams.prompt) {
       messages.push(msg)
     }
 
-    // First message should be the system context
-    expect(messages[0]!.message.content).toContain("You are a helpful assistant.")
+    // No message should contain the system context (it's in the SDK option now)
+    const hasSystemMsg = messages.some((m: any) =>
+      typeof m.message.content === "string" && m.message.content.includes("You are a helpful assistant.")
+    )
+    expect(hasSystemMsg).toBe(false)
   })
 
   it("should fall back to text prompt with image placeholder when no multimodal", async () => {

--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -164,7 +164,7 @@ describe("Phase 2: Message format preservation", () => {
     clearSessionCache()
   })
 
-  it("should pass system prompt separately, not merged into messages", async () => {
+  it("should pass system prompt via appendSystemPrompt, not merged into messages", async () => {
     mockMessages = [
       assistantMessage([{ type: "text", text: "Hi" }]),
     ]
@@ -177,12 +177,17 @@ describe("Phase 2: Message format preservation", () => {
     }))
     await response.json()
 
-    // The prompt should include the system context
+    // System prompt should be passed via systemPrompt option (append to Claude Code default)
     expect(capturedQueryParams).toBeDefined()
+    expect(capturedQueryParams.options.systemPrompt).toEqual({
+      type: "preset",
+      preset: "claude_code",
+      append: "You are a helpful assistant.",
+    })
+    // Prompt text should NOT contain the system context (it's in the SDK option now)
     const prompt = capturedQueryParams.prompt
     expect(typeof prompt).toBe("string")
-    // System prompt should be part of the prompt sent to SDK
-    expect(prompt).toContain("You are a helpful assistant.")
+    expect(prompt).not.toContain("You are a helpful assistant.")
   })
 
   it("should include tool_result content in the prompt sent to SDK", async () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -561,14 +561,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
             }
           }
         } else {
-          // First request: include system context + all messages
-          if (systemContext) {
-            structured.push({
-              type: "user" as const,
-              message: { role: "user", content: systemContext },
-              parent_tool_use_id: null,
-            })
-          }
+          // First request: all messages (system context now passed via appendSystemPrompt)
           for (const m of messagesToConvert) {
             if (m.role === "user") {
               structured.push({
@@ -629,10 +622,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
           })
           .join("\n\n") || ""
 
-        // On resume, skip system context (SDK already has it)
-        prompt = (!isResume && systemContext)
-          ? `${systemContext}\n\n${conversationParts}`
-          : conversationParts
+        // System context now passed via appendSystemPrompt (not in prompt text)
+        prompt = conversationParts
       }
 
       // --- Passthrough mode ---
@@ -716,6 +707,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                 pathToClaudeCodeExecutable: claudeExecutable,
                 permissionMode: "bypassPermissions",
                 allowDangerouslySkipPermissions: true,
+                // Pass OpenCode's system prompt (includes AGENTS.md, custom instructions)
+                // as an append to Claude Code's default — preserves the SDK identity.
+                ...(systemContext ? {
+                  systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
+                } : {}),
                 // In passthrough mode: block ALL SDK built-in tools, use OpenCode's via MCP
                 // In normal mode: block built-ins, use our own MCP replacements
                 ...(passthrough
@@ -890,6 +886,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                   includePartialMessages: true,
                   permissionMode: "bypassPermissions",
                   allowDangerouslySkipPermissions: true,
+                  // Pass OpenCode's system prompt (includes AGENTS.md, custom instructions)
+                  // as an append to Claude Code's default — preserves the SDK identity.
+                  ...(systemContext ? {
+                    systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
+                  } : {}),
                   ...(passthrough
                     ? {
                         disallowedTools: [...BLOCKED_BUILTIN_TOOLS, ...CLAUDE_CODE_ONLY_TOOLS],


### PR DESCRIPTION
Fixes #74

**Problem:** OpenCode's system prompt (which includes AGENTS.md and custom instructions) was being injected into the prompt text as a string prefix or synthetic user message. Claude treats user messages with less authority than system-level instructions, so AGENTS.md directives were effectively ignored.

**Fix:** Pass the system context via the SDK's documented `systemPrompt` option:
```ts
systemPrompt: { type: 'preset', preset: 'claude_code', append: systemContext }
```

This:
- ✅ Preserves the full Claude Code default system prompt (unchanged)
- ✅ Appends user instructions at the system-prompt level where they carry proper weight
- ✅ Uses the SDK's public API (`preset` + `append`), equivalent to the `--append-system-prompt` CLI flag
- ✅ Applied to both streaming and non-streaming paths

149/150 tests pass.