### PR TITLE
fix: add path parameter fallback in OpenCode file change tracking

### DIFF
--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -501,6 +501,21 @@ describe("openCodeAdapter.extractFileChangesFromToolUse", () => {
   it("should return empty for bash without redirects", () => {
     expect(openCodeAdapter.extractFileChangesFromToolUse!("bash", { command: "ls -la" })).toEqual([])
   })
+
+  it("should detect write with path parameter", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { path: "src/new.ts", content: "x" })
+    expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])
+  })
+
+  it("should detect edit with path parameter", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("edit", { path: "src/old.ts", oldString: "a", newString: "b" })
+    expect(result).toEqual([{ operation: "edited", path: "src/old.ts" }])
+  })
+
+  it("should prefer filePath over path", () => {
+    const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { filePath: "correct.ts", path: "fallback.ts" })
+    expect(result).toEqual([{ operation: "wrote", path: "correct.ts" }])
+  })
 })
 
 describe("crushAdapter.extractFileChangesFromToolUse", () => {

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -101,7 +101,7 @@ export const openCodeAdapter: AgentAdapter = {
    */
   extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
     const input = toolInput as Record<string, unknown> | null | undefined
-    const filePath = input?.filePath ?? input?.file_path
+    const filePath = input?.filePath ?? input?.file_path ?? input?.path
 
     const lowerName = toolName.toLowerCase()
     if (lowerName === "write" && filePath) {


### PR DESCRIPTION
Based on #253 by @endre82 — thank you!

## Problem

The OpenCode adapter only checked `filePath` and `file_path` when extracting file changes from tool_use blocks in passthrough mode. Tools using the `path` parameter (internal MCP convention) were silently missed in the "Files changed:" summary.

## Fix

Add `input?.path` as a third fallback: `filePath → file_path → path`

This matches the pattern already used by the Pi and Crush adapters, and is consistent with the internal MCP tools in `fileChanges.ts`.

## Tests

3 new test cases: write with `path`, edit with `path`, precedence (`filePath` wins over `path`). 849 tests pass.