### PR TITLE
fix: block LSP tool during compaction

### DIFF
--- a/src/proxy/tools.ts
+++ b/src/proxy/tools.ts
@@ -13,7 +13,8 @@
 export const BLOCKED_BUILTIN_TOOLS = [
   "Read", "Write", "Edit", "MultiEdit",
   "Bash", "Glob", "Grep", "NotebookEdit",
-  "WebFetch", "WebSearch", "TodoWrite"
+  "WebFetch", "WebSearch", "TodoWrite",
+  "LSP",              // Claude Code's language server protocol client — invoked during compaction but incompatible with agent tool systems
 ]
 
 /**


### PR DESCRIPTION
## Problem

Claude Code's `LSP` (Language Server Protocol) built-in tool gets invoked during conversation compaction. When running through a proxy (Meridian → Agent SDK), this tool call fails or causes errors because:

1. The LSP server process isn't available in the proxied context
2. The calling agent (OpenCode, etc.) has its own tool system that should take precedence
3. Failed LSP calls during compaction cause stalled compaction cycles (~300ms failures in logs)

## Fix

Add `"LSP"` to `BLOCKED_BUILTIN_TOOLS`. This follows the established pattern — every other tool in this list is blocked so the calling agent's tools take precedence over the Agent SDK's built-in equivalents.

## Impact

- Compaction will no longer attempt LSP calls through the proxy
- Prevents stalled/failed compaction cycles
- No functional change when not using a proxy (LSP is only invoked by Claude Code internally)

## Testing

Verified that `disallowedTools` (which `BLOCKED_BUILTIN_TOOLS` feeds into) is correctly passed through the `--disallowedTools` CLI flag to the Claude Code process via the Agent SDK.