### PR TITLE
ci: add Docker image build and publish workflow (ghcr.io)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/docker.yml` to build and publish the Docker image to `ghcr.io`
- Multi-platform: `linux/amd64` + `linux/arm64`
- Uses GHA layer cache for faster incremental builds
- Integrates with existing `release-please` workflow — version tags (`v*`) produce semver-tagged images automatically

## Behavior

| Trigger | Action |
|---------|--------|
| Push to `main` | Build + push `ghcr.io/rynfar/meridian:latest` |
| Tag `v1.2.3` | Build + push `ghcr.io/rynfar/meridian:1.2.3` and `1.2` |
| Pull request | Build only (validates Dockerfile, no push) |
| `workflow_dispatch` | Manual build + push |

## Motivation

Currently there is no official Docker image for meridian, which means users who want to run it in containers (NAS, homelab, Portainer, etc.) have to build it themselves. Publishing to `ghcr.io` requires no extra secrets — only the built-in `GITHUB_TOKEN`.

## Tested

Validated on fork [`beshkenadze/meridian`](https://github.com/beshkenadze/meridian/actions) — both PR (build-only) and push-to-main (build+push) runs completed successfully for both platforms.