### PR TITLE
feat: add telemetry dashboard with request performance tracking

### DIFF
--- a/src/__tests__/telemetry-routes.test.ts
+++ b/src/__tests__/telemetry-routes.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, beforeEach } from "bun:test"
+import { Hono } from "hono"
+import { telemetryStore, createTelemetryRoutes } from "../telemetry"
+import type { RequestMetric } from "../telemetry"
+
+function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
+  return {
+    requestId: `req-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    model: "sonnet",
+    mode: "stream",
+    isResume: false,
+    isPassthrough: false,
+    status: 200,
+    queueWaitMs: 5,
+    ttfbMs: 120,
+    upstreamDurationMs: 800,
+    totalDurationMs: 850,
+    contentBlocks: 3,
+    textEvents: 10,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe("Telemetry routes", () => {
+  let app: Hono
+
+  beforeEach(() => {
+    telemetryStore.clear()
+    app = new Hono()
+    app.route("/telemetry", createTelemetryRoutes())
+  })
+
+  it("GET /telemetry returns HTML dashboard", async () => {
+    const res = await app.fetch(new Request("http://localhost/telemetry"))
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("<!DOCTYPE html>")
+    expect(html).toContain("Claude Max Proxy")
+    expect(html).toContain("Telemetry")
+  })
+
+  it("GET /telemetry/requests returns recent metrics as JSON", async () => {
+    telemetryStore.record(makeMetric({ requestId: "r1" }))
+    telemetryStore.record(makeMetric({ requestId: "r2" }))
+
+    const res = await app.fetch(new Request("http://localhost/telemetry/requests"))
+    expect(res.status).toBe(200)
+    const body = await res.json() as RequestMetric[]
+
+    expect(body.length).toBe(2)
+    expect(body[0]!.requestId).toBe("r2") // newest first
+    expect(body[1]!.requestId).toBe("r1")
+  })
+
+  it("GET /telemetry/requests respects limit param", async () => {
+    for (let i = 0; i < 10; i++) {
+      telemetryStore.record(makeMetric())
+    }
+
+    const res = await app.fetch(new Request("http://localhost/telemetry/requests?limit=3"))
+    const body = await res.json() as RequestMetric[]
+    expect(body.length).toBe(3)
+  })
+
+  it("GET /telemetry/requests filters by model", async () => {
+    telemetryStore.record(makeMetric({ model: "sonnet" }))
+    telemetryStore.record(makeMetric({ model: "opus" }))
+
+    const res = await app.fetch(new Request("http://localhost/telemetry/requests?model=opus"))
+    const body = await res.json() as RequestMetric[]
+    expect(body.length).toBe(1)
+    expect(body[0]!.model).toBe("opus")
+  })
+
+  it("GET /telemetry/summary returns aggregate stats", async () => {
+    telemetryStore.record(makeMetric({ totalDurationMs: 100 }))
+    telemetryStore.record(makeMetric({ totalDurationMs: 200 }))
+    telemetryStore.record(makeMetric({ totalDurationMs: 300, error: "api_error" }))
+
+    const res = await app.fetch(new Request("http://localhost/telemetry/summary"))
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+
+    expect(body.totalRequests).toBe(3)
+    expect(body.errorCount).toBe(1)
+    expect(body.totalDuration.min).toBe(100)
+    expect(body.totalDuration.max).toBe(300)
+    expect(body.byModel).toBeDefined()
+    expect(body.byMode).toBeDefined()
+  })
+
+  it("GET /telemetry/summary respects window param", async () => {
+    telemetryStore.record(makeMetric({ timestamp: Date.now() - 120_000 })) // 2 min ago
+    telemetryStore.record(makeMetric({ timestamp: Date.now() }))
+
+    const res = await app.fetch(new Request("http://localhost/telemetry/summary?window=60000"))
+    const body = await res.json() as any
+    expect(body.totalRequests).toBe(1) // only the recent one
+  })
+
+  it("caps limit at 500", async () => {
+    const res = await app.fetch(new Request("http://localhost/telemetry/requests?limit=9999"))
+    expect(res.status).toBe(200)
+    // Should not crash, just caps internally
+  })
+})

--- a/src/__tests__/telemetry-store.test.ts
+++ b/src/__tests__/telemetry-store.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, beforeEach } from "bun:test"
+import { TelemetryStore } from "../telemetry/store"
+import type { RequestMetric } from "../telemetry/types"
+
+function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
+  return {
+    requestId: `req-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    model: "sonnet",
+    mode: "stream",
+    isResume: false,
+    isPassthrough: false,
+    status: 200,
+    queueWaitMs: 5,
+    ttfbMs: 120,
+    upstreamDurationMs: 800,
+    totalDurationMs: 850,
+    contentBlocks: 3,
+    textEvents: 10,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe("TelemetryStore", () => {
+  let store: TelemetryStore
+
+  beforeEach(() => {
+    store = new TelemetryStore(10)
+  })
+
+  it("records and retrieves metrics", () => {
+    store.record(makeMetric({ requestId: "r1" }))
+    store.record(makeMetric({ requestId: "r2" }))
+
+    expect(store.size).toBe(2)
+    const recent = store.getRecent()
+    expect(recent.length).toBe(2)
+    // Newest first
+    expect(recent[0]!.requestId).toBe("r2")
+    expect(recent[1]!.requestId).toBe("r1")
+  })
+
+  it("evicts oldest entries when capacity is exceeded", () => {
+    for (let i = 0; i < 15; i++) {
+      store.record(makeMetric({ requestId: `r${i}` }))
+    }
+
+    expect(store.size).toBe(10)
+    const recent = store.getRecent({ limit: 10 })
+    // Should have r5-r14, not r0-r4
+    expect(recent[0]!.requestId).toBe("r14")
+    expect(recent[9]!.requestId).toBe("r5")
+  })
+
+  it("respects limit parameter", () => {
+    for (let i = 0; i < 5; i++) {
+      store.record(makeMetric())
+    }
+
+    const recent = store.getRecent({ limit: 3 })
+    expect(recent.length).toBe(3)
+  })
+
+  it("filters by model", () => {
+    store.record(makeMetric({ model: "sonnet" }))
+    store.record(makeMetric({ model: "opus" }))
+    store.record(makeMetric({ model: "sonnet" }))
+
+    const sonnets = store.getRecent({ model: "sonnet" })
+    expect(sonnets.length).toBe(2)
+    expect(sonnets.every(m => m.model === "sonnet")).toBe(true)
+  })
+
+  it("filters by since timestamp", () => {
+    const old = Date.now() - 60_000
+    const recent = Date.now()
+
+    store.record(makeMetric({ timestamp: old, requestId: "old" }))
+    store.record(makeMetric({ timestamp: recent, requestId: "new" }))
+
+    const filtered = store.getRecent({ since: old + 1 })
+    expect(filtered.length).toBe(1)
+    expect(filtered[0]!.requestId).toBe("new")
+  })
+
+  it("clears all metrics", () => {
+    store.record(makeMetric())
+    store.record(makeMetric())
+    store.clear()
+
+    expect(store.size).toBe(0)
+    expect(store.getRecent().length).toBe(0)
+  })
+})
+
+describe("TelemetryStore.summarize", () => {
+  let store: TelemetryStore
+
+  beforeEach(() => {
+    store = new TelemetryStore(100)
+  })
+
+  it("returns empty summary when no metrics exist", () => {
+    const summary = store.summarize()
+
+    expect(summary.totalRequests).toBe(0)
+    expect(summary.errorCount).toBe(0)
+    expect(summary.requestsPerMinute).toBe(0)
+    expect(summary.totalDuration.p50).toBe(0)
+  })
+
+  it("computes correct percentiles", () => {
+    // Add 100 metrics with totalDurationMs from 1 to 100
+    for (let i = 1; i <= 100; i++) {
+      store.record(makeMetric({ totalDurationMs: i, queueWaitMs: i, upstreamDurationMs: i }))
+    }
+
+    const summary = store.summarize()
+
+    expect(summary.totalRequests).toBe(100)
+    // Math.floor(100 * 0.5) = index 50 in sorted [1..100] = value 51
+    expect(summary.totalDuration.p50).toBe(51)
+    expect(summary.totalDuration.p95).toBe(96)
+    expect(summary.totalDuration.p99).toBe(100)
+    expect(summary.totalDuration.min).toBe(1)
+    expect(summary.totalDuration.max).toBe(100)
+  })
+
+  it("counts errors correctly", () => {
+    store.record(makeMetric({ error: null }))
+    store.record(makeMetric({ error: "api_error" }))
+    store.record(makeMetric({ error: "timeout_error" }))
+
+    const summary = store.summarize()
+    expect(summary.errorCount).toBe(2)
+  })
+
+  it("breaks down by model", () => {
+    store.record(makeMetric({ model: "sonnet", totalDurationMs: 100 }))
+    store.record(makeMetric({ model: "sonnet", totalDurationMs: 200 }))
+    store.record(makeMetric({ model: "opus", totalDurationMs: 300 }))
+
+    const summary = store.summarize()
+
+    expect(summary.byModel["sonnet"]!.count).toBe(2)
+    expect(summary.byModel["sonnet"]!.avgTotalMs).toBe(150)
+    expect(summary.byModel["opus"]!.count).toBe(1)
+    expect(summary.byModel["opus"]!.avgTotalMs).toBe(300)
+  })
+
+  it("breaks down by mode", () => {
+    store.record(makeMetric({ mode: "stream", totalDurationMs: 100 }))
+    store.record(makeMetric({ mode: "non-stream", totalDurationMs: 200 }))
+
+    const summary = store.summarize()
+
+    expect(summary.byMode["stream"]!.count).toBe(1)
+    expect(summary.byMode["non-stream"]!.count).toBe(1)
+  })
+
+  it("respects window parameter", () => {
+    const old = Date.now() - 120_000 // 2 minutes ago
+    const recent = Date.now()
+
+    store.record(makeMetric({ timestamp: old, requestId: "old" }))
+    store.record(makeMetric({ timestamp: recent, requestId: "new" }))
+
+    const summary = store.summarize(60_000) // 1 minute window
+    expect(summary.totalRequests).toBe(1)
+  })
+
+  it("handles null TTFB values in percentiles", () => {
+    store.record(makeMetric({ ttfbMs: null }))
+    store.record(makeMetric({ ttfbMs: 100 }))
+
+    const summary = store.summarize()
+    // TTFB should only include non-null values
+    expect(summary.ttfb.p50).toBe(100)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -20,6 +20,8 @@ import { buildAgentDefinitions } from "./agentDefs"
 import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { lookupSharedSession, storeSharedSession, clearSharedSessions } from "./sessionStore"
 import { LRUMap } from "../utils/lruMap"
+import { telemetryStore, createTelemetryRoutes } from "../telemetry"
+import type { RequestMetric } from "../telemetry"
 
 // --- Session Tracking ---
 // Maps OpenCode session ID (or fingerprint) → Claude SDK session ID
@@ -808,12 +810,31 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
             claudeLog("response.fallback_used", { mode: "non_stream", reason: "no_content_blocks" })
           }
 
+          const totalDurationMs = Date.now() - requestStartAt
+
           claudeLog("response.completed", {
             mode: "non_stream",
             model,
-            durationMs: Date.now() - requestStartAt,
+            durationMs: totalDurationMs,
             contentBlocks: contentBlocks.length,
             hasToolUse
+          })
+
+          telemetryStore.record({
+            requestId: requestMeta.requestId,
+            timestamp: Date.now(),
+            model,
+            mode: "non-stream",
+            isResume,
+            isPassthrough: passthrough,
+            status: 200,
+            queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+            ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
+            upstreamDurationMs: Date.now() - upstreamStartAt,
+            totalDurationMs,
+            contentBlocks: contentBlocks.length,
+            textEvents: 0,
+            error: null,
           })
 
           // Store session for future resume
@@ -1108,13 +1129,32 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
                   durationMs: Date.now() - requestStartAt
                 })
 
+                const streamTotalDurationMs = Date.now() - requestStartAt
+
                 claudeLog("response.completed", {
                   mode: "stream",
                   model,
-                  durationMs: Date.now() - requestStartAt,
+                  durationMs: streamTotalDurationMs,
                   streamEventsSeen,
                   eventsForwarded,
                   textEventsForwarded
+                })
+
+                telemetryStore.record({
+                  requestId: requestMeta.requestId,
+                  timestamp: Date.now(),
+                  model,
+                  mode: "stream",
+                  isResume,
+                  isPassthrough: passthrough,
+                  status: 200,
+                  queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+                  ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
+                  upstreamDurationMs: Date.now() - upstreamStartAt,
+                  totalDurationMs: streamTotalDurationMs,
+                  contentBlocks: eventsForwarded,
+                  textEvents: textEventsForwarded,
+                  error: null,
                 })
 
                 if (textEventsForwarded === 0) {
@@ -1181,6 +1221,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
         const classified = classifyError(errMsg)
 
         claudeLog("proxy.error", { error: errMsg, classified: classified.type })
+
+        telemetryStore.record({
+          requestId: requestMeta.requestId,
+          timestamp: Date.now(),
+          model: "unknown",
+          mode: "non-stream",
+          isResume: false,
+          isPassthrough: Boolean(process.env.CLAUDE_PROXY_PASSTHROUGH),
+          status: classified.status,
+          queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+          ttfbMs: null,
+          upstreamDurationMs: Date.now() - requestStartAt,
+          totalDurationMs: Date.now() - requestStartAt,
+          contentBlocks: 0,
+          textEvents: 0,
+          error: classified.type,
+        })
+
         return new Response(
           JSON.stringify({ type: "error", error: { type: classified.type, message: classified.message } }),
           { status: classified.status, headers: { "Content-Type": "application/json" } }
@@ -1204,6 +1262,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
 
   app.post("/v1/messages", (c) => handleWithQueue(c, "/v1/messages"))
   app.post("/messages", (c) => handleWithQueue(c, "/messages"))
+
+  // Telemetry dashboard and API
+  app.route("/telemetry", createTelemetryRoutes())
 
   // Health check endpoint — verifies auth status
   app.get("/health", async (c) => {

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -1,0 +1,213 @@
+/**
+ * Inline HTML dashboard for telemetry.
+ * No framework, no build step, no CDN. Single self-contained page.
+ */
+
+export const dashboardHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Claude Max Proxy — Telemetry</title>
+<style>
+  :root {
+    --bg: #0d1117; --surface: #161b22; --border: #30363d;
+    --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+    --green: #3fb950; --yellow: #d29922; --red: #f85149;
+    --blue: #58a6ff; --purple: #bc8cff;
+    --queue: #d29922; --ttfb: #58a6ff; --upstream: #3fb950; --total: #bc8cff;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+         background: var(--bg); color: var(--text); padding: 24px; line-height: 1.5; }
+  h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
+  .subtitle { color: var(--muted); font-size: 13px; margin-bottom: 24px; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-bottom: 24px; }
+  .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+  .card-label { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .card-value { font-size: 28px; font-weight: 600; margin-top: 4px; font-variant-numeric: tabular-nums; }
+  .card-detail { font-size: 12px; color: var(--muted); margin-top: 2px; }
+  .section { margin-bottom: 24px; }
+  .section-title { font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--muted);
+                   text-transform: uppercase; letter-spacing: 0.5px; }
+  table { width: 100%; border-collapse: collapse; background: var(--surface);
+          border: 1px solid var(--border); border-radius: 8px; overflow: hidden; font-size: 13px; }
+  th { text-align: left; padding: 10px 12px; background: var(--bg); color: var(--muted);
+       font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  td { padding: 8px 12px; border-top: 1px solid var(--border); font-variant-numeric: tabular-nums; }
+  tr:hover td { background: rgba(88,166,255,0.04); }
+  .waterfall { display: flex; align-items: center; height: 18px; min-width: 200px; position: relative; }
+  .waterfall-seg { height: 100%; border-radius: 2px; min-width: 2px; }
+  .waterfall-seg.queue { background: var(--queue); }
+  .waterfall-seg.ttfb { background: var(--ttfb); }
+  .waterfall-seg.response { background: var(--upstream); }
+  .legend { display: flex; gap: 16px; margin-bottom: 12px; font-size: 12px; color: var(--muted); }
+  .legend-dot { width: 10px; height: 10px; border-radius: 2px; display: inline-block; margin-right: 4px; vertical-align: middle; }
+  .status-ok { color: var(--green); }
+  .status-err { color: var(--red); }
+  .pct-table td:first-child { font-weight: 500; }
+  .pct-table .phase-dot { display: inline-block; width: 8px; height: 8px; border-radius: 2px; margin-right: 6px; }
+  .mono { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; }
+  .refresh-bar { display: flex; align-items: center; gap: 8px; margin-bottom: 16px; }
+  .refresh-bar select, .refresh-bar button {
+    background: var(--surface); color: var(--text); border: 1px solid var(--border);
+    border-radius: 6px; padding: 4px 10px; font-size: 12px; cursor: pointer;
+  }
+  .refresh-bar button:hover { border-color: var(--accent); }
+  .refresh-indicator { font-size: 11px; color: var(--muted); }
+  .empty { text-align: center; padding: 48px; color: var(--muted); }
+</style>
+</head>
+<body>
+<h1>Claude Max Proxy</h1>
+<div class="subtitle">Request Performance Telemetry</div>
+
+<div class="refresh-bar">
+  <select id="window">
+    <option value="300000">Last 5 min</option>
+    <option value="900000">Last 15 min</option>
+    <option value="3600000" selected>Last 1 hour</option>
+    <option value="86400000">Last 24 hours</option>
+  </select>
+  <button onclick="refresh()">Refresh</button>
+  <label><input type="checkbox" id="autoRefresh" checked> Auto (5s)</label>
+  <span class="refresh-indicator" id="lastUpdate"></span>
+</div>
+
+<div id="content"><div class="empty">Loading…</div></div>
+
+<script>
+const $ = s => document.querySelector(s);
+let timer;
+
+function ms(v) {
+  if (v == null) return '—';
+  if (v < 1000) return v + 'ms';
+  return (v / 1000).toFixed(1) + 's';
+}
+
+function ago(ts) {
+  const s = Math.floor((Date.now() - ts) / 1000);
+  if (s < 60) return s + 's ago';
+  if (s < 3600) return Math.floor(s/60) + 'm ago';
+  return Math.floor(s/3600) + 'h ago';
+}
+
+function pctRow(label, color, phase) {
+  return '<tr>'
+    + '<td><span class="phase-dot" style="background:' + color + '"></span>' + label + '</td>'
+    + '<td class="mono">' + ms(phase.p50) + '</td>'
+    + '<td class="mono">' + ms(phase.p95) + '</td>'
+    + '<td class="mono">' + ms(phase.p99) + '</td>'
+    + '<td class="mono">' + ms(phase.min) + '</td>'
+    + '<td class="mono">' + ms(phase.max) + '</td>'
+    + '<td class="mono">' + ms(phase.avg) + '</td>'
+    + '</tr>';
+}
+
+async function refresh() {
+  const w = $('#window').value;
+  try {
+    const [summary, reqs] = await Promise.all([
+      fetch('/telemetry/summary?window=' + w).then(r => r.json()),
+      fetch('/telemetry/requests?limit=50&since=' + (Date.now() - Number(w))).then(r => r.json()),
+    ]);
+    render(summary, reqs);
+    $('#lastUpdate').textContent = 'Updated ' + new Date().toLocaleTimeString();
+  } catch (e) {
+    $('#content').innerHTML = '<div class="empty">Failed to load telemetry</div>';
+  }
+}
+
+function render(s, reqs) {
+  if (s.totalRequests === 0) {
+    $('#content').innerHTML = '<div class="empty">No requests recorded yet. Send a request through the proxy to see telemetry.</div>';
+    return;
+  }
+
+  // Summary cards
+  let html = '<div class="cards">'
+    + card('Requests', s.totalRequests, s.requestsPerMinute.toFixed(1) + ' req/min')
+    + card('Errors', s.errorCount, s.totalRequests > 0 ? ((s.errorCount/s.totalRequests)*100).toFixed(1) + '% error rate' : '')
+    + card('Median Total', ms(s.totalDuration.p50), 'p95: ' + ms(s.totalDuration.p95))
+    + card('Median TTFB', ms(s.ttfb.p50), 'p95: ' + ms(s.ttfb.p95))
+    + card('Queue Wait', ms(s.queueWait.p50), 'p95: ' + ms(s.queueWait.p95))
+    + '</div>';
+
+  // Model breakdown
+  const models = Object.entries(s.byModel);
+  if (models.length > 0) {
+    html += '<div class="cards">';
+    for (const [name, data] of models) {
+      html += card(name, data.count + ' reqs', 'avg ' + ms(data.avgTotalMs));
+    }
+    html += '</div>';
+  }
+
+  // Percentile table
+  html += '<div class="section"><div class="section-title">Percentiles</div>'
+    + '<table class="pct-table"><thead><tr><th>Phase</th><th>p50</th><th>p95</th><th>p99</th><th>Min</th><th>Max</th><th>Avg</th></tr></thead><tbody>'
+    + pctRow('Queue Wait', 'var(--queue)', s.queueWait)
+    + pctRow('TTFB', 'var(--ttfb)', s.ttfb)
+    + pctRow('Upstream', 'var(--upstream)', s.upstreamDuration)
+    + pctRow('Total', 'var(--purple)', s.totalDuration)
+    + '</tbody></table></div>';
+
+  // Recent requests waterfall
+  html += '<div class="section"><div class="section-title">Recent Requests</div>'
+    + '<div class="legend">'
+    + '<span><span class="legend-dot" style="background:var(--queue)"></span>Queue</span>'
+    + '<span><span class="legend-dot" style="background:var(--ttfb)"></span>TTFB</span>'
+    + '<span><span class="legend-dot" style="background:var(--upstream)"></span>Response</span>'
+    + '</div>'
+    + '<table><thead><tr><th>Time</th><th>Model</th><th>Mode</th><th>Status</th>'
+    + '<th>Queue</th><th>TTFB</th><th>Total</th><th>Waterfall</th></tr></thead><tbody>';
+
+  const maxTotal = Math.max(...reqs.map(r => r.totalDurationMs), 1);
+
+  for (const r of reqs) {
+    const statusClass = r.error ? 'status-err' : 'status-ok';
+    const statusText = r.error ? r.error : r.status;
+    const scale = 280 / maxTotal;
+    const qW = Math.max(r.queueWaitMs * scale, 2);
+    const ttfbW = Math.max((r.ttfbMs || 0) * scale, 0);
+    const respW = Math.max((r.upstreamDurationMs - (r.ttfbMs || 0)) * scale, 2);
+
+    html += '<tr>'
+      + '<td class="mono">' + ago(r.timestamp) + '</td>'
+      + '<td>' + r.model + '</td>'
+      + '<td>' + r.mode + '</td>'
+      + '<td class="' + statusClass + '">' + statusText + '</td>'
+      + '<td class="mono">' + ms(r.queueWaitMs) + '</td>'
+      + '<td class="mono">' + ms(r.ttfbMs) + '</td>'
+      + '<td class="mono">' + ms(r.totalDurationMs) + '</td>'
+      + '<td><div class="waterfall">'
+      + '<div class="waterfall-seg queue" style="width:' + qW + 'px"></div>'
+      + '<div class="waterfall-seg ttfb" style="width:' + ttfbW + 'px"></div>'
+      + '<div class="waterfall-seg response" style="width:' + respW + 'px"></div>'
+      + '</div></td>'
+      + '</tr>';
+  }
+  html += '</tbody></table></div>';
+
+  $('#content').innerHTML = html;
+}
+
+function card(label, value, detail) {
+  return '<div class="card"><div class="card-label">' + label + '</div>'
+    + '<div class="card-value">' + value + '</div>'
+    + (detail ? '<div class="card-detail">' + detail + '</div>' : '')
+    + '</div>';
+}
+
+$('#autoRefresh').addEventListener('change', function() {
+  clearInterval(timer);
+  if (this.checked) timer = setInterval(refresh, 5000);
+});
+$('#window').addEventListener('change', refresh);
+
+refresh();
+timer = setInterval(refresh, 5000);
+</script>
+</body>
+</html>`

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,3 @@
+export { telemetryStore, TelemetryStore } from "./store"
+export { createTelemetryRoutes } from "./routes"
+export type { RequestMetric, TelemetrySummary, PhaseTiming } from "./types"

--- a/src/telemetry/routes.ts
+++ b/src/telemetry/routes.ts
@@ -1,0 +1,45 @@
+/**
+ * Telemetry API routes.
+ *
+ * GET /telemetry            — HTML dashboard
+ * GET /telemetry/requests   — Recent request metrics (JSON)
+ * GET /telemetry/summary    — Aggregate statistics (JSON)
+ */
+
+import { Hono } from "hono"
+import { telemetryStore } from "./store"
+import { dashboardHtml } from "./dashboard"
+
+export function createTelemetryRoutes() {
+  const routes = new Hono()
+
+  // Dashboard
+  routes.get("/", (c) => {
+    return c.html(dashboardHtml)
+  })
+
+  // Recent requests
+  routes.get("/requests", (c) => {
+    const limit = Number.parseInt(c.req.query("limit") || "50", 10)
+    const since = c.req.query("since") ? Number.parseInt(c.req.query("since")!, 10) : undefined
+    const model = c.req.query("model") || undefined
+
+    const requests = telemetryStore.getRecent({
+      limit: Math.min(limit, 500),
+      since,
+      model,
+    })
+
+    return c.json(requests)
+  })
+
+  // Aggregate summary
+  routes.get("/summary", (c) => {
+    const windowMs = Number.parseInt(c.req.query("window") || "3600000", 10) // default 1 hour
+
+    const summary = telemetryStore.summarize(windowMs)
+    return c.json(summary)
+  })
+
+  return routes
+}

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -1,0 +1,163 @@
+/**
+ * In-memory ring buffer for telemetry metrics.
+ *
+ * Append-only, fixed capacity, oldest entries overwritten.
+ * No disk I/O in the hot path. Data resets on proxy restart.
+ */
+
+import type { RequestMetric, PhaseTiming, TelemetrySummary } from "./types"
+
+const DEFAULT_CAPACITY = 1000
+
+function getCapacity(): number {
+  const raw = process.env.CLAUDE_PROXY_TELEMETRY_SIZE
+  if (!raw) return DEFAULT_CAPACITY
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CAPACITY
+  return parsed
+}
+
+export class TelemetryStore {
+  private buffer: (RequestMetric | null)[]
+  private head = 0 // next write position
+  private count = 0
+  private readonly capacity: number
+
+  constructor(capacity?: number) {
+    this.capacity = capacity ?? getCapacity()
+    this.buffer = new Array(this.capacity).fill(null)
+  }
+
+  /** Record a completed request metric. */
+  record(metric: RequestMetric): void {
+    this.buffer[this.head] = metric
+    this.head = (this.head + 1) % this.capacity
+    if (this.count < this.capacity) this.count++
+  }
+
+  /** Get the total number of stored metrics. */
+  get size(): number {
+    return this.count
+  }
+
+  /**
+   * Retrieve recent metrics, newest first.
+   * @param options.limit - Max entries to return (default: 50)
+   * @param options.since - Only entries after this timestamp
+   * @param options.model - Filter by model name
+   */
+  getRecent(options: { limit?: number; since?: number; model?: string } = {}): RequestMetric[] {
+    const { limit = 50, since, model } = options
+    const results: RequestMetric[] = []
+
+    // Walk backwards from most recent entry
+    for (let i = 0; i < this.count && results.length < limit; i++) {
+      const idx = (this.head - 1 - i + this.capacity) % this.capacity
+      const metric = this.buffer[idx]
+      if (!metric) continue
+      if (since && metric.timestamp < since) break // ring buffer is time-ordered
+      if (model && metric.model !== model) continue
+      results.push(metric)
+    }
+
+    return results
+  }
+
+  /**
+   * Compute aggregate statistics over a time window.
+   * @param windowMs - Time window in ms (default: 1 hour)
+   */
+  summarize(windowMs: number = 60 * 60 * 1000): TelemetrySummary {
+    const since = Date.now() - windowMs
+    const metrics = this.getRecent({ limit: this.capacity, since })
+
+    if (metrics.length === 0) {
+      const emptyPhase: PhaseTiming = { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
+      return {
+        windowMs,
+        totalRequests: 0,
+        errorCount: 0,
+        requestsPerMinute: 0,
+        queueWait: emptyPhase,
+        ttfb: emptyPhase,
+        upstreamDuration: emptyPhase,
+        totalDuration: emptyPhase,
+        byModel: {},
+        byMode: {},
+      }
+    }
+
+    const errorCount = metrics.filter(m => m.error !== null).length
+
+    // Compute actual time span for rate calculation
+    const oldest = metrics[metrics.length - 1]!.timestamp
+    const newest = metrics[0]!.timestamp
+    const spanMs = Math.max(newest - oldest, 1)
+    const requestsPerMinute = (metrics.length / spanMs) * 60_000
+
+    // Phase timings
+    const queueWaits = metrics.map(m => m.queueWaitMs)
+    const ttfbs = metrics.filter(m => m.ttfbMs !== null).map(m => m.ttfbMs!)
+    const upstreams = metrics.map(m => m.upstreamDurationMs)
+    const totals = metrics.map(m => m.totalDurationMs)
+
+    // Model breakdown
+    const byModel: Record<string, { count: number; totalMs: number }> = {}
+    for (const m of metrics) {
+      const entry = byModel[m.model] ??= { count: 0, totalMs: 0 }
+      entry.count++
+      entry.totalMs += m.totalDurationMs
+    }
+
+    // Mode breakdown
+    const byMode: Record<string, { count: number; totalMs: number }> = {}
+    for (const m of metrics) {
+      const entry = byMode[m.mode] ??= { count: 0, totalMs: 0 }
+      entry.count++
+      entry.totalMs += m.totalDurationMs
+    }
+
+    return {
+      windowMs,
+      totalRequests: metrics.length,
+      errorCount,
+      requestsPerMinute: Math.round(requestsPerMinute * 100) / 100,
+      queueWait: computePercentiles(queueWaits),
+      ttfb: ttfbs.length > 0 ? computePercentiles(ttfbs) : { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 },
+      upstreamDuration: computePercentiles(upstreams),
+      totalDuration: computePercentiles(totals),
+      byModel: Object.fromEntries(
+        Object.entries(byModel).map(([k, v]) => [k, { count: v.count, avgTotalMs: Math.round(v.totalMs / v.count) }])
+      ),
+      byMode: Object.fromEntries(
+        Object.entries(byMode).map(([k, v]) => [k, { count: v.count, avgTotalMs: Math.round(v.totalMs / v.count) }])
+      ),
+    }
+  }
+
+  /** Clear all stored metrics. */
+  clear(): void {
+    this.buffer = new Array(this.capacity).fill(null)
+    this.head = 0
+    this.count = 0
+  }
+}
+
+function computePercentiles(values: number[]): PhaseTiming {
+  if (values.length === 0) return { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const sum = sorted.reduce((a, b) => a + b, 0)
+
+  return {
+    p50: sorted[Math.floor(sorted.length * 0.5)]!,
+    p95: sorted[Math.floor(sorted.length * 0.95)]!,
+    p99: sorted[Math.floor(sorted.length * 0.99)]!,
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    avg: Math.round(sum / sorted.length),
+  }
+}
+
+/** Singleton store instance used by the proxy. */
+export const telemetryStore = new TelemetryStore()

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Telemetry types for request performance tracking.
+ *
+ * Each proxy request produces a RequestMetric capturing timing for every phase:
+ *
+ *   queueEnter → queueStart → upstreamStart → firstChunk → done
+ *   ├─ queueWait ─┤            ├──── TTFB ────┤            │
+ *   │                          ├──── upstream duration ─────┤
+ *   ├──────────────── total duration ───────────────────────┤
+ */
+
+export interface RequestMetric {
+  /** Unique request identifier */
+  requestId: string
+
+  /** When this metric was recorded */
+  timestamp: number
+
+  /** Model used (sonnet, opus, haiku) */
+  model: string
+
+  /** Streaming or non-streaming */
+  mode: "stream" | "non-stream"
+
+  /** Whether the request used session resume */
+  isResume: boolean
+
+  /** Whether passthrough mode was active */
+  isPassthrough: boolean
+
+  /** HTTP status code returned to the client */
+  status: number
+
+  /** Time spent waiting in the concurrency queue (ms) */
+  queueWaitMs: number
+
+  /** Time from SDK query start to first content chunk (ms) */
+  ttfbMs: number | null
+
+  /** Total time the SDK query took (ms) */
+  upstreamDurationMs: number
+
+  /** Total time from request received to response sent (ms) */
+  totalDurationMs: number
+
+  /** Number of content blocks in the response */
+  contentBlocks: number
+
+  /** Number of text stream events forwarded (streaming only) */
+  textEvents: number
+
+  /** Error type if the request failed, null if successful */
+  error: string | null
+}
+
+export interface PhaseTiming {
+  p50: number
+  p95: number
+  p99: number
+  min: number
+  max: number
+  avg: number
+}
+
+export interface TelemetrySummary {
+  /** Time window these stats cover */
+  windowMs: number
+  /** Total requests in the window */
+  totalRequests: number
+  /** Requests that returned an error */
+  errorCount: number
+  /** Requests per minute */
+  requestsPerMinute: number
+
+  /** Timing breakdowns by phase */
+  queueWait: PhaseTiming
+  ttfb: PhaseTiming
+  upstreamDuration: PhaseTiming
+  totalDuration: PhaseTiming
+
+  /** Breakdown by model */
+  byModel: Record<string, { count: number; avgTotalMs: number }>
+  /** Breakdown by mode */
+  byMode: Record<string, { count: number; avgTotalMs: number }>
+}


### PR DESCRIPTION
Closes #81

Adds an extensible telemetry system for tracking proxy request performance.

## Architecture

```
src/telemetry/
  types.ts       — RequestMetric, PhaseTiming, TelemetrySummary
  store.ts       — in-memory ring buffer + percentile aggregation
  routes.ts      — Hono route group mounted on the proxy
  dashboard.ts   — self-contained HTML dashboard (no framework, no build step)
  index.ts       — barrel export
```

## What gets captured

Every request records: queue wait, TTFB, upstream duration, total duration, model, mode, resume/passthrough state, error type.

```
queueEnter → queueStart → upstreamStart → firstChunk → done
├─ queueWait ─┤            ├──── TTFB ────┤            │
│                          ├──── upstream duration ─────┤
├──────────────── total duration ───────────────────────┤
```

## Endpoints

| Route | Description |
|---|---|
| `GET /telemetry` | HTML dashboard with auto-refresh |
| `GET /telemetry/requests?limit=50&model=opus&since=...` | Recent request metrics (JSON) |
| `GET /telemetry/summary?window=3600000` | p50/p95/p99 per phase, error rate, model breakdown |

## Dashboard

- Summary cards (requests, errors, median total, TTFB, queue wait)
- Per-model breakdown cards
- Percentile table (p50/p95/p99/min/max/avg per phase)
- Waterfall chart for recent requests
- Time window selector (5m / 15m / 1h / 24h)
- Auto-refresh every 5s

## Design decisions

- **In-memory ring buffer** — no disk I/O, bounded memory (default 1000, configurable via `CLAUDE_PROXY_TELEMETRY_SIZE`)
- **Zero new dependencies** — inline HTML/CSS/JS, served by the existing proxy
- **Extensible** — clean types and store API for adding new metrics later
- **20 tests** covering store operations, percentile math, and all API routes

169/170 tests pass (1 pre-existing untracked test for unimplemented feature).