### PR TITLE
feat: add proxyOverheadMs metric to telemetry

### DIFF
--- a/src/__tests__/telemetry-routes.test.ts
+++ b/src/__tests__/telemetry-routes.test.ts
@@ -13,6 +13,7 @@ function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
     isPassthrough: false,
     status: 200,
     queueWaitMs: 5,
+    proxyOverheadMs: 12,
     ttfbMs: 120,
     upstreamDurationMs: 800,
     totalDurationMs: 850,

--- a/src/__tests__/telemetry-store.test.ts
+++ b/src/__tests__/telemetry-store.test.ts
@@ -12,6 +12,7 @@ function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
     isPassthrough: false,
     status: 200,
     queueWaitMs: 5,
+    proxyOverheadMs: 12,
     ttfbMs: 120,
     upstreamDurationMs: 800,
     totalDurationMs: 850,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -888,6 +888,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             hasToolUse
           })
 
+          const nonStreamQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
           telemetryStore.record({
             requestId: requestMeta.requestId,
             timestamp: Date.now(),
@@ -896,7 +897,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             isResume,
             isPassthrough: passthrough,
             status: 200,
-            queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+            queueWaitMs: nonStreamQueueWaitMs,
+            proxyOverheadMs: upstreamStartAt - requestStartAt - nonStreamQueueWaitMs,
             ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
             upstreamDurationMs: Date.now() - upstreamStartAt,
             totalDurationMs,
@@ -1208,6 +1210,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   textEventsForwarded
                 })
 
+                const streamQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
                 telemetryStore.record({
                   requestId: requestMeta.requestId,
                   timestamp: Date.now(),
@@ -1216,7 +1219,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   isResume,
                   isPassthrough: passthrough,
                   status: 200,
-                  queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+                  queueWaitMs: streamQueueWaitMs,
+                  proxyOverheadMs: upstreamStartAt - requestStartAt - streamQueueWaitMs,
                   ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
                   upstreamDurationMs: Date.now() - upstreamStartAt,
                   totalDurationMs: streamTotalDurationMs,
@@ -1290,6 +1294,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         claudeLog("proxy.error", { error: errMsg, classified: classified.type })
 
+        const errorQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
         telemetryStore.record({
           requestId: requestMeta.requestId,
           timestamp: Date.now(),
@@ -1298,7 +1303,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           isResume: false,
           isPassthrough: Boolean(process.env.CLAUDE_PROXY_PASSTHROUGH),
           status: classified.status,
-          queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+          queueWaitMs: errorQueueWaitMs,
+          proxyOverheadMs: Date.now() - requestStartAt - errorQueueWaitMs,
           ttfbMs: null,
           upstreamDurationMs: Date.now() - requestStartAt,
           totalDurationMs: Date.now() - requestStartAt,

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -39,6 +39,7 @@ export const dashboardHtml = `<!DOCTYPE html>
   .waterfall { display: flex; align-items: center; height: 18px; min-width: 200px; position: relative; }
   .waterfall-seg { height: 100%; border-radius: 2px; min-width: 2px; }
   .waterfall-seg.queue { background: var(--queue); }
+  .waterfall-seg.overhead { background: var(--yellow); }
   .waterfall-seg.ttfb { background: var(--ttfb); }
   .waterfall-seg.response { background: var(--upstream); }
   .legend { display: flex; gap: 16px; margin-bottom: 12px; font-size: 12px; color: var(--muted); }
@@ -131,6 +132,7 @@ function render(s, reqs) {
     + card('Errors', s.errorCount, s.totalRequests > 0 ? ((s.errorCount/s.totalRequests)*100).toFixed(1) + '% error rate' : '')
     + card('Median Total', ms(s.totalDuration.p50), 'p95: ' + ms(s.totalDuration.p95))
     + card('Median TTFB', ms(s.ttfb.p50), 'p95: ' + ms(s.ttfb.p95))
+    + card('Proxy Overhead', ms(s.proxyOverhead.p50), 'p95: ' + ms(s.proxyOverhead.p95))
     + card('Queue Wait', ms(s.queueWait.p50), 'p95: ' + ms(s.queueWait.p95))
     + '</div>';
 
@@ -148,6 +150,7 @@ function render(s, reqs) {
   html += '<div class="section"><div class="section-title">Percentiles</div>'
     + '<table class="pct-table"><thead><tr><th>Phase</th><th>p50</th><th>p95</th><th>p99</th><th>Min</th><th>Max</th><th>Avg</th></tr></thead><tbody>'
     + pctRow('Queue Wait', 'var(--queue)', s.queueWait)
+    + pctRow('Proxy Overhead', 'var(--yellow)', s.proxyOverhead)
     + pctRow('TTFB', 'var(--ttfb)', s.ttfb)
     + pctRow('Upstream', 'var(--upstream)', s.upstreamDuration)
     + pctRow('Total', 'var(--purple)', s.totalDuration)
@@ -157,11 +160,12 @@ function render(s, reqs) {
   html += '<div class="section"><div class="section-title">Recent Requests</div>'
     + '<div class="legend">'
     + '<span><span class="legend-dot" style="background:var(--queue)"></span>Queue</span>'
+    + '<span><span class="legend-dot" style="background:var(--yellow)"></span>Proxy</span>'
     + '<span><span class="legend-dot" style="background:var(--ttfb)"></span>TTFB</span>'
     + '<span><span class="legend-dot" style="background:var(--upstream)"></span>Response</span>'
     + '</div>'
     + '<table><thead><tr><th>Time</th><th>Model</th><th>Mode</th><th>Status</th>'
-    + '<th>Queue</th><th>TTFB</th><th>Total</th><th>Waterfall</th></tr></thead><tbody>';
+    + '<th>Queue</th><th>Proxy</th><th>TTFB</th><th>Total</th><th>Waterfall</th></tr></thead><tbody>';
 
   const maxTotal = Math.max(...reqs.map(r => r.totalDurationMs), 1);
 
@@ -170,6 +174,7 @@ function render(s, reqs) {
     const statusText = r.error ? r.error : r.status;
     const scale = 280 / maxTotal;
     const qW = Math.max(r.queueWaitMs * scale, 2);
+    const ohW = Math.max((r.proxyOverheadMs || 0) * scale, 0);
     const ttfbW = Math.max((r.ttfbMs || 0) * scale, 0);
     const respW = Math.max((r.upstreamDurationMs - (r.ttfbMs || 0)) * scale, 2);
 
@@ -179,10 +184,12 @@ function render(s, reqs) {
       + '<td>' + r.mode + '</td>'
       + '<td class="' + statusClass + '">' + statusText + '</td>'
       + '<td class="mono">' + ms(r.queueWaitMs) + '</td>'
+      + '<td class="mono">' + ms(r.proxyOverheadMs) + '</td>'
       + '<td class="mono">' + ms(r.ttfbMs) + '</td>'
       + '<td class="mono">' + ms(r.totalDurationMs) + '</td>'
       + '<td><div class="waterfall">'
       + '<div class="waterfall-seg queue" style="width:' + qW + 'px"></div>'
+      + '<div class="waterfall-seg overhead" style="width:' + ohW + 'px"></div>'
       + '<div class="waterfall-seg ttfb" style="width:' + ttfbW + 'px"></div>'
       + '<div class="waterfall-seg response" style="width:' + respW + 'px"></div>'
       + '</div></td>'

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -79,6 +79,7 @@ export class TelemetryStore {
         errorCount: 0,
         requestsPerMinute: 0,
         queueWait: emptyPhase,
+        proxyOverhead: emptyPhase,
         ttfb: emptyPhase,
         upstreamDuration: emptyPhase,
         totalDuration: emptyPhase,
@@ -97,6 +98,7 @@ export class TelemetryStore {
 
     // Phase timings
     const queueWaits = metrics.map(m => m.queueWaitMs)
+    const overheads = metrics.map(m => m.proxyOverheadMs)
     const ttfbs = metrics.filter(m => m.ttfbMs !== null).map(m => m.ttfbMs!)
     const upstreams = metrics.map(m => m.upstreamDurationMs)
     const totals = metrics.map(m => m.totalDurationMs)
@@ -123,6 +125,7 @@ export class TelemetryStore {
       errorCount,
       requestsPerMinute: Math.round(requestsPerMinute * 100) / 100,
       queueWait: computePercentiles(queueWaits),
+      proxyOverhead: computePercentiles(overheads),
       ttfb: ttfbs.length > 0 ? computePercentiles(ttfbs) : { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 },
       upstreamDuration: computePercentiles(upstreams),
       totalDuration: computePercentiles(totals),

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -3,10 +3,11 @@
  *
  * Each proxy request produces a RequestMetric capturing timing for every phase:
  *
- *   queueEnter → queueStart → upstreamStart → firstChunk → done
- *   ├─ queueWait ─┤            ├──── TTFB ────┤            │
- *   │                          ├──── upstream duration ─────┤
- *   ├──────────────── total duration ───────────────────────┤
+ *   queueEnter → queueStart → requestStart ──→ upstreamStart → firstChunk → done
+ *   ├─ queueWait ─┤           ├─ proxyOverhead ─┤              │            │
+ *   │                                            ├──── TTFB ────┤            │
+ *   │                                            ├── upstream duration ──────┤
+ *   ├──────────────────── total duration ────────────────────────────────────┤
  */
 
 export interface RequestMetric {
@@ -33,6 +34,11 @@ export interface RequestMetric {
 
   /** Time spent waiting in the concurrency queue (ms) */
   queueWaitMs: number
+
+  /** Time spent in proxy processing before SDK call — request parsing,
+   *  session lookup, prompt building (ms). If this is high, the proxy
+   *  is the bottleneck. Typically <50ms. */
+  proxyOverheadMs: number
 
   /** Time from SDK query start to first content chunk (ms) */
   ttfbMs: number | null
@@ -74,6 +80,7 @@ export interface TelemetrySummary {
 
   /** Timing breakdowns by phase */
   queueWait: PhaseTiming
+  proxyOverhead: PhaseTiming
   ttfb: PhaseTiming
   upstreamDuration: PhaseTiming
   totalDuration: PhaseTiming


### PR DESCRIPTION
Ref #104

Adds `proxyOverheadMs` to telemetry — the time spent in proxy processing before the SDK call (request parsing, session lookup, prompt building). Typically <50ms. This lets users immediately see whether the proxy or the upstream API is the latency bottleneck.

- Added to `RequestMetric` type, `TelemetrySummary`, and all 3 recording points (non-stream, stream, error)
- Dashboard: summary card, percentile table row, waterfall segment (yellow), per-request column
- Tests updated

187 pass, 0 fail.
