### PR TITLE
fix: enable 1M context window for Sonnet models

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -464,10 +464,10 @@ async function resolveClaudeExecutableAsync(): Promise<string> {
   }
 }
 
-function mapModelToClaudeModel(model: string): "sonnet" | "opus" | "opus[1m]" | "haiku" {
+function mapModelToClaudeModel(model: string): "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku" {
   if (model.includes("opus")) return "opus[1m]"
   if (model.includes("haiku")) return "haiku"
-  return "sonnet"
+  return "sonnet[1m]"
 }
 
 function isClosedControllerError(error: unknown): boolean {


### PR DESCRIPTION
Closes #124

## Problem

Sonnet sessions were hitting the 200K context limit and triggering auto-compaction far too early. Users reported context filling up quickly and compaction breaking their sessions.

## Root Cause

The `mapModelToClaudeModel` function mapped Sonnet to `"sonnet"` which gives a 200K context window. Opus was already mapped to `"opus[1m]"` (1M context) from an earlier PR, but Sonnet was missed.

The `[1m]` suffix tells the Claude Code CLI to use the 1M context variant, which is available for Max subscribers.

## Fix

One line: `return "sonnet"` → `return "sonnet[1m]"`

## Verified

```
claude --model sonnet   → /context shows 15k / 200k
claude --model sonnet[1m] → /context shows 15k / 1000k
```

SDK confirms `contextWindow: 1000000` with the `[1m]` suffix.

214 tests pass.
