### PR TITLE
fix: detect conversation divergence (undo/edit) via lineage hashing

### DIFF
--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Tests for conversation lineage verification.
+ *
+ * Validates that session resume correctly detects history divergence
+ * from undo, edit, branch, and normal continuation scenarios.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+type MockSdkMessage = Record<string, unknown>
+type TestApp = { fetch: (req: Request) => Promise<Response> }
+
+let mockMessages: MockSdkMessage[] = []
+let capturedQueryParams: { options?: { resume?: string } } | null = null
+let queuedSessionIds: string[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: unknown) => {
+    capturedQueryParams = params as { options?: { resume?: string } }
+    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    return (async function* () {
+      for (const msg of mockMessages) {
+        yield { ...msg, session_id: sessionId }
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+}))
+
+mock.module("../proxy/sessionStore", () => ({
+  lookupSharedSession: () => undefined,
+  storeSharedSession: () => {},
+  clearSharedSessions: () => {},
+}))
+
+const { createProxyServer, clearSessionCache, computeLineageHash } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app as TestApp
+}
+
+async function post(
+  app: TestApp,
+  session: string,
+  messages: Array<{ role: string; content: string }>,
+  sessionId: string
+) {
+  queuedSessionIds.push(sessionId)
+  const response = await app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-opencode-session": session,
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-5",
+      max_tokens: 128,
+      stream: false,
+      messages,
+    }),
+  }))
+  await response.json()
+}
+
+beforeEach(() => {
+  mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+  capturedQueryParams = null
+  queuedSessionIds = []
+  clearSessionCache()
+})
+
+describe("computeLineageHash", () => {
+  it("returns empty string for empty messages", () => {
+    expect(computeLineageHash([])).toBe("")
+  })
+
+  it("produces consistent hashes for same messages", () => {
+    const msgs = [{ role: "user", content: "hello" }]
+    expect(computeLineageHash(msgs)).toBe(computeLineageHash(msgs))
+  })
+
+  it("produces different hashes for different content", () => {
+    const a = [{ role: "user", content: "hello" }]
+    const b = [{ role: "user", content: "goodbye" }]
+    expect(computeLineageHash(a)).not.toBe(computeLineageHash(b))
+  })
+
+  it("produces different hashes for different roles", () => {
+    const a = [{ role: "user", content: "hello" }]
+    const b = [{ role: "assistant", content: "hello" }]
+    expect(computeLineageHash(a)).not.toBe(computeLineageHash(b))
+  })
+
+  it("produces different hashes for different message order", () => {
+    const a = [{ role: "user", content: "a" }, { role: "user", content: "b" }]
+    const b = [{ role: "user", content: "b" }, { role: "user", content: "a" }]
+    expect(computeLineageHash(a)).not.toBe(computeLineageHash(b))
+  })
+
+  it("handles array content (multimodal)", () => {
+    const msgs = [{ role: "user", content: [{ type: "text", text: "hello" }] }]
+    const hash = computeLineageHash(msgs as any)
+    expect(hash.length).toBe(32)
+  })
+})
+
+describe("Session lineage: undo detection", () => {
+  it("resumes normally when messages are a strict continuation", async () => {
+    const app = createTestApp()
+
+    // Turn 1
+    await post(app, "sess-1", [
+      { role: "user", content: "Good evening" },
+    ], "sdk-1")
+
+    // Turn 2 — strict continuation (adds assistant + new user message)
+    await post(app, "sess-1", [
+      { role: "user", content: "Good evening" },
+      { role: "assistant", content: "Good evening!" },
+      { role: "user", content: "Remember: Flobulator" },
+    ], "sdk-1")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
+  })
+
+  it("does NOT resume after undo (same message count, different content)", async () => {
+    const app = createTestApp()
+
+    // Turn 1
+    await post(app, "sess-1", [
+      { role: "user", content: "Good evening" },
+    ], "sdk-1")
+
+    // Turn 2
+    await post(app, "sess-1", [
+      { role: "user", content: "Good evening" },
+      { role: "assistant", content: "Good evening!" },
+      { role: "user", content: "Remember: Flobulator" },
+    ], "sdk-1")
+
+    // /undo removes turn 2, user sends a different message 2
+    // Message count is still 3 but content of message 3 is different
+    await post(app, "sess-1", [
+      { role: "user", content: "Good evening" },
+      { role: "assistant", content: "Good evening!" },
+      { role: "user", content: "Do you remember the word?" },
+    ], "sdk-new")
+
+    // Should NOT resume — lineage hash mismatch
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+
+  it("does NOT resume after multi-undo (fewer messages)", async () => {
+    const app = createTestApp()
+
+    // Build up 3 turns
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+    ], "sdk-1")
+
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "step 2" },
+    ], "sdk-1")
+
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "step 2" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "step 3" },
+    ], "sdk-1")
+
+    // Multi-undo back to turn 1, send new message
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "completely different" },
+    ], "sdk-new")
+
+    // Should NOT resume — fewer messages than stored + content changed
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+
+  it("does NOT resume when earlier message is edited", async () => {
+    const app = createTestApp()
+
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+    ], "sdk-1")
+
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "how are you?" },
+    ], "sdk-1")
+
+    // Edit the first message
+    await post(app, "sess-1", [
+      { role: "user", content: "EDITED hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "how are you?" },
+      { role: "assistant", content: "good" },
+      { role: "user", content: "great" },
+    ], "sdk-new")
+
+    // Should NOT resume — first message was edited, lineage broken
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+
+  it("resumes correctly after undo when a NEW session starts", async () => {
+    const app = createTestApp()
+
+    // Turn 1
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+    ], "sdk-1")
+
+    // Turn 2
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "remember X" },
+    ], "sdk-1")
+
+    // /undo + new message → starts fresh (no resume)
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "forget about X" },
+    ], "sdk-2")
+
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+
+    // Now continuing from the NEW session should resume with sdk-2
+    await post(app, "sess-1", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "forget about X" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "what do you know?" },
+    ], "sdk-2")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-2")
+  })
+})
+
+describe("Session lineage: fingerprint fallback", () => {
+  it("does NOT resume via fingerprint after undo", async () => {
+    const app = createTestApp()
+
+    // No session header — uses fingerprint (hash of first user message)
+    await post(app, "", [
+      { role: "user", content: "Good evening" },
+    ], "sdk-fp1")
+
+    // Manually clear session header, send via fingerprint
+    queuedSessionIds.push("sdk-fp1")
+    const r1 = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5", max_tokens: 128, stream: false,
+        messages: [
+          { role: "user", content: "Good evening" },
+          { role: "assistant", content: "Hi!" },
+          { role: "user", content: "Remember: Flobulator" },
+        ],
+      }),
+    }))
+    await r1.json()
+
+    // Undo + new message, still no session header
+    queuedSessionIds.push("sdk-fp-new")
+    capturedQueryParams = null
+    const r2 = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5", max_tokens: 128, stream: false,
+        messages: [
+          { role: "user", content: "Good evening" },
+          { role: "assistant", content: "Hi!" },
+          { role: "user", content: "Do you know the word?" },
+        ],
+      }),
+    }))
+    await r2.json()
+
+    // Should NOT resume — fingerprint matches but lineage diverged
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -29,6 +29,11 @@ interface SessionState {
   claudeSessionId: string
   lastAccess: number
   messageCount: number
+  /** Hash of messages[0..messageCount-1] for lineage verification.
+   *  Resume is only safe when the incoming messages are a strict prefix-extension
+   *  of what the SDK session has seen. If the hash doesn't match, history has
+   *  diverged (undo, edit, branch) and we must start a fresh session. */
+  lineageHash: string
 }
 
 const DEFAULT_MAX_SESSIONS = 1000
@@ -122,6 +127,53 @@ function getConversationFingerprint(messages: Array<{ role: string; content: any
   return createHash("sha256").update(text.slice(0, 2000)).digest("hex").slice(0, 16)
 }
 
+/**
+ * Compute a lineage hash of an ordered message array.
+ * Used to verify that the incoming conversation is a strict prefix-extension
+ * of what the SDK session has seen. Covers undo, edit, branch detection.
+ */
+export function computeLineageHash(messages: Array<{ role: string; content: any }>): string {
+  if (!messages || messages.length === 0) return ""
+  const parts = messages.map(m => {
+    const text = typeof m.content === "string"
+      ? m.content
+      : JSON.stringify(m.content)
+    return `${m.role}:${text}`
+  })
+  return createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 32)
+}
+
+/**
+ * Verify that incoming messages are a valid continuation of a cached session.
+ * Returns the session if lineage is intact, undefined if history has diverged.
+ */
+function verifyLineage(
+  cached: SessionState,
+  messages: Array<{ role: string; content: any }>,
+  cacheKey: string,
+  cache: typeof sessionCache | typeof fingerprintCache
+): SessionState | undefined {
+  // No stored lineage (legacy entry or first request) — allow resume
+  if (!cached.lineageHash || cached.messageCount === 0) return cached
+
+  // Messages were truncated — more removed than added (multi-undo)
+  if (messages.length < cached.messageCount) {
+    cache.delete(cacheKey)
+    return undefined
+  }
+
+  // Verify the prefix matches what the SDK session saw
+  const prefix = messages.slice(0, cached.messageCount)
+  const prefixHash = computeLineageHash(prefix)
+  if (prefixHash !== cached.lineageHash) {
+    // History diverged (undo, edit, branch) — invalidate and start fresh
+    cache.delete(cacheKey)
+    return undefined
+  }
+
+  return cached
+}
+
 /** Look up a cached session by header or fingerprint */
 function lookupSession(
   opencodeSessionId: string | undefined,
@@ -131,17 +183,20 @@ function lookupSession(
   // to fingerprint. A different session ID means a different session.
   if (opencodeSessionId) {
     const cached = sessionCache.get(opencodeSessionId)
-    if (cached) return cached
+    if (cached) return verifyLineage(cached, messages, opencodeSessionId, sessionCache)
     // Check shared file store
     const shared = lookupSharedSession(opencodeSessionId)
     if (shared) {
       const state: SessionState = {
         claudeSessionId: shared.claudeSessionId,
         lastAccess: shared.lastUsedAt,
-        messageCount: 0,
+        messageCount: shared.messageCount || 0,
+        lineageHash: shared.lineageHash || "",
       }
-      sessionCache.set(opencodeSessionId, state)
-      return state
+      // Verify lineage before caching
+      const verified = verifyLineage(state, messages, opencodeSessionId, sessionCache)
+      if (verified) sessionCache.set(opencodeSessionId, state)
+      return verified
     }
     return undefined
   }
@@ -150,36 +205,44 @@ function lookupSession(
   const fp = getConversationFingerprint(messages)
   if (fp) {
     const cached = fingerprintCache.get(fp)
-    if (cached) return cached
+    if (cached) return verifyLineage(cached, messages, fp, fingerprintCache)
     const shared = lookupSharedSession(fp)
     if (shared) {
       const state: SessionState = {
         claudeSessionId: shared.claudeSessionId,
         lastAccess: shared.lastUsedAt,
-        messageCount: 0,
+        messageCount: shared.messageCount || 0,
+        lineageHash: shared.lineageHash || "",
       }
-      fingerprintCache.set(fp, state)
-      return state
+      const verified = verifyLineage(state, messages, fp, fingerprintCache)
+      if (verified) fingerprintCache.set(fp, state)
+      return verified
     }
   }
   return undefined
 }
 
-/** Store a session mapping */
+/** Store a session mapping with lineage hash for divergence detection */
 function storeSession(
   opencodeSessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
   claudeSessionId: string
 ) {
   if (!claudeSessionId) return
-  const state: SessionState = { claudeSessionId, lastAccess: Date.now(), messageCount: messages?.length || 0 }
+  const lineageHash = computeLineageHash(messages)
+  const state: SessionState = {
+    claudeSessionId,
+    lastAccess: Date.now(),
+    messageCount: messages?.length || 0,
+    lineageHash,
+  }
   // In-memory cache
   if (opencodeSessionId) sessionCache.set(opencodeSessionId, state)
   const fp = getConversationFingerprint(messages)
   if (fp) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = opencodeSessionId || fp
-  if (key) storeSharedSession(key, claudeSessionId, state.messageCount)
+  if (key) storeSharedSession(key, claudeSessionId, state.messageCount, lineageHash)
 }
 
 /** Extract only the last user message (for resume — SDK already has history) */

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -29,6 +29,8 @@ export interface StoredSession {
   createdAt: number
   lastUsedAt: number
   messageCount: number
+  /** Hash of messages[0..messageCount-1] for conversation lineage verification */
+  lineageHash?: string
 }
 
 const SESSION_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
@@ -126,7 +128,7 @@ export function lookupSharedSession(key: string): StoredSession | undefined {
   return session
 }
 
-export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number): void {
+export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number, lineageHash?: string): void {
   const path = getStorePath()
   const lockPath = `${path}.lock`
   const hasLock = acquireLock(lockPath)
@@ -141,6 +143,7 @@ export function storeSharedSession(key: string, claudeSessionId: string, message
       createdAt: existing?.createdAt || Date.now(),
       lastUsedAt: Date.now(),
       messageCount: messageCount ?? existing?.messageCount ?? 0,
+      lineageHash: lineageHash ?? existing?.lineageHash,
     }
     writeStore(store)
   } finally {


### PR DESCRIPTION
Fixes #86

## Problem

When OpenCode's `/undo` removes a user+assistant exchange, the proxy's session resume logic doesn't detect the divergence. The SDK session still has the full history, so Claude responds as if the undo never happened.

## Solution: Conversation Lineage Verification

A SHA-256 hash of the message array (`lineageHash`) is stored alongside each session. On resume, the proxy hashes the prefix `messages[0..storedCount-1]` and compares. If the hash doesn't match, history has diverged and a fresh session starts.

Covers: undo (same count, different content), multi-undo, message editing, branching. Both session ID and fingerprint fallback paths protected. 12 new tests, manually verified against a running proxy with the exact Flobulator scenario from the issue.
