### PR TITLE
fix: correct ci.yml YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,3 @@ jobs:
       - run: bun install
       - run: npm test
       - run: bun run build
-</content>
-</invoke>


### PR DESCRIPTION
Removes stray `</content></invoke>` XML artifact that crept into the file, causing the workflow to fail with a YAML parse error.