### PR TITLE
fix: optimize Docker layer ordering to cache dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@
 FROM oven/bun:1 AS build
 
 WORKDIR /app
-COPY package.json bun.lock* tsconfig.json* ./
+COPY package.json bun.lock* ./
+RUN --mount=type=cache,target=/root/.bun \
+    bun install
+
+COPY tsconfig.json* ./
 COPY bin/ ./bin/
 COPY src/ ./src/
-
-RUN bun install
 # Run bun build directly (not "bun run build") to skip postbuild hook,
 # which calls "node --check" — unavailable in oven/bun image
 RUN rm -rf dist && bun build bin/cli.ts src/proxy/server.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --entry-naming '[name].js'


### PR DESCRIPTION
## Summary

Fixes #125 — Docker build was reinstalling all dependencies on every code change due to layer ordering.

## Changes

1. **Reordered COPY layers** — `bun install` now runs immediately after copying `package.json` + `bun.lock`, before any source files are copied. This means dependency installation is cached unless `package.json` or `bun.lock` change.

2. **Added BuildKit cache mount** — `--mount=type=cache,target=/root/.bun` persists Bun's download cache across builds, so even when the install layer is invalidated, packages don't need to be redownloaded.

## Before
```
COPY package.json bun.lock* tsconfig.json* ./
COPY bin/ ./bin/
COPY src/ ./src/
RUN bun install          # ← busted on every src change
```

## After
```
COPY package.json bun.lock* ./
RUN --mount=type=cache,target=/root/.bun \\
    bun install           # ← cached unless deps change

COPY tsconfig.json* ./
COPY bin/ ./bin/
COPY src/ ./src/
```

Runtime stage is untouched.