### PR TITLE
feat: add pi coding agent adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ---
 
-Meridian turns your Claude Max subscription into a local Anthropic API. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, Crush, Cline, Aider, Open WebUI — connects to Meridian and gets Claude, powered by your existing subscription through the official Claude Code SDK.
+Meridian turns your Claude Max subscription into a local Anthropic API. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, Crush, Cline, Aider, Pi, Droid, Open WebUI — connects to Meridian and gets Claude, powered by your existing subscription through the official Claude Code SDK.
 
 > [!NOTE]
 > **Renamed from `opencode-claude-max-proxy`.** If you're upgrading, see [`MIGRATION.md`](MIGRATION.md) for the checklist. Your existing sessions, env vars, and agent configs all continue to work.
@@ -192,6 +192,49 @@ Point any OpenAI-compatible tool at `http://127.0.0.1:3456` with any API key val
 
 > **Note:** Multi-turn conversations work by packing prior turns into the system prompt. Each request is a fresh SDK session — OpenAI clients replay full history themselves and don't use Meridian's session resumption.
 
+### Pi
+
+Pi uses the `@mariozechner/pi-ai` library which supports a configurable `baseUrl` on the model. Add a provider-level override in `~/.pi/agent/models.json`:
+
+```json
+{
+  "anthropic": {
+    "baseUrl": "http://127.0.0.1:3456"
+  }
+}
+```
+
+Then start Meridian with the pi default adapter:
+
+```bash
+MERIDIAN_DEFAULT_AGENT=pi meridian
+```
+
+Pi mimics Claude Code's User-Agent, so automatic detection isn't possible. The `MERIDIAN_DEFAULT_AGENT` env var tells Meridian to use the pi adapter for all unrecognized requests. If you run other agents alongside pi, use the `x-meridian-agent: pi` header instead (requires pi-ai support for custom headers).
+
+### OpenClaw
+
+OpenClaw uses `@mariozechner/pi-ai` under the hood, so the pi adapter handles it with no additional code. Add a provider override in `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "models": {
+    "providers": {
+      "anthropic": {
+        "baseUrl": "http://127.0.0.1:3456",
+        "apiKey": "dummy",
+        "models": [
+          { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (Meridian)" },
+          { "id": "claude-opus-4-6", "name": "Claude Opus 4.6 (Meridian)" }
+        ]
+      }
+    }
+  }
+}
+```
+
+Then start Meridian with the pi adapter: `MERIDIAN_DEFAULT_AGENT=pi meridian`
+
 ### Any Anthropic-compatible tool
 
 ```bash
@@ -209,6 +252,8 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 | [Cline](https://github.com/cline/cline) | ✅ Verified | Config (see above) — full tool support, file read/write/edit, bash, session resume |
 | [Aider](https://github.com/paul-gauthier/aider) | ✅ Verified | Env vars — file editing, streaming; `--no-stream` broken (litellm bug) |
 | [Open WebUI](https://github.com/open-webui/open-webui) | ✅ Verified | OpenAI-compatible endpoints — set base URL to `http://127.0.0.1:3456` |
+| [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see above) — requires `MERIDIAN_DEFAULT_AGENT=pi` |
+| [OpenClaw](https://github.com/openclaw/openclaw) | ✅ Verified | Provider config (see above) — uses pi adapter via `MERIDIAN_DEFAULT_AGENT=pi` |
 | [Continue](https://github.com/continuedev/continue) | 🔲 Untested | OpenAI-compatible endpoints should work — set `apiBase` to `http://127.0.0.1:3456` |
 
 Tested an agent or built a plugin? [Open an issue](https://github.com/rynfar/meridian/issues) and we'll add it.
@@ -224,6 +269,7 @@ src/proxy/
 │   ├── opencode.ts        ← OpenCode adapter
 │   ├── crush.ts           ← Crush adapter
 │   ├── droid.ts           ← Droid adapter
+│   ├── pi.ts              ← Pi adapter
 │   └── passthrough.ts     ← LiteLLM passthrough adapter
 ├── query.ts               ← SDK query options builder
 ├── errors.ts              ← Error classification
@@ -258,11 +304,13 @@ Sessions are stored in-memory (LRU) and persisted to `~/.cache/meridian/sessions
 
 Agents are identified from request headers automatically:
 
-| User-Agent prefix | Adapter |
+| Signal | Adapter |
 |---|---|
-| `Charm-Crush/` | Crush |
-| `factory-cli/` | Droid |
-| *(anything else)* | OpenCode (default) |
+| `x-meridian-agent` header | Explicit override (any adapter) |
+| `Charm-Crush/` User-Agent | Crush |
+| `factory-cli/` User-Agent | Droid |
+| `litellm/` UA or `x-litellm-*` headers | LiteLLM passthrough |
+| *(anything else)* | `MERIDIAN_DEFAULT_AGENT` env var, or OpenCode |
 
 ### Adding a New Agent
 
@@ -283,6 +331,7 @@ Implement the `AgentAdapter` interface in `src/proxy/adapters/`. See [`adapters/
 | `MERIDIAN_TELEMETRY_SIZE` | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
 | `MERIDIAN_NO_FILE_CHANGES` | `CLAUDE_PROXY_NO_FILE_CHANGES` | unset | Disable "Files changed" summary in responses |
 | `MERIDIAN_SONNET_MODEL` | `CLAUDE_PROXY_SONNET_MODEL` | `sonnet[1m]`* | Force sonnet tier: `sonnet` (200k) or `sonnet[1m]` (1M). Set to `sonnet` if you hit 1M context rate limits |
+| `MERIDIAN_DEFAULT_AGENT` | — | `opencode` | Default adapter for unrecognized agents: `opencode`, `pi`, `crush`, `droid`, `passthrough`. Requires restart. |
 
 *`sonnet[1m]` requires Max subscription with Extra Usage enabled. Falls back to `sonnet` automatically if not available.
 

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -11,6 +11,18 @@ import { openCodeAdapter } from "./opencode"
 import { droidAdapter } from "./droid"
 import { crushAdapter } from "./crush"
 import { passthroughAdapter } from "./passthrough"
+import { piAdapter } from "./pi"
+
+const ADAPTER_MAP: Record<string, AgentAdapter> = {
+  opencode: openCodeAdapter,
+  droid: droidAdapter,
+  crush: crushAdapter,
+  passthrough: passthroughAdapter,
+  pi: piAdapter,
+}
+
+const defaultAdapter: AgentAdapter =
+  ADAPTER_MAP[process.env.MERIDIAN_DEFAULT_AGENT || ""] ?? openCodeAdapter
 
 /**
  * Detect LiteLLM requests via User-Agent or x-litellm-* headers.
@@ -29,12 +41,18 @@ function isLiteLLMRequest(c: Context): boolean {
  * Detect which agent adapter to use based on request headers.
  *
  * Detection rules (evaluated in order):
- * 1. User-Agent starts with "factory-cli/"  → Droid adapter
- * 2. User-Agent starts with "Charm-Crush/"  → Crush adapter
- * 3. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
- * 4. Default                                → OpenCode adapter (backward compatible)
+ * 1. x-meridian-agent header               → explicit adapter override
+ * 2. User-Agent starts with "factory-cli/"  → Droid adapter
+ * 3. User-Agent starts with "Charm-Crush/"  → Crush adapter
+ * 4. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
+ * 5. Default                                → MERIDIAN_DEFAULT_AGENT env var, or OpenCode
  */
 export function detectAdapter(c: Context): AgentAdapter {
+  const agentOverride = c.req.header("x-meridian-agent")
+  if (agentOverride && ADAPTER_MAP[agentOverride]) {
+    return ADAPTER_MAP[agentOverride]!
+  }
+
   const userAgent = c.req.header("user-agent") || ""
 
   if (userAgent.startsWith("factory-cli/")) {
@@ -49,5 +67,5 @@ export function detectAdapter(c: Context): AgentAdapter {
     return passthroughAdapter
   }
 
-  return openCodeAdapter
+  return defaultAdapter
 }

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -1,0 +1,162 @@
+/**
+ * Pi coding agent adapter.
+ *
+ * Provides pi-specific behavior for session tracking, working directory
+ * extraction, content normalization, and tool configuration.
+ *
+ * Pi (@mariozechner/pi-coding-agent) is a CLI coding agent that makes
+ * standard Anthropic Messages API calls. When using a custom baseUrl
+ * (pointing at Meridian), pi operates in non-OAuth mode with lowercase
+ * tool names and its own tool execution loop.
+ *
+ * Key characteristics:
+ * - User-Agent: claude-cli/<version> (mimics Claude Code) or default SDK UA
+ * - No session header: relies on fingerprint-based session cache
+ * - CWD in system prompt: "Current working directory: /path/to/project"
+ * - 7 lowercase tools: read, write, edit, bash, grep, find, ls
+ * - Always streams (stream: true)
+ * - Manages its own tool execution loop: passthrough mode is appropriate
+ * - No subagent routing: pi-coding-agent is single-agent (pylon adds orchestration on top)
+ *
+ * Detection: pi mimics Claude Code's User-Agent, so automatic detection is
+ * unreliable. Use one of:
+ * - x-meridian-agent: pi header (per-request)
+ * - MERIDIAN_DEFAULT_AGENT=pi env var (global default)
+ */
+
+import type { Context } from "hono"
+import type { AgentAdapter } from "../adapter"
+import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
+import { normalizeContent } from "../messages"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../tools"
+
+const PI_MCP_SERVER_NAME = "pi"
+
+const PI_ALLOWED_MCP_TOOLS: readonly string[] = [
+  `mcp__${PI_MCP_SERVER_NAME}__read`,
+  `mcp__${PI_MCP_SERVER_NAME}__write`,
+  `mcp__${PI_MCP_SERVER_NAME}__edit`,
+  `mcp__${PI_MCP_SERVER_NAME}__bash`,
+  `mcp__${PI_MCP_SERVER_NAME}__grep`,
+]
+
+/**
+ * Extract the client's working directory from pi's system prompt.
+ *
+ * Pi embeds CWD as a plain line in the system prompt:
+ *   Current working directory: /path/to/project
+ *
+ * This differs from OpenCode's <env> block format.
+ */
+function extractPiCwd(body: any): string | undefined {
+  let systemText = ""
+  if (typeof body.system === "string") {
+    systemText = body.system
+  } else if (Array.isArray(body.system)) {
+    systemText = body.system
+      .filter((b: any) => b.type === "text" && b.text)
+      .map((b: any) => b.text)
+      .join("\n")
+  }
+  if (!systemText) return undefined
+
+  const match = systemText.match(/Current working directory:\s*([^\n]+)/i)
+  return match?.[1]?.trim() || undefined
+}
+
+export const piAdapter: AgentAdapter = {
+  name: "pi",
+
+  /**
+   * Pi sends no session header.
+   * Session continuity is maintained via fingerprint-based cache lookup.
+   */
+  getSessionId(_c: Context): string | undefined {
+    return undefined
+  },
+
+  extractWorkingDirectory(body: any): string | undefined {
+    return extractPiCwd(body)
+  },
+
+  normalizeContent(content: any): string {
+    return normalizeContent(content)
+  },
+
+  /**
+   * Pi uses lowercase tool names (read, write, edit, bash) which don't
+   * conflict with SDK built-in PascalCase names (Read, Write, Edit, Bash).
+   * Block the SDK built-ins regardless to prevent ambiguity.
+   */
+  getBlockedBuiltinTools(): readonly string[] {
+    return BLOCKED_BUILTIN_TOOLS
+  },
+
+  /**
+   * Pi doesn't have equivalents for Claude Code SDK-only tools
+   * (cron jobs, mode switching, worktree management, etc.).
+   */
+  getAgentIncompatibleTools(): readonly string[] {
+    return CLAUDE_CODE_ONLY_TOOLS
+  },
+
+  getMcpServerName(): string {
+    return PI_MCP_SERVER_NAME
+  },
+
+  getAllowedMcpTools(): readonly string[] {
+    return PI_ALLOWED_MCP_TOOLS
+  },
+
+  /**
+   * Pi manages its own subagents via pylon-orchestrator (an extension),
+   * not via SDK agent routing. No SDK definitions needed.
+   */
+  buildSdkAgents(_body: any, _mcpToolNames: readonly string[]): Record<string, any> {
+    return {}
+  },
+
+  /**
+   * No PreToolUse hooks needed — pi handles its own tool execution.
+   */
+  buildSdkHooks(_body: any, _sdkAgents: Record<string, any>): undefined {
+    return undefined
+  },
+
+  /**
+   * No additional system context needed for pi.
+   */
+  buildSystemContextAddendum(_body: any, _sdkAgents: Record<string, any>): string {
+    return ""
+  },
+
+  /**
+   * Pi handles its own tool execution loop (standard Anthropic tool_use /
+   * tool_result cycle). Passthrough mode is appropriate: the proxy returns
+   * tool_use blocks to pi, which executes them and sends back tool_results.
+   *
+   * Like Crush, defer to CLAUDE_PROXY_PASSTHROUGH env var so the same
+   * global setting controls both agents.
+   */
+  // usesPassthrough not defined — defers to CLAUDE_PROXY_PASSTHROUGH env var
+
+  /**
+   * Pi uses lowercase tool names: read, write, edit, bash.
+   * Input path field is filePath (camelCase).
+   */
+  extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
+    const input = toolInput as Record<string, unknown> | null | undefined
+    const filePath = input?.filePath ?? input?.file_path ?? input?.path
+
+    if (toolName === "write" && filePath) {
+      return [{ operation: "wrote", path: String(filePath) }]
+    }
+    if (toolName === "edit" && filePath) {
+      return [{ operation: "edited", path: String(filePath) }]
+    }
+    if (toolName === "bash" && input?.command) {
+      return extractFileChangesFromBash(String(input.command))
+    }
+    return []
+  },
+}


### PR DESCRIPTION
## What

Adds a Pi coding agent adapter so [@mariozechner/pi-coding-agent](https://github.com/nicobailey/pi-coding-agent) can route through Meridian.

## Why

Anthropic blocked OAuth subscription tokens for third-party tools on April 4, 2026. Pi (and tools built on pi-ai like OpenClaw) need Meridian to continue using Claude Max subscriptions.

## Changes

### New: `src/proxy/adapters/pi.ts`
Pi adapter implementing the full `AgentAdapter` interface:
- **Session tracking**: fingerprint-based (no session header)
- **CWD extraction**: parses `Current working directory: /path` from pi's system prompt
- **Tool mapping**: lowercase `read`, `write`, `edit`, `bash`, `grep` with `filePath` input
- **Passthrough**: defers to `CLAUDE_PROXY_PASSTHROUGH` env var
- **No subagent routing**: pi is single-agent (pylon-orchestrator adds orchestration separately)

### Updated: `src/proxy/adapters/detect.ts`
- **`x-meridian-agent` header**: explicit per-request adapter override (works for any adapter)
- **`MERIDIAN_DEFAULT_AGENT` env var**: configurable default adapter fallback
- Pi mimics Claude Code's User-Agent (`claude-cli/2.1.75`), so automatic UA detection isn't possible — use the env var or header instead

### Updated: `README.md`
- Pi setup section under Agent Setup
- Pi in Tested Agents table
- `pi.ts` in architecture tree
- Updated Agent Detection table with new detection rules
- `MERIDIAN_DEFAULT_AGENT` in Configuration table

## Testing

Verified end-to-end:
- `MERIDIAN_DEFAULT_AGENT=pi meridian` starts correctly
- Pi headless (`pi --print`) routes through Meridian and gets responses
- OpenClaw (`openclaw agent --local`) also works through the same adapter (uses pi-ai under the hood)
- Telemetry confirms requests flowing through proxy (status 200, passthrough mode)
- Zero new type errors (`tsc --noEmit` clean on `src/proxy/`)

## Setup

```bash
# Pi: ~/.pi/agent/models.json
{ "anthropic": { "baseUrl": "http://127.0.0.1:3456" } }

# Start Meridian
MERIDIAN_DEFAULT_AGENT=pi meridian
```