### PR TITLE
fix: use subscription type to determine sonnet model variant

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -1,10 +1,17 @@
 /**
  * Unit tests for model mapping and utility functions.
  */
-import { describe, it, expect } from "bun:test"
-import { mapModelToClaudeModel, isClosedControllerError } from "../proxy/models"
+import { afterEach, describe, it, expect } from "bun:test"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
+  const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
+
+  afterEach(() => {
+    if (originalSonnetModel === undefined) delete process.env.CLAUDE_PROXY_SONNET_MODEL
+    else process.env.CLAUDE_PROXY_SONNET_MODEL = originalSonnetModel
+    resetCachedClaudeAuthStatus()
+  })
   it("maps opus models to opus[1m]", () => {
     expect(mapModelToClaudeModel("claude-opus-4-5")).toBe("opus[1m]")
     expect(mapModelToClaudeModel("opus")).toBe("opus[1m]")
@@ -16,15 +23,29 @@ describe("mapModelToClaudeModel", () => {
     expect(mapModelToClaudeModel("haiku")).toBe("haiku")
   })
 
-  it("defaults to sonnet[1m] for sonnet models", () => {
-    expect(mapModelToClaudeModel("claude-sonnet-4-5")).toBe("sonnet[1m]")
-    expect(mapModelToClaudeModel("sonnet")).toBe("sonnet[1m]")
-    expect(mapModelToClaudeModel("claude-sonnet-4-5-20250929")).toBe("sonnet[1m]")
+  it("maps sonnet models to sonnet[1m] for max subscriptions", () => {
+    expect(mapModelToClaudeModel("claude-sonnet-4-5", "max")).toBe("sonnet[1m]")
+    expect(mapModelToClaudeModel("sonnet", "max")).toBe("sonnet[1m]")
+    expect(mapModelToClaudeModel("claude-sonnet-4-5-20250929", "max")).toBe("sonnet[1m]")
   })
 
-  it("defaults to sonnet[1m] for unknown models", () => {
-    expect(mapModelToClaudeModel("unknown-model")).toBe("sonnet[1m]")
-    expect(mapModelToClaudeModel("")).toBe("sonnet[1m]")
+  it("maps sonnet models to plain sonnet for non-max subscriptions", () => {
+    expect(mapModelToClaudeModel("claude-sonnet-4-5", "team")).toBe("sonnet")
+    expect(mapModelToClaudeModel("sonnet", "pro")).toBe("sonnet")
+    expect(mapModelToClaudeModel("claude-sonnet-4-5-20250929", "")).toBe("sonnet")
+  })
+
+  it("defaults unknown models to plain sonnet for non-max subscriptions", () => {
+    expect(mapModelToClaudeModel("unknown-model")).toBe("sonnet")
+    expect(mapModelToClaudeModel("", undefined)).toBe("sonnet")
+  })
+
+  it("respects explicit sonnet model override", () => {
+    process.env.CLAUDE_PROXY_SONNET_MODEL = "sonnet[1m]"
+    expect(mapModelToClaudeModel("sonnet", "team")).toBe("sonnet[1m]")
+
+    process.env.CLAUDE_PROXY_SONNET_MODEL = "sonnet"
+    expect(mapModelToClaudeModel("sonnet", "max")).toBe("sonnet")
   })
 })
 

--- a/src/__tests__/proxy-async-ops.test.ts
+++ b/src/__tests__/proxy-async-ops.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 
 const { createProxyServer, startProxyServer } = await import("../proxy/server")
+const { resetCachedClaudeAuthStatus } = await import("../proxy/models")
 const { runCli } = await import("../../bin/cli")
 
 describe("proxy async ops", () => {
@@ -45,6 +46,7 @@ describe("proxy async ops", () => {
   })
 
   it("returns degraded health when auth status command times out", async () => {
+    resetCachedClaudeAuthStatus()
     const originalPath = process.env.PATH
     process.env.PATH = ""
 

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -11,11 +11,47 @@ import { promisify } from "util"
 const exec = promisify(execCallback)
 
 export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku"
+export interface ClaudeAuthStatus {
+  loggedIn?: boolean
+  subscriptionType?: string
+  email?: string
+}
 
-export function mapModelToClaudeModel(model: string): ClaudeModel {
+const AUTH_STATUS_CACHE_TTL_MS = 60_000
+
+let cachedAuthStatus: ClaudeAuthStatus | null = null
+let cachedAuthStatusAt = 0
+let cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null = null
+
+export function mapModelToClaudeModel(model: string, subscriptionType?: string | null): ClaudeModel {
   if (model.includes("opus")) return "opus[1m]"
   if (model.includes("haiku")) return "haiku"
-  return "sonnet[1m]"
+  const sonnetOverride = process.env.CLAUDE_PROXY_SONNET_MODEL
+  if (sonnetOverride === "sonnet" || sonnetOverride === "sonnet[1m]") return sonnetOverride
+  return subscriptionType === "max" ? "sonnet[1m]" : "sonnet"
+}
+
+export async function getClaudeAuthStatusAsync(): Promise<ClaudeAuthStatus | null> {
+  if (cachedAuthStatus && Date.now() - cachedAuthStatusAt < AUTH_STATUS_CACHE_TTL_MS) return cachedAuthStatus
+  if (cachedAuthStatusPromise) return cachedAuthStatusPromise
+
+  cachedAuthStatusPromise = (async () => {
+    try {
+      const { stdout } = await exec("claude auth status", { timeout: 5000 })
+      const parsed = JSON.parse(stdout) as ClaudeAuthStatus
+      cachedAuthStatus = parsed
+      cachedAuthStatusAt = Date.now()
+      return parsed
+    } catch {
+      return null
+    }
+  })()
+
+  try {
+    return await cachedAuthStatusPromise
+  } finally {
+    cachedAuthStatusPromise = null
+  }
 }
 
 // --- Claude Executable Resolution ---
@@ -73,6 +109,13 @@ export async function resolveClaudeExecutableAsync(): Promise<string> {
 export function resetCachedClaudePath(): void {
   cachedClaudePath = null
   cachedClaudePathPromise = null
+}
+
+/** Reset cached auth status — for testing only */
+export function resetCachedClaudeAuthStatus(): void {
+  cachedAuthStatus = null
+  cachedAuthStatusAt = 0
+  cachedAuthStatusPromise = null
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -20,7 +20,7 @@ import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASST
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError } from "./errors"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync } from "./models"
 import { ALLOWED_MCP_TOOLS } from "./tools"
 import { getLastUserMessage } from "./messages"
 import { openCodeAdapter } from "./adapters/opencode"
@@ -108,7 +108,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
       try {
         const body = await c.req.json()
-        const model = mapModelToClaudeModel(body.model || "sonnet")
+        const authStatus = await getClaudeAuthStatusAsync()
+        const model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
         const stream = body.stream ?? true
         const adapter = openCodeAdapter
         const workingDirectory = adapter.extractWorkingDirectory(body) || process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
@@ -938,8 +939,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // Health check endpoint — verifies auth status
   app.get("/health", async (c) => {
     try {
-      const { stdout } = await exec("claude auth status", { timeout: 5000 })
-      const auth = JSON.parse(stdout)
+      const auth = await getClaudeAuthStatusAsync()
+      if (!auth) {
+        return c.json({
+          status: "degraded",
+          error: "Could not verify auth status",
+          mode: process.env.CLAUDE_PROXY_PASSTHROUGH ? "passthrough" : "internal",
+        })
+      }
       if (!auth.loggedIn) {
         return c.json({
           status: "unhealthy",


### PR DESCRIPTION
# Observed behavior

Team subscription works with `claude -p --model sonnet ...`
The proxy maps Sonnet requests to `sonnet[1m]`
`claude -p --model 'sonnet[1m]' ...` returns `API Error: Rate limit reached`

- Proxy rewrites that into `Claude Max rate limit reached. Wait a moment and try again.`
- `claude auth status` reports `subscriptionType: "team"` in this environment
- `opus[1m]` works here, while `sonnet[1m]` does not

## Proposed fix

- Read `subscriptionType` from `claude auth status`
- If `subscriptionType === "max"`, prefer `sonnet[1m]`
- Otherwise use plain `sonnet`
- If a preferred `sonnet[1m]` request fails with access/rate-limit/model-availability errors, retry once with plain `sonnet`
- Preserve upstream error details instead of always rewriting to a Max rate-limit message

## Simpler fix

```ts
export function mapModelToClaudeModel(model: string): ClaudeModel {
  if (model.includes("opus")) return "opus[1m]";
  if (model.includes("haiku")) return "haiku";
  return "sonnet"; // "[1m]" removed
}
```
