### PR TITLE
feat: add LiteLLM passthrough adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ src/proxy/
 │   ├── detect.ts          ← Agent detection from request headers
 │   ├── opencode.ts        ← OpenCode adapter
 │   ├── crush.ts           ← Crush (Charm) adapter
-│   └── droid.ts           ← Droid (Factory AI) adapter
+│   ├── droid.ts           ← Droid (Factory AI) adapter
+│   └── passthrough.ts     ← LiteLLM passthrough adapter
 ├── query.ts               ← SDK query options builder
 ├── errors.ts              ← Error classification
 ├── models.ts              ← Model mapping (sonnet/opus/haiku)

--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -14,7 +14,10 @@ import { crushAdapter } from "../proxy/adapters/crush"
 function makeContext(userAgent: string): any {
   return {
     req: {
-      header: (name: string) => name.toLowerCase() === "user-agent" ? userAgent : undefined,
+      header: (name?: string) => {
+        if (!name) return userAgent ? { "user-agent": userAgent } : {}
+        return name.toLowerCase() === "user-agent" ? userAgent : undefined
+      },
     },
   }
 }
@@ -70,7 +73,7 @@ describe("detectAdapter — OpenCode fallback", () => {
   })
 
   it("returns openCodeAdapter when User-Agent header is missing", () => {
-    const ctx = { req: { header: () => undefined } }
+    const ctx = { req: { header: (name?: string) => name ? undefined : {} } }
     const adapter = detectAdapter(ctx as any)
     expect(adapter).toBe(openCodeAdapter)
   })

--- a/src/__tests__/proxy-litellm-adapter.test.ts
+++ b/src/__tests__/proxy-litellm-adapter.test.ts
@@ -1,0 +1,260 @@
+/**
+ * LiteLLM passthrough adapter tests.
+ *
+ * Covers:
+ * - Adapter identity and interface compliance
+ * - Session ID extraction from x-litellm-session-id header
+ * - CWD extraction from <env> blocks and inline cwd= patterns
+ * - Tool configuration (passthrough mode — no built-in tool blocking)
+ * - Agent/hook/system-context stubs (all no-ops for passthrough)
+ * - usesPassthrough() always true
+ * - prefersStreaming() always false
+ * - detectAdapter() routing for LiteLLM requests
+ */
+
+import { describe, it, expect, mock } from "bun:test"
+import { passthroughAdapter } from "../proxy/adapters/passthrough"
+import { detectAdapter } from "../proxy/adapters/detect"
+
+// ============================================================
+// Identity
+// ============================================================
+
+describe("passthroughAdapter — identity", () => {
+  it("has name 'passthrough'", () => {
+    expect(passthroughAdapter.name).toBe("passthrough")
+  })
+})
+
+// ============================================================
+// Session ID
+// ============================================================
+
+describe("passthroughAdapter.getSessionId", () => {
+  it("returns session id from x-litellm-session-id header", () => {
+    const c = {
+      req: {
+        header: (name: string) => {
+          if (name === "x-litellm-session-id") return "litellm-abc123"
+          return undefined
+        },
+      },
+    }
+    expect(passthroughAdapter.getSessionId(c as any)).toBe("litellm-abc123")
+  })
+
+  it("returns undefined when no x-litellm-session-id header", () => {
+    const c = { req: { header: () => undefined } }
+    expect(passthroughAdapter.getSessionId(c as any)).toBeUndefined()
+  })
+
+  it("ignores x-opencode-session (that's a different adapter)", () => {
+    const c = {
+      req: {
+        header: (name: string) => {
+          if (name === "x-opencode-session") return "opencode-xyz"
+          return undefined
+        },
+      },
+    }
+    expect(passthroughAdapter.getSessionId(c as any)).toBeUndefined()
+  })
+})
+
+// ============================================================
+// Working directory extraction
+// ============================================================
+
+describe("passthroughAdapter.extractWorkingDirectory", () => {
+  it("extracts CWD from <env cwd='...'> block", () => {
+    const body = {
+      messages: [
+        { role: "user", content: "<env cwd=\"/home/user/project\">context</env>" },
+      ],
+    }
+    expect(passthroughAdapter.extractWorkingDirectory(body)).toBe("/home/user/project")
+  })
+
+  it("extracts CWD from inline cwd= pattern in prompt string", () => {
+    const body = { prompt: 'Working in cwd="/tmp/work" now.' }
+    expect(passthroughAdapter.extractWorkingDirectory(body)).toBe("/tmp/work")
+  })
+
+  it("extracts CWD from array message content", () => {
+    const body = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "<env cwd=\"/opt/app\">info</env>" },
+          ],
+        },
+      ],
+    }
+    expect(passthroughAdapter.extractWorkingDirectory(body)).toBe("/opt/app")
+  })
+
+  it("returns undefined when no CWD present", () => {
+    expect(passthroughAdapter.extractWorkingDirectory({})).toBeUndefined()
+  })
+
+  it("returns undefined for null/undefined body", () => {
+    expect(passthroughAdapter.extractWorkingDirectory(null)).toBeUndefined()
+    expect(passthroughAdapter.extractWorkingDirectory(undefined)).toBeUndefined()
+  })
+
+  it("returns undefined for messages without CWD", () => {
+    const body = {
+      messages: [{ role: "user", content: "Hello, help me with my code." }],
+    }
+    expect(passthroughAdapter.extractWorkingDirectory(body)).toBeUndefined()
+  })
+})
+
+// ============================================================
+// Content normalisation
+// ============================================================
+
+describe("passthroughAdapter.normalizeContent", () => {
+  it("passes string content through unchanged", () => {
+    expect(passthroughAdapter.normalizeContent("hello world")).toBe("hello world")
+  })
+
+  it("joins text blocks from array content", () => {
+    const content = [
+      { type: "text", text: "hello" },
+      { type: "text", text: " world" },
+    ]
+    expect(passthroughAdapter.normalizeContent(content)).toBe("hello\n world")
+  })
+
+  it("includes tool_use block description in normalised output", () => {
+    const content = [
+      { type: "tool_use", id: "tu_1", name: "bash", input: { command: "ls" } },
+    ]
+    const result = passthroughAdapter.normalizeContent(content)
+    expect(result).toContain("tool_use")
+    expect(result).toContain("bash")
+  })
+})
+
+// ============================================================
+// Tool configuration
+// ============================================================
+
+describe("passthroughAdapter — tool configuration", () => {
+  it("getBlockedBuiltinTools returns empty (passthrough hook handles blocking)", () => {
+    expect(passthroughAdapter.getBlockedBuiltinTools()).toHaveLength(0)
+  })
+
+  it("getAgentIncompatibleTools returns empty", () => {
+    expect(passthroughAdapter.getAgentIncompatibleTools()).toHaveLength(0)
+  })
+
+  it("getMcpServerName returns 'litellm'", () => {
+    expect(passthroughAdapter.getMcpServerName()).toBe("litellm")
+  })
+
+  it("getAllowedMcpTools returns exactly 6 standard tools", () => {
+    expect(passthroughAdapter.getAllowedMcpTools()).toHaveLength(6)
+  })
+
+  it("all allowed tools have mcp__litellm__ prefix", () => {
+    for (const tool of passthroughAdapter.getAllowedMcpTools()) {
+      expect(tool).toStartWith("mcp__litellm__")
+    }
+  })
+
+  it("getAllowedMcpTools covers the standard file system set", () => {
+    const tools = passthroughAdapter.getAllowedMcpTools()
+    expect(tools).toContain("mcp__litellm__read")
+    expect(tools).toContain("mcp__litellm__write")
+    expect(tools).toContain("mcp__litellm__edit")
+    expect(tools).toContain("mcp__litellm__bash")
+    expect(tools).toContain("mcp__litellm__glob")
+    expect(tools).toContain("mcp__litellm__grep")
+  })
+})
+
+// ============================================================
+// SDK stubs (no-ops for passthrough)
+// ============================================================
+
+describe("passthroughAdapter — SDK stubs", () => {
+  it("buildSdkAgents returns empty object", () => {
+    expect(passthroughAdapter.buildSdkAgents!({}, [])).toEqual({})
+  })
+
+  it("buildSdkHooks returns undefined", () => {
+    expect(passthroughAdapter.buildSdkHooks!({}, {})).toBeUndefined()
+  })
+
+  it("buildSystemContextAddendum returns empty string", () => {
+    expect(passthroughAdapter.buildSystemContextAddendum!({}, {})).toBe("")
+  })
+})
+
+// ============================================================
+// Passthrough and streaming flags
+// ============================================================
+
+describe("passthroughAdapter — passthrough and streaming", () => {
+  it("usesPassthrough always returns true", () => {
+    expect(passthroughAdapter.usesPassthrough!()).toBe(true)
+  })
+
+  it("prefersStreaming always returns false (LiteLLM needs non-streaming)", () => {
+    expect(passthroughAdapter.prefersStreaming!({})).toBe(false)
+    expect(passthroughAdapter.prefersStreaming!({ stream: true })).toBe(false)
+  })
+})
+
+// ============================================================
+// detectAdapter routing
+// ============================================================
+
+describe("detectAdapter — LiteLLM routing", () => {
+  function makeContext(ua: string, extraHeaders: Record<string, string> = {}) {
+    return {
+      req: {
+        header: (name?: string) => {
+          if (!name) return { "user-agent": ua, ...extraHeaders }
+          if (name === "user-agent") return ua || undefined
+          return extraHeaders[name] ?? extraHeaders[name.toLowerCase()] ?? undefined
+        },
+      },
+    }
+  }
+
+  it("routes litellm/* User-Agent to passthrough adapter", () => {
+    expect(detectAdapter(makeContext("litellm/1.0.0") as any).name).toBe("passthrough")
+  })
+
+  it("routes x-litellm-api-key header to passthrough adapter", () => {
+    expect(detectAdapter(makeContext("python-httpx/0.27.0", { "x-litellm-api-key": "sk-123" }) as any).name).toBe("passthrough")
+  })
+
+  it("routes x-litellm-model header to passthrough adapter", () => {
+    expect(detectAdapter(makeContext("python-httpx/0.27.0", { "x-litellm-model": "claude-sonnet-4-5" }) as any).name).toBe("passthrough")
+  })
+
+  it("routes any x-litellm-* header to passthrough (case-insensitive key)", () => {
+    expect(detectAdapter(makeContext("", { "x-litellm-custom-header": "val" }) as any).name).toBe("passthrough")
+  })
+
+  it("falls back to opencode for python-httpx without litellm headers", () => {
+    expect(detectAdapter(makeContext("python-httpx/0.27.0") as any).name).toBe("opencode")
+  })
+
+  it("Droid takes priority over LiteLLM headers", () => {
+    expect(detectAdapter(makeContext("factory-cli/1.0.0", { "x-litellm-api-key": "sk-123" }) as any).name).toBe("droid")
+  })
+
+  it("Crush takes priority over LiteLLM headers", () => {
+    expect(detectAdapter(makeContext("Charm-Crush/0.1.0", { "x-litellm-api-key": "sk-123" }) as any).name).toBe("crush")
+  })
+
+  it("routes empty User-Agent with litellm header to passthrough", () => {
+    expect(detectAdapter(makeContext("", { "x-litellm-session-id": "sess-1" }) as any).name).toBe("passthrough")
+  })
+})

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -78,6 +78,15 @@ export interface AgentAdapter {
   buildSystemContextAddendum?(body: any, sdkAgents: Record<string, any>): string
 
   /**
+   * Whether this agent prefers non-streaming (JSON) responses.
+   *
+   * When this method is defined and returns false, the proxy forces
+   * stream=false regardless of the client's body.stream setting.
+   * When undefined or returns true, body.stream is used (defaulting to true).
+   */
+  prefersStreaming?(body: any): boolean
+
+  /**
    * Whether this agent uses passthrough mode for tool execution.
    *
    * In passthrough mode the proxy returns tool_use blocks to the calling

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -10,6 +10,20 @@ import type { AgentAdapter } from "../adapter"
 import { openCodeAdapter } from "./opencode"
 import { droidAdapter } from "./droid"
 import { crushAdapter } from "./crush"
+import { passthroughAdapter } from "./passthrough"
+
+/**
+ * Detect LiteLLM requests via User-Agent or x-litellm-* headers.
+ *
+ * LiteLLM's default User-Agent is generic (python-httpx), so header-based
+ * detection is more reliable. LiteLLM sends x-litellm-* on regular requests
+ * but not on health checks — the User-Agent check catches both.
+ */
+function isLiteLLMRequest(c: Context): boolean {
+  if ((c.req.header("user-agent") || "").startsWith("litellm/")) return true
+  const headers = c.req.header()
+  return Object.keys(headers).some(k => k.toLowerCase().startsWith("x-litellm-"))
+}
 
 /**
  * Detect which agent adapter to use based on request headers.
@@ -17,7 +31,8 @@ import { crushAdapter } from "./crush"
  * Detection rules (evaluated in order):
  * 1. User-Agent starts with "factory-cli/"  → Droid adapter
  * 2. User-Agent starts with "Charm-Crush/"  → Crush adapter
- * 3. Default                                → OpenCode adapter (backward compatible)
+ * 3. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
+ * 4. Default                                → OpenCode adapter (backward compatible)
  */
 export function detectAdapter(c: Context): AgentAdapter {
   const userAgent = c.req.header("user-agent") || ""
@@ -28,6 +43,10 @@ export function detectAdapter(c: Context): AgentAdapter {
 
   if (userAgent.startsWith("Charm-Crush/")) {
     return crushAdapter
+  }
+
+  if (isLiteLLMRequest(c)) {
+    return passthroughAdapter
   }
 
   return openCodeAdapter

--- a/src/proxy/adapters/passthrough.ts
+++ b/src/proxy/adapters/passthrough.ts
@@ -1,0 +1,144 @@
+/**
+ * LiteLLM passthrough adapter.
+ *
+ * Handles requests from LiteLLM (detected via x-litellm-* headers or
+ * litellm/* User-Agent). LiteLLM manages its own tool execution loop,
+ * so this adapter forces passthrough mode — the proxy returns tool_use
+ * blocks to LiteLLM for execution rather than running them internally.
+ *
+ * Key characteristics:
+ * - Passthrough mode always enabled (overrides MERIDIAN_PASSTHROUGH env var)
+ * - Non-streaming: LiteLLM health checks don't send x-litellm-* headers
+ *   so we can't reliably distinguish them; non-streaming is safe for all requests
+ * - Session continuity: uses x-litellm-session-id header when present
+ * - CWD: extracts from <env cwd="..."> blocks in the prompt if available
+ * - MCP server name: "litellm" (tools appear as mcp__litellm__*)
+ */
+
+import type { Context } from "hono"
+import type { AgentAdapter } from "../adapter"
+import { normalizeContent } from "../messages"
+
+const MCP_SERVER_NAME = "litellm"
+
+const ALLOWED_MCP_TOOLS: readonly string[] = [
+  `mcp__${MCP_SERVER_NAME}__read`,
+  `mcp__${MCP_SERVER_NAME}__write`,
+  `mcp__${MCP_SERVER_NAME}__edit`,
+  `mcp__${MCP_SERVER_NAME}__bash`,
+  `mcp__${MCP_SERVER_NAME}__glob`,
+  `mcp__${MCP_SERVER_NAME}__grep`,
+]
+
+/**
+ * Extract the working directory from <env cwd="..."> blocks or inline
+ * cwd="..." patterns in the request body.
+ */
+function extractCwdFromBody(body: any): string | undefined {
+  if (!body) return undefined
+
+  let promptContent = ""
+  if (typeof body.prompt === "string") {
+    promptContent = body.prompt
+  } else if (Array.isArray(body.messages)) {
+    for (const msg of body.messages) {
+      if (msg.role === "user") {
+        if (typeof msg.content === "string") {
+          promptContent += msg.content
+        } else if (Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (block.type === "text" && block.text) {
+              promptContent += block.text
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const envMatch = promptContent.match(/<env[^>]*cwd=["']([^"']+)["']/s)
+  if (envMatch) return envMatch[1]
+
+  const cwdMatch = promptContent.match(/cwd=["']([^"']+)["']/)
+  if (cwdMatch) return cwdMatch[1]
+
+  return undefined
+}
+
+export const passthroughAdapter: AgentAdapter = {
+  name: "passthrough",
+
+  /**
+   * Use x-litellm-session-id for session continuity across requests.
+   */
+  getSessionId(c: Context): string | undefined {
+    return c.req.header("x-litellm-session-id")
+  },
+
+  extractWorkingDirectory(body: any): string | undefined {
+    return extractCwdFromBody(body)
+  },
+
+  normalizeContent(content: any): string {
+    return normalizeContent(content)
+  },
+
+  /**
+   * In passthrough mode the PreToolUse hook captures all tool_use blocks
+   * for forwarding to the client. No built-in tools need to be blocked
+   * via disallowedTools since allowedTools restricts Claude to only
+   * the client's registered tools.
+   */
+  getBlockedBuiltinTools(): readonly string[] {
+    return []
+  },
+
+  getAgentIncompatibleTools(): readonly string[] {
+    return []
+  },
+
+  getMcpServerName(): string {
+    return MCP_SERVER_NAME
+  },
+
+  getAllowedMcpTools(): readonly string[] {
+    return ALLOWED_MCP_TOOLS
+  },
+
+  /**
+   * LiteLLM manages subagents externally — no SDK agent definitions needed.
+   */
+  buildSdkAgents(_body: any, _mcpToolNames: readonly string[]): Record<string, any> {
+    return {}
+  },
+
+  /**
+   * No PreToolUse hook needed for agent name correction — passthrough mode
+   * injects its own hook automatically to capture tool_use blocks.
+   */
+  buildSdkHooks(_body: any, _sdkAgents: Record<string, any>): undefined {
+    return undefined
+  },
+
+  buildSystemContextAddendum(_body: any, _sdkAgents: Record<string, any>): string {
+    return ""
+  },
+
+  /**
+   * Always use passthrough mode regardless of MERIDIAN_PASSTHROUGH env var.
+   * LiteLLM sends tool_results back — the proxy must forward tool_use blocks
+   * to the client rather than executing them internally.
+   */
+  usesPassthrough(): boolean {
+    return true
+  },
+
+  /**
+   * LiteLLM expects non-streaming (JSON) responses.
+   * Health checks don't send x-litellm-* headers, so we can't distinguish
+   * them from regular requests — non-streaming is safe for all LiteLLM traffic.
+   */
+  prefersStreaming(_body: any): boolean {
+    return false
+  },
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -181,8 +181,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const body = await c.req.json()
         const authStatus = await getClaudeAuthStatusAsync()
         let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType)
-        const stream = body.stream ?? true
         const adapter = detectAdapter(c)
+        // Allow adapter to override streaming preference (e.g. LiteLLM requires non-streaming)
+        const adapterStreamPref = adapter.prefersStreaming?.(body)
+        const stream = adapterStreamPref !== undefined ? adapterStreamPref : (body.stream ?? true)
         const workingDirectory = (process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR) || adapter.extractWorkingDirectory(body) || process.cwd()
 
         // Strip env vars that would cause the SDK subprocess to loop back through


### PR DESCRIPTION
Closes #199. Based on original work in PR #201 by @endre82 — thank you.

## What this does

Auto-detects LiteLLM requests and routes them to a dedicated passthrough adapter. No configuration needed — it just works when LiteLLM points at Meridian.

**Detection:** `litellm/*` User-Agent or any `x-litellm-*` header (LiteLLM's default UA is generic `python-httpx`, so header detection catches requests that don't set a custom UA).

**Passthrough mode:** LiteLLM manages its own tool execution loop, so the adapter forces `usesPassthrough()=true` — the proxy returns `tool_use` blocks to LiteLLM rather than executing them internally.

**Non-streaming:** LiteLLM health checks don't send `x-litellm-*` headers, making it impossible to reliably distinguish them from regular requests. Non-streaming is safe for all LiteLLM traffic so `prefersStreaming()=false` is hardcoded.

**Session continuity:** `x-litellm-session-id` header used for session resume when present.

## Changes

| File | What changed |
|---|---|
| `adapters/passthrough.ts` | New LiteLLM adapter |
| `adapters/detect.ts` | `isLiteLLMRequest()` + passthrough wired as priority 3 |
| `adapter.ts` | Optional `prefersStreaming(body)` added to interface |
| `server.ts` | `detectAdapter` moved before stream; uses `adapter.prefersStreaming?.()` |
| `proxy-litellm-adapter.test.ts` | 32 new tests |
| `adapter-detection.test.ts` | Fix header() mock for no-arg call |
| `README.md` | LiteLLM setup section, tested agents table, architecture map |

## What's not in this PR (from #201)

- `MAX_CONCURRENT_SESSIONS` default change — users can set `MERIDIAN_MAX_CONCURRENT` themselves; noted in the LiteLLM docs
- Rate-limit retry after partial content — needs separate review
- `tsx` dev dependency — not needed
- `DEBUG_PROXY` env var — inconsistent with existing `CLAUDE_PROXY_DEBUG` mechanism

## Tests

639 tests total, all pass.