### PR TITLE
fix: prevent @hono/node-server from overriding global Response/Request

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -982,6 +982,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     fetch: app.fetch,
     port: finalConfig.port,
     hostname: finalConfig.host,
+    overrideGlobalObjects: false,
   }, (info) => {
     if (!finalConfig.silent) {
       console.log(`Meridian running at http://${finalConfig.host}:${info.port}`)


### PR DESCRIPTION
## Problem

`@hono/node-server`'s `serve()` replaces `global.Response` and `global.Request` with Hono's internal `_Response`/`_Request` wrappers via `Object.defineProperty`. When running under Bun (e.g. as an OpenCode plugin), this breaks `Bun.serve()` which requires native Response objects — producing:

```
error: Expected a Response object, but received '_Response { ... }'
```

This renders the OpenCode web UI unusable, showing Bun's default error page: *"You are seeing this page because the fetch() handler in Bun.serve() did not return a Response object."*

## Fix

Pass `overrideGlobalObjects: false` to `serve()`. This is a built-in option from `@hono/node-server` that skips the global override. The proxy's Hono adapter works fine without it since it references its internal Response/Request classes directly for request handling.

## Change

One line in `src/proxy/server.ts`.