### PR TITLE
fix: strip orchestration wrapper tags before text prompt flattening

### DIFF
--- a/src/__tests__/sanitize-unit.test.ts
+++ b/src/__tests__/sanitize-unit.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the per-block content sanitizer.
+ *
+ * Verifies that orchestration wrappers injected by agent harnesses are
+ * stripped from individual text content blocks before prompt flattening,
+ * while preserving legitimate user content.
+ *
+ * Related: https://github.com/rynfar/meridian/issues/167
+ */
+
+import { describe, it, expect } from "bun:test"
+import { sanitizeTextContent } from "../proxy/sanitize"
+
+// ── Orchestration tag stripping ──
+
+describe("sanitizeTextContent", () => {
+  // --- Droid ---
+
+  it("strips <system-reminder> blocks (Droid CWD injection)", () => {
+    const input = '<system-reminder>\nUser system info\n% pwd\n/home/user\n</system-reminder>\nactual question'
+    expect(sanitizeTextContent(input)).toBe("actual question")
+  })
+
+  it("strips multiline <system-reminder> with attributes", () => {
+    const input = 'hello\n<system-reminder id="sr-1">\nline one\nline two\n</system-reminder>\nworld'
+    expect(sanitizeTextContent(input)).toBe("hello\n\nworld")
+  })
+
+  // --- OpenCode / Crush ---
+
+  it("strips <env> blocks (OpenCode environment context)", () => {
+    const input = '<env>\n  Working directory: /home/user/project\n  Platform: darwin\n</env>\nwhat is this project?'
+    expect(sanitizeTextContent(input)).toBe("what is this project?")
+  })
+
+  // --- ForgeCode ---
+
+  it("strips <system_information> wrapper and children", () => {
+    const input = '<system_information>\n<operating_system>Darwin</operating_system>\n<current_working_directory>/path</current_working_directory>\n<default_shell>/bin/zsh</default_shell>\n<home_directory>/Users/dev</home_directory>\n</system_information>\ndo the thing'
+    expect(sanitizeTextContent(input)).toBe("do the thing")
+  })
+
+  it("strips standalone <current_working_directory>", () => {
+    const input = '<current_working_directory>/Users/dev/project</current_working_directory>read file.ts'
+    expect(sanitizeTextContent(input)).toBe("read file.ts")
+  })
+
+  // --- OpenCode orchestration ---
+
+  it("strips <task_metadata> blocks", () => {
+    const input = '<task_metadata>{"id":"task-1","status":"running"}</task_metadata>actual content'
+    expect(sanitizeTextContent(input)).toBe("actual content")
+  })
+
+  it("strips <tool_output> wrappers with attributes", () => {
+    const input = 'before<tool_output name="bash">result here</tool_output>after'
+    expect(sanitizeTextContent(input)).toBe("beforeafter")
+  })
+
+  it("strips self-closing <tool_exec> wrappers", () => {
+    const input = 'text<tool_exec name="read" />more'
+    expect(sanitizeTextContent(input)).toBe("textmore")
+  })
+
+  it("strips paired <tool_exec> wrappers", () => {
+    const input = '<tool_exec name="bash">ls -la</tool_exec>output'
+    expect(sanitizeTextContent(input)).toBe("output")
+  })
+
+  it("strips <skill_content> blocks", () => {
+    const input = '<skill_content name="gh">skill instructions</skill_content>rest'
+    expect(sanitizeTextContent(input)).toBe("rest")
+  })
+
+  it("strips <skill_files> blocks", () => {
+    const input = 'before<skill_files>\nfile1.ts\nfile2.ts\n</skill_files>after'
+    expect(sanitizeTextContent(input)).toBe("beforeafter")
+  })
+
+  it("strips <directories> blocks", () => {
+    const input = '<directories>\n  src/\n  lib/\n</directories>after'
+    expect(sanitizeTextContent(input)).toBe("after")
+  })
+
+  it("strips <available_skills> blocks", () => {
+    const input = '<available_skills>\n  skill1\n  skill2\n</available_skills>after'
+    expect(sanitizeTextContent(input)).toBe("after")
+  })
+
+  it("strips leaked <thinking> tags (text content, not structured blocks)", () => {
+    const input = 'text<thinking>model thoughts leaked here</thinking>more text'
+    expect(sanitizeTextContent(input)).toBe("textmore text")
+  })
+
+  // --- Non-XML markers ---
+
+  it("strips OMO_INTERNAL_INITIATOR comment", () => {
+    const input = "<!-- OMO_INTERNAL_INITIATOR -->proceed"
+    expect(sanitizeTextContent(input)).toBe("proceed")
+  })
+
+  it("strips OH-MY-OPENCODE system directive", () => {
+    const input = "[SYSTEM DIRECTIVE: OH-MY-OPENCODE use tool X]do the thing"
+    expect(sanitizeTextContent(input)).toBe("do the thing")
+  })
+
+  it("strips background_output markers", () => {
+    const input = "⚙ background_output [task_id=abc123]\nreal content"
+    expect(sanitizeTextContent(input)).toBe("real content")
+  })
+
+  it("strips Files changed blocks (meridian's own summary)", () => {
+    const input = "response text\n---\nFiles changed:\n  - edited /path/to/file.ts\n  - wrote /path/to/other.ts"
+    expect(sanitizeTextContent(input)).toBe("response text")
+  })
+
+  // --- Multiple patterns in one block ---
+
+  it("handles multiple patterns in one string", () => {
+    const input = '<system-reminder>x</system-reminder>\n<task_metadata>y</task_metadata>\nnormal content'
+    expect(sanitizeTextContent(input)).toBe("normal content")
+  })
+
+  it("returns empty string for all-wrapper input", () => {
+    const input = '<system-reminder>everything is internal</system-reminder>'
+    expect(sanitizeTextContent(input)).toBe("")
+  })
+
+  // --- False positive safety ---
+
+  it("is a no-op for clean text", () => {
+    const input = "Just a normal user message with no wrappers."
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("is a no-op for empty string", () => {
+    expect(sanitizeTextContent("")).toBe("")
+  })
+
+  it("preserves standard HTML tags", () => {
+    const input = '<div>content</div><span>text</span><p>paragraph</p>'
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("preserves self-closing HTML tags", () => {
+    const input = 'line one<br/>line two<hr/>end'
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("preserves code with angle brackets", () => {
+    const input = "Use Array<string> and Map<K,V> in TypeScript"
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("preserves H: and A: in content", () => {
+    expect(sanitizeTextContent("H: hydrogen is atomic number 1")).toBe("H: hydrogen is atomic number 1")
+    expect(sanitizeTextContent("A: the answer is 42")).toBe("A: the answer is 42")
+  })
+
+  it("preserves legitimate XML with underscores that aren't orchestration tags", () => {
+    const input = '<first_name>John</first_name><last_name>Doe</last_name>'
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("preserves web component tags with hyphens", () => {
+    const input = '<my-component>content</my-component>'
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("preserves user discussing system-reminder concept in prose", () => {
+    const input = "The system-reminder tag is used by Droid to inject CWD info"
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  it("preserves img and input self-closing tags", () => {
+    const input = '<img src="photo.jpg" /><input type="text" />'
+    expect(sanitizeTextContent(input)).toBe(input)
+  })
+
+  // --- Regression: the exact scenario from issue #167 ---
+
+  it("strips the compound leakage pattern from #167", () => {
+    const input = [
+      '<system-reminder>',
+      '  Current dir: /home/user',
+      '</system-reminder>',
+      '<thinking>The user wants me to handle the case...</thinking>',
+      '<task_metadata>{"id":"t1"}</task_metadata>',
+      '<!-- OMO_INTERNAL_INITIATOR -->',
+      'What is 2+2?',
+    ].join("\n")
+    expect(sanitizeTextContent(input)).toBe("What is 2+2?")
+  })
+})

--- a/src/proxy/sanitize.ts
+++ b/src/proxy/sanitize.ts
@@ -1,0 +1,95 @@
+/**
+ * Per-block content sanitizer for orchestration wrapper leakage.
+ *
+ * Agent harnesses (OpenCode, Droid, ForgeCode, oh-my-opencode, etc.) inject
+ * internal markup into message content — `<system-reminder>`, `<env>`,
+ * `<task_metadata>`, and similar tags. When the proxy flattens messages into
+ * a text prompt for the Agent SDK, these tags become model-visible text that
+ * can confuse the model or cause it to echo them back ("talking to itself").
+ *
+ * This module strips known orchestration tags from **individual text blocks**
+ * before flattening — not from the final concatenated string. Operating
+ * per-block eliminates the cross-message regex risk that makes full-string
+ * sanitization fragile.
+ *
+ * Pure module — no I/O, no imports from server.ts or session/.
+ *
+ * Fixes: https://github.com/rynfar/meridian/issues/167
+ */
+
+// ---------------------------------------------------------------------------
+// Exact tag names known to be orchestration-only.
+// These are NOT prefix patterns — each entry is a specific tag name that
+// harnesses inject and that never appears in legitimate user content.
+// ---------------------------------------------------------------------------
+
+const ORCHESTRATION_TAGS = [
+  // Droid: CWD + env info injected into first user message
+  "system-reminder",
+  // OpenCode / Crush: environment context blocks
+  "env",
+  // ForgeCode: system info wrapper and children
+  "system_information",
+  "current_working_directory",
+  "operating_system",
+  "default_shell",
+  "home_directory",
+  // OpenCode: task/tool/skill orchestration
+  "task_metadata",
+  "tool_exec",
+  "tool_output",
+  "skill_content",
+  "skill_files",
+  // OpenCode: context injection blocks
+  "directories",
+  "available_skills",
+  // Leaked thinking tags (NOT the structured content block type —
+  // these are raw XML tags that appear in text content on replay)
+  "thinking",
+]
+
+// Build regex for paired tags: <tagname ...>...</tagname>
+// Each tag gets its own regex to avoid cross-tag matching.
+const PAIRED_TAG_PATTERNS: RegExp[] = ORCHESTRATION_TAGS.map(
+  (tag) => new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi")
+)
+
+// Self-closing variants: <tagname ... />
+const SELF_CLOSING_TAG_PATTERNS: RegExp[] = ORCHESTRATION_TAGS.map(
+  (tag) => new RegExp(`<${tag}\\b[^>]*\\/>`, "gi")
+)
+
+// Non-XML orchestration markers (unique, branded — zero false-positive risk)
+const NON_XML_PATTERNS: RegExp[] = [
+  // oh-my-opencode internal markers
+  /<!--\s*OMO_INTERNAL_INITIATOR\s*-->/gi,
+  /\[SYSTEM DIRECTIVE: OH-MY-OPENCODE[^\]]*\]/gi,
+  // Background task markers
+  /⚙\s*background_output\s*\[task_id=[^\]]*\]\n?/g,
+  // Meridian's own file change summary leaking back into conversation
+  /\n?---\nFiles changed:[^\n]*(?:\n(?:  [-•*] [^\n]*))*\n?/g,
+]
+
+const ALL_PATTERNS = [
+  ...PAIRED_TAG_PATTERNS,
+  ...SELF_CLOSING_TAG_PATTERNS,
+  ...NON_XML_PATTERNS,
+]
+
+/**
+ * Strip orchestration wrappers from a single text string.
+ *
+ * Designed to be called on individual content blocks (not concatenated
+ * prompt strings) to eliminate cross-block regex matching risk.
+ */
+export function sanitizeTextContent(text: string): string {
+  let result = text
+  for (const pattern of ALL_PATTERNS) {
+    // Reset lastIndex for stateful regexes (those with 'g' flag)
+    pattern.lastIndex = 0
+    result = result.replace(pattern, "")
+  }
+  // Collapse runs of 3+ newlines into 2 (avoids large gaps where tags were)
+  result = result.replace(/\n{3,}/g, "\n\n")
+  return result.trim()
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -31,6 +31,7 @@ import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
 import { detectTokenAnomalies, formatAnomalyAlerts, type TokenSnapshot } from "./tokenHealth"
 import { computeCacheHitRate, formatUsageSummary } from "./tokenUsage"
+import { sanitizeTextContent } from "./sanitize"
 import {
   computeLineageHash,
   hashMessage,
@@ -112,11 +113,11 @@ function buildFreshPrompt(
       const role = m.role === "assistant" ? "Assistant" : "Human"
       let content: string
       if (typeof m.content === "string") {
-        content = m.content
+        content = sanitizeTextContent(m.content)
       } else if (Array.isArray(m.content)) {
         content = m.content
           .map((block: any) => {
-            if (block.type === "text" && block.text) return block.text
+            if (block.type === "text" && block.text) return sanitizeTextContent(block.text)
             if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
             if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
             if (block.type === "image") return "[Image attached]"
@@ -521,17 +522,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           }
         }
       } else {
-        // Text prompt — convert messages to string
+        // Text prompt — convert messages to string.
+        // Sanitize each text block before flattening to strip orchestration
+        // wrappers (<system-reminder>, <env>, etc.) that harnesses inject.
+        // Per-block sanitization avoids cross-message regex collateral.
         textPrompt = messagesToConvert
           ?.map((m: { role: string; content: string | Array<{ type: string; text?: string; content?: string; tool_use_id?: string; name?: string; input?: unknown; id?: string }> }) => {
             const role = m.role === "assistant" ? "Assistant" : "Human"
             let content: string
             if (typeof m.content === "string") {
-              content = m.content
+              content = sanitizeTextContent(m.content)
             } else if (Array.isArray(m.content)) {
               content = m.content
                 .map((block: any) => {
-                  if (block.type === "text" && block.text) return block.text
+                  if (block.type === "text" && block.text) return sanitizeTextContent(block.text)
                   if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
                   if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
                   if (block.type === "image") return "[Image attached]"


### PR DESCRIPTION
## Problem

Agent harnesses (OpenCode, Droid, ForgeCode, oh-my-opencode) inject internal markup into message content — `<system-reminder>`, `<env>`, `<task_metadata>`, and similar tags. When the proxy flattens messages into a text prompt for the Agent SDK, these tags become model-visible text that causes the model to echo them back — the "talking to itself" symptom described in #167.

## Why not structured messages?

The ideal fix would be to always use `AsyncIterable<SDKUserMessage>` (structured messages) instead of string prompts, keeping tags as inert content in structured blocks. We built and tested this approach but discovered the Agent SDK sets `isSingleUserTurn = false` for AsyncIterable prompts, which changes how `endInput()` is called on the subprocess stdin. This breaks passthrough tool execution — the model sees "Forwarding to client for execution" as a tool result instead of forwarding the tool call to the client.

Until the SDK supports a `singleUserTurn` flag for AsyncIterable prompts, we need the string prompt path.

## Solution

Per-block sanitization: strip known orchestration tags from individual text content blocks **before** flattening to a string prompt — not from the final concatenated string.

This approach:
- **Eliminates cross-message regex risk** — each content block is sanitized independently
- **Uses exact tag names, not prefix patterns** — no `task_*` / `tool_*` / `system-*` wildcards that could eat legitimate content
- **Preserves the string prompt path** — passthrough tool execution continues to work
- **Is a pure leaf module** — no I/O, no imports from server.ts or session/

### Tags stripped (exact names)

| Tag | Harness | Purpose |
|-----|---------|---------|
| `system-reminder` | Droid | CWD/env injection in first user message |
| `env` | OpenCode, Crush | Environment context blocks |
| `system_information` | ForgeCode | System info wrapper |
| `current_working_directory` | ForgeCode | CWD tag |
| `operating_system` | ForgeCode | OS identifier |
| `default_shell` | ForgeCode | Shell path |
| `home_directory` | ForgeCode | Home dir path |
| `task_metadata` | OpenCode | Task tracking |
| `tool_exec` | OpenCode | Tool execution markers |
| `tool_output` | OpenCode | Tool output wrappers |
| `skill_content` | OpenCode | Skill injection |
| `skill_files` | OpenCode | Skill file lists |
| `directories` | OpenCode | Directory context |
| `available_skills` | OpenCode | Skill listing |
| `thinking` | Various | Leaked thinking tags (not structured blocks) |

Plus non-XML markers: `<!-- OMO_INTERNAL_INITIATOR -->`, `[SYSTEM DIRECTIVE: OH-MY-OPENCODE...]`, `⚙ background_output [task_id=...]`, and Meridian's own `Files changed:` summary.

## Why this supersedes #317

PR #317 used prefix-matching (`task_*`, `tool_*`, `skill_*`, `system-*`) and generic `antml:*` patterns that would strip legitimate content like `<tool-tip>`, `<task-list>`, `<system-status>`, `<br/>`, `<img/>`. It also had two regex bugs in the `antml:*` patterns where the opening tag matcher was `<\w+` (any tag) instead of `<\w+`.

This PR uses exact tag names only, operates per-block instead of on the full string, and leaves the text prompt path intact for passthrough compatibility.

## Test plan

- [x] 31 unit tests in `src/__tests__/sanitize-unit.test.ts` covering:
  - Every known orchestration tag (Droid, OpenCode, Crush, ForgeCode, oh-my-opencode)
  - Non-XML markers (OMO, background_output, Files changed)
  - Multiple patterns in one block
  - False-positive safety: HTML tags, self-closing tags, web components, angle brackets in code, prose mentions of tag names, legitimate XML with underscores
  - Regression guard: compound leakage pattern from #167
- [x] Full test suite: 1080 tests across 62 files, 0 failures
- [x] Type check clean: `npx tsc --noEmit`
- [x] E2E verified via `opencode run`:
  - Basic text response ✓
  - Tool use (passthrough) ✓
  - Multi-turn session resume ✓
  - `<system-reminder>` injection via curl → stripped, model answered correctly ✓
  - Multi-turn OpenCode TUI session — no wrapper echoing observed ✓

Fixes #167
Supersedes #317