### PR TITLE
feat(telemetry): add SQLite-backed telemetry persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY bin/ ./bin/
 COPY src/ ./src/
 # Run bun build directly (not "bun run build") to skip postbuild hook,
 # which calls "node --check" — unavailable in oven/bun image
-RUN rm -rf dist && bun build bin/cli.ts src/proxy/server.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --entry-naming '[name].js'
+RUN rm -rf dist && bun build bin/cli.ts src/proxy/server.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --external libsql --entry-naming '[name].js'
 
 # ---- Runtime stage ----
 FROM node:22-alpine

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "opencode-claude-code-provider",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.89",
+        "libsql": "^0.5.29",
       },
       "devDependencies": {
         "@hono/node-server": "^1.19.11",
@@ -62,7 +63,27 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
+    "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.5.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A=="],
+
+    "@libsql/darwin-x64": ["@libsql/darwin-x64@0.5.29", "", { "os": "darwin", "cpu": "x64" }, "sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ=="],
+
+    "@libsql/linux-arm-gnueabihf": ["@libsql/linux-arm-gnueabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ=="],
+
+    "@libsql/linux-arm-musleabihf": ["@libsql/linux-arm-musleabihf@0.5.29", "", { "os": "linux", "cpu": "arm" }, "sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg=="],
+
+    "@libsql/linux-arm64-gnu": ["@libsql/linux-arm64-gnu@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w=="],
+
+    "@libsql/linux-arm64-musl": ["@libsql/linux-arm64-musl@0.5.29", "", { "os": "linux", "cpu": "arm64" }, "sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg=="],
+
+    "@libsql/linux-x64-gnu": ["@libsql/linux-x64-gnu@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg=="],
+
+    "@libsql/linux-x64-musl": ["@libsql/linux-x64-musl@0.5.29", "", { "os": "linux", "cpu": "x64" }, "sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w=="],
+
+    "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.29", "", { "os": "win32", "cpu": "x64" }, "sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
@@ -99,6 +120,8 @@
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "detect-libc": ["detect-libc@2.0.2", "", {}, "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -171,6 +194,8 @@
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
     "lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "proxy:direct": "bun run ./bin/cli.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.89"
+    "@anthropic-ai/claude-agent-sdk": "^0.2.89",
+    "libsql": "^0.5.29"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.11",

--- a/src/__tests__/telemetry-sqlite.test.ts
+++ b/src/__tests__/telemetry-sqlite.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { createSqliteStores } from "../telemetry/sqlite"
+import type { ITelemetryStore, IDiagnosticLogStore, RequestMetric } from "../telemetry/types"
+
+function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
+  return {
+    requestId: `req-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    model: "sonnet",
+    mode: "stream",
+    isResume: false,
+    isPassthrough: false,
+    status: 200,
+    queueWaitMs: 5,
+    proxyOverheadMs: 12,
+    ttfbMs: 120,
+    upstreamDurationMs: 800,
+    totalDurationMs: 850,
+    contentBlocks: 3,
+    textEvents: 10,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe("SqliteTelemetryStore", () => {
+  let tmpDir: string
+  let store: ITelemetryStore
+  let logStore: IDiagnosticLogStore
+  let close: () => void
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "meridian-test-"))
+    const dbPath = join(tmpDir, "test.db")
+    const stores = createSqliteStores(dbPath, 7)
+    store = stores.telemetry
+    logStore = stores.diagnostics
+    close = stores.close
+  })
+
+  afterEach(() => {
+    close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it("records and retrieves metrics (newest first)", () => {
+    store.record(makeMetric({ requestId: "r1", timestamp: 1000 }))
+    store.record(makeMetric({ requestId: "r2", timestamp: 2000 }))
+
+    expect(store.size).toBe(2)
+    const recent = store.getRecent()
+    expect(recent.length).toBe(2)
+    expect(recent[0]!.requestId).toBe("r2")
+    expect(recent[1]!.requestId).toBe("r1")
+  })
+
+  it("respects limit parameter", () => {
+    for (let i = 0; i < 10; i++) {
+      store.record(makeMetric({ timestamp: 1000 + i }))
+    }
+    const recent = store.getRecent({ limit: 3 })
+    expect(recent.length).toBe(3)
+  })
+
+  it("filters by model", () => {
+    store.record(makeMetric({ model: "sonnet" }))
+    store.record(makeMetric({ model: "opus" }))
+    store.record(makeMetric({ model: "sonnet" }))
+
+    const sonnets = store.getRecent({ model: "sonnet" })
+    expect(sonnets.length).toBe(2)
+    expect(sonnets.every(m => m.model === "sonnet")).toBe(true)
+  })
+
+  it("filters by since timestamp", () => {
+    store.record(makeMetric({ timestamp: 1000, requestId: "old" }))
+    store.record(makeMetric({ timestamp: 2000, requestId: "new" }))
+
+    const filtered = store.getRecent({ since: 1500 })
+    expect(filtered.length).toBe(1)
+    expect(filtered[0]!.requestId).toBe("new")
+  })
+
+  it("clears all metrics", () => {
+    store.record(makeMetric())
+    store.record(makeMetric())
+    store.clear()
+
+    expect(store.size).toBe(0)
+    expect(store.getRecent().length).toBe(0)
+  })
+
+  it("summarize output matches MemoryTelemetryStore for same data", () => {
+    const { MemoryTelemetryStore } = require("../telemetry/store")
+    const memStore = new MemoryTelemetryStore(100)
+
+    const metrics = [
+      makeMetric({ model: "sonnet", totalDurationMs: 100, timestamp: Date.now() - 1000 }),
+      makeMetric({ model: "opus", totalDurationMs: 300, timestamp: Date.now() }),
+      makeMetric({ model: "sonnet", totalDurationMs: 200, error: "api_error", timestamp: Date.now() }),
+    ]
+
+    for (const m of metrics) {
+      store.record(m)
+      memStore.record(m)
+    }
+
+    const sqlSummary = store.summarize(3600_000)
+    const memSummary = memStore.summarize(3600_000)
+
+    expect(sqlSummary.totalRequests).toBe(memSummary.totalRequests)
+    expect(sqlSummary.errorCount).toBe(memSummary.errorCount)
+    expect(sqlSummary.totalDuration.p50).toBe(memSummary.totalDuration.p50)
+    expect(sqlSummary.byModel["sonnet"]!.count).toBe(memSummary.byModel["sonnet"]!.count)
+  })
+
+  it("handles null ttfb values", () => {
+    store.record(makeMetric({ ttfbMs: null }))
+    store.record(makeMetric({ ttfbMs: 100 }))
+
+    const recent = store.getRecent()
+    expect(recent[0]!.ttfbMs).toBe(100)
+    expect(recent[1]!.ttfbMs).toBeNull()
+  })
+
+  it("preserves all RequestMetric fields through round-trip", () => {
+    const metric = makeMetric({
+      requestId: "rt-1",
+      adapter: "opencode",
+      model: "sonnet",
+      requestModel: "claude-sonnet-4-6-20250312",
+      mode: "stream",
+      isResume: true,
+      isPassthrough: true,
+      lineageType: "continuation",
+      messageCount: 5,
+      sdkSessionId: "sess-abc",
+      status: 200,
+      queueWaitMs: 5,
+      proxyOverheadMs: 12,
+      ttfbMs: 120,
+      upstreamDurationMs: 800,
+      totalDurationMs: 850,
+      contentBlocks: 3,
+      textEvents: 10,
+      error: null,
+    })
+
+    store.record(metric)
+    const [retrieved] = store.getRecent()
+
+    expect(retrieved!.requestId).toBe("rt-1")
+    expect(retrieved!.adapter).toBe("opencode")
+    expect(retrieved!.requestModel).toBe("claude-sonnet-4-6-20250312")
+    expect(retrieved!.isResume).toBe(true)
+    expect(retrieved!.isPassthrough).toBe(true)
+    expect(retrieved!.lineageType).toBe("continuation")
+    expect(retrieved!.messageCount).toBe(5)
+    expect(retrieved!.sdkSessionId).toBe("sess-abc")
+  })
+
+  it("handles interleaved timestamps correctly", () => {
+    store.record(makeMetric({ requestId: "r1", timestamp: 3000 }))
+    store.record(makeMetric({ requestId: "r2", timestamp: 1000 }))
+    store.record(makeMetric({ requestId: "r3", timestamp: 2000 }))
+
+    const recent = store.getRecent()
+    expect(recent[0]!.requestId).toBe("r1")
+    expect(recent[1]!.requestId).toBe("r3")
+    expect(recent[2]!.requestId).toBe("r2")
+  })
+
+  it("persists data across close/reopen", () => {
+    const dbPath = join(tmpDir, "persist-test.db")
+    const stores1 = createSqliteStores(dbPath, 7)
+    stores1.telemetry.record(makeMetric({ requestId: "survive" }))
+    stores1.close()
+
+    const stores2 = createSqliteStores(dbPath, 7)
+    const recent = stores2.telemetry.getRecent()
+    expect(recent.length).toBe(1)
+    expect(recent[0]!.requestId).toBe("survive")
+    stores2.close()
+  })
+})
+
+describe("SqliteDiagnosticLogStore", () => {
+  let tmpDir: string
+  let logStore: IDiagnosticLogStore
+  let close: () => void
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "meridian-test-"))
+    const dbPath = join(tmpDir, "test.db")
+    const stores = createSqliteStores(dbPath, 7)
+    logStore = stores.diagnostics
+    close = stores.close
+  })
+
+  afterEach(() => {
+    close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it("records and retrieves logs (newest first)", () => {
+    logStore.session("msg1")
+    logStore.error("msg2")
+
+    const logs = logStore.getRecent()
+    expect(logs.length).toBe(2)
+    expect(logs[0]!.message).toBe("msg2")
+    expect(logs[0]!.category).toBe("error")
+    expect(logs[1]!.message).toBe("msg1")
+    expect(logs[1]!.category).toBe("session")
+  })
+
+  it("filters by category", () => {
+    logStore.session("s1")
+    logStore.error("e1")
+    logStore.lineage("l1")
+
+    const errors = logStore.getRecent({ category: "error" })
+    expect(errors.length).toBe(1)
+    expect(errors[0]!.message).toBe("e1")
+  })
+
+  it("filters by since timestamp", () => {
+    logStore.log({ level: "info", category: "session", message: "old" })
+    logStore.log({ level: "info", category: "session", message: "new" })
+
+    const all = logStore.getRecent()
+    const since = all[all.length - 1]!.timestamp + 1
+    const filtered = logStore.getRecent({ since })
+    expect(filtered.length).toBeLessThan(all.length)
+  })
+
+  it("attaches requestId", () => {
+    logStore.session("test", "req-42")
+    const [log] = logStore.getRecent()
+    expect(log!.requestId).toBe("req-42")
+  })
+
+  it("clears all logs", () => {
+    logStore.session("x")
+    logStore.error("y")
+    logStore.clear()
+    expect(logStore.getRecent().length).toBe(0)
+  })
+})
+
+describe("SqliteTelemetryStore error handling", () => {
+  it("record() does not throw on disk error", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "meridian-test-"))
+    const dbPath = join(tmpDir, "err-test.db")
+    const stores = createSqliteStores(dbPath, 7)
+
+    stores.close()
+
+    expect(() => {
+      stores.telemetry.record(makeMetric())
+    }).not.toThrow()
+
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+})
+
+describe("SqliteTelemetryStore retention", () => {
+  it("cleanup removes rows older than retention period", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "meridian-test-"))
+    const dbPath = join(tmpDir, "retention-test.db")
+    const stores = createSqliteStores(dbPath, 1)
+
+    const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000
+    const now = Date.now()
+
+    stores.telemetry.record(makeMetric({ requestId: "old", timestamp: twoDaysAgo }))
+    stores.telemetry.record(makeMetric({ requestId: "new", timestamp: now }))
+
+    ;(stores.telemetry as any).cleanup()
+
+    const recent = stores.telemetry.getRecent({ limit: 100 })
+    expect(recent.length).toBe(1)
+    expect(recent[0]!.requestId).toBe("new")
+
+    stores.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+})

--- a/src/__tests__/telemetry-sqlite.test.ts
+++ b/src/__tests__/telemetry-sqlite.test.ts
@@ -147,6 +147,11 @@ describe("SqliteTelemetryStore", () => {
       contentBlocks: 3,
       textEvents: 10,
       error: null,
+      inputTokens: 1200,
+      outputTokens: 340,
+      cacheReadInputTokens: 900,
+      cacheCreationInputTokens: 120,
+      cacheHitRate: 0.88,
     })
 
     store.record(metric)
@@ -160,6 +165,22 @@ describe("SqliteTelemetryStore", () => {
     expect(retrieved!.lineageType).toBe("continuation")
     expect(retrieved!.messageCount).toBe(5)
     expect(retrieved!.sdkSessionId).toBe("sess-abc")
+    expect(retrieved!.inputTokens).toBe(1200)
+    expect(retrieved!.outputTokens).toBe(340)
+    expect(retrieved!.cacheReadInputTokens).toBe(900)
+    expect(retrieved!.cacheCreationInputTokens).toBe(120)
+    expect(retrieved!.cacheHitRate).toBe(0.88)
+  })
+
+  it("returns the latest successful metric for an SDK session", () => {
+    store.record(makeMetric({ requestId: "older-ok", sdkSessionId: "sdk-1", inputTokens: 100 }))
+    store.record(makeMetric({ requestId: "latest-error", sdkSessionId: "sdk-1", error: "api_error", inputTokens: 200 }))
+    store.record(makeMetric({ requestId: "other-session", sdkSessionId: "sdk-2", inputTokens: 300 }))
+
+    const metric = store.getLastForSession("sdk-1")
+
+    expect(metric?.requestId).toBe("older-ok")
+    expect(metric?.inputTokens).toBe(100)
   })
 
   it("handles interleaved timestamps correctly", () => {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,9 +1,43 @@
-export { telemetryStore, MemoryTelemetryStore } from "./store"
-export { diagnosticLog, MemoryDiagnosticLogStore } from "./logStore"
+import { env, envInt } from "../env"
+import { MemoryTelemetryStore } from "./store"
+import { MemoryDiagnosticLogStore } from "./logStore"
+import type { ITelemetryStore, IDiagnosticLogStore } from "./types"
+
+function createStores(): { telemetry: ITelemetryStore; diagnostics: IDiagnosticLogStore } {
+  if (env("TELEMETRY_PERSIST") === "false") {
+    return {
+      telemetry: new MemoryTelemetryStore(),
+      diagnostics: new MemoryDiagnosticLogStore(),
+    }
+  }
+
+  try {
+    const { createSqliteStores } = require("./sqlite") as typeof import("./sqlite")
+    const dbPath = env("TELEMETRY_DB") ?? "/home/claude/.claude/telemetry.db"
+    const retention = envInt("TELEMETRY_RETENTION_DAYS", 7)
+    const stores = createSqliteStores(dbPath, retention)
+    return { telemetry: stores.telemetry, diagnostics: stores.diagnostics }
+  } catch {
+    console.warn("[telemetry] SQLite unavailable, using in-memory store")
+    return {
+      telemetry: new MemoryTelemetryStore(),
+      diagnostics: new MemoryDiagnosticLogStore(),
+    }
+  }
+}
+
+const stores = createStores()
+
+export const telemetryStore: ITelemetryStore = stores.telemetry
+export const diagnosticLog: IDiagnosticLogStore = stores.diagnostics
+
+export { MemoryTelemetryStore } from "./store"
+export { MemoryDiagnosticLogStore } from "./logStore"
 export { createTelemetryRoutes } from "./routes"
 export { landingHtml } from "./landing"
 export { computePercentiles, computeSummary } from "./percentiles"
 export { renderPrometheusMetrics } from "./prometheus"
+export { createSqliteStores } from "./sqlite"
 export type {
   RequestMetric,
   TelemetrySummary,

--- a/src/telemetry/sqlite.ts
+++ b/src/telemetry/sqlite.ts
@@ -1,0 +1,284 @@
+import Database from "libsql"
+import type { RequestMetric, TelemetrySummary, ITelemetryStore, IDiagnosticLogStore, DiagnosticLog } from "./types"
+import { computeSummary } from "./percentiles"
+
+const METRICS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS metrics (
+  id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+  request_id           TEXT    NOT NULL,
+  timestamp            INTEGER NOT NULL,
+  adapter              TEXT,
+  model                TEXT    NOT NULL,
+  request_model        TEXT,
+  mode                 TEXT    NOT NULL,
+  is_resume            INTEGER NOT NULL,
+  is_passthrough       INTEGER NOT NULL,
+  lineage_type         TEXT,
+  message_count        INTEGER,
+  sdk_session_id       TEXT,
+  status               INTEGER NOT NULL,
+  queue_wait_ms        REAL    NOT NULL,
+  proxy_overhead_ms    REAL    NOT NULL,
+  ttfb_ms              REAL,
+  upstream_duration_ms REAL    NOT NULL,
+  total_duration_ms    REAL    NOT NULL,
+  content_blocks       INTEGER NOT NULL,
+  text_events          INTEGER NOT NULL,
+  error                TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_metrics_ts    ON metrics(timestamp);
+CREATE INDEX IF NOT EXISTS idx_metrics_model ON metrics(model);
+`
+
+const LOGS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS diagnostic_logs (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  timestamp  INTEGER NOT NULL,
+  level      TEXT    NOT NULL,
+  category   TEXT    NOT NULL,
+  request_id TEXT,
+  message    TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_logs_ts  ON diagnostic_logs(timestamp);
+CREATE INDEX IF NOT EXISTS idx_logs_cat ON diagnostic_logs(category);
+`
+
+const CLEANUP_INTERVAL = 1000
+
+function openDatabase(dbPath: string): Database.Database {
+  const db = new Database(dbPath)
+  db.pragma("journal_mode = WAL")
+  db.pragma("synchronous = NORMAL")
+  db.exec(METRICS_SCHEMA)
+  db.exec(LOGS_SCHEMA)
+  try { db.exec("VACUUM") } catch { /* ignore if busy */ }
+  return db
+}
+
+class SqliteTelemetryStore implements ITelemetryStore {
+  private db: Database.Database
+  private retentionMs: number
+  private insertCount = 0
+  private insertStmt: Database.Statement
+  private countStmt: Database.Statement
+
+  constructor(db: Database.Database, retentionDays: number) {
+    this.db = db
+    this.retentionMs = retentionDays * 24 * 60 * 60 * 1000
+
+    this.insertStmt = db.prepare(`
+      INSERT INTO metrics (
+        request_id, timestamp, adapter, model, request_model, mode,
+        is_resume, is_passthrough, lineage_type, message_count, sdk_session_id,
+        status, queue_wait_ms, proxy_overhead_ms, ttfb_ms,
+        upstream_duration_ms, total_duration_ms, content_blocks, text_events, error
+      ) VALUES (
+        @requestId, @timestamp, @adapter, @model, @requestModel, @mode,
+        @isResume, @isPassthrough, @lineageType, @messageCount, @sdkSessionId,
+        @status, @queueWaitMs, @proxyOverheadMs, @ttfbMs,
+        @upstreamDurationMs, @totalDurationMs, @contentBlocks, @textEvents, @error
+      )
+    `)
+
+    this.countStmt = db.prepare("SELECT COUNT(*) as cnt FROM metrics")
+  }
+
+  record(metric: RequestMetric): void {
+    try {
+      this.insertStmt.run({
+        requestId: metric.requestId,
+        timestamp: metric.timestamp,
+        adapter: metric.adapter ?? null,
+        model: metric.model,
+        requestModel: metric.requestModel ?? null,
+        mode: metric.mode,
+        isResume: metric.isResume ? 1 : 0,
+        isPassthrough: metric.isPassthrough ? 1 : 0,
+        lineageType: metric.lineageType ?? null,
+        messageCount: metric.messageCount ?? null,
+        sdkSessionId: metric.sdkSessionId ?? null,
+        status: metric.status,
+        queueWaitMs: metric.queueWaitMs,
+        proxyOverheadMs: metric.proxyOverheadMs,
+        ttfbMs: metric.ttfbMs ?? null,
+        upstreamDurationMs: metric.upstreamDurationMs,
+        totalDurationMs: metric.totalDurationMs,
+        contentBlocks: metric.contentBlocks,
+        textEvents: metric.textEvents,
+        error: metric.error ?? null,
+      })
+    } catch (err) {
+      console.error("[telemetry] SQLite write failed, skipping:", err)
+      return
+    }
+    if (++this.insertCount % CLEANUP_INTERVAL === 0) {
+      this.cleanup()
+    }
+  }
+
+  get size(): number {
+    try {
+      return (this.countStmt.get() as { cnt: number }).cnt
+    } catch {
+      return 0
+    }
+  }
+
+  getRecent(options: { limit?: number; since?: number; model?: string } = {}): RequestMetric[] {
+    const { limit = 50, since, model } = options
+    const conditions: string[] = []
+    const params: Record<string, unknown> = { limit }
+
+    if (since !== undefined) {
+      conditions.push("timestamp >= @since")
+      params.since = since
+    }
+    if (model !== undefined) {
+      conditions.push("model = @model")
+      params.model = model
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+    const sql = `SELECT * FROM metrics ${where} ORDER BY timestamp DESC, id DESC LIMIT @limit`
+
+    try {
+      const rows = this.db.prepare(sql).all(params) as Record<string, unknown>[]
+      return rows.map(rowToMetric)
+    } catch {
+      return []
+    }
+  }
+
+  summarize(windowMs: number = 60 * 60 * 1000): TelemetrySummary {
+    const since = Date.now() - windowMs
+    const metrics = this.getRecent({ limit: 100_000, since })
+    return computeSummary(metrics, windowMs)
+  }
+
+  clear(): void {
+    try {
+      this.db.exec("DELETE FROM metrics")
+    } catch { /* ignore */ }
+  }
+
+  cleanup(): void {
+    try {
+      const cutoff = Date.now() - this.retentionMs
+      this.db.prepare("DELETE FROM metrics WHERE timestamp < ?").run(cutoff)
+      this.db.prepare("DELETE FROM diagnostic_logs WHERE timestamp < ?").run(cutoff)
+      this.db.pragma("wal_checkpoint(TRUNCATE)")
+    } catch (err) {
+      console.error("[telemetry] SQLite cleanup failed:", err)
+    }
+  }
+}
+
+class SqliteDiagnosticLogStore implements IDiagnosticLogStore {
+  private db: Database.Database
+  private insertStmt: Database.Statement
+
+  constructor(db: Database.Database) {
+    this.db = db
+    this.insertStmt = db.prepare(`
+      INSERT INTO diagnostic_logs (timestamp, level, category, request_id, message)
+      VALUES (@timestamp, @level, @category, @requestId, @message)
+    `)
+  }
+
+  log(entry: Omit<DiagnosticLog, "timestamp">): void {
+    try {
+      this.insertStmt.run({
+        timestamp: Date.now(),
+        level: entry.level,
+        category: entry.category,
+        requestId: entry.requestId ?? null,
+        message: entry.message,
+      })
+    } catch (err) {
+      console.error("[telemetry] SQLite log write failed:", err)
+    }
+  }
+
+  session(message: string, requestId?: string): void {
+    this.log({ level: "info", category: "session", message, requestId })
+  }
+
+  lineage(message: string, requestId?: string): void {
+    this.log({ level: "warn", category: "lineage", message, requestId })
+  }
+
+  error(message: string, requestId?: string): void {
+    this.log({ level: "error", category: "error", message, requestId })
+  }
+
+  getRecent(options: { limit?: number; since?: number; category?: string } = {}): DiagnosticLog[] {
+    const { limit = 100, since, category } = options
+    const conditions: string[] = []
+    const params: Record<string, unknown> = { limit }
+
+    if (since !== undefined) {
+      conditions.push("timestamp >= @since")
+      params.since = since
+    }
+    if (category !== undefined) {
+      conditions.push("category = @category")
+      params.category = category
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : ""
+    const sql = `SELECT * FROM diagnostic_logs ${where} ORDER BY timestamp DESC, id DESC LIMIT @limit`
+
+    try {
+      const rows = this.db.prepare(sql).all(params) as Record<string, unknown>[]
+      return rows.map((r) => ({
+        timestamp: r.timestamp as number,
+        level: r.level as DiagnosticLog["level"],
+        category: r.category as DiagnosticLog["category"],
+        requestId: (r.request_id as string) ?? undefined,
+        message: r.message as string,
+      }))
+    } catch {
+      return []
+    }
+  }
+
+  clear(): void {
+    try {
+      this.db.exec("DELETE FROM diagnostic_logs")
+    } catch { /* ignore */ }
+  }
+}
+
+function rowToMetric(r: Record<string, unknown>): RequestMetric {
+  return {
+    requestId: r.request_id as string,
+    timestamp: r.timestamp as number,
+    adapter: (r.adapter as string) ?? undefined,
+    model: r.model as string,
+    requestModel: (r.request_model as string) ?? undefined,
+    mode: r.mode as RequestMetric["mode"],
+    isResume: r.is_resume === 1,
+    isPassthrough: r.is_passthrough === 1,
+    lineageType: (r.lineage_type as RequestMetric["lineageType"]) ?? undefined,
+    messageCount: (r.message_count as number) ?? undefined,
+    sdkSessionId: (r.sdk_session_id as string) ?? undefined,
+    status: r.status as number,
+    queueWaitMs: r.queue_wait_ms as number,
+    proxyOverheadMs: r.proxy_overhead_ms as number,
+    ttfbMs: (r.ttfb_ms as number) ?? null,
+    upstreamDurationMs: r.upstream_duration_ms as number,
+    totalDurationMs: r.total_duration_ms as number,
+    contentBlocks: r.content_blocks as number,
+    textEvents: r.text_events as number,
+    error: (r.error as string) ?? null,
+  }
+}
+
+export function createSqliteStores(dbPath: string, retentionDays: number) {
+  const db = openDatabase(dbPath)
+  return {
+    telemetry: new SqliteTelemetryStore(db, retentionDays) as ITelemetryStore,
+    diagnostics: new SqliteDiagnosticLogStore(db) as IDiagnosticLogStore,
+    close: () => { try { db.close() } catch { /* ignore */ } },
+  }
+}

--- a/src/telemetry/sqlite.ts
+++ b/src/telemetry/sqlite.ts
@@ -24,10 +24,16 @@ CREATE TABLE IF NOT EXISTS metrics (
   total_duration_ms    REAL    NOT NULL,
   content_blocks       INTEGER NOT NULL,
   text_events          INTEGER NOT NULL,
-  error                TEXT
+  error                TEXT,
+  input_tokens         INTEGER,
+  output_tokens        INTEGER,
+  cache_read_input_tokens INTEGER,
+  cache_creation_input_tokens INTEGER,
+  cache_hit_rate       REAL
 );
 CREATE INDEX IF NOT EXISTS idx_metrics_ts    ON metrics(timestamp);
 CREATE INDEX IF NOT EXISTS idx_metrics_model ON metrics(model);
+CREATE INDEX IF NOT EXISTS idx_metrics_session_success ON metrics(sdk_session_id, timestamp DESC, id DESC);
 `
 
 const LOGS_SCHEMA = `
@@ -71,12 +77,16 @@ class SqliteTelemetryStore implements ITelemetryStore {
         request_id, timestamp, adapter, model, request_model, mode,
         is_resume, is_passthrough, lineage_type, message_count, sdk_session_id,
         status, queue_wait_ms, proxy_overhead_ms, ttfb_ms,
-        upstream_duration_ms, total_duration_ms, content_blocks, text_events, error
+        upstream_duration_ms, total_duration_ms, content_blocks, text_events, error,
+        input_tokens, output_tokens, cache_read_input_tokens,
+        cache_creation_input_tokens, cache_hit_rate
       ) VALUES (
         @requestId, @timestamp, @adapter, @model, @requestModel, @mode,
         @isResume, @isPassthrough, @lineageType, @messageCount, @sdkSessionId,
         @status, @queueWaitMs, @proxyOverheadMs, @ttfbMs,
-        @upstreamDurationMs, @totalDurationMs, @contentBlocks, @textEvents, @error
+        @upstreamDurationMs, @totalDurationMs, @contentBlocks, @textEvents, @error,
+        @inputTokens, @outputTokens, @cacheReadInputTokens,
+        @cacheCreationInputTokens, @cacheHitRate
       )
     `)
 
@@ -106,6 +116,11 @@ class SqliteTelemetryStore implements ITelemetryStore {
         contentBlocks: metric.contentBlocks,
         textEvents: metric.textEvents,
         error: metric.error ?? null,
+        inputTokens: metric.inputTokens ?? null,
+        outputTokens: metric.outputTokens ?? null,
+        cacheReadInputTokens: metric.cacheReadInputTokens ?? null,
+        cacheCreationInputTokens: metric.cacheCreationInputTokens ?? null,
+        cacheHitRate: metric.cacheHitRate ?? null,
       })
     } catch (err) {
       console.error("[telemetry] SQLite write failed, skipping:", err)
@@ -146,6 +161,17 @@ class SqliteTelemetryStore implements ITelemetryStore {
       return rows.map(rowToMetric)
     } catch {
       return []
+    }
+  }
+
+  getLastForSession(sdkSessionId: string): RequestMetric | undefined {
+    try {
+      const row = this.db.prepare(
+        `SELECT * FROM metrics WHERE sdk_session_id = ? AND error IS NULL ORDER BY timestamp DESC, id DESC LIMIT 1`
+      ).get(sdkSessionId) as Record<string, unknown> | undefined
+      return row ? rowToMetric(row) : undefined
+    } catch {
+      return undefined
     }
   }
 
@@ -271,6 +297,11 @@ function rowToMetric(r: Record<string, unknown>): RequestMetric {
     contentBlocks: r.content_blocks as number,
     textEvents: r.text_events as number,
     error: (r.error as string) ?? null,
+    inputTokens: (r.input_tokens as number) ?? undefined,
+    outputTokens: (r.output_tokens as number) ?? undefined,
+    cacheReadInputTokens: (r.cache_read_input_tokens as number) ?? undefined,
+    cacheCreationInputTokens: (r.cache_creation_input_tokens as number) ?? undefined,
+    cacheHitRate: (r.cache_hit_rate as number) ?? undefined,
   }
 }
 


### PR DESCRIPTION
## Summary
- add `libsql`-backed telemetry and diagnostic log stores for durable persistence across restarts
- wire store selection through env-based fallback (`TELEMETRY_PERSIST`, `TELEMETRY_DB`, `TELEMETRY_RETENTION_DAYS`)
- update Dockerfile to externalize `libsql` from the bundle
- persist token health fields and support session lookup in SQLite store

## Validation
- `npm run build` passes
- `bun test src/__tests__/telemetry-sqlite.test.ts` — 18 tests pass
- full telemetry test suite (40 tests) passes

## Stack
Follows #337 (Prometheus endpoint, merged) and #335 (interface extraction, merged).