### PR TITLE
refactor(telemetry): extract telemetry store interfaces and memory implementations

### DIFF
--- a/src/__tests__/telemetry-store.test.ts
+++ b/src/__tests__/telemetry-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from "bun:test"
 import { MemoryTelemetryStore } from "../telemetry/store"
-import type { RequestMetric } from "../telemetry/types"
+import type { RequestMetric, ITelemetryStore } from "../telemetry/types"
 
 function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
   return {
@@ -178,5 +178,17 @@ describe("MemoryTelemetryStore.summarize", () => {
     const summary = store.summarize()
     // TTFB should only include non-null values
     expect(summary.ttfb.p50).toBe(100)
+  })
+})
+
+describe("ITelemetryStore conformance", () => {
+  it("MemoryTelemetryStore satisfies ITelemetryStore", () => {
+    const store: ITelemetryStore = new MemoryTelemetryStore(10)
+    store.record(makeMetric())
+    expect(store.size).toBe(1)
+    expect(store.getRecent().length).toBe(1)
+    expect(store.summarize().totalRequests).toBe(1)
+    store.clear()
+    expect(store.size).toBe(0)
   })
 })

--- a/src/__tests__/telemetry-store.test.ts
+++ b/src/__tests__/telemetry-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "bun:test"
-import { TelemetryStore } from "../telemetry/store"
+import { MemoryTelemetryStore } from "../telemetry/store"
 import type { RequestMetric } from "../telemetry/types"
 
 function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
@@ -23,11 +23,11 @@ function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
   }
 }
 
-describe("TelemetryStore", () => {
-  let store: TelemetryStore
+describe("MemoryTelemetryStore", () => {
+  let store: MemoryTelemetryStore
 
   beforeEach(() => {
-    store = new TelemetryStore(10)
+    store = new MemoryTelemetryStore(10)
   })
 
   it("records and retrieves metrics", () => {
@@ -95,11 +95,11 @@ describe("TelemetryStore", () => {
   })
 })
 
-describe("TelemetryStore.summarize", () => {
-  let store: TelemetryStore
+describe("MemoryTelemetryStore.summarize", () => {
+  let store: MemoryTelemetryStore
 
   beforeEach(() => {
-    store = new TelemetryStore(100)
+    store = new MemoryTelemetryStore(100)
   })
 
   it("returns empty summary when no metrics exist", () => {

--- a/src/__tests__/telemetry-store.test.ts
+++ b/src/__tests__/telemetry-store.test.ts
@@ -85,6 +85,16 @@ describe("MemoryTelemetryStore", () => {
     expect(filtered[0]!.requestId).toBe("new")
   })
 
+  it("returns the latest successful metric for an SDK session", () => {
+    store.record(makeMetric({ requestId: "older-ok", sdkSessionId: "sdk-1", totalDurationMs: 100 }))
+    store.record(makeMetric({ requestId: "latest-error", sdkSessionId: "sdk-1", error: "api_error", totalDurationMs: 200 }))
+    store.record(makeMetric({ requestId: "other-session", sdkSessionId: "sdk-2", totalDurationMs: 300 }))
+
+    const metric = store.getLastForSession("sdk-1")
+
+    expect(metric?.requestId).toBe("older-ok")
+  })
+
   it("clears all metrics", () => {
     store.record(makeMetric())
     store.record(makeMetric())

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,6 +1,13 @@
-export { telemetryStore, TelemetryStore } from "./store"
-export { diagnosticLog, DiagnosticLogStore } from "./logStore"
+export { telemetryStore, MemoryTelemetryStore, TelemetryStore } from "./store"
+export { diagnosticLog, MemoryDiagnosticLogStore, DiagnosticLogStore } from "./logStore"
 export { createTelemetryRoutes } from "./routes"
 export { landingHtml } from "./landing"
-export type { RequestMetric, TelemetrySummary, PhaseTiming } from "./types"
-export type { DiagnosticLog } from "./logStore"
+export { computePercentiles, computeSummary } from "./percentiles"
+export type {
+  RequestMetric,
+  TelemetrySummary,
+  PhaseTiming,
+  ITelemetryStore,
+  IDiagnosticLogStore,
+  DiagnosticLog,
+} from "./types"

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,5 +1,5 @@
-export { telemetryStore, MemoryTelemetryStore, TelemetryStore } from "./store"
-export { diagnosticLog, MemoryDiagnosticLogStore, DiagnosticLogStore } from "./logStore"
+export { telemetryStore, MemoryTelemetryStore } from "./store"
+export { diagnosticLog, MemoryDiagnosticLogStore } from "./logStore"
 export { createTelemetryRoutes } from "./routes"
 export { landingHtml } from "./landing"
 export { computePercentiles, computeSummary } from "./percentiles"

--- a/src/telemetry/logStore.ts
+++ b/src/telemetry/logStore.ts
@@ -65,6 +65,3 @@ export class MemoryDiagnosticLogStore implements IDiagnosticLogStore {
 
 /** Singleton instance used by the proxy. */
 export const diagnosticLog = new MemoryDiagnosticLogStore()
-
-/** @deprecated Use MemoryDiagnosticLogStore */
-export { MemoryDiagnosticLogStore as DiagnosticLogStore }

--- a/src/telemetry/logStore.ts
+++ b/src/telemetry/logStore.ts
@@ -6,22 +6,12 @@
  * for users to dig through stderr to report issues.
  */
 
-export interface DiagnosticLog {
-  /** Unix timestamp */
-  timestamp: number
-  /** Log level */
-  level: "info" | "warn" | "error"
-  /** Log category for filtering */
-  category: "session" | "lineage" | "error" | "lifecycle" | "token"
-  /** Request ID (if associated with a request) */
-  requestId?: string
-  /** Human-readable message */
-  message: string
-}
+import type { DiagnosticLog, IDiagnosticLogStore } from "./types"
+export type { DiagnosticLog } from "./types"
 
 const DEFAULT_CAPACITY = 500
 
-export class DiagnosticLogStore {
+export class MemoryDiagnosticLogStore implements IDiagnosticLogStore {
   private buffer: (DiagnosticLog | null)[]
   private head = 0
   private count = 0
@@ -32,34 +22,24 @@ export class DiagnosticLogStore {
     this.buffer = new Array(this.capacity).fill(null)
   }
 
-  /** Append a log entry. */
   log(entry: Omit<DiagnosticLog, "timestamp">): void {
     this.buffer[this.head] = { ...entry, timestamp: Date.now() }
     this.head = (this.head + 1) % this.capacity
     if (this.count < this.capacity) this.count++
   }
 
-  /** Convenience: log a session event. */
   session(message: string, requestId?: string): void {
     this.log({ level: "info", category: "session", message, requestId })
   }
 
-  /** Convenience: log a lineage event (compaction, undo, diverged). */
   lineage(message: string, requestId?: string): void {
     this.log({ level: "warn", category: "lineage", message, requestId })
   }
 
-  /** Convenience: log an error. */
   error(message: string, requestId?: string): void {
     this.log({ level: "error", category: "error", message, requestId })
   }
 
-  /**
-   * Retrieve recent logs, newest first.
-   * @param options.limit - Max entries (default: 100)
-   * @param options.since - Only entries after this timestamp
-   * @param options.category - Filter by category
-   */
   getRecent(options: { limit?: number; since?: number; category?: string } = {}): DiagnosticLog[] {
     const { limit = 100, since, category } = options
     const results: DiagnosticLog[] = []
@@ -76,7 +56,6 @@ export class DiagnosticLogStore {
     return results
   }
 
-  /** Clear all stored logs. */
   clear(): void {
     this.buffer = new Array(this.capacity).fill(null)
     this.head = 0
@@ -85,4 +64,7 @@ export class DiagnosticLogStore {
 }
 
 /** Singleton instance used by the proxy. */
-export const diagnosticLog = new DiagnosticLogStore()
+export const diagnosticLog = new MemoryDiagnosticLogStore()
+
+/** @deprecated Use MemoryDiagnosticLogStore */
+export { MemoryDiagnosticLogStore as DiagnosticLogStore }

--- a/src/telemetry/percentiles.ts
+++ b/src/telemetry/percentiles.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared percentile computation used by all telemetry store implementations.
+ */
+
+import type { RequestMetric, PhaseTiming, TelemetrySummary } from "./types"
+
+export function computePercentiles(values: number[]): PhaseTiming {
+  if (values.length === 0) return { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const sum = sorted.reduce((a, b) => a + b, 0)
+
+  return {
+    p50: sorted[Math.floor(sorted.length * 0.5)]!,
+    p95: sorted[Math.floor(sorted.length * 0.95)]!,
+    p99: sorted[Math.floor(sorted.length * 0.99)]!,
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    avg: Math.round(sum / sorted.length),
+  }
+}
+
+/**
+ * Compute a TelemetrySummary from an array of RequestMetric.
+ * Both MemoryTelemetryStore and SqliteTelemetryStore use this
+ * to guarantee identical output.
+ */
+export function computeSummary(metrics: RequestMetric[], windowMs: number): TelemetrySummary {
+  if (metrics.length === 0) {
+    const emptyPhase: PhaseTiming = { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
+    return {
+      windowMs,
+      totalRequests: 0,
+      errorCount: 0,
+      requestsPerMinute: 0,
+      queueWait: emptyPhase,
+      proxyOverhead: emptyPhase,
+      ttfb: emptyPhase,
+      upstreamDuration: emptyPhase,
+      totalDuration: emptyPhase,
+      byModel: {},
+      byMode: {},
+      tokenUsage: {
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCacheReadTokens: 0,
+        totalCacheCreationTokens: 0,
+        avgCacheHitRate: 0,
+        cacheMissOnResumeCount: 0,
+      },
+    }
+  }
+
+  const errorCount = metrics.filter(m => m.error !== null).length
+
+  const oldest = metrics[metrics.length - 1]!.timestamp
+  const newest = metrics[0]!.timestamp
+  const spanMs = Math.max(newest - oldest, 1)
+  const requestsPerMinute = (metrics.length / spanMs) * 60_000
+
+  const queueWaits = metrics.map(m => m.queueWaitMs)
+  const overheads = metrics.map(m => m.proxyOverheadMs)
+  const ttfbs = metrics.filter(m => m.ttfbMs !== null).map(m => m.ttfbMs!)
+  const upstreams = metrics.map(m => m.upstreamDurationMs)
+  const totals = metrics.map(m => m.totalDurationMs)
+
+  const byModel: Record<string, { count: number; totalMs: number }> = {}
+  for (const m of metrics) {
+    const modelKey = m.requestModel || m.model
+    const entry = byModel[modelKey] ??= { count: 0, totalMs: 0 }
+    entry.count++
+    entry.totalMs += m.totalDurationMs
+  }
+
+  const byMode: Record<string, { count: number; totalMs: number }> = {}
+  for (const m of metrics) {
+    const entry = byMode[m.mode] ??= { count: 0, totalMs: 0 }
+    entry.count++
+    entry.totalMs += m.totalDurationMs
+  }
+
+  let totalInputTokens = 0
+  let totalOutputTokens = 0
+  let totalCacheReadTokens = 0
+  let totalCacheCreationTokens = 0
+  let cacheHitRateSum = 0
+  let cacheHitRateCount = 0
+  let cacheMissOnResumeCount = 0
+
+  for (const m of metrics) {
+    totalInputTokens += m.inputTokens ?? 0
+    totalOutputTokens += m.outputTokens ?? 0
+    totalCacheReadTokens += m.cacheReadInputTokens ?? 0
+    totalCacheCreationTokens += m.cacheCreationInputTokens ?? 0
+    if (m.cacheHitRate !== undefined) {
+      cacheHitRateSum += m.cacheHitRate
+      cacheHitRateCount++
+    }
+    if (m.isResume && m.cacheHitRate !== undefined && m.cacheHitRate === 0) {
+      cacheMissOnResumeCount++
+    }
+  }
+
+  return {
+    windowMs,
+    totalRequests: metrics.length,
+    errorCount,
+    requestsPerMinute: Math.round(requestsPerMinute * 100) / 100,
+    queueWait: computePercentiles(queueWaits),
+    proxyOverhead: computePercentiles(overheads),
+    ttfb: ttfbs.length > 0 ? computePercentiles(ttfbs) : { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 },
+    upstreamDuration: computePercentiles(upstreams),
+    totalDuration: computePercentiles(totals),
+    byModel: Object.fromEntries(
+      Object.entries(byModel).map(([k, v]) => [k, { count: v.count, avgTotalMs: Math.round(v.totalMs / v.count) }])
+    ),
+    byMode: Object.fromEntries(
+      Object.entries(byMode).map(([k, v]) => [k, { count: v.count, avgTotalMs: Math.round(v.totalMs / v.count) }])
+    ),
+    tokenUsage: {
+      totalInputTokens,
+      totalOutputTokens,
+      totalCacheReadTokens,
+      totalCacheCreationTokens,
+      avgCacheHitRate: cacheHitRateCount > 0
+        ? Math.round((cacheHitRateSum / cacheHitRateCount) * 100) / 100
+        : 0,
+      cacheMissOnResumeCount,
+    },
+  }
+}

--- a/src/telemetry/routes.ts
+++ b/src/telemetry/routes.ts
@@ -11,8 +11,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { resolve, dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Hono } from "hono"
-import { telemetryStore } from "./store"
-import { diagnosticLog } from "./logStore"
+import { telemetryStore, diagnosticLog } from "./index"
 import { dashboardHtml } from "./dashboard"
 
 // Read once at module load — src/telemetry/ is two levels below the package root

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -97,6 +97,3 @@ export class MemoryTelemetryStore implements ITelemetryStore {
 
 /** Singleton store instance used by the proxy. */
 export const telemetryStore = new MemoryTelemetryStore()
-
-/** @deprecated Use MemoryTelemetryStore */
-export { MemoryTelemetryStore as TelemetryStore }

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -5,7 +5,7 @@
  * No disk I/O in the hot path. Data resets on proxy restart.
  */
 
-import type { RequestMetric, TelemetrySummary } from "./types"
+import type { RequestMetric, TelemetrySummary, ITelemetryStore } from "./types"
 import { computeSummary } from "./percentiles"
 
 const DEFAULT_CAPACITY = 1000
@@ -18,7 +18,7 @@ function getCapacity(): number {
   return parsed
 }
 
-export class TelemetryStore {
+export class MemoryTelemetryStore implements ITelemetryStore {
   private buffer: (RequestMetric | null)[]
   private head = 0 // next write position
   private count = 0
@@ -96,4 +96,7 @@ export class TelemetryStore {
 }
 
 /** Singleton store instance used by the proxy. */
-export const telemetryStore = new TelemetryStore()
+export const telemetryStore = new MemoryTelemetryStore()
+
+/** @deprecated Use MemoryTelemetryStore */
+export { MemoryTelemetryStore as TelemetryStore }

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -5,7 +5,8 @@
  * No disk I/O in the hot path. Data resets on proxy restart.
  */
 
-import type { RequestMetric, PhaseTiming, TelemetrySummary } from "./types"
+import type { RequestMetric, TelemetrySummary } from "./types"
+import { computeSummary } from "./percentiles"
 
 const DEFAULT_CAPACITY = 1000
 
@@ -83,114 +84,7 @@ export class TelemetryStore {
   summarize(windowMs: number = 60 * 60 * 1000): TelemetrySummary {
     const since = Date.now() - windowMs
     const metrics = this.getRecent({ limit: this.capacity, since })
-
-    if (metrics.length === 0) {
-      const emptyPhase: PhaseTiming = { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
-      return {
-        windowMs,
-        totalRequests: 0,
-        errorCount: 0,
-        requestsPerMinute: 0,
-        queueWait: emptyPhase,
-        proxyOverhead: emptyPhase,
-        ttfb: emptyPhase,
-        upstreamDuration: emptyPhase,
-        totalDuration: emptyPhase,
-        byModel: {},
-        byMode: {},
-        tokenUsage: {
-          totalInputTokens: 0,
-          totalOutputTokens: 0,
-          totalCacheReadTokens: 0,
-          totalCacheCreationTokens: 0,
-          avgCacheHitRate: 0,
-          cacheMissOnResumeCount: 0,
-        },
-      }
-    }
-
-    const errorCount = metrics.filter(m => m.error !== null).length
-
-    // Compute actual time span for rate calculation
-    const oldest = metrics[metrics.length - 1]!.timestamp
-    const newest = metrics[0]!.timestamp
-    const spanMs = Math.max(newest - oldest, 1)
-    const requestsPerMinute = (metrics.length / spanMs) * 60_000
-
-    // Phase timings
-    const queueWaits = metrics.map(m => m.queueWaitMs)
-    const overheads = metrics.map(m => m.proxyOverheadMs)
-    const ttfbs = metrics.filter(m => m.ttfbMs !== null).map(m => m.ttfbMs!)
-    const upstreams = metrics.map(m => m.upstreamDurationMs)
-    const totals = metrics.map(m => m.totalDurationMs)
-
-    // Model breakdown — use the client's original model string when available
-    const byModel: Record<string, { count: number; totalMs: number }> = {}
-    for (const m of metrics) {
-      const modelKey = m.requestModel || m.model
-      const entry = byModel[modelKey] ??= { count: 0, totalMs: 0 }
-      entry.count++
-      entry.totalMs += m.totalDurationMs
-    }
-
-    // Mode breakdown
-    const byMode: Record<string, { count: number; totalMs: number }> = {}
-    for (const m of metrics) {
-      const entry = byMode[m.mode] ??= { count: 0, totalMs: 0 }
-      entry.count++
-      entry.totalMs += m.totalDurationMs
-    }
-
-    // Token usage aggregation
-    let totalInputTokens = 0
-    let totalOutputTokens = 0
-    let totalCacheReadTokens = 0
-    let totalCacheCreationTokens = 0
-    let cacheHitRateSum = 0
-    let cacheHitRateCount = 0
-    let cacheMissOnResumeCount = 0
-
-    for (const m of metrics) {
-      totalInputTokens += m.inputTokens ?? 0
-      totalOutputTokens += m.outputTokens ?? 0
-      totalCacheReadTokens += m.cacheReadInputTokens ?? 0
-      totalCacheCreationTokens += m.cacheCreationInputTokens ?? 0
-      if (m.cacheHitRate !== undefined) {
-        cacheHitRateSum += m.cacheHitRate
-        cacheHitRateCount++
-      }
-      if (m.isResume && m.cacheHitRate !== undefined && m.cacheHitRate === 0) {
-        cacheMissOnResumeCount++
-      }
-    }
-
-    return {
-      windowMs,
-      totalRequests: metrics.length,
-      errorCount,
-      requestsPerMinute: Math.round(requestsPerMinute * 100) / 100,
-      queueWait: computePercentiles(queueWaits),
-      proxyOverhead: computePercentiles(overheads),
-      ttfb: ttfbs.length > 0 ? computePercentiles(ttfbs) : { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 },
-      upstreamDuration: computePercentiles(upstreams),
-      totalDuration: computePercentiles(totals),
-      byModel: Object.fromEntries(
-        Object.entries(byModel).map(([k, v]) => [k, { count: v.count, avgTotalMs: Math.round(v.totalMs / v.count) }])
-      ),
-      byMode: Object.fromEntries(
-        Object.entries(byMode).map(([k, v]) => [k, { count: v.count, avgTotalMs: Math.round(v.totalMs / v.count) }])
-      ),
-      tokenUsage: {
-        totalInputTokens,
-        totalOutputTokens,
-        totalCacheReadTokens,
-        totalCacheCreationTokens,
-        avgCacheHitRate: cacheHitRateCount > 0
-          ? Math.round((cacheHitRateSum / cacheHitRateCount) * 100) / 100
-          : 0,
-        cacheMissOnResumeCount,
-      },
-    }
+    return computeSummary(metrics, windowMs)
   }
 
   /** Clear all stored metrics. */
@@ -198,22 +92,6 @@ export class TelemetryStore {
     this.buffer = new Array(this.capacity).fill(null)
     this.head = 0
     this.count = 0
-  }
-}
-
-function computePercentiles(values: number[]): PhaseTiming {
-  if (values.length === 0) return { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
-
-  const sorted = [...values].sort((a, b) => a - b)
-  const sum = sorted.reduce((a, b) => a + b, 0)
-
-  return {
-    p50: sorted[Math.floor(sorted.length * 0.5)]!,
-    p95: sorted[Math.floor(sorted.length * 0.95)]!,
-    p99: sorted[Math.floor(sorted.length * 0.99)]!,
-    min: sorted[0]!,
-    max: sorted[sorted.length - 1]!,
-    avg: Math.round(sum / sorted.length),
   }
 }
 

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -178,7 +178,7 @@ export interface DiagnosticLog {
   /** Log level */
   level: "info" | "warn" | "error"
   /** Log category for filtering */
-  category: "session" | "lineage" | "error" | "lifecycle"
+  category: "session" | "lineage" | "error" | "lifecycle" | "token"
   /** Request ID (if associated with a request) */
   requestId?: string
   /** Human-readable message */

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -189,14 +189,20 @@ export interface DiagnosticLog {
 
 /** Storage backend for diagnostic logs. */
 export interface IDiagnosticLogStore {
+  /** Append a log entry (timestamp is added automatically). */
   log(entry: Omit<DiagnosticLog, "timestamp">): void
+  /** Log a session event. */
   session(message: string, requestId?: string): void
+  /** Log a lineage event (compaction, undo, diverged). */
   lineage(message: string, requestId?: string): void
+  /** Log an error. */
   error(message: string, requestId?: string): void
+  /** Retrieve recent logs, newest first. */
   getRecent(options?: {
     limit?: number
     since?: number
     category?: string
   }): DiagnosticLog[]
+  /** Clear all stored logs. */
   clear(): void
 }

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -165,6 +165,8 @@ export interface ITelemetryStore {
     since?: number
     model?: string
   }): RequestMetric[]
+  /** Find the latest successful metric for a given SDK session. */
+  getLastForSession(sdkSessionId: string): RequestMetric | undefined
   /** Compute aggregate statistics over a time window. */
   summarize(windowMs?: number): TelemetrySummary
   /** Clear all stored metrics. */

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -152,3 +152,49 @@ export interface TelemetrySummary {
     cacheMissOnResumeCount: number
   }
 }
+
+/** Storage backend for request metrics. */
+export interface ITelemetryStore {
+  /** Record a completed request metric. */
+  record(metric: RequestMetric): void
+  /** Number of stored metrics. */
+  readonly size: number
+  /** Retrieve recent metrics, newest first. */
+  getRecent(options?: {
+    limit?: number
+    since?: number
+    model?: string
+  }): RequestMetric[]
+  /** Compute aggregate statistics over a time window. */
+  summarize(windowMs?: number): TelemetrySummary
+  /** Clear all stored metrics. */
+  clear(): void
+}
+
+/** Diagnostic log entry. */
+export interface DiagnosticLog {
+  /** Unix timestamp */
+  timestamp: number
+  /** Log level */
+  level: "info" | "warn" | "error"
+  /** Log category for filtering */
+  category: "session" | "lineage" | "error" | "lifecycle"
+  /** Request ID (if associated with a request) */
+  requestId?: string
+  /** Human-readable message */
+  message: string
+}
+
+/** Storage backend for diagnostic logs. */
+export interface IDiagnosticLogStore {
+  log(entry: Omit<DiagnosticLog, "timestamp">): void
+  session(message: string, requestId?: string): void
+  lineage(message: string, requestId?: string): void
+  error(message: string, requestId?: string): void
+  getRecent(options?: {
+    limit?: number
+    since?: number
+    category?: string
+  }): DiagnosticLog[]
+  clear(): void
+}


### PR DESCRIPTION
Based on #332 by @beshkenadze — all original commits preserved with authorship intact.

## Summary
- Introduce explicit `ITelemetryStore` and `IDiagnosticLogStore` contracts for telemetry storage
- Extract percentile and summary aggregation into a shared module
- Rename memory-backed implementations to `Memory*` prefix to make backend swaps explicit
- Add store conformance test and expose session lookup on the telemetry store contract

## Additional changes (on top of #332)
- Drop unnecessary `@deprecated` re-exports (no external consumers)
- Add JSDoc comments to `IDiagnosticLogStore` interface methods

## Validation
- npm run build ✓
- npm test ✓

Closes #332