### PR TITLE
feat: OpenAI-compatible /v1/chat/completions and /v1/models endpoints

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -78,6 +78,9 @@ kill $(lsof -ti :3456)
 | E22 | [OAuth Token Refresh](#e22-oauth-token-refresh) | Expired access token auto-refreshed inline; request succeeds without manual `claude login` | 2026-04-02 |
 | E23 | [Subagent Model Selection](#e23-subagent-model-selection) | `x-opencode-agent-mode: subagent` header selects base model; primary gets 1M; proxy log shows `agent=subagent` | 2026-04-02 |
 | E24 | [Default Non-Streaming](#e24-default-non-streaming) | Omitting `stream` field returns JSON (not SSE), matching Anthropic API spec | - |
+| E25 | [OpenAI Compat: Non-Streaming](#e25-openai-compat-non-streaming) | `/v1/chat/completions` returns valid OpenAI completion shape | - |
+| E26 | [OpenAI Compat: Streaming](#e26-openai-compat-streaming) | `/v1/chat/completions` with `stream: true` returns OpenAI SSE chunks | - |
+| E27 | [OpenAI Compat: Models](#e27-openai-compat-models) | `GET /v1/models` returns Claude model list in OpenAI format | - |
 
 ---
 
@@ -1050,6 +1053,83 @@ rm /tmp/e2e-headers.txt
 - Proxy log: `stream=false`
 
 **What's being tested:** The `body.stream ?? false` default in `server.ts`. Prior to this fix, omitting `stream` defaulted to `true` (SSE), which broke SDK clients calling `messages.create()` without an explicit `stream` parameter.
+
+---
+
+## E25: OpenAI Compat: Non-Streaming
+
+**Verifies:** `POST /v1/chat/completions` accepts an OpenAI-format request and returns a valid OpenAI completion JSON object.
+
+```bash
+curl -s http://127.0.0.1:3456/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -d '{
+    "model": "claude-haiku-4-5-20251001",
+    "max_tokens": 20,
+    "stream": false,
+    "messages": [{"role": "user", "content": "Say: OK"}]
+  }' | python3 -m json.tool
+```
+
+**Pass criteria:**
+- `"object": "chat.completion"`
+- `id` starts with `chatcmpl-`
+- `choices[0].message.role` is `"assistant"`
+- `choices[0].message.content` contains a response
+- `choices[0].finish_reason` is `"stop"`
+- `usage.prompt_tokens`, `usage.completion_tokens`, `usage.total_tokens` are numbers
+- Proxy log: `stream=false` (non-streaming path used internally)
+
+**What's being tested:** `translateOpenAiToAnthropic()` and `translateAnthropicToOpenAi()` in `openai.ts`, internal routing via `app.fetch()` to `/v1/messages`.
+
+---
+
+## E26: OpenAI Compat: Streaming
+
+**Verifies:** `POST /v1/chat/completions` with `stream: true` returns OpenAI SSE chunks in the correct format.
+
+```bash
+curl -sN http://127.0.0.1:3456/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -d '{
+    "model": "claude-haiku-4-5-20251001",
+    "max_tokens": 20,
+    "stream": true,
+    "messages": [{"role": "user", "content": "Say: hello"}]
+  }'
+```
+
+**Pass criteria:**
+- Response `Content-Type: text/event-stream`
+- First data chunk has `"object": "chat.completion.chunk"` and `choices[0].delta.role == "assistant"`
+- At least one chunk has non-empty `choices[0].delta.content`
+- A chunk has `choices[0].finish_reason == "stop"`
+- Stream ends with `data: [DONE]`
+- All chunks share the same `id` starting with `chatcmpl-`
+- Proxy log: `stream=true`
+
+**What's being tested:** `translateAnthropicSseEvent()` in `openai.ts`, SSE stream translation in `server.ts`.
+
+---
+
+## E27: OpenAI Compat: Models
+
+**Verifies:** `GET /v1/models` returns available Claude models in OpenAI format with correct context windows for the subscription tier.
+
+```bash
+curl -s http://127.0.0.1:3456/v1/models | python3 -m json.tool
+```
+
+**Pass criteria:**
+- `"object": "list"`
+- `data` array contains `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5-20251001`
+- Each model has `object: "model"`, `owned_by: "anthropic"`, `context_window > 0`
+- For Max subscription: sonnet and opus have `context_window: 1000000`
+- Haiku always has `context_window: 200000`
+
+**What's being tested:** `buildModelList()` in `openai.ts`, `GET /v1/models` route in `server.ts`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ---
 
-Meridian turns your Claude Max subscription into a local Anthropic API. Any tool that speaks the Anthropic protocol — OpenCode, Crush, Cline, Aider — connects to Meridian and gets Claude, powered by your existing subscription through the official Claude Code SDK.
+Meridian turns your Claude Max subscription into a local Anthropic API. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, Crush, Cline, Aider, Open WebUI — connects to Meridian and gets Claude, powered by your existing subscription through the official Claude Code SDK.
 
 > [!NOTE]
 > **Renamed from `opencode-claude-max-proxy`.** If you're upgrading, see [`MIGRATION.md`](MIGRATION.md) for the checklist. Your existing sessions, env vars, and agent configs all continue to work.
@@ -53,6 +53,7 @@ Meridian bridges that gap. It runs locally, accepts standard Anthropic API reque
 ## Features
 
 - **Standard Anthropic API** — drop-in compatible with any tool that supports a custom `base_url`
+- **OpenAI-compatible API** — `/v1/chat/completions` and `/v1/models` for tools that only speak the OpenAI protocol (Open WebUI, Continue, etc.) — no LiteLLM needed
 - **Session management** — conversations persist across requests, survive compaction and undo, resume after proxy restarts
 - **Streaming** — full SSE streaming with MCP tool filtering
 - **Concurrent sessions** — run parent and subagent requests in parallel
@@ -173,6 +174,24 @@ ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://127.0.0.1:3456 \
 
 > **Note:** `--no-stream` is incompatible due to a litellm parsing issue — use the default streaming mode.
 
+### OpenAI-compatible tools (Open WebUI, Continue, etc.)
+
+Meridian speaks the OpenAI protocol natively — no LiteLLM or translation proxy needed.
+
+**`POST /v1/chat/completions`** — accepts OpenAI chat format, returns OpenAI completion format (streaming and non-streaming)
+
+**`GET /v1/models`** — returns available Claude models in OpenAI format
+
+Point any OpenAI-compatible tool at `http://127.0.0.1:3456` with any API key value:
+
+```bash
+# Open WebUI: set OpenAI API base to http://127.0.0.1:3456, API key to any value
+# Continue: set apiBase to http://127.0.0.1:3456 with provider: openai
+# Any OpenAI SDK: set base_url="http://127.0.0.1:3456", api_key="dummy"
+```
+
+> **Note:** Multi-turn conversations work by packing prior turns into the system prompt. Each request is a fresh SDK session — OpenAI clients replay full history themselves and don't use Meridian's session resumption.
+
 ### Any Anthropic-compatible tool
 
 ```bash
@@ -189,7 +208,8 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 | [Crush](https://github.com/charmbracelet/crush) | ✅ Verified | Provider config (see above) — full tool support, session resume, headless `crush run` |
 | [Cline](https://github.com/cline/cline) | ✅ Verified | Config (see above) — full tool support, file read/write/edit, bash, session resume |
 | [Aider](https://github.com/paul-gauthier/aider) | ✅ Verified | Env vars — file editing, streaming; `--no-stream` broken (litellm bug) |
-| [Continue](https://github.com/continuedev/continue) | 🔲 Untested | Should work — standard Anthropic API |
+| [Open WebUI](https://github.com/open-webui/open-webui) | ✅ Verified | OpenAI-compatible endpoints — set base URL to `http://127.0.0.1:3456` |
+| [Continue](https://github.com/continuedev/continue) | 🔲 Untested | OpenAI-compatible endpoints should work — set `apiBase` to `http://127.0.0.1:3456` |
 
 Tested an agent or built a plugin? [Open an issue](https://github.com/rynfar/meridian/issues) and we'll add it.
 
@@ -209,6 +229,7 @@ src/proxy/
 ├── errors.ts              ← Error classification
 ├── models.ts              ← Model mapping (sonnet/opus/haiku, agentMode)
 ├── tokenRefresh.ts        ← Cross-platform OAuth token refresh
+├── openai.ts              ← OpenAI ↔ Anthropic format translation (pure)
 ├── setup.ts               ← OpenCode plugin configuration
 ├── session/
 │   ├── lineage.ts         ← Per-message hashing, mutation classification (pure)
@@ -272,6 +293,8 @@ Implement the `AgentAdapter` interface in `src/proxy/adapters/`. See [`adapters/
 | `GET /` | Landing page |
 | `POST /v1/messages` | Anthropic Messages API |
 | `POST /messages` | Alias for `/v1/messages` |
+| `POST /v1/chat/completions` | OpenAI-compatible chat completions |
+| `GET /v1/models` | OpenAI-compatible model list |
 | `GET /health` | Auth status, mode, plugin status |
 | `POST /auth/refresh` | Manually refresh the OAuth token |
 | `GET /telemetry` | Performance dashboard |

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Unit tests for src/proxy/openai.ts — pure translation functions.
+ * No I/O, no mocks required.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  extractOpenAiContent,
+  translateOpenAiToAnthropic,
+  translateAnthropicToOpenAi,
+  translateAnthropicSseEvent,
+  buildModelList,
+} from "../proxy/openai"
+
+// ---------------------------------------------------------------------------
+// extractOpenAiContent
+// ---------------------------------------------------------------------------
+
+describe("extractOpenAiContent", () => {
+  it("returns string content as-is", () => {
+    expect(extractOpenAiContent("hello world")).toBe("hello world")
+  })
+
+  it("extracts text from content array", () => {
+    expect(extractOpenAiContent([
+      { type: "text", text: "hello" },
+      { type: "text", text: " world" },
+    ])).toBe("hello world")
+  })
+
+  it("skips non-text content parts", () => {
+    expect(extractOpenAiContent([
+      { type: "image_url", text: undefined },
+      { type: "text", text: "only this" },
+    ])).toBe("only this")
+  })
+
+  it("returns empty string for empty array", () => {
+    expect(extractOpenAiContent([])).toBe("")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateOpenAiToAnthropic
+// ---------------------------------------------------------------------------
+
+describe("translateOpenAiToAnthropic", () => {
+  it("returns null for missing messages", () => {
+    expect(translateOpenAiToAnthropic({})).toBeNull()
+  })
+
+  it("returns null for empty messages array", () => {
+    expect(translateOpenAiToAnthropic({ messages: [] })).toBeNull()
+  })
+
+  it("translates a single user message", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hello" }],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.messages).toEqual([{ role: "user", content: "Hello" }])
+    expect(result!.system).toBeUndefined()
+  })
+
+  it("extracts system message into system field", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "Hi" },
+      ],
+    })
+    expect(result!.system).toBe("You are helpful.")
+    expect(result!.messages).toEqual([{ role: "user", content: "Hi" }])
+  })
+
+  it("concatenates multiple system messages", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "system", content: "Rule 1." },
+        { role: "system", content: "Rule 2." },
+        { role: "user", content: "Hi" },
+      ],
+    })
+    expect(result!.system).toBe("Rule 1.\nRule 2.")
+  })
+
+  it("packs multi-turn history into system context", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "What is 2+2?" },
+        { role: "assistant", content: "4" },
+        { role: "user", content: "And 3+3?" },
+      ],
+    })
+    // Only the last message is sent
+    expect(result!.messages).toEqual([{ role: "user", content: "And 3+3?" }])
+    // Prior turns packed into system
+    expect(result!.system).toContain("<conversation_history>")
+    expect(result!.system).toContain("user: What is 2+2?")
+    expect(result!.system).toContain("assistant: 4")
+  })
+
+  it("prepends system message before conversation history", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "system", content: "Be concise." },
+        { role: "user", content: "Turn 1" },
+        { role: "assistant", content: "OK" },
+        { role: "user", content: "Turn 2" },
+      ],
+    })
+    expect(result!.system).toMatch(/^Be concise\./)
+    expect(result!.system).toContain("<conversation_history>")
+  })
+
+  it("defaults model to claude-sonnet-4-6", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+    })
+    expect(result!.model).toBe("claude-sonnet-4-6")
+  })
+
+  it("passes through specified model", () => {
+    const result = translateOpenAiToAnthropic({
+      model: "claude-haiku-4-5-20251001",
+      messages: [{ role: "user", content: "Hi" }],
+    })
+    expect(result!.model).toBe("claude-haiku-4-5-20251001")
+  })
+
+  it("defaults max_tokens to 8192", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+    })
+    expect(result!.max_tokens).toBe(8192)
+  })
+
+  it("uses max_completion_tokens as fallback", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      max_completion_tokens: 4096,
+    })
+    expect(result!.max_tokens).toBe(4096)
+  })
+
+  it("max_tokens takes precedence over max_completion_tokens", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      max_tokens: 1024,
+      max_completion_tokens: 4096,
+    })
+    expect(result!.max_tokens).toBe(1024)
+  })
+
+  it("forwards temperature when present", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      temperature: 0.7,
+    })
+    expect(result!.temperature).toBe(0.7)
+  })
+
+  it("does not include temperature when absent", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+    })
+    expect(result!.temperature).toBeUndefined()
+  })
+
+  it("forwards top_p when present", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      top_p: 0.9,
+    })
+    expect(result!.top_p).toBe(0.9)
+  })
+
+  it("maps assistant role correctly", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello" },
+        { role: "user", content: "How are you?" },
+      ],
+    })
+    expect(result!.system).toContain("assistant: Hello")
+  })
+
+  it("handles structured content in messages", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{
+        role: "user",
+        content: [{ type: "text", text: "structured" }],
+      }],
+    })
+    expect(result!.messages[0].content).toBe("structured")
+  })
+
+  it("sets stream from body", () => {
+    const resultStream = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      stream: true,
+    })
+    expect(resultStream!.stream).toBe(true)
+
+    const resultNoStream = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      stream: false,
+    })
+    expect(resultNoStream!.stream).toBe(false)
+  })
+
+  it("defaults stream to false when omitted", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+    })
+    expect(result!.stream).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateAnthropicToOpenAi
+// ---------------------------------------------------------------------------
+
+describe("translateAnthropicToOpenAi", () => {
+  const ID = "chatcmpl-test"
+  const MODEL = "claude-sonnet-4-6"
+  const CREATED = 1234567890
+
+  it("returns correct OpenAI completion shape", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [{ type: "text", text: "Hello!" }], stop_reason: "end_turn", usage: { input_tokens: 10, output_tokens: 5 } },
+      ID, MODEL, CREATED
+    )
+    expect(result.id).toBe(ID)
+    expect(result.object).toBe("chat.completion")
+    expect(result.created).toBe(CREATED)
+    expect(result.model).toBe(MODEL)
+    expect(result.choices[0].message.role).toBe("assistant")
+    expect(result.choices[0].message.content).toBe("Hello!")
+    expect(result.choices[0].finish_reason).toBe("stop")
+    expect(result.usage.prompt_tokens).toBe(10)
+    expect(result.usage.completion_tokens).toBe(5)
+    expect(result.usage.total_tokens).toBe(15)
+  })
+
+  it("maps max_tokens stop_reason to length finish_reason", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [{ type: "text", text: "truncated" }], stop_reason: "max_tokens" },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0].finish_reason).toBe("length")
+  })
+
+  it("filters out thinking blocks", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [
+          { type: "thinking", text: "let me think..." },
+          { type: "text", text: "actual answer" },
+        ],
+        stop_reason: "end_turn",
+      },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0].message.content).toBe("actual answer")
+  })
+
+  it("handles empty content", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [], stop_reason: "end_turn" },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0].message.content).toBe("")
+  })
+
+  it("handles missing usage", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" },
+      ID, MODEL, CREATED
+    )
+    expect(result.usage.prompt_tokens).toBe(0)
+    expect(result.usage.completion_tokens).toBe(0)
+    expect(result.usage.total_tokens).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateAnthropicSseEvent
+// ---------------------------------------------------------------------------
+
+describe("translateAnthropicSseEvent", () => {
+  const ID = "chatcmpl-test"
+  const MODEL = "claude-sonnet-4-6"
+  const CREATED = 1234567890
+
+  it("message_start → role announcement chunk", () => {
+    const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED)
+    expect(chunk).not.toBeNull()
+    expect(chunk!.choices[0].delta.role).toBe("assistant")
+    expect(chunk!.choices[0].delta.content).toBe("")
+    expect(chunk!.choices[0].finish_reason).toBeNull()
+  })
+
+  it("content_block_delta text_delta → content chunk", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "content_block_delta", delta: { type: "text_delta", text: "hello" } },
+      ID, MODEL, CREATED
+    )
+    expect(chunk).not.toBeNull()
+    expect(chunk!.choices[0].delta.content).toBe("hello")
+    expect(chunk!.choices[0].finish_reason).toBeNull()
+  })
+
+  it("content_block_delta thinking_delta → null (skipped)", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "content_block_delta", delta: { type: "thinking_delta", text: "thinking..." } },
+      ID, MODEL, CREATED
+    )
+    expect(chunk).toBeNull()
+  })
+
+  it("message_delta end_turn → finish chunk with stop", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      ID, MODEL, CREATED
+    )
+    expect(chunk).not.toBeNull()
+    expect(chunk!.choices[0].finish_reason).toBe("stop")
+    expect(chunk!.choices[0].delta).toEqual({})
+  })
+
+  it("message_delta max_tokens → finish chunk with length", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "message_delta", delta: { stop_reason: "max_tokens" } },
+      ID, MODEL, CREATED
+    )
+    expect(chunk!.choices[0].finish_reason).toBe("length")
+  })
+
+  it("ping → null", () => {
+    expect(translateAnthropicSseEvent({ type: "ping" }, ID, MODEL, CREATED)).toBeNull()
+  })
+
+  it("content_block_start → null", () => {
+    expect(translateAnthropicSseEvent({ type: "content_block_start" }, ID, MODEL, CREATED)).toBeNull()
+  })
+
+  it("content_block_stop → null", () => {
+    expect(translateAnthropicSseEvent({ type: "content_block_stop" }, ID, MODEL, CREATED)).toBeNull()
+  })
+
+  it("message_stop → null", () => {
+    expect(translateAnthropicSseEvent({ type: "message_stop" }, ID, MODEL, CREATED)).toBeNull()
+  })
+
+  it("chunk carries correct id, model, created, object", () => {
+    const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED)
+    expect(chunk!.id).toBe(ID)
+    expect(chunk!.model).toBe(MODEL)
+    expect(chunk!.created).toBe(CREATED)
+    expect(chunk!.object).toBe("chat.completion.chunk")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildModelList
+// ---------------------------------------------------------------------------
+
+describe("buildModelList", () => {
+  it("returns 3 models", () => {
+    expect(buildModelList(true).length).toBe(3)
+    expect(buildModelList(false).length).toBe(3)
+  })
+
+  it("Max subscription gets 1M context for sonnet and opus", () => {
+    const models = buildModelList(true)
+    const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
+    const opus = models.find(m => m.id === "claude-opus-4-6")!
+    expect(sonnet.context_window).toBe(1_000_000)
+    expect(opus.context_window).toBe(1_000_000)
+  })
+
+  it("non-Max gets 200k context for sonnet and opus", () => {
+    const models = buildModelList(false)
+    const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
+    const opus = models.find(m => m.id === "claude-opus-4-6")!
+    expect(sonnet.context_window).toBe(200_000)
+    expect(opus.context_window).toBe(200_000)
+  })
+
+  it("haiku is always 200k regardless of subscription", () => {
+    expect(buildModelList(true).find(m => m.id === "claude-haiku-4-5-20251001")!.context_window).toBe(200_000)
+    expect(buildModelList(false).find(m => m.id === "claude-haiku-4-5-20251001")!.context_window).toBe(200_000)
+  })
+
+  it("all models have correct object type", () => {
+    buildModelList(true).forEach(m => expect(m.object).toBe("model"))
+  })
+
+  it("uses provided timestamp", () => {
+    const ts = 9999999
+    buildModelList(true, ts).forEach(m => expect(m.created).toBe(ts))
+  })
+})

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Integration tests for OpenAI-compatible endpoints.
+ *
+ * Tests /v1/chat/completions (streaming + non-streaming) and /v1/models
+ * through the full HTTP layer with a mocked SDK.
+ *
+ * These tests verify:
+ *   1. Correct OpenAI response shapes (no regressions in the translation)
+ *   2. Proper routing to the internal /v1/messages handler
+ *   3. Error handling (empty messages, upstream errors)
+ *   4. Existing /v1/messages behavior is unaffected (no regressions)
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+  assistantMessage,
+  parseSSE,
+} from "./helpers"
+
+let mockMessages: unknown[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => {
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function postChatCompletion(app: ReturnType<typeof createTestApp>, body: Record<string, unknown>) {
+  return app.fetch(new Request("http://localhost/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/chat/completions — non-streaming", () => {
+  beforeEach(() => {
+    mockMessages = []
+    clearSessionCache()
+  })
+
+  it("returns OpenAI completion shape for a simple message", async () => {
+    mockMessages = [assistantMessage([{ type: "text", text: "Hello!" }])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 50,
+      stream: false,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.object).toBe("chat.completion")
+    expect(typeof body.id).toBe("string")
+    expect((body.id as string).startsWith("chatcmpl-")).toBe(true)
+    expect(body.model).toBe("claude-haiku-4-5-20251001")
+    const choices = body.choices as Array<Record<string, unknown>>
+    expect(choices).toBeArray()
+    expect(choices[0].message).toEqual({ role: "assistant", content: "Hello!" })
+    expect(choices[0].finish_reason).toBe("stop")
+    const usage = body.usage as Record<string, number>
+    expect(typeof usage.prompt_tokens).toBe("number")
+    expect(typeof usage.completion_tokens).toBe("number")
+    expect(typeof usage.total_tokens).toBe("number")
+  })
+
+  it("returns 400 for missing messages field", async () => {
+    const app = createTestApp()
+    const res = await postChatCompletion(app, {
+      model: "claude-haiku-4-5-20251001",
+      stream: false,
+      // messages intentionally omitted
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.type).toBe("error")
+  })
+
+  it("returns 400 for empty messages array", async () => {
+    const app = createTestApp()
+    const res = await postChatCompletion(app, {
+      model: "claude-haiku-4-5-20251001",
+      stream: false,
+      messages: [],
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it("filters thinking blocks from response", async () => {
+    mockMessages = [assistantMessage([
+      { type: "thinking", thinking: "internal thoughts" },
+      { type: "text", text: "public answer" },
+    ])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: false,
+      messages: [{ role: "user", content: "think" }],
+    })
+
+    const body = await res.json() as Record<string, unknown>
+    const choices = body.choices as Array<Record<string, unknown>>
+    expect((choices[0].message as Record<string, unknown>).content).toBe("public answer")
+  })
+
+  it("handles system message correctly", async () => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: false,
+      messages: [
+        { role: "system", content: "You are a pirate." },
+        { role: "user", content: "Hello" },
+      ],
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it("response has Content-Type application/json", async () => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: false,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(res.headers.get("content-type")).toContain("application/json")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/chat/completions — streaming", () => {
+  beforeEach(() => {
+    mockMessages = []
+    clearSessionCache()
+  })
+
+  async function readStream(res: Response): Promise<string> {
+    const reader = res.body!.getReader()
+    const decoder = new TextDecoder()
+    let text = ""
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      text += decoder.decode(value, { stream: true })
+    }
+    return text
+  }
+
+  it("returns text/event-stream content type", async () => {
+    mockMessages = [
+      messageStart("msg_1"), textBlockStart(0), textDelta(0, "hi"),
+      blockStop(0), messageDelta("end_turn"), messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("text/event-stream")
+  })
+
+  it("emits OpenAI SSE chunks with correct shape", async () => {
+    mockMessages = [
+      messageStart("msg_1"), textBlockStart(0), textDelta(0, "hello"),
+      blockStop(0), messageDelta("end_turn"), messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    const dataLines = text.split("\n").filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+    expect(dataLines.length).toBeGreaterThan(0)
+
+    const firstChunk = JSON.parse(dataLines[0].slice(6)) as Record<string, unknown>
+    expect(firstChunk.object).toBe("chat.completion.chunk")
+    expect(typeof firstChunk.id).toBe("string")
+    expect((firstChunk.id as string).startsWith("chatcmpl-")).toBe(true)
+
+    const choices = firstChunk.choices as Array<Record<string, unknown>>
+    expect(choices[0].delta).toHaveProperty("role", "assistant")
+  })
+
+  it("emits text content chunks", async () => {
+    mockMessages = [
+      messageStart("msg_1"), textBlockStart(0),
+      textDelta(0, "Hello"), textDelta(0, " World"),
+      blockStop(0), messageDelta("end_turn"), messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    const contentChunks = text.split("\n")
+      .filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+      .map(l => JSON.parse(l.slice(6)) as Record<string, unknown>)
+      .filter(c => {
+        const choices = c.choices as Array<Record<string, unknown>>
+        const delta = choices[0].delta as Record<string, unknown>
+        return typeof delta.content === "string" && delta.content.length > 0
+      })
+      .map(c => {
+        const choices = c.choices as Array<Record<string, unknown>>
+        return (choices[0].delta as Record<string, unknown>).content as string
+      })
+
+    expect(contentChunks.join("")).toBe("Hello World")
+  })
+
+  it("emits finish_reason stop in final chunk", async () => {
+    mockMessages = [
+      messageStart("msg_1"), textBlockStart(0), textDelta(0, "done"),
+      blockStop(0), messageDelta("end_turn"), messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    const chunks = text.split("\n")
+      .filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+      .map(l => JSON.parse(l.slice(6)) as Record<string, unknown>)
+
+    const finishChunk = chunks.find(c => {
+      const choices = c.choices as Array<Record<string, unknown>>
+      return choices[0].finish_reason !== null
+    })
+    expect(finishChunk).toBeDefined()
+    const choices = finishChunk!.choices as Array<Record<string, unknown>>
+    expect(choices[0].finish_reason).toBe("stop")
+  })
+
+  it("ends stream with data: [DONE]", async () => {
+    mockMessages = [
+      messageStart("msg_1"), textBlockStart(0), textDelta(0, "ok"),
+      blockStop(0), messageDelta("end_turn"), messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    expect(text).toContain("data: [DONE]")
+  })
+
+  it("all chunks share the same completion id", async () => {
+    mockMessages = [
+      messageStart("msg_1"), textBlockStart(0),
+      textDelta(0, "a"), textDelta(0, "b"),
+      blockStop(0), messageDelta("end_turn"), messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    const ids = text.split("\n")
+      .filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+      .map(l => (JSON.parse(l.slice(6)) as Record<string, unknown>).id as string)
+
+    const uniqueIds = new Set(ids)
+    expect(uniqueIds.size).toBe(1)
+    expect([...uniqueIds][0]).toMatch(/^chatcmpl-/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /v1/models
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/models", () => {
+  it("returns model list in OpenAI format", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/models"))
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.object).toBe("list")
+    const data = body.data as Array<Record<string, unknown>>
+    expect(data).toBeArray()
+    expect(data.length).toBeGreaterThan(0)
+  })
+
+  it("includes claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5-20251001", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await res.json() as Record<string, unknown>
+    const ids = (body.data as Array<Record<string, unknown>>).map(m => m.id)
+    expect(ids).toContain("claude-sonnet-4-6")
+    expect(ids).toContain("claude-opus-4-6")
+    expect(ids).toContain("claude-haiku-4-5-20251001")
+  })
+
+  it("each model has required fields", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await res.json() as Record<string, unknown>
+    for (const model of body.data as Array<Record<string, unknown>>) {
+      expect(model.object).toBe("model")
+      expect(typeof model.id).toBe("string")
+      expect(typeof model.context_window).toBe("number")
+      expect(typeof model.created).toBe("number")
+    }
+  })
+
+  it("context_window is a positive number for all models", async () => {
+    // Subscription-dependent value tested in openai.test.ts unit tests
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await res.json() as Record<string, unknown>
+    for (const model of body.data as Array<Record<string, unknown>>) {
+      expect(model.context_window as number).toBeGreaterThan(0)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: existing /v1/messages still works
+// ---------------------------------------------------------------------------
+
+describe("Regression: /v1/messages unaffected", () => {
+  beforeEach(() => {
+    mockMessages = []
+    clearSessionCache()
+  })
+
+  it("still returns Anthropic format from /v1/messages", async () => {
+    mockMessages = [assistantMessage([{ type: "text", text: "Anthropic response" }])]
+    const app = createTestApp()
+
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: 50,
+        stream: false,
+        messages: [{ role: "user", content: "Hi" }],
+      }),
+    }))
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    // Anthropic format has "type": "message", not "object": "chat.completion"
+    expect(body.type).toBe("message")
+    expect(body.role).toBe("assistant")
+    expect(body.object).toBeUndefined()
+  })
+
+  it("/v1/messages 400 for missing messages still works", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "claude-haiku-4-5-20251001", stream: false }),
+    }))
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -1,0 +1,339 @@
+/**
+ * OpenAI ↔ Anthropic format translation.
+ *
+ * Pure functions — no I/O, no side effects. Used by the /v1/chat/completions
+ * and /v1/models routes in server.ts.
+ *
+ * Design note: OpenAI clients always send the full conversation history on
+ * every request. Feeding that directly into Meridian's session system would
+ * classify every turn as "undo" or "diverged" (since the message list keeps
+ * changing). Instead:
+ *   1. The last user message becomes the actual SDK request
+ *   2. Prior turns are packed into a <conversation_history> block in the
+ *      system prompt so Claude has context
+ *   3. Each chat completions request gets a fresh SDK session
+ * This is intentional — OpenAI-format clients replay full history themselves
+ * and don't benefit from Meridian's session resumption.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type OpenAiRole = "system" | "user" | "assistant"
+
+export interface OpenAiContentPart {
+  type: string
+  text?: string
+}
+
+export interface OpenAiMessage {
+  role: OpenAiRole
+  content: string | OpenAiContentPart[]
+}
+
+export interface OpenAiChatRequest {
+  model?: string
+  messages?: OpenAiMessage[]
+  stream?: boolean
+  max_tokens?: number
+  max_completion_tokens?: number
+  temperature?: number
+  top_p?: number
+}
+
+export interface AnthropicMessage {
+  role: "user" | "assistant"
+  content: string
+}
+
+export interface AnthropicRequestBody {
+  model: string
+  messages: AnthropicMessage[]
+  max_tokens: number
+  stream: boolean
+  system?: string
+  temperature?: number
+  top_p?: number
+}
+
+export interface AnthropicUsage {
+  input_tokens?: number
+  output_tokens?: number
+}
+
+export interface AnthropicContentBlock {
+  type: string
+  text?: string
+}
+
+export interface AnthropicResponse {
+  content?: AnthropicContentBlock[]
+  stop_reason?: string
+  usage?: AnthropicUsage
+}
+
+export interface OpenAiStreamChunk {
+  id: string
+  object: "chat.completion.chunk"
+  created: number
+  model: string
+  choices: Array<{
+    index: 0
+    delta: { role?: "assistant"; content?: string }
+    finish_reason: "stop" | "length" | null
+  }>
+}
+
+export interface OpenAiCompletion {
+  id: string
+  object: "chat.completion"
+  created: number
+  model: string
+  choices: Array<{
+    index: 0
+    message: { role: "assistant"; content: string }
+    finish_reason: "stop" | "length"
+  }>
+  usage: {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+  }
+}
+
+export interface OpenAiModel {
+  id: string
+  object: "model"
+  created: number
+  owned_by: string
+  display_name: string
+  context_window: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalise an OpenAI message content field to a plain string.
+ * Handles both string content and structured content arrays.
+ */
+export function extractOpenAiContent(content: string | OpenAiContentPart[]): string {
+  if (typeof content === "string") return content
+  return content
+    .filter(p => p.type === "text" && typeof p.text === "string")
+    .map(p => p.text!)
+    .join("")
+}
+
+// ---------------------------------------------------------------------------
+// Request translation: OpenAI → Anthropic
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate an OpenAI /v1/chat/completions request body into an Anthropic
+ * /v1/messages request body.
+ *
+ * Returns null if the request has no messages (caller should return 400).
+ */
+export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRequestBody | null {
+  const messages = body.messages ?? []
+  if (messages.length === 0) return null
+
+  // Separate system messages from conversation turns
+  const systemParts: string[] = []
+  const turns: AnthropicMessage[] = []
+
+  for (const msg of messages) {
+    const text = extractOpenAiContent(msg.content ?? "")
+    if (msg.role === "system") {
+      if (text) systemParts.push(text)
+    } else {
+      turns.push({
+        role: msg.role === "assistant" ? "assistant" : "user",
+        content: text,
+      })
+    }
+  }
+
+  // Pack prior turns into system context so each request is a fresh session.
+  // OpenAI clients resend full history; Meridian's session system would
+  // misclassify repeated history as undo/diverged. This avoids that.
+  let systemPrompt = systemParts.join("\n")
+  let messagesToSend: AnthropicMessage[] = turns
+
+  if (turns.length > 1) {
+    const history = turns.slice(0, -1)
+      .map(m => `${m.role}: ${m.content}`)
+      .join("\n")
+    const historyBlock =
+      `<conversation_history>\n${history}\n</conversation_history>\n\n` +
+      `Continue this conversation naturally. Respond to the user's latest message.`
+    systemPrompt = systemPrompt
+      ? `${systemPrompt}\n\n${historyBlock}`
+      : historyBlock
+    messagesToSend = turns.slice(-1)
+  }
+
+  const result: AnthropicRequestBody = {
+    model: body.model ?? "claude-sonnet-4-6",
+    messages: messagesToSend,
+    max_tokens: body.max_tokens ?? body.max_completion_tokens ?? 8192,
+    stream: body.stream ?? false,
+  }
+
+  if (systemPrompt) result.system = systemPrompt
+  if (body.temperature !== undefined) result.temperature = body.temperature
+  if (body.top_p !== undefined) result.top_p = body.top_p
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Response translation: Anthropic → OpenAI (non-streaming)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an Anthropic stop_reason to an OpenAI finish_reason.
+ */
+function toFinishReason(stopReason: string | undefined): "stop" | "length" {
+  if (stopReason === "max_tokens") return "length"
+  return "stop"
+}
+
+/**
+ * Translate a complete Anthropic /v1/messages response to OpenAI format.
+ * Thinking blocks are filtered out — only text blocks are included.
+ */
+export function translateAnthropicToOpenAi(
+  response: AnthropicResponse,
+  completionId: string,
+  model: string,
+  created: number
+): OpenAiCompletion {
+  const content = (response.content ?? [])
+    .filter(b => b.type === "text" && typeof b.text === "string")
+    .map(b => b.text!)
+    .join("")
+
+  const promptTokens = response.usage?.input_tokens ?? 0
+  const completionTokens = response.usage?.output_tokens ?? 0
+
+  return {
+    id: completionId,
+    object: "chat.completion",
+    created,
+    model,
+    choices: [{
+      index: 0,
+      message: { role: "assistant", content },
+      finish_reason: toFinishReason(response.stop_reason),
+    }],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stream translation: Anthropic SSE event → OpenAI SSE chunk
+// ---------------------------------------------------------------------------
+
+interface AnthropicSseEvent {
+  type: string
+  delta?: { type?: string; text?: string; stop_reason?: string }
+  message?: { id?: string }
+}
+
+/**
+ * Translate one parsed Anthropic SSE event into an OpenAI stream chunk.
+ * Returns null for events that should be skipped (pings, block starts, etc).
+ */
+export function translateAnthropicSseEvent(
+  event: AnthropicSseEvent,
+  completionId: string,
+  model: string,
+  created: number
+): OpenAiStreamChunk | null {
+  // Initial chunk: role announcement
+  if (event.type === "message_start") {
+    return {
+      id: completionId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{ index: 0, delta: { role: "assistant", content: "" }, finish_reason: null }],
+    }
+  }
+
+  // Text content delta
+  if (
+    event.type === "content_block_delta" &&
+    event.delta?.type === "text_delta" &&
+    typeof event.delta.text === "string"
+  ) {
+    return {
+      id: completionId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{ index: 0, delta: { content: event.delta.text }, finish_reason: null }],
+    }
+  }
+
+  // Finish chunk
+  if (event.type === "message_delta" && event.delta?.stop_reason) {
+    return {
+      id: completionId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: toFinishReason(event.delta.stop_reason) }],
+    }
+  }
+
+  // All other events (ping, content_block_start, content_block_stop,
+  // message_stop, thinking_delta, etc.) are skipped
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Model list
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the static list of available Claude models in OpenAI format.
+ * Context windows reflect subscription capabilities.
+ */
+export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date.now() / 1000)): OpenAiModel[] {
+  const extendedContext = isMaxSubscription ? 1_000_000 : 200_000
+  return [
+    {
+      id: "claude-sonnet-4-6",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Sonnet 4.6",
+      context_window: extendedContext,
+    },
+    {
+      id: "claude-opus-4-6",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Opus 4.6",
+      context_window: extendedContext,
+    },
+    {
+      id: "claude-haiku-4-5-20251001",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Haiku 4.5",
+      context_window: 200_000,
+    },
+  ]
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -21,6 +21,7 @@ import { classifyError, isStaleSessionError, isRateLimitError, isExtraUsageRequi
 import { refreshOAuthToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
+import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, translateAnthropicSseEvent, buildModelList } from "./openai"
 import { getLastUserMessage } from "./messages"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -140,7 +141,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         status: "ok",
         service: "meridian",
         format: "anthropic",
-        endpoints: ["/v1/messages", "/messages", "/telemetry", "/health"]
+        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/models", "/telemetry", "/health"]
       })
     }
     return c.html(landingHtml)
@@ -1422,6 +1423,108 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       { success: false, message: "Token refresh failed. If the problem persists, run 'claude login'." },
       500
     )
+  })
+
+  // --- OpenAI Chat Completions Compatibility ---
+  // Translates OpenAI /v1/chat/completions requests to Anthropic format and
+  // routes them through the internal /v1/messages handler via app.fetch().
+  // No network roundtrip — Hono resolves the route in-process.
+  // See src/proxy/openai.ts for the translation logic and design rationale.
+  app.post("/v1/chat/completions", async (c) => {
+    const rawBody = await c.req.json() as Record<string, unknown>
+    const anthropicBody = translateOpenAiToAnthropic(rawBody)
+
+    if (!anthropicBody) {
+      return c.json(
+        { type: "error", error: { type: "invalid_request_error", message: "messages: Field required" } },
+        400
+      )
+    }
+
+    // Route internally via app.fetch() — no network roundtrip.
+    // Hono resolves the path in-process; the URL scheme/host are ignored.
+    const internalReq = new Request("http://internal/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(anthropicBody),
+    })
+    const internalRes = await app.fetch(internalReq)
+
+    if (!internalRes.ok) {
+      const errBody = await internalRes.text()
+      return c.json(
+        { type: "error", error: { type: "upstream_error", message: errBody } },
+        internalRes.status as 400 | 401 | 429 | 500
+      )
+    }
+
+    const completionId = `chatcmpl-${randomUUID()}`
+    const created = Math.floor(Date.now() / 1000)
+    const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : "claude-sonnet-4-6"
+
+    if (!anthropicBody.stream) {
+      const anthropicRes = await internalRes.json() as Record<string, unknown>
+      return c.json(translateAnthropicToOpenAi(anthropicRes, completionId, model, created))
+    }
+
+    // Streaming: translate Anthropic SSE events to OpenAI SSE chunks
+    const encoder = new TextEncoder()
+    const readable = new ReadableStream({
+      async start(controller) {
+        const reader = internalRes.body?.getReader()
+        if (!reader) { controller.close(); return }
+
+        const decoder = new TextDecoder()
+        let buffer = ""
+        let streamError: Error | null = null
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+
+            buffer += decoder.decode(value, { stream: true })
+            const lines = buffer.split("\n")
+            buffer = lines.pop() ?? ""
+
+            for (const line of lines) {
+              if (!line.startsWith("data: ")) continue
+              const dataStr = line.slice(6).trim()
+              if (!dataStr) continue
+
+              let event: Record<string, unknown>
+              try { event = JSON.parse(dataStr) as Record<string, unknown> }
+              catch { continue }
+
+              const chunk = translateAnthropicSseEvent(event, completionId, model, created)
+              if (chunk) controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
+            }
+          }
+        } catch (err) {
+          streamError = err instanceof Error ? err : new Error(String(err))
+        } finally {
+          if (!streamError) controller.enqueue(encoder.encode("data: [DONE]\n\n"))
+          controller.close()
+        }
+      },
+    })
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      },
+    })
+  })
+
+  // --- Model Discovery ---
+  // Returns available Claude models in OpenAI-compatible format.
+  // Context window reflects the subscription tier (Max = 1M, others = 200k).
+  app.get("/v1/models", async (c) => {
+    const authStatus = await getClaudeAuthStatusAsync()
+    const isMax = authStatus?.subscriptionType === "max"
+    return c.json({ object: "list", data: buildModelList(isMax) })
   })
 
   // Catch-all: log unhandled requests


### PR DESCRIPTION
## Summary

- Adds `POST /v1/chat/completions` — translates OpenAI chat format to Anthropic `/v1/messages` internally, with full streaming (SSE) and non-streaming support
- Adds `GET /v1/models` — returns available Claude models in OpenAI-compatible format, with context window based on subscription type
- Enables clients like **Open WebUI** to connect directly to Meridian without needing LiteLLM or other translation proxies

## Motivation

Many popular LLM frontends (Open WebUI, Continue, etc.) only speak the OpenAI protocol. Currently, using Meridian with these tools requires an intermediate proxy like LiteLLM to translate between OpenAI and Anthropic formats. This adds complexity, an extra container to manage, and introduces streaming translation bugs.

These two endpoints make Meridian a drop-in replacement that works with any OpenAI-compatible client out of the box.

## Implementation Details

**`/v1/chat/completions`**
- Extracts system prompts from the OpenAI messages array into Anthropic's top-level `system` field
- For multi-turn conversations, packs prior messages into system context and sends only the last user message — this avoids conflicts with Meridian's session resumption (OpenAI clients send full history with every request, they don't use session continuations)
- Translates Anthropic SSE events (`content_block_delta`, `message_delta`, `message_start`) to OpenAI SSE chunks (`chat.completion.chunk`)
- Forwards `temperature`, `top_p`, `max_tokens`/`max_completion_tokens`

**`/v1/models`**
- Returns `claude-sonnet-4-6`, `claude-opus-4-6`, `claude-haiku-4-5-20251001`
- Sets `context_window` to 1M for Max subscriptions, 200K otherwise
- Response format matches what clients expect from `/v1/models`

## Test plan

- [x] Non-streaming single message
- [x] Streaming single message
- [x] Multi-turn conversation (3+ turns, streaming)
- [x] System prompt handling
- [x] Multiple system messages (concatenated)
- [x] Different models (Sonnet, Opus, Haiku)
- [x] Temperature and top_p passthrough
- [x] Minimal payload (no model, no max_tokens — defaults applied)
- [x] Empty messages array (returns error correctly)
- [x] Unknown model names (graceful fallback to Sonnet)
- [x] `/v1/models` returns correct model list
- [x] Open WebUI integration — full end-to-end chat with streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)