### PR TITLE
fix: use component-specific output keys in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,8 +21,8 @@ jobs:
     if: ${{ !inputs.publish_only }}
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs['meridian--release_created'] }}
+      tag_name: ${{ steps.release.outputs['meridian--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "component": "meridian",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
Release Please v4 with a component name outputs `release_created` as `meridian--release_created`, not `release_created`. The workflow was checking the wrong key, so `release_created` was always empty and the publish job never fired after merging a release PR.

This is why every release since v1.35.0 required manual tag creation and `publish_only` dispatch.

### Changes
- `release-please-config.json` — add explicit `component: 'meridian'`
- `.github/workflows/release-please.yml` — use `meridian--release_created` and `meridian--tag_name` output keys

### How to verify
Next time a release PR is merged, the publish job should fire automatically without manual intervention.