### PR TITLE
fix: use envBool() for passthrough detection — Boolean('0') was truthy

### DIFF
--- a/src/__tests__/env-passthrough.test.ts
+++ b/src/__tests__/env-passthrough.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for envBool("PASSTHROUGH") behavior.
+ *
+ * Verifies that the passthrough env var is parsed correctly — in particular
+ * that "0" and "false" disable passthrough (Boolean("0") is true in JS,
+ * which was the original bug).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { envBool } from "../env"
+
+describe("envBool — PASSTHROUGH", () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    saved.MERIDIAN_PASSTHROUGH = process.env.MERIDIAN_PASSTHROUGH
+    saved.CLAUDE_PROXY_PASSTHROUGH = process.env.CLAUDE_PROXY_PASSTHROUGH
+    delete process.env.MERIDIAN_PASSTHROUGH
+    delete process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+
+  afterEach(() => {
+    if (saved.MERIDIAN_PASSTHROUGH !== undefined) {
+      process.env.MERIDIAN_PASSTHROUGH = saved.MERIDIAN_PASSTHROUGH
+    } else {
+      delete process.env.MERIDIAN_PASSTHROUGH
+    }
+    if (saved.CLAUDE_PROXY_PASSTHROUGH !== undefined) {
+      process.env.CLAUDE_PROXY_PASSTHROUGH = saved.CLAUDE_PROXY_PASSTHROUGH
+    } else {
+      delete process.env.CLAUDE_PROXY_PASSTHROUGH
+    }
+  })
+
+  it("returns true for MERIDIAN_PASSTHROUGH=1", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    expect(envBool("PASSTHROUGH")).toBe(true)
+  })
+
+  it("returns true for MERIDIAN_PASSTHROUGH=true", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "true"
+    expect(envBool("PASSTHROUGH")).toBe(true)
+  })
+
+  it("returns true for MERIDIAN_PASSTHROUGH=yes", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "yes"
+    expect(envBool("PASSTHROUGH")).toBe(true)
+  })
+
+  it("returns false for MERIDIAN_PASSTHROUGH=0 (Boolean('0') bug)", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+    expect(envBool("PASSTHROUGH")).toBe(false)
+  })
+
+  it("returns false for MERIDIAN_PASSTHROUGH=false", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "false"
+    expect(envBool("PASSTHROUGH")).toBe(false)
+  })
+
+  it("returns false for MERIDIAN_PASSTHROUGH=no", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "no"
+    expect(envBool("PASSTHROUGH")).toBe(false)
+  })
+
+  it("returns false for empty string", () => {
+    process.env.MERIDIAN_PASSTHROUGH = ""
+    expect(envBool("PASSTHROUGH")).toBe(false)
+  })
+
+  it("returns false when neither env var is set", () => {
+    expect(envBool("PASSTHROUGH")).toBe(false)
+  })
+
+  it("falls back to CLAUDE_PROXY_PASSTHROUGH when MERIDIAN_ is not set", () => {
+    process.env.CLAUDE_PROXY_PASSTHROUGH = "1"
+    expect(envBool("PASSTHROUGH")).toBe(true)
+  })
+
+  it("MERIDIAN_ takes precedence over CLAUDE_PROXY_", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+    process.env.CLAUDE_PROXY_PASSTHROUGH = "1"
+    expect(envBool("PASSTHROUGH")).toBe(false)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -5,6 +5,7 @@ import type { Server } from "node:http"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
+import { envBool } from "../env"
 import type { ProxyConfig, ProxyInstance, ProxyServer } from "./types"
 export type { ProxyConfig, ProxyInstance, ProxyServer }
 import { claudeLog } from "../logger"
@@ -450,7 +451,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const adapterPassthrough = adapter.usesPassthrough?.()
       const passthrough = adapterPassthrough !== undefined
         ? adapterPassthrough
-        : Boolean((process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH))
+        : envBool("PASSTHROUGH")
       const capturedToolUses: Array<{ id: string; name: string; input: any }> = []
       const fileChanges: FileChange[] = []
 
@@ -1455,7 +1456,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           requestModel: undefined,
           mode: "non-stream",
           isResume: false,
-          isPassthrough: Boolean((process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH)),
+          isPassthrough: envBool("PASSTHROUGH"),
           lineageType: undefined,
           messageCount: undefined,
           sdkSessionId: undefined,
@@ -1505,7 +1506,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         return c.json({
           status: "degraded",
           error: "Could not verify auth status",
-          mode: (process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH) ? "passthrough" : "internal",
+          mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         })
       }
       if (!auth.loggedIn) {
@@ -1522,14 +1523,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           email: auth.email,
           subscriptionType: auth.subscriptionType,
         },
-        mode: (process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH) ? "passthrough" : "internal",
+        mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         plugin: { opencode: checkPluginConfigured() ? "configured" : "not-configured" },
       })
     } catch {
       return c.json({
         status: "degraded",
         error: "Could not verify auth status",
-        mode: (process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH) ? "passthrough" : "internal",
+        mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
       })
     }
   })


### PR DESCRIPTION
Based on #261 by @beshkenadze — thank you!

## Problem

`Boolean('0')` is `true` in JavaScript, so `MERIDIAN_PASSTHROUGH=0` did **not** disable passthrough. Docker/Portainer users toggling env vars were affected.

## Fix

Replace 5 manual `Boolean(process.env.MERIDIAN_PASSTHROUGH ?? ...)` checks with `envBool('PASSTHROUGH')` which uses a whitelist: only `'1'`, `'true'`, `'yes'` enable passthrough.

## Headless validation

| Env value | Expected | Result |
|---|---|---|
| `1` | passthrough | ✅ passthrough |
| `0` | internal | ✅ internal (was broken) |
| `false` | internal | ✅ internal (was broken) |

## Tests

New `env-passthrough.test.ts` — 10 tests covering truthy values, falsy values, empty string, unset, legacy fallback, and precedence.