### PR TITLE
feat(telemetry): add Prometheus metrics renderer and /metrics endpoint

### DIFF
--- a/src/__tests__/telemetry-prometheus.test.ts
+++ b/src/__tests__/telemetry-prometheus.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeEach } from "bun:test"
+import { MemoryTelemetryStore } from "../telemetry/store"
+import { renderPrometheusMetrics } from "../telemetry/prometheus"
+import type { RequestMetric } from "../telemetry/types"
+
+function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
+  return {
+    requestId: `req-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    model: "sonnet",
+    mode: "stream",
+    isResume: false,
+    isPassthrough: false,
+    status: 200,
+    queueWaitMs: 5,
+    proxyOverheadMs: 12,
+    ttfbMs: 120,
+    upstreamDurationMs: 800,
+    totalDurationMs: 850,
+    contentBlocks: 3,
+    textEvents: 10,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe("renderPrometheusMetrics", () => {
+  let store: MemoryTelemetryStore
+
+  beforeEach(() => {
+    store = new MemoryTelemetryStore(100)
+  })
+
+  it("returns valid output for empty store", () => {
+    const output = renderPrometheusMetrics(store)
+    expect(output).toContain("# HELP meridian_requests_total")
+    expect(output).toContain("# TYPE meridian_requests_total counter")
+    expect(output).toContain("# HELP meridian_request_duration_ms")
+    expect(output).toContain("# TYPE meridian_request_duration_ms histogram")
+    // Must be valid (no NaN, no undefined)
+    expect(output).not.toContain("NaN")
+    expect(output).not.toContain("undefined")
+  })
+
+  it("counts requests by model, mode, status", () => {
+    store.record(makeMetric({ model: "sonnet", mode: "stream", status: 200 }))
+    store.record(makeMetric({ model: "sonnet", mode: "stream", status: 200 }))
+    store.record(makeMetric({ model: "opus", mode: "non-stream", status: 200 }))
+    store.record(makeMetric({ model: "sonnet", mode: "stream", status: 500, error: "api_error" }))
+
+    const output = renderPrometheusMetrics(store)
+    expect(output).toContain('meridian_requests_total{model="sonnet",mode="stream",status="200"} 2')
+    expect(output).toContain('meridian_requests_total{model="opus",mode="non-stream",status="200"} 1')
+    expect(output).toContain('meridian_requests_total{model="sonnet",mode="stream",status="500"} 1')
+  })
+
+  it("produces valid histogram buckets with +Inf, _count, _sum", () => {
+    store.record(makeMetric({ totalDurationMs: 50 }))
+    store.record(makeMetric({ totalDurationMs: 150 }))
+
+    const output = renderPrometheusMetrics(store)
+
+    // Must have +Inf bucket
+    expect(output).toContain('meridian_request_duration_ms_bucket{phase="total",le="+Inf"} 2')
+    // Must have _count and _sum
+    expect(output).toContain('meridian_request_duration_ms_count{phase="total"} 2')
+    expect(output).toContain('meridian_request_duration_ms_sum{phase="total"} 200')
+
+    // Bucket boundaries: 50ms falls in le="50" and above
+    expect(output).toContain('meridian_request_duration_ms_bucket{phase="total",le="50"} 1')
+    expect(output).toContain('meridian_request_duration_ms_bucket{phase="total",le="250"} 2')
+  })
+
+  it("includes all five phases in histogram", () => {
+    store.record(makeMetric())
+
+    const output = renderPrometheusMetrics(store)
+    for (const phase of ["queue_wait", "proxy_overhead", "ttfb", "upstream", "total"]) {
+      expect(output).toContain(`phase="${phase}"`)
+    }
+  })
+
+  it("skips null ttfb values in histogram", () => {
+    store.record(makeMetric({ ttfbMs: null }))
+    store.record(makeMetric({ ttfbMs: 100 }))
+
+    const output = renderPrometheusMetrics(store)
+    // ttfb count should be 1 (only the non-null one)
+    expect(output).toContain('meridian_request_duration_ms_count{phase="ttfb"} 1')
+    expect(output).toContain('meridian_request_duration_ms_sum{phase="ttfb"} 100')
+  })
+
+  it("escapes label values correctly", () => {
+    store.record(makeMetric({ model: 'sonnet"special' }))
+
+    const output = renderPrometheusMetrics(store)
+    // Quotes in label values must be escaped
+    expect(output).toContain('model="sonnet\\"special"')
+  })
+
+  it("each metric family has exactly one HELP and TYPE line", () => {
+    store.record(makeMetric())
+    store.record(makeMetric({ model: "opus" }))
+
+    const output = renderPrometheusMetrics(store)
+    const helpLines = output.split("\n").filter(l => l.startsWith("# HELP"))
+    const typeLines = output.split("\n").filter(l => l.startsWith("# TYPE"))
+
+    // Two families: meridian_requests_total, meridian_request_duration_ms
+    expect(helpLines.length).toBe(2)
+    expect(typeLines.length).toBe(2)
+  })
+})

--- a/src/__tests__/telemetry-routes.test.ts
+++ b/src/__tests__/telemetry-routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from "bun:test"
 import { Hono } from "hono"
-import { telemetryStore, createTelemetryRoutes } from "../telemetry"
+import { telemetryStore, createTelemetryRoutes, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 
 function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
@@ -36,6 +36,12 @@ describe("Telemetry routes", () => {
     telemetryStore.clear()
     app = new Hono()
     app.route("/telemetry", createTelemetryRoutes())
+    app.get("/metrics", (c) => {
+      const body = renderPrometheusMetrics(telemetryStore)
+      return c.body(body, 200, {
+        "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
+      })
+    })
   })
 
   it("GET /telemetry returns HTML dashboard", async () => {
@@ -173,5 +179,25 @@ describe("Telemetry routes", () => {
     expect(body.tokenUsage.totalCacheCreationTokens).toBe(1650)
     expect(body.tokenUsage.cacheMissOnResumeCount).toBe(1)
     expect(body.tokenUsage.avgCacheHitRate).toBeCloseTo(0.53, 1)
+  })
+
+  it("GET /metrics returns Prometheus format with correct content type", async () => {
+    telemetryStore.record(makeMetric())
+
+    const res = await app.fetch(new Request("http://localhost/metrics"))
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("text/plain")
+    const body = await res.text()
+    expect(body).toContain("# TYPE meridian_requests_total counter")
+    expect(body).toContain("# TYPE meridian_request_duration_ms histogram")
+  })
+
+  it("GET /metrics returns 200 with valid output when store is empty", async () => {
+    const res = await app.fetch(new Request("http://localhost/metrics"))
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain("# HELP meridian_requests_total")
+    expect(body).not.toContain("NaN")
+    expect(body).not.toContain("undefined")
   })
 })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -15,7 +15,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 
-import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml } from "../telemetry"
+import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken } from "./tokenRefresh"
@@ -213,7 +213,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         status: "ok",
         service: "meridian",
         format: "anthropic",
-        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/models", "/telemetry", "/health"]
+        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/models", "/telemetry", "/metrics", "/health"]
       })
     }
     return c.html(landingHtml)
@@ -1710,6 +1710,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
   // Telemetry dashboard and API
   app.route("/telemetry", createTelemetryRoutes())
+
+  // Prometheus metrics endpoint
+  app.get("/metrics", (c) => {
+    const body = renderPrometheusMetrics(telemetryStore)
+    return c.body(body, 200, {
+      "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
+    })
+  })
 
   // Health check endpoint — verifies auth status
   app.get("/health", async (c) => {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -3,6 +3,7 @@ export { diagnosticLog, MemoryDiagnosticLogStore } from "./logStore"
 export { createTelemetryRoutes } from "./routes"
 export { landingHtml } from "./landing"
 export { computePercentiles, computeSummary } from "./percentiles"
+export { renderPrometheusMetrics } from "./prometheus"
 export type {
   RequestMetric,
   TelemetrySummary,

--- a/src/telemetry/prometheus.ts
+++ b/src/telemetry/prometheus.ts
@@ -1,0 +1,78 @@
+/**
+ * Prometheus exposition format renderer.
+ *
+ * Generates text/plain output from ITelemetryStore data.
+ * No dependencies — hand-rolled per the exposition format spec:
+ * https://prometheus.io/docs/instrumenting/exposition_formats/
+ */
+
+import type { ITelemetryStore, RequestMetric } from "./types"
+
+const DURATION_BUCKETS = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000]
+
+const PHASES: { key: string; extract: (m: RequestMetric) => number | null }[] = [
+  { key: "queue_wait", extract: (m) => m.queueWaitMs },
+  { key: "proxy_overhead", extract: (m) => m.proxyOverheadMs },
+  { key: "ttfb", extract: (m) => m.ttfbMs },
+  { key: "upstream", extract: (m) => m.upstreamDurationMs },
+  { key: "total", extract: (m) => m.totalDurationMs },
+]
+
+function escapeLabelValue(v: string): string {
+  return v.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")
+}
+
+function formatLabels(labels: Record<string, string>): string {
+  return Object.entries(labels)
+    .map(([k, v]) => `${k}="${escapeLabelValue(v)}"`)
+    .join(",")
+}
+
+export function renderPrometheusMetrics(store: ITelemetryStore): string {
+  const metrics = store.getRecent({ limit: 10000 })
+  const lines: string[] = []
+
+  // --- Counter: meridian_requests_total ---
+  lines.push("# HELP meridian_requests_total Total proxy requests")
+  lines.push("# TYPE meridian_requests_total counter")
+
+  const counters = new Map<string, number>()
+  for (const m of metrics) {
+    const key = `${m.model}\0${m.mode}\0${m.status}`
+    counters.set(key, (counters.get(key) ?? 0) + 1)
+  }
+  for (const [key, count] of counters) {
+    const [model, mode, status] = key.split("\0")
+    lines.push(`meridian_requests_total{${formatLabels({ model: model!, mode: mode!, status: status! })}} ${count}`)
+  }
+
+  // --- Histogram: meridian_request_duration_ms ---
+  lines.push("")
+  lines.push("# HELP meridian_request_duration_ms Request duration by phase in milliseconds")
+  lines.push("# TYPE meridian_request_duration_ms histogram")
+
+  for (const phase of PHASES) {
+    const values: number[] = []
+    for (const m of metrics) {
+      const v = phase.extract(m)
+      if (v !== null) values.push(v)
+    }
+
+    const phaseLabel = `phase="${escapeLabelValue(phase.key)}"`
+
+    // Buckets (cumulative)
+    for (const le of DURATION_BUCKETS) {
+      const count = values.filter((v) => v <= le).length
+      lines.push(`meridian_request_duration_ms_bucket{${phaseLabel},le="${le}"} ${count}`)
+    }
+    lines.push(`meridian_request_duration_ms_bucket{${phaseLabel},le="+Inf"} ${values.length}`)
+
+    // Sum and count
+    const sum = values.reduce((a, b) => a + b, 0)
+    lines.push(`meridian_request_duration_ms_sum{${phaseLabel}} ${sum}`)
+    lines.push(`meridian_request_duration_ms_count{${phaseLabel}} ${values.length}`)
+  }
+
+  lines.push("")
+  return lines.join("\n")
+}


### PR DESCRIPTION
## Summary
- add a Prometheus exposition format renderer for telemetry summaries
- export the renderer through the telemetry barrel and mount a `GET /metrics` endpoint in the proxy server
- add renderer unit tests and route integration tests for `/metrics`

## Validation
- `npm run build` passes
- `bun test src/__tests__/telemetry-prometheus.test.ts src/__tests__/telemetry-routes.test.ts` — 34 tests pass

## Stack
Follows #335 (telemetry interface extraction, merged).