### PR TITLE
fix: passthrough mode tool_use broken for multi-turn and streaming

### DIFF
--- a/src/__tests__/proxy-passthrough-concept.test.ts
+++ b/src/__tests__/proxy-passthrough-concept.test.ts
@@ -1,13 +1,13 @@
 /**
  * Passthrough Architecture Concept Tests
  *
- * Tests the idea of using maxTurns:1 so the SDK generates one response
+ * Tests the idea of using maxTurns:2 so the SDK generates one response
  * and stops. If that response has tool_use blocks, we forward them to
  * OpenCode. OpenCode handles the tools (including Task for agent delegation)
  * and sends tool_result back.
  *
  * Key questions this validates:
- * 1. With maxTurns:1, does the SDK return tool_use blocks in the response?
+ * 1. With maxTurns:2, does the SDK return tool_use blocks in the response?
  * 2. Can we correctly extract tool_use blocks and return stop_reason:"tool_use"?
  * 3. Can we accept tool_result and resume the session?
  * 4. Does Task tool_use get forwarded to OpenCode (not handled internally)?
@@ -15,7 +15,7 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
-// Simulated SDK messages for maxTurns:1 scenarios
+// Simulated SDK messages for maxTurns:2 scenarios
 const toolUseMessage = {
   type: "assistant" as const,
   message: {

--- a/src/__tests__/proxy-passthrough-tool-use.test.ts
+++ b/src/__tests__/proxy-passthrough-tool-use.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Passthrough Mode: tool_use Bug Fixes
+ *
+ * Regression tests for two bugs that broke tool_use flows in passthrough mode:
+ *
+ * Bug 1 (non-streaming): maxTurns:1 caused HTTP 500 on multi-turn tool flows.
+ *   The SDK needs a second internal turn to process the blocked-tool handoff
+ *   before returning. Fixed by raising maxTurns to 2.
+ *
+ * Bug 2 (streaming): After the model emitted message_delta(stop_reason:tool_use),
+ *   the SDK continued by executing the passthrough MCP no-op (→ "passthrough"),
+ *   feeding that back to the model, and the model produced a junk fallback response
+ *   which got forwarded to the client. Fixed by breaking the stream loop immediately
+ *   on tool_use stop in passthrough mode.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import {
+  messageStart,
+  textBlockStart,
+  toolUseBlockStart,
+  inputJsonDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+  textDelta,
+  parseSSE,
+  assistantMessage,
+  makeRequest,
+  READ_TOOL,
+} from "./helpers"
+
+// --- Mock the Claude SDK ---
+let mockMessages: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () =>
+    (async function* () {
+      for (const msg of mockMessages) yield msg
+    })(),
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "test",
+    // Provide a minimal instance that supports tool() registration
+    instance: { tool: () => {} },
+  }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+// Prefix the SDK uses for passthrough MCP tools
+const PASSTHROUGH_PREFIX = "mcp__oc__"
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function postStream(app: any, tools: any[] = [READ_TOOL]): Promise<string> {
+  const req = new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      makeRequest({
+        stream: true,
+        tools,
+        messages: [{ role: "user", content: "Read the file /tmp/test.txt" }],
+      })
+    ),
+  })
+  const response = await app.fetch(req)
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return result
+}
+
+async function postNonStream(app: any, tools: any[] = [READ_TOOL]): Promise<Response> {
+  const req = new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      makeRequest({
+        stream: false,
+        tools,
+        messages: [{ role: "user", content: "Read the file /tmp/test.txt" }],
+      })
+    ),
+  })
+  return app.fetch(req)
+}
+
+// ============================================================
+// Bug 2: Streaming — early termination on tool_use stop
+// ============================================================
+
+describe("Passthrough streaming: early termination on tool_use stop", () => {
+  let origEnv: string | undefined
+
+  beforeEach(() => {
+    mockMessages = []
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv !== undefined) {
+      process.env.MERIDIAN_PASSTHROUGH = origEnv
+    } else {
+      delete process.env.MERIDIAN_PASSTHROUGH
+    }
+  })
+
+  it("stream ends with message_stop immediately after message_delta(stop_reason:tool_use)", async () => {
+    // Simulate: model streams a passthrough tool_use, then the SDK would
+    // normally continue (turn 2) — but we should break before that happens.
+    mockMessages = [
+      messageStart(),
+      // Passthrough MCP tool block (mcp__oc__ prefix) — should be stripped and forwarded
+      toolUseBlockStart(0, `${PASSTHROUGH_PREFIX}Read`, "toolu_read1"),
+      inputJsonDelta(0, '{"file_path":"/tmp/test.txt"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      messageStop(),
+      // Turn 2 — SDK would normally continue here after executing the MCP no-op.
+      // With the fix, we should never reach these events.
+      messageStart("msg_turn2"),
+      textBlockStart(0),
+      textDelta(0, "I was unable to read the file as the tool returned 'passthrough'."),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const app = createTestApp()
+    const raw = await postStream(app)
+    const events = parseSSE(raw)
+
+    // The stream must end with message_stop
+    const lastEvent = events[events.length - 1]
+    expect(lastEvent?.event).toBe("message_stop")
+
+    // The tool_use block should be forwarded with the prefix stripped
+    const toolStarts = events.filter(
+      (e) => e.event === "content_block_start" && (e.data as any).content_block?.type === "tool_use"
+    )
+    expect(toolStarts.length).toBe(1)
+    expect((toolStarts[0]?.data as any).content_block.name).toBe("Read")
+
+    // No text from turn 2 should appear after the tool_use stop
+    const textDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
+    )
+    expect(textDeltas.length).toBe(0)
+
+    // The message_delta with stop_reason:tool_use must be forwarded before message_stop
+    const toolUseDelta = events.find(
+      (e) => e.event === "message_delta" && (e.data as any).delta?.stop_reason === "tool_use"
+    )
+    expect(toolUseDelta).toBeDefined()
+  })
+
+  it("stream ends with message_stop after multiple passthrough tool_use blocks", async () => {
+    mockMessages = [
+      messageStart(),
+      toolUseBlockStart(0, `${PASSTHROUGH_PREFIX}Read`, "toolu_1"),
+      inputJsonDelta(0, '{"file_path":"/tmp/a.txt"}'),
+      blockStop(0),
+      toolUseBlockStart(1, `${PASSTHROUGH_PREFIX}Bash`, "toolu_2"),
+      inputJsonDelta(1, '{"command":"ls -la"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      messageStop(),
+      // Turn 2 junk — should never be forwarded
+      messageStart("msg_turn2"),
+      textBlockStart(0),
+      textDelta(0, "The tools returned passthrough, I cannot continue."),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const app = createTestApp()
+    const raw = await postStream(app, [READ_TOOL, { name: "Bash", description: "Run bash", input_schema: { type: "object", properties: { command: { type: "string" } } } }])
+    const events = parseSSE(raw)
+
+    // Two tool_use blocks forwarded (prefix stripped)
+    const toolStarts = events.filter(
+      (e) => e.event === "content_block_start" && (e.data as any).content_block?.type === "tool_use"
+    )
+    expect(toolStarts.length).toBe(2)
+    expect((toolStarts[0]?.data as any).content_block.name).toBe("Read")
+    expect((toolStarts[1]?.data as any).content_block.name).toBe("Bash")
+
+    // Stream ends cleanly
+    const lastEvent = events[events.length - 1]
+    expect(lastEvent?.event).toBe("message_stop")
+
+    // No turn-2 text
+    const textDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
+    )
+    expect(textDeltas.length).toBe(0)
+  })
+
+  it("does NOT terminate early when stop_reason is end_turn (no tool_use)", async () => {
+    mockMessages = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "I can help with that."),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const app = createTestApp()
+    const raw = await postStream(app)
+    const events = parseSSE(raw)
+
+    // Normal end_turn stream — text should be present
+    const textDeltas = events.filter(
+      (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
+    )
+    expect(textDeltas.length).toBeGreaterThan(0)
+    expect((textDeltas[0]?.data as any).delta.text).toBe("I can help with that.")
+
+    const lastEvent = events[events.length - 1]
+    expect(lastEvent?.event).toBe("message_stop")
+  })
+})
+
+// ============================================================
+// Bug 1: Non-streaming — maxTurns fix (no HTTP 500)
+// ============================================================
+
+describe("Passthrough non-streaming: tool_use returned without HTTP 500", () => {
+  let origEnv: string | undefined
+
+  beforeEach(() => {
+    mockMessages = []
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv !== undefined) {
+      process.env.MERIDIAN_PASSTHROUGH = origEnv
+    } else {
+      delete process.env.MERIDIAN_PASSTHROUGH
+    }
+  })
+
+  it("returns 200 with tool_use stop_reason when model calls a passthrough tool", async () => {
+    // The SDK (with maxTurns:2) completes successfully.
+    // The assistant message contains a tool_use block.
+    mockMessages = [
+      assistantMessage([
+        { type: "text", text: "Let me read that file." },
+        { type: "tool_use", id: "toolu_read1", name: `${PASSTHROUGH_PREFIX}Read`, input: { file_path: "/tmp/test.txt" } },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await postNonStream(app)
+    expect(response.status).toBe(200)
+
+    const body = await response.json() as any
+    expect(body.type).toBe("message")
+    expect(body.stop_reason).toBe("tool_use")
+
+    // Tool name should have the prefix stripped
+    const toolBlock = body.content.find((b: any) => b.type === "tool_use")
+    expect(toolBlock).toBeDefined()
+    expect(toolBlock.name).toBe("Read")
+    expect(toolBlock.id).toBe("toolu_read1")
+  })
+
+  it("returns 200 with end_turn when model responds with text only", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "text", text: "I cannot access that file directly." },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await postNonStream(app)
+    expect(response.status).toBe(200)
+
+    const body = await response.json() as any
+    expect(body.stop_reason).toBe("end_turn")
+    const textBlock = body.content.find((b: any) => b.type === "text")
+    expect(textBlock?.text).toContain("I cannot access that file directly.")
+  })
+})

--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -2,7 +2,7 @@
  * Phase 2: Transparent Tool Handling Tests
  *
  * The proxy must NOT define its own tools. Instead, it should:
- * 1. Use maxTurns: 1 so Claude returns tool_use to the client (not executing internally)
+ * 1. Use maxTurns: 2 so Claude returns tool_use to the client (not executing internally)
  * 2. Not inject MCP tools or blocked/allowed tool lists
  * 3. Let OpenCode control the tool execution loop
  *

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -38,9 +38,9 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).includePartialMessages).toBe(true)
   })
 
-  it("sets maxTurns to 1 in passthrough mode", () => {
+  it("sets maxTurns to 2 in passthrough mode (needs 2 turns for blocked-tool handoff)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true }))
-    expect(result.options.maxTurns).toBe(1)
+    expect(result.options.maxTurns).toBe(2)
   })
 
   it("includes system prompt as preset in normal mode", () => {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -61,7 +61,12 @@ export function buildQueryOptions(ctx: QueryContext) {
   return {
     prompt,
     options: {
-      maxTurns: passthrough ? 1 : 200,
+      // NOTE: agent-specific (passthrough mode) — 2 turns are required, not 1.
+      // Turn 1: model generates tool_use blocks (captured by PreToolUse hook).
+      // Turn 2: SDK processes the blocked-tool handoff before the generator
+      //         returns. maxTurns: 1 throws "Reached maximum number of turns (1)"
+      //         before the response is complete, causing HTTP 500s.
+      maxTurns: passthrough ? 2 : 200,
       cwd: workingDirectory,
       model,
       pathToClaudeCodeExecutable: claudeExecutable,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -965,6 +965,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }
                     eventsForwarded += 1
 
+                    // NOTE: agent-specific (passthrough mode) — break immediately when
+                    // the model stops for tool_use so the client can execute the tools
+                    // and send results back. Without this the SDK executes the passthrough
+                    // MCP no-op (→ "passthrough"), feeds that back to the model, and the
+                    // model produces an incorrect fallback response which gets forwarded.
+                    if (
+                      passthrough &&
+                      eventType === "message_delta" &&
+                      (event as any).delta?.stop_reason === "tool_use" &&
+                      streamedToolUseIds.size > 0
+                    ) {
+                      safeEnqueue(
+                        encoder.encode(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`),
+                        "passthrough_tool_stream_stop"
+                      )
+                      streamClosed = true
+                      controller.close()
+                      break
+                    }
+
                     if (eventType === "content_block_delta") {
                       const delta = (event as any).delta
                       if (delta?.type === "text_delta") {


### PR DESCRIPTION
## Summary

Fixes two bugs in passthrough mode (`MERIDIAN_PASSTHROUGH=1`) that broke `tool_use` flows. Closes #206 (supersedes that PR with a cleaner implementation).

---

### Bug 1: `maxTurns:1` causes HTTP 500 on tool_use requests (non-streaming)

The Claude SDK needs a second internal turn to process the blocked-tool handoff from the PreToolUse hook before the generator returns. With `maxTurns:1` the SDK threw "Reached maximum number of turns (1)" before completing.

**Fix:** `maxTurns: passthrough ? 2 : 200` — minimal increase, with a comment explaining the two-turn requirement.

### Bug 2: Streaming path continues after `tool_use` stop, forwarding junk to client

After `message_delta(stop_reason:tool_use)`, the SDK continued by executing the passthrough MCP no-op (returns `"passthrough"`), fed that back to the model, and the model produced a fallback error response which was forwarded to the client alongside the real tool_use events.

**Fix:** Break the stream loop immediately when `message_delta(stop_reason:tool_use)` is detected in passthrough mode (and passthrough tool blocks were streamed), emit `message_stop`, close the controller.

---

## Changes

- `src/proxy/query.ts`: `maxTurns: passthrough ? 1 : 200` → `maxTurns: passthrough ? 2 : 200` with rationale comment
- `src/proxy/server.ts`: early stream termination on passthrough `tool_use` stop
- `src/__tests__/query.test.ts`: update `maxTurns` assertion `1 → 2`
- `src/__tests__/proxy-passthrough-tool-use.test.ts`: **5 new regression tests** covering both bugs
- `src/__tests__/proxy-passthrough-concept.test.ts` + `proxy-transparent-tools.test.ts`: update stale `maxTurns:1` comments

## Differences from PR #206

| | PR #206 | This PR |
|---|---|---|
| `maxTurns` | `10` (arbitrary) | `2` with rationale comment |
| Empty catch block | `try { controller.close() } catch {}` | Direct `controller.close()` — no empty catch |
| Existing test breakage | `query.test.ts` would fail | Fixed |
| New tests | None | 5 regression tests |
| Stale comments | Not updated | Updated |

## Testing

**Unit/integration (587 tests):** All pass (`npm test`)

**E2E (E17 non-stream + stream, E1, E2) — verified with Claude Max:**

| Test | Result |
|---|---|
| E17 non-stream: HTTP 200, `stop_reason:"tool_use"`, tool block present | ✅ |
| E17 stream: ends at `message_stop`, no turn-2 junk text | ✅ |
| E1 basic non-stream | ✅ |
| E2 basic stream | ✅ |