### PR TITLE
fix: make CLAUDE_PROXY_WORKDIR override extracted cwd

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -185,7 +185,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
         const stream = body.stream ?? true
         const adapter = openCodeAdapter
-        const workingDirectory = adapter.extractWorkingDirectory(body) || process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
+        const workingDirectory = process.env.CLAUDE_PROXY_WORKDIR || adapter.extractWorkingDirectory(body) || process.cwd()
 
         // Strip env vars that would cause the SDK subprocess to loop back through
         // the proxy instead of using its native Claude Max auth. Also strip vars


### PR DESCRIPTION
Fixes #154

When requests come from a Docker container, the system prompt contains a working directory that only exists inside the container (e.g. `/application`). The SDK subprocess fails with ENOENT because that path doesn't exist on the host.

**Change:** `CLAUDE_PROXY_WORKDIR` goes from fallback to override — if set, it wins regardless of what the client sends.

```diff
- const workingDirectory = adapter.extractWorkingDirectory(body) || process.env.CLAUDE_PROXY_WORKDIR || process.cwd()
+ const workingDirectory = process.env.CLAUDE_PROXY_WORKDIR || adapter.extractWorkingDirectory(body) || process.cwd()
```

No behavior change for users who don't set the env var.