### PR TITLE
fix: Fix missing path parameter fallback in OpenCode file change tracking

### DIFF
--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -501,6 +501,21 @@ describe("openCodeAdapter.extractFileChangesFromToolUse", () => {
   it("should return empty for bash without redirects", () => {
     expect(openCodeAdapter.extractFileChangesFromToolUse!("bash", { command: "ls -la" })).toEqual([])
   })
+
+  it("should detect write with path parameter", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { path: "src/new.ts", content: "x" })
+    expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])
+  })
+
+  it("should detect edit with path parameter", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("edit", { path: "src/old.ts", oldString: "a", newString: "b" })
+    expect(result).toEqual([{ operation: "edited", path: "src/old.ts" }])
+  })
+
+  it("should prefer filePath over path", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { filePath: "correct.ts", path: "fallback.ts" })
+    expect(result).toEqual([{ operation: "wrote", path: "correct.ts" }])
+  })
 })
 
 describe("crushAdapter.extractFileChangesFromToolUse", () => {

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -101,7 +101,7 @@ export const openCodeAdapter: AgentAdapter = {
    */
   extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
     const input = toolInput as Record<string, unknown> | null | undefined
-    const filePath = input?.filePath ?? input?.file_path
+    const filePath = input?.filePath ?? input?.file_path ?? input?.path
 
     const lowerName = toolName.toLowerCase()
     if (lowerName === "write" && filePath) {


### PR DESCRIPTION
**Problem**
In passthrough mode, the extractFileChangesFromToolUse method in the OpenCode adapter only checked for filePath and file_path parameters when extracting file changes from tool_use blocks. This caused the "Files changed:" summary to silently miss edit/write operations when tools use the path parameter name.

**Impact**
- Passthrough mode users (OpenCode/Build via Meridian) don't see file changes reflected in the "Files changed:" summary
- LiteLLM users (which also use passthrough mode) have no visibility into which files were modified
- The diff block rendering in OpenCode is unaffected (client-side feature), but the file change summary is incomplete

**Root cause**
The parameter resolution chain was incomplete:
// Before
const filePath = input?.filePath ?? input?.file_path
// Missing fallback for tools that use 'path' parameter
This is inconsistent with:
- Internal mode (fileChanges.ts): uses path for all MCP tool inputs
- Crush adapter (adapters/crush.ts): already includes file_path ?? path

**Solution**
Add input?.path as a fallback in the parameter resolution chain:
// After
const filePath = input?.filePath ?? input?.file_path ?? input?.path
Precedence order (most to least specific):
1. filePath — OpenCode native convention
2. file_path — SDK passthrough convention  
3. path — internal MCP tool convention

**Testing**
Added three test cases to verify:
- ✅ Write operations with path parameter
- ✅ Edit operations with path parameter
- ✅ Correct precedence: filePath wins over path
Existing test coverage ensures filePath wins over file_path.

**Scope**
- Files changed: 2
  - src/proxy/adapters/opencode.ts (1 line)
  - src/__tests__/file-changes-unit.test.ts (15 lines)
- No breaking changes — purely additive fallback
- Isolated to OpenCode adapter — crush and internal mode unaffected