### PR TITLE
Correct configuration for Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,10 @@ Pi uses the `@mariozechner/pi-ai` library which supports a configurable `baseUrl
 	"providers": {
 		"anthropic": {
 			"baseUrl": "http://127.0.0.1:3456",
-			"apiKey": "x"
+			"apiKey": "x",
+			"headers": {
+				"x-meridian-agent": "pi"
+			}
 		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -318,9 +318,12 @@ Pi uses the `@mariozechner/pi-ai` library which supports a configurable `baseUrl
 
 ```json
 {
-  "anthropic": {
-    "baseUrl": "http://127.0.0.1:3456"
-  }
+	"providers": {
+		"anthropic": {
+			"baseUrl": "http://127.0.0.1:3456",
+			"apiKey": "x"
+		}
+	}
 }
 ```
 


### PR DESCRIPTION
The provided example config for Pi does not work. It must be wrapped in a top-level `providers` key, and the `apiKey` must also be specified to activate the provider. I also added the `x-meridian-agent: pi` to the headers, to correctly inform meridian of the adapter.