### PR TITLE
fix: remove mock.module leak that breaks session store tests

### DIFF
--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -6,6 +6,9 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { assistantMessage } from "./helpers"
 
 type MockSdkMessage = Record<string, unknown>
@@ -37,13 +40,17 @@ mock.module("../mcpTools", () => ({
   opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
 }))
 
-mock.module("../proxy/sessionStore", () => ({
-  lookupSharedSession: () => undefined,
-  storeSharedSession: () => {},
-  clearSharedSessions: () => {},
-}))
+const lineageTmpDir = mkdtempSync(join(tmpdir(), "session-lineage-test-"))
+process.env.CLAUDE_PROXY_SESSION_DIR = lineageTmpDir
 
 const { createProxyServer, clearSessionCache, computeLineageHash } = await import("../proxy/server")
+const { clearSharedSessions } = await import("../proxy/sessionStore")
+
+afterAll(() => {
+  rmSync(lineageTmpDir, { recursive: true, force: true })
+  delete process.env.CLAUDE_PROXY_SESSION_DIR
+  mock.restore()
+})
 
 function createTestApp() {
   const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
@@ -78,6 +85,7 @@ beforeEach(() => {
   capturedQueryParams = null
   queuedSessionIds = []
   clearSessionCache()
+  clearSharedSessions()
 })
 
 describe("computeLineageHash", () => {


### PR DESCRIPTION
## Summary

- `session-lineage.test.ts` used top-level `mock.module("../proxy/sessionStore", ...)` which replaced the sessionStore module globally in Bun's module registry
- This caused **10 test failures** in `proxy-session-store.test.ts` (6) and `proxy-session-store-locking.test.ts` (4) when running the full suite — tests passed individually but failed together
- Root cause: `lookupSharedSession` always returned `undefined` because the mocked version was served to all test files

## Fix

Replace the module mock with a real tmpDir-backed sessionStore (matching the pattern used by other test files):
- Set `CLAUDE_PROXY_SESSION_DIR` to an isolated temp directory
- Call `clearSharedSessions()` in `beforeEach` to prevent cross-test interference
- Clean up tmpDir and env var in `afterAll`

## Verification

`bun test` — 177 pass, 0 fail (was 167 pass, 10 fail before fix)