### PR TITLE
fix: treat identical message replay as diverged, not continuation

### DIFF
--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -244,6 +244,46 @@ describe("verifyLineage", () => {
     expect(result.type).toBe("undo")
   })
 
+  it("returns diverged when identical messages are replayed (same count, same content)", () => {
+    // Bug fix: identical message arrays should start a fresh session,
+    // not resume the old one — otherwise ghost context accumulates.
+    const msgs = [msg("user", "say hello world")]
+    const session = makeSession({
+      lineageHash: computeLineageHash(msgs),
+      messageCount: msgs.length,
+      messageHashes: computeMessageHashes(msgs),
+    })
+    const result = verifyLineage(session, msgs, "key", mockCache)
+    expect(result.type).toBe("diverged")
+  })
+
+  it("returns diverged when identical multi-message conversation is replayed", () => {
+    const msgs = [
+      msg("user", "hello"), msg("assistant", "hi"),
+      msg("user", "how are you?"), msg("assistant", "good"),
+    ]
+    const session = makeSession({
+      lineageHash: computeLineageHash(msgs),
+      messageCount: msgs.length,
+      messageHashes: computeMessageHashes(msgs),
+    })
+    const result = verifyLineage(session, msgs, "key", mockCache)
+    expect(result.type).toBe("diverged")
+  })
+
+  it("still returns continuation when messages grow beyond cached count", () => {
+    // Ensure the fix doesn't break normal continuation flow
+    const msgs = [msg("user", "hello")]
+    const session = makeSession({
+      lineageHash: computeLineageHash(msgs),
+      messageCount: msgs.length,
+      messageHashes: computeMessageHashes(msgs),
+    })
+    const extended = [...msgs, msg("assistant", "hi"), msg("user", "how are you?")]
+    const result = verifyLineage(session, extended, "key", mockCache)
+    expect(result.type).toBe("continuation")
+  })
+
   it("returns compaction when suffix matches on long conversation", () => {
     // Need >= 6 stored messages and >= MIN_SUFFIX_FOR_COMPACTION suffix overlap
     const msgs = [

--- a/src/__tests__/proxy-cache-eviction.test.ts
+++ b/src/__tests__/proxy-cache-eviction.test.ts
@@ -70,6 +70,21 @@ async function send(app: TestApp, session: string | undefined, firstMessage: str
   await response.json()
 }
 
+async function sendContinuation(app: TestApp, session: string, firstMessage: string, followUp: string, sessionId: string) {
+  queuedSessionIds.push(sessionId)
+  const response = await post(app, {
+    model: "claude-sonnet-4-5",
+    max_tokens: 128,
+    stream: false,
+    messages: [
+      { role: "user", content: firstMessage },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      { role: "user", content: followUp },
+    ],
+  }, { "x-opencode-session": session })
+  await response.json()
+}
+
 beforeEach(() => {
   mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
   capturedQueryParams = null
@@ -97,15 +112,19 @@ describe("Session cache LRU eviction", () => {
   it("refreshes recency when a key is accessed", async () => {
     const app = createTestApp()
 
+    // Store two sessions (cache limit = 2)
     await send(app, "oc-A", "first-A", "sdk-A")
     await send(app, "oc-B", "first-B", "sdk-B")
 
-    await send(app, "oc-A", "first-A", "sdk-A")
+    // Access A with a continuation (growing messages) to refresh its recency
+    await sendContinuation(app, "oc-A", "first-A", "follow-up-A", "sdk-A")
     expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
 
+    // Store C — should evict B (not A, since A was accessed more recently)
     await send(app, "oc-C", "first-C", "sdk-C")
 
-    await send(app, "oc-B", "first-B", "sdk-B-new")
+    // B should be evicted — continuation attempt should not resume
+    await sendContinuation(app, "oc-B", "first-B", "follow-up-B", "sdk-B-new")
     expect(capturedQueryParams?.options?.resume).toBeUndefined()
   })
 

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -141,6 +141,13 @@ export function verifyLineage(
   const prefix = messages.slice(0, cached.messageCount)
   const prefixHash = computeLineageHash(prefix)
   if (prefixHash === cached.lineageHash) {
+    // Same or fewer messages with matching hash = replay/retry, not continuation.
+    // Without this guard, identical requests resume the old SDK session and
+    // re-send the last user message, causing ghost context accumulation.
+    if (messages.length <= cached.messageCount) {
+      cache.delete(cacheKey)
+      return { type: "diverged" }
+    }
     return { type: "continuation", session: cached }
   }
 


### PR DESCRIPTION
## Summary

When a client sends the exact same message array as a previous request (same count, same content), `verifyLineage` incorrectly classified it as `"continuation"` and resumed the existing SDK session. This caused the SDK session to accumulate duplicate context — ghost messages the client never intended.

## Root Cause

In the fast-path of `verifyLineage` (lineage.ts), when `messages.slice(0, cached.messageCount)` produces a hash matching the stored lineage hash, the function returned `"continuation"` unconditionally. When `messages.length === cached.messageCount`, this is a replay, not a continuation — there are no new messages. The prompt builder then falls back to `getLastUserMessage`, re-sending the last user message into a session that already has it.

## Fix

Add a guard in the fast-path: when `messages.length <= cached.messageCount` and the hash matches, delete the cache entry and return `"diverged"` instead of `"continuation"`.

```typescript
if (prefixHash === cached.lineageHash) {
    if (messages.length <= cached.messageCount) {
        cache.delete(cacheKey)
        return { type: "diverged" }
    }
    return { type: "continuation", session: cached }
}
```

Normal continuation flow (messages grow beyond cached count) is unaffected.

## Tests

- **3 new unit tests** in `lineage-unit.test.ts`: single-message replay → diverged, multi-message replay → diverged, normal continuation still works
- **Updated** `proxy-cache-eviction.test.ts`: the LRU recency test now uses actual continuations (growing message arrays) instead of relying on replay being classified as continuation
- All 383 tests pass

Fixes #171