### PR TITLE
Enable 1M context window for Opus via opus[1m] alias

### DIFF
--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -95,8 +95,8 @@ describe("buildAgentDefinitions", () => {
 
 describe("mapModelTier", () => {
   it("should map opus models", () => {
-    expect(mapModelTier("anthropic/claude-opus-4-6")).toBe("opus")
-    expect(mapModelTier("claude-opus-4")).toBe("opus")
+    expect(mapModelTier("anthropic/claude-opus-4-6")).toBe("opus[1m]")
+    expect(mapModelTier("claude-opus-4")).toBe("opus[1m]")
   })
 
   it("should map sonnet models", () => {

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -51,10 +51,10 @@ export function parseAgentDescriptions(taskDescription: string): Map<string, str
  * We map based on the model name pattern, defaulting to 'inherit'
  * for non-Anthropic models (they'll use the parent session's model).
  */
-export function mapModelTier(model?: string): "sonnet" | "opus" | "haiku" | "inherit" {
+export function mapModelTier(model?: string): "sonnet" | "opus" | "opus[1m]" | "haiku" | "inherit" {
   if (!model) return "inherit"
   const lower = model.toLowerCase()
-  if (lower.includes("opus")) return "opus"
+  if (lower.includes("opus")) return "opus[1m]"
   if (lower.includes("haiku")) return "haiku"
   if (lower.includes("sonnet")) return "sonnet"
   return "inherit"

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -379,8 +379,8 @@ async function resolveClaudeExecutableAsync(): Promise<string> {
   }
 }
 
-function mapModelToClaudeModel(model: string): "sonnet" | "opus" | "haiku" {
-  if (model.includes("opus")) return "opus"
+function mapModelToClaudeModel(model: string): "sonnet" | "opus" | "opus[1m]" | "haiku" {
+  if (model.includes("opus")) return "opus[1m]"
   if (model.includes("haiku")) return "haiku"
   return "sonnet"
 }


### PR DESCRIPTION
Currently the proxy maps all Opus requests to just `"opus"`, which defaults 
to a 200K context window. The problem is that OpenCode gets stuck when it 
hits compaction at 200K — you get "Conversation history too large to compact - 
exceeds model context limit" and the session is effectively dead.

Claude Max subscribers already have access to the 1M context window for 
Opus 4.6 through the `opus[1m]` alias, but the proxy strips it in 
`mapModelToClaudeModel`. Using the full 1M context avoids hitting compaction 
entirely for most sessions, which keeps things running smoothly.

The change is small — just return `"opus[1m]"` instead of `"opus"` in the 
two model mapping functions.