### PR TITLE
feat: add env var to disable file change summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ See [`adapters/detect.ts`](src/proxy/adapters/detect.ts) and [`adapters/opencode
 | `MERIDIAN_WORKDIR` | `CLAUDE_PROXY_WORKDIR` | `cwd()` | Default working directory for SDK |
 | `MERIDIAN_IDLE_TIMEOUT_SECONDS` | `CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS` | `120` | HTTP keep-alive timeout |
 | `MERIDIAN_TELEMETRY_SIZE` | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
+| `MERIDIAN_NO_FILE_CHANGES` | `CLAUDE_PROXY_NO_FILE_CHANGES` | unset | Disable "Files changed" summary in responses |
 
 ## Programmatic API
 

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -7,7 +7,7 @@
  * GitHub issue #189: "Build command lacks file change visibility"
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 import {
   assistantMessage,
   messageStart,
@@ -435,5 +435,127 @@ describe("File change visibility: streaming response", () => {
     for (let i = 1; i < indices.length; i++) {
       expect(indices[i]).toBeGreaterThan(indices[i - 1]!)
     }
+  })
+})
+
+describe("File change visibility: MERIDIAN_NO_FILE_CHANGES opt-out", () => {
+  let origMeridian: string | undefined
+  let origClaude: string | undefined
+
+  beforeEach(() => {
+    mockMessages = []
+    capturedQueryParams = null
+    clearSessionCache()
+    origMeridian = process.env.MERIDIAN_NO_FILE_CHANGES
+    origClaude = process.env.CLAUDE_PROXY_NO_FILE_CHANGES
+  })
+
+  afterEach(() => {
+    if (origMeridian !== undefined) process.env.MERIDIAN_NO_FILE_CHANGES = origMeridian
+    else delete process.env.MERIDIAN_NO_FILE_CHANGES
+    if (origClaude !== undefined) process.env.CLAUDE_PROXY_NO_FILE_CHANGES = origClaude
+    else delete process.env.CLAUDE_PROXY_NO_FILE_CHANGES
+  })
+
+  it("should suppress PostToolUse hook registration when MERIDIAN_NO_FILE_CHANGES=1", async () => {
+    process.env.MERIDIAN_NO_FILE_CHANGES = "1"
+    mockMessages = [assistantMessage([{ type: "text", text: "Done" }])]
+
+    const app = createTestApp()
+    await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Do something" }],
+    })
+
+    expect(capturedQueryParams?.options?.hooks?.PostToolUse).toBeUndefined()
+  })
+
+  it("should suppress file change summary in non-streaming response when MERIDIAN_NO_FILE_CHANGES=1", async () => {
+    process.env.MERIDIAN_NO_FILE_CHANGES = "1"
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_w1", name: "mcp__opencode__write", input: { path: "src/new-file.ts", content: "export const x = 1" } },
+      ]),
+      assistantMessage([{ type: "text", text: "I created the file." }]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Create a file" }],
+    })).json()
+
+    const allText = response.content
+      .filter((b: any) => b.type === "text")
+      .map((b: any) => b.text)
+      .join("")
+    expect(allText).not.toContain("Files changed:")
+    expect(allText).toContain("I created the file.")
+  })
+
+  it("should suppress file change SSE block in streaming response when MERIDIAN_NO_FILE_CHANGES=1", async () => {
+    process.env.MERIDIAN_NO_FILE_CHANGES = "1"
+    mockMessages = [
+      messageStart(),
+      toolUseBlockStart(0, "mcp__opencode__write", "toolu_w2"),
+      inputJsonDelta(0, '{"path":"src/out.ts","content":"export {}"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      messageStop(),
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "File written."),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const app = createTestApp()
+    const events = await postStream(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: true,
+      messages: [{ role: "user", content: "Write a file" }],
+    })
+
+    // No file change text block should be present
+    const textBlockStarts = events.filter(
+      (e) => e.event === "content_block_start" && (e.data as any).content_block?.type === "text"
+    )
+    const fileChangeBlocks = textBlockStarts.filter((e) => {
+      const deltas = events.filter(
+        (d) => d.event === "content_block_delta" && (d.data as any).index === (e.data as any).index
+      )
+      return deltas.some((d) => (d.data as any).delta?.text?.includes("Files changed:"))
+    })
+    expect(fileChangeBlocks).toHaveLength(0)
+  })
+
+  it("should suppress summary when CLAUDE_PROXY_NO_FILE_CHANGES=1 (fallback env var)", async () => {
+    process.env.CLAUDE_PROXY_NO_FILE_CHANGES = "1"
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_w3", name: "mcp__opencode__write", input: { path: "src/f.ts", content: "x" } },
+      ]),
+      assistantMessage([{ type: "text", text: "Done." }]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Write a file" }],
+    })).json()
+
+    const allText = response.content
+      .filter((b: any) => b.type === "text")
+      .map((b: any) => b.text)
+      .join("")
+    expect(allText).not.toContain("Files changed:")
   })
 })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -413,7 +413,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // PostToolUse hook tracks file changes from MCP tools (internal mode only).
       // Catches write, edit, AND bash redirects (>, >>, tee, sed -i).
       const mcpPrefix = `mcp__${adapter.getMcpServerName()}__`
-      const trackFileChanges = !process.env.MERIDIAN_NO_FILE_CHANGES
+      const trackFileChanges = !(process.env.MERIDIAN_NO_FILE_CHANGES ?? process.env.CLAUDE_PROXY_NO_FILE_CHANGES)
       const fileChangeHook = trackFileChanges ? createFileChangeHook(fileChanges, mcpPrefix) : undefined
 
       const sdkHooks = passthrough


### PR DESCRIPTION
## Summary

Adds `MERIDIAN_NO_FILE_CHANGES` / `CLAUDE_PROXY_NO_FILE_CHANGES` env var to opt out of the "Files changed" summary appended to responses (introduced in #189).

## Usage

```bash
MERIDIAN_NO_FILE_CHANGES=1 npm start
# or
CLAUDE_PROXY_NO_FILE_CHANGES=1 npm start
```

## Changes

Original work by @davdroman in #200. Three fixes applied before merge:

**1 — Added `CLAUDE_PROXY_` fallback** (from #200 review)
Every other env var in the codebase uses `MERIDIAN_X ?? CLAUDE_PROXY_X`. The original PR only had `MERIDIAN_NO_FILE_CHANGES`. Fixed to:
```typescript
const trackFileChanges = !(process.env.MERIDIAN_NO_FILE_CHANGES ?? process.env.CLAUDE_PROXY_NO_FILE_CHANGES)
```

**2 — Added 4 regression tests** (from #200 review)
- PostToolUse hook not registered when disabled
- Non-streaming summary suppressed
- Streaming SSE block suppressed
- `CLAUDE_PROXY_NO_FILE_CHANGES` fallback works

**3 — Updated README env var table** (from #200 review)
`MERIDIAN_NO_FILE_CHANGES` and `CLAUDE_PROXY_NO_FILE_CHANGES` added to the configuration table.

## Testing

607 tests, all pass (`npm test`).