### PR TITLE
fix: replace global claude-code install with SDK cli.js shim in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,21 @@ RUN deluser --remove-home node 2>/dev/null; \
     && mkdir -p /home/claude/.claude \
     && chown -R claude:claude /home/claude
 
-RUN npm install -g @anthropic-ai/claude-code \
-    && npm cache clean --force
-
 USER claude
 WORKDIR /app
 
 COPY --from=build --chown=claude:claude /app/node_modules ./node_modules
 COPY --from=build --chown=claude:claude /app/dist ./dist
 COPY --from=build --chown=claude:claude /app/package.json ./
+
+# Create a 'claude' wrapper that delegates to the SDK's cli.js.
+# This replaces the global @anthropic-ai/claude-code install which
+# ships a native binary that crashes under QEMU ARM emulation.
+# The SDK's cli.js supports all commands the proxy needs (auth status, etc.).
+RUN mkdir -p /app/bin/shims \
+    && printf '#!/bin/sh\nexec node /app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js "$@"\n' > /app/bin/shims/claude \
+    && chmod +x /app/bin/shims/claude
+ENV PATH="/app/bin/shims:$PATH"
 COPY --chown=claude:claude bin/docker-entrypoint.sh bin/claude-proxy-supervisor.sh ./bin/
 RUN chmod +x ./bin/docker-entrypoint.sh ./bin/claude-proxy-supervisor.sh
 


### PR DESCRIPTION
## Problem

The Docker workflow (#257) builds multi-platform images (amd64 + arm64). The arm64 build crashes during `npm install -g @anthropic-ai/claude-code` because the package ships a native binary that fails under QEMU emulation:

```
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
```

## Fix

Replace the global `claude-code` install with a lightweight shell shim:

```sh
#!/bin/sh
exec node /app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js "$@"
```

The SDK's bundled `cli.js` supports all commands the proxy needs (`auth status`, etc.), runs under plain Node.js on any platform, and is already present in `node_modules` from the build stage.

## Verified

- `node cli.js auth status` produces identical output to the native `claude` binary
- Removes ~200MB+ from the image (no global claude-code install)
- Unblocks arm64 Docker builds