### PR TITLE
fix: stop appending file change summaries for opencode

### DIFF
--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -443,6 +443,10 @@ describe("extractFileChangesFromMessages", () => {
 describe("openCodeAdapter.extractFileChangesFromToolUse", () => {
   const { openCodeAdapter } = require("../../src/proxy/adapters/opencode") as typeof import("../proxy/adapters/opencode")
 
+  it("should disable synthetic file change summaries", () => {
+    expect(openCodeAdapter.shouldTrackFileChanges?.()).toBe(false)
+  })
+
   it("should detect lowercase write (opencode native)", () => {
     const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { filePath: "src/new.ts", content: "x" })
     expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -139,7 +139,7 @@ describe("File change visibility: PostToolUse hook registration", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("should register PostToolUse hooks in SDK options", async () => {
+  it("should not register PostToolUse hooks in SDK options for opencode", async () => {
     const app = createTestApp()
     await (await post(app, {
       model: "claude-sonnet-4-5",
@@ -149,11 +149,10 @@ describe("File change visibility: PostToolUse hook registration", () => {
     })).json()
 
     expect(capturedQueryParams.options.hooks).toBeDefined()
-    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
-    expect(capturedQueryParams.options.hooks.PostToolUse.length).toBeGreaterThan(0)
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeUndefined()
   })
 
-  it("should register PostToolUse alongside PreToolUse when Task tool is present", async () => {
+  it("should not register PostToolUse alongside PreToolUse when Task tool is present", async () => {
     const TASK_TOOL = {
       name: "task",
       description: "Launch a new agent.\n\nAvailable agent types and the tools they have access to:\n- build: Default agent\n- explore: Explorer",
@@ -174,7 +173,7 @@ describe("File change visibility: PostToolUse hook registration", () => {
     })).json()
 
     expect(capturedQueryParams.options.hooks.PreToolUse).toBeDefined()
-    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeUndefined()
   })
 
   it("should not register PostToolUse in passthrough mode", async () => {
@@ -223,7 +222,7 @@ describe("File change visibility: non-streaming response", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("should append file change summary to response when files are written", async () => {
+  it("should not append file change summary to response when files are written", async () => {
     // Simulate SDK executing mcp__opencode__write internally, then returning text
     mockMessages = [
       // First the SDK calls the write tool (internal, won't be in final content)
@@ -244,14 +243,12 @@ describe("File change visibility: non-streaming response", () => {
       messages: [{ role: "user", content: "Create a file" }],
     })).json()
 
-    // The response should include file change summary in the text
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toContain("Files changed:")
-    expect(allText).toContain("wrote src/new-file.ts")
+    expect(allText).toBe("I created the file for you.")
   })
 
-  it("should append file change summary when files are edited", async () => {
+  it("should not append file change summary when files are edited", async () => {
     mockMessages = [
       assistantMessage([
         { type: "tool_use", id: "toolu_e1", name: "mcp__opencode__edit", input: { path: "src/existing.ts", oldString: "foo", newString: "bar" } },
@@ -271,8 +268,7 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toContain("Files changed:")
-    expect(allText).toContain("edited src/existing.ts")
+    expect(allText).toBe("I fixed the bug.")
   })
 
   it("should not include summary when only reads occur", async () => {
@@ -298,7 +294,7 @@ describe("File change visibility: non-streaming response", () => {
     expect(allText).not.toContain("Files changed:")
   })
 
-  it("should show multiple file changes", async () => {
+  it("should not append file change summary when multiple files change", async () => {
     mockMessages = [
       assistantMessage([
         { type: "tool_use", id: "toolu_w1", name: "mcp__opencode__write", input: { path: "src/a.ts", content: "a" } },
@@ -324,9 +320,7 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toContain("wrote src/a.ts")
-    expect(allText).toContain("edited src/b.ts")
-    expect(allText).toContain("wrote src/c.ts")
+    expect(allText).toBe("All done.")
   })
 })
 
@@ -346,7 +340,7 @@ describe("File change visibility: streaming response", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("should emit file change text block before message_stop in stream", async () => {
+  it("should not emit file change text block before message_stop in stream", async () => {
     // Multi-turn: MCP write tool → text response
     mockMessages = [
       messageStart(),
@@ -377,15 +371,12 @@ describe("File change visibility: streaming response", () => {
       messages: [{ role: "user", content: "Create a file" }],
     })
 
-    // Should have a text delta containing the file change summary
     const allTextDeltas = events.filter(
       (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
     )
     const allText = allTextDeltas.map((e) => (e.data as any).delta.text).join("")
-    expect(allText).toContain("Files changed:")
-    expect(allText).toContain("wrote src/streamed.ts")
+    expect(allText).toBe("File created.")
 
-    // File change block should come BEFORE message_stop
     const lastEvent = events[events.length - 1]
     expect(lastEvent?.event).toBe("message_stop")
   })
@@ -415,8 +406,7 @@ describe("File change visibility: streaming response", () => {
     expect(allText).not.toContain("Files changed:")
   })
 
-  it("should use correct block index for file change text block", async () => {
-    // Text block at index 0, then MCP tool (skipped), then file change block should be index 1
+  it("should not add an extra text block for file changes", async () => {
     mockMessages = [
       messageStart(),
       textBlockStart(0),
@@ -449,20 +439,10 @@ describe("File change visibility: streaming response", () => {
       messages: [{ role: "user", content: "Edit a file" }],
     })
 
-    // Find the file change block start
-    const blockStarts = events.filter((e) => e.event === "content_block_start")
-    const fileChangeBlock = blockStarts.find(
-      (e) => {
-        const text = (e.data as any).content_block?.text
-        return text !== undefined && (e.data as any).content_block?.type === "text"
-      }
+    const textBlockStarts = events.filter(
+      (e) => e.event === "content_block_start" && (e.data as any).content_block?.type === "text"
     )
-
-    // All block indices should be monotonically increasing
-    const indices = blockStarts.map((e) => (e.data as any).index)
-    for (let i = 1; i < indices.length; i++) {
-      expect(indices[i]).toBeGreaterThan(indices[i - 1]!)
-    }
+    expect(textBlockStarts).toHaveLength(2)
   })
 })
 

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -136,6 +136,15 @@ export interface AgentAdapter {
   supportsThinking?(): boolean
 
   /**
+   * Whether the proxy should append synthetic file-change summaries to the
+   * agent-visible response.
+   *
+   * Return false for agents that already expose file edits natively or where
+   * the extra block is noisy. When undefined, the proxy defaults to true.
+   */
+  shouldTrackFileChanges?(): boolean
+
+  /**
    * Map a client-side tool_use block to file changes (passthrough mode).
    *
    * In passthrough mode the SDK doesn't execute tools, so PostToolUse

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -63,6 +63,14 @@ export const openCodeAdapter: AgentAdapter = {
   },
 
   /**
+   * NOTE: OpenCode-specific. OpenCode already exposes file edits in its own UI,
+   * so Meridian should not append a synthetic "Files changed:" block.
+   */
+  shouldTrackFileChanges(): boolean {
+    return false
+  },
+
+  /**
    * NOTE: OpenCode-specific. Parses the Task tool description to extract
    * subagent names and build SDK AgentDefinition objects for native subagent routing.
    */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -643,6 +643,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // Catches write, edit, AND bash redirects (>, >>, tee, sed -i).
       const mcpPrefix = `mcp__${adapter.getMcpServerName()}__`
       const trackFileChanges = !(process.env.MERIDIAN_NO_FILE_CHANGES ?? process.env.CLAUDE_PROXY_NO_FILE_CHANGES)
+        && adapter.shouldTrackFileChanges?.() !== false
       const fileChangeHook = trackFileChanges ? createFileChangeHook(fileChanges, mcpPrefix) : undefined
 
       // Track tools discovered via ToolSearch (deferred tools that get called)


### PR DESCRIPTION
## Summary
- add an adapter-level file change summary opt-out and disable it for OpenCode
- stop registering PostToolUse/file-change summary handling for OpenCode responses and streams
- update OpenCode tests to assert the synthetic \`Files changed:\` block is no longer appended

## Verification
- bun test src/__tests__/file-changes-unit.test.ts src/__tests__/proxy-file-changes.test.ts
- bun run typecheck
- bun run build *(fails in this shell during postbuild because the repo requires Node >=22 and this environment has Node 20)*