### PR TITLE
feat: add version field to /health endpoint response

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -166,7 +166,7 @@ export async function runCli(
     enableDiskProfileDiscovery()
   }
 
-  const proxy = await start({ port, host, idleTimeoutSeconds, profiles, defaultProfile })
+  const proxy = await start({ port, host, idleTimeoutSeconds, profiles, defaultProfile, version })
 
   // Handle EADDRINUSE — preserve CLI behavior of exiting on port conflict
   proxy.server.on("error", (error: NodeJS.ErrnoException) => {

--- a/src/__tests__/proxy-async-ops.test.ts
+++ b/src/__tests__/proxy-async-ops.test.ts
@@ -16,30 +16,31 @@ describe("proxy async ops", () => {
     expect(typeof proxyB.server.keepAliveTimeout).toBe("number")
   })
 
-  it("serves async health endpoint with unchanged response schema", async () => {
+  it("serves async health endpoint with correct response schema", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
     const response = await app.fetch(new Request("http://localhost/health"))
     const body = await response.json() as any
 
     expect(typeof body.status).toBe("string")
+    expect(typeof body.version).toBe("string")
     expect(typeof body.mode).toBe("string")
     expect(["healthy", "degraded", "unhealthy"]).toContain(body.status)
 
     if (body.status === "healthy") {
       expect(typeof body.auth.loggedIn).toBe("boolean")
       expect(body.auth.loggedIn).toBe(true)
-      expect(Object.keys(body).sort()).toEqual(["auth", "mode", "plugin", "status"])
+      expect(Object.keys(body).sort()).toEqual(["auth", "mode", "plugin", "status", "version"])
     }
 
     if (body.status === "unhealthy") {
       expect(typeof body.error).toBe("string")
       expect(body.auth.loggedIn).toBe(false)
-      expect(Object.keys(body).sort()).toEqual(["auth", "error", "status"])
+      expect(Object.keys(body).sort()).toEqual(["auth", "error", "status", "version"])
     }
 
     if (body.status === "degraded") {
       expect(typeof body.error).toBe("string")
-      expect(Object.keys(body).sort()).toEqual(["error", "mode", "status"])
+      expect(Object.keys(body).sort()).toEqual(["error", "mode", "status", "version"])
     }
 
     expect(response.status).toBe(body.status === "unhealthy" ? 503 : 200)
@@ -48,21 +49,28 @@ describe("proxy async ops", () => {
   it("returns degraded health when auth status command times out", async () => {
     resetCachedClaudeAuthStatus()
     const originalPath = process.env.PATH
+    const originalClaudeProxyPassthrough = process.env.CLAUDE_PROXY_PASSTHROUGH
+    const originalMeridianPassthrough = process.env.MERIDIAN_PASSTHROUGH
     process.env.PATH = ""
+    process.env.CLAUDE_PROXY_PASSTHROUGH = "0"
+    process.env.MERIDIAN_PASSTHROUGH = "0"
 
     try {
       const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
       const response = await app.fetch(new Request("http://localhost/health"))
-      const body = await response.json()
+      const body = await response.json() as Record<string, unknown>
 
       expect(response.status).toBe(200)
-      expect(body).toEqual({
-        status: "degraded",
-        error: "Could not verify auth status",
-        mode: "internal",
-      })
+      expect(body.status).toBe("degraded")
+      expect(body.error).toBe("Could not verify auth status")
+      expect(body.mode).toBe("internal")
+      expect(typeof body.version).toBe("string")
     } finally {
       process.env.PATH = originalPath
+      if (originalClaudeProxyPassthrough === undefined) delete process.env.CLAUDE_PROXY_PASSTHROUGH
+      else process.env.CLAUDE_PROXY_PASSTHROUGH = originalClaudeProxyPassthrough
+      if (originalMeridianPassthrough === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+      else process.env.MERIDIAN_PASSTHROUGH = originalMeridianPassthrough
     }
   })
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -11,7 +11,6 @@ export type { ProxyConfig, ProxyInstance, ProxyServer }
 import { claudeLog } from "../logger"
 import { exec as execCallback } from "child_process"
 import { promisify } from "util"
-
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
@@ -194,6 +193,7 @@ function checkTokenHealth(
 
 export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServer {
   const finalConfig = { ...DEFAULT_PROXY_CONFIG, ...config }
+  const serverVersion = finalConfig.version ?? "unknown"
 
   // Restore persisted active profile from last session
   restoreActiveProfile(finalConfig.profiles)
@@ -1724,6 +1724,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       if (!auth) {
         return c.json({
           status: "degraded",
+          version: serverVersion,
           error: "Could not verify auth status",
           mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         })
@@ -1731,12 +1732,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       if (!auth.loggedIn) {
         return c.json({
           status: "unhealthy",
+          version: serverVersion,
           error: "Not logged in. Run: claude login",
           auth: { loggedIn: false }
         }, 503)
       }
       return c.json({
         status: "healthy",
+        version: serverVersion,
         auth: {
           loggedIn: true,
           email: auth.email,
@@ -1748,6 +1751,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     } catch {
       return c.json({
         status: "degraded",
+        version: serverVersion,
         error: "Could not verify auth status",
         mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
       })

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -11,6 +11,8 @@ export interface ProxyConfig {
   profiles?: ProfileConfig[]
   /** Default profile ID when no header is sent */
   defaultProfile?: string
+  /** Package version, exposed via /health endpoint */
+  version?: string
 }
 
 export interface ProxyInstance {
@@ -38,4 +40,5 @@ export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
   silent: false,
   profiles: undefined,
   defaultProfile: undefined,
+  version: undefined,
 }


### PR DESCRIPTION
## Problem

Client tools (pi extensions, OpenCode plugins, Aider, etc.) have no way to know what version of Meridian is running. The npm package version and the running process version can diverge — the process was started days ago and the package updated since. This matters for:

- **Update notifications** — clients want to warn users when their running Meridian is outdated. Currently there's no way to compare the running version against the latest npm release without fragile heuristics.
- **Feature detection** — clients adjust behavior based on what the running version supports (passthrough mode, multi-profile, Pi adapter, etc.).
- **Debugging** — knowing the exact running version is critical. `npm list -g` shows what's installed, not what's running.

## Solution

Add a `version` string field to all `/health` response branches:

```json
{
  "status": "healthy",
  "version": "1.34.1",
  "auth": { "loggedIn": true, "email": "...", "subscriptionType": "max" },
  "mode": "passthrough",
  "plugin": { "opencode": "configured" }
}
```

The same field appears in `degraded` and `unhealthy` responses.

## Design decisions

**Version flows through config, not `createRequire`.** The initial approach imported `package.json` directly in `server.ts` via `createRequire`. That fails in the bundled output because `../../package.json` resolves outside the package root when the code runs from `dist/cli-*.js`. Instead, `bin/cli.ts` already reads `../package.json` (which resolves correctly from `dist/cli.js`), so it passes `version` through the `ProxyConfig` to the server.

**Fallback is `"unknown"`.** When `createProxyServer` is called without `version` (tests, library usage), the health response returns `"unknown"` rather than omitting the field. This keeps the response schema consistent.

## Changes

| File | What |
|------|------|
| `src/proxy/types.ts` | Add optional `version?: string` to `ProxyConfig` |
| `src/proxy/server.ts` | Derive `serverVersion = finalConfig.version ?? "unknown"`, include in all `/health` responses |
| `bin/cli.ts` | Pass `version` (already imported from `package.json`) to `startProxyServer` |
| `src/__tests__/proxy-async-ops.test.ts` | Assert `version` field in all health states; fix env var cleanup to `delete` instead of assigning `undefined` |

## Backward compatibility

Non-breaking. Adding a field to an existing JSON response. All existing clients that consume `/health` simply see an extra field they can ignore.

The `/health` response shape is listed as a stable API contract in `CLAUDE.md`. This is an additive change — no fields removed, no types changed.