### PR TITLE
fix: use envBool() for passthrough env var detection

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -5,6 +5,7 @@ import type { Server } from "node:http"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
+import { envBool } from "../env"
 import type { ProxyConfig, ProxyInstance, ProxyServer } from "./types"
 export type { ProxyConfig, ProxyInstance, ProxyServer }
 import { claudeLog } from "../logger"
@@ -449,7 +450,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const adapterPassthrough = adapter.usesPassthrough?.()
       const passthrough = adapterPassthrough !== undefined
         ? adapterPassthrough
-        : Boolean((process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH))
+        : envBool("PASSTHROUGH")
       const capturedToolUses: Array<{ id: string; name: string; input: any }> = []
       const fileChanges: FileChange[] = []
 
@@ -1389,7 +1390,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           requestModel: undefined,
           mode: "non-stream",
           isResume: false,
-          isPassthrough: Boolean((process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH)),
+          isPassthrough: envBool("PASSTHROUGH"),
           lineageType: undefined,
           messageCount: undefined,
           sdkSessionId: undefined,
@@ -1439,7 +1440,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         return c.json({
           status: "degraded",
           error: "Could not verify auth status",
-          mode: (process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH) ? "passthrough" : "internal",
+          mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         })
       }
       if (!auth.loggedIn) {
@@ -1456,14 +1457,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           email: auth.email,
           subscriptionType: auth.subscriptionType,
         },
-        mode: (process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH) ? "passthrough" : "internal",
+        mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         plugin: { opencode: checkPluginConfigured() ? "configured" : "not-configured" },
       })
     } catch {
       return c.json({
         status: "degraded",
         error: "Could not verify auth status",
-        mode: (process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH) ? "passthrough" : "internal",
+        mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
       })
     }
   })


### PR DESCRIPTION
## Summary
Replace manual `Boolean(process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH)` checks in `server.ts` with the existing `envBool("PASSTHROUGH")` helper from `src/env.ts`.

`envBool()` uses a whitelist approach — only `"1"`, `"true"`, `"yes"` enable passthrough. Everything else (including `"0"`, `"false"`, `""`, unset) disables it.

## Problem
- `Boolean("0")` is `true` in JavaScript, so `MERIDIAN_PASSTHROUGH=0` does **not** disable passthrough
- Some orchestrators (Portainer GitOps, etc.) strip empty-string env vars, so `MERIDIAN_PASSTHROUGH=""` may not override the Dockerfile default `CLAUDE_PROXY_PASSTHROUGH=1`
- The `envBool()` helper already exists in `src/env.ts` but wasn't being used for passthrough detection

## Changes
- Import `envBool` from `../env` in `server.ts`
- Replace 5 manual `Boolean()` / ternary passthrough checks with `envBool("PASSTHROUGH")`
- No Dockerfile changes — existing default preserved for backward compatibility

## Test plan
- [ ] `MERIDIAN_PASSTHROUGH=1` → `/health` returns `"mode":"passthrough"`
- [ ] `MERIDIAN_PASSTHROUGH=true` → `"mode":"passthrough"`
- [ ] `MERIDIAN_PASSTHROUGH=0` → `"mode":"internal"` (previously broken: was `"passthrough"`)
- [ ] `MERIDIAN_PASSTHROUGH=false` → `"mode":"internal"`
- [ ] No env var set → falls back to `CLAUDE_PROXY_PASSTHROUGH` from Dockerfile → `"mode":"passthrough"`