### PR TITLE
docs: clean up and streamline README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub stars](https://img.shields.io/github/stars/rynfar/opencode-claude-max-proxy.svg)](https://github.com/rynfar/opencode-claude-max-proxy/stargazers)
 
-A transparent proxy that allows a Claude Max subscription to be used with [OpenCode](https://opencode.ai), preserving multi-model agent routing.
+A transparent proxy that lets a Claude Max subscription power [OpenCode](https://opencode.ai), preserving multi-model agent routing.
 
-OpenCode targets the Anthropic API, while Claude Max provides access to Claude via the [Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk). The proxy forwards tool calls from Claude Max to OpenCode so agent routing works correctly.
+> **Just want to get running?** The [opencode-with-claude](https://github.com/ianjwhite99/opencode-with-claude) installer handles everything — proxy, CLI, config — in one command. The rest of this README covers the proxy itself.
 
-Tool execution is handled within the Agent SDK, which is responsible for running tools, coordinating sub-agents, and streaming responses. Because the SDK only has access to Claude models, any tool calls or delegated tasks are executed within that scope. In configurations such as [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode), where agents may be assigned to OpenaI, Gemini, or other providers, those assignments are not preserved at execution time, and all work is effectively routed through Claude.
+## Why This Exists
 
-We avoid that limitation by forwarding tool calls instead of executing them. When a `tool_use` event is emitted, the proxy intercepts it, halts the current turn, and sends the raw payload back to OpenCode. OpenCode executes the tool, including any agent routing, and returns the result as a `tool_result`. The proxy then resumes the SDK session.
+OpenCode targets the Anthropic API. Claude Max provides access to Claude via the [Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk). This proxy bridges the two.
 
-From Claude’s perspective, tool usage proceeds normally. From OpenCode’s perspective, it is interacting with the Anthropic API. Execution remains distributed according to the configured agents, allowing different models to handle different roles without being constrained by the SDK.
+The problem: if the Agent SDK executes tools directly, everything runs through Claude — even when your OpenCode config routes agents to GPT, Gemini, or other providers. The proxy solves this by intercepting tool calls and forwarding them to OpenCode, so your agent routing stays intact.
+
+## How It Works
 
 ```
 OpenCode ──► Proxy (localhost) ──► Claude Max (Agent SDK)
@@ -33,65 +35,53 @@ OpenCode ──► Proxy (localhost) ──► Claude Max (Agent SDK)
 OpenCode ◄── final response
 ```
 
-## How Passthrough Works
+The Claude Agent SDK exposes a `PreToolUse` hook that fires before any tool executes. Combined with `maxTurns: 1`, this gives precise control over the execution boundary:
 
-The Claude Agent SDK exposes a `PreToolUse` hook that fires before any tool executes. Combined with `maxTurns: 1`, it gives us precise control over the execution boundary without monkey-patching or stream rewriting.
-
-1. **Claude generates a response** with `tool_use` blocks (Read a file, delegate to an agent, run a command)
-2. **The PreToolUse hook fires** for each tool call - we capture the tool name, input, and ID, then return `decision: "block"` to prevent SDK-internal execution
+1. **Claude generates a response** with `tool_use` blocks (read a file, delegate to an agent, run a command)
+2. **The PreToolUse hook fires** — we capture the tool name, input, and ID, then return `decision: "block"`
 3. **The SDK stops** (blocked tool + maxTurns:1 = turn complete) and we have the full tool_use payload
 4. **The proxy returns it to OpenCode** as a standard Anthropic API response with `stop_reason: "tool_use"`
 5. **OpenCode handles everything** — file reads, shell commands, and crucially, `Task` delegation through its own agent system with full model routing
 6. **OpenCode sends `tool_result` back**, the proxy resumes the SDK session, and Claude continues
 
-## Quick Start
+From Claude's perspective, tool usage proceeds normally. From OpenCode's perspective, it's talking to the Anthropic API.
 
-### One-Liner Install
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/ianjwhite99/opencode-with-claude/main/install.sh | bash
-```
-
-Installs everything (Claude CLI, OpenCode, proxy) and gives you an `oc` command. See [opencode-with-claude](https://github.com/ianjwhite99/opencode-with-claude) for details.
-
-### Prerequisites
+## Prerequisites
 
 1. **Claude Max subscription** — [Subscribe here](https://claude.ai/settings/billing)
-2. **Claude CLI** authenticated: `npm install -g @anthropic-ai/claude-code && claude login`
-3. **Clear any existing OpenCode Anthropic auth** — if you previously used OpenCode with a real Anthropic API key, log out first or the cached auth will override the proxy:
+2. **Claude CLI authenticated:**
+   ```bash
+   npm install -g @anthropic-ai/claude-code
+   claude login
+   ```
+3. **Clear any existing OpenCode Anthropic auth** — cached auth overrides the proxy:
    ```bash
    opencode auth logout   # select "anthropic" when prompted
    ```
 
-### Option A: npm Install
+## Install
+
+### npm (recommended)
 
 ```bash
 npm install -g opencode-claude-max-proxy
-
-# Start in passthrough mode (recommended)
-CLAUDE_PROXY_PASSTHROUGH=1 claude-max-proxy
 ```
 
-### Option B: From Source
+### From Source
 
 ```bash
 git clone https://github.com/rynfar/opencode-claude-max-proxy
 cd opencode-claude-max-proxy
 bun install
-
-# Start in passthrough mode (recommended)
-CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy
 ```
 
-> **Note:** Running from source requires [Bun](https://bun.sh): `curl -fsSL https://bun.sh/install | bash`
+> Requires [Bun](https://bun.sh): `curl -fsSL https://bun.sh/install | bash`
 
-### Option C: Docker
+### Docker
 
 ```bash
 git clone https://github.com/rynfar/opencode-claude-max-proxy
 cd opencode-claude-max-proxy
-
-# Start the container
 docker compose up -d
 
 # Login to Claude inside the container (one-time)
@@ -101,32 +91,18 @@ docker compose exec proxy claude login
 curl http://127.0.0.1:3456/health
 ```
 
-> **Note:** On macOS, use `./bin/docker-auth.sh` to copy host credentials into the container (handles the keychain/scopes format difference). On Linux, volume-mounting `~/.claude` may work directly.
+> On macOS, use `./bin/docker-auth.sh` to copy host credentials into the container (handles the keychain/scopes format difference). On Linux, volume-mounting `~/.claude` may work directly.
 
-### Connect OpenCode
+## Connect OpenCode
 
-#### Per-Terminal Launcher (recommended)
+Once the proxy is running, point OpenCode at it via environment variables or config file.
 
-```bash
-./bin/oc.sh
-```
-
-Each terminal gets its own proxy on a random port. Proxy starts automatically, connects OpenCode, and cleans up on exit. Sessions resume across terminals via a shared file store.
-
-Shell alias:
-
-```bash
-# ~/.zshrc or ~/.bashrc
-alias oc='/path/to/opencode-claude-max-proxy/bin/oc.sh'
-```
-
-#### Shared Proxy
-
-For a single long-running proxy:
+### Environment Variables
 
 ```bash
 # Terminal 1: start the proxy
-CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy
+CLAUDE_PROXY_PASSTHROUGH=1 claude-max-proxy
+# or: CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy (from source)
 
 # Terminal 2+: connect OpenCode
 ANTHROPIC_API_KEY=dummy ANTHROPIC_BASE_URL=http://127.0.0.1:3456 opencode
@@ -134,9 +110,9 @@ ANTHROPIC_API_KEY=dummy ANTHROPIC_BASE_URL=http://127.0.0.1:3456 opencode
 
 `ANTHROPIC_API_KEY` can be any non-empty string. Authentication is handled by `claude login`.
 
-#### OpenCode Desktop / Config File
+### Config File
 
-Set the proxy URL in `~/.config/opencode/opencode.json` to use with Desktop or avoid env vars.
+Set the proxy URL in `~/.config/opencode/opencode.json` (global) or your project's `opencode.json`:
 
 ```json
 {
@@ -151,29 +127,25 @@ Set the proxy URL in `~/.config/opencode/opencode.json` to use with Desktop or a
 }
 ```
 
-> Desktop requires the shared proxy on a fixed port. Run `CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy` in the background. Sessions are shared between Desktop and terminal instances.
+This also works with OpenCode Desktop.
 
 ## Modes
 
-### Passthrough Mode (recommended)
+### Passthrough (recommended)
 
 ```bash
-CLAUDE_PROXY_PASSTHROUGH=1 bun run proxy
+CLAUDE_PROXY_PASSTHROUGH=1 claude-max-proxy
 ```
 
-All tool execution is forwarded to OpenCode. This enables:
+All tool execution is forwarded to OpenCode. Multi-model agent routing works. Full agent system prompts are preserved.
 
-- **Multi-model agent delegation** — oh-my-opencode routes each agent to its configured model
-- **Full agent system prompts** — not abbreviated descriptions, the real prompts
-- **OpenCode manages everything** — tools, agents, permissions, lifecycle
-
-### Internal Mode (default)
+### Internal
 
 ```bash
-bun run proxy
+claude-max-proxy
 ```
 
-Tools execute inside the proxy via MCP. Subagents run on Claude via the SDK's native agent system. Simpler setup, but all agents use Claude regardless of oh-my-opencode config.
+Tools execute inside the proxy via MCP. Subagents run on Claude via the SDK's native system. Simpler conceptually, but all agents use Claude regardless of your config.
 
 |                       | Passthrough            | Internal            |
 | --------------------- | ---------------------- | ------------------- |
@@ -181,34 +153,29 @@ Tools execute inside the proxy via MCP. Subagents run on Claude via the SDK's na
 | Agent delegation      | OpenCode → multi-model | SDK → Claude only   |
 | oh-my-opencode models | ✅ Respected           | ❌ All Claude       |
 | Agent system prompts  | ✅ Full                | ⚠️ Description only |
-| Setup complexity      | Same                   | Same                |
 
-## Works With Any Agent Framework
+## Agent Compatibility
 
-The proxy extracts agent definitions from the `Task` tool description that OpenCode sends in each request. This means it works automatically with:
+The proxy extracts agent definitions from the `Task` tool description that OpenCode sends in each request. It works with:
 
 - **Native OpenCode** — `build` and `plan` agents
-- **oh-my-opencode** — `oracle`, `explore`, `librarian`, `sisyphus-junior`, `metis`, `momus`, etc.
-- **Custom agents** — anything you define in `opencode.json`
+- **[oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)** — `oracle`, `explore`, `librarian`, `sisyphus-junior`, `metis`, `momus`, etc.
+- **Custom agents** — anything defined in your `opencode.json`
 
-In internal mode, a `PreToolUse` hook fuzzy-matches agent names as a safety net (e.g., `general-purpose` → `general`, `Explore` → `explore`, `code-reviewer` → `oracle`). In passthrough mode, OpenCode handles agent names directly.
+In internal mode, a `PreToolUse` hook fuzzy-matches agent names (e.g., `general-purpose` → `general`, `Explore` → `explore`). In passthrough mode, OpenCode handles names directly.
 
 ## Session Resume
 
-The proxy tracks SDK session IDs and resumes conversations on follow-up requests. Sessions are stored in `~/.cache/opencode-claude-max-proxy/sessions.json`, shared across all proxy instances (including per-terminal proxies).
+The proxy tracks SDK session IDs and resumes conversations on follow-up requests. Sessions are stored in `~/.cache/opencode-claude-max-proxy/sessions.json`, shared across all proxy instances.
 
 Lookup order:
 
-1. **Header-based** — add the included OpenCode plugin to inject session headers:
-
+1. **Header-based** — use the included OpenCode plugin to inject session headers:
    ```json
    {
-     "plugin": [
-       "./path/to/opencode-claude-max-proxy/src/plugin/claude-max-headers.ts"
-     ]
+     "plugin": ["./path/to/opencode-claude-max-proxy/src/plugin/claude-max-headers.ts"]
    }
    ```
-
 2. **Fingerprint-based** (automatic fallback) — hashes the first user message to match returning conversations
 
 Sessions expire after 24 hours.
@@ -226,60 +193,38 @@ Sessions expire after 24 hours.
 
 ## Concurrency
 
-Per-terminal proxies (`oc.sh`) avoid concurrency issues entirely. Each terminal gets its own proxy.
+The proxy supports concurrent requests, but the SDK's `cli.js` subprocess can segfault during stream cleanup ([oven-sh/bun#17947](https://github.com/oven-sh/bun/issues/17947)). Responses are always delivered correctly; the crash occurs after completion. The supervisor auto-restarts within a few seconds.
 
-The shared proxy supports concurrent requests but the SDK's `cli.js` subprocess (compiled with Bun) can segfault during stream cleanup ([oven-sh/bun#17947](https://github.com/oven-sh/bun/issues/17947)). Responses are always delivered correctly; the crash occurs after completion. The supervisor auto-restarts within a few seconds.
+> The [opencode-with-claude](https://github.com/ianjwhite99/opencode-with-claude) launcher avoids this by giving each terminal its own proxy on a random port.
 
 ## FAQ
 
-<details>
-<summary><strong>Why passthrough mode instead of handling tools internally?</strong></summary>
+### Does this work without oh-my-opencode?
 
-If the Agent SDK executes tools directly, everything runs through Claude. Any agent routing defined in OpenCode is bypassed. Passthrough mode just sends the tool calls to OpenCode to run.
+Yes. Both modes work with native OpenCode and any custom agents. oh-my-opencode just adds more agents and model routing.
 
-</details>
+### Why do I need `ANTHROPIC_API_KEY=dummy`?
 
-<details>
-<summary><strong>Does this work without oh-my-opencode?</strong></summary>
+OpenCode requires an API key to be set. The proxy never uses it — authentication is handled by your `claude login` session through the Agent SDK.
 
-Yes. Both modes work with native OpenCode (build + plan agents) and with any custom agents defined in your `opencode.json`. oh-my-opencode just adds more agents and model routing. The proxy handles whatever OpenCode sends.
+### What about rate limits?
 
-</details>
+Your Claude Max subscription has its own usage limits. The proxy doesn't add any additional limits.
 
-<details>
-<summary><strong>Why do I need `ANTHROPIC_API_KEY=dummy`?</strong></summary>
-
-OpenCode requires an API key to be set, but the proxy never uses it. Authentication is handled by your `claude login` session through the Agent SDK.
-
-</details>
-
-<details>
-<summary><strong>What about rate limits?</strong></summary>
-
-Your Claude Max subscription has its own usage limits. The proxy doesn't add any additional limits. Concurrent requests are supported.
-
-</details>
-
-<details>
-<summary><strong>Is my data sent anywhere else?</strong></summary>
+### Is my data sent anywhere else?
 
 No. The proxy runs locally. Requests go directly to Claude through the official SDK. In passthrough mode, tool execution happens in OpenCode on your machine.
 
-</details>
+### Why does internal mode use MCP tools?
 
-<details>
-<summary><strong>Why does internal mode use MCP tools?</strong></summary>
-
-The Claude Agent SDK uses different parameter names for tools than OpenCode (e.g., `file_path` vs `filePath`). Internal mode provides its own MCP tools with SDK-compatible parameter names. Passthrough mode doesn't need this since OpenCode handles tool execution directly.
-
-</details>
+The Claude Agent SDK uses different parameter names than OpenCode (e.g., `file_path` vs `filePath`). Internal mode provides its own MCP tools with SDK-compatible names. Passthrough mode doesn't need this since OpenCode handles execution directly.
 
 ## Troubleshooting
 
 | Problem                       | Solution                                                                  |
 | ----------------------------- | ------------------------------------------------------------------------- |
 | "Authentication failed"       | Run `claude login` to authenticate                                        |
-| "Connection refused"          | Make sure the proxy is running: `bun run proxy`                           |
+| "Connection refused"          | Make sure the proxy is running                                            |
 | "Port 3456 is already in use" | `kill $(lsof -ti :3456)` or use `CLAUDE_PROXY_PORT=4567`                  |
 | Title generation fails        | Set `"small_model": "anthropic/claude-haiku-4-5"` in your OpenCode config |
 
@@ -317,19 +262,10 @@ launchctl load ~/Library/LaunchAgents/com.claude-max-proxy.plist
 
 ## Development
 
-### Run tests
-
 ```bash
-bun test
+bun test                              # Run tests
+curl http://127.0.0.1:3456/health     # Auth status, subscription, mode
 ```
-
-### Health Endpoint
-
-```bash
-curl http://127.0.0.1:3456/health
-```
-
-Returns auth status, subscription type, and proxy mode. Use this to verify the proxy is running and authenticated before connecting OpenCode.
 
 ### Architecture
 
@@ -348,9 +284,9 @@ src/
 
 ## Disclaimer
 
-This project is an **unofficial wrapper** around Anthropic's publicly available [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk). It is not affiliated with, endorsed by, or supported by Anthropic.
+This is an **unofficial wrapper** around Anthropic's publicly available [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk). It is not affiliated with, endorsed by, or supported by Anthropic.
 
-**Use at your own risk.** The authors make no claims regarding compliance with Anthropic's Terms of Service. It is your responsibility to review and comply with [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms) and [Authorized Usage Policy](https://www.anthropic.com/legal/aup). Terms may change at any time.
+**Use at your own risk.** It is your responsibility to review and comply with [Anthropic's Terms of Service](https://www.anthropic.com/legal/consumer-terms) and [Authorized Usage Policy](https://www.anthropic.com/legal/aup).
 
 This project calls `query()` from Anthropic's public npm package using your own authenticated account. No API keys are intercepted, no authentication is bypassed, and no proprietary systems are reverse-engineered.
 


### PR DESCRIPTION
## Summary
- Restructured README with clearer sections (Why This Exists, How It Works, Prerequisites, Install, Connect OpenCode)
- Added opencode-with-claude callout at the top for users who just want to get running
- Simplified install steps by separating proxy start commands from install commands
- Replaced collapsible FAQ sections with standard headings for better readability
- Tightened wording throughout (removed redundant notes, simplified descriptions)
- Updated commands to use `claude-max-proxy` (npm) as the primary example instead of `bun run proxy`