### PR TITLE
fix: reduce token overhead in passthrough mode

### DIFF
--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -43,12 +43,18 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(1)
   })
 
-  it("includes system prompt when provided", () => {
+  it("includes system prompt as preset in normal mode", () => {
     const result = buildQueryOptions(makeContext({ systemContext: "Be helpful" }))
     const sp = (result.options as any).systemPrompt
     expect(sp).toBeDefined()
     expect(sp.type).toBe("preset")
     expect(sp.append).toBe("Be helpful")
+  })
+
+  it("uses raw system prompt in passthrough mode", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, systemContext: "Be helpful" }))
+    const sp = (result.options as any).systemPrompt
+    expect(sp).toBe("Be helpful")
   })
 
   it("omits system prompt when empty", () => {
@@ -121,6 +127,18 @@ describe("buildQueryOptions", () => {
     const env = (result.options as any).env
     expect(env.HOME).toBe("/home/user")
     expect(env.ENABLE_TOOL_SEARCH).toBe("false")
+  })
+
+  it("disables Claude.ai MCP servers in passthrough mode", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true }))
+    const env = (result.options as any).env
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
+  })
+
+  it("does not disable Claude.ai MCP servers in normal mode", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: false }))
+    const env = (result.options as any).env
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBeUndefined()
   })
 
   it("includes hooks when provided", () => {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -69,7 +69,9 @@ export function buildQueryOptions(ctx: QueryContext) {
       permissionMode: "bypassPermissions" as const,
       allowDangerouslySkipPermissions: true,
       ...(systemContext ? {
-        systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
+        systemPrompt: passthrough
+          ? systemContext
+          : { type: "preset" as const, preset: "claude_code" as const, append: systemContext }
       } : {}),
       ...(passthrough
         ? {
@@ -85,7 +87,11 @@ export function buildQueryOptions(ctx: QueryContext) {
             mcpServers: { [mcpServerName]: createOpencodeMcpServer() },
           }),
       plugins: [],
-      env: { ...cleanEnv, ENABLE_TOOL_SEARCH: "false" },
+      env: {
+        ...cleanEnv,
+        ENABLE_TOOL_SEARCH: "false",
+        ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
+      },
       ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
       ...(isUndo ? { forkSession: true, ...(undoRollbackUuid ? { resumeSessionAt: undoRollbackUuid } : {}) } : {}),


### PR DESCRIPTION
## Problem

In passthrough mode, every SDK subprocess spawns with two sources of unnecessary token overhead:

### 1. Claude Code preset system prompt (~15K tokens/turn)

The SDK query always used `systemPrompt: { type: "preset", preset: "claude_code", append: systemContext }`, which loads Claude Code's full system prompt (~15-25K tokens) containing coding guidelines, built-in tool descriptions, and behavioral instructions.

In passthrough mode this is dead weight — the calling agent (OpenCode, Crush, etc.) provides its own system prompt via `systemContext`, and tool execution is handled by the agent, not the SDK subprocess. Worse, the preset teaches Claude about Claude Code's tool schemas (`Read`, `Write`, `Edit`) which conflict with the agent's own tools (`read`, `write`, `edit`) registered as passthrough MCP tools.

### 2. Claude.ai remote MCP servers (~7 servers fetched per subprocess)

The SDK subprocess fetches remote MCP servers from `https://api.anthropic.com/v1/mcp_servers` on every spawn — Gmail, Google Calendar, Cloudflare, Slack, Atlassian, Figma, Mermaid Chart. Each connection:
- Adds tool definitions to the API call (more input tokens)
- Takes 800-2000ms to connect (latency per tool cycle)
- Some fail with auth errors (wasted connection attempts)

With `maxTurns: 1`, a new subprocess spawns per tool cycle. A 10-tool-call conversation triggers 10 fetches of 7 remote MCP servers — none of which the calling agent can interact with.

### Measured impact

Captured via `debugFile` on a live proxy with OpenCode:

| Metric | Before | After |
|--------|--------|-------|
| Remote MCP fetches per subprocess | 7 servers | 0 |
| MCP config resolve time | 100ms+ | 2ms |
| Claude.ai MCP connections | Gmail, Calendar, Cloudflare, Slack, Atlassian, Figma, Mermaid | None |
| System prompt overhead | ~15K tokens (preset) + agent prompt | Agent prompt only |

## Fix

**`query.ts`** — two changes, both gated on `passthrough: true`:

1. **Raw system prompt**: Pass the agent's system prompt directly instead of wrapping in the `claude_code` preset. The SDK's `customSystemPrompt` path replaces `defaultSystemPrompt` in the subprocess's `qS()` function, so the Claude Code preset is cleanly skipped.

```typescript
systemPrompt: passthrough
  ? systemContext                    // raw — agent provides its own instructions
  : { type: "preset", ... }         // internal mode — keep Claude Code preset
```

2. **Disable remote MCP**: Set `ENABLE_CLAUDEAI_MCP_SERVERS: "false"` in the subprocess env. This is the documented env var checked by the CLI's `claudeai-mcp` module before fetching.

```typescript
env: {
  ...cleanEnv,
  ENABLE_TOOL_SEARCH: "false",
  ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
}
```

**Internal mode is completely unaffected** — both changes are gated on `passthrough`. Droid (which forces `usesPassthrough() → false`) and any agent using internal mode continue to use the Claude Code preset and remote MCP servers as before.

## Test plan

- [x] 509 unit tests pass (507 existing + 2 new)
- [x] New test: raw system prompt in passthrough mode
- [x] New test: `ENABLE_CLAUDEAI_MCP_SERVERS` set in passthrough, absent in normal mode
- [x] E17 (passthrough mode E2E) passes — `stop_reason: "tool_use"`, clean tool names, no MCP prefix leak
- [x] Droid integration tests unaffected (`passthrough = false` code path unchanged)
- [x] Crush integration tests unaffected (same passthrough gate)
- [x] Live OpenCode session through proxy — passthrough tool forwarding works, session resume works