### PR TITLE
fix: prevent env var loop and MCP server transport reuse with SDK >=0.2.81

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -48,7 +48,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer } = await import("../proxy/server")

--- a/src/__tests__/proxy-cache-eviction.test.ts
+++ b/src/__tests__/proxy-cache-eviction.test.ts
@@ -30,7 +30,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 mock.module("../proxy/sessionStore", () => ({

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Environment Variable Stripping Tests
+ *
+ * Verifies that ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL, and ANTHROPIC_AUTH_TOKEN
+ * are stripped from the environment passed to SDK subprocesses, preventing:
+ *   1. Infinite loops when the proxy sets these vars for OpenCode
+ *   2. The subprocess using a fake "dummy" API key instead of native Claude Max auth
+ *
+ * Related: https://github.com/rynfar/opencode-claude-max-proxy/issues/XXX
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+
+// Capture the env passed to query()
+let capturedQueryOptions: any = null
+const savedEnv: Record<string, string | undefined> = {}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryOptions = params.options
+    return (async function* () {
+      yield {
+        type: "assistant",
+        message: {
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: "sess-env-test",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }))
+}
+
+const BASIC_REQUEST = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "hello" }],
+}
+
+describe("Environment variable stripping", () => {
+  beforeEach(() => {
+    capturedQueryOptions = null
+    clearSessionCache()
+    // Save current env
+    for (const key of ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"]) {
+      savedEnv[key] = process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    // Restore env
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  })
+
+  it("should strip ANTHROPIC_API_KEY from subprocess env", async () => {
+    process.env.ANTHROPIC_API_KEY = "dummy"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions).toBeDefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_API_KEY).toBeUndefined()
+  })
+
+  it("should strip ANTHROPIC_BASE_URL from subprocess env", async () => {
+    process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:3456"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions).toBeDefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_BASE_URL).toBeUndefined()
+  })
+
+  it("should strip ANTHROPIC_AUTH_TOKEN from subprocess env", async () => {
+    process.env.ANTHROPIC_AUTH_TOKEN = "some-token"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions).toBeDefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+  })
+
+  it("should strip all three Anthropic env vars simultaneously", async () => {
+    process.env.ANTHROPIC_API_KEY = "dummy"
+    process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:3456"
+    process.env.ANTHROPIC_AUTH_TOKEN = "tok-123"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions).toBeDefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_BASE_URL).toBeUndefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined()
+  })
+
+  it("should preserve other env vars", async () => {
+    process.env.ANTHROPIC_API_KEY = "dummy"
+    process.env.MY_CUSTOM_VAR = "keep-me"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.MY_CUSTOM_VAR).toBe("keep-me")
+    delete process.env.MY_CUSTOM_VAR
+  })
+
+  it("should set ENABLE_TOOL_SEARCH to false", async () => {
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ENABLE_TOOL_SEARCH).toBe("false")
+  })
+
+  it("should still strip CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS", async () => {
+    process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "true"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBeUndefined()
+    delete process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
+  })
+
+  it("should work in streaming mode too", async () => {
+    process.env.ANTHROPIC_API_KEY = "dummy"
+    process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:3456"
+    const app = createTestApp()
+    const res = await post(app, { ...BASIC_REQUEST, stream: true })
+    // Consume the stream to trigger the query
+    await res.text()
+    expect(capturedQueryOptions).toBeDefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_API_KEY).toBeUndefined()
+    expect(capturedQueryOptions.env.ANTHROPIC_BASE_URL).toBeUndefined()
+  })
+})

--- a/src/__tests__/proxy-error-handling.test.ts
+++ b/src/__tests__/proxy-error-handling.test.ts
@@ -42,7 +42,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/proxy-mcp-filtering.test.ts
+++ b/src/__tests__/proxy-mcp-filtering.test.ts
@@ -37,7 +37,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer } = await import("../proxy/server")

--- a/src/__tests__/proxy-mcp-server-per-request.test.ts
+++ b/src/__tests__/proxy-mcp-server-per-request.test.ts
@@ -1,0 +1,195 @@
+/**
+ * MCP Server Per-Request Tests
+ *
+ * Verifies that createOpencodeMcpServer() is called fresh for each request,
+ * not shared as a singleton. SDK ≥0.2.81 enforces single-use Protocol
+ * transports, so reusing a server across requests causes:
+ *   "Already connected to a transport. Call close() before connecting to a
+ *    new transport, or use a separate Protocol instance per connection."
+ *
+ * Related: https://github.com/rynfar/opencode-claude-max-proxy/issues/XXX
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+// Track how many times createOpencodeMcpServer is called and what's passed to query
+let mcpServerCreateCount = 0
+let capturedMcpServers: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    if (params.options?.mcpServers) {
+      capturedMcpServers.push(params.options.mcpServers)
+    }
+    return (async function* () {
+      yield {
+        type: "assistant",
+        message: {
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: `sess-${Date.now()}`,
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+// Each call returns a unique object so we can verify they're different instances
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => {
+    mcpServerCreateCount++
+    return { type: "sdk", name: "opencode", instance: {}, _id: mcpServerCreateCount }
+  },
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const BASIC_REQUEST = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "hello" }],
+}
+
+describe("MCP server per-request lifecycle", () => {
+  beforeEach(() => {
+    mcpServerCreateCount = 0
+    capturedMcpServers = []
+    clearSessionCache()
+  })
+
+  it("should create a new MCP server for each non-streaming request", async () => {
+    const app = createTestApp()
+
+    await post(app, BASIC_REQUEST)
+    await post(app, BASIC_REQUEST)
+    await post(app, BASIC_REQUEST)
+
+    // Each request should have created its own MCP server
+    expect(mcpServerCreateCount).toBe(3)
+  })
+
+  it("should create a new MCP server for each streaming request", async () => {
+    const app = createTestApp()
+    const streamRequest = { ...BASIC_REQUEST, stream: true }
+
+    const res1 = await post(app, streamRequest)
+    await res1.text() // consume stream
+    const res2 = await post(app, streamRequest)
+    await res2.text()
+
+    expect(mcpServerCreateCount).toBe(2)
+  })
+
+  it("should pass unique MCP server instances to each query call", async () => {
+    const app = createTestApp()
+
+    await post(app, BASIC_REQUEST)
+    await post(app, BASIC_REQUEST)
+
+    expect(capturedMcpServers.length).toBe(2)
+
+    const server1 = capturedMcpServers[0]!.opencode
+    const server2 = capturedMcpServers[1]!.opencode
+
+    // Each should be a distinct object (different _id from our mock)
+    expect(server1._id).not.toBe(server2._id)
+  })
+
+  it("should create a new MCP server even for resumed sessions", async () => {
+    const app = createTestApp()
+
+    // First request: establish session
+    await post(app, BASIC_REQUEST, { "x-opencode-session": "session-abc" })
+
+    // Second request: resume session (same session header, extended messages)
+    await post(app, {
+      ...BASIC_REQUEST,
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "follow up" },
+      ],
+    }, { "x-opencode-session": "session-abc" })
+
+    // Both requests should get fresh MCP server instances
+    expect(mcpServerCreateCount).toBe(2)
+  })
+
+  it("should not share MCP server between concurrent requests", async () => {
+    const app = createTestApp()
+
+    // Fire 3 concurrent requests
+    const results = await Promise.all([
+      post(app, BASIC_REQUEST),
+      post(app, BASIC_REQUEST),
+      post(app, BASIC_REQUEST),
+    ])
+
+    // All should succeed
+    for (const res of results) {
+      expect(res.status).toBe(200)
+    }
+
+    // Each should have its own MCP server
+    expect(mcpServerCreateCount).toBe(3)
+    const ids = capturedMcpServers.map(s => s.opencode._id)
+    const uniqueIds = new Set(ids)
+    expect(uniqueIds.size).toBe(3)
+  })
+})
+
+describe("MCP server in passthrough mode", () => {
+  beforeEach(() => {
+    mcpServerCreateCount = 0
+    capturedMcpServers = []
+    clearSessionCache()
+  })
+
+  it("should NOT create opencode MCP server in passthrough mode", async () => {
+    const origPassthrough = process.env.CLAUDE_PROXY_PASSTHROUGH
+    process.env.CLAUDE_PROXY_PASSTHROUGH = "1"
+
+    try {
+      const app = createTestApp()
+      await post(app, {
+        ...BASIC_REQUEST,
+        tools: [{ name: "Read", description: "read a file", input_schema: { type: "object", properties: {} } }],
+      })
+
+      // In passthrough mode, the opencode MCP server is not used
+      // (passthrough creates its own MCP server for forwarding)
+      expect(mcpServerCreateCount).toBe(0)
+    } finally {
+      if (origPassthrough === undefined) {
+        delete process.env.CLAUDE_PROXY_PASSTHROUGH
+      } else {
+        process.env.CLAUDE_PROXY_PASSTHROUGH = origPassthrough
+      }
+    }
+  })
+})

--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -38,7 +38,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -33,7 +33,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/proxy-session-resume.test.ts
+++ b/src/__tests__/proxy-session-resume.test.ts
@@ -53,7 +53,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/proxy-streaming-message.test.ts
+++ b/src/__tests__/proxy-streaming-message.test.ts
@@ -42,7 +42,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -52,7 +52,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer } = await import("../proxy/server")

--- a/src/__tests__/proxy-tool-forwarding.test.ts
+++ b/src/__tests__/proxy-tool-forwarding.test.ts
@@ -54,7 +54,7 @@ mock.module("../logger", () => ({
 
 // Mock mcpTools
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 // Import AFTER mocking

--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -52,7 +52,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/proxy-working-directory.test.ts
+++ b/src/__tests__/proxy-working-directory.test.ts
@@ -30,7 +30,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")

--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -42,7 +42,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const fpTmpDir = mkdtempSync(join(tmpdir(), "session-fp-context-test-"))

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -37,7 +37,7 @@ mock.module("../logger", () => ({
 }))
 
 mock.module("../mcpTools", () => ({
-  opencodeMcpServer: { type: "sdk", name: "opencode", instance: {} },
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const lineageTmpDir = mkdtempSync(join(tmpdir(), "session-lineage-test-"))

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -10,7 +10,21 @@ const execAsync = promisify(exec)
 
 const getCwd = () => process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
 
-export const opencodeMcpServer = createSdkMcpServer({
+/**
+ * Create a fresh MCP server instance per request.
+ *
+ * SDK ≥0.2.81 enforces "one Protocol per transport connection". The internal
+ * McpServer holds a Protocol whose connect() throws if reused:
+ *   "Already connected to a transport. Call close() before connecting to a
+ *    new transport, or use a separate Protocol instance per connection."
+ *
+ * Each query() call connects its own transport to the MCP server, so sharing
+ * a singleton across requests triggers this guard on the second request.
+ * Creating a fresh instance avoids the conflict entirely — the same pattern
+ * used by createPassthroughMcpServer().
+ */
+export function createOpencodeMcpServer() {
+  return createSdkMcpServer({
   name: "opencode",
   version: "1.0.0",
   tools: [
@@ -182,4 +196,5 @@ export const opencodeMcpServer = createSdkMcpServer({
       }
     )
   ]
-})
+  })
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -13,7 +13,7 @@ import { existsSync } from "fs"
 import { fileURLToPath } from "url"
 import { join, dirname } from "path"
 import { promisify } from "util"
-import { opencodeMcpServer } from "../mcpTools"
+import { createOpencodeMcpServer } from "../mcpTools"
 import { randomUUID, createHash } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { fuzzyMatchAgentName } from "./agentMatch"
@@ -514,8 +514,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const stream = body.stream ?? true
         const workingDirectory = process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
 
-        // Strip env vars that cause SDK subprocess to load unwanted plugins/features
-        const { CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS, ...cleanEnv } = process.env
+        // Strip env vars that would cause the SDK subprocess to loop back through
+        // the proxy instead of using its native Claude Max auth. Also strip vars
+        // that cause unwanted SDK plugin/feature loading.
+        const {
+          CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,
+          ANTHROPIC_API_KEY: _dropApiKey,
+          ANTHROPIC_BASE_URL: _dropBaseUrl,
+          ANTHROPIC_AUTH_TOKEN: _dropAuthToken,
+          ...cleanEnv
+        } = process.env
 
         let systemContext = ""
         if (body.system) {
@@ -795,7 +803,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   : {
                       disallowedTools: [...BLOCKED_BUILTIN_TOOLS],
                       allowedTools: [...ALLOWED_MCP_TOOLS],
-                      mcpServers: { [MCP_SERVER_NAME]: opencodeMcpServer },
+                      mcpServers: { [MCP_SERVER_NAME]: createOpencodeMcpServer() },
                     }),
                 plugins: [],
                 env: { ...cleanEnv, ENABLE_TOOL_SEARCH: "false" },
@@ -991,7 +999,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     : {
                         disallowedTools: [...BLOCKED_BUILTIN_TOOLS],
                         allowedTools: [...ALLOWED_MCP_TOOLS],
-                        mcpServers: { [MCP_SERVER_NAME]: opencodeMcpServer },
+                        mcpServers: { [MCP_SERVER_NAME]: createOpencodeMcpServer() },
                       }),
                   plugins: [],
                   env: { ...cleanEnv, ENABLE_TOOL_SEARCH: "false" },


### PR DESCRIPTION
## Problem

After upgrading `@anthropic-ai/claude-agent-sdk` to 0.2.81 (bundled with Claude Code 2.1.81), the proxy hangs on every request. Two independent bugs compound:

### Bug 1: Environment variable infinite loop (critical)
The proxy inherits `ANTHROPIC_API_KEY=dummy` and `ANTHROPIC_BASE_URL=http://127.0.0.1:3456` from its parent environment (set by OpenCode). When it spawns `claude` subprocesses via `query()`, those subprocesses inherit these env vars and attempt to use the proxy as their API backend instead of native Claude Max auth → **infinite loop**, every request hangs forever.

With the env vars set, `claude auth status` shows `subscriptionType: null` and `apiKeySource: "ANTHROPIC_API_KEY"`. Without them, it correctly shows `subscriptionType: "max"` using native OAuth.

### Bug 2: MCP server Protocol reuse (SDK >=0.2.81)
`opencodeMcpServer` was a module-level singleton. SDK 0.2.81 added a guard in `Protocol.connect()`:
> "Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection."

Each `query()` call connects its own transport to the MCP server, so the second request throws.

## Fix

1. **Strip proxy env vars** from subprocess environment: `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN` — subprocess falls back to native Claude Max OAuth auth.

2. **Factory instead of singleton**: `export const opencodeMcpServer` → `export function createOpencodeMcpServer()` — fresh instance per request, same pattern as `createPassthroughMcpServer()`.

## Tests

- 8 new tests for env var stripping (stream + non-stream, individual + combined, preserves other vars)
- 6 new tests for MCP server per-request lifecycle (unique instances, concurrent requests, resume, passthrough mode)
- 14 existing test mocks updated for factory pattern
- All 187 tests pass