### PR TITLE
Feat/token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,32 @@ It works with any Claude subscription that supports the Claude Code SDK. Max is 
 **What happens if my session expires?**
 The SDK handles token refresh automatically. If it can't refresh, Meridian returns a clear error telling you to run `claude login`.
 
+## Token Refresh
+
+The OAuth token expires periodically. While the SDK subprocess refreshes tokens automatically when needed, you can also refresh manually on a schedule:
+
+```bash
+# Manual refresh
+meridian refresh-token
+
+# Schedule with cron (every 6 hours)
+0 */6 * * * meridian refresh-token
+
+# Or with systemd timer — create /etc/systemd/system/meridian-refresh.timer
+[Unit]
+Description=Refresh Meridian OAuth token
+After=network.target
+
+[Timer]
+OnBootSec=30min
+OnUnitActiveSec=6h
+
+[Install]
+WantedBy=timers.target
+```
+
+Exit code: 0 on success, 1 on failure. Logging goes to stderr and `~/.cache/claude/logs/` (via the SDK).
+
 ## Contributing
 
 Issues and PRs welcome. See [`ARCHITECTURE.md`](ARCHITECTURE.md) for module structure and dependency rules, [`CLAUDE.md`](CLAUDE.md) for coding guidelines, and [`E2E.md`](E2E.md) for end-to-end test procedures.

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -20,7 +20,11 @@ if (args.includes("--help") || args.includes("-h")) {
 
 Local Anthropic API powered by your Claude Max subscription.
 
-Usage: meridian [options]
+Usage: meridian [command] [options]
+
+Commands:
+  (default)         Start the proxy server
+  refresh-token     Refresh the Claude Code OAuth token
 
 Options:
   -v, --version   Show version
@@ -34,6 +38,18 @@ Environment variables:
 
 See https://github.com/rynfar/meridian for full documentation.`)
   process.exit(0)
+}
+
+if (args[0] === "refresh-token") {
+  const { refreshOAuthToken } = await import("../src/proxy/tokenRefresh")
+  const success = await refreshOAuthToken()
+  if (success) {
+    console.log("Token refreshed successfully")
+    process.exit(0)
+  } else {
+    console.error("Token refresh failed")
+    process.exit(1)
+  }
 }
 
 const exec = promisify(execCallback)

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -1,15 +1,11 @@
 /**
- * Unit tests for tokenRefresh — stamp file logic and OAuth refresh flow.
+ * Unit tests for tokenRefresh — OAuth refresh flow.
  */
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test"
 import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 
-// We test the module's exported functions by mocking fs and fetch at the module level.
-// Import after setting up spies so we can control behavior per test.
-
-const STAMP = path.join(os.tmpdir(), "meridian-token-refresh")
 const CREDS = path.join(os.homedir(), ".claude", ".credentials.json")
 
 const MOCK_CREDENTIALS = {
@@ -24,50 +20,26 @@ const MOCK_CREDENTIALS = {
 }
 
 describe("tokenRefresh", () => {
-  let statSyncSpy: ReturnType<typeof spyOn>
   let readFileSyncSpy: ReturnType<typeof spyOn>
   let writeFileSyncSpy: ReturnType<typeof spyOn>
   let originalFetch: typeof globalThis.fetch
 
   beforeEach(() => {
-    statSyncSpy = spyOn(fs, "statSync")
     readFileSyncSpy = spyOn(fs, "readFileSync")
     writeFileSyncSpy = spyOn(fs, "writeFileSync")
     originalFetch = globalThis.fetch
   })
 
   afterEach(() => {
-    statSyncSpy.mockRestore()
     readFileSyncSpy.mockRestore()
     writeFileSyncSpy.mockRestore()
     globalThis.fetch = originalFetch
   })
 
-  describe("stampFileAgeMs", () => {
-    it("returns Infinity when stamp file does not exist", async () => {
-      statSyncSpy.mockImplementation((p: string) => {
-        if (p === STAMP) throw new Error("ENOENT")
-        return { mtimeMs: Date.now() } as fs.Stats
-      })
-      const { stampFileAgeMs } = await import("../proxy/tokenRefresh")
-      expect(stampFileAgeMs()).toBe(Infinity)
-    })
-
-    it("returns age in ms when stamp file exists", async () => {
-      const fiveHoursAgo = Date.now() - 5 * 60 * 60 * 1000
-      statSyncSpy.mockImplementation((_p: string) => ({ mtimeMs: fiveHoursAgo } as fs.Stats))
-      const { stampFileAgeMs } = await import("../proxy/tokenRefresh")
-      const age = stampFileAgeMs()
-      expect(age).toBeGreaterThan(4.9 * 60 * 60 * 1000)
-      expect(age).toBeLessThan(5.1 * 60 * 60 * 1000)
-    })
-  })
-
   describe("refreshOAuthToken", () => {
     it("returns false when credentials file cannot be read", async () => {
-      readFileSyncSpy.mockImplementation((p: unknown) => {
-        if (p === CREDS) throw new Error("ENOENT")
-        return ""
+      readFileSyncSpy.mockImplementation((_p: unknown) => {
+        throw new Error("ENOENT")
       })
       const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
       const result = await refreshOAuthToken()
@@ -102,23 +74,36 @@ describe("tokenRefresh", () => {
       expect(result).toBe(false)
     })
 
+    it("returns false when response JSON is invalid", async () => {
+      readFileSyncSpy.mockImplementation((_p: unknown) => JSON.stringify(MOCK_CREDENTIALS))
+      globalThis.fetch = mock(async () =>
+        new Response("not json", { status: 200 })
+      )
+      const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+      const result = await refreshOAuthToken()
+      expect(result).toBe(false)
+    })
+
     it("returns false when credentials cannot be written", async () => {
       readFileSyncSpy.mockImplementation((_p: unknown) => JSON.stringify(MOCK_CREDENTIALS))
       globalThis.fetch = mock(async () =>
-        new Response(JSON.stringify({ access_token: "new-token", expires_in: 3600 }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        })
+        new Response(
+          JSON.stringify({
+            access_token: "new-token",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
       )
-      writeFileSyncSpy.mockImplementation((p: unknown) => {
-        if (p === CREDS) throw new Error("EACCES")
+      writeFileSyncSpy.mockImplementation((_p: unknown) => {
+        throw new Error("EACCES")
       })
       const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
       const result = await refreshOAuthToken()
       expect(result).toBe(false)
     })
 
-    it("writes updated credentials and stamp file on success", async () => {
+    it("returns true and writes credentials on success", async () => {
       readFileSyncSpy.mockImplementation((_p: unknown) => JSON.stringify(MOCK_CREDENTIALS))
       globalThis.fetch = mock(async () =>
         new Response(
@@ -130,85 +115,38 @@ describe("tokenRefresh", () => {
           { status: 200, headers: { "Content-Type": "application/json" } }
         )
       )
-      const writtenFiles: string[] = []
-      writeFileSyncSpy.mockImplementation((p: unknown) => {
-        writtenFiles.push(p as string)
+      const writtenData: string[] = []
+      writeFileSyncSpy.mockImplementation((_p: unknown, data: unknown) => {
+        writtenData.push(data as string)
       })
 
       const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
       const result = await refreshOAuthToken()
 
       expect(result).toBe(true)
-      expect(writtenFiles).toContain(CREDS)
-      expect(writtenFiles).toContain(STAMP)
+      expect(writtenData.length).toBe(1)
+      const written = JSON.parse(writtenData[0])
+      expect(written.claudeAiOauth.accessToken).toBe("new-access-token")
+      expect(written.claudeAiOauth.refreshToken).toBe("new-refresh-token")
     })
 
-    it("does NOT write stamp file when refresh fails", async () => {
+    it("preserves old refreshToken if new one is not in response", async () => {
       readFileSyncSpy.mockImplementation((_p: unknown) => JSON.stringify(MOCK_CREDENTIALS))
       globalThis.fetch = mock(async () =>
-        new Response("Bad Gateway", { status: 502 })
+        new Response(
+          JSON.stringify({
+            access_token: "new-access-token",
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
       )
-      const writtenFiles: string[] = []
-      writeFileSyncSpy.mockImplementation((p: unknown) => {
-        writtenFiles.push(p as string)
-      })
+      writeFileSyncSpy.mockImplementation((_p: unknown) => {})
 
       const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
       const result = await refreshOAuthToken()
 
-      expect(result).toBe(false)
-      expect(writtenFiles).not.toContain(STAMP)
-    })
-  })
-
-  describe("refreshTokenIfNeeded", () => {
-    it("does not refresh when stamp is recent (< 6h)", async () => {
-      const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000
-      statSyncSpy.mockImplementation((_p: unknown) => ({ mtimeMs: twoHoursAgo } as fs.Stats))
-      const fetchMock = mock(async () => new Response("{}", { status: 200 }))
-      globalThis.fetch = fetchMock
-
-      const { refreshTokenIfNeeded } = await import("../proxy/tokenRefresh")
-      await refreshTokenIfNeeded()
-
-      expect(fetchMock).not.toHaveBeenCalled()
-    })
-
-    it("refreshes when stamp is old (> 6h)", async () => {
-      const sevenHoursAgo = Date.now() - 7 * 60 * 60 * 1000
-      statSyncSpy.mockImplementation((_p: unknown) => ({ mtimeMs: sevenHoursAgo } as fs.Stats))
-      readFileSyncSpy.mockImplementation((_p: unknown) => JSON.stringify(MOCK_CREDENTIALS))
-      const fetchMock = mock(async () =>
-        new Response(
-          JSON.stringify({ access_token: "t", expires_in: 3600 }),
-          { status: 200, headers: { "Content-Type": "application/json" } }
-        )
-      )
-      globalThis.fetch = fetchMock
-      writeFileSyncSpy.mockImplementation((_p: unknown) => {})
-
-      const { refreshTokenIfNeeded } = await import("../proxy/tokenRefresh")
-      await refreshTokenIfNeeded()
-
-      expect(fetchMock).toHaveBeenCalledTimes(1)
-    })
-
-    it("refreshes when stamp file is missing (Infinity age)", async () => {
-      statSyncSpy.mockImplementation((_p: string) => { throw new Error("ENOENT") })
-      readFileSyncSpy.mockImplementation((_p: unknown) => JSON.stringify(MOCK_CREDENTIALS))
-      const fetchMock = mock(async () =>
-        new Response(
-          JSON.stringify({ access_token: "t", expires_in: 3600 }),
-          { status: 200, headers: { "Content-Type": "application/json" } }
-        )
-      )
-      globalThis.fetch = fetchMock
-      writeFileSyncSpy.mockImplementation((_p: unknown) => {})
-
-      const { refreshTokenIfNeeded } = await import("../proxy/tokenRefresh")
-      await refreshTokenIfNeeded()
-
-      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(result).toBe(true)
     })
   })
 })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -32,7 +32,6 @@ import {
 // Re-export for backwards compatibility (existing tests import from here)
 
 import { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession } from "./session/cache"
-import { refreshTokenIfNeeded } from "./tokenRefresh"
 // Re-export for backwards compatibility (existing tests import from here)
 export { computeLineageHash, hashMessage, computeMessageHashes }
 export { clearSessionCache, getMaxSessionsLimit }
@@ -1287,7 +1286,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const requestId = c.req.header("x-request-id") || randomUUID()
     const queueEnteredAt = Date.now()
     claudeLog("request.enter", { requestId, endpoint })
-    refreshTokenIfNeeded().catch(() => {}) // background token refresh, non-blocking
     await acquireSession()
     const queueStartedAt = Date.now()
     try {

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -1,19 +1,14 @@
 /**
- * OAuth token refresh for Claude Code credentials.
- *
- * Uses a stamp file to rate-limit refresh attempts: only refreshes once per
- * REFRESH_THRESHOLD_MS (6 hours). The stamp file is only updated on a
- * successful refresh so that failures cause a retry on the next request.
+ * Manual OAuth token refresh for Claude Code credentials.
+ * Refreshes the access token using the refresh token from ~/.claude/.credentials.json.
+ * Returns true on success, false on any error (credentials read, network, parse, write).
  */
 
-import { readFileSync, writeFileSync, statSync, utimesSync } from "fs"
-import { tmpdir, homedir } from "os"
-import { join } from "path"
+import { readFileSync, writeFileSync } from "fs"
+import { homedir } from "os"
 import { claudeLog } from "../logger"
 
-const STAMP_FILE = join(tmpdir(), "meridian-token-refresh")
-const CREDENTIALS_FILE = join(homedir(), ".claude", ".credentials.json")
-const REFRESH_THRESHOLD_MS = 6 * 60 * 60 * 1000 // 6 hours
+const CREDENTIALS_FILE = `${homedir()}/.claude/.credentials.json`
 const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
@@ -38,39 +33,10 @@ interface OAuthTokenResponse {
   scope?: string
 }
 
-export function stampFileAgeMs(): number {
-  try {
-    const stat = statSync(STAMP_FILE)
-    return Date.now() - stat.mtimeMs
-  } catch {
-    return Infinity
-  }
-}
-
-function readCredentials(): CredentialsFile {
-  const raw = readFileSync(CREDENTIALS_FILE, "utf-8")
-  return JSON.parse(raw) as CredentialsFile
-}
-
-function writeCredentials(updated: CredentialsFile): void {
-  const tmp = CREDENTIALS_FILE + ".tmp"
-  writeFileSync(tmp, JSON.stringify(updated, null, 2), "utf-8")
-  // Atomic rename — writeFileSync to final path directly risks partial writes
-  writeFileSync(CREDENTIALS_FILE, JSON.stringify(updated, null, 2), "utf-8")
-}
-
-function touchStampFile(): void {
-  try {
-    writeFileSync(STAMP_FILE, "", "utf-8")
-  } catch (err) {
-    claudeLog("token_refresh.stamp_write_failed", { error: String(err) })
-  }
-}
-
 export async function refreshOAuthToken(): Promise<boolean> {
   let credentials: CredentialsFile
   try {
-    credentials = readCredentials()
+    credentials = JSON.parse(readFileSync(CREDENTIALS_FILE, "utf-8"))
   } catch (err) {
     claudeLog("token_refresh.credentials_read_failed", { error: String(err) })
     return false
@@ -126,27 +92,12 @@ export async function refreshOAuthToken(): Promise<boolean> {
   }
 
   try {
-    writeCredentials(credentials)
+    writeFileSync(CREDENTIALS_FILE, JSON.stringify(credentials, null, 2), "utf-8")
   } catch (err) {
     claudeLog("token_refresh.credentials_write_failed", { error: String(err) })
     return false
   }
 
-  touchStampFile()
   claudeLog("token_refresh.success", { expiresAt })
   return true
-}
-
-let refreshInProgress = false
-
-export async function refreshTokenIfNeeded(): Promise<void> {
-  if (stampFileAgeMs() < REFRESH_THRESHOLD_MS) return
-  if (refreshInProgress) return
-
-  refreshInProgress = true
-  try {
-    await refreshOAuthToken()
-  } finally {
-    refreshInProgress = false
-  }
 }


### PR DESCRIPTION
#223

- Simplify tokenRefresh.ts to expose only refreshOAuthToken()
- Remove auto-refresh from request handler (scheduling is ops concern)
- Add 'refresh-token' CLI subcommand for manual/scheduled token refresh
- Exit code: 0 (success), 1 (failure) for integration with cron/systemd
- Update tests: keep OAuth logic, remove scheduling tests
- Document in README with cron and systemd timer examples
- Users can now: meridian refresh-token OR cron schedule it externally