### PR TITLE
fix: fall back from sonnet[1m] to sonnet when extra usage not enabled

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, isStaleSessionError } from "../proxy/errors"
+import { classifyError, isStaleSessionError, isExtraUsageRequiredError } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -166,6 +166,31 @@ describe("classifyError", () => {
       expect(isStaleSessionError("No message found with message.uuid")).toBe(false)
       expect(isStaleSessionError(null)).toBe(false)
       expect(isStaleSessionError(undefined)).toBe(false)
+    })
+  })
+
+  describe("extra usage required", () => {
+    it("detects the exact error from Claude SDK", () => {
+      expect(isExtraUsageRequiredError(
+        "Claude Code returned an error result: API Error: Extra usage is required for 1M context · enable extra usage at claude.ai/settings/usage, or use --model to switch"
+      )).toBe(true)
+    })
+
+    it("detects lowercase variant", () => {
+      expect(isExtraUsageRequiredError("extra usage is required for 1m context")).toBe(true)
+    })
+
+    it("returns false for unrelated errors", () => {
+      expect(isExtraUsageRequiredError("rate limit exceeded")).toBe(false)
+      expect(isExtraUsageRequiredError("authentication failed")).toBe(false)
+    })
+
+    it("returns false when only 'extra usage' but no '1m'", () => {
+      expect(isExtraUsageRequiredError("extra usage enabled")).toBe(false)
+    })
+
+    it("returns false when only '1m' but no 'extra usage'", () => {
+      expect(isExtraUsageRequiredError("using 1m context window")).toBe(false)
     })
   })
 

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for extra-usage-required fallback.
+ *
+ * Verifies that when a "extra usage required for 1M context" error occurs:
+ * 1. Models with [1m] context fall back to the base model (immediate retry, no backoff)
+ * 2. The fallback only triggers when the model has extended context
+ * 3. The error propagates normally when the model is already base
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+  parseSSE,
+} from "./helpers"
+
+// Track query calls to verify retry behavior
+let queryCalls: Array<{ model: string; callIndex: number }> = []
+let queryCallCount = 0
+
+// Control what the mock does
+let mockBehavior: "extra_usage_then_succeed" | "always_extra_usage" | "succeed" = "succeed"
+
+const EXTRA_USAGE_ERROR = "Claude Code returned an error result: API Error: Extra usage is required for 1M context · enable extra usage at claude.ai/settings/usage, or use --model to switch"
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    queryCallCount++
+    const callIndex = queryCallCount
+    const model = opts.options?.model || "sonnet"
+    queryCalls.push({ model, callIndex })
+    const isStreaming = opts.options?.includePartialMessages === true
+
+    return (async function* () {
+      if (mockBehavior === "always_extra_usage") {
+        throw new Error(EXTRA_USAGE_ERROR)
+      }
+
+      if (mockBehavior === "extra_usage_then_succeed" && callIndex === 1) {
+        throw new Error(EXTRA_USAGE_ERROR)
+      }
+
+      // Success path
+      if (isStreaming) {
+        yield messageStart(`msg-${callIndex}`)
+        yield textBlockStart(0)
+        yield textDelta(0, `response-${callIndex}`)
+        yield blockStop(0)
+        yield messageDelta("end_turn")
+        yield messageStop()
+      }
+      yield {
+        type: "assistant",
+        uuid: `uuid-${callIndex}`,
+        message: {
+          id: `msg-${callIndex}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: `response-${callIndex}` }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: `sdk-session-${callIndex}`,
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    })
+  )
+}
+
+describe("Extra usage required fallback", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    queryCalls = []
+    queryCallCount = 0
+    mockBehavior = "succeed"
+  })
+
+  describe("Non-streaming", () => {
+    it("falls back from [1m] to base model on extra usage error", async () => {
+      mockBehavior = "extra_usage_then_succeed"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })
+
+      // Should succeed after fallback (no backoff delay)
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.content).toBeDefined()
+    })
+
+    it("propagates error when model is already base (no [1m] to strip)", async () => {
+      mockBehavior = "always_extra_usage"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })
+
+      // After stripping [1m] (if applicable) and retrying, the error
+      // should eventually propagate since the base model also fails
+      expect(response.status).toBe(500)
+    })
+  })
+
+  describe("Streaming", () => {
+    it("falls back from [1m] to base model on extra usage error", async () => {
+      mockBehavior = "extra_usage_then_succeed"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      })
+
+      expect(response.status).toBe(200)
+      const text = await response.text()
+      // Should contain successful stream content after fallback
+      expect(text).toContain("event: message_start")
+    })
+
+    it("returns error event when model is already base", async () => {
+      mockBehavior = "always_extra_usage"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      })
+
+      expect(response.status).toBe(200) // SSE always returns 200
+      const text = await response.text()
+      const events = parseSSE(text)
+      const errorEvent = events.find((e) => e.event === "error")
+      expect(errorEvent).toBeDefined()
+    })
+  })
+
+  describe("No backoff needed", () => {
+    it("does not use exponential backoff for extra usage errors", async () => {
+      mockBehavior = "extra_usage_then_succeed"
+      const app = createTestApp()
+
+      const start = Date.now()
+      await post(app, {
+        model: "sonnet",
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })
+      const elapsed = Date.now() - start
+
+      // Should complete nearly instantly (no 1s+ backoff delay)
+      // Rate limit retry uses 1000ms minimum — extra usage should be <500ms
+      expect(elapsed).toBeLessThan(500)
+    })
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -131,3 +131,13 @@ export function isRateLimitError(errMsg: string): boolean {
   const lower = errMsg.toLowerCase()
   return lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
 }
+
+/**
+ * Detect errors caused by the 1M context window requiring Extra Usage.
+ * Max subscribers without Extra Usage enabled get this error when using
+ * sonnet[1m] or opus[1m]. The fix is to fall back to the base model.
+ */
+export function isExtraUsageRequiredError(errMsg: string): boolean {
+  const lower = errMsg.toLowerCase()
+  return lower.includes("extra usage") && lower.includes("1m")
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -17,7 +17,7 @@ import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASST
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, isStaleSessionError, isRateLimitError } from "./errors"
+import { classifyError, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError } from "./errors"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync, hasExtendedContext, stripExtendedContext } from "./models"
 import { getLastUserMessage } from "./messages"
 import { detectAdapter } from "./adapters/detect"
@@ -528,6 +528,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     return
                   }
 
+                  // Extra Usage required: strip [1m] immediately (no backoff needed)
+                  if (isExtraUsageRequiredError(errMsg) && hasExtendedContext(model)) {
+                    const from = model
+                    model = stripExtendedContext(model)
+                    claudeLog("upstream.context_fallback", {
+                      mode: "non_stream",
+                      from,
+                      to: model,
+                      reason: "extra_usage_required",
+                    })
+                    console.error(`[PROXY] ${requestMeta.requestId} extra usage required for [1m], falling back to ${model}`)
+                    continue
+                  }
+
                   // Rate-limit retry: first strip [1m] (free, different tier), then backoff
                   if (isRateLimitError(errMsg)) {
                     if (hasExtendedContext(model)) {
@@ -821,6 +835,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,
                       }))
                       return
+                    }
+
+                    // Extra Usage required: strip [1m] immediately (no backoff needed)
+                    if (isExtraUsageRequiredError(errMsg) && hasExtendedContext(model)) {
+                      const from = model
+                      model = stripExtendedContext(model)
+                      claudeLog("upstream.context_fallback", {
+                        mode: "stream",
+                        from,
+                        to: model,
+                        reason: "extra_usage_required",
+                      })
+                      console.error(`[PROXY] ${requestMeta.requestId} extra usage required for [1m], falling back to ${model}`)
+                      continue
                     }
 
                     // Rate-limit retry: first strip [1m] (free, different tier), then backoff


### PR DESCRIPTION
## Problem

Max subscribers without **Extra Usage** enabled get this error when the proxy selects `sonnet[1m]`:

> *Claude Code returned an error result: API Error: Extra usage is required for 1M context · enable extra usage at claude.ai/settings/usage, or use --model to switch*

There's no way to detect whether a user has Extra Usage enabled ahead of time — `claude auth status` only exposes `loggedIn`, `subscriptionType`, and `email`.

## Fix

Catch the "extra usage required" error and immediately retry with the base model (`sonnet` instead of `sonnet[1m]`). This mirrors the existing rate-limit fallback pattern but **without exponential backoff**, since this is a permanent account configuration issue, not transient load.

### How it works for users
Request → proxy picks `sonnet[1m]` → SDK returns "extra usage required" → proxy catches it → strips to `sonnet` (200k) → retries immediately → succeeds. **Zero configuration needed.**

## Changes

| File | What |
|------|------|
| `src/proxy/errors.ts` | New `isExtraUsageRequiredError()` detector |
| `src/proxy/server.ts` | Check before rate-limit handler in both stream/non-stream retry loops |
| `src/__tests__/errors.test.ts` | 5 unit tests for the detector |
| `src/__tests__/proxy-extra-usage-fallback.test.ts` | 5 integration tests (fallback, error propagation, no-backoff timing) |

All 651 tests pass.

Closes #227