### PR TITLE
chore: fix 85 TypeScript type errors, add tsc --noEmit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
 
       - run: bun install
+      - run: npm run typecheck
       - run: npm test
       - run: bun run build

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -108,7 +108,7 @@ export function assistantMessage(content: Array<Record<string, unknown>>): SDKMe
     parent_tool_use_id: null,
     uuid: crypto.randomUUID(),
     session_id: "test-session",
-  } as SDKMessage
+  } as unknown as SDKMessage
 }
 
 // --- Request Factories ---

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -83,7 +83,7 @@ describe("getLastUserMessage", () => {
     ]
     const result = getLastUserMessage(messages)
     expect(result).toHaveLength(1)
-    expect(result[0].content).toBe("second")
+    expect(result[0]!.content).toBe("second")
   })
 
   it("returns last message as fallback when no user messages", () => {
@@ -92,7 +92,7 @@ describe("getLastUserMessage", () => {
     ]
     const result = getLastUserMessage(messages)
     expect(result).toHaveLength(1)
-    expect(result[0].content).toBe("reply")
+    expect(result[0]!.content).toBe("reply")
   })
 
   it("handles empty array", () => {
@@ -104,6 +104,6 @@ describe("getLastUserMessage", () => {
     const messages = [{ role: "user", content: "only" }]
     const result = getLastUserMessage(messages)
     expect(result).toHaveLength(1)
-    expect(result[0].content).toBe("only")
+    expect(result[0]!.content).toBe("only")
   })
 })

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -193,7 +193,7 @@ describe("translateOpenAiToAnthropic", () => {
         content: [{ type: "text", text: "structured" }],
       }],
     })
-    expect(result!.messages[0].content).toBe("structured")
+    expect(result!.messages[0]!.content).toBe("structured")
   })
 
   it("sets stream from body", () => {
@@ -236,9 +236,9 @@ describe("translateAnthropicToOpenAi", () => {
     expect(result.object).toBe("chat.completion")
     expect(result.created).toBe(CREATED)
     expect(result.model).toBe(MODEL)
-    expect(result.choices[0].message.role).toBe("assistant")
-    expect(result.choices[0].message.content).toBe("Hello!")
-    expect(result.choices[0].finish_reason).toBe("stop")
+    expect(result.choices[0]!.message.role).toBe("assistant")
+    expect(result.choices[0]!.message.content).toBe("Hello!")
+    expect(result.choices[0]!.finish_reason).toBe("stop")
     expect(result.usage.prompt_tokens).toBe(10)
     expect(result.usage.completion_tokens).toBe(5)
     expect(result.usage.total_tokens).toBe(15)
@@ -249,7 +249,7 @@ describe("translateAnthropicToOpenAi", () => {
       { content: [{ type: "text", text: "truncated" }], stop_reason: "max_tokens" },
       ID, MODEL, CREATED
     )
-    expect(result.choices[0].finish_reason).toBe("length")
+    expect(result.choices[0]!.finish_reason).toBe("length")
   })
 
   it("filters out thinking blocks", () => {
@@ -263,7 +263,7 @@ describe("translateAnthropicToOpenAi", () => {
       },
       ID, MODEL, CREATED
     )
-    expect(result.choices[0].message.content).toBe("actual answer")
+    expect(result.choices[0]!.message.content).toBe("actual answer")
   })
 
   it("handles empty content", () => {
@@ -271,7 +271,7 @@ describe("translateAnthropicToOpenAi", () => {
       { content: [], stop_reason: "end_turn" },
       ID, MODEL, CREATED
     )
-    expect(result.choices[0].message.content).toBe("")
+    expect(result.choices[0]!.message.content).toBe("")
   })
 
   it("handles missing usage", () => {
@@ -297,9 +297,9 @@ describe("translateAnthropicSseEvent", () => {
   it("message_start → role announcement chunk", () => {
     const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED)
     expect(chunk).not.toBeNull()
-    expect(chunk!.choices[0].delta.role).toBe("assistant")
-    expect(chunk!.choices[0].delta.content).toBe("")
-    expect(chunk!.choices[0].finish_reason).toBeNull()
+    expect(chunk!.choices[0]!.delta.role).toBe("assistant")
+    expect(chunk!.choices[0]!.delta.content).toBe("")
+    expect(chunk!.choices[0]!.finish_reason).toBeNull()
   })
 
   it("content_block_delta text_delta → content chunk", () => {
@@ -308,8 +308,8 @@ describe("translateAnthropicSseEvent", () => {
       ID, MODEL, CREATED
     )
     expect(chunk).not.toBeNull()
-    expect(chunk!.choices[0].delta.content).toBe("hello")
-    expect(chunk!.choices[0].finish_reason).toBeNull()
+    expect(chunk!.choices[0]!.delta.content).toBe("hello")
+    expect(chunk!.choices[0]!.finish_reason).toBeNull()
   })
 
   it("content_block_delta thinking_delta → null (skipped)", () => {
@@ -326,8 +326,8 @@ describe("translateAnthropicSseEvent", () => {
       ID, MODEL, CREATED
     )
     expect(chunk).not.toBeNull()
-    expect(chunk!.choices[0].finish_reason).toBe("stop")
-    expect(chunk!.choices[0].delta).toEqual({})
+    expect(chunk!.choices[0]!.finish_reason).toBe("stop")
+    expect(chunk!.choices[0]!.delta).toEqual({})
   })
 
   it("message_delta max_tokens → finish chunk with length", () => {
@@ -335,7 +335,7 @@ describe("translateAnthropicSseEvent", () => {
       { type: "message_delta", delta: { stop_reason: "max_tokens" } },
       ID, MODEL, CREATED
     )
-    expect(chunk!.choices[0].finish_reason).toBe("length")
+    expect(chunk!.choices[0]!.finish_reason).toBe("length")
   })
 
   it("ping → null", () => {

--- a/src/__tests__/pi-adapter.test.ts
+++ b/src/__tests__/pi-adapter.test.ts
@@ -222,7 +222,7 @@ describe("piAdapter.extractFileChangesFromToolUse", () => {
   it("detects bash commands with output redirects", () => {
     const changes = piAdapter.extractFileChangesFromToolUse!("bash", { command: "echo hello > /tmp/out.txt" })
     expect(changes.length).toBeGreaterThan(0)
-    expect(changes[0].path).toBe("/tmp/out.txt")
+    expect(changes[0]!.path).toBe("/tmp/out.txt")
   })
 
   it("returns empty for read tool", () => {

--- a/src/__tests__/proxy-cache-eviction.test.ts
+++ b/src/__tests__/proxy-cache-eviction.test.ts
@@ -60,7 +60,7 @@ async function post(app: TestApp, body: Record<string, unknown>, headers: Record
 
 async function send(app: TestApp, session: string | undefined, firstMessage: string, sessionId: string) {
   queuedSessionIds.push(sessionId)
-  const headers = session ? { "x-opencode-session": session } : {}
+  const headers: Record<string, string> = session ? { "x-opencode-session": session } : {}
   const response = await post(app, {
     model: "claude-sonnet-4-5",
     max_tokens: 128,

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -249,8 +249,8 @@ describe("Extra usage required fallback", () => {
       expect(body.content).toBeDefined()
       // Two query calls: first (sonnet[1m]) failed, second (sonnet) succeeded
       expect(queryCalls.length).toBe(2)
-      expect(queryCalls[0].model).toBe("sonnet[1m]")
-      expect(queryCalls[1].model).toBe("sonnet")
+      expect(queryCalls[0]!.model).toBe("sonnet[1m]")
+      expect(queryCalls[1]!.model).toBe("sonnet")
     })
   })
 })

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -87,8 +87,8 @@ describe("POST /v1/chat/completions — non-streaming", () => {
     expect(body.model).toBe("claude-haiku-4-5-20251001")
     const choices = body.choices as Array<Record<string, unknown>>
     expect(choices).toBeArray()
-    expect(choices[0].message).toEqual({ role: "assistant", content: "Hello!" })
-    expect(choices[0].finish_reason).toBe("stop")
+    expect(choices[0]!.message).toEqual({ role: "assistant", content: "Hello!" })
+    expect(choices[0]!.finish_reason).toBe("stop")
     const usage = body.usage as Record<string, number>
     expect(typeof usage.prompt_tokens).toBe("number")
     expect(typeof usage.completion_tokens).toBe("number")
@@ -131,7 +131,7 @@ describe("POST /v1/chat/completions — non-streaming", () => {
 
     const body = await res.json() as Record<string, unknown>
     const choices = body.choices as Array<Record<string, unknown>>
-    expect((choices[0].message as Record<string, unknown>).content).toBe("public answer")
+    expect((choices[0]!.message as Record<string, unknown>).content).toBe("public answer")
   })
 
   it("handles system message correctly", async () => {
@@ -216,13 +216,13 @@ describe("POST /v1/chat/completions — streaming", () => {
     const dataLines = text.split("\n").filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
     expect(dataLines.length).toBeGreaterThan(0)
 
-    const firstChunk = JSON.parse(dataLines[0].slice(6)) as Record<string, unknown>
+    const firstChunk = JSON.parse(dataLines[0]!.slice(6)) as Record<string, unknown>
     expect(firstChunk.object).toBe("chat.completion.chunk")
     expect(typeof firstChunk.id).toBe("string")
     expect((firstChunk.id as string).startsWith("chatcmpl-")).toBe(true)
 
     const choices = firstChunk.choices as Array<Record<string, unknown>>
-    expect(choices[0].delta).toHaveProperty("role", "assistant")
+    expect(choices[0]!.delta).toHaveProperty("role", "assistant")
   })
 
   it("emits text content chunks", async () => {
@@ -244,12 +244,12 @@ describe("POST /v1/chat/completions — streaming", () => {
       .map(l => JSON.parse(l.slice(6)) as Record<string, unknown>)
       .filter(c => {
         const choices = c.choices as Array<Record<string, unknown>>
-        const delta = choices[0].delta as Record<string, unknown>
+        const delta = choices[0]!.delta as Record<string, unknown>
         return typeof delta.content === "string" && delta.content.length > 0
       })
       .map(c => {
         const choices = c.choices as Array<Record<string, unknown>>
-        return (choices[0].delta as Record<string, unknown>).content as string
+        return (choices[0]!.delta as Record<string, unknown>).content as string
       })
 
     expect(contentChunks.join("")).toBe("Hello World")
@@ -274,11 +274,11 @@ describe("POST /v1/chat/completions — streaming", () => {
 
     const finishChunk = chunks.find(c => {
       const choices = c.choices as Array<Record<string, unknown>>
-      return choices[0].finish_reason !== null
+      return choices[0]!.finish_reason !== null
     })
     expect(finishChunk).toBeDefined()
     const choices = finishChunk!.choices as Array<Record<string, unknown>>
-    expect(choices[0].finish_reason).toBe("stop")
+    expect(choices[0]!.finish_reason).toBe("stop")
   })
 
   it("ends stream with data: [DONE]", async () => {

--- a/src/__tests__/proxy-passthrough-thinking.test.ts
+++ b/src/__tests__/proxy-passthrough-thinking.test.ts
@@ -370,7 +370,7 @@ describe("passthrough streaming — thinking block filtering", () => {
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
       session_id: "test-session",
-    } as SDKMessage
+    } as unknown as SDKMessage
 
     mockMessages = [
       messageStart(),

--- a/src/__tests__/proxy-stale-uuid-retry.test.ts
+++ b/src/__tests__/proxy-stale-uuid-retry.test.ts
@@ -134,13 +134,13 @@ describe("Stale UUID retry", () => {
     expect(body.content.some((b: any) => b.type === "text")).toBe(true)
 
     // First call should have had resumeSessionAt (the undo attempt)
-    expect(queryCalls[0].resumeSessionAt).toBe("uuid-assistant-1")
-    expect(queryCalls[0].forkSession).toBe(true)
+    expect(queryCalls[0]!.resumeSessionAt).toBe("uuid-assistant-1")
+    expect(queryCalls[0]!.forkSession).toBe(true)
 
     // Second call should be a fresh session (retry after stale UUID)
-    expect(queryCalls[1].resume).toBeUndefined()
-    expect(queryCalls[1].forkSession).toBeUndefined()
-    expect(queryCalls[1].resumeSessionAt).toBeUndefined()
+    expect(queryCalls[1]!.resume).toBeUndefined()
+    expect(queryCalls[1]!.forkSession).toBeUndefined()
+    expect(queryCalls[1]!.resumeSessionAt).toBeUndefined()
   })
 
   it("retries as fresh session when undo hits stale UUID (streaming)", async () => {
@@ -179,8 +179,8 @@ describe("Stale UUID retry", () => {
     expect(text).not.toContain("No message found with message.uuid")
 
     // Verify retry happened: first call with resumeSessionAt, second without
-    expect(queryCalls[0].resumeSessionAt).toBe("uuid-assistant-1")
-    expect(queryCalls[1].resumeSessionAt).toBeUndefined()
+    expect(queryCalls[0]!.resumeSessionAt).toBe("uuid-assistant-1")
+    expect(queryCalls[1]!.resumeSessionAt).toBeUndefined()
   })
 
   it("evicts stale session from cache after retry", async () => {
@@ -235,7 +235,7 @@ describe("Stale UUID retry", () => {
 
     // The second request should NOT have resumeSessionAt
     // (it may have resume if the fresh session was stored, which is fine)
-    expect(queryCalls[0].resumeSessionAt).toBeUndefined()
+    expect(queryCalls[0]!.resumeSessionAt).toBeUndefined()
   })
 
   it("propagates non-stale errors normally", async () => {

--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -27,7 +27,9 @@ type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
 
 let mockMessages: MockSdkMessage[] = []
-let capturedQueryParams: { prompt?: any; options?: { resume?: string } } | null = null
+interface CapturedFPQueryParams { prompt?: unknown; options?: { resume?: string; forkSession?: boolean } }
+let capturedQueryParams: CapturedFPQueryParams | null = null
+function getCaptured(): CapturedFPQueryParams | null { return capturedQueryParams }
 let queuedSessionIds: string[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
@@ -131,7 +133,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
     ], "sdk-1", "System v2: file tree has 15 files, 3 diagnostics")
 
     // MUST resume — fingerprint doesn't include systemContext
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.resume).toBe("sdk-1")
   })
 
   it("resumes when systemContext changes between requests (stream)", async () => {
@@ -148,7 +150,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
       { role: "user", content: "what can you do?" },
     ], "sdk-stream-1", "System v2 with more context", true)
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-stream-1")
+    expect(getCaptured()?.options?.resume).toBe("sdk-stream-1")
   })
 
   it("resumes when systemContext is added where there was none", async () => {
@@ -166,7 +168,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
     ], "sdk-no-ctx", "You are a helpful assistant.")
 
     // MUST resume — systemContext not in fingerprint
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-no-ctx")
+    expect(getCaptured()?.options?.resume).toBe("sdk-no-ctx")
   })
 
   it("resumes when systemContext is removed", async () => {
@@ -183,7 +185,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
       { role: "user", content: "thanks" },
     ], "sdk-ctx")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-ctx")
+    expect(getCaptured()?.options?.resume).toBe("sdk-ctx")
   })
 })
 
@@ -213,8 +215,8 @@ describe("Fingerprint resume: cross-project safety via lineage", () => {
     ], "sdk-project-b")
 
     // Prefix overlap ("hello") → undo/branch detected → forks from project A
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-project-a")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBe("sdk-project-a")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
   })
 
   it("resumes correctly after cross-project rejection creates new session", async () => {
@@ -247,7 +249,7 @@ describe("Fingerprint resume: cross-project safety via lineage", () => {
       { role: "user", content: "more B work" },
     ], "sdk-project-b")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-project-b")
+    expect(getCaptured()?.options?.resume).toBe("sdk-project-b")
   })
 })
 
@@ -266,7 +268,7 @@ describe("Fingerprint resume: different first messages", () => {
       { role: "user", content: "wait" },
     ], "sdk-goodbye")
 
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 })
 
@@ -295,7 +297,7 @@ describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
     ], "sdk-tools", "System prompt v2 with updated file tree")
 
     // MUST resume even though system changed and history has tool blocks
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-tools")
+    expect(getCaptured()?.options?.resume).toBe("sdk-tools")
   })
 
   it("does NOT resume after undo even with tool_use in history", async () => {
@@ -320,8 +322,8 @@ describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
     ], "sdk-tools-undo-new")
 
     // Prefix overlap ("create a file", "I'll create that file.") → undo → fork
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-tools-undo")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBe("sdk-tools-undo")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
   })
 })
 
@@ -340,6 +342,6 @@ describe("Fingerprint resume: backward compat", () => {
       { role: "user", content: "thanks" },
     ], "sdk-no-ctx")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-no-ctx")
+    expect(getCaptured()?.options?.resume).toBe("sdk-no-ctx")
   })
 })

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -20,7 +20,10 @@ type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
 
 let mockMessages: MockSdkMessage[] = []
-let capturedQueryParams: { options?: { resume?: string } } | null = null
+interface CapturedQueryParams { options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string } }
+let capturedQueryParams: CapturedQueryParams | null = null
+/** Access capturedQueryParams without TS narrowing to `never` after null assignments */
+function getCaptured(): CapturedQueryParams | null { return capturedQueryParams }
 let queuedSessionIds: string[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
@@ -216,7 +219,7 @@ describe("Session lineage: normal continuation", () => {
       { role: "user", content: "Remember: Flobulator" },
     ], "sdk-1")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.resume).toBe("sdk-1")
   })
 })
 
@@ -246,9 +249,9 @@ describe("Session lineage: undo detection", () => {
     ], "sdk-new")
 
     // Should resume the original session with fork
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
-    expect(capturedQueryParams?.options?.resumeSessionAt).toBeDefined()
+    expect(getCaptured()?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resumeSessionAt).toBeDefined()
   })
 
   it("forks session on multi-undo (fewer messages)", async () => {
@@ -279,8 +282,8 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "completely different" },
     ], "sdk-new")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
   })
 
   it("does NOT resume when earlier message is edited", async () => {
@@ -305,7 +308,7 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "great" },
     ], "sdk-new")
 
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 
   it("undo forks then subsequent turns resume the fork", async () => {
@@ -329,8 +332,8 @@ describe("Session lineage: undo detection", () => {
     ], "sdk-2")
 
     // Should fork from original session
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-1")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
 
     // Continuing from the fork should resume with sdk-2
     capturedQueryParams = null
@@ -342,8 +345,8 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "what do you know?" },
     ], "sdk-2")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-2")
-    expect(capturedQueryParams?.options?.forkSession).toBeUndefined()
+    expect(getCaptured()?.options?.resume).toBe("sdk-2")
+    expect(getCaptured()?.options?.forkSession).toBeUndefined()
   })
 })
 
@@ -404,7 +407,7 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "topic E" },
     ], "sdk-c")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-c")
+    expect(getCaptured()?.options?.resume).toBe("sdk-c")
   })
 
   it("resumes after compaction reduces message count", async () => {
@@ -430,7 +433,7 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "step 6" },
     ], "sdk-s")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-s")
+    expect(getCaptured()?.options?.resume).toBe("sdk-s")
   })
 
   it("does NOT resume when both prefix AND suffix changed (real branch)", async () => {
@@ -463,9 +466,9 @@ describe("Session lineage: compaction survival", () => {
     ], "sdk-new")
 
     // Prefix overlap (hello, hi) → undo detected → forks from rollback point
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-b")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
-    expect(capturedQueryParams?.options?.resumeSessionAt).toBeDefined()
+    expect(getCaptured()?.options?.resume).toBe("sdk-b")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resumeSessionAt).toBeDefined()
   })
 
   it("rejects aggressive compaction where nothing is preserved", async () => {
@@ -486,7 +489,7 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "now do something new" },
     ], "sdk-new")
 
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 })
 
@@ -533,7 +536,7 @@ describe("Session lineage: pruning survival", () => {
     ], "sdk-p")
 
     // Should resume — suffix (last 2+) of stored messages preserved
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-p")
+    expect(getCaptured()?.options?.resume).toBe("sdk-p")
   })
 })
 
@@ -601,7 +604,7 @@ describe("Session lineage: post-compaction behavior", () => {
       { role: "user", content: "F" },
     ], "sdk-pc")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-pc")
+    expect(getCaptured()?.options?.resume).toBe("sdk-pc")
   })
 
   it("second compaction is also detected correctly", async () => {
@@ -653,7 +656,7 @@ describe("Session lineage: post-compaction behavior", () => {
       { role: "user", content: "H" },
     ], "sdk-2c")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-2c")
+    expect(getCaptured()?.options?.resume).toBe("sdk-2c")
   })
 
   it("undo after compaction is correctly rejected", async () => {
@@ -714,8 +717,8 @@ describe("Session lineage: post-compaction behavior", () => {
     ], "sdk-new")
 
     // Prefix overlap (Summary, C done, D, D done match) → undo → fork
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-uc")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBe("sdk-uc")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
   })
 })
 
@@ -764,8 +767,8 @@ describe("Session lineage: fingerprint fallback", () => {
     await r2.json()
 
     // Prefix overlap (Good evening, Hi!) → undo → fork via fingerprint
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-fp1")
-    expect(capturedQueryParams?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBe("sdk-fp1")
+    expect(getCaptured()?.options?.forkSession).toBe(true)
   })
 })
 
@@ -792,7 +795,7 @@ describe("Session lastAccess refresh on lookup", () => {
       { role: "user", content: "still here?" },
     ], "sdk-A")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+    expect(getCaptured()?.options?.resume).toBe("sdk-A")
 
     capturedQueryParams = null
     await post(app, "sess-A", [
@@ -803,6 +806,6 @@ describe("Session lastAccess refresh on lookup", () => {
       { role: "user", content: "one more" },
     ], "sdk-A")
 
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+    expect(getCaptured()?.options?.resume).toBe("sdk-A")
   })
 })

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -9,6 +9,11 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 import type { CredentialStore } from "../proxy/tokenRefresh"
 
+/** Assign a mock to globalThis.fetch without TS complaining about missing `preconnect` */
+function mockFetch(fn: (...args: unknown[]) => Promise<Response | never>): void {
+  globalThis.fetch = fn as typeof fetch
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -108,21 +113,21 @@ describe("refreshOAuthToken", () => {
 
   it("returns false when fetch throws", async () => {
     const { store } = makeStore()
-    globalThis.fetch = mock(async () => { throw new Error("network error") })
+    mockFetch(mock(async () => { throw new Error("network error") }))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
     expect(await refreshOAuthToken(store)).toBe(false)
   })
 
   it("returns false on non-ok HTTP response", async () => {
     const { store } = makeStore()
-    globalThis.fetch = mock(async () => new Response("Unauthorized", { status: 401 }))
+    mockFetch(mock(async () => new Response("Unauthorized", { status: 401 })))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
     expect(await refreshOAuthToken(store)).toBe(false)
   })
 
   it("returns false when response body is invalid JSON", async () => {
     const { store } = makeStore()
-    globalThis.fetch = mock(async () => new Response("not-json", { status: 200 }))
+    mockFetch(mock(async () => new Response("not-json", { status: 200 })))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
     expect(await refreshOAuthToken(store)).toBe(false)
   })
@@ -133,7 +138,7 @@ describe("refreshOAuthToken", () => {
 
   it("returns false when credential write fails", async () => {
     const store = makeFailingWriteStore()
-    globalThis.fetch = mock(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    mockFetch(mock(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
     expect(await refreshOAuthToken(store)).toBe(false)
   })
@@ -144,7 +149,7 @@ describe("refreshOAuthToken", () => {
 
   it("returns true and writes updated tokens on success", async () => {
     const { store, getStored } = makeStore()
-    globalThis.fetch = mock(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    mockFetch(mock(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     expect(await refreshOAuthToken(store)).toBe(true)
@@ -154,9 +159,9 @@ describe("refreshOAuthToken", () => {
 
   it("preserves old refreshToken when response omits it", async () => {
     const { store, getStored } = makeStore()
-    globalThis.fetch = mock(async () =>
+    mockFetch(mock(async () =>
       makeSuccessResponse({ access_token: "new-access-token", expires_in: 3600 })
-    )
+    ))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     expect(await refreshOAuthToken(store)).toBe(true)
@@ -165,7 +170,7 @@ describe("refreshOAuthToken", () => {
 
   it("preserves extra top-level credential file fields", async () => {
     const { store, getStored } = makeStore()
-    globalThis.fetch = mock(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    mockFetch(mock(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     expect(await refreshOAuthToken(store)).toBe(true)
@@ -175,9 +180,9 @@ describe("refreshOAuthToken", () => {
   it("sets expiresAt from expires_in", async () => {
     const { store, getStored } = makeStore()
     const before = Date.now()
-    globalThis.fetch = mock(async () =>
+    mockFetch(mock(async () =>
       makeSuccessResponse({ access_token: "tok", expires_in: 3600 })
-    )
+    ))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     expect(await refreshOAuthToken(store)).toBe(true)
@@ -189,9 +194,9 @@ describe("refreshOAuthToken", () => {
   it("prefers expires_at over expires_in when both present", async () => {
     const { store, getStored } = makeStore()
     const fixedExpiry = Date.now() + 9999999
-    globalThis.fetch = mock(async () =>
+    mockFetch(mock(async () =>
       makeSuccessResponse({ access_token: "tok", expires_at: fixedExpiry, expires_in: 3600 })
-    )
+    ))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     expect(await refreshOAuthToken(store)).toBe(true)
@@ -205,10 +210,10 @@ describe("refreshOAuthToken", () => {
   it("concurrent calls share one in-flight request", async () => {
     const { store } = makeStore()
     let fetchCount = 0
-    globalThis.fetch = mock(async () => {
+    mockFetch(mock(async () => {
       fetchCount++
       return makeSuccessResponse(MOCK_TOKEN_RESPONSE)
-    })
+    }))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     const [r1, r2, r3] = await Promise.all([
@@ -226,10 +231,10 @@ describe("refreshOAuthToken", () => {
   it("allows a second refresh after the first completes", async () => {
     const { store } = makeStore()
     let fetchCount = 0
-    globalThis.fetch = mock(async () => {
+    mockFetch(mock(async () => {
       fetchCount++
       return makeSuccessResponse(MOCK_TOKEN_RESPONSE)
-    })
+    }))
     const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
 
     await refreshOAuthToken(store)


### PR DESCRIPTION
Closes #244

## Summary

Fix all 85 `tsc --noEmit` errors across 12 test files. Add type checking to CI so future PRs are blocked by type errors.

## Changes

| Category | Files | Fix |
|---|---|---|
| Mock type narrowing to `never` | session-lineage, session-fingerprint-context | Interface + `getCaptured()` helper |
| Missing `preconnect` on mock fetch | token-refresh | `mockFetch()` wrapper |
| `Object is possibly undefined` | openai, proxy-openai-compat, stale-uuid-retry, messages, extra-usage-fallback, pi-adapter | Non-null assertion on array index |
| SDKMessage type drift | helpers, proxy-passthrough-thinking | Cast through `unknown` |
| Union type incompatibility | proxy-cache-eviction | Explicit type annotation |

**CI**: Added `npm run typecheck` (`tsc --noEmit`) before `npm test` in `.github/workflows/ci.yml`.

**Result**: 0 type errors, 849 tests pass.