### PR TITLE
fix: return empty object from PreToolUse hook for ToolSearch

### DIFF
--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -321,3 +321,74 @@ describe("PreToolUse hook: cleanup of old hacks", () => {
     expect(capturedQueryParams).toBeDefined()
   })
 })
+
+describe("PreToolUse hook: passthrough ToolSearch", () => {
+  // Regression test for the Zod validation bug where returning `undefined`
+  // from the passthrough PreToolUse hook caused the SDK to throw
+  // `ZodError: expected object, received undefined` and cascade into
+  // `Reached maximum number of turns (2)`. The hook must return an object
+  // (at minimum `{}`) so the SDK can continue handling ToolSearch internally.
+  beforeEach(() => {
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    mockMessages = [assistantMessage([{ type: "text", text: "Done" }])]
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  it("returns an object (not undefined) for ToolSearch so the SDK's Zod schema accepts it", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })).json()
+
+    const allMatcher = capturedQueryParams.options.hooks.PreToolUse.find((h: any) => h.matcher === "")
+    expect(allMatcher).toBeDefined()
+    const hookFn = allMatcher.hooks[0]
+
+    const result = await hookFn({
+      hook_event_name: "PreToolUse",
+      tool_name: "ToolSearch",
+      tool_input: { query: "select:Read", max_results: 5 },
+      tool_use_id: "toolu_tool_search",
+    }, undefined, { signal: new AbortController().signal })
+
+    expect(result).toBeDefined()
+    expect(typeof result).toBe("object")
+    expect(result).not.toBeNull()
+    // No `decision` — ToolSearch must pass through to the SDK's internal handler,
+    // not be blocked for client forwarding like other tools.
+    expect((result as any).decision).toBeUndefined()
+  })
+
+  it("still blocks non-ToolSearch tools for client-side execution", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })).json()
+
+    const allMatcher = capturedQueryParams.options.hooks.PreToolUse.find((h: any) => h.matcher === "")
+    const hookFn = allMatcher.hooks[0]
+
+    const result = await hookFn({
+      hook_event_name: "PreToolUse",
+      tool_name: "Read",
+      tool_input: { file_path: "/tmp/test.txt" },
+      tool_use_id: "toolu_read",
+    }, undefined, { signal: new AbortController().signal })
+
+    expect(result.decision).toBe("block")
+    expect(result.reason).toBe("Forwarding to client for execution")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -655,7 +655,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               hooks: [async (input: any) => {
                 // Let the SDK handle ToolSearch internally for deferred tool loading.
                 // ToolSearch is filtered from the response stream below.
-                if (input.tool_name === "ToolSearch") return undefined
+                if (input.tool_name === "ToolSearch") return {}
                 // Track deferred tools that were discovered via ToolSearch
                 const toolName = stripMcpPrefix(input.tool_name)
                 if (hasDeferredTools && coreSet && !coreSet.has(toolName.toLowerCase())) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -655,6 +655,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               hooks: [async (input: any) => {
                 // Let the SDK handle ToolSearch internally for deferred tool loading.
                 // ToolSearch is filtered from the response stream below.
+                // Return {} — NOT undefined. SDK validates hook returns with Zod and
+                // rejects undefined ("expected object, received undefined"), which also
+                // cascades into "Reached maximum number of turns (2)". {} is the no-op.
                 if (input.tool_name === "ToolSearch") return {}
                 // Track deferred tools that were discovered via ToolSearch
                 const toolName = stripMcpPrefix(input.tool_name)


### PR DESCRIPTION
The passthrough PreToolUse hook returned `undefined` for ToolSearch tools. The Claude Agent SDK validates hook return values with Zod and requires an object — `undefined` fails validation with:

```
ZodError: expected object, received undefined
```

This also caused a cascading `Reached maximum number of turns (2)` error because the ZodError consumed turns without completing processing.

**Fix:** `return undefined` → `return {}` in the ToolSearch branch of the passthrough PreToolUse hook (`server.ts:658`).