### PR TITLE
fix: extract client working directory from system prompt for remote proxy

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -108,6 +108,32 @@ export function clearSessionCache() {
 // uses count-based pruning. SDK sessions persist on Anthropic's side for
 // weeks — we should never discard a valid mapping before the SDK does.
 
+/**
+ * Extract the client's working directory from the system prompt.
+ * OpenCode embeds it inside an <env> block:
+ *   <env>
+ *     Working directory: /path/to/project
+ *     ...
+ *   </env>
+ *
+ * Returns the path if found, or undefined to fall back to server defaults.
+ */
+function extractClientCwd(body: any): string | undefined {
+  let systemText = ""
+  if (typeof body.system === "string") {
+    systemText = body.system
+  } else if (Array.isArray(body.system)) {
+    systemText = body.system
+      .filter((b: any) => b.type === "text" && b.text)
+      .map((b: any) => b.text)
+      .join("\n")
+  }
+  if (!systemText) return undefined
+
+  const match = systemText.match(/<env>\s*[\s\S]*?Working directory:\s*([^\n<]+)/i)
+  return match?.[1]?.trim() || undefined
+}
+
 /** Hash the first user message + working directory to fingerprint a conversation.
  *  Used to find a cached session when no x-opencode-session header is present.
  *  Includes workingDirectory (stable per project, unlike systemContext which
@@ -528,7 +554,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const body = await c.req.json()
         const model = mapModelToClaudeModel(body.model || "sonnet")
         const stream = body.stream ?? true
-        const workingDirectory = process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
+        const workingDirectory = extractClientCwd(body) || process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
 
         // Strip env vars that would cause the SDK subprocess to loop back through
         // the proxy instead of using its native Claude Max auth. Also strip vars


### PR DESCRIPTION
## Summary

Fixes #123 — When the proxy runs on a remote host (Docker, VPS), Claude's responses referenced file paths from the server's filesystem instead of the client's.

## Root Cause

`workingDirectory` was always resolved from the server:
```typescript
const workingDirectory = process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
```

This meant Claude's system prompt was anchored to e.g. `/app` (Docker) instead of the user's actual project path.

## Fix

OpenCode embeds the client's working directory in the system prompt inside an `<env>` block:
```
<env>
  Working directory: /Users/me/my-project
  ...
</env>
```

The new `extractClientCwd()` function parses this and uses it as the SDK's `cwd`. Priority chain:

```
client cwd (from system prompt) → CLAUDE_PROXY_WORKDIR env → process.cwd()
```

## Testing

- **Unit tests**: 214 pass, 0 fail
- **E2E verified**: Proxy started from `/tmp` (simulating remote), OpenCode ran from `/tmp/test-project-125`. Claude correctly responded with the client's path, not the server's.
- **Backward compatible**: If no `<env>` block is present, falls back to existing behavior.