### PR TITLE
fix: OpenCode auto-detection, adapter telemetry, pi adapter improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,12 @@
     "opencode",
     "cline",
     "aider",
+    "crush",
+    "charmbracelet",
+    "droid",
+    "factory-ai",
+    "pi-coding-agent",
+    "open-webui",
     "llm",
     "coding-assistant",
     "opencode-claude-max-proxy"

--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -10,13 +10,22 @@ import { detectAdapter } from "../proxy/adapters/detect"
 import { openCodeAdapter } from "../proxy/adapters/opencode"
 import { droidAdapter } from "../proxy/adapters/droid"
 import { crushAdapter } from "../proxy/adapters/crush"
+import { piAdapter } from "../proxy/adapters/pi"
+import { passthroughAdapter } from "../proxy/adapters/passthrough"
 
-function makeContext(userAgent: string): any {
+function makeContext(userAgent: string, extraHeaders?: Record<string, string>): any {
+  const allHeaders: Record<string, string> = {}
+  if (userAgent) allHeaders["user-agent"] = userAgent
+  if (extraHeaders) {
+    for (const [k, v] of Object.entries(extraHeaders)) {
+      allHeaders[k.toLowerCase()] = v
+    }
+  }
   return {
     req: {
       header: (name?: string) => {
-        if (!name) return userAgent ? { "user-agent": userAgent } : {}
-        return name.toLowerCase() === "user-agent" ? userAgent : undefined
+        if (!name) return { ...allHeaders }
+        return allHeaders[name.toLowerCase()]
       },
     },
   }
@@ -101,6 +110,81 @@ describe("detectAdapter — OpenCode fallback", () => {
 
   it("does NOT match 'Charm-Crush' as OpenCode", () => {
     expect(detectAdapter(makeContext("Charm-Crush/v0.51.2")).name).toBe("crush")
+  })
+})
+
+describe("detectAdapter — x-meridian-agent header override", () => {
+  it("returns piAdapter when x-meridian-agent is 'pi'", () => {
+    const adapter = detectAdapter(makeContext("", { "x-meridian-agent": "pi" }))
+    expect(adapter).toBe(piAdapter)
+    expect(adapter.name).toBe("pi")
+  })
+
+  it("returns crushAdapter when x-meridian-agent is 'crush'", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "crush" }))).toBe(crushAdapter)
+  })
+
+  it("returns openCodeAdapter when x-meridian-agent is 'opencode'", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "opencode" }))).toBe(openCodeAdapter)
+  })
+
+  it("returns droidAdapter when x-meridian-agent is 'droid'", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "droid" }))).toBe(droidAdapter)
+  })
+
+  it("returns passthroughAdapter when x-meridian-agent is 'passthrough'", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "passthrough" }))).toBe(passthroughAdapter)
+  })
+
+  it("is case-insensitive on header value", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "Pi" })).name).toBe("pi")
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "PI" })).name).toBe("pi")
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "CRUSH" })).name).toBe("crush")
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "OpenCode" })).name).toBe("opencode")
+  })
+
+  it("takes precedence over User-Agent detection", () => {
+    expect(detectAdapter(makeContext("factory-cli/1.0.0", { "x-meridian-agent": "pi" }))).toBe(piAdapter)
+  })
+
+  it("takes precedence over x-opencode-session detection", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "pi", "x-opencode-session": "sess-123" }))).toBe(piAdapter)
+  })
+
+  it("falls through for unknown header values", () => {
+    expect(detectAdapter(makeContext("factory-cli/1.0.0", { "x-meridian-agent": "unknown" }))).toBe(droidAdapter)
+  })
+})
+
+describe("detectAdapter — OpenCode detection", () => {
+  it("returns openCodeAdapter when x-opencode-session is present", () => {
+    const adapter = detectAdapter(makeContext("", { "x-opencode-session": "sess-abc" }))
+    expect(adapter).toBe(openCodeAdapter)
+    expect(adapter.name).toBe("opencode")
+  })
+
+  it("returns openCodeAdapter when x-session-affinity is present", () => {
+    const adapter = detectAdapter(makeContext("", { "x-session-affinity": "ses_2a50aeb32ffe" }))
+    expect(adapter).toBe(openCodeAdapter)
+  })
+
+  it("returns openCodeAdapter for 'opencode/' User-Agent", () => {
+    const adapter = detectAdapter(makeContext("opencode/1.3.15 ai-sdk/provider-utils/4.0.21"))
+    expect(adapter).toBe(openCodeAdapter)
+  })
+
+  it("returns openCodeAdapter for any 'opencode/' version", () => {
+    expect(detectAdapter(makeContext("opencode/0.1.0")).name).toBe("opencode")
+    expect(detectAdapter(makeContext("opencode/2.0.0")).name).toBe("opencode")
+    expect(detectAdapter(makeContext("opencode/99.99.99")).name).toBe("opencode")
+  })
+
+  it("returns openCodeAdapter regardless of User-Agent when session header present", () => {
+    expect(detectAdapter(makeContext("claude-cli/1.0.0", { "x-opencode-session": "sess-xyz" }))).toBe(openCodeAdapter)
+  })
+
+  it("returns openCodeAdapter even with unknown UA when session-affinity present", () => {
+    expect(detectAdapter(makeContext("curl/7.88.0", { "x-session-affinity": "ses_123" }))).toBe(openCodeAdapter)
   })
 })
 

--- a/src/__tests__/pi-adapter.test.ts
+++ b/src/__tests__/pi-adapter.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the Pi coding agent adapter.
+ */
+import { describe, it, expect } from "bun:test"
+import { piAdapter } from "../proxy/adapters/pi"
+
+describe("piAdapter — identity", () => {
+  it("has name 'pi'", () => {
+    expect(piAdapter.name).toBe("pi")
+  })
+})
+
+describe("piAdapter.getSessionId", () => {
+  it("always returns undefined — Pi sends no session header", () => {
+    const ctx = {
+      req: { header: () => "any-value" },
+    }
+    expect(piAdapter.getSessionId(ctx as any)).toBeUndefined()
+  })
+
+  it("returns undefined even when x-opencode-session is present", () => {
+    const ctx = {
+      req: {
+        header: (name: string) =>
+          name === "x-opencode-session" ? "sess-abc" : undefined,
+      },
+    }
+    expect(piAdapter.getSessionId(ctx as any)).toBeUndefined()
+  })
+})
+
+describe("piAdapter.extractWorkingDirectory", () => {
+  it("extracts CWD from string system prompt", () => {
+    const body = {
+      system: "You are an expert coding assistant.\nCurrent working directory: /Users/test/project\nMore instructions here.",
+    }
+    expect(piAdapter.extractWorkingDirectory(body)).toBe("/Users/test/project")
+  })
+
+  it("extracts CWD from array system prompt", () => {
+    const body = {
+      system: [
+        { type: "text", text: "You are an expert coding assistant." },
+        { type: "text", text: "Current working directory: /tmp/my-repo" },
+      ],
+    }
+    expect(piAdapter.extractWorkingDirectory(body)).toBe("/tmp/my-repo")
+  })
+
+  it("extracts CWD case-insensitively", () => {
+    const body = {
+      system: "current working directory: /home/user/project",
+    }
+    expect(piAdapter.extractWorkingDirectory(body)).toBe("/home/user/project")
+  })
+
+  it("returns undefined when system prompt is missing", () => {
+    expect(piAdapter.extractWorkingDirectory({})).toBeUndefined()
+  })
+
+  it("returns undefined when system prompt has no CWD line", () => {
+    const body = {
+      system: "You are a helpful assistant. No directory info here.",
+    }
+    expect(piAdapter.extractWorkingDirectory(body)).toBeUndefined()
+  })
+
+  it("returns undefined for empty string system", () => {
+    expect(piAdapter.extractWorkingDirectory({ system: "" })).toBeUndefined()
+  })
+
+  it("returns undefined for empty array system", () => {
+    expect(piAdapter.extractWorkingDirectory({ system: [] })).toBeUndefined()
+  })
+
+  it("handles system array with non-text blocks", () => {
+    const body = {
+      system: [
+        { type: "image", source: {} },
+        { type: "text", text: "Current working directory: /opt/app" },
+      ],
+    }
+    expect(piAdapter.extractWorkingDirectory(body)).toBe("/opt/app")
+  })
+
+  it("trims trailing whitespace from CWD", () => {
+    const body = {
+      system: "Current working directory: /Users/test/project   \nNext line",
+    }
+    expect(piAdapter.extractWorkingDirectory(body)).toBe("/Users/test/project")
+  })
+})
+
+describe("piAdapter.normalizeContent", () => {
+  it("normalizes string content", () => {
+    expect(piAdapter.normalizeContent("hello world")).toBe("hello world")
+  })
+
+  it("normalizes array of text blocks", () => {
+    const content = [
+      { type: "text", text: "First block" },
+      { type: "text", text: "Second block" },
+    ]
+    const result = piAdapter.normalizeContent(content)
+    expect(result).toContain("First block")
+    expect(result).toContain("Second block")
+  })
+
+  it("normalizes tool_use blocks", () => {
+    const content = [
+      { type: "tool_use", id: "tu_1", name: "bash", input: { command: "ls" } },
+    ]
+    const result = piAdapter.normalizeContent(content)
+    expect(result).toContain("tool_use")
+    expect(result).toContain("bash")
+  })
+
+  it("handles null content", () => {
+    expect(piAdapter.normalizeContent(null as any)).toBe("null")
+  })
+})
+
+describe("piAdapter tool configuration", () => {
+  it("getBlockedBuiltinTools includes SDK PascalCase tool names", () => {
+    const blocked = piAdapter.getBlockedBuiltinTools()
+    expect(blocked).toContain("Read")
+    expect(blocked).toContain("Write")
+    expect(blocked).toContain("Edit")
+    expect(blocked).toContain("Bash")
+    expect(blocked).toContain("Glob")
+    expect(blocked).toContain("Grep")
+  })
+
+  it("getBlockedBuiltinTools does NOT include Pi's lowercase tool names", () => {
+    const blocked = piAdapter.getBlockedBuiltinTools()
+    expect(blocked).not.toContain("bash")
+    expect(blocked).not.toContain("edit")
+    expect(blocked).not.toContain("write")
+    expect(blocked).not.toContain("read")
+    expect(blocked).not.toContain("grep")
+  })
+
+  it("getAgentIncompatibleTools includes Claude-Code-only tools", () => {
+    const incompatible = piAdapter.getAgentIncompatibleTools()
+    expect(incompatible).toContain("EnterPlanMode")
+    expect(incompatible).toContain("ExitPlanMode")
+    expect(incompatible).toContain("ToolSearch")
+    expect(incompatible).toContain("CronCreate")
+    expect(incompatible).toContain("EnterWorktree")
+  })
+
+  it("getMcpServerName returns 'pi'", () => {
+    expect(piAdapter.getMcpServerName()).toBe("pi")
+  })
+
+  it("getAllowedMcpTools returns exactly 6 tools", () => {
+    expect(piAdapter.getAllowedMcpTools()).toHaveLength(6)
+  })
+
+  it("getAllowedMcpTools all have mcp__pi__ prefix", () => {
+    for (const tool of piAdapter.getAllowedMcpTools()) {
+      expect(tool).toStartWith("mcp__pi__")
+    }
+  })
+
+  it("getAllowedMcpTools covers the standard set", () => {
+    const tools = piAdapter.getAllowedMcpTools()
+    expect(tools).toContain("mcp__pi__read")
+    expect(tools).toContain("mcp__pi__write")
+    expect(tools).toContain("mcp__pi__edit")
+    expect(tools).toContain("mcp__pi__bash")
+    expect(tools).toContain("mcp__pi__glob")
+    expect(tools).toContain("mcp__pi__grep")
+  })
+})
+
+describe("piAdapter.buildSdkAgents", () => {
+  it("always returns empty object", () => {
+    expect(piAdapter.buildSdkAgents!({}, [])).toEqual({})
+  })
+})
+
+describe("piAdapter.buildSdkHooks", () => {
+  it("always returns undefined", () => {
+    expect(piAdapter.buildSdkHooks!({}, {})).toBeUndefined()
+  })
+})
+
+describe("piAdapter.buildSystemContextAddendum", () => {
+  it("always returns empty string", () => {
+    expect(piAdapter.buildSystemContextAddendum!({}, {})).toBe("")
+  })
+})
+
+describe("piAdapter.usesPassthrough", () => {
+  it("is not defined — defers to CLAUDE_PROXY_PASSTHROUGH env var", () => {
+    expect(piAdapter.usesPassthrough).toBeUndefined()
+  })
+})
+
+describe("piAdapter.extractFileChangesFromToolUse", () => {
+  it("detects write with filePath", () => {
+    const changes = piAdapter.extractFileChangesFromToolUse!("write", { filePath: "/tmp/test.ts", content: "hello" })
+    expect(changes).toEqual([{ operation: "wrote", path: "/tmp/test.ts" }])
+  })
+
+  it("detects write with file_path fallback", () => {
+    const changes = piAdapter.extractFileChangesFromToolUse!("write", { file_path: "/tmp/test.ts" })
+    expect(changes).toEqual([{ operation: "wrote", path: "/tmp/test.ts" }])
+  })
+
+  it("detects write with path fallback", () => {
+    const changes = piAdapter.extractFileChangesFromToolUse!("write", { path: "/tmp/test.ts" })
+    expect(changes).toEqual([{ operation: "wrote", path: "/tmp/test.ts" }])
+  })
+
+  it("detects edit with filePath", () => {
+    const changes = piAdapter.extractFileChangesFromToolUse!("edit", { filePath: "/tmp/test.ts" })
+    expect(changes).toEqual([{ operation: "edited", path: "/tmp/test.ts" }])
+  })
+
+  it("detects bash commands with output redirects", () => {
+    const changes = piAdapter.extractFileChangesFromToolUse!("bash", { command: "echo hello > /tmp/out.txt" })
+    expect(changes.length).toBeGreaterThan(0)
+    expect(changes[0].path).toBe("/tmp/out.txt")
+  })
+
+  it("returns empty for read tool", () => {
+    expect(piAdapter.extractFileChangesFromToolUse!("read", { filePath: "/tmp/test.ts" })).toEqual([])
+  })
+
+  it("returns empty for grep tool", () => {
+    expect(piAdapter.extractFileChangesFromToolUse!("grep", { pattern: "TODO" })).toEqual([])
+  })
+
+  it("returns empty for write with no path", () => {
+    expect(piAdapter.extractFileChangesFromToolUse!("write", { content: "hello" })).toEqual([])
+  })
+
+  it("returns empty for bash with no command", () => {
+    expect(piAdapter.extractFileChangesFromToolUse!("bash", {})).toEqual([])
+  })
+
+  it("returns empty for null input", () => {
+    expect(piAdapter.extractFileChangesFromToolUse!("write", null)).toEqual([])
+  })
+})

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -21,8 +21,14 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   pi: piAdapter,
 }
 
-const defaultAdapter: AgentAdapter =
-  ADAPTER_MAP[process.env.MERIDIAN_DEFAULT_AGENT || ""] ?? openCodeAdapter
+const envDefault = process.env.MERIDIAN_DEFAULT_AGENT || ""
+if (envDefault && !ADAPTER_MAP[envDefault]) {
+  console.warn(
+    `[meridian] Unknown MERIDIAN_DEFAULT_AGENT="${envDefault}". ` +
+    `Valid values: ${Object.keys(ADAPTER_MAP).join(", ")}. Falling back to opencode.`
+  )
+}
+const defaultAdapter: AgentAdapter = ADAPTER_MAP[envDefault] ?? openCodeAdapter
 
 /**
  * Detect LiteLLM requests via User-Agent or x-litellm-* headers.
@@ -42,18 +48,30 @@ function isLiteLLMRequest(c: Context): boolean {
  *
  * Detection rules (evaluated in order):
  * 1. x-meridian-agent header               → explicit adapter override
- * 2. User-Agent starts with "factory-cli/"  → Droid adapter
- * 3. User-Agent starts with "Charm-Crush/"  → Crush adapter
- * 4. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
- * 5. Default                                → MERIDIAN_DEFAULT_AGENT env var, or OpenCode
+ * 2. x-opencode-session or x-session-affinity header → OpenCode adapter
+ * 3. User-Agent starts with "opencode/"     → OpenCode adapter
+ * 4. User-Agent starts with "factory-cli/"  → Droid adapter
+ * 5. User-Agent starts with "Charm-Crush/"  → Crush adapter
+ * 6. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
+ * 7. Default                                → MERIDIAN_DEFAULT_AGENT env var, or OpenCode
  */
 export function detectAdapter(c: Context): AgentAdapter {
-  const agentOverride = c.req.header("x-meridian-agent")
+  const agentOverride = c.req.header("x-meridian-agent")?.toLowerCase()
   if (agentOverride && ADAPTER_MAP[agentOverride]) {
     return ADAPTER_MAP[agentOverride]!
   }
 
+  // OpenCode: plugin injects x-opencode-session; newer versions use x-session-affinity
+  if (c.req.header("x-opencode-session") || c.req.header("x-session-affinity")) {
+    return openCodeAdapter
+  }
+
   const userAgent = c.req.header("user-agent") || ""
+
+  // OpenCode User-Agent: opencode/<version>
+  if (userAgent.startsWith("opencode/")) {
+    return openCodeAdapter
+  }
 
   if (userAgent.startsWith("factory-cli/")) {
     return droidAdapter

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -37,6 +37,7 @@ const PI_ALLOWED_MCP_TOOLS: readonly string[] = [
   `mcp__${PI_MCP_SERVER_NAME}__write`,
   `mcp__${PI_MCP_SERVER_NAME}__edit`,
   `mcp__${PI_MCP_SERVER_NAME}__bash`,
+  `mcp__${PI_MCP_SERVER_NAME}__glob`,
   `mcp__${PI_MCP_SERVER_NAME}__grep`,
 ]
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -192,6 +192,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const requestStartAt = Date.now()
 
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
+      // Hoist adapter detection before try so it's available in the catch block for telemetry
+      const adapter = detectAdapter(c)
       try {
         const body = await c.req.json()
 
@@ -206,7 +208,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const authStatus = await getClaudeAuthStatusAsync()
         const agentMode = c.req.header("x-opencode-agent-mode") ?? null
         let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType, agentMode)
-        const adapter = detectAdapter(c)
         // Allow adapter to override streaming preference (e.g. LiteLLM requires non-streaming)
         const adapterStreamPref = adapter.prefersStreaming?.(body)
         const stream = adapterStreamPref !== undefined ? adapterStreamPref : (body.stream ?? false)
@@ -281,7 +282,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }).join(" → ")
         const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
         const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
-        const requestLogLine = `${requestMeta.requestId} model=${model} stream=${stream} tools=${body.tools?.length ?? 0} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
+        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name} model=${model} stream=${stream} tools=${body.tools?.length ?? 0} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
         console.error(`[PROXY] ${requestLogLine} msgs=${msgSummary}`)
         diagnosticLog.session(`${requestLogLine}`, requestMeta.requestId)
 
@@ -804,6 +805,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           telemetryStore.record({
             requestId: requestMeta.requestId,
             timestamp: Date.now(),
+            adapter: adapter.name,
             model,
             requestModel: body.model || undefined,
             mode: "non-stream",
@@ -1337,6 +1339,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 telemetryStore.record({
                   requestId: requestMeta.requestId,
                   timestamp: Date.now(),
+                  adapter: adapter.name,
                   model,
                   requestModel: body.model || undefined,
                   mode: "stream",
@@ -1447,6 +1450,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         telemetryStore.record({
           requestId: requestMeta.requestId,
           timestamp: Date.now(),
+          adapter: adapter.name,
           model: "unknown",
           requestModel: undefined,
           mode: "non-stream",

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -236,7 +236,7 @@ function render(s, reqs, logs) {
     + '<span><span class="legend-dot" style="background:var(--ttfb)"></span>TTFB</span>'
     + '<span><span class="legend-dot" style="background:var(--upstream)"></span>Response</span>'
     + '</div>'
-    + '<table><thead><tr><th>Time</th><th>Model</th><th>Mode</th><th>Session</th><th>Status</th>'
+    + '<table><thead><tr><th>Time</th><th>Adapter</th><th>Model</th><th>Mode</th><th>Session</th><th>Status</th>'
     + '<th>Queue</th><th>Proxy</th><th>TTFB</th><th>Total</th><th>Waterfall</th></tr></thead><tbody>';
 
   const maxTotal = Math.max(...reqs.map(r => r.totalDurationMs), 1);
@@ -256,6 +256,7 @@ function render(s, reqs, logs) {
 
     html += '<tr>'
       + '<td class="mono">' + ago(r.timestamp) + '</td>'
+      + '<td>' + (r.adapter || '—') + '</td>'
       + '<td>' + (r.requestModel || r.model) + '<br><span style="font-size:10px;color:var(--muted)">' + r.model + '</span></td>'
       + '<td>' + r.mode + '</td>'
       + '<td class="mono">' + sessionShort + ' ' + lineageBadge + '<br><span style="font-size:10px;color:var(--muted)">' + msgCount + ' msgs</span></td>'

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -17,6 +17,9 @@ export interface RequestMetric {
   /** When this metric was recorded */
   timestamp: number
 
+  /** Which agent adapter handled this request */
+  adapter?: string
+
   /** Model used for SDK query (sonnet, opus, haiku, sonnet[1m], etc.) */
   model: string
 


### PR DESCRIPTION
## Summary

Improvements to the pi adapter and adapter detection system — OpenCode auto-detection, adapter telemetry, and pi adapter fixes.

## Changes

### OpenCode auto-detection (multi-agent support)
Previously, running Pi and OpenCode simultaneously required manual header configuration because Pi mimics Claude Code's User-Agent. Now OpenCode is auto-detected via three signals:
- `x-opencode-session` header (Meridian plugin)
- `x-session-affinity` header (newer OpenCode versions)
- `opencode/` User-Agent prefix

This means `MERIDIAN_DEFAULT_AGENT=pi` works correctly alongside OpenCode — no second proxy needed.

### Adapter telemetry
- `adapter=pi` / `adapter=opencode` in stderr log lines for debugging
- `adapter` field in telemetry JSON (`/telemetry/requests`)
- Adapter column in the telemetry dashboard (`/telemetry`)

### Pi adapter fixes
- Added missing `glob` to `PI_ALLOWED_MCP_TOOLS` (was 5 tools, now 6 — matching all other adapters)

### Detection hardening
- `x-meridian-agent` header value is now case-insensitive (`Pi`, `PI`, `pi` all work)
- Startup warning for invalid `MERIDIAN_DEFAULT_AGENT` values
- `MERIDIAN_DEFAULT_AGENT` restart requirement noted in README

### Tests
- New `pi-adapter.test.ts` — 34 tests covering all adapter methods
- Updated `adapter-detection.test.ts` — 68 new lines covering `x-meridian-agent` (all adapters, case-insensitive, precedence) and OpenCode detection (session headers, UA)

### Discoverability
- Added `crush`, `charmbracelet`, `droid`, `factory-ai`, `pi-coding-agent`, `open-webui` to package.json keywords
- Updated README detection table
