### PR TITLE
feat: multi-profile routing with auth and admin protection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM node:22-alpine
 
 RUN deluser --remove-home node 2>/dev/null; \
     adduser -D -u 1000 claude \
-    && mkdir -p /home/claude/.claude \
+    && mkdir -p /home/claude/.claude /home/claude/.config/meridian \
     && chown -R claude:claude /home/claude
 
 RUN npm install -g @anthropic-ai/claude-code \

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Example:
 {
   "port": 4567,
   "defaultProfile": "personal",
+  "protectAdminRoutes": true,
   "requiredApiKeys": ["env:MERIDIAN_LAPTOP_KEY", "env:MERIDIAN_DESKTOP_KEY"],
   "profiles": [
     { "id": "personal", "claudeConfigDir": "~/.claude" },
@@ -196,6 +197,34 @@ Plaintext keys also work if you want a fully self-contained local config:
 ```
 
 That is supported, but safer practice is to keep secret values in env vars and reference them from JSON.
+
+To lock down telemetry and health endpoints separately from message traffic, you can turn on admin-route protection and optionally use a different key set:
+
+```json
+{
+  "protectAdminRoutes": true,
+  "requiredApiKeys": ["env:MERIDIAN_CLIENT_KEY"],
+  "adminApiKeys": ["env:MERIDIAN_ADMIN_KEY"]
+}
+```
+
+For browser-friendly access, you can also enable Basic Auth on protected admin routes:
+
+```json
+{
+  "protectAdminRoutes": true,
+  "adminUsername": "admin",
+  "adminPassword": "env:MERIDIAN_ADMIN_PASSWORD"
+}
+```
+
+When `protectAdminRoutes` is enabled:
+
+- `/health` requires an admin key
+- `/telemetry` and `/telemetry/*` require an admin key
+- Basic Auth also works when `adminUsername` and `adminPassword` are configured
+- `/` remains public
+- if `adminApiKeys` is omitted, Meridian falls back to `requiredApiKeys`
 
 String values support:
 
@@ -215,6 +244,10 @@ String values support:
 | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
 | `CLAUDE_PROXY_CONFIG` | unset | Explicit path to a JSON config file |
 | `CLAUDE_PROXY_API_KEYS` | unset | Comma-separated allowed inbound API keys |
+| `CLAUDE_PROXY_ADMIN_API_KEYS` | unset | Comma-separated admin keys for `/health` and `/telemetry/*` |
+| `CLAUDE_PROXY_PROTECT_ADMIN_ROUTES` | `0` | Require API keys on `/health` and `/telemetry/*` |
+| `CLAUDE_PROXY_ADMIN_USERNAME` | unset | Optional Basic Auth username for protected admin routes |
+| `CLAUDE_PROXY_ADMIN_PASSWORD` | unset | Optional Basic Auth password for protected admin routes |
 
 ## Programmatic API
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,42 @@ See [`adapters/opencode.ts`](src/proxy/adapters/opencode.ts) for reference.
 
 ## Configuration
 
+Meridian can load a JSON config file from either:
+
+- `~/.config/meridian/config.json`
+- `./meridian.config.json`
+
+Set `CLAUDE_PROXY_CONFIG=/path/to/config.json` to use an explicit file.
+
+Example:
+
+```json
+{
+  "port": 4567,
+  "defaultProfile": "personal",
+  "requiredApiKeys": ["env:MERIDIAN_LAPTOP_KEY", "env:MERIDIAN_DESKTOP_KEY"],
+  "profiles": [
+    { "id": "personal", "claudeConfigDir": "~/.claude" },
+    { "id": "company", "claudeConfigDir": "~/.claude-company" }
+  ]
+}
+```
+
+Plaintext keys also work if you want a fully self-contained local config:
+
+```json
+{
+  "requiredApiKeys": ["laptop-secret", "desktop-secret"]
+}
+```
+
+That is supported, but safer practice is to keep secret values in env vars and reference them from JSON.
+
+String values support:
+
+- `~/...` home expansion
+- `env:NAME` or `$env:NAME` environment variable expansion
+
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CLAUDE_PROXY_PORT` | `3456` | Port to listen on |
@@ -177,6 +213,8 @@ See [`adapters/opencode.ts`](src/proxy/adapters/opencode.ts) for reference.
 | `CLAUDE_PROXY_WORKDIR` | `cwd()` | Default working directory for SDK |
 | `CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS` | `120` | HTTP keep-alive timeout |
 | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
+| `CLAUDE_PROXY_CONFIG` | unset | Explicit path to a JSON config file |
+| `CLAUDE_PROXY_API_KEYS` | unset | Comma-separated allowed inbound API keys |
 
 ## Programmatic API
 
@@ -255,11 +293,41 @@ See [`examples/opencode-plugin/`](examples/opencode-plugin/) for a reference imp
 docker run -v ~/.claude:/home/claude/.claude -p 3456:3456 meridian
 ```
 
+To use config-file-driven profiles and API keys in Docker, mount your config to the default path inside the container:
+
+```bash
+docker run \
+  -v ~/.claude:/home/claude/.claude \
+  -v ~/.config/meridian/config.json:/home/claude/.config/meridian/config.json:ro \
+  -e MERIDIAN_LAPTOP_KEY="$MERIDIAN_LAPTOP_KEY" \
+  -e MERIDIAN_DESKTOP_KEY="$MERIDIAN_DESKTOP_KEY" \
+  -p 3456:3456 \
+  meridian
+```
+
+If you prefer plaintext keys in the mounted JSON, you can omit the extra env vars and keep the file fully self-contained.
+
 Or with docker-compose:
 
 ```bash
 docker compose up -d
 ```
+
+Example `docker-compose.yml` service override:
+
+```yaml
+services:
+  proxy:
+    environment:
+      CLAUDE_PROXY_CONFIG: /home/claude/.config/meridian/config.json
+      MERIDIAN_LAPTOP_KEY: ${MERIDIAN_LAPTOP_KEY}
+      MERIDIAN_DESKTOP_KEY: ${MERIDIAN_DESKTOP_KEY}
+    volumes:
+      - claude-auth:/home/claude/.claude
+      - ./meridian.config.json:/home/claude/.config/meridian/config.json:ro
+```
+
+The container now creates `/home/claude/.config/meridian` automatically, so the default config-file path works without extra setup.
 
 ## Testing
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -28,6 +28,14 @@ function getEnvConfigOverrides(env: NodeJS.ProcessEnv = process.env): Partial<Pr
   if (env.CLAUDE_PROXY_API_KEYS) {
     overrides.requiredApiKeys = env.CLAUDE_PROXY_API_KEYS.split(",").map((key) => key.trim()).filter(Boolean)
   }
+  if (env.CLAUDE_PROXY_ADMIN_API_KEYS) {
+    overrides.adminApiKeys = env.CLAUDE_PROXY_ADMIN_API_KEYS.split(",").map((key) => key.trim()).filter(Boolean)
+  }
+  if (env.CLAUDE_PROXY_PROTECT_ADMIN_ROUTES) {
+    overrides.protectAdminRoutes = env.CLAUDE_PROXY_PROTECT_ADMIN_ROUTES === "1"
+  }
+  if (env.CLAUDE_PROXY_ADMIN_USERNAME) overrides.adminUsername = env.CLAUDE_PROXY_ADMIN_USERNAME
+  if (env.CLAUDE_PROXY_ADMIN_PASSWORD) overrides.adminPassword = env.CLAUDE_PROXY_ADMIN_PASSWORD
 
   return overrides
 }

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
 import { startProxyServer } from "../src/proxy/server"
+import { loadProxyConfigFile } from "../src/proxy/configLoader"
 import { exec as execCallback } from "child_process"
 import { promisify } from "util"
+import type { ProxyConfig } from "../src/proxy/types"
 
 const exec = promisify(execCallback)
 
@@ -14,9 +16,21 @@ process.on("unhandledRejection", (reason) => {
   console.error(`[PROXY] Unhandled rejection (recovered): ${reason instanceof Error ? reason.message : reason}`)
 })
 
-const port = parseInt(process.env.CLAUDE_PROXY_PORT || "3456", 10)
-const host = process.env.CLAUDE_PROXY_HOST || "127.0.0.1"
-const idleTimeoutSeconds = parseInt(process.env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS || "120", 10)
+function getEnvConfigOverrides(env: NodeJS.ProcessEnv = process.env): Partial<ProxyConfig> {
+  const overrides: Partial<ProxyConfig> = {}
+
+  if (env.CLAUDE_PROXY_PORT) overrides.port = parseInt(env.CLAUDE_PROXY_PORT, 10)
+  if (env.CLAUDE_PROXY_HOST) overrides.host = env.CLAUDE_PROXY_HOST
+  if (env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS) {
+    overrides.idleTimeoutSeconds = parseInt(env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS, 10)
+  }
+  if (env.CLAUDE_PROXY_DEBUG) overrides.debug = env.CLAUDE_PROXY_DEBUG === "1"
+  if (env.CLAUDE_PROXY_API_KEYS) {
+    overrides.requiredApiKeys = env.CLAUDE_PROXY_API_KEYS.split(",").map((key) => key.trim()).filter(Boolean)
+  }
+
+  return overrides
+}
 
 export async function runCli(
   start = startProxyServer,
@@ -37,7 +51,9 @@ export async function runCli(
     console.error("\x1b[33m⚠ Could not verify Claude auth status. If requests fail, run: claude login\x1b[0m")
   }
 
-  const proxy = await start({ port, host, idleTimeoutSeconds })
+  const fileConfig = loadProxyConfigFile()
+  const envOverrides = getEnvConfigOverrides()
+  const proxy = await start({ ...fileConfig, ...envOverrides })
 
   // Handle EADDRINUSE — preserve CLI behavior of exiting on port conflict
   proxy.server.on("error", (error: NodeJS.ErrnoException) => {
@@ -48,5 +64,10 @@ export async function runCli(
 }
 
 if (import.meta.main) {
-  await runCli()
+  try {
+    await runCli()
+  } catch (error) {
+    console.error(`[PROXY] ${error instanceof Error ? error.message : String(error)}`)
+    process.exit(1)
+  }
 }

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -6,6 +6,9 @@
 CLAUDE_DIR="/home/claude/.claude"
 CLAUDE_JSON="/home/claude/.claude.json"
 CLAUDE_JSON_VOL="$CLAUDE_DIR/.claude.json"
+MERIDIAN_CONFIG_DIR="/home/claude/.config/meridian"
+
+mkdir -p "$MERIDIAN_CONFIG_DIR"
 
 # Fix ownership if volume was created as root
 if [ -d "$CLAUDE_DIR" ] && [ ! -w "$CLAUDE_DIR" ]; then

--- a/examples/claude-code-profile.sh
+++ b/examples/claude-code-profile.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE="${1:-personal}"
+BASE_URL="${ANTHROPIC_BASE_URL:-http://127.0.0.1:4567}"
+
+case "$PROFILE" in
+  personal|company)
+    ;;
+  *)
+    printf 'Usage: %s [personal|company]\n' "$0" >&2
+    exit 1
+    ;;
+esac
+
+ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-x}" \
+ANTHROPIC_BASE_URL="$BASE_URL" \
+ANTHROPIC_CUSTOM_HEADERS="x-meridian-profile: $PROFILE" \
+claude "${@:2}"

--- a/examples/meridian.config.example.json
+++ b/examples/meridian.config.example.json
@@ -1,0 +1,19 @@
+{
+  "port": 4567,
+  "host": "127.0.0.1",
+  "defaultProfile": "personal",
+  "requiredApiKeys": [
+    "env:MERIDIAN_LAPTOP_KEY",
+    "env:MERIDIAN_DESKTOP_KEY"
+  ],
+  "profiles": [
+    {
+      "id": "personal",
+      "claudeConfigDir": "~/.claude"
+    },
+    {
+      "id": "company",
+      "claudeConfigDir": "~/.claude-company"
+    }
+  ]
+}

--- a/examples/profile-routing-local.ts
+++ b/examples/profile-routing-local.ts
@@ -1,0 +1,33 @@
+import { startProxyServer } from "../src/proxy/server"
+
+const port = Number.parseInt(process.env.CLAUDE_PROXY_PORT || "3456", 10)
+const host = process.env.CLAUDE_PROXY_HOST || "127.0.0.1"
+
+const personalDir = process.env.MERIDIAN_PERSONAL_CLAUDE_DIR
+const companyDir = process.env.MERIDIAN_COMPANY_CLAUDE_DIR
+
+if (!personalDir || !companyDir) {
+  throw new Error("Set MERIDIAN_PERSONAL_CLAUDE_DIR and MERIDIAN_COMPANY_CLAUDE_DIR before running this example")
+}
+
+const proxy = await startProxyServer({
+  port,
+  host,
+  profiles: [
+    { id: "personal", claudeConfigDir: personalDir },
+    { id: "company", claudeConfigDir: companyDir },
+  ],
+  defaultProfile: "personal",
+})
+
+const stop = async () => {
+  await proxy.close()
+  process.exit(0)
+}
+
+process.on("SIGINT", () => { void stop() })
+process.on("SIGTERM", () => { void stop() })
+
+console.log(`Profile test proxy running at http://${host}:${port}`)
+console.log("Profiles: personal, company")
+console.log("Use x-meridian-profile to select a profile per request")

--- a/src/__tests__/adapter.test.ts
+++ b/src/__tests__/adapter.test.ts
@@ -25,6 +25,15 @@ describe("openCodeAdapter", () => {
     expect(openCodeAdapter.getSessionId(mockContext as any)).toBeUndefined()
   })
 
+  it("extracts profile ID from x-meridian-profile header", () => {
+    const mockContext = {
+      req: {
+        header: (name: string) => name === "x-meridian-profile" ? "company" : undefined
+      }
+    }
+    expect(openCodeAdapter.getProfileId(mockContext as any)).toBe("company")
+  })
+
   it("extracts working directory from system prompt env block", () => {
     const body = {
       system: "<env>\n  Working directory: /Users/test/project\n</env>"

--- a/src/__tests__/configLoader.test.ts
+++ b/src/__tests__/configLoader.test.ts
@@ -62,8 +62,11 @@ describe("configLoader", () => {
     try {
       process.env.MERIDIAN_SHARED_KEY = "shared-secret"
       process.env.MERIDIAN_API_KEY = "profile-secret"
+      process.env.MERIDIAN_ADMIN_PASSWORD = "admin-secret"
 
       writeFileSync(join(cwd, "meridian.config.json"), JSON.stringify({
+        adminUsername: "admin",
+        adminPassword: "env:MERIDIAN_ADMIN_PASSWORD",
         requiredApiKeys: ["env:MERIDIAN_SHARED_KEY"],
         profiles: [{
           id: "company",
@@ -74,6 +77,8 @@ describe("configLoader", () => {
       }))
 
       const config = loadProxyConfigFile({ cwd, homeDir })
+      expect(config.adminUsername).toBe("admin")
+      expect(config.adminPassword).toBe("admin-secret")
       expect(config.requiredApiKeys).toEqual(["shared-secret"])
       expect(config.profiles?.[0]?.apiKey).toBe("profile-secret")
       expect(config.profiles?.[0]?.claudeConfigDir).toBe(join(homeDir, ".claude-company"))

--- a/src/__tests__/configLoader.test.ts
+++ b/src/__tests__/configLoader.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { loadProxyConfigFile } from "../proxy/configLoader"
+
+describe("configLoader", () => {
+  const envKeys = ["CLAUDE_PROXY_CONFIG", "MERIDIAN_SHARED_KEY", "MERIDIAN_API_KEY"] as const
+  const originalEnv = new Map<string, string | undefined>(envKeys.map((key) => [key, process.env[key]]))
+
+  afterEach(() => {
+    for (const [key, value] of originalEnv.entries()) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
+  it("loads the default config file from the current working directory", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "meridian-config-cwd-"))
+
+    try {
+      writeFileSync(join(cwd, "meridian.config.json"), JSON.stringify({
+        defaultProfile: "company",
+        requiredApiKeys: ["alpha", "beta"],
+      }))
+
+      const config = loadProxyConfigFile({ cwd, homeDir: cwd })
+      expect(config.defaultProfile).toBe("company")
+      expect(config.requiredApiKeys).toEqual(["alpha", "beta"])
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it("merges home config first and lets cwd config override it", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "meridian-config-merge-cwd-"))
+    const homeDir = mkdtempSync(join(tmpdir(), "meridian-config-merge-home-"))
+
+    try {
+      mkdirSync(join(homeDir, ".config", "meridian"), { recursive: true })
+      writeFileSync(join(homeDir, ".config", "meridian", "config.json"), JSON.stringify({
+        defaultProfile: "personal",
+        requiredApiKeys: ["alpha"],
+      }))
+      writeFileSync(join(cwd, "meridian.config.json"), JSON.stringify({
+        defaultProfile: "company",
+      }))
+
+      const config = loadProxyConfigFile({ cwd, homeDir })
+      expect(config.defaultProfile).toBe("company")
+      expect(config.requiredApiKeys).toEqual(["alpha"])
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
+
+  it("resolves env references and home paths in config values", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "meridian-config-env-cwd-"))
+    const homeDir = mkdtempSync(join(tmpdir(), "meridian-config-env-home-"))
+
+    try {
+      process.env.MERIDIAN_SHARED_KEY = "shared-secret"
+      process.env.MERIDIAN_API_KEY = "profile-secret"
+
+      writeFileSync(join(cwd, "meridian.config.json"), JSON.stringify({
+        requiredApiKeys: ["env:MERIDIAN_SHARED_KEY"],
+        profiles: [{
+          id: "company",
+          type: "api",
+          apiKey: "$env:MERIDIAN_API_KEY",
+          claudeConfigDir: "~/.claude-company",
+        }],
+      }))
+
+      const config = loadProxyConfigFile({ cwd, homeDir })
+      expect(config.requiredApiKeys).toEqual(["shared-secret"])
+      expect(config.profiles?.[0]?.apiKey).toBe("profile-secret")
+      expect(config.profiles?.[0]?.claudeConfigDir).toBe(join(homeDir, ".claude-company"))
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+  })
+
+  it("throws when an explicit config path is missing", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "meridian-config-missing-cwd-"))
+
+    try {
+      expect(() => loadProxyConfigFile({ cwd, homeDir: cwd, configPath: "missing.json" })).toThrow("Config file not found")
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/proxy-admin-auth.test.ts
+++ b/src/__tests__/proxy-admin-auth.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../proxy/models", () => ({
+  mapModelToClaudeModel: () => "sonnet",
+  resolveClaudeExecutableAsync: async () => "/usr/bin/claude",
+  isClosedControllerError: () => false,
+  getClaudeAuthStatusAsync: async () => ({ loggedIn: true, email: "test@example.com", subscriptionType: "max" }),
+  hasExtendedContext: () => false,
+  stripExtendedContext: (model: string) => model,
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { telemetryStore } = await import("../telemetry")
+
+function createTestApp(config: Record<string, unknown> = {}) {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", ...config })
+  return app
+}
+
+function basicAuthHeader(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+}
+
+describe("Proxy admin route auth", () => {
+  beforeEach(() => {
+    telemetryStore.clear()
+  })
+
+  it("keeps admin routes open when protection is disabled", async () => {
+    const app = createTestApp()
+
+    const health = await app.fetch(new Request("http://localhost/health"))
+    const telemetry = await app.fetch(new Request("http://localhost/telemetry/summary"))
+
+    expect(health.status).toBe(200)
+    expect(telemetry.status).toBe(200)
+  })
+
+  it("protects health and telemetry routes with requiredApiKeys by default", async () => {
+    const app = createTestApp({
+      protectAdminRoutes: true,
+      requiredApiKeys: ["shared-admin-key"],
+    })
+
+    const denied = await app.fetch(new Request("http://localhost/health"))
+    const allowed = await app.fetch(new Request("http://localhost/telemetry/summary", {
+      headers: { "x-api-key": "shared-admin-key" },
+    }))
+
+    expect(denied.status).toBe(401)
+    expect(allowed.status).toBe(200)
+  })
+
+  it("uses adminApiKeys when configured", async () => {
+    const app = createTestApp({
+      protectAdminRoutes: true,
+      requiredApiKeys: ["message-key"],
+      adminApiKeys: ["admin-only-key"],
+    })
+
+    const wrongKey = await app.fetch(new Request("http://localhost/health", {
+      headers: { "x-api-key": "message-key" },
+    }))
+    const rightKey = await app.fetch(new Request("http://localhost/health", {
+      headers: { authorization: "Bearer admin-only-key" },
+    }))
+
+    expect(wrongKey.status).toBe(401)
+    expect(rightKey.status).toBe(200)
+  })
+
+  it("accepts browser-style Basic Auth when configured", async () => {
+    const app = createTestApp({
+      protectAdminRoutes: true,
+      adminUsername: "admin",
+      adminPassword: "secret",
+    })
+
+    const response = await app.fetch(new Request("http://localhost/telemetry/summary", {
+      headers: { authorization: basicAuthHeader("admin", "secret") },
+    }))
+
+    expect(response.status).toBe(200)
+  })
+
+  it("returns a browser Basic Auth challenge on invalid admin credentials", async () => {
+    const app = createTestApp({
+      protectAdminRoutes: true,
+      adminUsername: "admin",
+      adminPassword: "secret",
+    })
+
+    const response = await app.fetch(new Request("http://localhost/health", {
+      headers: { authorization: basicAuthHeader("admin", "wrong") },
+    }))
+    const body = await response.json() as any
+
+    expect(response.status).toBe(401)
+    expect(response.headers.get("www-authenticate")).toBe('Basic realm="Meridian Admin"')
+    expect(body.error.type).toBe("authentication_error")
+  })
+
+  it("accepts either admin API key or Basic Auth when both are configured", async () => {
+    const app = createTestApp({
+      protectAdminRoutes: true,
+      adminApiKeys: ["admin-only-key"],
+      adminUsername: "admin",
+      adminPassword: "secret",
+    })
+
+    const withKey = await app.fetch(new Request("http://localhost/health", {
+      headers: { "x-api-key": "admin-only-key" },
+    }))
+    const withBasic = await app.fetch(new Request("http://localhost/health", {
+      headers: { authorization: basicAuthHeader("admin", "secret") },
+    }))
+
+    expect(withKey.status).toBe(200)
+    expect(withBasic.status).toBe(200)
+  })
+
+  it("keeps the landing page route public when admin protection is enabled", async () => {
+    const app = createTestApp({
+      protectAdminRoutes: true,
+      adminApiKeys: ["admin-only-key"],
+    })
+
+    const response = await app.fetch(new Request("http://localhost/", {
+      headers: { Accept: "text/html" },
+    }))
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain("Meridian")
+  })
+})

--- a/src/__tests__/proxy-async-ops.test.ts
+++ b/src/__tests__/proxy-async-ops.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 const { createProxyServer, startProxyServer } = await import("../proxy/server")
 const { resetCachedClaudeAuthStatus } = await import("../proxy/models")
@@ -91,5 +94,40 @@ describe("proxy async ops", () => {
 
     expect(startCalled).toBe(1)
     expect(errors.some((line) => line.includes("Could not verify Claude auth status"))).toBe(true)
+  })
+
+  it("loads config from a JSON file before starting the CLI proxy", async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "meridian-cli-config-"))
+    const originalConfigPath = process.env.CLAUDE_PROXY_CONFIG
+    const configPath = join(tmpDir, "meridian.config.json")
+    writeFileSync(configPath, JSON.stringify({
+      port: 8123,
+      host: "0.0.0.0",
+      defaultProfile: "company",
+      requiredApiKeys: ["alpha", "beta"],
+    }))
+
+    let capturedConfig: any
+    try {
+      process.env.CLAUDE_PROXY_CONFIG = configPath
+
+      await runCli(
+        async (config) => {
+          capturedConfig = config
+          const { EventEmitter } = await import("events")
+          return { server: new EventEmitter(), config: {}, close: async () => {} } as any
+        },
+        ((async () => ({ stdout: JSON.stringify({ loggedIn: true, subscriptionType: "max" }) })) as any),
+      )
+    } finally {
+      if (originalConfigPath === undefined) delete process.env.CLAUDE_PROXY_CONFIG
+      else process.env.CLAUDE_PROXY_CONFIG = originalConfigPath
+      rmSync(tmpDir, { recursive: true, force: true })
+    }
+
+    expect(capturedConfig.port).toBe(8123)
+    expect(capturedConfig.host).toBe("0.0.0.0")
+    expect(capturedConfig.defaultProfile).toBe("company")
+    expect(capturedConfig.requiredApiKeys).toEqual(["alpha", "beta"])
   })
 })

--- a/src/__tests__/proxy-auth.test.ts
+++ b/src/__tests__/proxy-auth.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+
+let queryCallCount = 0
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => {
+    queryCallCount += 1
+    return (async function* () {
+      yield {
+        type: "assistant",
+        message: {
+          id: "msg-auth",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 1, output_tokens: 1 },
+        },
+        session_id: "sdk-auth",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+mock.module("../proxy/models", () => ({
+  mapModelToClaudeModel: () => "sonnet",
+  resolveClaudeExecutableAsync: async () => "/usr/bin/claude",
+  isClosedControllerError: () => false,
+  getClaudeAuthStatusAsync: async () => ({ loggedIn: true, subscriptionType: "max" }),
+  hasExtendedContext: () => false,
+  stripExtendedContext: (model: string) => model,
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+
+function createTestApp(config: Record<string, unknown> = {}) {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", ...config })
+  return app
+}
+
+async function post(app: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-5",
+      max_tokens: 64,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+  }))
+}
+
+describe("Proxy API key auth", () => {
+  beforeEach(() => {
+    queryCallCount = 0
+  })
+
+  it("allows requests when API key auth is disabled", async () => {
+    const app = createTestApp()
+
+    const response = await post(app, { "x-api-key": "dummy" })
+    expect(response.status).toBe(200)
+    expect(queryCallCount).toBe(1)
+  })
+
+  it("allows requests with a configured x-api-key", async () => {
+    const app = createTestApp({ requiredApiKeys: ["alpha", "beta"] })
+
+    const response = await post(app, { "x-api-key": "beta" })
+    expect(response.status).toBe(200)
+    expect(queryCallCount).toBe(1)
+  })
+
+  it("allows requests with a bearer token", async () => {
+    const app = createTestApp({ requiredApiKeys: ["alpha", "beta"] })
+
+    const response = await post(app, { authorization: "Bearer alpha" })
+    expect(response.status).toBe(200)
+    expect(queryCallCount).toBe(1)
+  })
+
+  it("rejects requests with no key when auth is enabled", async () => {
+    const app = createTestApp({ requiredApiKeys: ["alpha"] })
+
+    const response = await post(app)
+    const body = await response.json() as any
+
+    expect(response.status).toBe(401)
+    expect(body.error.type).toBe("authentication_error")
+    expect(queryCallCount).toBe(0)
+  })
+
+  it("rejects requests with the wrong key", async () => {
+    const app = createTestApp({ requiredApiKeys: ["alpha"] })
+
+    const response = await post(app, { "x-api-key": "wrong" })
+    const body = await response.json() as any
+
+    expect(response.status).toBe(401)
+    expect(body.error.type).toBe("authentication_error")
+    expect(queryCallCount).toBe(0)
+  })
+})

--- a/src/__tests__/proxy-profiles.test.ts
+++ b/src/__tests__/proxy-profiles.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+let capturedQueryOptions: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryOptions.push(params.options)
+    const profileDir = params.options?.env?.CLAUDE_CONFIG_DIR
+    const sessionSuffix = typeof profileDir === "string"
+      ? profileDir.split("/").at(-1)
+      : params.options?.env?.ANTHROPIC_API_KEY
+        ? "api"
+        : "default"
+
+    return (async function* () {
+      yield {
+        type: "assistant",
+        message: {
+          id: `msg-${sessionSuffix}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: `ok-${sessionSuffix}` }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: `sdk-session-${sessionSuffix}`,
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+mock.module("../proxy/models", () => ({
+  mapModelToClaudeModel: () => "sonnet",
+  resolveClaudeExecutableAsync: async () => "/usr/bin/claude",
+  isClosedControllerError: () => false,
+  getClaudeAuthStatusAsync: async () => ({ loggedIn: true, subscriptionType: "max" }),
+  hasExtendedContext: () => false,
+  stripExtendedContext: (model: string) => model,
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp(config: Record<string, any> = {}) {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", ...config })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  }))
+}
+
+const BASIC_REQUEST = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 128,
+  stream: false,
+  messages: [{ role: "user", content: "hello" }],
+}
+
+describe("Profile routing", () => {
+  const savedEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    capturedQueryOptions = []
+    clearSessionCache()
+    for (const key of ["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"]) {
+      savedEnv[key] = process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+  })
+
+  it("passes CLAUDE_CONFIG_DIR for a claude-max profile", async () => {
+    const app = createTestApp({
+      profiles: [{ id: "company", claudeConfigDir: "/tmp/company-profile" }],
+      defaultProfile: "company",
+    })
+
+    await (await post(app, BASIC_REQUEST)).json()
+
+    expect(capturedQueryOptions[0]?.env?.CLAUDE_CONFIG_DIR).toBe("/tmp/company-profile")
+  })
+
+  it("overlays API profile auth env after inherited Anthropic vars are stripped", async () => {
+    process.env.ANTHROPIC_API_KEY = "dummy-key"
+    process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:3456"
+    process.env.ANTHROPIC_AUTH_TOKEN = "dummy-token"
+
+    const app = createTestApp({
+      profiles: [{
+        id: "api-direct",
+        type: "api",
+        apiKey: "real-key",
+        baseUrl: "https://api.example.test",
+        authToken: "real-token",
+      }],
+      defaultProfile: "api-direct",
+    })
+
+    await (await post(app, BASIC_REQUEST)).json()
+
+    expect(capturedQueryOptions[0]?.env?.ANTHROPIC_API_KEY).toBe("real-key")
+    expect(capturedQueryOptions[0]?.env?.ANTHROPIC_BASE_URL).toBe("https://api.example.test")
+    expect(capturedQueryOptions[0]?.env?.ANTHROPIC_AUTH_TOKEN).toBe("real-token")
+  })
+
+  it("keeps session resume isolated by requested profile", async () => {
+    const app = createTestApp({
+      profiles: [
+        { id: "personal", claudeConfigDir: "/tmp/personal-profile" },
+        { id: "company", claudeConfigDir: "/tmp/company-profile" },
+      ],
+      defaultProfile: "personal",
+    })
+
+    await (await post(app, BASIC_REQUEST, {
+      "x-opencode-session": "shared-session",
+      "x-meridian-profile": "personal",
+    })).json()
+
+    await (await post(app, BASIC_REQUEST, {
+      "x-opencode-session": "shared-session",
+      "x-meridian-profile": "company",
+    })).json()
+
+    await (await post(app, {
+      ...BASIC_REQUEST,
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: [{ type: "text", text: "ok-personal-profile" }] },
+        { role: "user", content: "remember me" },
+      ],
+    }, {
+      "x-opencode-session": "shared-session",
+      "x-meridian-profile": "personal",
+    })).json()
+
+    expect(capturedQueryOptions[0]?.resume).toBeUndefined()
+    expect(capturedQueryOptions[1]?.resume).toBeUndefined()
+    expect(capturedQueryOptions[2]?.resume).toBe("sdk-session-personal-profile")
+  })
+})

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -21,6 +21,7 @@ export interface AgentAdapter {
    * Returns undefined if the agent doesn't provide session tracking.
    */
   getSessionId(c: Context): string | undefined
+  getProfileId(c: Context): string | undefined
 
   /**
    * Extract the client's working directory from the request body.

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -18,6 +18,10 @@ export const openCodeAdapter: AgentAdapter = {
     return c.req.header("x-opencode-session")
   },
 
+  getProfileId(c: Context): string | undefined {
+    return c.req.header("x-meridian-profile")
+  },
+
   extractWorkingDirectory(body: any): string | undefined {
     return extractClientCwd(body)
   },

--- a/src/proxy/auth.ts
+++ b/src/proxy/auth.ts
@@ -10,6 +10,38 @@ export function extractRequestApiKey(xApiKey?: string, authorization?: string): 
   return bearerToken || undefined
 }
 
+export interface BasicAuthCredentials {
+  username: string
+  password: string
+}
+
+export function normalizeBasicAuthCredentials(
+  username?: string,
+  password?: string,
+): BasicAuthCredentials | undefined {
+  const normalizedUsername = username?.trim()
+  const normalizedPassword = password?.trim()
+  if (!normalizedUsername || !normalizedPassword) return undefined
+  return { username: normalizedUsername, password: normalizedPassword }
+}
+
+export function extractBasicAuthCredentials(authorization?: string): BasicAuthCredentials | undefined {
+  const basicMatch = authorization?.match(/^Basic\s+(.+)$/i)
+  const encoded = basicMatch?.[1]?.trim()
+  if (!encoded) return undefined
+
+  try {
+    const decoded = Buffer.from(encoded, "base64").toString("utf8")
+    const separatorIndex = decoded.indexOf(":")
+    if (separatorIndex < 0) return undefined
+    const username = decoded.slice(0, separatorIndex)
+    const password = decoded.slice(separatorIndex + 1)
+    return normalizeBasicAuthCredentials(username, password)
+  } catch {
+    return undefined
+  }
+}
+
 export function isApiKeyAuthEnabled(requiredApiKeys?: string[]): boolean {
   return normalizeRequiredApiKeys(requiredApiKeys).length > 0
 }
@@ -19,4 +51,20 @@ export function isApiKeyAuthorized(providedApiKey: string | undefined, requiredA
   if (normalizedKeys.length === 0) return true
   if (!providedApiKey) return false
   return normalizedKeys.includes(providedApiKey)
+}
+
+export function isBasicAuthEnabled(username?: string, password?: string): boolean {
+  return Boolean(normalizeBasicAuthCredentials(username, password))
+}
+
+export function isBasicAuthAuthorized(
+  providedCredentials: BasicAuthCredentials | undefined,
+  expectedUsername?: string,
+  expectedPassword?: string,
+): boolean {
+  const expectedCredentials = normalizeBasicAuthCredentials(expectedUsername, expectedPassword)
+  if (!expectedCredentials) return true
+  if (!providedCredentials) return false
+  return providedCredentials.username === expectedCredentials.username
+    && providedCredentials.password === expectedCredentials.password
 }

--- a/src/proxy/auth.ts
+++ b/src/proxy/auth.ts
@@ -1,0 +1,22 @@
+export function normalizeRequiredApiKeys(keys?: string[]): string[] {
+  return (keys ?? []).map((key) => key.trim()).filter(Boolean)
+}
+
+export function extractRequestApiKey(xApiKey?: string, authorization?: string): string | undefined {
+  if (xApiKey?.trim()) return xApiKey.trim()
+
+  const bearerMatch = authorization?.match(/^Bearer\s+(.+)$/i)
+  const bearerToken = bearerMatch?.[1]?.trim()
+  return bearerToken || undefined
+}
+
+export function isApiKeyAuthEnabled(requiredApiKeys?: string[]): boolean {
+  return normalizeRequiredApiKeys(requiredApiKeys).length > 0
+}
+
+export function isApiKeyAuthorized(providedApiKey: string | undefined, requiredApiKeys?: string[]): boolean {
+  const normalizedKeys = normalizeRequiredApiKeys(requiredApiKeys)
+  if (normalizedKeys.length === 0) return true
+  if (!providedApiKey) return false
+  return normalizedKeys.includes(providedApiKey)
+}

--- a/src/proxy/configLoader.ts
+++ b/src/proxy/configLoader.ts
@@ -35,6 +35,8 @@ function normalizeProfile(profile: ProfileConfig, homeDir: string): ProfileConfi
 function normalizeConfig(config: Partial<ProxyConfig>, homeDir: string): Partial<ProxyConfig> {
   return {
     ...config,
+    adminUsername: config.adminUsername ? resolveConfigString(config.adminUsername, homeDir) : undefined,
+    adminPassword: config.adminPassword ? resolveConfigString(config.adminPassword, homeDir) : undefined,
     requiredApiKeys: config.requiredApiKeys
       ?.map((key) => resolveConfigString(key, homeDir))
       .filter((key): key is string => Boolean(key)),

--- a/src/proxy/configLoader.ts
+++ b/src/proxy/configLoader.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { isAbsolute, join } from "node:path"
+import type { ProfileConfig, ProxyConfig } from "./types"
+
+function expandHome(filePath: string, homeDir: string): string {
+  return filePath === "~" ? homeDir : filePath.startsWith("~/") ? join(homeDir, filePath.slice(2)) : filePath
+}
+
+function resolveEnvReference(value: string): string | undefined {
+  const match = value.match(/^(?:\$env:|env:)(.+)$/)
+  if (!match) return undefined
+  return process.env[match[1]?.trim() ?? ""]
+}
+
+function resolveConfigString(value: string, homeDir: string): string | undefined {
+  const envValue = resolveEnvReference(value)
+  const resolved = envValue ?? value
+  return expandHome(resolved, homeDir)
+}
+
+function normalizeProfile(profile: ProfileConfig, homeDir: string): ProfileConfig {
+  return {
+    ...profile,
+    claudeConfigDir: profile.claudeConfigDir ? resolveConfigString(profile.claudeConfigDir, homeDir) : undefined,
+    claudeExecutable: profile.claudeExecutable ? resolveConfigString(profile.claudeExecutable, homeDir) : undefined,
+    apiKey: profile.apiKey ? resolveConfigString(profile.apiKey, homeDir) : undefined,
+    apiKeyEnv: profile.apiKeyEnv,
+    baseUrl: profile.baseUrl ? resolveConfigString(profile.baseUrl, homeDir) : undefined,
+    authToken: profile.authToken ? resolveConfigString(profile.authToken, homeDir) : undefined,
+    authTokenEnv: profile.authTokenEnv,
+  }
+}
+
+function normalizeConfig(config: Partial<ProxyConfig>, homeDir: string): Partial<ProxyConfig> {
+  return {
+    ...config,
+    requiredApiKeys: config.requiredApiKeys
+      ?.map((key) => resolveConfigString(key, homeDir))
+      .filter((key): key is string => Boolean(key)),
+    profiles: config.profiles?.map((profile) => normalizeProfile(profile, homeDir)),
+  }
+}
+
+function mergeConfigs(base: Partial<ProxyConfig>, override: Partial<ProxyConfig>): Partial<ProxyConfig> {
+  return {
+    ...base,
+    ...Object.fromEntries(Object.entries(override).filter(([, value]) => value !== undefined)),
+  }
+}
+
+function getDefaultConfigPaths(cwd: string, homeDir: string): string[] {
+  return [
+    join(homeDir, ".config", "meridian", "config.json"),
+    join(cwd, "meridian.config.json"),
+  ]
+}
+
+export interface ConfigLoaderOptions {
+  cwd?: string
+  homeDir?: string
+  configPath?: string
+}
+
+export function loadProxyConfigFile(options: ConfigLoaderOptions = {}): Partial<ProxyConfig> {
+  const cwd = options.cwd ?? process.cwd()
+  const homeDir = options.homeDir ?? homedir()
+  const explicitConfigPath = options.configPath ?? process.env.CLAUDE_PROXY_CONFIG
+  const configPaths = explicitConfigPath
+    ? [expandHome(explicitConfigPath, homeDir)]
+    : getDefaultConfigPaths(cwd, homeDir)
+
+  if (explicitConfigPath) {
+    const filePath = isAbsolute(configPaths[0]!) ? configPaths[0]! : join(cwd, configPaths[0]!)
+    if (!existsSync(filePath)) {
+      throw new Error(`Config file not found: ${filePath}`)
+    }
+  }
+
+  return configPaths.reduce<Partial<ProxyConfig>>((merged, candidatePath) => {
+    const filePath = isAbsolute(candidatePath) ? candidatePath : join(cwd, candidatePath)
+    if (!existsSync(filePath)) return merged
+
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as Partial<ProxyConfig>
+    const normalized = normalizeConfig(parsed, homeDir)
+    return mergeConfigs(merged, normalized)
+  }, {})
+}

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -30,6 +30,41 @@ let cachedAuthStatusAt = 0
 let cachedAuthStatusIsFailure = false
 let cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null = null
 
+type AuthStatusCache = {
+  cachedAuthStatus: ClaudeAuthStatus | null
+  lastKnownGoodAuthStatus: ClaudeAuthStatus | null
+  cachedAuthStatusAt: number
+  cachedAuthStatusIsFailure: boolean
+  cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null
+}
+
+const authStatusCacheByKey = new Map<string, AuthStatusCache>()
+
+function getAuthStatusCacheKey(envOverrides?: Record<string, string | undefined>): string {
+  if (!envOverrides) return "default"
+  return JSON.stringify({
+    CLAUDE_CONFIG_DIR: envOverrides.CLAUDE_CONFIG_DIR,
+    ANTHROPIC_API_KEY: envOverrides.ANTHROPIC_API_KEY,
+    ANTHROPIC_BASE_URL: envOverrides.ANTHROPIC_BASE_URL,
+    ANTHROPIC_AUTH_TOKEN: envOverrides.ANTHROPIC_AUTH_TOKEN,
+  })
+}
+
+function getAuthStatusCache(key: string): AuthStatusCache {
+  let cache = authStatusCacheByKey.get(key)
+  if (!cache) {
+    cache = {
+      cachedAuthStatus,
+      lastKnownGoodAuthStatus,
+      cachedAuthStatusAt,
+      cachedAuthStatusIsFailure,
+      cachedAuthStatusPromise,
+    }
+    authStatusCacheByKey.set(key, cache)
+  }
+  return cache
+}
+
 /**
  * Only Claude 4.6 models support the 1M extended context window.
  * Older models (4.5 and earlier) do not.
@@ -72,39 +107,43 @@ export function hasExtendedContext(model: ClaudeModel): boolean {
   return model.endsWith("[1m]")
 }
 
-export async function getClaudeAuthStatusAsync(): Promise<ClaudeAuthStatus | null> {
+export async function getClaudeAuthStatusAsync(envOverrides?: Record<string, string | undefined>): Promise<ClaudeAuthStatus | null> {
+  const cache = getAuthStatusCache(getAuthStatusCacheKey(envOverrides))
   // Return cached result if within TTL — use shorter TTL for failures to recover faster
-  const ttl = cachedAuthStatusIsFailure ? AUTH_STATUS_FAILURE_TTL_MS : AUTH_STATUS_CACHE_TTL_MS
-  if (cachedAuthStatusAt > 0 && Date.now() - cachedAuthStatusAt < ttl) {
+  const ttl = cache.cachedAuthStatusIsFailure ? AUTH_STATUS_FAILURE_TTL_MS : AUTH_STATUS_CACHE_TTL_MS
+  if (cache.cachedAuthStatusAt > 0 && Date.now() - cache.cachedAuthStatusAt < ttl) {
     // On failure, return last known good status (preserves subscription type for model selection)
-    return cachedAuthStatus ?? lastKnownGoodAuthStatus
+    return cache.cachedAuthStatus ?? cache.lastKnownGoodAuthStatus
   }
-  if (cachedAuthStatusPromise) return cachedAuthStatusPromise
+  if (cache.cachedAuthStatusPromise) return cache.cachedAuthStatusPromise
 
-  cachedAuthStatusPromise = (async () => {
+  cache.cachedAuthStatusPromise = (async () => {
     try {
-      const { stdout } = await exec("claude auth status", { timeout: 5000 })
+      const { stdout } = await exec("claude auth status", {
+        timeout: 5000,
+        env: { ...process.env, ...envOverrides },
+      })
       const parsed = JSON.parse(stdout) as ClaudeAuthStatus
-      cachedAuthStatus = parsed
-      lastKnownGoodAuthStatus = parsed
-      cachedAuthStatusAt = Date.now()
-      cachedAuthStatusIsFailure = false
+      cache.cachedAuthStatus = parsed
+      cache.lastKnownGoodAuthStatus = parsed
+      cache.cachedAuthStatusAt = Date.now()
+      cache.cachedAuthStatusIsFailure = false
       return parsed
     } catch {
       // Short-lived negative cache: retry in 5s instead of 60s.
       // Return last known good status so model selection doesn't degrade
       // (e.g. sonnet[1m] → sonnet) during transient auth command failures.
-      cachedAuthStatusIsFailure = true
-      cachedAuthStatusAt = Date.now()
-      cachedAuthStatus = null
-      return lastKnownGoodAuthStatus
+      cache.cachedAuthStatusIsFailure = true
+      cache.cachedAuthStatusAt = Date.now()
+      cache.cachedAuthStatus = null
+      return cache.lastKnownGoodAuthStatus
     }
   })()
 
   try {
-    return await cachedAuthStatusPromise
+    return await cache.cachedAuthStatusPromise
   } finally {
-    cachedAuthStatusPromise = null
+    cache.cachedAuthStatusPromise = null
   }
 }
 
@@ -172,6 +211,7 @@ export function resetCachedClaudeAuthStatus(): void {
   cachedAuthStatusAt = 0
   cachedAuthStatusIsFailure = false
   cachedAuthStatusPromise = null
+  authStatusCacheByKey.clear()
 }
 
 /** Expire the auth status cache without clearing lastKnownGoodAuthStatus — for testing only.
@@ -180,6 +220,10 @@ export function resetCachedClaudeAuthStatus(): void {
 export function expireAuthStatusCache(): void {
   cachedAuthStatusAt = 0
   cachedAuthStatusPromise = null
+  for (const cache of authStatusCacheByKey.values()) {
+    cache.cachedAuthStatusAt = 0
+    cache.cachedAuthStatusPromise = null
+  }
 }
 
 /**

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -1,0 +1,61 @@
+import type { ProfileConfig, ProfileType, ProxyConfig } from "./types"
+
+export const DEFAULT_PROFILE_ID = "default"
+
+export interface ResolvedProfile {
+  id: string
+  type: ProfileType
+  claudeExecutable?: string
+  env: Record<string, string | undefined>
+}
+
+function getProfileType(profile: ProfileConfig): ProfileType {
+  return profile.type ?? "claude-max"
+}
+
+function getEnvValue(directValue: string | undefined, envName: string | undefined): string | undefined {
+  if (directValue) return directValue
+  if (!envName) return undefined
+  return process.env[envName]
+}
+
+function buildProfileEnv(profile: ProfileConfig): Record<string, string | undefined> {
+  const type = getProfileType(profile)
+
+  if (type === "api") {
+    return {
+      ANTHROPIC_API_KEY: getEnvValue(profile.apiKey, profile.apiKeyEnv),
+      ANTHROPIC_BASE_URL: profile.baseUrl,
+      ANTHROPIC_AUTH_TOKEN: getEnvValue(profile.authToken, profile.authTokenEnv),
+    }
+  }
+
+  return {
+    ...(profile.claudeConfigDir ? { CLAUDE_CONFIG_DIR: profile.claudeConfigDir } : {}),
+  }
+}
+
+export function resolveProfile(config: ProxyConfig, requestedProfileId?: string): ResolvedProfile {
+  const configuredProfiles = config.profiles ?? []
+
+  if (configuredProfiles.length === 0) {
+    return {
+      id: requestedProfileId ?? config.defaultProfile ?? DEFAULT_PROFILE_ID,
+      type: "claude-max",
+      env: {},
+    }
+  }
+
+  const resolvedId = requestedProfileId ?? config.defaultProfile ?? configuredProfiles[0]!.id
+  const profile = configuredProfiles.find((candidate) => candidate.id === resolvedId)
+  if (!profile) {
+    throw new Error(`Unknown profile: ${resolvedId}`)
+  }
+
+  return {
+    id: profile.id,
+    type: getProfileType(profile),
+    claudeExecutable: profile.claudeExecutable,
+    env: buildProfileEnv(profile),
+  }
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -191,7 +191,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     }
 
     const headers = adminBasicAuthEnabled
-      ? { "WWW-Authenticate": 'Basic realm="Meridian Admin"' }
+      ? { "WWW-Authenticate": 'Basic realm="Admin"' }
       : undefined
 
     return c.json(
@@ -212,6 +212,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   app.use("/v1/messages", validateApiKey)
   app.use("/messages", validateApiKey)
   if (finalConfig.protectAdminRoutes) {
+    app.use("/", validateAdminAccess)
     app.use("/health", validateAdminAccess)
     app.use("/telemetry", validateAdminAccess)
     app.use("/telemetry/*", validateAdminAccess)
@@ -1276,7 +1277,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // Health check endpoint — verifies auth status
   app.get("/health", async (c) => {
     try {
-      const auth = await getClaudeAuthStatusAsync()
+      const defaultProfile = resolveProfile(finalConfig)
+      const auth = await getClaudeAuthStatusAsync(defaultProfile.env)
       if (!auth) {
         return c.json({
           status: "degraded",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -25,7 +25,14 @@ import { ALLOWED_MCP_TOOLS } from "./tools"
 import { getLastUserMessage } from "./messages"
 import { openCodeAdapter } from "./adapters/opencode"
 import { buildQueryOptions, type QueryContext } from "./query"
-import { extractRequestApiKey, isApiKeyAuthEnabled, isApiKeyAuthorized } from "./auth"
+import {
+  extractBasicAuthCredentials,
+  extractRequestApiKey,
+  isApiKeyAuthEnabled,
+  isApiKeyAuthorized,
+  isBasicAuthAuthorized,
+  isBasicAuthEnabled,
+} from "./auth"
 import { resolveProfile } from "./profiles"
 import {
   computeLineageHash,
@@ -162,9 +169,53 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   }
 
   const validateApiKey = createApiKeyMiddleware(finalConfig.requiredApiKeys)
+  const adminRouteKeys = finalConfig.adminApiKeys ?? finalConfig.requiredApiKeys
+  const adminBasicAuthEnabled = isBasicAuthEnabled(finalConfig.adminUsername, finalConfig.adminPassword)
+  const validateAdminAccess = async (c: Context, next: () => Promise<void>) => {
+    const authorization = c.req.header("authorization")
+    const providedApiKey = extractRequestApiKey(c.req.header("x-api-key"), authorization)
+    const providedBasicAuth = extractBasicAuthCredentials(authorization)
+    const apiKeyEnabled = isApiKeyAuthEnabled(adminRouteKeys)
+    const apiKeyAuthorized = apiKeyEnabled && isApiKeyAuthorized(providedApiKey, adminRouteKeys)
+    const basicAuthorized = adminBasicAuthEnabled
+      && isBasicAuthAuthorized(providedBasicAuth, finalConfig.adminUsername, finalConfig.adminPassword)
+
+    if (!apiKeyEnabled && !adminBasicAuthEnabled) {
+      await next()
+      return
+    }
+
+    if (apiKeyAuthorized || basicAuthorized) {
+      await next()
+      return
+    }
+
+    const headers = adminBasicAuthEnabled
+      ? { "WWW-Authenticate": 'Basic realm="Meridian Admin"' }
+      : undefined
+
+    return c.json(
+      {
+        type: "error",
+        error: {
+          type: "authentication_error",
+          message: adminBasicAuthEnabled
+            ? "Invalid or missing admin credentials"
+            : "Invalid or missing API key",
+        },
+      },
+      401,
+      headers,
+    )
+  }
 
   app.use("/v1/messages", validateApiKey)
   app.use("/messages", validateApiKey)
+  if (finalConfig.protectAdminRoutes) {
+    app.use("/health", validateAdminAccess)
+    app.use("/telemetry", validateAdminAccess)
+    app.use("/telemetry/*", validateAdminAccess)
+  }
 
   app.get("/", (c) => {
     // API clients get JSON, browsers get the landing page

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -25,6 +25,7 @@ import { ALLOWED_MCP_TOOLS } from "./tools"
 import { getLastUserMessage } from "./messages"
 import { openCodeAdapter } from "./adapters/opencode"
 import { buildQueryOptions, type QueryContext } from "./query"
+import { resolveProfile } from "./profiles"
 import {
   computeLineageHash,
   hashMessage,
@@ -181,11 +182,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
       try {
         const body = await c.req.json()
-        const authStatus = await getClaudeAuthStatusAsync()
-        let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
         const stream = body.stream ?? true
         const adapter = openCodeAdapter
+        const requestedProfile = resolveProfile(finalConfig, adapter.getProfileId(c))
         const workingDirectory = process.env.CLAUDE_PROXY_WORKDIR || adapter.extractWorkingDirectory(body) || process.cwd()
+        const opencodeSessionId = adapter.getSessionId(c)
+        const lineageResult = lookupSession(opencodeSessionId, body.messages || [], workingDirectory, requestedProfile.id)
+        const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
+        const isUndo = lineageResult.type === "undo"
+        const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
+        const effectiveProfile = resolveProfile(finalConfig, cachedSession?.profileId || requestedProfile.id)
+        const authStatus = await getClaudeAuthStatusAsync(effectiveProfile.env)
+        let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
 
         // Strip env vars that would cause the SDK subprocess to loop back through
         // the proxy instead of using its native Claude Max auth. Also strip vars
@@ -197,6 +205,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ANTHROPIC_AUTH_TOKEN: _dropAuthToken,
           ...cleanEnv
         } = process.env
+        const runtimeEnv = { ...cleanEnv, ...effectiveProfile.env }
+        let runtimeClaudeExecutable = effectiveProfile.claudeExecutable || claudeExecutable
 
         let systemContext = ""
         if (body.system) {
@@ -210,12 +220,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           }
         }
 
-        // Session resume: look up cached Claude SDK session and classify mutation
-        const opencodeSessionId = adapter.getSessionId(c)
-        const lineageResult = lookupSession(opencodeSessionId, body.messages || [], workingDirectory)
-        const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
-        const isUndo = lineageResult.type === "undo"
-        const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         const resumeSessionId = cachedSession?.claudeSessionId
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
@@ -478,8 +482,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
           try {
             // Lazy-resolve executable if not already set (e.g. when using createProxyServer directly)
-            if (!claudeExecutable) {
-              claudeExecutable = await resolveClaudeExecutableAsync()
+            if (!runtimeClaudeExecutable) {
+              runtimeClaudeExecutable = await resolveClaudeExecutableAsync()
             }
 
             // Wrap SDK call with transparent retry for recoverable errors.
@@ -502,8 +506,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 let didYieldContent = false
                 try {
                   for await (const event of query(buildQueryOptions({
-                    prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
-                    passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
+                    prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable: runtimeClaudeExecutable,
+                    passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: runtimeEnv,
                     resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
                   }))) {
                     if ((event as any).type === "assistant") {
@@ -526,13 +530,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       resumeSessionId,
                     })
                     console.error(`[PROXY] Stale session UUID, evicting and retrying as fresh session`)
-                    evictSession(opencodeSessionId, workingDirectory, allMessages)
+                    evictSession(opencodeSessionId, workingDirectory, allMessages, requestedProfile.id)
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                     yield* query(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, stripCacheControl),
-                      model, workingDirectory, systemContext, claudeExecutable,
-                      passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
+                        model, workingDirectory, systemContext, claudeExecutable: runtimeClaudeExecutable,
+                        passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: runtimeEnv,
                       resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter,
                     }))
                     return
@@ -684,7 +688,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
           // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory, sdkUuidMap)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory, sdkUuidMap, requestedProfile.id, effectiveProfile.id)
               }
 
               const responseSessionId = currentSessionId || resumeSessionId || `session_${Date.now()}`
@@ -768,8 +772,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   let didYieldClientEvent = false
                   try {
                     for await (const event of query(buildQueryOptions({
-                      prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
-                      passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
+                      prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable: runtimeClaudeExecutable,
+                      passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: runtimeEnv,
                       resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
                     }))) {
                       if ((event as any).type === "stream_event") {
@@ -792,13 +796,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         resumeSessionId,
                       })
                       console.error(`[PROXY] Stale session UUID, evicting and retrying as fresh session`)
-                      evictSession(opencodeSessionId, workingDirectory, allMessages)
+                      evictSession(opencodeSessionId, workingDirectory, allMessages, requestedProfile.id)
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                       yield* query(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, stripCacheControl),
-                        model, workingDirectory, systemContext, claudeExecutable,
-                        passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
+                        model, workingDirectory, systemContext, claudeExecutable: runtimeClaudeExecutable,
+                        passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: runtimeEnv,
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter,
                       }))
                       return
@@ -971,7 +975,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               // Store session for future resume
               if (currentSessionId) {
-                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory, sdkUuidMap)
+                storeSession(opencodeSessionId, body.messages || [], currentSessionId, workingDirectory, sdkUuidMap, requestedProfile.id, effectiveProfile.id)
               }
 
               if (!streamClosed) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -25,6 +25,7 @@ import { ALLOWED_MCP_TOOLS } from "./tools"
 import { getLastUserMessage } from "./messages"
 import { openCodeAdapter } from "./adapters/opencode"
 import { buildQueryOptions, type QueryContext } from "./query"
+import { extractRequestApiKey, isApiKeyAuthEnabled, isApiKeyAuthorized } from "./auth"
 import { resolveProfile } from "./profiles"
 import {
   computeLineageHash,
@@ -132,6 +133,38 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   const app = new Hono()
 
   app.use("*", cors())
+
+  const createApiKeyMiddleware = (requiredKeys?: string[]) => async (c: Context, next: () => Promise<void>) => {
+    if (!isApiKeyAuthEnabled(requiredKeys)) {
+      await next()
+      return
+    }
+
+    const providedApiKey = extractRequestApiKey(
+      c.req.header("x-api-key"),
+      c.req.header("authorization"),
+    )
+
+    if (!isApiKeyAuthorized(providedApiKey, requiredKeys)) {
+      return c.json(
+        {
+          type: "error",
+          error: {
+            type: "authentication_error",
+            message: "Invalid or missing API key",
+          },
+        },
+        401,
+      )
+    }
+
+    await next()
+  }
+
+  const validateApiKey = createApiKeyMiddleware(finalConfig.requiredApiKeys)
+
+  app.use("/v1/messages", validateApiKey)
+  app.use("/messages", validateApiKey)
 
   app.get("/", (c) => {
     // API clients get JSON, browsers get the landing page

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -19,6 +19,7 @@ import {
 // --- Cache setup ---
 
 const DEFAULT_MAX_SESSIONS = 1000
+const IMPLICIT_DEFAULT_PROFILE_ID = "default"
 
 export function getMaxSessionsLimit(): number {
   const raw = process.env.CLAUDE_PROXY_MAX_SESSIONS
@@ -31,6 +32,11 @@ export function getMaxSessionsLimit(): number {
   }
 
   return parsed
+}
+
+function buildScopedKey(key: string, profileId?: string): string {
+  if (!profileId || profileId === IMPLICIT_DEFAULT_PROFILE_ID) return key
+  return `${profileId}:${key}`
 }
 
 function removeFingerprintEntriesByClaudeSessionId(claudeSessionId: string): void {
@@ -89,25 +95,28 @@ export function clearSessionCache() {
 export function evictSession(
   sessionId: string | undefined,
   workingDirectory?: string,
-  messages?: Array<{ role: string; content: any }>
+  messages?: Array<{ role: string; content: any }>,
+  profileId?: string
 ): void {
   if (sessionId) {
-    const cached = sessionCache.get(sessionId)
+    const scopedSessionId = buildScopedKey(sessionId, profileId)
+    const cached = sessionCache.get(scopedSessionId)
     if (cached) {
       removeFingerprintEntriesByClaudeSessionId(cached.claudeSessionId)
-      sessionCache.delete(sessionId)
+      sessionCache.delete(scopedSessionId)
     }
-    try { evictSharedSession(sessionId) } catch {}
+    try { evictSharedSession(scopedSessionId) } catch {}
   }
   if (messages) {
     const fp = getConversationFingerprint(messages, workingDirectory)
     if (fp) {
-      const cached = fingerprintCache.get(fp)
+      const scopedFingerprint = buildScopedKey(fp, profileId)
+      const cached = fingerprintCache.get(scopedFingerprint)
       if (cached) {
         removeSessionEntriesByClaudeSessionId(cached.claudeSessionId)
-        fingerprintCache.delete(fp)
+        fingerprintCache.delete(scopedFingerprint)
       }
-      try { evictSharedSession(fp) } catch {}
+      try { evictSharedSession(scopedFingerprint) } catch {}
     }
   }
 }
@@ -126,28 +135,31 @@ function touchSession(state: SessionState): SessionState {
 export function lookupSession(
   sessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
-  workingDirectory?: string
+  workingDirectory?: string,
+  profileId?: string
 ): LineageResult {
   if (sessionId) {
-    const cached = sessionCache.get(sessionId)
+    const scopedSessionId = buildScopedKey(sessionId, profileId)
+    const cached = sessionCache.get(scopedSessionId)
     if (cached) {
-      const result = verifyLineage(cached, messages, sessionId, sessionCache)
+      const result = verifyLineage(cached, messages, scopedSessionId, sessionCache)
       if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
       return result
     }
-    const shared = lookupSharedSession(sessionId)
+    const shared = lookupSharedSession(scopedSessionId)
     if (shared) {
       const state: SessionState = {
         claudeSessionId: shared.claudeSessionId,
+        profileId: shared.profileId,
         lastAccess: Date.now(),
         messageCount: shared.messageCount || 0,
         lineageHash: shared.lineageHash || "",
         messageHashes: shared.messageHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
       }
-      const result = verifyLineage(state, messages, sessionId, sessionCache)
+      const result = verifyLineage(state, messages, scopedSessionId, sessionCache)
       if (result.type === "continuation" || result.type === "compaction") {
-        sessionCache.set(sessionId, state)
+        sessionCache.set(scopedSessionId, state)
       }
       return result
     }
@@ -156,25 +168,27 @@ export function lookupSession(
 
   const fp = getConversationFingerprint(messages, workingDirectory)
   if (fp) {
-    const cached = fingerprintCache.get(fp)
+    const scopedFingerprint = buildScopedKey(fp, profileId)
+    const cached = fingerprintCache.get(scopedFingerprint)
     if (cached) {
-      const result = verifyLineage(cached, messages, fp, fingerprintCache)
+      const result = verifyLineage(cached, messages, scopedFingerprint, fingerprintCache)
       if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
       return result
     }
-    const shared = lookupSharedSession(fp)
+    const shared = lookupSharedSession(scopedFingerprint)
     if (shared) {
       const state: SessionState = {
         claudeSessionId: shared.claudeSessionId,
+        profileId: shared.profileId,
         lastAccess: Date.now(),
         messageCount: shared.messageCount || 0,
         lineageHash: shared.lineageHash || "",
         messageHashes: shared.messageHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
       }
-      const result = verifyLineage(state, messages, fp, fingerprintCache)
+      const result = verifyLineage(state, messages, scopedFingerprint, fingerprintCache)
       if (result.type === "continuation" || result.type === "compaction") {
-        fingerprintCache.set(fp, state)
+        fingerprintCache.set(scopedFingerprint, state)
       }
       return result
     }
@@ -190,13 +204,16 @@ export function storeSession(
   messages: Array<{ role: string; content: any }>,
   claudeSessionId: string,
   workingDirectory?: string,
-  sdkMessageUuids?: Array<string | null>
+  sdkMessageUuids?: Array<string | null>,
+  profileId?: string,
+  effectiveProfileId?: string
 ) {
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
   const messageHashes = computeMessageHashes(messages)
   const state: SessionState = {
     claudeSessionId,
+    profileId: effectiveProfileId,
     lastAccess: Date.now(),
     messageCount: messages?.length || 0,
     lineageHash,
@@ -204,10 +221,20 @@ export function storeSession(
     sdkMessageUuids,
   }
   // In-memory cache
-  if (sessionId) sessionCache.set(sessionId, state)
+  if (sessionId) sessionCache.set(buildScopedKey(sessionId, profileId), state)
   const fp = getConversationFingerprint(messages, workingDirectory)
-  if (fp) fingerprintCache.set(fp, state)
+  if (fp) fingerprintCache.set(buildScopedKey(fp, profileId), state)
   // Shared file store (cross-proxy resume)
   const key = sessionId || fp
-  if (key) storeSharedSession(key, claudeSessionId, state.messageCount, lineageHash, messageHashes, sdkMessageUuids)
+  if (key) {
+    storeSharedSession(
+      buildScopedKey(key, profileId),
+      claudeSessionId,
+      state.messageCount,
+      lineageHash,
+      messageHashes,
+      sdkMessageUuids,
+      effectiveProfileId,
+    )
+  }
 }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -17,6 +17,7 @@ export const MIN_SUFFIX_FOR_COMPACTION = 2
 
 export interface SessionState {
   claudeSessionId: string
+  profileId?: string
   lastAccess: number
   messageCount: number
   /** Hash of messages[0..messageCount-1] for fast-path lineage verification.

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -26,6 +26,7 @@ import { join } from "node:path"
 
 export interface StoredSession {
   claudeSessionId: string
+  profileId?: string
   createdAt: number
   lastUsedAt: number
   messageCount: number
@@ -131,7 +132,15 @@ export function lookupSharedSession(key: string): StoredSession | undefined {
   return store[key]
 }
 
-export function storeSharedSession(key: string, claudeSessionId: string, messageCount?: number, lineageHash?: string, messageHashes?: string[], sdkMessageUuids?: Array<string | null>): void {
+export function storeSharedSession(
+  key: string,
+  claudeSessionId: string,
+  messageCount?: number,
+  lineageHash?: string,
+  messageHashes?: string[],
+  sdkMessageUuids?: Array<string | null>,
+  profileId?: string
+): void {
   const path = getStorePath()
   const lockPath = `${path}.lock`
   const hasLock = acquireLock(lockPath)
@@ -143,6 +152,7 @@ export function storeSharedSession(key: string, claudeSessionId: string, message
     const existing = store[key]
     store[key] = {
       claudeSessionId,
+      profileId: profileId ?? existing?.profileId,
       createdAt: existing?.createdAt || Date.now(),
       lastUsedAt: Date.now(),
       messageCount: messageCount ?? existing?.messageCount ?? 0,

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -7,6 +7,10 @@ export interface ProxyConfig {
   idleTimeoutSeconds: number
   silent: boolean
   requiredApiKeys?: string[]
+  adminApiKeys?: string[]
+  protectAdminRoutes?: boolean
+  adminUsername?: string
+  adminPassword?: string
   profiles?: ProfileConfig[]
   defaultProfile?: string
 }
@@ -58,6 +62,10 @@ export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   idleTimeoutSeconds: 120,
   silent: false,
   requiredApiKeys: parseRequiredApiKeys(process.env.CLAUDE_PROXY_API_KEYS),
+  adminApiKeys: parseRequiredApiKeys(process.env.CLAUDE_PROXY_ADMIN_API_KEYS),
+  protectAdminRoutes: process.env.CLAUDE_PROXY_PROTECT_ADMIN_ROUTES === "1",
+  adminUsername: process.env.CLAUDE_PROXY_ADMIN_USERNAME,
+  adminPassword: process.env.CLAUDE_PROXY_ADMIN_PASSWORD,
   profiles: undefined,
   defaultProfile: undefined,
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -6,6 +6,22 @@ export interface ProxyConfig {
   debug: boolean
   idleTimeoutSeconds: number
   silent: boolean
+  profiles?: ProfileConfig[]
+  defaultProfile?: string
+}
+
+export type ProfileType = "claude-max" | "api"
+
+export interface ProfileConfig {
+  id: string
+  type?: ProfileType
+  claudeConfigDir?: string
+  claudeExecutable?: string
+  apiKey?: string
+  apiKeyEnv?: string
+  baseUrl?: string
+  authToken?: string
+  authTokenEnv?: string
 }
 
 export interface ProxyInstance {
@@ -31,4 +47,6 @@ export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   debug: process.env.CLAUDE_PROXY_DEBUG === "1",
   idleTimeoutSeconds: 120,
   silent: false,
+  profiles: undefined,
+  defaultProfile: undefined,
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -6,8 +6,18 @@ export interface ProxyConfig {
   debug: boolean
   idleTimeoutSeconds: number
   silent: boolean
+  requiredApiKeys?: string[]
   profiles?: ProfileConfig[]
   defaultProfile?: string
+}
+
+function parseRequiredApiKeys(envValue: string | undefined): string[] | undefined {
+  const keys = envValue
+    ?.split(",")
+    .map((key) => key.trim())
+    .filter(Boolean)
+
+  return keys && keys.length > 0 ? keys : undefined
 }
 
 export type ProfileType = "claude-max" | "api"
@@ -47,6 +57,7 @@ export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   debug: process.env.CLAUDE_PROXY_DEBUG === "1",
   idleTimeoutSeconds: 120,
   silent: false,
+  requiredApiKeys: parseRequiredApiKeys(process.env.CLAUDE_PROXY_API_KEYS),
   profiles: undefined,
   defaultProfile: undefined,
 }


### PR DESCRIPTION
## Summary
- Add profile-based routing so Meridian can distinguish between multiple Claude accounts/contexts
- Add config file loading with optional request API key authentication
- Add optional admin route protection (API keys + Basic Auth) for `/health` and `/telemetry`
- Fix health check to use the default profile's `CLAUDE_CONFIG_DIR` instead of the unmounted default path
- Add Docker two-profile example and Claude Code profile launcher docs

## Use Case
Run a single Meridian instance for multiple machines over a private network or Tailscale, routing requests to the right Claude profile from each client. Tighter control over who can see health/telemetry vs who can call `/v1/messages`.

## Health Check Fix
The `/health` endpoint was calling `getClaudeAuthStatusAsync()` with no env overrides, so it checked `~/.claude` instead of the configured profile's `CLAUDE_CONFIG_DIR`. In multi-profile Docker setups where only profile dirs are mounted, this always returned "degraded" even though requests worked fine.

## Test plan
- [ ] `npm test` — all tests pass
- [ ] `npm run build` — clean build
- [ ] Deploy with two-profile Docker config and verify `/health` returns healthy
- [ ] Verify profile routing via `x-meridian-profile` header

Supersedes #164, #163, #162. Builds on #161.