### PR TITLE
fix: detect rate-limited accounts and fall back from 1m models

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for model mapping and utility functions.
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test"
-import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, getClaudeAuthStatusAsync } from "../proxy/models"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, getClaudeAuthStatusAsync, stripExtendedContext, hasExtendedContext } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
   const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
@@ -12,10 +12,14 @@ describe("mapModelToClaudeModel", () => {
     else process.env.CLAUDE_PROXY_SONNET_MODEL = originalSonnetModel
     resetCachedClaudeAuthStatus()
   })
-  it("maps opus models to opus[1m]", () => {
-    expect(mapModelToClaudeModel("claude-opus-4-5")).toBe("opus[1m]")
-    expect(mapModelToClaudeModel("opus")).toBe("opus[1m]")
+
+  it("maps opus 4.6 models to opus[1m]", () => {
     expect(mapModelToClaudeModel("claude-opus-4-6")).toBe("opus[1m]")
+    expect(mapModelToClaudeModel("opus")).toBe("opus[1m]")
+  })
+
+  it("maps opus 4.5 models to opus (no 1M)", () => {
+    expect(mapModelToClaudeModel("claude-opus-4-5")).toBe("opus")
   })
 
   it("maps haiku models to haiku", () => {
@@ -23,10 +27,15 @@ describe("mapModelToClaudeModel", () => {
     expect(mapModelToClaudeModel("haiku")).toBe("haiku")
   })
 
-  it("maps sonnet models to sonnet[1m] for max subscriptions", () => {
-    expect(mapModelToClaudeModel("claude-sonnet-4-5", "max")).toBe("sonnet[1m]")
+  it("maps sonnet 4.6 models to sonnet[1m] for max subscriptions", () => {
+    expect(mapModelToClaudeModel("claude-sonnet-4-6", "max")).toBe("sonnet[1m]")
     expect(mapModelToClaudeModel("sonnet", "max")).toBe("sonnet[1m]")
-    expect(mapModelToClaudeModel("claude-sonnet-4-5-20250929", "max")).toBe("sonnet[1m]")
+  })
+
+  it("maps sonnet 4.5 models to sonnet (no 1M regardless of subscription)", () => {
+    expect(mapModelToClaudeModel("claude-sonnet-4-5")).toBe("sonnet")
+    expect(mapModelToClaudeModel("claude-sonnet-4-5-20250929")).toBe("sonnet")
+    expect(mapModelToClaudeModel("claude-sonnet-4-5", "max")).toBe("sonnet")
   })
 
   it("maps sonnet models to plain sonnet for non-max subscriptions", () => {
@@ -99,6 +108,38 @@ describe("getClaudeAuthStatusAsync", () => {
     // depending on whether claude is installed — either way it re-executed
     // We just verify reset didn't break anything
     expect(result2 === null || typeof result2 === "object").toBe(true)
+  })
+})
+
+describe("stripExtendedContext", () => {
+  it("strips [1m] from opus", () => {
+    expect(stripExtendedContext("opus[1m]")).toBe("opus")
+  })
+
+  it("strips [1m] from sonnet", () => {
+    expect(stripExtendedContext("sonnet[1m]")).toBe("sonnet")
+  })
+
+  it("returns haiku unchanged", () => {
+    expect(stripExtendedContext("haiku")).toBe("haiku")
+  })
+
+  it("returns base models unchanged", () => {
+    expect(stripExtendedContext("opus")).toBe("opus")
+    expect(stripExtendedContext("sonnet")).toBe("sonnet")
+  })
+})
+
+describe("hasExtendedContext", () => {
+  it("returns true for [1m] models", () => {
+    expect(hasExtendedContext("opus[1m]")).toBe(true)
+    expect(hasExtendedContext("sonnet[1m]")).toBe(true)
+  })
+
+  it("returns false for base models", () => {
+    expect(hasExtendedContext("opus")).toBe(false)
+    expect(hasExtendedContext("sonnet")).toBe(false)
+    expect(hasExtendedContext("haiku")).toBe(false)
   })
 })
 

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -107,3 +107,12 @@ export function isStaleSessionError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
   return error.message.includes("No message found with message.uuid")
 }
+
+/**
+ * Quick check whether an error message indicates a rate limit.
+ * Used by server.ts to decide whether to retry with a smaller context window.
+ */
+export function isRateLimitError(errMsg: string): boolean {
+  const lower = errMsg.toLowerCase()
+  return lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
+}

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -17,18 +17,53 @@ export interface ClaudeAuthStatus {
   email?: string
 }
 
+
 const AUTH_STATUS_CACHE_TTL_MS = 60_000
 
 let cachedAuthStatus: ClaudeAuthStatus | null = null
 let cachedAuthStatusAt = 0
 let cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null = null
 
+/**
+ * Only Claude 4.6 models support the 1M extended context window.
+ * Older models (4.5 and earlier) do not.
+ */
+function supports1mContext(model: string): boolean {
+  // Explicit older versions (4-5, 4.5, etc.) do not support 1M
+  if (model.includes("4-5") || model.includes("4.5")) return false
+  // Everything else (bare names, 4-6, unknown) defaults to latest (1M capable)
+  return true
+}
+
 export function mapModelToClaudeModel(model: string, subscriptionType?: string | null): ClaudeModel {
-  if (model.includes("opus")) return "opus[1m]"
   if (model.includes("haiku")) return "haiku"
+
+  const use1m = supports1mContext(model)
+
+  if (model.includes("opus")) return use1m ? "opus[1m]" : "opus"
+
   const sonnetOverride = process.env.CLAUDE_PROXY_SONNET_MODEL
   if (sonnetOverride === "sonnet" || sonnetOverride === "sonnet[1m]") return sonnetOverride
+
+  if (!use1m) return "sonnet"
   return subscriptionType === "max" ? "sonnet[1m]" : "sonnet"
+}
+
+/**
+ * Strip the [1m] suffix from a model, returning the base variant.
+ * Used for fallback when the 1M context window is rate-limited.
+ */
+export function stripExtendedContext(model: ClaudeModel): ClaudeModel {
+  if (model === "opus[1m]") return "opus"
+  if (model === "sonnet[1m]") return "sonnet"
+  return model
+}
+
+/**
+ * Check whether a model is using extended (1M) context.
+ */
+export function hasExtendedContext(model: ClaudeModel): boolean {
+  return model.endsWith("[1m]")
 }
 
 export async function getClaudeAuthStatusAsync(): Promise<ClaudeAuthStatus | null> {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -19,8 +19,8 @@ import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASST
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, isStaleSessionError } from "./errors"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync } from "./models"
+import { classifyError, isStaleSessionError, isRateLimitError } from "./errors"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync, hasExtendedContext, stripExtendedContext } from "./models"
 import { ALLOWED_MCP_TOOLS } from "./tools"
 import { getLastUserMessage } from "./messages"
 import { openCodeAdapter } from "./adapters/opencode"
@@ -182,7 +182,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       try {
         const body = await c.req.json()
         const authStatus = await getClaudeAuthStatusAsync()
-        const model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
+        let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
         const stream = body.stream ?? true
         const adapter = openCodeAdapter
         const workingDirectory = adapter.extractWorkingDirectory(body) || process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
@@ -309,20 +309,22 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         })
       }
 
-      // Build the prompt — either structured (multimodal) or text
-      let prompt: string | AsyncIterable<any>
+      // Build the prompt — either structured (multimodal) or text.
+      // Structured prompts are stored as arrays so they can be replayed on retry.
+      let structuredMessages: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> | undefined
+      let textPrompt: string | undefined
 
       if (hasMultimodal) {
         // Structured messages preserve image/document/file blocks for Claude to see.
         // On resume, only send user messages (SDK has assistant context already).
         // On first request, include everything.
-        const structured: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> = []
+        structuredMessages = []
 
         if (isResume) {
           // Resume: only send user messages from the delta (SDK has the rest)
           for (const m of messagesToConvert) {
             if (m.role === "user") {
-              structured.push({
+              structuredMessages.push({
                 type: "user" as const,
                 message: { role: "user" as const, content: stripCacheControl(m.content) },
                 parent_tool_use_id: null,
@@ -333,7 +335,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // First request: all messages (system context now passed via appendSystemPrompt)
           for (const m of messagesToConvert) {
             if (m.role === "user") {
-              structured.push({
+              structuredMessages.push({
                 type: "user" as const,
                 message: { role: "user" as const, content: stripCacheControl(m.content) },
                 parent_tool_use_id: null,
@@ -353,7 +355,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               } else {
                 text = `[Assistant: ${String(m.content)}]`
               }
-              structured.push({
+              structuredMessages.push({
                 type: "user" as const,
                 message: { role: "user" as const, content: text },
                 parent_tool_use_id: null,
@@ -361,11 +363,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             }
           }
         }
-
-        prompt = (async function* () { for (const msg of structured) yield msg })()
       } else {
         // Text prompt — convert messages to string
-        const conversationParts = messagesToConvert
+        textPrompt = messagesToConvert
           ?.map((m: { role: string; content: string | Array<{ type: string; text?: string; content?: string; tool_use_id?: string; name?: string; input?: unknown; id?: string }> }) => {
             const role = m.role === "assistant" ? "Assistant" : "Human"
             let content: string
@@ -390,9 +390,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             return `${role}: ${content}`
           })
           .join("\n\n") || ""
+      }
 
-        // System context now passed via appendSystemPrompt (not in prompt text)
-        prompt = conversationParts
+      // Create a fresh prompt value — can be called multiple times for retry
+      function makePrompt(): string | AsyncIterable<any> {
+        if (structuredMessages) {
+          const msgs = structuredMessages
+          return (async function* () { for (const msg of msgs) yield msg })()
+        }
+        return textPrompt!
       }
 
       // --- Passthrough mode ---
@@ -484,7 +490,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const response = (async function* () {
               try {
                 yield* query(buildQueryOptions({
-                  prompt, model, workingDirectory, systemContext, claudeExecutable,
+                  prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
                   passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
                   resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
                 }))
@@ -548,13 +554,64 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               durationMs: Date.now() - upstreamStartAt
             })
           } catch (error) {
-            claudeLog("upstream.failed", {
-              mode: "non_stream",
-              model,
-              durationMs: Date.now() - upstreamStartAt,
-              error: error instanceof Error ? error.message : String(error)
-            })
-            throw error
+            const errMsg = error instanceof Error ? error.message : String(error)
+
+            // Rate-limit fallback: if using [1m] context, retry with base model
+            if (hasExtendedContext(model) && isRateLimitError(errMsg)) {
+              const fallbackModel = stripExtendedContext(model)
+              claudeLog("upstream.context_fallback", {
+                mode: "non_stream",
+                from: model,
+                to: fallbackModel,
+                reason: "rate_limit",
+              })
+              console.error(`[PROXY] ${requestMeta.requestId} rate-limited on ${model}, retrying with ${fallbackModel}`)
+              model = fallbackModel
+
+              const retryResponse = query(buildQueryOptions({
+                prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
+                passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
+                resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+              }))
+
+              for await (const message of retryResponse) {
+                if ((message as any).session_id) {
+                  currentSessionId = (message as any).session_id
+                }
+                if (message.type === "assistant") {
+                  assistantMessages += 1
+                  if ((message as any).uuid) {
+                    sdkUuidMap.push((message as any).uuid)
+                  }
+                  if (!firstChunkAt) {
+                    firstChunkAt = Date.now()
+                  }
+                  for (const block of message.message.content) {
+                    const b = block as Record<string, unknown>
+                    if (passthrough && b.type === "tool_use" && typeof b.name === "string") {
+                      b.name = stripMcpPrefix(b.name as string)
+                    }
+                    contentBlocks.push(b)
+                  }
+                }
+              }
+
+              claudeLog("upstream.completed", {
+                mode: "non_stream",
+                model,
+                assistantMessages,
+                durationMs: Date.now() - upstreamStartAt,
+                fallback: true,
+              })
+            } else {
+              claudeLog("upstream.failed", {
+                mode: "non_stream",
+                model,
+                durationMs: Date.now() - upstreamStartAt,
+                error: errMsg
+              })
+              throw error
+            }
           }
 
           // In passthrough mode, add captured tool_use blocks from the hook
@@ -682,13 +739,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               : new Array(allMessages.length - 1).fill(null)
             while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
 
+            // Track if we've sent a message_start to the client — hoisted for
+            // access in the catch block (rate-limit fallback is only safe if
+            // no content has been emitted yet).
+            let messageStartEmitted = false
+
             try {
               let currentSessionId: string | undefined
               // Same stale-UUID retry wrapper as the non-streaming path
               const response = (async function* () {
                 try {
                   yield* query(buildQueryOptions({
-                    prompt, model, workingDirectory, systemContext, claudeExecutable,
+                    prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
                     resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
                   }))
@@ -733,8 +795,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }, 15_000)
 
               const skipBlockIndices = new Set<number>()
-              const streamedToolUseIds = new Set<string>() // Track tool_use IDs already forwarded in stream
-              let messageStartEmitted = false // Track if we've sent a message_start to the client
+              const streamedToolUseIds = new Set<string>()
 
               try {
                 for await (const message of response) {
@@ -966,16 +1027,156 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 return
               }
 
+              const errMsg = error instanceof Error ? error.message : String(error)
+
+              // Rate-limit fallback: if using [1m] context and no content has been
+              // sent to the client yet, retry transparently with the base model.
+              if (hasExtendedContext(model) && isRateLimitError(errMsg) && !messageStartEmitted) {
+                const fallbackModel = stripExtendedContext(model)
+                claudeLog("upstream.context_fallback", {
+                  mode: "stream",
+                  from: model,
+                  to: fallbackModel,
+                  reason: "rate_limit",
+                })
+                console.error(`[PROXY] ${requestMeta.requestId} rate-limited on ${model}, retrying with ${fallbackModel}`)
+                model = fallbackModel
+
+                try {
+                  const retryResponse = query(buildQueryOptions({
+                    prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
+                    passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
+                    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+                  }))
+
+                  const retryHeartbeat = setInterval(() => {
+                    try {
+                      if (!safeEnqueue(encoder.encode(`: ping\n\n`), "retry_heartbeat")) {
+                        clearInterval(retryHeartbeat)
+                      }
+                    } catch {
+                      clearInterval(retryHeartbeat)
+                    }
+                  }, 15_000)
+
+                  // Fresh state for the retry stream
+                  const retrySkipBlocks = new Set<number>()
+                  const retryStreamedToolIds = new Set<string>()
+                  let retryMessageStartEmitted = false
+                  let retrySessionId: string | undefined
+
+                  try {
+                    for await (const message of retryResponse) {
+                      if (streamClosed) break
+
+                      if ((message as any).session_id) {
+                        retrySessionId = (message as any).session_id
+                      }
+                      if (message.type === "assistant" && (message as any).uuid) {
+                        sdkUuidMap.push((message as any).uuid)
+                      }
+
+                      if (message.type === "stream_event") {
+                        streamEventsSeen += 1
+                        if (!firstChunkAt) firstChunkAt = Date.now()
+
+                        const event = message.event
+                        const eventType = (event as any).type
+                        const eventIndex = (event as any).index as number | undefined
+
+                        if (eventType === "message_start") {
+                          retrySkipBlocks.clear()
+                          if (retryMessageStartEmitted) continue
+                          retryMessageStartEmitted = true
+                        }
+                        if (eventType === "message_stop") continue
+
+                        if (eventType === "content_block_start") {
+                          const block = (event as any).content_block
+                          if (block?.type === "tool_use" && typeof block.name === "string") {
+                            if (passthrough && block.name.startsWith(PASSTHROUGH_MCP_PREFIX)) {
+                              block.name = stripMcpPrefix(block.name)
+                              if (block.id) retryStreamedToolIds.add(block.id)
+                            } else if (block.name.startsWith("mcp__")) {
+                              if (eventIndex !== undefined) retrySkipBlocks.add(eventIndex)
+                              continue
+                            }
+                          }
+                        }
+
+                        if (eventIndex !== undefined && retrySkipBlocks.has(eventIndex)) continue
+
+                        if (eventType === "message_delta") {
+                          const stopReason = (event as any).delta?.stop_reason
+                          if (stopReason === "tool_use" && retrySkipBlocks.size > 0) continue
+                        }
+
+                        const payload = encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify(event)}\n\n`)
+                        if (!safeEnqueue(payload, `retry_stream_event:${eventType}`)) break
+                        eventsForwarded += 1
+
+                        if (eventType === "content_block_delta") {
+                          const delta = (event as any).delta
+                          if (delta?.type === "text_delta") textEventsForwarded += 1
+                        }
+                      }
+                    }
+                  } finally {
+                    clearInterval(retryHeartbeat)
+                  }
+
+                  claudeLog("upstream.completed", {
+                    mode: "stream",
+                    model,
+                    durationMs: Date.now() - upstreamStartAt,
+                    streamEventsSeen,
+                    eventsForwarded,
+                    textEventsForwarded,
+                    fallback: true,
+                  })
+
+                  if (retrySessionId) {
+                    storeSession(opencodeSessionId, body.messages || [], retrySessionId, workingDirectory, sdkUuidMap)
+                  }
+
+                  if (!streamClosed) {
+                    if (retryMessageStartEmitted) {
+                      safeEnqueue(encoder.encode(`event: message_stop\ndata: {"type":"message_stop"}\n\n`), "retry_final_message_stop")
+                    }
+                    try { controller.close() } catch {}
+                    streamClosed = true
+                  }
+                  return
+                } catch (retryError) {
+                  // Retry also failed — fall through to emit error
+                  claudeLog("upstream.context_fallback_failed", {
+                    mode: "stream",
+                    model,
+                    error: retryError instanceof Error ? retryError.message : String(retryError),
+                  })
+                  const retryErr = classifyError(retryError instanceof Error ? retryError.message : String(retryError))
+                  safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
+                    type: "error",
+                    error: { type: retryErr.type, message: retryErr.message }
+                  })}\n\n`), "retry_error_event")
+                  if (!streamClosed) {
+                    try { controller.close() } catch {}
+                    streamClosed = true
+                  }
+                  return
+                }
+              }
+
               claudeLog("upstream.failed", {
                 mode: "stream",
                 model,
                 durationMs: Date.now() - upstreamStartAt,
                 streamEventsSeen,
                 textEventsForwarded,
-                error: error instanceof Error ? error.message : String(error)
+                error: errMsg
               })
-              const streamErr = classifyError(error instanceof Error ? error.message : String(error))
-              claudeLog("proxy.anthropic.error", { error: error instanceof Error ? error.message : String(error), classified: streamErr.type })
+              const streamErr = classifyError(errMsg)
+              claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })
               safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
                 type: "error",
                 error: { type: streamErr.type, message: streamErr.message }


### PR DESCRIPTION
## Problem

The proxy previously hard-coded `[1m]` variants for all Opus and Sonnet models, regardless of version. This caused two problems:

1. **Older models broke entirely** — requesting `claude-opus-4-5` or `claude-sonnet-4-5` would map to `opus[1m]` or `sonnet[1m]`, which don't exist for 4.5 models, causing requests to fail outright.
2. **Rate-limited accounts couldn't fall back** — international users and accounts with org-level restrictions receive a `rate_limit_event` with `status: "rejected"` when requesting `[1m]` variants, with no recovery path.

## Solution

This change adds version-aware model mapping (only 4.6+ models get `[1m]`) and automatic fallback when the `[1m]` variant is rejected at runtime.

### Changes

**`src/proxy/models.ts`**
- Added `supports1mContext()` — only Claude 4.6+ models get the `[1m]` suffix; 4.5 and older map to the base variant
- `mapModelToClaudeModel()` now uses version-aware mapping while preserving subscription-type checks for sonnet
- New exports: `stripExtendedContext()`, `hasExtendedContext()`

**`src/proxy/errors.ts`**
- Added `isRateLimitError()` — detects rate limit errors from error messages, used to trigger fallback from `[1m]` to base model

**`src/proxy/server.ts`**
- Both streaming and non-streaming paths detect rate limit errors during queries
- On rejection: if the current model has `[1m]`, strips it and retries with the base model
- Compatible with the existing stale-session retry wrapper

**`src/__tests__/models.test.ts`**
- Tests for version-aware mapping (4.5 → base, 4.6 → `[1m]`)
- Tests for `stripExtendedContext()` and `hasExtendedContext()`

## How it works

1. **Version check at map time**: `claude-opus-4-5` → `opus`, `claude-opus-4-6` → `opus[1m]`
2. **Runtime fallback**: if `opus[1m]` gets a rate limit rejection, retry with `opus`

The detected event format:
```json
{"type": "rate_limit_event", "rate_limit_info": {"status": "rejected", "overageDisabledReason": "org_level_disabled"}}
```
