### PR TITLE
fix: forward accumulated usage on non-stream responses

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -307,3 +307,93 @@ describe("Integration: Concurrent subagent requests", () => {
     }
   })
 })
+
+// ============================================================
+// NON-STREAM USAGE PROPAGATION
+// ============================================================
+
+describe("Integration: Non-stream usage propagation", () => {
+  let app: any
+
+  beforeAll(() => {
+    app = createTestApp()
+  })
+
+  beforeEach(() => {
+    mockMessages = []
+  })
+
+  it("forwards input/output tokens from the SDK assistant message", async () => {
+    mockMessages = [
+      assistantMessage([{ type: "text", text: "Done." }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "ping" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    // `assistantMessage` helper seeds usage with input=10, output=50
+    expect(body.usage.input_tokens).toBe(10)
+    expect(body.usage.output_tokens).toBe(50)
+  })
+
+  it("forwards cache tokens when present", async () => {
+    mockMessages = [
+      {
+        type: "assistant",
+        message: {
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "Cached." }],
+          model: "claude-sonnet-4-5-20250929",
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 3,
+            output_tokens: 12,
+            cache_read_input_tokens: 28933,
+            cache_creation_input_tokens: 0,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: crypto.randomUUID(),
+        session_id: "test-session",
+      } as any,
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "ping" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    expect(body.usage.input_tokens).toBe(3)
+    expect(body.usage.output_tokens).toBe(12)
+    expect(body.usage.cache_read_input_tokens).toBe(28933)
+    expect(body.usage.cache_creation_input_tokens).toBe(0)
+  })
+
+  it("falls back to zeros when no SDK assistant message is produced", async () => {
+    mockMessages = []
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "ping" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    expect(body.usage.input_tokens).toBe(0)
+    expect(body.usage.output_tokens).toBe(0)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1023,7 +1023,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             content: contentBlocks,
             model: body.model,
             stop_reason: stopReason,
-            usage: { input_tokens: 0, output_tokens: 0 }
+            // Forward the usage accumulated from SDK assistant messages so
+            // clients calling `messages.create()` can track cost and rate limits.
+            usage: {
+              input_tokens: lastUsage?.input_tokens ?? 0,
+              output_tokens: lastUsage?.output_tokens ?? 0,
+              cache_read_input_tokens: lastUsage?.cache_read_input_tokens,
+              cache_creation_input_tokens: lastUsage?.cache_creation_input_tokens,
+            },
           }), {
             headers: {
               "Content-Type": "application/json",


### PR DESCRIPTION
## Problem

The non-stream `/v1/messages` handler returns hardcoded zeros in the `usage` field:

```ts
// src/proxy/server.ts (before)
return new Response(JSON.stringify({
  ...,
  usage: { input_tokens: 0, output_tokens: 0 }
}))
```

Clients calling `messages.create()` (Anthropic SDK non-stream path) therefore receive `input_tokens=0, output_tokens=0` and `undefined` for cache fields, even though the SDK actually reported real usage. This breaks cost tracking and rate-limit observability for any tool that relies on the response body's `usage` — cost trackers, usage meters, OpenAI-compat wrappers, etc.

The stream path is unaffected — clients assemble usage from `message_delta` events there.

### Root cause

`lastUsage` is already accumulated from SDK assistant messages a few hundred lines earlier and forwarded to telemetry and the session store:

```ts
const msgUsage = message.message.usage as TokenUsage | undefined
if (msgUsage) lastUsage = { ...lastUsage, ...msgUsage }
```

The non-stream response builder just never reads it — the hardcoded literal looks like an initial placeholder that was never wired up.

### Reproduction

```python
import anthropic, asyncio

async def probe():
    c = anthropic.AsyncAnthropic(base_url="http://127.0.0.1:3456", api_key="x")
    r = await c.messages.create(
        model="claude-haiku-4-5-20251001",
        max_tokens=100,
        messages=[{"role": "user", "content": "hi"}],
    )
    print(r.usage)

asyncio.run(probe())
```

Before: `Usage(input_tokens=0, output_tokens=0, cache_read_input_tokens=None, ...)`
After:  `Usage(input_tokens=3, output_tokens=1, cache_read_input_tokens=25143, ...)`

## Fix

Forward `lastUsage` into the response body, falling back to zeros when no SDK assistant message was produced (e.g. the existing `response.fallback_used` path).

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun test src/__tests__/integration.test.ts` (8 pass / 0 fail)
- [x] Live probe against a locally built binary — non-stream responses now carry real input/output/cache tokens

Three regression cases added in `integration.test.ts`:

1. Forwards input/output tokens from the SDK assistant message
2. Forwards cache tokens (`cache_read_input_tokens`, `cache_creation_input_tokens`) when present
3. Falls back to zeros when no assistant message is produced