### PR TITLE
fix: passthrough mode tool_use broken for multi-turn and streaming

### DIFF
--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -61,7 +61,7 @@ export function buildQueryOptions(ctx: QueryContext) {
   return {
     prompt,
     options: {
-      maxTurns: passthrough ? 1 : 200,
+      maxTurns: passthrough ? 10 : 200,
       cwd: workingDirectory,
       model,
       pathToClaudeCodeExecutable: claudeExecutable,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -965,6 +965,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }
                     eventsForwarded += 1
 
+                    // Passthrough mode: when the model stops for tool_use, end the stream
+                    // immediately so the client can execute the tools and send results back.
+                    // Without this, the SDK continues processing "passthrough" tool results
+                    // internally, wasting tokens and producing incorrect responses.
+                    if (passthrough && eventType === "message_delta" && (event as any).delta?.stop_reason === "tool_use" && streamedToolUseIds.size > 0) {
+                      safeEnqueue(encoder.encode(`event: message_stop\ndata: ${JSON.stringify({type: "message_stop"})}\n\n`), "passthrough_tool_stream_stop")
+                      streamClosed = true
+                      try { controller.close() } catch {}
+                      break
+                    }
+
                     if (eventType === "content_block_delta") {
                       const delta = (event as any).delta
                       if (delta?.type === "text_delta") {


### PR DESCRIPTION
## Summary

Fixes two bugs in passthrough mode (`MERIDIAN_PASSTHROUGH=true`) that break tool_use flows:

### Bug 1: `maxTurns=1` causes HTTP 500 on multi-turn tool flows

When a client sends tools and the model responds with `tool_use`, the SDK needs at least one more turn to process the tool result. With `maxTurns=1`, the SDK immediately errors with "Reached maximum number of turns (1)".

**Fix**: Changed `maxTurns` from `1` to `10` in passthrough mode to allow multi-step tool flows.

### Bug 2: Streaming path continues after `tool_use` stop, producing incorrect responses

In streaming mode, when the model emits `stop_reason: tool_use`, the SDK continues internally — it executes the passthrough MCP tools (which return placeholder `"passthrough"` text), feeds that back to the model, and the model generates a fallback text response thinking the tools failed. The client never gets a chance to execute the tools.

**Fix**: Break the stream loop immediately when `message_delta` with `stop_reason: tool_use` is detected in passthrough mode, emitting `message_stop` and closing the controller so the client can execute tools and send results back.

## Changes

- `src/proxy/query.ts`: `maxTurns: passthrough ? 1 : 200` → `maxTurns: passthrough ? 10 : 200`
- `src/proxy/server.ts`: Add early stream termination on `tool_use` stop in passthrough mode

## Testing

Tested with a multi-step tool_use flow (weather → recommendation) in both non-streaming and streaming modes:
- Non-streaming: model returns `tool_use` blocks, client sends `tool_result`, model responds correctly
- Streaming: SSE stream ends cleanly at `tool_use` stop, client processes tools, sends results, gets final response
