### PR TITLE
fix: support running as root (Docker, Unraid, NAS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD node -e "const r=await fetch('http://127.0.0.1:3456/health');process.exit(r.ok?0:1)"
 
 ENV CLAUDE_PROXY_PASSTHROUGH=1 \
-    CLAUDE_PROXY_HOST=0.0.0.0
+    CLAUDE_PROXY_HOST=0.0.0.0 \
+    IS_SANDBOX=1
 ENTRYPOINT ["./bin/docker-entrypoint.sh"]
 CMD ["./bin/claude-proxy-supervisor.sh"]

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -119,6 +119,11 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
         ...cleanEnv,
         ENABLE_TOOL_SEARCH: "false",
         ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
+        // When running as root (Docker, Unraid, NAS), set IS_SANDBOX=1 to
+        // bypass the SDK's root check. Without this, the SDK exits with:
+        // "--dangerously-skip-permissions cannot be used with root/sudo"
+        // See: https://github.com/rynfar/meridian/issues/256
+        ...(process.getuid?.() === 0 ? { IS_SANDBOX: "1" } : {}),
       },
       ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),


### PR DESCRIPTION
Closes #256

## Problem

The Claude Code SDK rejects `--dangerously-skip-permissions` when running as root (uid 0), exiting with code 1:

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

This blocks Meridian on platforms that only have root: Unraid, some Docker setups, NAS appliances.

## Root cause

The SDK's cli.js has a hard check:
```javascript
process.getuid() === 0 && process.env.IS_SANDBOX !== "1"
```

## Fix

- Set `IS_SANDBOX=1` in the SDK subprocess environment when `process.getuid() === 0` (2-line change in `query.ts`)
- Also set `IS_SANDBOX=1` in the Dockerfile for Docker users

This uses the SDK's own official escape hatch for container/sandbox environments. The optional chaining (`process.getuid?.()`) handles Windows where `getuid` doesn't exist.

## Note

Cannot fully verify headless (not running as root on dev machine). Requesting the issue reporter (@Joly0) test the fix.