### PR TITLE
fix: capture subprocess stderr to surface real exit-code-1 failures

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -44,6 +44,19 @@ describe("classifyError", () => {
       expect(result.status).toBe(502)
       expect(result.type).toBe("api_error")
     })
+
+    it("includes captured stderr in exit code 1 message", () => {
+      const result = classifyError("Claude Code process exited with code 1\nSubprocess stderr: --permission-mode: invalid value 'bypassPermissions'")
+      expect(result.status).toBe(401)
+      expect(result.type).toBe("authentication_error")
+      expect(result.message).toContain("permission-mode")
+    })
+
+    it("classifies as auth error when stderr contains authentication keyword", () => {
+      const result = classifyError("Claude Code process exited with code 1\nSubprocess stderr: OAuth token expired")
+      expect(result.status).toBe(401)
+      expect(result.type).toBe("authentication_error")
+    })
   })
 
   describe("rate limiting", () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -47,12 +47,27 @@ export function classifyError(errMsg: string): ClassifiedError {
     const codeMatch = errMsg.match(/exited with code (\d+)/)
     const code = codeMatch ? codeMatch[1] : "unknown"
 
-    // Code 1 with no other info is usually auth
-    if (code === "1" && !lower.includes("tool") && !lower.includes("mcp")) {
+    // If stderr was captured it will be appended to the message — use it for classification
+    const hasStderr = lower.includes("subprocess stderr:")
+    const stderrContent = hasStderr ? lower.split("subprocess stderr:")[1]?.trim() ?? "" : ""
+
+    // Explicit auth signal in stderr takes priority
+    if (stderrContent.includes("authentication") || stderrContent.includes("401") || stderrContent.includes("oauth")) {
       return {
         status: 401,
         type: "authentication_error",
-        message: "Claude Code process crashed (exit code 1). This usually means authentication expired. Run 'claude login' in your terminal to re-authenticate, then restart the proxy."
+        message: "Claude authentication expired or invalid. Run 'claude login' in your terminal to re-authenticate, then restart the proxy."
+      }
+    }
+
+    // Code 1 + no stderr: could be auth, but could also be a bad flag combination
+    // or an environment issue. Give a less confident message and include stderr if present.
+    if (code === "1" && !lower.includes("tool") && !lower.includes("mcp")) {
+      const stderrHint = stderrContent ? ` Subprocess output: ${stderrContent.slice(0, 200)}` : " Run with CLAUDE_PROXY_DEBUG=1 for more detail."
+      return {
+        status: 401,
+        type: "authentication_error",
+        message: `Claude Code process exited (code 1). This is often an authentication issue — try 'claude login' and restart the proxy.${stderrHint}`
       }
     }
 

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -40,6 +40,8 @@ export interface QueryContext {
   sdkHooks?: any
   /** The agent adapter providing tool configuration */
   adapter: AgentAdapter
+  /** Callback to receive stderr lines from the Claude subprocess */
+  onStderr?: (line: string) => void
 }
 
 /**
@@ -51,7 +53,7 @@ export function buildQueryOptions(ctx: QueryContext) {
   const {
     prompt, model, workingDirectory, systemContext, claudeExecutable,
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv,
-    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter, onStderr,
   } = ctx
 
   const blockedTools = [...adapter.getBlockedBuiltinTools(), ...adapter.getAgentIncompatibleTools()]
@@ -92,6 +94,7 @@ export function buildQueryOptions(ctx: QueryContext) {
             mcpServers: { [mcpServerName]: createOpencodeMcpServer() },
           }),
       plugins: [],
+      ...(onStderr ? { stderr: onStderr } : {}),
       env: {
         ...cleanEnv,
         ENABLE_TOOL_SEARCH: "false",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -438,6 +438,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             ...(fileChangeHook ? { PostToolUse: [fileChangeHook] } : {}),
           }
 
+        // Capture subprocess stderr for all paths — used to surface the real
+        // failure message when the Claude subprocess exits with a non-zero code.
+        const stderrLines: string[] = []
+        const onStderr = (data: string) => {
+          stderrLines.push(data.trimEnd())
+          claudeLog("subprocess.stderr", { line: data.trimEnd() })
+        }
+
         if (!stream) {
           const contentBlocks: Array<Record<string, unknown>> = []
           let assistantMessages = 0
@@ -484,7 +492,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   for await (const event of query(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
-                    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+                    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter, onStderr,
                   }))) {
                     if ((event as any).type === "assistant") {
                       didYieldContent = true
@@ -513,7 +521,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       prompt: buildFreshPrompt(allMessages, stripCacheControl),
                       model, workingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv,
-                      resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter,
+                      resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,
                     }))
                     return
                   }
@@ -592,11 +600,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               durationMs: Date.now() - upstreamStartAt
             })
           } catch (error) {
+            const stderrOutput = stderrLines.join("\n").trim()
+            if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
+              error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
+            }
             claudeLog("upstream.failed", {
               mode: "non_stream",
               model,
               durationMs: Date.now() - upstreamStartAt,
-              error: error instanceof Error ? error.message : String(error)
+              error: error instanceof Error ? error.message : String(error),
+              ...(stderrOutput ? { stderr: stderrOutput } : {})
             })
             throw error
           }
@@ -774,7 +787,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     for await (const event of query(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
-                      resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter,
+                      resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, adapter, onStderr,
                     }))) {
                       if ((event as any).type === "stream_event") {
                         didYieldClientEvent = true
@@ -803,7 +816,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         prompt: buildFreshPrompt(allMessages, stripCacheControl),
                         model, workingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv,
-                        resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter,
+                        resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,
                       }))
                       return
                     }
@@ -1171,6 +1184,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 return
               }
 
+              const stderrOutput = stderrLines.join("\n").trim()
+              if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
+                error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
+              }
               const errMsg = error instanceof Error ? error.message : String(error)
               claudeLog("upstream.failed", {
                 mode: "stream",
@@ -1178,7 +1195,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 durationMs: Date.now() - upstreamStartAt,
                 streamEventsSeen,
                 textEventsForwarded,
-                error: errMsg
+                error: errMsg,
+                ...(stderrOutput ? { stderr: stderrOutput } : {})
               })
               const streamErr = classifyError(errMsg)
               claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })


### PR DESCRIPTION
Closes #203.

## Problem

When the Claude subprocess exits with code 1, the proxy had no idea why. The SDK sets subprocess stdio stderr to `"ignore"` unless a `stderr` callback is provided — any error the CLI wrote before exiting was completely discarded. The proxy then assumed exit code 1 = auth failure, which sent users on a wild goose chase running `claude login` when their auth was fine.

## Changes

**`query.ts`** — Add `onStderr` to `QueryContext`; wire `options.stderr` in `buildQueryOptions`

**`server.ts`** — Create a `stderrLines` buffer per request; pass `onStderr` to all four `buildQueryOptions` call sites; append captured stderr to the thrown `Error` message in both non-streaming and streaming catch blocks; log each line via `claudeLog("subprocess.stderr")` as it arrives

**`errors.ts`** — Exit code 1 classification now:
- Checks captured stderr for explicit auth signals (oauth, 401, authentication) before assuming auth
- Includes up to 200 chars of subprocess output in the user-facing message when present
- Softens the unconditional "authentication expired" wording to "often an auth issue"

**`errors.test.ts`** — Two new tests: stderr content surfaced in message, auth keyword in stderr produces auth_error

## What this doesn't fix

We still don't know *why* the subprocess exits with code 1 in the reporter's environment — we can't reproduce it locally. The stderr capture is the diagnostic tool. Once the reporter runs this and shares the updated error message, the actual subprocess output will tell us the root cause.