### PR TITLE
docs: document plugin API contract and move reference plugin to examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,21 @@ session/
   cache.ts         → LRU caches, lookupSession, storeSession (stateful)
 ```
 
+## Stable API Contract
+
+External plugins depend on these interfaces. **Do not change without project owner approval.**
+
+| Interface | Location | Used by |
+|-----------|----------|---------|
+| `startProxyServer(config)` → `ProxyInstance` | `server.ts` | Plugins that spawn proxy instances |
+| `ProxyInstance.close()` | `types.ts` | Plugins for graceful shutdown |
+| `ProxyConfig` type | `types.ts` | Plugin configuration |
+| `x-opencode-session` header | `adapters/opencode.ts` | Session tracking from agent plugins |
+| `GET /health` response shape | `server.ts` | Plugin health checks |
+| `POST /v1/messages` request/response format | `server.ts` | All agents (Anthropic API contract) |
+
+If you need to modify any of these, open an issue first — breaking changes affect downstream plugin authors.
+
 ## Git
 
 - Commit format: `type: brief description`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Meridian bridges that gap. It runs locally, accepts standard Anthropic API reque
 ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://127.0.0.1:3456 opencode
 ```
 
-Or use the [OpenCode plugin](src/plugin/claude-max-headers.ts) for automatic session header injection.
+For automatic session tracking, use a plugin like [opencode-meridian](https://github.com/ianjwhite99/opencode-meridian), or see the [reference plugin](examples/opencode-plugin/claude-max-headers.ts) to build your own.
 
 ### Crush
 
@@ -100,15 +100,15 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 
 ## Tested Agents
 
-| Agent | Status | Notes |
-|-------|--------|-------|
-| [OpenCode](https://github.com/opencode-ai/opencode) | ✅ Verified | Full tool support, session resume, streaming, subagents |
-| [Crush](https://github.com/charmbracelet/crush) | ✅ Verified | Tool execution, multi-turn, headless mode |
-| [Cline](https://github.com/cline/cline) | 🔲 Untested | Should work — standard Anthropic API |
-| [Continue](https://github.com/continuedev/continue) | 🔲 Untested | Should work — standard Anthropic API |
-| [Aider](https://github.com/paul-gauthier/aider) | 🔲 Untested | Should work — standard Anthropic API |
+| Agent | Status | Plugin | Notes |
+|-------|--------|--------|-------|
+| [OpenCode](https://github.com/opencode-ai/opencode) | ✅ Verified | [opencode-meridian](https://github.com/ianjwhite99/opencode-meridian) | Full tool support, session resume, streaming, subagents |
+| [Crush](https://github.com/charmbracelet/crush) | ✅ Verified | — | Tool execution, multi-turn, headless mode |
+| [Cline](https://github.com/cline/cline) | 🔲 Untested | — | Should work — standard Anthropic API |
+| [Continue](https://github.com/continuedev/continue) | 🔲 Untested | — | Should work — standard Anthropic API |
+| [Aider](https://github.com/paul-gauthier/aider) | 🔲 Untested | — | Should work — standard Anthropic API |
 
-Tested an agent? [Open an issue](https://github.com/rynfar/opencode-claude-max-proxy/issues) and we'll add it.
+Tested an agent or built a plugin? [Open an issue](https://github.com/rynfar/opencode-claude-max-proxy/issues) and we'll add it.
 
 ## Architecture
 
@@ -177,6 +177,64 @@ See [`adapters/opencode.ts`](src/proxy/adapters/opencode.ts) for reference.
 | `CLAUDE_PROXY_WORKDIR` | `cwd()` | Default working directory for SDK |
 | `CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS` | `120` | HTTP keep-alive timeout |
 | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
+
+## Programmatic API
+
+Meridian can be used as a library for building agent plugins and integrations.
+
+```typescript
+import { startProxyServer } from "opencode-claude-max-proxy"
+
+// Start a proxy instance
+const instance = await startProxyServer({
+  port: 3456,
+  host: "127.0.0.1",
+  silent: true,  // suppress console output
+})
+
+// instance.config  — resolved ProxyConfig
+// instance.server  — underlying http.Server
+
+// Shut down cleanly
+await instance.close()
+```
+
+### Session Header Contract
+
+For reliable session tracking, agents should send a session identifier via HTTP header. Without it, the proxy falls back to fingerprint-based matching (hashing the first user message + working directory), which is less reliable.
+
+| Header | Purpose |
+|--------|---------|
+| `x-opencode-session` | Maps agent conversations to Claude SDK sessions for resume, undo, and compaction |
+
+The proxy uses this header to maintain conversation continuity across requests. Plugin authors should inject it on every request to `/v1/messages`.
+
+### Plugin Architecture
+
+Meridian is the proxy. Plugins live in the agent's ecosystem.
+
+```
+┌──────────────┐         ┌──────────────┐         ┌──────────────┐
+│  Agent        │  HTTP   │  Meridian    │   SDK   │  Claude Max  │
+│  (OpenCode,   │────────▶│  Proxy       │────────▶│              │
+│   Crush, etc) │◀────────│              │◀────────│              │
+└──────────────┘         └──────────────┘         └──────────────┘
+       │
+       │ plugin injects headers,
+       │ manages proxy lifecycle
+       │
+┌──────────────┐
+│  Agent Plugin │
+│  (optional)   │
+└──────────────┘
+```
+
+A plugin's job is to:
+1. Start/stop a Meridian instance (`startProxyServer` / `instance.close()`)
+2. Inject session headers into outgoing requests
+3. Check proxy health (`GET /health`)
+
+See [`examples/opencode-plugin/`](examples/opencode-plugin/) for a reference implementation.
 
 ## Endpoints
 

--- a/examples/opencode-plugin/claude-max-headers.ts
+++ b/examples/opencode-plugin/claude-max-headers.ts
@@ -1,23 +1,23 @@
 /**
- * OpenCode plugin that injects session tracking headers into Anthropic API requests.
+ * OpenCode plugin — reference implementation.
  *
- * This enables the claude-max-proxy to reliably track sessions and resume
- * Claude Agent SDK conversations instead of starting fresh every time.
+ * Injects session tracking headers into Anthropic API requests so the
+ * proxy can reliably map OpenCode sessions to Claude SDK sessions.
  *
- * Installation:
- *   Add to your opencode.json:
- *     { "plugin": ["./path/to/claude-max-headers.ts"] }
+ * This is a minimal example. For a full-featured OpenCode plugin with
+ * automatic proxy lifecycle management, see:
+ *   https://github.com/ianjwhite99/opencode-meridian
  *
- *   Or copy to your project's .opencode/plugin/ directory.
- *
- * What it does:
- *   Adds x-opencode-session and x-opencode-request headers to requests
- *   sent to the Anthropic provider. The proxy uses these to map OpenCode
- *   sessions to Claude SDK sessions for conversation resumption.
+ * Usage:
+ *   Copy this file into your project and add to opencode.json:
+ *     { "plugin": ["./claude-max-headers.ts"] }
  *
  * Without this plugin:
  *   The proxy falls back to fingerprint-based session matching (hashing
- *   the first user message). This works but is less reliable.
+ *   the first user message + working directory). This works but is less
+ *   reliable for session resume.
+ *
+ * See the Programmatic API section in the README for the full plugin contract.
  */
 
 type ChatHeadersHook = (


### PR DESCRIPTION
Related to #137

## Changes

**Moved reference plugin to examples**
- `src/plugin/claude-max-headers.ts` -> `examples/opencode-plugin/claude-max-headers.ts`
- Was dead code — not built or shipped in the npm package
- Updated header comment to reference the full-featured opencode-meridian plugin

**Documented the plugin API contract**
- Added Programmatic API section to README with `startProxyServer` / `ProxyInstance` usage
- Documented session header contract (`x-opencode-session`)
- Added plugin architecture diagram showing the boundary between proxy and agent plugins
- Added Plugin column to the Tested Agents table

**Protected stable interfaces in CLAUDE.md**
- Added Stable API Contract table listing interfaces external plugins depend on
- `startProxyServer`, `ProxyInstance.close()`, `ProxyConfig`, session headers, `/health`, `/v1/messages`
- Marked as "do not change without project owner approval" so AI agents and contributors don't break downstream plugins

No runtime code changes. All 359 tests pass.
