### PR TITLE
fix: respect client stream parameter in passthrough adapter

### DIFF
--- a/src/proxy/adapters/passthrough.ts
+++ b/src/proxy/adapters/passthrough.ts
@@ -134,11 +134,11 @@ export const passthroughAdapter: AgentAdapter = {
   },
 
   /**
-   * LiteLLM expects non-streaming (JSON) responses.
-   * Health checks don't send x-litellm-* headers, so we can't distinguish
-   * them from regular requests — non-streaming is safe for all LiteLLM traffic.
+   * Respect the client's stream parameter.
+   * LiteLLM sends stream=true for streaming requests and stream=false (or omits it)
+   * for non-streaming requests including health checks.
    */
-  prefersStreaming(_body: any): boolean {
-    return false
+  prefersStreaming(body: any): boolean {
+    return body?.stream === true
   },
 }


### PR DESCRIPTION
## Summary

The passthrough adapter (for LiteLLM requests) hardcodes `prefersStreaming()` to always return `false`, forcing non-streaming JSON responses regardless of the client's `stream` parameter.

This breaks LiteLLM streaming: when LiteLLM sends `stream: true`, it expects SSE events back but receives a JSON blob instead. LiteLLM's streaming handler then produces a single empty chunk, causing downstream consumers (e.g. OpenClaw) to receive no content.

**Fix:** Change `prefersStreaming` to check `body.stream` instead of hardcoding `false`:
- `stream: true` → SSE event stream (streaming works)
- `stream: false` or omitted → JSON response (non-streaming + health checks still work)

## Root cause analysis

LiteLLM sets `User-Agent: litellm/*`, which triggers Meridian's passthrough adapter detection. The adapter then forces `stream=false` on the Claude SDK call. LiteLLM's streaming handler receives a complete JSON response instead of SSE chunks, and its Anthropic-to-OpenAI streaming converter silently produces an empty `finish_reason: "stop"` chunk with no content.

## Test plan

- [x] LiteLLM streaming requests (`stream: true`) return proper SSE events with content
- [x] LiteLLM non-streaming requests (`stream: false`) return JSON responses
- [x] Health checks (no `stream` parameter) continue to work
- [x] Meridian health endpoint returns healthy status