### PR TITLE
fix: pass systemContext to storeSession for consistent fingerprinting

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -225,7 +225,8 @@ function lookupSession(
 function storeSession(
   opencodeSessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
-  claudeSessionId: string
+  claudeSessionId: string,
+  systemContext?: string
 ) {
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
@@ -237,7 +238,7 @@ function storeSession(
   }
   // In-memory cache
   if (opencodeSessionId) sessionCache.set(opencodeSessionId, state)
-  const fp = getConversationFingerprint(messages)
+  const fp = getConversationFingerprint(messages, systemContext)
   if (fp) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = opencodeSessionId || fp
@@ -1124,7 +1125,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}) {
 
               // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId, systemContext)
               }
 
               if (!streamClosed) {


### PR DESCRIPTION
## Summary

- Fixes fingerprint mismatch between `storeSession` and `lookupSession` that prevented session resume via fingerprint
- Adds missing `systemContext` argument to the stream-path `storeSession` call

## Problem

`lookupSession` computes fingerprints with `systemContext` (introduced in v1.13.0 for cross-project collision prevention), but `storeSession` computes them without it. The hashes never match, so fingerprint-based session resume silently fails. Every request is treated as new, causing the full message history — including tool_use blocks serialized as `[Tool Use: ...]` text — to be re-sent, which the model then echoes back as raw text instead of executing.

Fixes #94