### PR TITLE
fix: strip anthropic-beta headers for Max subscriptions to prevent extra usage billing

### DIFF
--- a/src/__tests__/profile-switch-integration.test.ts
+++ b/src/__tests__/profile-switch-integration.test.ts
@@ -156,23 +156,15 @@ describe("Session cache eviction on profile switch", () => {
     const app = createTestApp(profiles)
 
     // Store a session in the cache
-    storeSession("test-session-123", {
-      claudeSessionId: "claude-abc",
-      lastAccess: Date.now(),
-      messageCount: 5,
-      lineageHash: "hash123",
-      messageHashes: ["h1", "h2", "h3", "h4", "h5"],
-      sdkMessageUuids: ["u1", "u2", "u3", "u4", "u5"],
-    })
-
-    // Verify session exists
-    const before = lookupSession("test-session-123", [
+    const msgs = [
       { role: "user", content: "a" },
       { role: "assistant", content: "b" },
       { role: "user", content: "c" },
-      { role: "assistant", content: "d" },
-      { role: "user", content: "e" },
-    ])
+    ]
+    storeSession("test-session-123", msgs, "claude-abc")
+
+    // Verify session exists
+    const before = lookupSession("test-session-123", msgs)
     expect(before.type).not.toBe("new")
 
     // Switch profile via API
@@ -184,23 +176,15 @@ describe("Session cache eviction on profile switch", () => {
     expect(res.status).toBe(200)
 
     // Session should be gone — new lookup returns diverged (sessionId known but no cache entry)
-    const after = lookupSession("test-session-123", [
-      { role: "user", content: "a" },
-    ])
+    const after = lookupSession("test-session-123", msgs)
     expect(after.type).toBe("diverged")
   })
 
   test("switching to same profile still clears cache", async () => {
     const app = createTestApp(profiles)
 
-    storeSession("session-same", {
-      claudeSessionId: "claude-same",
-      lastAccess: Date.now(),
-      messageCount: 1,
-      lineageHash: "h",
-      messageHashes: ["m1"],
-      sdkMessageUuids: ["u1"],
-    })
+    const msgs = [{ role: "user", content: "x" }]
+    storeSession("session-same", msgs, "claude-same")
 
     // Switch to first profile (already active)
     await app.fetch(req("/profiles/active", {
@@ -209,7 +193,7 @@ describe("Session cache eviction on profile switch", () => {
       body: JSON.stringify({ profile: "personal" }),
     }))
 
-    const after = lookupSession("session-same", [{ role: "user", content: "x" }])
+    const after = lookupSession("session-same", msgs)
     expect(after.type).toBe("diverged")
   })
 })

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -146,16 +146,34 @@ describe("SDK param passthrough — header overrides", () => {
     expect(capturedOptions.taskBudget).toEqual({ total: 9999 })
   })
 
-  it("anthropic-beta header populates betas array", async () => {
+  it("anthropic-beta header is stripped for claude-max profiles to prevent extra usage billing", async () => {
+    // See: https://github.com/rynfar/meridian/issues/278
     const app = createTestApp()
     await post(app, BASE_BODY, { "anthropic-beta": "context-1m-2025-08-07" })
-    expect(capturedOptions.betas).toEqual(["context-1m-2025-08-07"])
+    expect(capturedOptions.betas).toBeUndefined()
   })
 
-  it("comma-separated anthropic-beta header splits into multiple betas", async () => {
+  it("comma-separated anthropic-beta header is also stripped for claude-max", async () => {
     const app = createTestApp()
     await post(app, BASE_BODY, { "anthropic-beta": "context-1m-2025-08-07, interleaved-thinking-2025-05-14" })
-    expect(capturedOptions.betas).toEqual(["context-1m-2025-08-07", "interleaved-thinking-2025-05-14"])
+    expect(capturedOptions.betas).toBeUndefined()
+  })
+
+  it("anthropic-beta header is forwarded for api-type profiles", async () => {
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1",
+      profiles: [{ id: "apiuser", type: "api", apiKey: "sk-test" }],
+    })
+    await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": "dummy",
+        "anthropic-beta": "context-1m-2025-08-07",
+      },
+      body: JSON.stringify(BASE_BODY),
+    }))
+    expect(capturedOptions.betas).toEqual(["context-1m-2025-08-07"])
   })
 
   it("malformed x-opencode-thinking header is ignored — request succeeds", async () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -261,7 +261,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const effortHeader = c.req.header("x-opencode-effort")
         const thinkingHeader = c.req.header("x-opencode-thinking")
         const taskBudgetHeader = c.req.header("x-opencode-task-budget")
-        const betaHeader = c.req.header("anthropic-beta")
+        // NOTE: anthropic-beta headers are intentionally NOT forwarded for
+        // claude-max profiles. These headers trigger API-key billing mode on
+        // Anthropic's servers, causing Max subscribers to be charged extra usage.
+        // Only forward betas for api-type profiles where they are valid.
+        // See: https://github.com/rynfar/meridian/issues/278
+        const betaHeader = profile.type === "api"
+          ? c.req.header("anthropic-beta")
+          : undefined
 
         const effort = effortHeader
           || body.effort
@@ -281,6 +288,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const betas = betaHeader
           ? betaHeader.split(",").map((b: string) => b.trim()).filter(Boolean)
           : undefined
+        if (!betaHeader && c.req.header("anthropic-beta")) {
+          console.error(`[PROXY] ${requestMeta.requestId} stripped anthropic-beta header (Max subscription — betas trigger extra usage billing)`)
+        }
 
         // Session resume: look up cached Claude SDK session and classify mutation
         const agentSessionId = adapter.getSessionId(c)


### PR DESCRIPTION
## Problem

When upstream clients like OpenClaw 2026.4.2+ route requests through Meridian, they add `anthropic-beta` headers. Meridian forwards these to the Claude Code SDK, which triggers API-key billing mode on Anthropic servers — causing Max subscribers to be charged **extra usage** instead of their subscription.

Closes #278

## Root Cause

OpenClaw 2026.4.2 introduced endpoint classification that adds `anthropic-beta` headers when `baseUrl` points to a non-Anthropic host (like `127.0.0.1:3456`). The Claude SDK warns: *"Custom betas are only available for API key users"* but still forwards them, triggering extra usage billing.

## Fix

- **claude-max profiles** (default): `anthropic-beta` headers are stripped before reaching the SDK, with a log message
- **api-type profiles**: Headers are forwarded normally (betas are valid for API key users)

The check uses the already-resolved `profile.type` so there is zero overhead.

## Changes

- `src/proxy/server.ts` — Conditionally read `anthropic-beta` header based on profile type
- `src/__tests__/proxy-sdk-params.test.ts` — Updated 2 existing tests + added 1 new test for api-type profile forwarding
- `src/__tests__/profile-switch-integration.test.ts` — Fixed `storeSession` call signatures (from multi-profile merge)

## Testing

- 888 tests total, 885 pass, 3 pre-existing failures (unrelated)
- New test verifies api-type profiles still forward betas correctly