### PR TITLE
fix: redesign session management with per-message hashing, SDK-native undo, and compaction survival

### DIFF
--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -93,7 +93,7 @@ describe("Phase 2: SDK should not use internal tools", () => {
     capturedQueryParams = null
   })
 
-  it("should use maxTurns: 100 for multi-turn tool execution", async () => {
+  it("should use maxTurns: 200 for multi-turn tool execution", async () => {
     mockMessages = [
       messageStart(),
       textBlockStart(0),
@@ -108,7 +108,7 @@ describe("Phase 2: SDK should not use internal tools", () => {
     await readStreamFull(response)
 
     expect(capturedQueryParams).toBeDefined()
-    expect(capturedQueryParams.options.maxTurns).toBe(100)
+    expect(capturedQueryParams.options.maxTurns).toBe(200)
   })
 
   it("should include MCP tools for internal tool execution", async () => {

--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -212,8 +212,9 @@ describe("Fingerprint resume: cross-project safety via lineage", () => {
       { role: "user", content: "list the project B files" },
     ], "sdk-project-b")
 
-    // Should NOT resume project A — lineage diverged at message[1]
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    // Prefix overlap ("hello") → undo/branch detected → forks from project A
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-project-a")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
   })
 
   it("resumes correctly after cross-project rejection creates new session", async () => {
@@ -318,8 +319,9 @@ describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
       { role: "user", content: "actually, delete that file instead" },
     ], "sdk-tools-undo-new")
 
-    // Should NOT resume — lineage diverged
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    // Prefix overlap ("create a file", "I'll create that file.") → undo → fork
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-tools-undo")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
   })
 })
 

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -1,8 +1,13 @@
 /**
  * Tests for conversation lineage verification.
  *
- * Validates that session resume correctly detects history divergence
- * from undo, edit, branch, and normal continuation scenarios.
+ * Validates that session resume correctly handles:
+ *   - Normal continuation (new messages appended)
+ *   - Undo / branch (recent messages changed)
+ *   - Compaction (older messages rewritten, recent preserved)
+ *   - Pruning (middle messages modified, both ends preserved)
+ *   - Multiple compactions in sequence
+ *   - Post-compaction normal resume and undo
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
@@ -43,7 +48,13 @@ mock.module("../mcpTools", () => ({
 const lineageTmpDir = mkdtempSync(join(tmpdir(), "session-lineage-test-"))
 process.env.CLAUDE_PROXY_SESSION_DIR = lineageTmpDir
 
-const { createProxyServer, clearSessionCache, computeLineageHash } = await import("../proxy/server")
+const {
+  createProxyServer,
+  clearSessionCache,
+  computeLineageHash,
+  hashMessage,
+  computeMessageHashes,
+} = await import("../proxy/server")
 const { clearSharedSessions } = await import("../proxy/sessionStore")
 
 afterAll(() => {
@@ -68,7 +79,7 @@ async function post(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "x-opencode-session": session,
+      ...(session ? { "x-opencode-session": session } : {}),
     },
     body: JSON.stringify({
       model: "claude-sonnet-4-5",
@@ -87,6 +98,10 @@ beforeEach(() => {
   clearSessionCache()
   clearSharedSessions()
 })
+
+// ---------------------------------------------------------------------------
+// Unit tests for hash functions
+// ---------------------------------------------------------------------------
 
 describe("computeLineageHash", () => {
   it("returns empty string for empty messages", () => {
@@ -123,7 +138,6 @@ describe("computeLineageHash", () => {
   })
 
   it("produces identical hashes for string vs array content format", () => {
-    // OpenCode sends content as string on first request, array on follow-ups
     const asString = [{ role: "user", content: "hello world" }]
     const asArray = [{ role: "user", content: [{ type: "text", text: "hello world" }] }]
     expect(computeLineageHash(asString)).toBe(computeLineageHash(asArray as any))
@@ -137,7 +151,6 @@ describe("computeLineageHash", () => {
         { type: "tool_use", id: "toolu_123", name: "bash", input: { command: "ls" } },
       ]},
     ]
-    // Same content, same hash regardless of internal format
     expect(computeLineageHash(withToolUse as any)).toBe(computeLineageHash(withToolUse as any))
   })
 
@@ -152,16 +165,51 @@ describe("computeLineageHash", () => {
   })
 })
 
-describe("Session lineage: undo detection", () => {
-  it("resumes normally when messages are a strict continuation", async () => {
+describe("hashMessage / computeMessageHashes", () => {
+  it("hashMessage produces consistent hashes", () => {
+    const msg = { role: "user", content: "hello" }
+    expect(hashMessage(msg)).toBe(hashMessage(msg))
+  })
+
+  it("hashMessage differs for different content", () => {
+    expect(hashMessage({ role: "user", content: "a" }))
+      .not.toBe(hashMessage({ role: "user", content: "b" }))
+  })
+
+  it("hashMessage normalises string vs array content", () => {
+    const str = { role: "user", content: "hello" }
+    const arr = { role: "user", content: [{ type: "text", text: "hello" }] }
+    expect(hashMessage(str)).toBe(hashMessage(arr as any))
+  })
+
+  it("computeMessageHashes returns one hash per message", () => {
+    const msgs = [
+      { role: "user", content: "a" },
+      { role: "assistant", content: "b" },
+      { role: "user", content: "c" },
+    ]
+    const hashes = computeMessageHashes(msgs)
+    expect(hashes).toHaveLength(3)
+    expect(new Set(hashes).size).toBe(3) // all different
+  })
+
+  it("computeMessageHashes returns empty array for empty input", () => {
+    expect(computeMessageHashes([])).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 1: Normal continuation
+// ---------------------------------------------------------------------------
+
+describe("Session lineage: normal continuation", () => {
+  it("resumes when messages are a strict continuation", async () => {
     const app = createTestApp()
 
-    // Turn 1
     await post(app, "sess-1", [
       { role: "user", content: "Good evening" },
     ], "sdk-1")
 
-    // Turn 2 — strict continuation (adds assistant + new user message)
     await post(app, "sess-1", [
       { role: "user", content: "Good evening" },
       { role: "assistant", content: "Good evening!" },
@@ -170,38 +218,42 @@ describe("Session lineage: undo detection", () => {
 
     expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
   })
+})
 
-  it("does NOT resume after undo (same message count, different content)", async () => {
+// ---------------------------------------------------------------------------
+// Scenarios 2-4: Undo / branch / edit
+// ---------------------------------------------------------------------------
+
+describe("Session lineage: undo detection", () => {
+  it("forks session on undo (same count, different last message)", async () => {
     const app = createTestApp()
 
-    // Turn 1
     await post(app, "sess-1", [
       { role: "user", content: "Good evening" },
     ], "sdk-1")
 
-    // Turn 2
     await post(app, "sess-1", [
       { role: "user", content: "Good evening" },
       { role: "assistant", content: "Good evening!" },
       { role: "user", content: "Remember: Flobulator" },
     ], "sdk-1")
 
-    // /undo removes turn 2, user sends a different message 2
-    // Message count is still 3 but content of message 3 is different
+    // Undo last turn, new message → should fork the session
     await post(app, "sess-1", [
       { role: "user", content: "Good evening" },
       { role: "assistant", content: "Good evening!" },
       { role: "user", content: "Do you remember the word?" },
     ], "sdk-new")
 
-    // Should NOT resume — lineage hash mismatch
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    // Should resume the original session with fork
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(capturedQueryParams?.options?.resumeSessionAt).toBeDefined()
   })
 
-  it("does NOT resume after multi-undo (fewer messages)", async () => {
+  it("forks session on multi-undo (fewer messages)", async () => {
     const app = createTestApp()
 
-    // Build up 3 turns
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
     ], "sdk-1")
@@ -220,15 +272,15 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "step 3" },
     ], "sdk-1")
 
-    // Multi-undo back to turn 1, send new message
+    // Multi-undo back to turn 1 → fork
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "completely different" },
     ], "sdk-new")
 
-    // Should NOT resume — fewer messages than stored + content changed
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
   })
 
   it("does NOT resume when earlier message is edited", async () => {
@@ -244,7 +296,7 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "how are you?" },
     ], "sdk-1")
 
-    // Edit the first message
+    // Edit the first message (short conversation — no suffix overlap)
     await post(app, "sess-1", [
       { role: "user", content: "EDITED hello" },
       { role: "assistant", content: "hi" },
@@ -253,35 +305,35 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "great" },
     ], "sdk-new")
 
-    // Should NOT resume — first message was edited, lineage broken
     expect(capturedQueryParams?.options?.resume).toBeUndefined()
   })
 
-  it("resumes correctly after undo when a NEW session starts", async () => {
+  it("undo forks then subsequent turns resume the fork", async () => {
     const app = createTestApp()
 
-    // Turn 1
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
     ], "sdk-1")
 
-    // Turn 2
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "remember X" },
     ], "sdk-1")
 
-    // /undo + new message → starts fresh (no resume)
+    // Undo + new message → forks from sdk-1, gets new session sdk-2
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "forget about X" },
     ], "sdk-2")
 
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    // Should fork from original session
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
 
-    // Now continuing from the NEW session should resume with sdk-2
+    // Continuing from the fork should resume with sdk-2
+    capturedQueryParams = null
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
@@ -291,61 +343,394 @@ describe("Session lineage: undo detection", () => {
     ], "sdk-2")
 
     expect(capturedQueryParams?.options?.resume).toBe("sdk-2")
+    expect(capturedQueryParams?.options?.forkSession).toBeUndefined()
   })
 })
 
-describe("Session lastAccess refresh on lookup", () => {
-  it("keeps actively-used sessions alive in LRU by refreshing lastAccess", async () => {
+// ---------------------------------------------------------------------------
+// Scenarios 5-7: Compaction
+// ---------------------------------------------------------------------------
+
+describe("Session lineage: compaction survival", () => {
+  it("resumes after compaction rewrites older messages (suffix preserved)", async () => {
     const app = createTestApp()
 
-    // Create 2 sessions (LRU limit is 1000 in tests, so no eviction pressure,
-    // but we can verify resume works across multiple lookups — proving the
-    // session stays accessible and its timestamp is refreshed)
+    // Build a 9-message conversation
+    await post(app, "sess-c", [{ role: "user", content: "hello" }], "sdk-c")
 
-    // Session A — created first
-    await post(app, "sess-A", [
-      { role: "user", content: "session A" },
-    ], "sdk-A")
+    await post(app, "sess-c", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "topic A" },
+    ], "sdk-c")
 
-    // Session B — created second
-    await post(app, "sess-B", [
-      { role: "user", content: "session B" },
-    ], "sdk-B")
+    await post(app, "sess-c", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "topic A" },
+      { role: "assistant", content: "A explained" },
+      { role: "user", content: "topic B" },
+    ], "sdk-c")
 
-    // Come back to session A much later — should still resume
+    await post(app, "sess-c", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "topic A" },
+      { role: "assistant", content: "A explained" },
+      { role: "user", content: "topic B" },
+      { role: "assistant", content: "B explained" },
+      { role: "user", content: "topic C" },
+    ], "sdk-c")
+
+    await post(app, "sess-c", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "topic A" },
+      { role: "assistant", content: "A explained" },
+      { role: "user", content: "topic B" },
+      { role: "assistant", content: "B explained" },
+      { role: "user", content: "topic C" },
+      { role: "assistant", content: "C explained" },
+      { role: "user", content: "topic D" },
+    ], "sdk-c")
+
+    // Compaction: beginning summarised, last 4 messages + 2 new
     capturedQueryParams = null
-    await post(app, "sess-A", [
-      { role: "user", content: "session A" },
-      { role: "assistant", content: "ok" },
-      { role: "user", content: "still here?" },
-    ], "sdk-A")
+    await post(app, "sess-c", [
+      { role: "user", content: "[Summary: A, B and C discussed]" },
+      { role: "assistant", content: "C explained" },
+      { role: "user", content: "topic D" },
+      { role: "assistant", content: "D explained" },
+      { role: "user", content: "topic E" },
+    ], "sdk-c")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-c")
+  })
 
-    // And again — third access to same session, still resumes
+  it("resumes after compaction reduces message count", async () => {
+    const app = createTestApp()
+
+    // Build to 9 messages
+    const msgs: Array<{ role: string; content: string }> = []
+    for (let i = 1; i <= 5; i++) {
+      msgs.push({ role: "user", content: `step ${i}` })
+      if (i < 5) msgs.push({ role: "assistant", content: `done ${i}` })
+      await post(app, "sess-s", [...msgs], "sdk-s")
+    }
+
+    // Compaction: 9 msgs → 7 (summary + preserved tail + new)
     capturedQueryParams = null
-    await post(app, "sess-A", [
-      { role: "user", content: "session A" },
-      { role: "assistant", content: "ok" },
-      { role: "user", content: "still here?" },
-      { role: "assistant", content: "yes" },
-      { role: "user", content: "one more" },
-    ], "sdk-A")
+    await post(app, "sess-s", [
+      { role: "user", content: "[Summary: steps 1-3]" },
+      { role: "assistant", content: "done 3" },
+      { role: "user", content: "step 4" },
+      { role: "assistant", content: "done 4" },
+      { role: "user", content: "step 5" },
+      { role: "assistant", content: "done 5" },
+      { role: "user", content: "step 6" },
+    ], "sdk-s")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-s")
+  })
+
+  it("does NOT resume when both prefix AND suffix changed (real branch)", async () => {
+    const app = createTestApp()
+
+    await post(app, "sess-b", [{ role: "user", content: "hello" }], "sdk-b")
+
+    await post(app, "sess-b", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "do task A" },
+    ], "sdk-b")
+
+    await post(app, "sess-b", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "do task A" },
+      { role: "assistant", content: "done with A" },
+      { role: "user", content: "now do B" },
+    ], "sdk-b")
+
+    // Completely different direction
+    capturedQueryParams = null
+    await post(app, "sess-b", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "do task C instead" },
+      { role: "assistant", content: "ok doing C" },
+      { role: "user", content: "continue with C" },
+    ], "sdk-new")
+
+    // Prefix overlap (hello, hi) → undo detected → forks from rollback point
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-b")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(capturedQueryParams?.options?.resumeSessionAt).toBeDefined()
+  })
+
+  it("rejects aggressive compaction where nothing is preserved", async () => {
+    const app = createTestApp()
+
+    await post(app, "sess-agg", [{ role: "user", content: "start" }], "sdk-agg")
+    await post(app, "sess-agg", [
+      { role: "user", content: "start" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "continue" },
+    ], "sdk-agg")
+
+    // Nothing from the original survives
+    capturedQueryParams = null
+    await post(app, "sess-agg", [
+      { role: "user", content: "[Full summary of everything]" },
+      { role: "assistant", content: "I understand the summary" },
+      { role: "user", content: "now do something new" },
+    ], "sdk-new")
+
+    expect(capturedQueryParams?.options?.resume).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Scenario 8: Pruning (middle messages modified)
+// ---------------------------------------------------------------------------
+
+describe("Session lineage: pruning survival", () => {
+  it("resumes when middle messages are pruned (tool outputs removed)", async () => {
+    const app = createTestApp()
+
+    // Build a conversation where middle messages will be "pruned"
+    const fullConvo = [
+      { role: "user", content: "start project" },
+      { role: "assistant", content: "reading files..." },
+      { role: "user", content: "tool result: file contents here" },
+      { role: "assistant", content: "I see the files" },
+      { role: "user", content: "now edit them" },
+      { role: "assistant", content: "editing..." },
+      { role: "user", content: "tool result: edit applied" },
+      { role: "assistant", content: "done editing" },
+      { role: "user", content: "run tests" },
+    ]
+
+    // Build up incrementally
+    for (let i = 0; i < fullConvo.length; i += 2) {
+      await post(app, "sess-p", fullConvo.slice(0, i + 1), "sdk-p")
+    }
+
+    // Pruning: tool outputs in messages 2 and 6 are replaced with truncated versions
+    capturedQueryParams = null
+    await post(app, "sess-p", [
+      { role: "user", content: "start project" },           // same
+      { role: "assistant", content: "reading files..." },    // same
+      { role: "user", content: "[pruned tool output]" },     // PRUNED
+      { role: "assistant", content: "I see the files" },     // same
+      { role: "user", content: "now edit them" },            // same
+      { role: "assistant", content: "editing..." },          // same
+      { role: "user", content: "[pruned tool output]" },     // PRUNED
+      { role: "assistant", content: "done editing" },        // same
+      { role: "user", content: "run tests" },                // same
+      { role: "assistant", content: "tests passed" },        // new
+      { role: "user", content: "deploy" },                   // new
+    ], "sdk-p")
+
+    // Should resume — suffix (last 2+) of stored messages preserved
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-p")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenarios 9-11: Multiple compactions and post-compaction behavior
+// ---------------------------------------------------------------------------
+
+describe("Session lineage: post-compaction behavior", () => {
+  it("normal resume works after compaction is accepted", async () => {
+    const app = createTestApp()
+
+    // Build to 9 messages
+    await post(app, "sess-pc", [{ role: "user", content: "hello" }], "sdk-pc")
+    await post(app, "sess-pc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+    ], "sdk-pc")
+    await post(app, "sess-pc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A done" },
+      { role: "user", content: "B" },
+    ], "sdk-pc")
+    await post(app, "sess-pc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A done" },
+      { role: "user", content: "B" },
+      { role: "assistant", content: "B done" },
+      { role: "user", content: "C" },
+    ], "sdk-pc")
+    await post(app, "sess-pc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A done" },
+      { role: "user", content: "B" },
+      { role: "assistant", content: "B done" },
+      { role: "user", content: "C" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+    ], "sdk-pc")
+
+    // Compaction
+    await post(app, "sess-pc", [
+      { role: "user", content: "[Summary: A B C]" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+      { role: "assistant", content: "D done" },
+      { role: "user", content: "E" },
+    ], "sdk-pc")
+
+    // Normal follow-up after compaction
+    capturedQueryParams = null
+    await post(app, "sess-pc", [
+      { role: "user", content: "[Summary: A B C]" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+      { role: "assistant", content: "D done" },
+      { role: "user", content: "E" },
+      { role: "assistant", content: "E done" },
+      { role: "user", content: "F" },
+    ], "sdk-pc")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-pc")
+  })
+
+  it("second compaction is also detected correctly", async () => {
+    const app = createTestApp()
+
+    // Build to 9 messages
+    const topics = ["A", "B", "C", "D"]
+    let msgs: Array<{ role: string; content: string }> = []
+    for (const t of topics) {
+      msgs.push({ role: "user", content: t })
+      await post(app, "sess-2c", [...msgs], "sdk-2c")
+      msgs.push({ role: "assistant", content: `${t} done` })
+      await post(app, "sess-2c", [...msgs], "sdk-2c")
+    }
+    msgs.push({ role: "user", content: "E" })
+    await post(app, "sess-2c", [...msgs], "sdk-2c")
+
+    // First compaction
+    await post(app, "sess-2c", [
+      { role: "user", content: "[Summary: A B C]" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+      { role: "assistant", content: "D done" },
+      { role: "user", content: "E" },
+      { role: "assistant", content: "E done" },
+      { role: "user", content: "F" },
+    ], "sdk-2c")
+
+    // Continue to build up again
+    await post(app, "sess-2c", [
+      { role: "user", content: "[Summary: A B C]" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+      { role: "assistant", content: "D done" },
+      { role: "user", content: "E" },
+      { role: "assistant", content: "E done" },
+      { role: "user", content: "F" },
+      { role: "assistant", content: "F done" },
+      { role: "user", content: "G" },
+    ], "sdk-2c")
+
+    // Second compaction
+    capturedQueryParams = null
+    await post(app, "sess-2c", [
+      { role: "user", content: "[Summary: A-F]" },
+      { role: "assistant", content: "F done" },
+      { role: "user", content: "G" },
+      { role: "assistant", content: "G done" },
+      { role: "user", content: "H" },
+    ], "sdk-2c")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-2c")
+  })
+
+  it("undo after compaction is correctly rejected", async () => {
+    const app = createTestApp()
+
+    // Build to 9 messages
+    await post(app, "sess-uc", [{ role: "user", content: "hello" }], "sdk-uc")
+    await post(app, "sess-uc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+    ], "sdk-uc")
+    await post(app, "sess-uc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A done" },
+      { role: "user", content: "B" },
+    ], "sdk-uc")
+    await post(app, "sess-uc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A done" },
+      { role: "user", content: "B" },
+      { role: "assistant", content: "B done" },
+      { role: "user", content: "C" },
+    ], "sdk-uc")
+    await post(app, "sess-uc", [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "A" },
+      { role: "assistant", content: "A done" },
+      { role: "user", content: "B" },
+      { role: "assistant", content: "B done" },
+      { role: "user", content: "C" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+    ], "sdk-uc")
+
+    // Compaction
+    await post(app, "sess-uc", [
+      { role: "user", content: "[Summary: A B C]" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+      { role: "assistant", content: "D done" },
+      { role: "user", content: "E" },
+    ], "sdk-uc")
+
+    // Undo after compaction — end changes, forks from rollback point
+    capturedQueryParams = null
+    await post(app, "sess-uc", [
+      { role: "user", content: "[Summary: A B C]" },
+      { role: "assistant", content: "C done" },
+      { role: "user", content: "D" },
+      { role: "assistant", content: "D done" },
+      { role: "user", content: "DIFFERENT from E" },
+    ], "sdk-new")
+
+    // Prefix overlap (Summary, C done, D, D done match) → undo → fork
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-uc")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario 12: Fingerprint fallback (no session header)
+// ---------------------------------------------------------------------------
 
 describe("Session lineage: fingerprint fallback", () => {
   it("does NOT resume via fingerprint after undo", async () => {
     const app = createTestApp()
 
-    // No session header — uses fingerprint (hash of first user message)
     await post(app, "", [
       { role: "user", content: "Good evening" },
     ], "sdk-fp1")
 
-    // Manually clear session header, send via fingerprint
     queuedSessionIds.push("sdk-fp1")
     const r1 = await app.fetch(new Request("http://localhost/v1/messages", {
       method: "POST",
@@ -361,7 +746,7 @@ describe("Session lineage: fingerprint fallback", () => {
     }))
     await r1.json()
 
-    // Undo + new message, still no session header
+    // Undo + new message
     queuedSessionIds.push("sdk-fp-new")
     capturedQueryParams = null
     const r2 = await app.fetch(new Request("http://localhost/v1/messages", {
@@ -378,7 +763,46 @@ describe("Session lineage: fingerprint fallback", () => {
     }))
     await r2.json()
 
-    // Should NOT resume — fingerprint matches but lineage diverged
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    // Prefix overlap (Good evening, Hi!) → undo → fork via fingerprint
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-fp1")
+    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// LRU / session refresh
+// ---------------------------------------------------------------------------
+
+describe("Session lastAccess refresh on lookup", () => {
+  it("keeps actively-used sessions alive in LRU by refreshing lastAccess", async () => {
+    const app = createTestApp()
+
+    await post(app, "sess-A", [
+      { role: "user", content: "session A" },
+    ], "sdk-A")
+
+    await post(app, "sess-B", [
+      { role: "user", content: "session B" },
+    ], "sdk-B")
+
+    capturedQueryParams = null
+    await post(app, "sess-A", [
+      { role: "user", content: "session A" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "still here?" },
+    ], "sdk-A")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+
+    capturedQueryParams = null
+    await post(app, "sess-A", [
+      { role: "user", content: "session A" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "still here?" },
+      { role: "assistant", content: "yes" },
+      { role: "user", content: "one more" },
+    ], "sdk-A")
+
+    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
   })
 })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -26,15 +26,31 @@ import type { RequestMetric } from "../telemetry"
 
 // --- Session Tracking ---
 // Maps OpenCode session ID (or fingerprint) → Claude SDK session ID
+/** Minimum suffix overlap (stored messages found at the end of incoming)
+ *  required to classify a mutation as compaction rather than a branch. */
+const MIN_SUFFIX_FOR_COMPACTION = 2
+
 interface SessionState {
   claudeSessionId: string
   lastAccess: number
   messageCount: number
-  /** Hash of messages[0..messageCount-1] for lineage verification.
-   *  Resume is only safe when the incoming messages are a strict prefix-extension
-   *  of what the SDK session has seen. If the hash doesn't match, history has
-   *  diverged (undo, edit, branch) and we must start a fresh session. */
+  /** Hash of messages[0..messageCount-1] for fast-path lineage verification.
+   *  When the full prefix matches, the conversation is a strict continuation
+   *  and we skip the per-message diff entirely. */
   lineageHash: string
+  /** Per-message content hashes from the last stored request.
+   *  Used for precise diff-based mutation classification when the aggregate
+   *  lineageHash mismatches.  By comparing which stored hashes survive in the
+   *  incoming messages we can deterministically distinguish:
+   *    - Compaction  (beginning changed, end preserved → suffix overlap)
+   *    - Undo/branch (beginning preserved, end changed  → prefix-only overlap)
+   *    - Pruning     (middle changed, both ends preserved)  */
+  messageHashes?: string[]
+  /** SDK assistant message UUIDs indexed by message position.
+   *  Only assistant messages have UUIDs (user messages are null).
+   *  Used to find the rollback point for undo: the last matching
+   *  assistant message UUID becomes the `resumeSessionAt` target. */
+  sdkMessageUuids?: Array<string | null>
 }
 
 const DEFAULT_MAX_SESSIONS = 1000
@@ -173,8 +189,8 @@ function normalizeContent(content: any): string {
 
 /**
  * Compute a lineage hash of an ordered message array.
- * Used to verify that the incoming conversation is a strict prefix-extension
- * of what the SDK session has seen. Covers undo, edit, branch detection.
+ * Used as a fast-path check: if the aggregate hash matches, the messages
+ * are an exact prefix-extension and we skip the per-message diff.
  */
 export function computeLineageHash(messages: Array<{ role: string; content: any }>): string {
   if (!messages || messages.length === 0) return ""
@@ -183,34 +199,150 @@ export function computeLineageHash(messages: Array<{ role: string; content: any 
 }
 
 /**
+ * Compute a content hash for a single message (role + normalised content).
+ * Used to build per-message hash arrays for precise diff-based verification.
+ */
+export function hashMessage(message: { role: string; content: any }): string {
+  return createHash("sha256")
+    .update(`${message.role}:${normalizeContent(message.content)}`)
+    .digest("hex")
+    .slice(0, 32)
+}
+
+/**
+ * Compute per-message hashes for an entire message array.
+ */
+export function computeMessageHashes(messages: Array<{ role: string; content: any }>): string[] {
+  if (!messages || messages.length === 0) return []
+  return messages.map(hashMessage)
+}
+
+/**
+ * Measure how many stored hashes match from the START of the stored array
+ * against the incoming hashes (order-preserving).
+ *
+ * Prefix overlap means the beginning of the conversation is intact (undo
+ * changes the end but preserves the beginning).
+ */
+function measurePrefixOverlap(storedHashes: string[], incomingSet: Set<string>): number {
+  let overlap = 0
+  for (const h of storedHashes) {
+    if (incomingSet.has(h)) overlap++
+    else break
+  }
+  return overlap
+}
+
+/**
+ * Measure how many stored hashes match from the END of the stored array
+ * against the incoming hashes (order-preserving).
+ *
+ * Suffix overlap means the recent conversation is intact (compaction
+ * changes the beginning but preserves the end).
+ */
+function measureSuffixOverlap(storedHashes: string[], incomingSet: Set<string>): number {
+  let overlap = 0
+  for (let i = storedHashes.length - 1; i >= 0; i--) {
+    if (incomingSet.has(storedHashes[i]!)) overlap++
+    else break
+  }
+  return overlap
+}
+
+/**
+ * Result of lineage verification — classifies the mutation and provides
+ * the information needed to take the correct SDK action.
+ */
+export type LineageResult =
+  | { type: "continuation"; session: SessionState }
+  | { type: "compaction";   session: SessionState }
+  | { type: "undo";         session: SessionState; prefixOverlap: number; rollbackUuid: string | undefined }
+  | { type: "diverged" }
+
+/**
  * Verify that incoming messages are a valid continuation of a cached session.
- * Returns the session if lineage is intact, undefined if history has diverged.
+ * Uses per-message hash comparison to deterministically classify mutations.
+ *
+ * Decision matrix:
+ *   Full prefix match (fast-path)          → continuation (resume normally)
+ *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume normally)
+ *   Prefix overlap > 0, no suffix          → undo         (fork at rollback point)
+ *   No overlap                             → diverged     (start fresh)
  */
 function verifyLineage(
   cached: SessionState,
   messages: Array<{ role: string; content: any }>,
   cacheKey: string,
   cache: typeof sessionCache | typeof fingerprintCache
-): SessionState | undefined {
+): LineageResult {
   // No stored lineage (legacy entry or first request) — allow resume
-  if (!cached.lineageHash || cached.messageCount === 0) return cached
-
-  // Messages were truncated — more removed than added (multi-undo)
-  if (messages.length < cached.messageCount) {
-    cache.delete(cacheKey)
-    return undefined
+  if (!cached.lineageHash || cached.messageCount === 0) {
+    return { type: "continuation", session: cached }
   }
 
-  // Verify the prefix matches what the SDK session saw
+  // --- Fast path: aggregate lineage hash ---
   const prefix = messages.slice(0, cached.messageCount)
   const prefixHash = computeLineageHash(prefix)
-  if (prefixHash !== cached.lineageHash) {
-    // History diverged (undo, edit, branch) — invalidate and start fresh
-    cache.delete(cacheKey)
-    return undefined
+  if (prefixHash === cached.lineageHash) {
+    return { type: "continuation", session: cached }
   }
 
-  return cached
+  // --- Slow path: per-message diff ---
+  if (!cached.messageHashes || cached.messageHashes.length === 0) {
+    // No per-message hashes stored (legacy session). Can't diff — reject.
+    cache.delete(cacheKey)
+    return { type: "diverged" }
+  }
+
+  const incomingHashes = computeMessageHashes(messages)
+  const incomingSet = new Set(incomingHashes)
+
+  const prefixOverlap = measurePrefixOverlap(cached.messageHashes, incomingSet)
+  const suffixOverlap = measureSuffixOverlap(cached.messageHashes, incomingSet)
+
+  // Compaction: suffix preserved, long enough conversation
+  const MIN_STORED_FOR_COMPACTION = 6
+  if (
+    suffixOverlap >= MIN_SUFFIX_FOR_COMPACTION &&
+    cached.messageHashes.length >= MIN_STORED_FOR_COMPACTION
+  ) {
+    console.error(
+      `[PROXY] Compaction detected (key=${cacheKey.slice(0, 8)}…): ` +
+      `suffix overlap ${suffixOverlap}/${cached.messageHashes.length}. Allowing resume.`
+    )
+    cached.lineageHash = computeLineageHash(messages)
+    cached.messageHashes = incomingHashes
+    cached.messageCount = messages.length
+    return { type: "compaction", session: cached }
+  }
+
+  // Undo: prefix preserved (beginning intact) but suffix changed
+  if (prefixOverlap > 0 && suffixOverlap === 0) {
+    // Find the SDK UUID at the last matching position.
+    // The last matching stored message is at index (prefixOverlap - 1).
+    // We need the most recent ASSISTANT UUID at or before that position.
+    let rollbackUuid: string | undefined
+    if (cached.sdkMessageUuids) {
+      for (let i = prefixOverlap - 1; i >= 0; i--) {
+        if (cached.sdkMessageUuids[i]) {
+          rollbackUuid = cached.sdkMessageUuids[i]!
+          break
+        }
+      }
+    }
+    console.error(
+      `[PROXY] Undo detected (key=${cacheKey.slice(0, 8)}…): ` +
+      `prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, ` +
+      `rollback UUID: ${rollbackUuid || "none (legacy session)"}.`
+    )
+    // Don't delete the cache entry — we keep the original session for reference.
+    // The caller will fork it.
+    return { type: "undo", session: cached, prefixOverlap, rollbackUuid }
+  }
+
+  // No meaningful overlap — completely different conversation.
+  cache.delete(cacheKey)
+  return { type: "diverged" }
 }
 
 /** Refresh lastAccess on a verified session so LRU eviction reflects actual usage */
@@ -219,17 +351,20 @@ function touchSession(state: SessionState): SessionState {
   return state
 }
 
-/** Look up a cached session by header or fingerprint */
+/** Look up a cached session by header or fingerprint.
+ *  Returns a LineageResult that classifies the mutation and includes the
+ *  session state needed for the correct SDK action. */
 function lookupSession(
   opencodeSessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
   workingDirectory?: string
-): SessionState | undefined {
+): LineageResult {
   if (opencodeSessionId) {
     const cached = sessionCache.get(opencodeSessionId)
     if (cached) {
-      const verified = verifyLineage(cached, messages, opencodeSessionId, sessionCache)
-      return verified ? touchSession(verified) : undefined
+      const result = verifyLineage(cached, messages, opencodeSessionId, sessionCache)
+      if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
+      return result
     }
     const shared = lookupSharedSession(opencodeSessionId)
     if (shared) {
@@ -238,20 +373,25 @@ function lookupSession(
         lastAccess: Date.now(),
         messageCount: shared.messageCount || 0,
         lineageHash: shared.lineageHash || "",
+        messageHashes: shared.messageHashes,
+        sdkMessageUuids: shared.sdkMessageUuids,
       }
-      const verified = verifyLineage(state, messages, opencodeSessionId, sessionCache)
-      if (verified) sessionCache.set(opencodeSessionId, state)
-      return verified
+      const result = verifyLineage(state, messages, opencodeSessionId, sessionCache)
+      if (result.type === "continuation" || result.type === "compaction") {
+        sessionCache.set(opencodeSessionId, state)
+      }
+      return result
     }
-    return undefined
+    return { type: "diverged" }
   }
 
   const fp = getConversationFingerprint(messages, workingDirectory)
   if (fp) {
     const cached = fingerprintCache.get(fp)
     if (cached) {
-      const verified = verifyLineage(cached, messages, fp, fingerprintCache)
-      return verified ? touchSession(verified) : undefined
+      const result = verifyLineage(cached, messages, fp, fingerprintCache)
+      if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
+      return result
     }
     const shared = lookupSharedSession(fp)
     if (shared) {
@@ -260,29 +400,39 @@ function lookupSession(
         lastAccess: Date.now(),
         messageCount: shared.messageCount || 0,
         lineageHash: shared.lineageHash || "",
+        messageHashes: shared.messageHashes,
+        sdkMessageUuids: shared.sdkMessageUuids,
       }
-      const verified = verifyLineage(state, messages, fp, fingerprintCache)
-      if (verified) fingerprintCache.set(fp, state)
-      return verified
+      const result = verifyLineage(state, messages, fp, fingerprintCache)
+      if (result.type === "continuation" || result.type === "compaction") {
+        fingerprintCache.set(fp, state)
+      }
+      return result
     }
   }
-  return undefined
+  return { type: "diverged" }
 }
 
-/** Store a session mapping with lineage hash for divergence detection */
+/** Store a session mapping with lineage hash and SDK UUIDs for divergence detection.
+ *  @param sdkMessageUuids — per-message SDK assistant UUIDs (null for user messages).
+ *    If provided, merged with any previously stored UUIDs to build a complete map. */
 function storeSession(
   opencodeSessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
   claudeSessionId: string,
-  workingDirectory?: string
+  workingDirectory?: string,
+  sdkMessageUuids?: Array<string | null>
 ) {
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
+  const messageHashes = computeMessageHashes(messages)
   const state: SessionState = {
     claudeSessionId,
     lastAccess: Date.now(),
     messageCount: messages?.length || 0,
     lineageHash,
+    messageHashes,
+    sdkMessageUuids,
   }
   // In-memory cache
   if (opencodeSessionId) sessionCache.set(opencodeSessionId, state)
@@ -290,7 +440,7 @@ function storeSession(
   if (fp) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = opencodeSessionId || fp
-  if (key) storeSharedSession(key, claudeSessionId, state.messageCount, lineageHash)
+  if (key) storeSharedSession(key, claudeSessionId, state.messageCount, lineageHash, messageHashes, sdkMessageUuids)
 }
 
 /** Extract only the last user message (for resume — SDK already has history) */
@@ -579,11 +729,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           }
         }
 
-        // Session resume: look up cached Claude SDK session
+        // Session resume: look up cached Claude SDK session and classify mutation
         const opencodeSessionId = c.req.header("x-opencode-session")
-        const cachedSession = lookupSession(opencodeSessionId, body.messages || [], workingDirectory)
+        const lineageResult = lookupSession(opencodeSessionId, body.messages || [], workingDirectory)
+        const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
+        const isUndo = lineageResult.type === "undo"
+        const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         const resumeSessionId = cachedSession?.claudeSessionId
-        const isResume = Boolean(resumeSessionId)
+        // For undo: fork the session at the rollback point
+        const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
 
         // Debug: log request details
         const msgSummary = body.messages?.map((m: any) => {
@@ -592,7 +746,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             : "string"
           return `${m.role}[${contentTypes}]`
         }).join(" → ")
-        console.error(`[PROXY] ${requestMeta.requestId} model=${model} stream=${stream} tools=${body.tools?.length ?? 0} resume=${isResume} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgs=${msgSummary}`)
+        const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
+        const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
+        console.error(`[PROXY] ${requestMeta.requestId} model=${model} stream=${stream} tools=${body.tools?.length ?? 0} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount} msgs=${msgSummary}`)
 
         claudeLog("request.received", {
           model,
@@ -630,11 +786,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const allMessages = body.messages || []
       let messagesToConvert: typeof allMessages
 
-      if (isResume && cachedSession) {
-        const knownCount = cachedSession.messageCount || 0
-        if (knownCount > 0 && knownCount < allMessages.length) {
-          messagesToConvert = allMessages.slice(knownCount)
+      if ((isResume || isUndo) && cachedSession) {
+        if (isUndo && undoRollbackUuid) {
+          // Undo with SDK rollback: the SDK will fork to the correct point,
+          // so we only need to send the new user message.
+          messagesToConvert = getLastUserMessage(allMessages)
+        } else if (isResume) {
+          const knownCount = cachedSession.messageCount || 0
+          if (knownCount > 0 && knownCount < allMessages.length) {
+            messagesToConvert = allMessages.slice(knownCount)
+          } else {
+            messagesToConvert = getLastUserMessage(allMessages)
+          }
         } else {
+          // Undo without UUID (legacy session) — fall back to last user message
+          // to avoid the catastrophic flat text replay.
           messagesToConvert = getLastUserMessage(allMessages)
         }
       } else {
@@ -810,6 +976,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           let firstChunkAt: number | undefined
           let currentSessionId: string | undefined
 
+          // Build SDK UUID map: start with previously stored UUIDs (if resuming),
+          // then capture new ones from the response. Declared outside try so
+          // storeSession (in the finally/after block) can access it.
+          const sdkUuidMap: Array<string | null> = cachedSession?.sdkMessageUuids
+            ? [...cachedSession.sdkMessageUuids]
+            : new Array(allMessages.length - 1).fill(null)
+          // Pad to current message count (the last user message has no UUID yet)
+          while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
+
           claudeLog("upstream.start", { mode: "non_stream", model })
 
           try {
@@ -821,14 +996,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const response = query({
               prompt,
               options: {
-                maxTurns: passthrough ? 1 : 100,
+                maxTurns: passthrough ? 1 : 200,
                 cwd: workingDirectory,
                 model,
                 pathToClaudeCodeExecutable: claudeExecutable,
                 permissionMode: "bypassPermissions",
                 allowDangerouslySkipPermissions: true,
-                // Pass OpenCode's system prompt (includes AGENTS.md, custom instructions)
-                // as an append to Claude Code's default — preserves the SDK identity.
                 ...(systemContext ? {
                   systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
                 } : {}),
@@ -849,6 +1022,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 env: { ...cleanEnv, ENABLE_TOOL_SEARCH: "false" },
                 ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
                 ...(resumeSessionId ? { resume: resumeSessionId } : {}),
+                ...(isUndo ? { forkSession: true, ...(undoRollbackUuid ? { resumeSessionAt: undoRollbackUuid } : {}) } : {}),
                 ...(sdkHooks ? { hooks: sdkHooks } : {}),
               }
             })
@@ -860,6 +1034,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }
               if (message.type === "assistant") {
                 assistantMessages += 1
+                // Capture SDK assistant UUID for undo rollback
+                if ((message as any).uuid) {
+                  sdkUuidMap.push((message as any).uuid)
+                }
                 if (!firstChunkAt) {
                   firstChunkAt = Date.now()
                   claudeLog("upstream.first_chunk", {
@@ -944,6 +1122,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             mode: "non-stream",
             isResume,
             isPassthrough: passthrough,
+            lineageType,
+            messageCount: allMessages.length,
+            sdkSessionId: currentSessionId || resumeSessionId,
             status: 200,
             queueWaitMs: nonStreamQueueWaitMs,
             proxyOverheadMs: upstreamStartAt - requestStartAt - nonStreamQueueWaitMs,
@@ -957,7 +1138,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
           // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory, sdkUuidMap)
               }
 
               const responseSessionId = currentSessionId || resumeSessionId || `session_${Date.now()}`
@@ -1013,20 +1194,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }
             }
 
+            // Build SDK UUID map for the streaming path (declared before try for storeSession access)
+            const sdkUuidMap: Array<string | null> = cachedSession?.sdkMessageUuids
+              ? [...cachedSession.sdkMessageUuids]
+              : new Array(allMessages.length - 1).fill(null)
+            while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
+
             try {
               let currentSessionId: string | undefined
               const response = query({
                 prompt,
                 options: {
-                  maxTurns: passthrough ? 1 : 100,
+                  maxTurns: passthrough ? 1 : 200,
                   cwd: workingDirectory,
                   model,
                   pathToClaudeCodeExecutable: claudeExecutable,
                   includePartialMessages: true,
                   permissionMode: "bypassPermissions",
                   allowDangerouslySkipPermissions: true,
-                  // Pass OpenCode's system prompt (includes AGENTS.md, custom instructions)
-                  // as an append to Claude Code's default — preserves the SDK identity.
                   ...(systemContext ? {
                     systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
                   } : {}),
@@ -1047,6 +1232,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   env: { ...cleanEnv, ENABLE_TOOL_SEARCH: "false" },
                   ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
                   ...(resumeSessionId ? { resume: resumeSessionId } : {}),
+                  ...(isUndo ? { forkSession: true, ...(undoRollbackUuid ? { resumeSessionAt: undoRollbackUuid } : {}) } : {}),
                   ...(sdkHooks ? { hooks: sdkHooks } : {}),
                 }
               })
@@ -1081,9 +1267,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     break
                   }
 
-                  // Capture session ID from any SDK message
+                  // Capture session ID and assistant UUID from any SDK message
                   if ((message as any).session_id) {
                     currentSessionId = (message as any).session_id
+                  }
+                  if (message.type === "assistant" && (message as any).uuid) {
+                    sdkUuidMap.push((message as any).uuid)
                   }
 
                   if (message.type === "stream_event") {
@@ -1181,7 +1370,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory, sdkUuidMap)
               }
 
               if (!streamClosed) {
@@ -1266,6 +1455,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   mode: "stream",
                   isResume,
                   isPassthrough: passthrough,
+                  lineageType,
+                  messageCount: allMessages.length,
+                  sdkSessionId: currentSessionId || resumeSessionId,
                   status: 200,
                   queueWaitMs: streamQueueWaitMs,
                   proxyOverheadMs: upstreamStartAt - requestStartAt - streamQueueWaitMs,
@@ -1350,6 +1542,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           mode: "non-stream",
           isResume: false,
           isPassthrough: Boolean(process.env.CLAUDE_PROXY_PASSTHROUGH),
+          lineageType: undefined,
+          messageCount: undefined,
+          sdkSessionId: undefined,
           status: classified.status,
           queueWaitMs: errorQueueWaitMs,
           proxyOverheadMs: Date.now() - requestStartAt - errorQueueWaitMs,

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -31,6 +31,10 @@ export interface StoredSession {
   messageCount: number
   /** Hash of messages[0..messageCount-1] for conversation lineage verification */
   lineageHash?: string
+  /** Per-message content hashes for precise diff-based compaction detection */
+  messageHashes?: string[]
+  /** Per-message SDK assistant UUIDs for undo rollback (null for user messages) */
+  sdkMessageUuids?: Array<string | null>
 }
 
 // No time-based session expiry. SDK sessions persist on Anthropic's side
@@ -127,7 +131,7 @@ export function lookupSharedSession(key: string): StoredSession | undefined {
   return store[key]
 }
 
-export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number, lineageHash?: string): void {
+export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number, lineageHash?: string, messageHashes?: string[], sdkMessageUuids?: Array<string | null>): void {
   const path = getStorePath()
   const lockPath = `${path}.lock`
   const hasLock = acquireLock(lockPath)
@@ -143,6 +147,8 @@ export function storeSharedSession(key: string, claudeSessionId: string, message
       lastUsedAt: Date.now(),
       messageCount: messageCount ?? existing?.messageCount ?? 0,
       lineageHash: lineageHash ?? existing?.lineageHash,
+      messageHashes: messageHashes ?? existing?.messageHashes,
+      sdkMessageUuids: sdkMessageUuids ?? existing?.sdkMessageUuids,
     }
 
     // Prune oldest entries if over capacity (count-based, not time-based)

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -164,7 +164,7 @@ function render(s, reqs) {
     + '<span><span class="legend-dot" style="background:var(--ttfb)"></span>TTFB</span>'
     + '<span><span class="legend-dot" style="background:var(--upstream)"></span>Response</span>'
     + '</div>'
-    + '<table><thead><tr><th>Time</th><th>Model</th><th>Mode</th><th>Status</th>'
+    + '<table><thead><tr><th>Time</th><th>Model</th><th>Mode</th><th>Session</th><th>Status</th>'
     + '<th>Queue</th><th>Proxy</th><th>TTFB</th><th>Total</th><th>Waterfall</th></tr></thead><tbody>';
 
   const maxTotal = Math.max(...reqs.map(r => r.totalDurationMs), 1);
@@ -178,10 +178,15 @@ function render(s, reqs) {
     const ttfbW = Math.max((r.ttfbMs || 0) * scale, 0);
     const respW = Math.max((r.upstreamDurationMs - (r.ttfbMs || 0)) * scale, 2);
 
+    const lineageBadge = r.lineageType ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:' + ({continuation:'var(--green)',compaction:'var(--yellow)',undo:'var(--purple)',diverged:'var(--red)',new:'var(--muted)'}[r.lineageType] || 'var(--muted)') + ';color:var(--bg)">' + r.lineageType + '</span>' : '';
+    const sessionShort = r.sdkSessionId ? r.sdkSessionId.slice(0, 8) : '—';
+    const msgCount = r.messageCount != null ? r.messageCount : '?';
+
     html += '<tr>'
       + '<td class="mono">' + ago(r.timestamp) + '</td>'
       + '<td>' + r.model + '</td>'
       + '<td>' + r.mode + '</td>'
+      + '<td class="mono">' + sessionShort + ' ' + lineageBadge + '<br><span style="font-size:10px;color:var(--muted)">' + msgCount + ' msgs</span></td>'
       + '<td class="' + statusClass + '">' + statusText + '</td>'
       + '<td class="mono">' + ms(r.queueWaitMs) + '</td>'
       + '<td class="mono">' + ms(r.proxyOverheadMs) + '</td>'

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -29,6 +29,20 @@ export interface RequestMetric {
   /** Whether passthrough mode was active */
   isPassthrough: boolean
 
+  /** Session lineage classification: how the incoming messages related to the stored session.
+   *  - continuation: normal follow-up (prefix matched)
+   *  - compaction:   older messages rewritten, recent preserved (suffix matched)
+   *  - undo:         user undid recent messages (prefix preserved, suffix changed) → SDK fork
+   *  - diverged:     no overlap with stored session → fresh start
+   *  - new:          first request, no stored session to compare */
+  lineageType?: "continuation" | "compaction" | "undo" | "diverged" | "new"
+
+  /** Number of messages in the request */
+  messageCount?: number
+
+  /** SDK session ID used for this request (for correlating across turns) */
+  sdkSessionId?: string
+
   /** HTTP status code returned to the client */
   status: number
 


### PR DESCRIPTION
## Summary

Fixes #106 #118 #124 — Complete redesign of session lineage verification to properly handle compaction, undo, and pruning.

## The Problem

The proxy used a single aggregate hash of the entire message array to verify session continuity. Any change to any message broke the hash, causing resume to fail. When resume failed, the entire conversation was replayed as flat text to a new SDK session — producing the "talking to itself" behavior (#106) and tool passthrough failures (#118).

This was triggered by:
- **Compaction**: OpenCode summarizes older messages → hash breaks
- **Undo**: User removes last turn → hash breaks
- **Pruning**: Tool outputs get trimmed → hash breaks

## The Solution

### Per-message content hashing (detection layer)
Instead of one hash for the whole array, we store a hash for each individual message. On each request, we compare which stored hashes survive in the incoming messages:

| Prefix overlap | Suffix overlap | Classification | SDK Action |
|---|---|---|---|
| Full match | — | **Continuation** | `resume: sessionId` |
| — | ≥ 2 | **Compaction** | `resume: sessionId` (update hashes) |
| > 0 | 0 | **Undo** | `resume + resumeSessionAt + forkSession` |
| 0 | 0 | **Diverged** | Fresh session |

### SDK-native undo (execution layer)
We now capture `uuid` from every `SDKAssistantMessage` and store them alongside message hashes. When undo is detected, we use the SDK's built-in `resumeSessionAt` + `forkSession: true` to roll back to the exact correct point — no flat text replay.

### Telemetry
Every request now logs `lineage=continuation|compaction|undo|diverged|new` with session ID, message count, and rollback UUIDs. The dashboard shows a session column with lineage badges.

### maxTurns
Bumped from 100 to 200 to match the Claude SDK's own default.

## Test Results

- 227 unit tests pass (29 lineage-specific covering all scenarios)
- E2E verified: continuation ✅, compaction ✅, undo with rollback UUID ✅, diverged ✅
- Telemetry verified: lineageType, messageCount, sdkSessionId all logged correctly