### PR TITLE
fix: retry as fresh session when undo hits stale UUID

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError } from "../proxy/errors"
+import { classifyError, isStaleSessionError } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -132,6 +132,27 @@ describe("classifyError", () => {
     it("detects 'overloaded' keyword", () => {
       const result = classifyError("service overloaded")
       expect(result.status).toBe(503)
+    })
+  })
+
+  describe("stale session detection", () => {
+    it("detects 'No message found with message.uuid' errors", () => {
+      expect(isStaleSessionError(new Error("No message found with message.uuid of: e663b687-6d08-4cc4-b9a9-5245ce8f1e07"))).toBe(true)
+    })
+
+    it("detects the error embedded in longer messages", () => {
+      expect(isStaleSessionError(new Error("claude code returned an error result: No message found with message.uuid of: abc123"))).toBe(true)
+    })
+
+    it("returns false for unrelated errors", () => {
+      expect(isStaleSessionError(new Error("rate limit exceeded"))).toBe(false)
+      expect(isStaleSessionError(new Error("authentication failed"))).toBe(false)
+    })
+
+    it("returns false for non-Error values", () => {
+      expect(isStaleSessionError("No message found with message.uuid")).toBe(false)
+      expect(isStaleSessionError(null)).toBe(false)
+      expect(isStaleSessionError(undefined)).toBe(false)
     })
   })
 

--- a/src/__tests__/proxy-stale-uuid-retry.test.ts
+++ b/src/__tests__/proxy-stale-uuid-retry.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for stale session UUID retry behavior.
+ *
+ * When an undo operation fails because the rollback UUID no longer exists
+ * in the upstream Claude session, the proxy should evict the stale session
+ * and retry as a fresh session instead of propagating the error.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+// Track query calls to verify retry behavior
+let queryCalls: Array<Record<string, any>> = []
+let queryCallCount = 0
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    queryCallCount++
+    const callIndex = queryCallCount
+    queryCalls.push(opts.options || {})
+    const isStreaming = opts.options?.includePartialMessages === true
+
+    return (async function* () {
+      // First call with resumeSessionAt: simulate stale UUID error
+      if (callIndex === 1 && opts.options?.resumeSessionAt) {
+        throw new Error(
+          `No message found with message.uuid of: ${opts.options.resumeSessionAt}`
+        )
+      }
+      // Success: yield appropriate message type
+      if (isStreaming) {
+        yield messageStart(`msg-${callIndex}`)
+        yield textBlockStart(0)
+        yield textDelta(0, `response-${callIndex}`)
+        yield blockStop(0)
+        yield messageDelta("end_turn")
+        yield messageStop()
+      }
+      yield {
+        type: "assistant",
+        uuid: `uuid-${callIndex}`,
+        message: {
+          id: `msg-${callIndex}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: `response-${callIndex}` }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: `sdk-fresh-${callIndex}`,
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    })
+  )
+}
+
+describe("Stale UUID retry", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    queryCalls = []
+    queryCallCount = 0
+  })
+
+  it("retries as fresh session when undo hits stale UUID (non-streaming)", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-stale-test"
+
+    // Seed a cached session with UUIDs (simulates a prior conversation)
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something" },
+      { role: "assistant", content: "done" },
+    ]
+    storeSession(sessionId, messages, "sdk-original", "/tmp/test", [
+      null,
+      "uuid-assistant-1",
+      null,
+      "uuid-assistant-2",
+    ])
+
+    // Send an "undo" request: same prefix but different last message
+    // This triggers undo detection with rollback to uuid-assistant-1
+    const undoMessages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something different" },
+    ]
+
+    const response = await post(
+      app,
+      { model: "sonnet", stream: false, messages: undoMessages },
+      { "x-opencode-session": sessionId }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.content).toBeDefined()
+    expect(body.content.some((b: any) => b.type === "text")).toBe(true)
+
+    // First call should have had resumeSessionAt (the undo attempt)
+    expect(queryCalls[0].resumeSessionAt).toBe("uuid-assistant-1")
+    expect(queryCalls[0].forkSession).toBe(true)
+
+    // Second call should be a fresh session (retry after stale UUID)
+    expect(queryCalls[1].resume).toBeUndefined()
+    expect(queryCalls[1].forkSession).toBeUndefined()
+    expect(queryCalls[1].resumeSessionAt).toBeUndefined()
+  })
+
+  it("retries as fresh session when undo hits stale UUID (streaming)", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-stale-stream"
+
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something" },
+      { role: "assistant", content: "done" },
+    ]
+    storeSession(sessionId, messages, "sdk-original-stream", "/tmp/test", [
+      null,
+      "uuid-assistant-1",
+      null,
+      "uuid-assistant-2",
+    ])
+
+    const undoMessages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something different" },
+    ]
+
+    const response = await post(
+      app,
+      { model: "sonnet", stream: true, messages: undoMessages },
+      { "x-opencode-session": sessionId }
+    )
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    // Should contain SSE events from the retry (not an error)
+    expect(text).toContain("event: message_start")
+    expect(text).not.toContain("No message found with message.uuid")
+
+    // Verify retry happened: first call with resumeSessionAt, second without
+    expect(queryCalls[0].resumeSessionAt).toBe("uuid-assistant-1")
+    expect(queryCalls[1].resumeSessionAt).toBeUndefined()
+  })
+
+  it("evicts stale session from cache after retry", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-stale-evict"
+
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something" },
+      { role: "assistant", content: "done" },
+    ]
+    storeSession(sessionId, messages, "sdk-stale", "/tmp/test", [
+      null,
+      "uuid-assistant-1",
+      null,
+      "uuid-assistant-2",
+    ])
+
+    // First request: undo triggers stale UUID → retry as fresh
+    const undoMessages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "new message" },
+    ]
+
+    const response1 = await post(
+      app,
+      { model: "sonnet", stream: false, messages: undoMessages },
+      { "x-opencode-session": sessionId }
+    )
+    expect(response1.status).toBe(200)
+
+    // Reset tracking
+    queryCalls = []
+    queryCallCount = 0
+
+    // Second request with the same session: should NOT try to resume
+    // the stale session (it was evicted). Instead it should start fresh.
+    const followUpMessages = [
+      ...undoMessages,
+      { role: "assistant", content: "response" },
+      { role: "user", content: "follow up" },
+    ]
+
+    const response2 = await post(
+      app,
+      { model: "sonnet", stream: false, messages: followUpMessages },
+      { "x-opencode-session": sessionId }
+    )
+    expect(response2.status).toBe(200)
+
+    // The second request should NOT have resumeSessionAt
+    // (it may have resume if the fresh session was stored, which is fine)
+    expect(queryCalls[0].resumeSessionAt).toBeUndefined()
+  })
+
+  it("propagates non-stale errors normally", async () => {
+    const app = createTestApp()
+
+    // A request that will trigger an error from the first query call
+    // (queryCallCount resets in beforeEach, and the mock only throws
+    // on calls with resumeSessionAt — this tests without it)
+    const response = await post(app, {
+      model: "sonnet",
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    // Should succeed (no resumeSessionAt → no stale error)
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.content[0].text).toContain("response")
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -97,3 +97,13 @@ export function classifyError(errMsg: string): ClassifiedError {
     message: errMsg || "Unknown error"
   }
 }
+
+/**
+ * Detect errors caused by stale session/message UUIDs.
+ * These happen when the upstream Claude session no longer contains
+ * the referenced message (expired, compacted server-side, etc.).
+ */
+export function isStaleSessionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  return error.message.includes("No message found with message.uuid")
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -19,7 +19,7 @@ import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASST
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError } from "./errors"
+import { classifyError, isStaleSessionError } from "./errors"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync } from "./models"
 import { ALLOWED_MCP_TOOLS } from "./tools"
 import { getLastUserMessage } from "./messages"
@@ -33,7 +33,7 @@ import {
 } from "./session/lineage"
 // Re-export for backwards compatibility (existing tests import from here)
 
-import { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit } from "./session/cache"
+import { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession } from "./session/cache"
 // Re-export for backwards compatibility (existing tests import from here)
 export { computeLineageHash, hashMessage, computeMessageHashes }
 export { clearSessionCache, getMaxSessionsLimit }
@@ -52,6 +52,79 @@ export type { LineageResult }
 const exec = promisify(execCallback)
 
 let claudeExecutable = ""
+
+/**
+ * Build a prompt from all messages for a fresh (non-resume) session.
+ * Used when retrying after a stale session UUID error.
+ */
+function buildFreshPrompt(
+  messages: Array<{ role: string; content: any }>,
+  stripCacheControl: (content: any) => any
+): string | AsyncIterable<any> {
+  const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
+  const hasMultimodal = messages.some((m) =>
+    Array.isArray(m.content) && m.content.some((b: any) => MULTIMODAL_TYPES.has(b.type))
+  )
+
+  if (hasMultimodal) {
+    const structured: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> = []
+    for (const m of messages) {
+      if (m.role === "user") {
+        structured.push({
+          type: "user" as const,
+          message: { role: "user" as const, content: stripCacheControl(m.content) },
+          parent_tool_use_id: null,
+        })
+      } else {
+        let text: string
+        if (typeof m.content === "string") {
+          text = `[Assistant: ${m.content}]`
+        } else if (Array.isArray(m.content)) {
+          text = m.content.map((b: any) => {
+            if (b.type === "text" && b.text) return `[Assistant: ${b.text}]`
+            if (b.type === "tool_use") return `[Tool Use: ${b.name}(${JSON.stringify(b.input)})]`
+            if (b.type === "tool_result") return `[Tool Result: ${typeof b.content === "string" ? b.content : JSON.stringify(b.content)}]`
+            return ""
+          }).filter(Boolean).join("\n")
+        } else {
+          text = `[Assistant: ${String(m.content)}]`
+        }
+        structured.push({
+          type: "user" as const,
+          message: { role: "user" as const, content: text },
+          parent_tool_use_id: null,
+        })
+      }
+    }
+    return (async function* () { for (const msg of structured) yield msg })()
+  }
+
+  return messages
+    .map((m) => {
+      const role = m.role === "assistant" ? "Assistant" : "Human"
+      let content: string
+      if (typeof m.content === "string") {
+        content = m.content
+      } else if (Array.isArray(m.content)) {
+        content = m.content
+          .map((block: any) => {
+            if (block.type === "text" && block.text) return block.text
+            if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
+            if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
+            if (block.type === "image") return "[Image attached]"
+            if (block.type === "document") return "[Document attached]"
+            if (block.type === "file") return "[File attached]"
+            return ""
+          })
+          .filter(Boolean)
+          .join("\n")
+      } else {
+        content = String(m.content)
+      }
+      return `${role}: ${content}`
+    })
+    .join("\n\n") || ""
+}
 
 export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServer {
   const finalConfig = { ...DEFAULT_PROXY_CONFIG, ...config }
@@ -403,11 +476,38 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               claudeExecutable = await resolveClaudeExecutableAsync()
             }
 
-            const response = query(buildQueryOptions({
-              prompt, model, workingDirectory, systemContext, claudeExecutable,
-              passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
-              resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
-            }))
+            // Wrap SDK call with retry for stale undo UUIDs.
+            // If the first query fails because resumeSessionAt points to a
+            // UUID that no longer exists, evict the stale session and retry
+            // as a fresh session. The generator makes this transparent to the
+            // existing message-processing loop.
+            const response = (async function* () {
+              try {
+                yield* query(buildQueryOptions({
+                  prompt, model, workingDirectory, systemContext, claudeExecutable,
+                  passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
+                  resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+                }))
+              } catch (error) {
+                if (!isStaleSessionError(error)) throw error
+                claudeLog("session.stale_uuid_retry", {
+                  mode: "non_stream",
+                  rollbackUuid: undoRollbackUuid,
+                  resumeSessionId,
+                })
+                console.error(`[PROXY] Stale session UUID, evicting and retrying as fresh session`)
+                evictSession(opencodeSessionId, workingDirectory, allMessages)
+                // Reset UUID tracking for fresh session
+                sdkUuidMap.length = 0
+                for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
+                yield* query(buildQueryOptions({
+                  prompt: buildFreshPrompt(allMessages, stripCacheControl),
+                  model, workingDirectory, systemContext, claudeExecutable,
+                  passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
+                  resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter,
+                }))
+              }
+            })()
 
             for await (const message of response) {
               // Capture session ID from SDK messages
@@ -584,11 +684,33 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
             try {
               let currentSessionId: string | undefined
-              const response = query(buildQueryOptions({
-                prompt, model, workingDirectory, systemContext, claudeExecutable,
-                passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
-                resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
-              }))
+              // Same stale-UUID retry wrapper as the non-streaming path
+              const response = (async function* () {
+                try {
+                  yield* query(buildQueryOptions({
+                    prompt, model, workingDirectory, systemContext, claudeExecutable,
+                    passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
+                    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+                  }))
+                } catch (error) {
+                  if (!isStaleSessionError(error)) throw error
+                  claudeLog("session.stale_uuid_retry", {
+                    mode: "stream",
+                    rollbackUuid: undoRollbackUuid,
+                    resumeSessionId,
+                  })
+                  console.error(`[PROXY] Stale session UUID, evicting and retrying as fresh session`)
+                  evictSession(opencodeSessionId, workingDirectory, allMessages)
+                  sdkUuidMap.length = 0
+                  for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
+                  yield* query(buildQueryOptions({
+                    prompt: buildFreshPrompt(allMessages, stripCacheControl),
+                    model, workingDirectory, systemContext, claudeExecutable,
+                    passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
+                    resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter,
+                  }))
+                }
+              })()
 
               const heartbeat = setInterval(() => {
                 heartbeatCount += 1

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -6,7 +6,7 @@
  */
 
 import { LRUMap } from "../../utils/lruMap"
-import { lookupSharedSession, storeSharedSession, clearSharedSessions } from "../sessionStore"
+import { lookupSharedSession, storeSharedSession, clearSharedSessions, evictSharedSession } from "../sessionStore"
 import { getConversationFingerprint } from "./fingerprint"
 import {
   computeLineageHash,
@@ -82,6 +82,34 @@ export function clearSessionCache() {
   }
   // Also clear shared file store
   try { clearSharedSessions() } catch {}
+}
+
+/** Evict a stale session from all caches and the shared store.
+ *  Used when a resume/undo fails because the upstream Claude session is gone. */
+export function evictSession(
+  sessionId: string | undefined,
+  workingDirectory?: string,
+  messages?: Array<{ role: string; content: any }>
+): void {
+  if (sessionId) {
+    const cached = sessionCache.get(sessionId)
+    if (cached) {
+      removeFingerprintEntriesByClaudeSessionId(cached.claudeSessionId)
+      sessionCache.delete(sessionId)
+    }
+    try { evictSharedSession(sessionId) } catch {}
+  }
+  if (messages) {
+    const fp = getConversationFingerprint(messages, workingDirectory)
+    if (fp) {
+      const cached = fingerprintCache.get(fp)
+      if (cached) {
+        removeSessionEntriesByClaudeSessionId(cached.claudeSessionId)
+        fingerprintCache.delete(fp)
+      }
+      try { evictSharedSession(fp) } catch {}
+    }
+  }
 }
 
 // --- Session operations ---

--- a/src/proxy/session/index.ts
+++ b/src/proxy/session/index.ts
@@ -4,4 +4,4 @@
 export { computeLineageHash, hashMessage, computeMessageHashes, verifyLineage, measurePrefixOverlap, measureSuffixOverlap, MIN_SUFFIX_FOR_COMPACTION } from "./lineage"
 export type { SessionState, LineageResult, SessionCacheLike } from "./lineage"
 export { extractClientCwd, getConversationFingerprint } from "./fingerprint"
-export { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit } from "./cache"
+export { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession } from "./cache"

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -170,6 +170,28 @@ export function storeSharedSession(key: string, claudeSessionId: string, message
   }
 }
 
+/** Remove a single session from the shared file store.
+ *  Used when a session is detected as stale (e.g. expired upstream). */
+export function evictSharedSession(key: string): void {
+  const path = getStorePath()
+  const lockPath = `${path}.lock`
+  const hasLock = acquireLock(lockPath)
+  if (!hasLock) {
+    console.warn("[sessionStore] could not acquire lock for eviction, proceeding without")
+  }
+  try {
+    const store = readStore()
+    if (store[key]) {
+      delete store[key]
+      writeStore(store)
+    }
+  } finally {
+    if (hasLock) {
+      releaseLock(lockPath)
+    }
+  }
+}
+
 export function clearSharedSessions(): void {
   const path = getStorePath()
   try {


### PR DESCRIPTION
Closes #140

## Problem

When the proxy detects an undo and tries to fork with `resumeSessionAt` pointing to a UUID that no longer exists upstream (session expired, compacted server-side, etc.), the SDK throws:

> No message found with message.uuid of: \<uuid\>

This propagated directly to the user with no recovery. The stale session remained cached, so the error persisted across retries until a proxy restart.

## Fix

Both the streaming and non-streaming SDK call paths now wrap the `query()` call in an async generator that:

1. **Detects** the stale UUID error via `isStaleSessionError()`
2. **Evicts** the stale session from in-memory LRU caches, fingerprint cache, and the shared file store
3. **Retries once** as a fresh session — rebuilds the prompt from all messages, strips resume/fork/rollback options

The generator wrapper makes the retry transparent to the existing message-processing loops — no changes to response handling code.

## New modules

| Function | Location | Purpose |
|----------|----------|---------|
| `isStaleSessionError()` | `errors.ts` | Detects "No message found with message.uuid" errors |
| `evictSession()` | `session/cache.ts` | Removes session from both LRU caches + shared store |
| `evictSharedSession()` | `sessionStore.ts` | Removes a single entry from the file store |
| `buildFreshPrompt()` | `server.ts` | Rebuilds prompt from all messages for retry (text + multimodal) |

## Testing

- **Unit tests**: `isStaleSessionError` detection in `errors.test.ts`
- **Integration tests**: New `proxy-stale-uuid-retry.test.ts` covering:
  - Non-streaming: stale UUID -> retry as fresh -> valid response
  - Streaming: stale UUID -> retry as fresh -> valid SSE stream
  - Cache eviction: stale session removed, subsequent requests don't reuse it
  - Non-stale errors propagate normally (no false-positive retries)
- **E2E verified**: Injected fake UUIDs into the shared session store, triggered undo against live Claude Max, confirmed retry fires and returns valid responses in both streaming and non-streaming modes

All 359 tests pass.
