### PR TITLE
fix: stabilize fingerprint resume by removing volatile systemContext and normalizing content format

### DIFF
--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -1,13 +1,20 @@
 /**
- * Tests for fingerprint-based session resume with system context.
+ * Tests for fingerprint-based session resume.
  *
- * Validates that:
- * 1. Fingerprint resume works when systemContext matches (store and lookup agree)
- * 2. Different systemContext produces different fingerprints (cross-project isolation)
- * 3. Fingerprint resume works end-to-end through the proxy (streaming + non-streaming)
+ * The fingerprint hashes the first user message only (not systemContext).
+ * OpenCode's system prompt contains dynamic content (file trees, diagnostics)
+ * that changes every request, making systemContext-based hashing unstable.
  *
- * These tests prevent regressions like #94 where storeSession and lookupSession
- * computed fingerprints with different inputs, breaking resume entirely.
+ * Cross-project safety is handled by lineage verification — different
+ * projects will have different message content after turn 1, so the
+ * lineage hash will mismatch and prevent incorrect resume.
+ *
+ * These tests cover:
+ * - Resume works even when systemContext changes between requests
+ * - Resume works across stream and non-stream
+ * - Lineage catches cross-project collisions (same first message, different history)
+ * - Different first messages produce different fingerprints
+ * - Backward compat without systemContext
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
@@ -86,7 +93,6 @@ async function postNoSession(
   }))
 
   if (stream) {
-    // Consume the stream fully
     const reader = response.body?.getReader()
     if (reader) {
       while (true) {
@@ -107,90 +113,220 @@ beforeEach(() => {
   clearSharedSessions()
 })
 
-describe("Fingerprint resume with system context", () => {
-  it("resumes via fingerprint when system context matches (non-stream)", async () => {
+describe("Fingerprint resume: stable across dynamic systemContext", () => {
+  it("resumes when systemContext changes between requests (non-stream)", async () => {
     const app = createTestApp()
-    const system = "You are a helpful assistant. Project: /home/user/my-project"
 
-    // Turn 1 — no session header, fingerprint created with systemContext
+    // Turn 1 — system prompt v1
     await postNoSession(app, [
       { role: "user", content: "hello" },
-    ], "sdk-1", system)
+    ], "sdk-1", "System v1: file tree has 10 files")
 
-    // Turn 2 — same first message + same system → fingerprint matches → should resume
+    // Turn 2 — system prompt changed (dynamic content), same first user message
     capturedQueryParams = null
     await postNoSession(app, [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "how are you?" },
-    ], "sdk-1", system)
+    ], "sdk-1", "System v2: file tree has 15 files, 3 diagnostics")
 
+    // MUST resume — fingerprint doesn't include systemContext
     expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
   })
 
-  it("resumes via fingerprint when system context matches (stream)", async () => {
+  it("resumes when systemContext changes between requests (stream)", async () => {
     const app = createTestApp()
-    const system = "You are a coding assistant."
 
-    // Turn 1 — streaming, no session header
     await postNoSession(app, [
       { role: "user", content: "hello" },
-    ], "sdk-stream-1", system, true)
+    ], "sdk-stream-1", "System v1", true)
 
-    // Turn 2 — same system context → should resume
     capturedQueryParams = null
     await postNoSession(app, [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "what can you do?" },
-    ], "sdk-stream-1", system, true)
+    ], "sdk-stream-1", "System v2 with more context", true)
 
     expect(capturedQueryParams?.options?.resume).toBe("sdk-stream-1")
   })
 
-  it("does NOT resume when system context differs (cross-project isolation)", async () => {
+  it("resumes when systemContext is added where there was none", async () => {
     const app = createTestApp()
 
-    // Project A
     await postNoSession(app, [
       { role: "user", content: "hello" },
-    ], "sdk-project-a", "Project: /home/user/project-a")
+    ], "sdk-no-ctx")
 
-    // Project B — same first message but different system context
-    capturedQueryParams = null
-    await postNoSession(app, [
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "hi" },
-      { role: "user", content: "list files" },
-    ], "sdk-project-b", "Project: /home/user/project-b")
-
-    // Should NOT resume project A's session
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
-  })
-
-  it("does NOT resume when system context is added where there was none", async () => {
-    const app = createTestApp()
-
-    // First request with no system context
-    await postNoSession(app, [
-      { role: "user", content: "hello" },
-    ], "sdk-no-system")
-
-    // Second request adds system context — fingerprint should differ
     capturedQueryParams = null
     await postNoSession(app, [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "help me" },
-    ], "sdk-with-system", "You are a helpful assistant.")
+    ], "sdk-no-ctx", "You are a helpful assistant.")
 
+    // MUST resume — systemContext not in fingerprint
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-no-ctx")
+  })
+
+  it("resumes when systemContext is removed", async () => {
+    const app = createTestApp()
+
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+    ], "sdk-ctx", "You are a helpful assistant.")
+
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "thanks" },
+    ], "sdk-ctx")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-ctx")
+  })
+})
+
+describe("Fingerprint resume: cross-project safety via lineage", () => {
+  it("does NOT resume wrong project when first message matches but history diverges", async () => {
+    const app = createTestApp()
+
+    // Project A: "hello" → assistant responds → user asks about project A files
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+    ], "sdk-project-a")
+
+    // Simulate project A continuing
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi, how can I help with project A?" },
+      { role: "user", content: "list the project A files" },
+    ], "sdk-project-a")
+
+    // Project B: same "hello" start, but different assistant response (different project)
+    // Lineage hash will mismatch because messages[1] differs
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi, how can I help with project B?" },
+      { role: "user", content: "list the project B files" },
+    ], "sdk-project-b")
+
+    // Should NOT resume project A — lineage diverged at message[1]
     expect(capturedQueryParams?.options?.resume).toBeUndefined()
   })
 
-  it("resumes correctly without system context (backward compat)", async () => {
+  it("resumes correctly after cross-project rejection creates new session", async () => {
     const app = createTestApp()
 
-    // No system context at all — old behavior should still work
+    // Project A
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+    ], "sdk-project-a")
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "project A response" },
+      { role: "user", content: "continue A" },
+    ], "sdk-project-a")
+
+    // Project B — different history, creates fresh session
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "project B response" },
+      { role: "user", content: "continue B" },
+    ], "sdk-project-b")
+
+    // Project B continues — should resume sdk-project-b
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "project B response" },
+      { role: "user", content: "continue B" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "more B work" },
+    ], "sdk-project-b")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-project-b")
+  })
+})
+
+describe("Fingerprint resume: different first messages", () => {
+  it("does NOT resume when first user message differs", async () => {
+    const app = createTestApp()
+
+    await postNoSession(app, [
+      { role: "user", content: "hello" },
+    ], "sdk-hello")
+
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "goodbye" },
+      { role: "assistant", content: "bye" },
+      { role: "user", content: "wait" },
+    ], "sdk-goodbye")
+
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+})
+
+describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
+  it("resumes correctly when history contains tool_use and tool_result", async () => {
+    const app = createTestApp()
+
+    // Turn 1
+    await postNoSession(app, [
+      { role: "user", content: "create a file" },
+    ], "sdk-tools", "System prompt v1")
+
+    // Turn 2 — history has tool_use/tool_result (this is what OpenCode sends)
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "create a file" },
+      { role: "assistant", content: [
+        { type: "text", text: "I'll create that file." },
+        { type: "tool_use", id: "toolu_123", name: "write", input: { path: "test.txt", content: "hello" } },
+      ] as any },
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_123", content: "File written." },
+      ] as any },
+      { role: "assistant", content: "Done! File created." },
+      { role: "user", content: "now read it back" },
+    ], "sdk-tools", "System prompt v2 with updated file tree")
+
+    // MUST resume even though system changed and history has tool blocks
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-tools")
+  })
+
+  it("does NOT resume after undo even with tool_use in history", async () => {
+    const app = createTestApp()
+
+    await postNoSession(app, [
+      { role: "user", content: "create a file" },
+    ], "sdk-tools-undo")
+
+    await postNoSession(app, [
+      { role: "user", content: "create a file" },
+      { role: "assistant", content: "I'll create that file." },
+      { role: "user", content: "use bash to list files" },
+    ], "sdk-tools-undo")
+
+    // /undo — different message 3
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "create a file" },
+      { role: "assistant", content: "I'll create that file." },
+      { role: "user", content: "actually, delete that file instead" },
+    ], "sdk-tools-undo-new")
+
+    // Should NOT resume — lineage diverged
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+  })
+})
+
+describe("Fingerprint resume: backward compat", () => {
+  it("resumes correctly without systemContext", async () => {
+    const app = createTestApp()
+
     await postNoSession(app, [
       { role: "user", content: "hello" },
     ], "sdk-no-ctx")

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -121,6 +121,35 @@ describe("computeLineageHash", () => {
     const hash = computeLineageHash(msgs as any)
     expect(hash.length).toBe(32)
   })
+
+  it("produces identical hashes for string vs array content format", () => {
+    // OpenCode sends content as string on first request, array on follow-ups
+    const asString = [{ role: "user", content: "hello world" }]
+    const asArray = [{ role: "user", content: [{ type: "text", text: "hello world" }] }]
+    expect(computeLineageHash(asString)).toBe(computeLineageHash(asArray as any))
+  })
+
+  it("produces identical hashes for tool_use in string vs structured format", () => {
+    const withToolUse = [
+      { role: "user", content: "do something" },
+      { role: "assistant", content: [
+        { type: "text", text: "I'll help." },
+        { type: "tool_use", id: "toolu_123", name: "bash", input: { command: "ls" } },
+      ]},
+    ]
+    // Same content, same hash regardless of internal format
+    expect(computeLineageHash(withToolUse as any)).toBe(computeLineageHash(withToolUse as any))
+  })
+
+  it("produces different hashes for different tool_use content", () => {
+    const a = [{ role: "assistant", content: [
+      { type: "tool_use", id: "toolu_1", name: "bash", input: { command: "ls" } },
+    ]}]
+    const b = [{ role: "assistant", content: [
+      { type: "tool_use", id: "toolu_1", name: "bash", input: { command: "pwd" } },
+    ]}]
+    expect(computeLineageHash(a as any)).not.toBe(computeLineageHash(b as any))
+  })
 })
 
 describe("Session lineage: undo detection", () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -108,10 +108,14 @@ export function clearSessionCache() {
 // uses count-based pruning. SDK sessions persist on Anthropic's side for
 // weeks — we should never discard a valid mapping before the SDK does.
 
-/** Hash the first user message + system context to fingerprint a conversation.
- *  Including system context prevents cross-project collisions when different
- *  projects happen to start with the same first message. */
-function getConversationFingerprint(messages: Array<{ role: string; content: any }>, systemContext?: string): string {
+/** Hash the first user message to fingerprint a conversation.
+ *  Used to find a cached session when no x-opencode-session header is present.
+ *  Does NOT include systemContext because OpenCode's system prompt contains
+ *  dynamic content (file trees, diagnostics) that changes every request,
+ *  making the hash unstable and preventing resume.
+ *  Cross-project safety is handled by lineage verification — different
+ *  projects will have different message content after turn 1. */
+function getConversationFingerprint(messages: Array<{ role: string; content: any }>): string {
   const firstUser = messages?.find((m) => m.role === "user")
   if (!firstUser) return ""
   const text = typeof firstUser.content === "string"
@@ -120,8 +124,25 @@ function getConversationFingerprint(messages: Array<{ role: string; content: any
       ? firstUser.content.filter((b: any) => b.type === "text").map((b: any) => b.text).join("")
       : ""
   if (!text) return ""
-  const seed = systemContext ? `${systemContext}\n${text.slice(0, 2000)}` : text.slice(0, 2000)
-  return createHash("sha256").update(seed).digest("hex").slice(0, 16)
+  return createHash("sha256").update(text.slice(0, 2000)).digest("hex").slice(0, 16)
+}
+
+/**
+ * Normalize message content to a stable string representation.
+ * OpenCode sends content as a string on the first request but as an array
+ * of content blocks on follow-up requests. Both must hash identically.
+ */
+function normalizeContent(content: any): string {
+  if (typeof content === "string") return content
+  if (Array.isArray(content)) {
+    return content.map((block: any) => {
+      if (block.type === "text" && block.text) return block.text
+      if (block.type === "tool_use") return `tool_use:${block.id}:${block.name}:${JSON.stringify(block.input)}`
+      if (block.type === "tool_result") return `tool_result:${block.tool_use_id}:${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}`
+      return JSON.stringify(block)
+    }).join("\n")
+  }
+  return String(content)
 }
 
 /**
@@ -131,12 +152,7 @@ function getConversationFingerprint(messages: Array<{ role: string; content: any
  */
 export function computeLineageHash(messages: Array<{ role: string; content: any }>): string {
   if (!messages || messages.length === 0) return ""
-  const parts = messages.map(m => {
-    const text = typeof m.content === "string"
-      ? m.content
-      : JSON.stringify(m.content)
-    return `${m.role}:${text}`
-  })
+  const parts = messages.map(m => `${m.role}:${normalizeContent(m.content)}`)
   return createHash("sha256").update(parts.join("\n")).digest("hex").slice(0, 32)
 }
 
@@ -180,8 +196,7 @@ function touchSession(state: SessionState): SessionState {
 /** Look up a cached session by header or fingerprint */
 function lookupSession(
   opencodeSessionId: string | undefined,
-  messages: Array<{ role: string; content: any }>,
-  systemContext?: string
+  messages: Array<{ role: string; content: any }>
 ): SessionState | undefined {
   if (opencodeSessionId) {
     const cached = sessionCache.get(opencodeSessionId)
@@ -204,7 +219,7 @@ function lookupSession(
     return undefined
   }
 
-  const fp = getConversationFingerprint(messages, systemContext)
+  const fp = getConversationFingerprint(messages)
   if (fp) {
     const cached = fingerprintCache.get(fp)
     if (cached) {
@@ -231,8 +246,7 @@ function lookupSession(
 function storeSession(
   opencodeSessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
-  claudeSessionId: string,
-  systemContext?: string
+  claudeSessionId: string
 ) {
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
@@ -244,7 +258,7 @@ function storeSession(
   }
   // In-memory cache
   if (opencodeSessionId) sessionCache.set(opencodeSessionId, state)
-  const fp = getConversationFingerprint(messages, systemContext)
+  const fp = getConversationFingerprint(messages)
   if (fp) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = opencodeSessionId || fp
@@ -539,7 +553,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         // Session resume: look up cached Claude SDK session
         const opencodeSessionId = c.req.header("x-opencode-session")
-        const cachedSession = lookupSession(opencodeSessionId, body.messages || [], systemContext)
+        const cachedSession = lookupSession(opencodeSessionId, body.messages || [])
         const resumeSessionId = cachedSession?.claudeSessionId
         const isResume = Boolean(resumeSessionId)
 
@@ -915,7 +929,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
           // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId, systemContext)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId)
               }
 
               const responseSessionId = currentSessionId || resumeSessionId || `session_${Date.now()}`
@@ -1139,7 +1153,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId, systemContext)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId)
               }
 
               if (!streamClosed) {


### PR DESCRIPTION
Ref #111

## Problem

Session resume never worked via the fingerprint fallback path (when OpenCode doesn't send `x-opencode-session`). Every request showed `resume=false`, causing full message history to be replayed as flat text — tool_use blocks became `[Tool Use: ...]` strings that Claude echoed back.

## Root Cause

Two hash mismatches prevented resume:

**1. Fingerprint included volatile systemContext.** OpenCode's system prompt contains dynamic content (file trees, diagnostics) that changes every request. The fingerprint hash never matched on follow-ups.

**2. Lineage hash didn't normalize content format.** OpenCode sends content as a string (`"hello"`) on request 1, then as an array (`[{"type":"text","text":"hello"}]`) on request 2. `computeLineageHash` treated them as different content.

## Fix

- **Fingerprint**: removed systemContext from hash. Cross-project safety is handled by lineage verification (different message content → different lineage → no resume).
- **Lineage**: added `normalizeContent()` that extracts text identically from both string and array content formats, including tool_use and tool_result blocks.

## Verification

- **Unit tests**: 214 pass, 0 fail. 27 tests cover fingerprint stability, content normalization, cross-project safety, tool_use in history, and undo detection.
- **Manual end-to-end**: OpenCode headless in passthrough mode, multi-turn with tool calls. Proxy logs show `resume=true` on every follow-up (was `resume=false` on every request before the fix).
