### PR TITLE
fix: force executable to node in buildQueryOptions

### DIFF
--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -63,6 +63,11 @@ export function buildQueryOptions(ctx: QueryContext) {
   return {
     prompt,
     options: {
+      // Force Node as the executable. The claude-agent-sdk auto-detects Bun
+      // via process.versions.bun and defaults to spawning `bun cli.js`.
+      // Hosts like OpenCode embed Bun, so the check fires even when `bun`
+      // is not in PATH — causing subprocess spawns to fail.
+      executable: "node" as const,
       // NOTE: agent-specific (passthrough mode) — 2 turns are required, not 1.
       // Turn 1: model generates tool_use blocks (captured by PreToolUse hook).
       // Turn 2: SDK processes the blocked-tool handoff before the generator


### PR DESCRIPTION
## Problem

The claude-agent-sdk auto-detects Bun via `process.versions.bun` and defaults to spawning `bun cli.js`. Hosts like OpenCode embed Bun in their native binary, so `process.versions.bun` is set even when `bun` is not available in the system PATH. This causes the SDK's `child_process.spawn("bun", ...)` to fail with ENOENT.

## Fix

Add `executable: "node"` to the options returned by `buildQueryOptions()`. This tells the SDK to always use Node to run the CLI subprocess, bypassing the auto-detection.

## Who this affects

Users running meridian under environments that embed Bun (e.g. OpenCode) but don't have `bun` installed system-wide. Common in Docker containers and CI environments.