### PR TITLE
fix: respect client stream parameter in passthrough adapter

### DIFF
--- a/src/__tests__/proxy-litellm-adapter.test.ts
+++ b/src/__tests__/proxy-litellm-adapter.test.ts
@@ -203,9 +203,12 @@ describe("passthroughAdapter — passthrough and streaming", () => {
     expect(passthroughAdapter.usesPassthrough!()).toBe(true)
   })
 
-  it("prefersStreaming always returns false (LiteLLM needs non-streaming)", () => {
+  it("prefersStreaming respects body.stream", () => {
+    expect(passthroughAdapter.prefersStreaming!({ stream: true })).toBe(true)
+    expect(passthroughAdapter.prefersStreaming!({ stream: false })).toBe(false)
     expect(passthroughAdapter.prefersStreaming!({})).toBe(false)
-    expect(passthroughAdapter.prefersStreaming!({ stream: true })).toBe(false)
+    expect(passthroughAdapter.prefersStreaming!(undefined)).toBe(false)
+    expect(passthroughAdapter.prefersStreaming!(null)).toBe(false)
   })
 })
 

--- a/src/proxy/adapters/passthrough.ts
+++ b/src/proxy/adapters/passthrough.ts
@@ -8,8 +8,7 @@
  *
  * Key characteristics:
  * - Passthrough mode always enabled (overrides MERIDIAN_PASSTHROUGH env var)
- * - Non-streaming: LiteLLM health checks don't send x-litellm-* headers
- *   so we can't reliably distinguish them; non-streaming is safe for all requests
+ * - Streaming: respects the client's stream parameter (body.stream)
  * - Session continuity: uses x-litellm-session-id header when present
  * - CWD: extracts from <env cwd="..."> blocks in the prompt if available
  * - MCP server name: "litellm" (tools appear as mcp__litellm__*)


### PR DESCRIPTION
Based on #254 by @dayjoyx — thank you!

## Summary

The passthrough adapter (LiteLLM) hardcoded `prefersStreaming()` to `false`, breaking streaming for LiteLLM clients that send `stream: true`. LiteLLM's streaming handler received a JSON blob instead of SSE events, producing empty chunks.

## Changes

- `prefersStreaming(body)` now returns `body?.stream === true` instead of `false`
- Updated stale module-level comment (health check concern was unfounded — `/health` is a separate GET route)
- Updated existing test + added null/undefined edge cases

## Tested

- Non-streaming (`stream: false`): JSON response ✅
- Streaming (`stream: true`): SSE events with content ✅
- All 836 tests pass