### PR TITLE
feat: file change visibility in responses (#189)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,7 @@ src/
 │   ├── agentDefs.ts           ← Subagent definition extraction from tool descriptions
 │   ├── agentMatch.ts          ← Fuzzy agent name matching
 │   └── passthroughTools.ts    ← Tool forwarding mode (agent handles execution)
+├── fileChanges.ts             ← PostToolUse hook: tracks write/edit ops, formats summary
 ├── mcpTools.ts                ← MCP tool definitions (read, write, edit, bash, glob, grep)
 ├── logger.ts                  ← Logging with AsyncLocalStorage context
 ├── utils/
@@ -89,6 +90,7 @@ server.ts (HTTP layer)
     │                    ──► sessionStore.ts
     ├── agentDefs.ts
     ├── agentMatch.ts
+    ├── fileChanges.ts
     ├── passthroughTools.ts
     ├── mcpTools.ts
     └── telemetry/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ errors.ts          → classifyError (pure)
 models.ts          → mapModelToClaudeModel, resolveClaudeExecutableAsync
 tools.ts           → BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME
 messages.ts        → normalizeContent, getLastUserMessage (pure)
+fileChanges.ts     → PostToolUse hook: file write/edit tracking + summary formatting (pure)
 session/
   lineage.ts       → Hashing, lineage verification (PURE — no I/O)
   fingerprint.ts   → extractClientCwd, getConversationFingerprint

--- a/E2E.md
+++ b/E2E.md
@@ -69,6 +69,12 @@ kill $(lsof -ti :3456)
 | CL6 | [Cline: Session Continuation](#cl6-cline-session-continuation) | `-T taskId` resumes session; `lineage=continuation` in proxy log | 2026-03-29 |
 | CL7 | [Cline: Model Routing](#cl7-cline-model-routing) | sonnet-4-6→sonnet[1m], opus-4-6→opus[1m], haiku→haiku | 2026-03-29 |
 | CL8 | [Cline: Multi-Agent Coexistence](#cl8-cline-multi-agent-coexistence) | Cline + Crush + OpenCode on same port simultaneously | 2026-03-29 |
+| FC1 | [File Changes: Write (non-stream)](#fc1-file-changes-write-non-stream) | PostToolUse hook tracks write, appends "Files changed" to non-stream response | 2026-03-30 |
+| FC2 | [File Changes: Write (stream)](#fc2-file-changes-write-stream) | PostToolUse hook tracks write, emits file change text block in SSE stream | 2026-03-30 |
+| FC3 | [File Changes: Edit](#fc3-file-changes-edit) | Edit operations tracked as "edited" in summary | 2026-03-30 |
+| FC4 | [File Changes: Read-only (no summary)](#fc4-file-changes-read-only-no-summary) | Read-only operations produce no "Files changed" section | 2026-03-30 |
+| FC5 | [File Changes: Multiple ops](#fc5-file-changes-multiple-ops) | Multiple writes + edits listed in a single summary | 2026-03-30 |
+| FC6 | [File Changes: Multiple ops (stream)](#fc6-file-changes-multiple-ops-stream) | Multiple file changes emitted as a text block in SSE stream | 2026-03-30 |
 
 ---
 
@@ -908,6 +914,7 @@ Which proxy modules each E2E test exercises:
 | `agentMatch.ts` | E19 (fuzzy matching in PreToolUse hook) |
 | `passthroughTools.ts` | E17 |
 | `mcpTools.ts` | E3, E10 |
+| `fileChanges.ts` | FC1, FC2, FC3, FC4, FC5, FC6 |
 | `telemetry/` | E11 |
 
 ---
@@ -1720,3 +1727,234 @@ curl -s http://127.0.0.1:3456/v1/messages \
 - All three respond correctly
 - No cross-contamination between sessions
 - Proxy handles all three without errors
+
+---
+
+## File Change Visibility Tests
+
+These tests verify the PostToolUse hook that tracks file write/edit operations and appends a "Files changed" summary to responses. This feature is **internal mode only** — passthrough mode forwards tools to the client, so the proxy never sees tool execution results.
+
+**Requires:** Proxy running in internal mode (no `MERIDIAN_PASSTHROUGH` env var). Use a separate port if your default service runs in passthrough mode.
+
+```bash
+kill $(lsof -ti :3457) 2>/dev/null; sleep 1
+CLAUDE_PROXY_PORT=3457 bun run ./bin/cli.ts > /tmp/proxy-fc-e2e.log 2>&1 &
+sleep 5
+curl -s http://127.0.0.1:3457/health | python3 -m json.tool
+# → mode: "internal"
+```
+
+---
+
+## FC1: File Changes Write (non-stream)
+
+**Verifies:** PostToolUse hook captures a write operation and appends "Files changed" summary to non-streaming response.
+
+```bash
+rm -f /tmp/e2e-fc-write.txt
+
+curl -s http://127.0.0.1:3457/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-opencode-session: e2e-fc-write-001" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250514",
+    "max_tokens": 300,
+    "stream": false,
+    "messages": [{"role": "user", "content": "Write the text FILECHANGE_OK to /tmp/e2e-fc-write.txt. Just write it, nothing else."}]
+  }' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+texts = [b['text'] for b in d['content'] if b['type'] == 'text']
+full = '\n'.join(texts)
+print(full)
+"
+
+cat /tmp/e2e-fc-write.txt   # → FILECHANGE_OK
+rm /tmp/e2e-fc-write.txt
+```
+
+**Pass criteria:**
+- File `/tmp/e2e-fc-write.txt` exists on disk with content `FILECHANGE_OK`
+- Response text includes `Files changed:` followed by `- wrote /tmp/e2e-fc-write.txt`
+- `"type": "message"` in response (valid Anthropic format)
+
+---
+
+## FC2: File Changes Write (stream)
+
+**Verifies:** PostToolUse hook captures a write operation and emits a file change text block in the SSE stream, before `message_stop`.
+
+```bash
+rm -f /tmp/e2e-fc-stream.txt
+
+curl -sN http://127.0.0.1:3457/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-opencode-session: e2e-fc-stream-001" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250514",
+    "max_tokens": 300,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Write the text STREAMFC_OK to /tmp/e2e-fc-stream.txt. Just write it."}]
+  }' | tee /tmp/fc-stream-raw.txt | grep -E "text_delta.*Files changed"
+
+cat /tmp/e2e-fc-stream.txt   # → STREAMFC_OK
+rm -f /tmp/e2e-fc-stream.txt /tmp/fc-stream-raw.txt
+```
+
+**Pass criteria:**
+- File exists on disk with `STREAMFC_OK`
+- SSE stream contains a `text_delta` event with `Files changed:\n- wrote /tmp/e2e-fc-stream.txt`
+- The file change block comes BEFORE `message_stop` in the event stream
+- Block index is monotonically increasing (no index collision)
+
+---
+
+## FC3: File Changes Edit
+
+**Verifies:** Edit operations are tracked as "edited" (not "wrote") in the file change summary.
+
+```bash
+echo "function greet() { return 'hello' }" > /tmp/e2e-fc-edit.js
+
+curl -s http://127.0.0.1:3457/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-opencode-session: e2e-fc-edit-001" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250514",
+    "max_tokens": 300,
+    "stream": false,
+    "messages": [{"role": "user", "content": "Edit /tmp/e2e-fc-edit.js to change hello to world. Do not rewrite the whole file, just edit it."}]
+  }' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+texts = [b['text'] for b in d['content'] if b['type'] == 'text']
+print('\n'.join(texts))
+"
+
+cat /tmp/e2e-fc-edit.js   # → function greet() { return 'world' }
+rm /tmp/e2e-fc-edit.js
+```
+
+**Pass criteria:**
+- File on disk contains `'world'` instead of `'hello'`
+- Response text includes `Files changed:` followed by `- edited /tmp/e2e-fc-edit.js`
+- Not `- wrote` — the operation must be `edited`
+
+---
+
+## FC4: File Changes Read-only (no summary)
+
+**Verifies:** Read-only tool operations (read, glob, grep) do NOT produce a "Files changed" section in the response.
+
+```bash
+echo "READ_ONLY_CONTENT" > /tmp/e2e-fc-readonly.txt
+
+curl -s http://127.0.0.1:3457/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-opencode-session: e2e-fc-readonly-001" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250514",
+    "max_tokens": 200,
+    "stream": false,
+    "messages": [{"role": "user", "content": "Read the file /tmp/e2e-fc-readonly.txt and tell me what it contains. Do not modify it."}]
+  }' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+texts = [b['text'] for b in d['content'] if b['type'] == 'text']
+full = '\n'.join(texts)
+has_fc = 'Files changed' in full
+print(f'Contains Files changed: {has_fc} (should be False)')
+print(f'Contains READ_ONLY_CONTENT: {\"READ_ONLY_CONTENT\" in full}')
+"
+
+rm /tmp/e2e-fc-readonly.txt
+```
+
+**Pass criteria:**
+- Response text includes `READ_ONLY_CONTENT` (file was read)
+- Response text does NOT contain `Files changed:` — no write/edit occurred
+- No extra text block appended
+
+---
+
+## FC5: File Changes Multiple ops
+
+**Verifies:** Multiple file operations (write + edit) within one turn are all tracked and listed in the summary.
+
+```bash
+rm -f /tmp/e2e-fc-multi-a.txt
+echo "original content" > /tmp/e2e-fc-multi-b.txt
+
+curl -s http://127.0.0.1:3457/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-opencode-session: e2e-fc-multi-001" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250514",
+    "max_tokens": 400,
+    "stream": false,
+    "messages": [{"role": "user", "content": "Do two things: 1) Write MULTI_A to /tmp/e2e-fc-multi-a.txt. 2) Edit /tmp/e2e-fc-multi-b.txt to change \"original\" to \"modified\". Do both."}]
+  }' | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+texts = [b['text'] for b in d['content'] if b['type'] == 'text']
+full = '\n'.join(texts)
+idx = full.find('Files changed:')
+if idx >= 0:
+    print(full[idx:])
+else:
+    print('NO FILES CHANGED SECTION FOUND')
+"
+
+cat /tmp/e2e-fc-multi-a.txt   # → MULTI_A
+cat /tmp/e2e-fc-multi-b.txt   # → modified content
+rm -f /tmp/e2e-fc-multi-a.txt /tmp/e2e-fc-multi-b.txt
+```
+
+**Pass criteria:**
+- Both files modified on disk
+- Summary includes both: `- wrote /tmp/e2e-fc-multi-a.txt` and `- edited /tmp/e2e-fc-multi-b.txt`
+- Deduplication works — each path+operation listed once even if the model called the tool multiple times
+
+---
+
+## FC6: File Changes Multiple ops (stream)
+
+**Verifies:** Multiple file changes in streaming mode are emitted as a single text block before `message_stop`.
+
+```bash
+rm -f /tmp/e2e-fc-stream-multi-a.txt /tmp/e2e-fc-stream-multi-b.txt
+
+curl -sN http://127.0.0.1:3457/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-opencode-session: e2e-fc-stream-multi-001" \
+  -d '{
+    "model": "claude-sonnet-4-5-20250514",
+    "max_tokens": 400,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Write FOO to /tmp/e2e-fc-stream-multi-a.txt and BAR to /tmp/e2e-fc-stream-multi-b.txt"}]
+  }' | grep "text_delta" | grep "Files changed"
+
+cat /tmp/e2e-fc-stream-multi-a.txt   # → FOO
+cat /tmp/e2e-fc-stream-multi-b.txt   # → BAR
+rm -f /tmp/e2e-fc-stream-multi-a.txt /tmp/e2e-fc-stream-multi-b.txt
+```
+
+**Pass criteria:**
+- Both files exist on disk with correct content
+- A `text_delta` event contains `Files changed:\n- wrote /tmp/e2e-fc-stream-multi-a.txt\n- wrote /tmp/e2e-fc-stream-multi-b.txt`
+- Only one file change text block (not one per file)
+
+---
+
+## FC Cleanup
+
+```bash
+kill $(lsof -ti :3457) 2>/dev/null
+rm -f /tmp/proxy-fc-e2e.log
+```

--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Unit tests for fileChanges.ts — pure functions, no mocks needed.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { extractFileChange, extractFileChangesFromBash, extractFileChangesFromMessages, formatFileChangeSummary, createFileChangeHook, type FileChange } from "../proxy/fileChanges"
+
+const PREFIX = "mcp__opencode__"
+
+describe("extractFileChange", () => {
+  it("should extract a write operation", () => {
+    const result = extractFileChange("mcp__opencode__write", { path: "src/foo.ts", content: "hello" }, PREFIX)
+    expect(result).toEqual({ operation: "wrote", path: "src/foo.ts" })
+  })
+
+  it("should extract an edit operation", () => {
+    const result = extractFileChange("mcp__opencode__edit", { path: "src/bar.ts", oldString: "a", newString: "b" }, PREFIX)
+    expect(result).toEqual({ operation: "edited", path: "src/bar.ts" })
+  })
+
+  it("should return undefined for read (read-only)", () => {
+    const result = extractFileChange("mcp__opencode__read", { path: "src/foo.ts" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for glob", () => {
+    const result = extractFileChange("mcp__opencode__glob", { pattern: "**/*.ts" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for grep", () => {
+    const result = extractFileChange("mcp__opencode__grep", { pattern: "TODO" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for bash", () => {
+    const result = extractFileChange("mcp__opencode__bash", { command: "ls" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for non-MCP tools", () => {
+    const result = extractFileChange("Task", { description: "do thing" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for different adapter prefix", () => {
+    const result = extractFileChange("mcp__droid__write", { path: "foo.ts", content: "x" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should work with droid prefix", () => {
+    const result = extractFileChange("mcp__droid__write", { path: "foo.ts", content: "x" }, "mcp__droid__")
+    expect(result).toEqual({ operation: "wrote", path: "foo.ts" })
+  })
+
+  it("should return undefined for write without path", () => {
+    const result = extractFileChange("mcp__opencode__write", { content: "hello" }, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for null input", () => {
+    const result = extractFileChange("mcp__opencode__write", null, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined for undefined input", () => {
+    const result = extractFileChange("mcp__opencode__write", undefined, PREFIX)
+    expect(result).toBeUndefined()
+  })
+
+  it("should coerce non-string path to string", () => {
+    const result = extractFileChange("mcp__opencode__write", { path: 42, content: "x" }, PREFIX)
+    expect(result).toEqual({ operation: "wrote", path: "42" })
+  })
+})
+
+describe("extractFileChangesFromBash", () => {
+  it("should detect simple echo redirect", () => {
+    expect(extractFileChangesFromBash('echo hello > /tmp/test.txt'))
+      .toEqual([{ operation: "wrote", path: "/tmp/test.txt" }])
+  })
+
+  it("should detect append redirect", () => {
+    expect(extractFileChangesFromBash('echo hello >> /tmp/test.txt'))
+      .toEqual([{ operation: "wrote", path: "/tmp/test.txt" }])
+  })
+
+  it("should detect multiple redirects", () => {
+    expect(extractFileChangesFromBash('echo a > x.txt && echo b > y.txt'))
+      .toEqual([
+        { operation: "wrote", path: "x.txt" },
+        { operation: "wrote", path: "y.txt" },
+      ])
+  })
+
+  it("should detect quoted paths", () => {
+    expect(extractFileChangesFromBash('echo x > "/tmp/my file.txt"'))
+      .toEqual([{ operation: "wrote", path: "/tmp/my" }]) // only gets up to space — acceptable limitation
+  })
+
+  it("should filter /dev/null", () => {
+    expect(extractFileChangesFromBash('command > /dev/null')).toEqual([])
+  })
+
+  it("should filter /dev/stderr", () => {
+    expect(extractFileChangesFromBash('command > /dev/stderr')).toEqual([])
+  })
+
+  it("should skip stderr redirects (2>)", () => {
+    expect(extractFileChangesFromBash('command 2> /tmp/err.log')).toEqual([])
+  })
+
+  it("should detect tee", () => {
+    expect(extractFileChangesFromBash('echo hello | tee /tmp/tee-test.txt'))
+      .toEqual([{ operation: "wrote", path: "/tmp/tee-test.txt" }])
+  })
+
+  it("should detect tee -a (append)", () => {
+    expect(extractFileChangesFromBash('echo hello | tee -a /tmp/tee-test.txt'))
+      .toEqual([{ operation: "wrote", path: "/tmp/tee-test.txt" }])
+  })
+
+  it("should return empty for non-writing commands", () => {
+    expect(extractFileChangesFromBash('ls -la')).toEqual([])
+    expect(extractFileChangesFromBash('grep pattern file.txt')).toEqual([])
+    expect(extractFileChangesFromBash('cat file.txt')).toEqual([])
+  })
+
+  it("should detect cat heredoc redirect", () => {
+    expect(extractFileChangesFromBash("cat > /tmp/heredoc.txt << 'EOF'"))
+      .toEqual([{ operation: "wrote", path: "/tmp/heredoc.txt" }])
+  })
+
+  it("should deduplicate same file", () => {
+    expect(extractFileChangesFromBash('echo a > f.txt; echo b > f.txt'))
+      .toEqual([{ operation: "wrote", path: "f.txt" }])
+  })
+
+  it("should handle printf redirect", () => {
+    expect(extractFileChangesFromBash('printf "content" > /tmp/printf.txt'))
+      .toEqual([{ operation: "wrote", path: "/tmp/printf.txt" }])
+  })
+})
+
+describe("formatFileChangeSummary", () => {
+  it("should return undefined for empty array", () => {
+    expect(formatFileChangeSummary([])).toBeUndefined()
+  })
+
+  it("should format a single write", () => {
+    const result = formatFileChangeSummary([{ operation: "wrote", path: "src/foo.ts" }])
+    expect(result).toBe("\n\nFiles changed:\n- wrote src/foo.ts")
+  })
+
+  it("should format a single edit", () => {
+    const result = formatFileChangeSummary([{ operation: "edited", path: "src/bar.ts" }])
+    expect(result).toBe("\n\nFiles changed:\n- edited src/bar.ts")
+  })
+
+  it("should format multiple changes", () => {
+    const changes: FileChange[] = [
+      { operation: "wrote", path: "src/a.ts" },
+      { operation: "edited", path: "src/b.ts" },
+      { operation: "wrote", path: "src/c.ts" },
+    ]
+    const result = formatFileChangeSummary(changes)
+    expect(result).toBe("\n\nFiles changed:\n- wrote src/a.ts\n- edited src/b.ts\n- wrote src/c.ts")
+  })
+
+  it("should deduplicate identical entries", () => {
+    const changes: FileChange[] = [
+      { operation: "edited", path: "src/foo.ts" },
+      { operation: "edited", path: "src/foo.ts" },
+      { operation: "edited", path: "src/foo.ts" },
+    ]
+    const result = formatFileChangeSummary(changes)
+    expect(result).toBe("\n\nFiles changed:\n- edited src/foo.ts")
+  })
+
+  it("should keep different operations on same path", () => {
+    const changes: FileChange[] = [
+      { operation: "wrote", path: "src/foo.ts" },
+      { operation: "edited", path: "src/foo.ts" },
+    ]
+    const result = formatFileChangeSummary(changes)
+    expect(result).toBe("\n\nFiles changed:\n- wrote src/foo.ts\n- edited src/foo.ts")
+  })
+
+  it("should keep same operation on different paths", () => {
+    const changes: FileChange[] = [
+      { operation: "wrote", path: "src/a.ts" },
+      { operation: "wrote", path: "src/b.ts" },
+    ]
+    const result = formatFileChangeSummary(changes)
+    expect(result).toBe("\n\nFiles changed:\n- wrote src/a.ts\n- wrote src/b.ts")
+  })
+})
+
+describe("createFileChangeHook", () => {
+  it("should return a matcher with empty string (match all)", () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    expect(hook.matcher).toBe("")
+    expect(hook.hooks.length).toBe(1)
+  })
+
+  it("should capture write operations", async () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    const hookFn = hook.hooks[0]!
+
+    await hookFn({
+      tool_name: "mcp__opencode__write",
+      tool_input: { path: "src/new.ts", content: "export const x = 1" },
+      tool_response: "Successfully wrote to src/new.ts",
+      tool_use_id: "toolu_123",
+    })
+
+    expect(changes).toEqual([{ operation: "wrote", path: "src/new.ts" }])
+  })
+
+  it("should capture edit operations", async () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    const hookFn = hook.hooks[0]!
+
+    await hookFn({
+      tool_name: "mcp__opencode__edit",
+      tool_input: { path: "src/old.ts", oldString: "foo", newString: "bar" },
+      tool_response: "Successfully edited src/old.ts",
+      tool_use_id: "toolu_456",
+    })
+
+    expect(changes).toEqual([{ operation: "edited", path: "src/old.ts" }])
+  })
+
+  it("should not capture read operations", async () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    const hookFn = hook.hooks[0]!
+
+    await hookFn({
+      tool_name: "mcp__opencode__read",
+      tool_input: { path: "README.md" },
+      tool_response: "file contents here",
+      tool_use_id: "toolu_789",
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it("should not capture non-MCP tools", async () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    const hookFn = hook.hooks[0]!
+
+    await hookFn({
+      tool_name: "Task",
+      tool_input: { subagent_type: "build", prompt: "do stuff" },
+      tool_response: "task completed",
+      tool_use_id: "toolu_aaa",
+    })
+
+    expect(changes).toEqual([])
+  })
+
+  it("should accumulate multiple changes", async () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    const hookFn = hook.hooks[0]!
+
+    await hookFn({
+      tool_name: "mcp__opencode__write",
+      tool_input: { path: "a.ts", content: "x" },
+      tool_response: "ok",
+      tool_use_id: "toolu_1",
+    })
+    await hookFn({
+      tool_name: "mcp__opencode__edit",
+      tool_input: { path: "b.ts", oldString: "x", newString: "y" },
+      tool_response: "ok",
+      tool_use_id: "toolu_2",
+    })
+    await hookFn({
+      tool_name: "mcp__opencode__read",
+      tool_input: { path: "c.ts" },
+      tool_response: "contents",
+      tool_use_id: "toolu_3",
+    })
+
+    expect(changes).toEqual([
+      { operation: "wrote", path: "a.ts" },
+      { operation: "edited", path: "b.ts" },
+    ])
+  })
+
+  it("should return empty object (no modifications to tool output)", async () => {
+    const changes: FileChange[] = []
+    const hook = createFileChangeHook(changes, PREFIX)
+    const hookFn = hook.hooks[0]!
+
+    const result = await hookFn({
+      tool_name: "mcp__opencode__write",
+      tool_input: { path: "x.ts", content: "y" },
+      tool_response: "ok",
+      tool_use_id: "toolu_test",
+    })
+
+    expect(result).toEqual({})
+  })
+})
+
+describe("extractFileChangesFromMessages", () => {
+  // Simple extractor for OpenCode-style tools (Write/Edit with file_path)
+  const openCodeExtract = (name: string, input: unknown): FileChange[] => {
+    const inp = input as Record<string, unknown> | null | undefined
+    const fp = inp?.file_path
+    if (name === "Write" && fp) return [{ operation: "wrote", path: String(fp) }]
+    if (name === "Edit" && fp) return [{ operation: "edited", path: String(fp) }]
+    return []
+  }
+
+  it("should extract file changes from a complete tool loop", () => {
+    const messages = [
+      { role: "user", content: "fix the bug" },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "tu_1", name: "Write", input: { file_path: "src/foo.ts", content: "x" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_1", content: "success" },
+      ]},
+      { role: "assistant", content: [
+        { type: "text", text: "Done!" },
+      ]},
+    ]
+    const result = extractFileChangesFromMessages(messages, openCodeExtract)
+    expect(result).toEqual([{ operation: "wrote", path: "src/foo.ts" }])
+  })
+
+  it("should extract multiple file changes", () => {
+    const messages = [
+      { role: "user", content: "fix bugs" },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "tu_1", name: "Write", input: { file_path: "a.ts", content: "a" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_1", content: "ok" },
+      ]},
+      { role: "assistant", content: [
+        { type: "tool_use", id: "tu_2", name: "Edit", input: { file_path: "b.ts", old: "x", new: "y" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_2", content: "ok" },
+      ]},
+      { role: "assistant", content: [
+        { type: "text", text: "All done" },
+      ]},
+    ]
+    const result = extractFileChangesFromMessages(messages, openCodeExtract)
+    expect(result).toEqual([
+      { operation: "wrote", path: "a.ts" },
+      { operation: "edited", path: "b.ts" },
+    ])
+  })
+
+  it("should skip tool_use blocks without a corresponding tool_result", () => {
+    const messages = [
+      { role: "user", content: "do something" },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "tu_1", name: "Write", input: { file_path: "orphan.ts", content: "x" } },
+      ]},
+      // No tool_result for tu_1 — tool was proposed but not executed
+    ]
+    const result = extractFileChangesFromMessages(messages, openCodeExtract)
+    expect(result).toEqual([])
+  })
+
+  it("should skip read-only tools", () => {
+    const messages = [
+      { role: "user", content: "read file" },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "tu_1", name: "Read", input: { file_path: "readme.md" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_1", content: "file contents" },
+      ]},
+    ]
+    const result = extractFileChangesFromMessages(messages, openCodeExtract)
+    expect(result).toEqual([])
+  })
+
+  it("should handle empty messages", () => {
+    expect(extractFileChangesFromMessages([], openCodeExtract)).toEqual([])
+  })
+
+  it("should handle messages with string content (no tool_use)", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ]
+    const result = extractFileChangesFromMessages(messages, openCodeExtract)
+    expect(result).toEqual([])
+  })
+})
+
+describe("openCodeAdapter.extractFileChangesFromToolUse", () => {
+  const { openCodeAdapter } = require("../../src/proxy/adapters/opencode") as typeof import("../proxy/adapters/opencode")
+
+  it("should detect lowercase write (opencode native)", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { filePath: "src/new.ts", content: "x" })
+    expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])
+  })
+
+  it("should detect PascalCase Write (SDK passthrough)", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("Write", { file_path: "src/new.ts", content: "x" })
+    expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])
+  })
+
+  it("should detect lowercase edit", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("edit", { filePath: "src/old.ts", oldString: "a", newString: "b" })
+    expect(result).toEqual([{ operation: "edited", path: "src/old.ts" }])
+  })
+
+  it("should detect PascalCase Edit", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("Edit", { file_path: "src/old.ts" })
+    expect(result).toEqual([{ operation: "edited", path: "src/old.ts" }])
+  })
+
+  it("should detect MultiEdit tool (any case)", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("MultiEdit", { file_path: "src/multi.ts" })
+    expect(result).toEqual([{ operation: "edited", path: "src/multi.ts" }])
+  })
+
+  it("should prefer filePath over file_path", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { filePath: "correct.ts", file_path: "fallback.ts" })
+    expect(result).toEqual([{ operation: "wrote", path: "correct.ts" }])
+  })
+
+  it("should return empty for read", () => {
+    expect(openCodeAdapter.extractFileChangesFromToolUse!("read", { filePath: "x.ts" })).toEqual([])
+  })
+
+  it("should return empty for write without path", () => {
+    expect(openCodeAdapter.extractFileChangesFromToolUse!("write", { content: "x" })).toEqual([])
+  })
+
+  it("should return empty for null input", () => {
+    expect(openCodeAdapter.extractFileChangesFromToolUse!("write", null)).toEqual([])
+  })
+
+  it("should detect bash echo redirect", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("bash", { command: 'echo hello > /tmp/test.txt' })
+    expect(result).toEqual([{ operation: "wrote", path: "/tmp/test.txt" }])
+  })
+
+  it("should detect bash with multiple redirects", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("bash", { command: 'echo a > x.txt && echo b > y.txt' })
+    expect(result).toEqual([
+      { operation: "wrote", path: "x.txt" },
+      { operation: "wrote", path: "y.txt" },
+    ])
+  })
+
+  it("should return empty for bash without redirects", () => {
+    expect(openCodeAdapter.extractFileChangesFromToolUse!("bash", { command: "ls -la" })).toEqual([])
+  })
+})
+
+describe("crushAdapter.extractFileChangesFromToolUse", () => {
+  const { crushAdapter } = require("../../src/proxy/adapters/crush") as typeof import("../proxy/adapters/crush")
+
+  it("should detect write tool (lowercase)", () => {
+    const result = crushAdapter.extractFileChangesFromToolUse!("write", { file_path: "src/new.ts", content: "x" })
+    expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])
+  })
+
+  it("should detect edit tool (lowercase)", () => {
+    const result = crushAdapter.extractFileChangesFromToolUse!("edit", { file_path: "src/old.ts" })
+    expect(result).toEqual([{ operation: "edited", path: "src/old.ts" }])
+  })
+
+  it("should detect patch tool", () => {
+    const result = crushAdapter.extractFileChangesFromToolUse!("patch", { path: "src/patched.ts" })
+    expect(result).toEqual([{ operation: "edited", path: "src/patched.ts" }])
+  })
+
+  it("should return empty for PascalCase Write (not Crush convention)", () => {
+    expect(crushAdapter.extractFileChangesFromToolUse!("Write", { file_path: "x.ts" })).toEqual([])
+  })
+
+  it("should detect bash redirect in Crush", () => {
+    const result = crushAdapter.extractFileChangesFromToolUse!("bash", { command: 'echo x > /tmp/crush.txt' })
+    expect(result).toEqual([{ operation: "wrote", path: "/tmp/crush.txt" }])
+  })
+})

--- a/src/__tests__/proxy-crush-integration.test.ts
+++ b/src/__tests__/proxy-crush-integration.test.ts
@@ -251,8 +251,9 @@ describe("Crush adapter: no subagent routing", () => {
   it("no PreToolUse hooks for Crush requests", async () => {
     const app = createTestApp()
     await (await post(app, CRUSH_BODY, { "User-Agent": CRUSH_UA })).json()
-    // crushAdapter.buildSdkHooks returns undefined → no hooks in non-passthrough mode
-    expect(capturedQueryParams.options.hooks).toBeUndefined()
+    // crushAdapter.buildSdkHooks returns undefined → no PreToolUse in non-passthrough mode
+    // PostToolUse may be present (file change tracking is adapter-agnostic)
+    expect(capturedQueryParams.options.hooks?.PreToolUse).toBeUndefined()
   })
 })
 

--- a/src/__tests__/proxy-droid-integration.test.ts
+++ b/src/__tests__/proxy-droid-integration.test.ts
@@ -184,8 +184,9 @@ describe("Droid adapter: no subagent routing", () => {
     const app = createTestApp()
     const body = { ...DROID_BODY, tools: [TASK_TOOL] }
     await (await post(app, body, { "User-Agent": DROID_UA })).json()
-    // No hooks because droid.buildSdkHooks returns undefined
-    expect(capturedQueryParams.options.hooks).toBeUndefined()
+    // No PreToolUse hooks because droid.buildSdkHooks returns undefined
+    // PostToolUse may be present (file change tracking is adapter-agnostic)
+    expect(capturedQueryParams.options.hooks?.PreToolUse).toBeUndefined()
   })
 
   it("OpenCode still gets Task PreToolUse hooks when Task tool present", async () => {

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -1,0 +1,439 @@
+/**
+ * File Change Visibility Integration Tests
+ *
+ * Verifies that the PostToolUse hook captures file operations (write/edit/bash)
+ * and injects a summary into the response — both streaming and non-streaming.
+ *
+ * GitHub issue #189: "Build command lacks file change visibility"
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  assistantMessage,
+  messageStart,
+  textBlockStart,
+  toolUseBlockStart,
+  textDelta,
+  inputJsonDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+  parseSSE,
+} from "./helpers"
+
+let mockMessages: any[] = []
+let capturedQueryParams: any = null
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParams = params
+
+    // If PostToolUse hooks are registered, call them for MCP tool events
+    // This simulates what the SDK does internally when tools execute
+    return (async function* () {
+      const postToolUseHooks = params.options?.hooks?.PostToolUse
+      for (const msg of mockMessages) {
+        yield msg
+
+        // After yielding an assistant message with tool results, fire PostToolUse
+        // for any MCP tool blocks (simulating the SDK's internal tool execution)
+        if (msg.type === "assistant" && postToolUseHooks) {
+          for (const block of msg.message?.content || []) {
+            if (block.type === "tool_use" && block.name?.startsWith("mcp__")) {
+              for (const matcher of postToolUseHooks) {
+                for (const hookFn of matcher.hooks) {
+                  await hookFn({
+                    hook_event_name: "PostToolUse",
+                    tool_name: block.name,
+                    tool_input: block.input,
+                    tool_response: `Success: ${block.name}`,
+                    tool_use_id: block.id,
+                  })
+                }
+              }
+            }
+          }
+        }
+
+        // For streaming: fire PostToolUse after tool_use content_block_start
+        if (msg.type === "stream_event" && postToolUseHooks) {
+          const event = msg.event
+          if (event.type === "content_block_start" && event.content_block?.type === "tool_use" && event.content_block?.name?.startsWith("mcp__")) {
+            const toolName = event.content_block.name
+            const toolInput = event.content_block.input || {}
+            const toolId = event.content_block.id
+            for (const matcher of postToolUseHooks) {
+              for (const hookFn of matcher.hooks) {
+                await hookFn({
+                  hook_event_name: "PostToolUse",
+                  tool_name: toolName,
+                  tool_input: toolInput,
+                  tool_response: `Success: ${toolName}`,
+                  tool_use_id: toolId,
+                })
+              }
+            }
+          }
+        }
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }))
+}
+
+async function postStream(app: any, body: any) {
+  const response = await app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }))
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return parseSSE(result)
+}
+
+describe("File change visibility: PostToolUse hook registration", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "Done" }])]
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  it("should register PostToolUse hooks in SDK options", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })).json()
+
+    expect(capturedQueryParams.options.hooks).toBeDefined()
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
+    expect(capturedQueryParams.options.hooks.PostToolUse.length).toBeGreaterThan(0)
+  })
+
+  it("should register PostToolUse alongside PreToolUse when Task tool is present", async () => {
+    const TASK_TOOL = {
+      name: "task",
+      description: "Launch a new agent.\n\nAvailable agent types and the tools they have access to:\n- build: Default agent\n- explore: Explorer",
+      input_schema: {
+        type: "object",
+        properties: { subagent_type: { type: "string" }, description: { type: "string" } },
+        required: ["subagent_type", "description"],
+      },
+    }
+
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+      tools: [TASK_TOOL],
+    })).json()
+
+    expect(capturedQueryParams.options.hooks.PreToolUse).toBeDefined()
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
+  })
+
+  it("should not register PostToolUse in passthrough mode", async () => {
+    const origPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    const origCPPassthrough = process.env.CLAUDE_PROXY_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+
+    try {
+      const app = createTestApp()
+      await (await post(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 1024,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })).json()
+
+      const hooks = capturedQueryParams.options.hooks
+      expect(hooks.PreToolUse).toBeDefined()
+      expect(hooks.PostToolUse).toBeUndefined()
+    } finally {
+      if (origPassthrough !== undefined) {
+        process.env.MERIDIAN_PASSTHROUGH = origPassthrough
+      } else {
+        delete process.env.MERIDIAN_PASSTHROUGH
+      }
+      if (origCPPassthrough !== undefined) {
+        process.env.CLAUDE_PROXY_PASSTHROUGH = origCPPassthrough
+      }
+    }
+  })
+})
+
+describe("File change visibility: non-streaming response", () => {
+  beforeEach(() => {
+    mockMessages = []
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  it("should append file change summary to response when files are written", async () => {
+    // Simulate SDK executing mcp__opencode__write internally, then returning text
+    mockMessages = [
+      // First the SDK calls the write tool (internal, won't be in final content)
+      assistantMessage([
+        { type: "tool_use", id: "toolu_w1", name: "mcp__opencode__write", input: { path: "src/new-file.ts", content: "export const x = 1" } },
+      ]),
+      // Then SDK returns the text response after tool execution
+      assistantMessage([
+        { type: "text", text: "I created the file for you." },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Create a file" }],
+    })).json()
+
+    // The response should include file change summary in the text
+    const textBlocks = response.content.filter((b: any) => b.type === "text")
+    const allText = textBlocks.map((b: any) => b.text).join("")
+    expect(allText).toContain("Files changed:")
+    expect(allText).toContain("wrote src/new-file.ts")
+  })
+
+  it("should append file change summary when files are edited", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_e1", name: "mcp__opencode__edit", input: { path: "src/existing.ts", oldString: "foo", newString: "bar" } },
+      ]),
+      assistantMessage([
+        { type: "text", text: "I fixed the bug." },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Fix the bug" }],
+    })).json()
+
+    const textBlocks = response.content.filter((b: any) => b.type === "text")
+    const allText = textBlocks.map((b: any) => b.text).join("")
+    expect(allText).toContain("Files changed:")
+    expect(allText).toContain("edited src/existing.ts")
+  })
+
+  it("should not include summary when only reads occur", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_r1", name: "mcp__opencode__read", input: { path: "README.md" } },
+      ]),
+      assistantMessage([
+        { type: "text", text: "The README says hello." },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Read README" }],
+    })).json()
+
+    const textBlocks = response.content.filter((b: any) => b.type === "text")
+    const allText = textBlocks.map((b: any) => b.text).join("")
+    expect(allText).not.toContain("Files changed:")
+  })
+
+  it("should show multiple file changes", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_w1", name: "mcp__opencode__write", input: { path: "src/a.ts", content: "a" } },
+      ]),
+      assistantMessage([
+        { type: "tool_use", id: "toolu_e1", name: "mcp__opencode__edit", input: { path: "src/b.ts", oldString: "x", newString: "y" } },
+      ]),
+      assistantMessage([
+        { type: "tool_use", id: "toolu_w2", name: "mcp__opencode__write", input: { path: "src/c.ts", content: "c" } },
+      ]),
+      assistantMessage([
+        { type: "text", text: "All done." },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Create multiple files" }],
+    })).json()
+
+    const textBlocks = response.content.filter((b: any) => b.type === "text")
+    const allText = textBlocks.map((b: any) => b.text).join("")
+    expect(allText).toContain("wrote src/a.ts")
+    expect(allText).toContain("edited src/b.ts")
+    expect(allText).toContain("wrote src/c.ts")
+  })
+})
+
+describe("File change visibility: streaming response", () => {
+  beforeEach(() => {
+    mockMessages = []
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  it("should emit file change text block before message_stop in stream", async () => {
+    // Multi-turn: MCP write tool → text response
+    mockMessages = [
+      messageStart(),
+      // MCP tool (internal, filtered from stream)
+      toolUseBlockStart(0, "mcp__opencode__write", "toolu_sw1"),
+      inputJsonDelta(0, '{"path":"src/streamed.ts","content":"hello"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      messageStop(),
+      // After tool execution, SDK returns text
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "File created."),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    // Override input on the tool block for the hook to read
+    const toolBlock = (mockMessages[1] as any).event.content_block
+    toolBlock.input = { path: "src/streamed.ts", content: "hello" }
+
+    const app = createTestApp()
+    const events = await postStream(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: true,
+      messages: [{ role: "user", content: "Create a file" }],
+    })
+
+    // Should have a text delta containing the file change summary
+    const allTextDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
+    )
+    const allText = allTextDeltas.map((e) => (e.data as any).delta.text).join("")
+    expect(allText).toContain("Files changed:")
+    expect(allText).toContain("wrote src/streamed.ts")
+
+    // File change block should come BEFORE message_stop
+    const lastEvent = events[events.length - 1]
+    expect(lastEvent?.event).toBe("message_stop")
+  })
+
+  it("should not emit file change block when no files changed", async () => {
+    mockMessages = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "Hello there!"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const app = createTestApp()
+    const events = await postStream(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: true,
+      messages: [{ role: "user", content: "Say hello" }],
+    })
+
+    const allTextDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
+    )
+    const allText = allTextDeltas.map((e) => (e.data as any).delta.text).join("")
+    expect(allText).not.toContain("Files changed:")
+  })
+
+  it("should use correct block index for file change text block", async () => {
+    // Text block at index 0, then MCP tool (skipped), then file change block should be index 1
+    mockMessages = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "Working on it."),
+      blockStop(0),
+      // MCP tool (hidden)
+      toolUseBlockStart(1, "mcp__opencode__edit", "toolu_idx"),
+      inputJsonDelta(1, '{"path":"src/idx.ts","oldString":"a","newString":"b"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      messageStop(),
+      // Final text
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "Done."),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    // Set input on tool block
+    const toolBlock = (mockMessages[4] as any).event.content_block
+    toolBlock.input = { path: "src/idx.ts", oldString: "a", newString: "b" }
+
+    const app = createTestApp()
+    const events = await postStream(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: true,
+      messages: [{ role: "user", content: "Edit a file" }],
+    })
+
+    // Find the file change block start
+    const blockStarts = events.filter((e) => e.event === "content_block_start")
+    const fileChangeBlock = blockStarts.find(
+      (e) => {
+        const text = (e.data as any).content_block?.text
+        return text !== undefined && (e.data as any).content_block?.type === "text"
+      }
+    )
+
+    // All block indices should be monotonically increasing
+    const indices = blockStarts.map((e) => (e.data as any).index)
+    for (let i = 1; i < indices.length; i++) {
+      expect(indices[i]).toBeGreaterThan(indices[i - 1]!)
+    }
+  })
+})

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -87,4 +87,22 @@ export interface AgentAdapter {
    * When defined, takes precedence over the env var for this agent.
    */
   usesPassthrough?(): boolean
+
+  /**
+   * Map a client-side tool_use block to file changes (passthrough mode).
+   *
+   * In passthrough mode the SDK doesn't execute tools, so PostToolUse
+   * hooks never fire. Instead, the proxy scans the conversation history
+   * in body.messages for assistant tool_use blocks and uses this method
+   * to identify file-writing operations.
+   *
+   * Returns an array of FileChange entries. Most tools produce 0 or 1 entry,
+   * but bash commands can produce multiple (e.g., `echo a > x && echo b > y`).
+   *
+   * Each adapter knows its agent's tool naming convention:
+   * - OpenCode: "write" / "edit" / "bash" (with redirect parsing)
+   * - Crush: "write" / "edit" / "bash"
+   * - Cline: "write_to_file" / "apply_diff"
+   */
+  extractFileChangesFromToolUse?(toolName: string, toolInput: unknown): import("./fileChanges").FileChange[]
 }

--- a/src/proxy/adapters/crush.ts
+++ b/src/proxy/adapters/crush.ts
@@ -20,6 +20,7 @@
 
 import type { Context } from "hono"
 import type { AgentAdapter } from "../adapter"
+import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
 import { normalizeContent } from "../messages"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../tools"
 
@@ -100,4 +101,24 @@ export const crushAdapter: AgentAdapter = {
    * passthrough=1 setting that serves OpenCode also serves Crush correctly.
    */
   // usesPassthrough not defined — defers to CLAUDE_PROXY_PASSTHROUGH env var
+
+  /**
+   * Crush uses lowercase tool names: write, edit, patch, bash.
+   * Input path field is "file_path".
+   */
+  extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
+    const input = toolInput as Record<string, unknown> | null | undefined
+    const filePath = input?.file_path ?? input?.path
+
+    if (toolName === "write" && filePath) {
+      return [{ operation: "wrote", path: String(filePath) }]
+    }
+    if ((toolName === "edit" || toolName === "patch") && filePath) {
+      return [{ operation: "edited", path: String(filePath) }]
+    }
+    if (toolName === "bash" && input?.command) {
+      return extractFileChangesFromBash(String(input.command))
+    }
+    return []
+  },
 }

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -7,6 +7,7 @@
 
 import type { Context } from "hono"
 import type { AgentAdapter } from "../adapter"
+import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
 import { normalizeContent } from "../messages"
 import { extractClientCwd } from "../session/fingerprint"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../tools"
@@ -89,5 +90,29 @@ export const openCodeAdapter: AgentAdapter = {
     const validAgentNames = Object.keys(sdkAgents)
     if (validAgentNames.length === 0) return ""
     return `\n\nIMPORTANT: When using the task/Task tool, the subagent_type parameter must be one of these exact values (case-sensitive, lowercase): ${validAgentNames.join(", ")}. Do NOT capitalize or modify these names.`
+  },
+
+  /**
+   * NOTE: OpenCode-specific. Maps OpenCode's tool names to file changes.
+   * OpenCode uses lowercase tool names (write, edit, multiedit) with filePath input.
+   * The passthrough proxy may also return PascalCase names (Write, Edit, MultiEdit)
+   * from the SDK's tool registration, so we match both.
+   * Bash commands are parsed for output redirects (>, >>), tee, and sed -i.
+   */
+  extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
+    const input = toolInput as Record<string, unknown> | null | undefined
+    const filePath = input?.filePath ?? input?.file_path
+
+    const lowerName = toolName.toLowerCase()
+    if (lowerName === "write" && filePath) {
+      return [{ operation: "wrote", path: String(filePath) }]
+    }
+    if ((lowerName === "edit" || lowerName === "multiedit") && filePath) {
+      return [{ operation: "edited", path: String(filePath) }]
+    }
+    if (lowerName === "bash" && input?.command) {
+      return extractFileChangesFromBash(String(input.command))
+    }
+    return []
   },
 }

--- a/src/proxy/fileChanges.ts
+++ b/src/proxy/fileChanges.ts
@@ -1,0 +1,208 @@
+/**
+ * File change tracking for both internal and passthrough modes.
+ *
+ * Internal mode: PostToolUse hooks capture MCP tool executions (write/edit).
+ * Passthrough mode: Scans body.messages for client-side tool_use blocks.
+ *
+ * This is a leaf module — no imports from server.ts or session/.
+ */
+
+/** A recorded file operation from an MCP tool execution. */
+export interface FileChange {
+  /** The operation type: "wrote" or "edited" */
+  operation: "wrote" | "edited"
+  /** The file path from the tool input */
+  path: string
+}
+
+/**
+ * Extract a FileChange from a PostToolUse hook input, if applicable.
+ *
+ * Only tracks write and edit operations — read/glob/grep are read-only.
+ * Returns undefined for non-file-changing tools.
+ *
+ * @param toolName - The full MCP tool name (e.g. "mcp__opencode__write")
+ * @param toolInput - The tool's input parameters
+ * @param mcpPrefix - The MCP prefix to match (e.g. "mcp__opencode__")
+ */
+export function extractFileChange(
+  toolName: string,
+  toolInput: unknown,
+  mcpPrefix: string
+): FileChange | undefined {
+  if (!toolName.startsWith(mcpPrefix)) return undefined
+
+  const shortName = toolName.slice(mcpPrefix.length)
+  const input = toolInput as Record<string, unknown> | null | undefined
+
+  if (shortName === "write" && input?.path) {
+    return { operation: "wrote", path: String(input.path) }
+  }
+
+  if (shortName === "edit" && input?.path) {
+    return { operation: "edited", path: String(input.path) }
+  }
+
+  return undefined
+}
+
+/**
+ * Create a PostToolUse hook matcher that captures file changes.
+ *
+ * The hook pushes FileChange entries into the provided array.
+ * The caller (server.ts) reads this array after the SDK completes
+ * to inject a summary into the response.
+ *
+ * @param changes - Mutable array to push changes into (shared with caller)
+ * @param mcpPrefix - The MCP prefix for this adapter (e.g. "mcp__opencode__")
+ */
+export function createFileChangeHook(
+  changes: FileChange[],
+  mcpPrefix: string
+) {
+  return {
+    matcher: "",  // Match ALL tools (filter inside the hook)
+    hooks: [async (input: {
+      tool_name: string
+      tool_input: unknown
+      tool_response: unknown
+      tool_use_id: string
+    }) => {
+      // Check for MCP write/edit tools first
+      const change = extractFileChange(input.tool_name, input.tool_input, mcpPrefix)
+      if (change) {
+        changes.push(change)
+        return {}
+      }
+      // Check for bash commands with redirects (>, >>, tee, sed -i)
+      if (input.tool_name === `${mcpPrefix}bash`) {
+        const toolInput = input.tool_input as Record<string, unknown> | null | undefined
+        if (toolInput?.command) {
+          const bashChanges = extractFileChangesFromBash(String(toolInput.command))
+          changes.push(...bashChanges)
+        }
+      }
+      return {}
+    }],
+  }
+}
+
+/**
+ * Extract file paths from a bash command string by detecting output redirects
+ * and common file-mutating commands (sed -i, tee, cp, mv).
+ *
+ * This is a best-effort heuristic — it won't catch every possible way bash
+ * can write files, but it handles the patterns coding agents use most often.
+ *
+ * @param command - The bash command string
+ */
+export function extractFileChangesFromBash(command: string): FileChange[] {
+  const changes: FileChange[] = []
+  const seen = new Set<string>()
+
+  const addChange = (operation: FileChange["operation"], path: string) => {
+    // Filter out /dev/null and common non-file targets
+    if (path === "/dev/null" || path === "/dev/stderr" || path === "/dev/stdout") return
+    // Filter empty or whitespace-only paths
+    if (!path.trim()) return
+    const key = `${operation}:${path}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      changes.push({ operation, path })
+    }
+  }
+
+  // 1. Output redirects: > file or >> file (but not stderr 2> or 2>>)
+  //    Match: optional space, then > or >>, then the target path
+  //    Negative lookbehind for digits (to skip 2>, 1>, etc.)
+  const redirectRegex = /(?<![0-9])>{1,2}\s*['"]?([^\s'";&|)]+)['"]?/g
+  let match
+  while ((match = redirectRegex.exec(command)) !== null) {
+    addChange("wrote", match[1]!)
+  }
+
+  // 2. tee [-a] file
+  const teeRegex = /\btee\s+(?:-[a-zA-Z]\s+)*['"]?([^\s'";&|)]+)['"]?/g
+  while ((match = teeRegex.exec(command)) !== null) {
+    addChange("wrote", match[1]!)
+  }
+
+  // 3. sed -i (in-place edit)
+  const sedRegex = /\bsed\s+(?:-[a-zA-Z]*i[a-zA-Z]*|-i)\b.*?['"]?([^\s'";&|)]+)['"]?\s*$/gm
+  while ((match = sedRegex.exec(command)) !== null) {
+    addChange("edited", match[1]!)
+  }
+
+  return changes
+}
+
+/**
+ * Extract file changes from conversation history (passthrough mode).
+ *
+ * In passthrough mode the SDK doesn't execute tools — the client does.
+ * The conversation history in body.messages contains assistant tool_use
+ * blocks from completed tool loops. We scan these to build the file
+ * change list.
+ *
+ * Only scans tool_use blocks that have a corresponding tool_result
+ * (i.e., the tool was actually executed, not just proposed).
+ *
+ * @param messages - The body.messages array from the request
+ * @param extractFn - Adapter's extractFileChangesFromToolUse method
+ */
+export function extractFileChangesFromMessages(
+  messages: Array<{ role: string; content: unknown }>,
+  extractFn: (toolName: string, toolInput: unknown) => FileChange[]
+): FileChange[] {
+  const changes: FileChange[] = []
+  // Collect tool_use IDs that have a corresponding tool_result
+  const executedToolIds = new Set<string>()
+  for (const msg of messages) {
+    if (msg.role !== "user") continue
+    const content = Array.isArray(msg.content) ? msg.content : []
+    for (const block of content) {
+      if (block?.type === "tool_result" && block.tool_use_id) {
+        executedToolIds.add(block.tool_use_id)
+      }
+    }
+  }
+
+  // Scan assistant tool_use blocks that were actually executed
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue
+    const content = Array.isArray(msg.content) ? msg.content : []
+    for (const block of content) {
+      if (block?.type !== "tool_use") continue
+      if (!executedToolIds.has(block.id)) continue
+      const blockChanges = extractFn(block.name, block.input)
+      changes.push(...blockChanges)
+    }
+  }
+  return changes
+}
+
+/**
+ * Format file changes into a human-readable summary string.
+ *
+ * Deduplicates by path+operation and returns a newline-separated list.
+ * Returns undefined if no changes to report.
+ *
+ * @param changes - Array of recorded file changes
+ */
+export function formatFileChangeSummary(changes: FileChange[]): string | undefined {
+  if (changes.length === 0) return undefined
+
+  // Deduplicate: same path+operation only listed once
+  const seen = new Set<string>()
+  const unique: FileChange[] = []
+  for (const c of changes) {
+    const key = `${c.operation}:${c.path}`
+    if (!seen.has(key)) {
+      seen.add(key)
+      unique.push(c)
+    }
+  }
+
+  const lines = unique.map((c) => `- ${c.operation} ${c.path}`)
+  return `\n\nFiles changed:\n${lines.join("\n")}`
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -22,6 +22,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedController
 import { getLastUserMessage } from "./messages"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
+import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
 import {
   computeLineageHash,
   hashMessage,
@@ -396,6 +397,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         ? adapterPassthrough
         : Boolean((process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH))
       const capturedToolUses: Array<{ id: string; name: string; input: any }> = []
+      const fileChanges: FileChange[] = []
 
       // In passthrough mode, register OpenCode's tools as MCP tools so Claude
       // can actually call them (not just see them as text descriptions).
@@ -408,6 +410,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
       // In passthrough mode: block ALL tools, capture them for forwarding (agent-agnostic).
       // In normal mode: delegate hook construction to the adapter.
+      // PostToolUse hook tracks file changes from MCP tools (internal mode only).
+      // Catches write, edit, AND bash redirects (>, >>, tee, sed -i).
+      const mcpPrefix = `mcp__${adapter.getMcpServerName()}__`
+      const fileChangeHook = createFileChangeHook(fileChanges, mcpPrefix)
+
       const sdkHooks = passthrough
         ? {
             PreToolUse: [{
@@ -425,9 +432,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }],
             }],
           }
-        : adapter.buildSdkHooks?.(body, sdkAgents) ?? undefined
-
-
+        : {
+            ...(adapter.buildSdkHooks?.(body, sdkAgents) ?? {}),
+            PostToolUse: [fileChangeHook],
+          }
 
         if (!stream) {
           const contentBlocks: Array<Record<string, unknown>> = []
@@ -566,7 +574,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
                 // Preserve ALL content blocks (text, tool_use, thinking, etc.)
                 for (const block of message.message.content) {
-                  const b = block as Record<string, unknown>
+                  const b = block as unknown as Record<string, unknown>
                   // In passthrough mode, strip MCP prefix from tool names
                   if (passthrough && b.type === "tool_use" && typeof b.name === "string") {
                     b.name = stripMcpPrefix(b.name as string)
@@ -611,6 +619,27 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // Determine stop_reason based on content: tool_use if any tool blocks, else end_turn
           const hasToolUse = contentBlocks.some((b) => b.type === "tool_use")
           const stopReason = hasToolUse ? "tool_use" : "end_turn"
+
+          // Append file change summary:
+          // - Internal mode: fileChanges populated by PostToolUse hook
+          // - Passthrough mode: scan body.messages for executed tool_use blocks
+          if (passthrough && stopReason === "end_turn" && adapter.extractFileChangesFromToolUse) {
+            const passthroughChanges = extractFileChangesFromMessages(
+              body.messages || [],
+              adapter.extractFileChangesFromToolUse.bind(adapter)
+            )
+            fileChanges.push(...passthroughChanges)
+          }
+          const fileChangeSummary = formatFileChangeSummary(fileChanges)
+          if (fileChangeSummary) {
+            const lastTextBlock = [...contentBlocks].reverse().find((b) => b.type === "text")
+            if (lastTextBlock) {
+              lastTextBlock.text = (lastTextBlock.text as string) + fileChangeSummary
+            } else {
+              contentBlocks.push({ type: "text", text: fileChangeSummary.trimStart() })
+            }
+            claudeLog("response.file_changes", { mode: "non_stream", count: fileChanges.length })
+          }
 
           // If no content at all, add a fallback text block
           if (contentBlocks.length === 0) {
@@ -1006,6 +1035,42 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       usage: { output_tokens: 0 }
                     })}\n\n`
                   ), "passthrough_message_delta")
+                }
+
+                // Passthrough mode: scan body.messages for file changes on end_turn
+                if (passthrough && adapter.extractFileChangesFromToolUse) {
+                  const passthroughChanges = extractFileChangesFromMessages(
+                    body.messages || [],
+                    adapter.extractFileChangesFromToolUse.bind(adapter)
+                  )
+                  fileChanges.push(...passthroughChanges)
+                }
+
+                // Emit file change summary as a text block before closing
+                const streamFileChangeSummary = formatFileChangeSummary(fileChanges)
+                if (streamFileChangeSummary && messageStartEmitted) {
+                  const fcBlockIndex = nextClientBlockIndex++
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_start\ndata: ${JSON.stringify({
+                      type: "content_block_start",
+                      index: fcBlockIndex,
+                      content_block: { type: "text", text: "" },
+                    })}\n\n`
+                  ), "file_changes_block_start")
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_delta\ndata: ${JSON.stringify({
+                      type: "content_block_delta",
+                      index: fcBlockIndex,
+                      delta: { type: "text_delta", text: streamFileChangeSummary },
+                    })}\n\n`
+                  ), "file_changes_text_delta")
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_stop\ndata: ${JSON.stringify({
+                      type: "content_block_stop",
+                      index: fcBlockIndex,
+                    })}\n\n`
+                  ), "file_changes_block_stop")
+                  claudeLog("response.file_changes", { mode: "stream", count: fileChanges.length })
                 }
 
                 // Emit the final message_stop (we skipped all intermediate ones)


### PR DESCRIPTION
## Summary

Appends a **Files changed** summary to responses when the model writes or edits files. Works in both proxy modes.

### Example output
```
I've fixed the bug in the add function.

Files changed:
- edited src/math.ts
- wrote src/__tests__/math.test.ts
```

### How it works

**Passthrough mode** (OpenCode, Crush, Cline):
- On `stop_reason: "end_turn"`, scans `body.messages` for executed `tool_use` blocks
- Each adapter maps its tool names to file changes (write/edit + bash redirects)
- Stateless — no cross-request tracking needed

**Internal mode** (Droid, direct API):
- PostToolUse hook captures MCP tool executions (write, edit)
- Also parses bash commands for output redirects (`>`, `>>`, `tee`, `sed -i`)

### What's tracked

| Pattern | Tracked? |
|---------|----------|
| `write` / `edit` / `multiedit` tools | ✅ |
| `bash` with `echo X > file` | ✅ |
| `bash` with `>> file` (append) | ✅ |
| `bash` with `tee file` | ✅ |
| `bash` with `sed -i` | ✅ |
| `bash` with `cp` / `mv` | ❌ (no redirect to parse) |
| Arbitrary scripts (`python3 -c`, etc.) | ❌ |

### Testing

- **36 new unit tests** — pure functions, adapter methods, bash parsing
- **10 integration tests** — mocked SDK, streaming + non-streaming
- **E2E verified** with real `opencode run --format json`:
  - write tool → ✅ `Files changed: - wrote ...`
  - edit tool → ✅ `Files changed: - edited ...`
  - bash echo redirect → ✅ `Files changed: - wrote ...`
  - read-only → ✅ no summary
  - pure text → ✅ no summary
  - bash ls → ✅ no summary
- **579 total tests pass, 0 fail**

### New files
- `src/proxy/fileChanges.ts` — leaf module, pure functions
- `src/__tests__/file-changes-unit.test.ts` — 36 unit tests
- `src/__tests__/proxy-file-changes.test.ts` — 10 integration tests

Closes #189