### PR TITLE
fix: block CLAUDE_CODE_ONLY_TOOLS in normal (non-passthrough) mode

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -790,8 +790,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 ...(systemContext ? {
                   systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
                 } : {}),
-                // In passthrough mode: block ALL SDK built-in tools, use OpenCode's via MCP
-                // In normal mode: block built-ins, use our own MCP replacements
                 ...(passthrough
                   ? {
                       disallowedTools: [...BLOCKED_BUILTIN_TOOLS, ...CLAUDE_CODE_ONLY_TOOLS],
@@ -801,7 +799,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       } : {}),
                     }
                   : {
-                      disallowedTools: [...BLOCKED_BUILTIN_TOOLS],
+                      disallowedTools: [...BLOCKED_BUILTIN_TOOLS, ...CLAUDE_CODE_ONLY_TOOLS],
                       allowedTools: [...ALLOWED_MCP_TOOLS],
                       mcpServers: { [MCP_SERVER_NAME]: createOpencodeMcpServer() },
                     }),
@@ -999,7 +997,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         } : {}),
                       }
                     : {
-                        disallowedTools: [...BLOCKED_BUILTIN_TOOLS],
+                        disallowedTools: [...BLOCKED_BUILTIN_TOOLS, ...CLAUDE_CODE_ONLY_TOOLS],
                         allowedTools: [...ALLOWED_MCP_TOOLS],
                         mcpServers: { [MCP_SERVER_NAME]: createOpencodeMcpServer() },
                       }),


### PR DESCRIPTION
## Summary

- **Bug**: In normal (non-passthrough) mode, only `BLOCKED_BUILTIN_TOOLS` were added to `disallowedTools`. The `CLAUDE_CODE_ONLY_TOOLS` list (`Agent`, `Skill`, `TaskOutput`, `TaskStop`, `WebSearch`, etc.) was only blocked in passthrough mode, allowing the SDK's native versions to leak through instead of being replaced by their OpenCode MCP equivalents.
- **Fix**: Adds `...CLAUDE_CODE_ONLY_TOOLS` to `disallowedTools` in both normal-mode code paths (initial query and streaming resumption), matching the passthrough-mode behavior.
- Removes two now-inaccurate comments that described different blocking strategies for passthrough vs normal mode (they now use the same strategy).

## Test plan

- [ ] Verify normal (non-passthrough) mode no longer exposes Claude Code-only tools like `Agent`, `Skill`, `WebSearch`
- [ ] Verify passthrough mode behavior is unchanged
- [ ] Verify OpenCode MCP tool replacements (`delegate_task`, `websearch_web_search_exa`, etc.) still work correctly in normal mode


Made with [Cursor](https://cursor.com)