### PR TITLE
fix: stop appending file change summaries for opencode (with regression guards)

### DIFF
--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -443,6 +443,10 @@ describe("extractFileChangesFromMessages", () => {
 describe("openCodeAdapter.extractFileChangesFromToolUse", () => {
   const { openCodeAdapter } = require("../../src/proxy/adapters/opencode") as typeof import("../proxy/adapters/opencode")
 
+  it("should disable synthetic file change summaries", () => {
+    expect(openCodeAdapter.shouldTrackFileChanges?.()).toBe(false)
+  })
+
   it("should detect lowercase write (opencode native)", () => {
     const result = openCodeAdapter.extractFileChangesFromToolUse!("write", { filePath: "src/new.ts", content: "x" })
     expect(result).toEqual([{ operation: "wrote", path: "src/new.ts" }])

--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -549,3 +549,42 @@ describe("crushAdapter.extractFileChangesFromToolUse", () => {
     expect(result).toEqual([{ operation: "wrote", path: "/tmp/crush.txt" }])
   })
 })
+
+/**
+ * Regression guard: only OpenCode opts out of the synthetic "Files changed:"
+ * summary. Every other adapter must leave the hook undefined so the proxy's
+ * default-true path fires. If someone accidentally adds `shouldTrackFileChanges`
+ * to another adapter, these tests catch it.
+ */
+describe("shouldTrackFileChanges: per-adapter opt-out policy", () => {
+  const { piAdapter } = require("../../src/proxy/adapters/pi") as typeof import("../proxy/adapters/pi")
+  const { crushAdapter } = require("../../src/proxy/adapters/crush") as typeof import("../proxy/adapters/crush")
+  const { droidAdapter } = require("../../src/proxy/adapters/droid") as typeof import("../proxy/adapters/droid")
+  const { forgeCodeAdapter } = require("../../src/proxy/adapters/forgecode") as typeof import("../proxy/adapters/forgecode")
+  const { passthroughAdapter } = require("../../src/proxy/adapters/passthrough") as typeof import("../proxy/adapters/passthrough")
+  const { openCodeAdapter } = require("../../src/proxy/adapters/opencode") as typeof import("../proxy/adapters/opencode")
+
+  it("opencode opts out", () => {
+    expect(openCodeAdapter.shouldTrackFileChanges?.()).toBe(false)
+  })
+
+  it("pi does not opt out (summary stays on)", () => {
+    expect(piAdapter.shouldTrackFileChanges?.()).not.toBe(false)
+  })
+
+  it("crush does not opt out (summary stays on)", () => {
+    expect(crushAdapter.shouldTrackFileChanges?.()).not.toBe(false)
+  })
+
+  it("droid does not opt out (summary stays on)", () => {
+    expect(droidAdapter.shouldTrackFileChanges?.()).not.toBe(false)
+  })
+
+  it("forgecode does not opt out (summary stays on)", () => {
+    expect(forgeCodeAdapter.shouldTrackFileChanges?.()).not.toBe(false)
+  })
+
+  it("passthrough does not opt out (summary stays on)", () => {
+    expect(passthroughAdapter.shouldTrackFileChanges?.()).not.toBe(false)
+  })
+})

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -139,7 +139,7 @@ describe("File change visibility: PostToolUse hook registration", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("should register PostToolUse hooks in SDK options", async () => {
+  it("should not register PostToolUse hooks in SDK options for opencode", async () => {
     const app = createTestApp()
     await (await post(app, {
       model: "claude-sonnet-4-5",
@@ -149,11 +149,10 @@ describe("File change visibility: PostToolUse hook registration", () => {
     })).json()
 
     expect(capturedQueryParams.options.hooks).toBeDefined()
-    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
-    expect(capturedQueryParams.options.hooks.PostToolUse.length).toBeGreaterThan(0)
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeUndefined()
   })
 
-  it("should register PostToolUse alongside PreToolUse when Task tool is present", async () => {
+  it("should not register PostToolUse alongside PreToolUse when Task tool is present", async () => {
     const TASK_TOOL = {
       name: "task",
       description: "Launch a new agent.\n\nAvailable agent types and the tools they have access to:\n- build: Default agent\n- explore: Explorer",
@@ -174,7 +173,7 @@ describe("File change visibility: PostToolUse hook registration", () => {
     })).json()
 
     expect(capturedQueryParams.options.hooks.PreToolUse).toBeDefined()
-    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeUndefined()
   })
 
   it("should not register PostToolUse in passthrough mode", async () => {
@@ -223,7 +222,7 @@ describe("File change visibility: non-streaming response", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("should append file change summary to response when files are written", async () => {
+  it("should not append file change summary to response when files are written", async () => {
     // Simulate SDK executing mcp__opencode__write internally, then returning text
     mockMessages = [
       // First the SDK calls the write tool (internal, won't be in final content)
@@ -244,14 +243,12 @@ describe("File change visibility: non-streaming response", () => {
       messages: [{ role: "user", content: "Create a file" }],
     })).json()
 
-    // The response should include file change summary in the text
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toContain("Files changed:")
-    expect(allText).toContain("wrote src/new-file.ts")
+    expect(allText).toBe("I created the file for you.")
   })
 
-  it("should append file change summary when files are edited", async () => {
+  it("should not append file change summary when files are edited", async () => {
     mockMessages = [
       assistantMessage([
         { type: "tool_use", id: "toolu_e1", name: "mcp__opencode__edit", input: { path: "src/existing.ts", oldString: "foo", newString: "bar" } },
@@ -271,8 +268,7 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toContain("Files changed:")
-    expect(allText).toContain("edited src/existing.ts")
+    expect(allText).toBe("I fixed the bug.")
   })
 
   it("should not include summary when only reads occur", async () => {
@@ -298,7 +294,7 @@ describe("File change visibility: non-streaming response", () => {
     expect(allText).not.toContain("Files changed:")
   })
 
-  it("should show multiple file changes", async () => {
+  it("should not append file change summary when multiple files change", async () => {
     mockMessages = [
       assistantMessage([
         { type: "tool_use", id: "toolu_w1", name: "mcp__opencode__write", input: { path: "src/a.ts", content: "a" } },
@@ -324,9 +320,7 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toContain("wrote src/a.ts")
-    expect(allText).toContain("edited src/b.ts")
-    expect(allText).toContain("wrote src/c.ts")
+    expect(allText).toBe("All done.")
   })
 })
 
@@ -346,7 +340,7 @@ describe("File change visibility: streaming response", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("should emit file change text block before message_stop in stream", async () => {
+  it("should not emit file change text block before message_stop in stream", async () => {
     // Multi-turn: MCP write tool → text response
     mockMessages = [
       messageStart(),
@@ -377,15 +371,12 @@ describe("File change visibility: streaming response", () => {
       messages: [{ role: "user", content: "Create a file" }],
     })
 
-    // Should have a text delta containing the file change summary
     const allTextDeltas = events.filter(
       (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
     )
     const allText = allTextDeltas.map((e) => (e.data as any).delta.text).join("")
-    expect(allText).toContain("Files changed:")
-    expect(allText).toContain("wrote src/streamed.ts")
+    expect(allText).toBe("File created.")
 
-    // File change block should come BEFORE message_stop
     const lastEvent = events[events.length - 1]
     expect(lastEvent?.event).toBe("message_stop")
   })
@@ -415,8 +406,7 @@ describe("File change visibility: streaming response", () => {
     expect(allText).not.toContain("Files changed:")
   })
 
-  it("should use correct block index for file change text block", async () => {
-    // Text block at index 0, then MCP tool (skipped), then file change block should be index 1
+  it("should not add an extra text block for file changes", async () => {
     mockMessages = [
       messageStart(),
       textBlockStart(0),
@@ -449,20 +439,10 @@ describe("File change visibility: streaming response", () => {
       messages: [{ role: "user", content: "Edit a file" }],
     })
 
-    // Find the file change block start
-    const blockStarts = events.filter((e) => e.event === "content_block_start")
-    const fileChangeBlock = blockStarts.find(
-      (e) => {
-        const text = (e.data as any).content_block?.text
-        return text !== undefined && (e.data as any).content_block?.type === "text"
-      }
+    const textBlockStarts = events.filter(
+      (e) => e.event === "content_block_start" && (e.data as any).content_block?.type === "text"
     )
-
-    // All block indices should be monotonically increasing
-    const indices = blockStarts.map((e) => (e.data as any).index)
-    for (let i = 1; i < indices.length; i++) {
-      expect(indices[i]).toBeGreaterThan(indices[i - 1]!)
-    }
+    expect(textBlockStarts).toHaveLength(2)
   })
 })
 

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -245,7 +245,8 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toBe("I created the file for you.")
+    expect(allText).not.toContain("Files changed:")
+    expect(allText).not.toContain("wrote src/new-file.ts")
   })
 
   it("should not append file change summary when files are edited", async () => {
@@ -268,7 +269,8 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toBe("I fixed the bug.")
+    expect(allText).not.toContain("Files changed:")
+    expect(allText).not.toContain("edited src/existing.ts")
   })
 
   it("should not include summary when only reads occur", async () => {
@@ -320,7 +322,10 @@ describe("File change visibility: non-streaming response", () => {
 
     const textBlocks = response.content.filter((b: any) => b.type === "text")
     const allText = textBlocks.map((b: any) => b.text).join("")
-    expect(allText).toBe("All done.")
+    expect(allText).not.toContain("Files changed:")
+    expect(allText).not.toContain("wrote src/a.ts")
+    expect(allText).not.toContain("edited src/b.ts")
+    expect(allText).not.toContain("wrote src/c.ts")
   })
 })
 
@@ -375,7 +380,8 @@ describe("File change visibility: streaming response", () => {
       (e) => e.event === "content_block_delta" && (e.data as any).delta?.type === "text_delta"
     )
     const allText = allTextDeltas.map((e) => (e.data as any).delta.text).join("")
-    expect(allText).toBe("File created.")
+    expect(allText).not.toContain("Files changed:")
+    expect(allText).not.toContain("wrote src/streamed.ts")
 
     const lastEvent = events[events.length - 1]
     expect(lastEvent?.event).toBe("message_stop")
@@ -570,5 +576,75 @@ describe("File change visibility: MERIDIAN_NO_FILE_CHANGES opt-out", () => {
       .map((b: any) => b.text)
       .join("")
     expect(allText).not.toContain("Files changed:")
+  })
+})
+
+/**
+ * Regression guard: the OpenCode opt-out must NOT suppress the file change
+ * summary for other adapters. Uses the `x-meridian-agent` header to force
+ * the pi adapter (which does not override shouldTrackFileChanges, so the
+ * default-true path is exercised).
+ */
+describe("File change visibility: other adapters still track", () => {
+  let savedPassthrough: string | undefined
+
+  beforeEach(() => {
+    mockMessages = []
+    capturedQueryParams = null
+    clearSessionCache()
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  async function postAs(app: any, agent: string, body: any) {
+    return app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-meridian-agent": agent },
+      body: JSON.stringify(body),
+    }))
+  }
+
+  it("pi adapter: PostToolUse hook is registered (summary path is active)", async () => {
+    const app = createTestApp()
+    await (await postAs(app, "pi", {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })).json()
+
+    expect(capturedQueryParams.options.hooks.PostToolUse).toBeDefined()
+    expect(capturedQueryParams.options.hooks.PostToolUse.length).toBeGreaterThan(0)
+  })
+
+  it("pi adapter: appends file change summary when files are written", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_pi1", name: "mcp__pi__write", input: { path: "src/pi-file.ts", content: "export const y = 2" } },
+      ]),
+      assistantMessage([
+        { type: "text", text: "Wrote the file." },
+      ]),
+    ]
+
+    const app = createTestApp()
+    const response = await (await postAs(app, "pi", {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Create a file" }],
+    })).json()
+
+    const allText = response.content
+      .filter((b: any) => b.type === "text")
+      .map((b: any) => b.text)
+      .join("")
+    expect(allText).toContain("Files changed:")
+    expect(allText).toContain("wrote src/pi-file.ts")
   })
 })

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -136,6 +136,15 @@ export interface AgentAdapter {
   supportsThinking?(): boolean
 
   /**
+   * Whether the proxy should append synthetic file-change summaries to the
+   * agent-visible response.
+   *
+   * Return false for agents that already expose file edits natively or where
+   * the extra block is noisy. When undefined, the proxy defaults to true.
+   */
+  shouldTrackFileChanges?(): boolean
+
+  /**
    * Map a client-side tool_use block to file changes (passthrough mode).
    *
    * In passthrough mode the SDK doesn't execute tools, so PostToolUse

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -63,6 +63,14 @@ export const openCodeAdapter: AgentAdapter = {
   },
 
   /**
+   * NOTE: OpenCode-specific. OpenCode already exposes file edits in its own UI,
+   * so Meridian should not append a synthetic "Files changed:" block.
+   */
+  shouldTrackFileChanges(): boolean {
+    return false
+  },
+
+  /**
    * NOTE: OpenCode-specific. Parses the Task tool description to extract
    * subagent names and build SDK AgentDefinition objects for native subagent routing.
    */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -643,6 +643,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // Catches write, edit, AND bash redirects (>, >>, tee, sed -i).
       const mcpPrefix = `mcp__${adapter.getMcpServerName()}__`
       const trackFileChanges = !(process.env.MERIDIAN_NO_FILE_CHANGES ?? process.env.CLAUDE_PROXY_NO_FILE_CHANGES)
+        && adapter.shouldTrackFileChanges?.() !== false
       const fileChangeHook = trackFileChanges ? createFileChangeHook(fileChanges, mcpPrefix) : undefined
 
       // Track tools discovered via ToolSearch (deferred tools that get called)


### PR DESCRIPTION
## Summary
Rebased version of #360 (by @briankeefe) with additional test coverage to prevent silent regressions in other adapters. Full credit to @briankeefe for the fix — his two commits are preserved intact on this branch.

- disable synthetic \`Files changed:\` summary for OpenCode (opts out via new \`shouldTrackFileChanges()\` adapter method; default remains on for all other adapters)
- add positive-path integration tests using \`x-meridian-agent: pi\` header to prove the summary still works for non-OpenCode adapters after the opt-out is introduced
- add per-adapter unit assertions that pi/crush/droid/forgecode/passthrough do NOT opt out, catching any future accidental copy-paste that would disable the feature elsewhere
- soften the flipped assertions in the OpenCode test path from exact \`.toBe("...")\` matches against mock text back to \`.not.toContain("Files changed:")\` for robustness

## Credit
Commits \`aad51431\` and \`6a24ff31\` authored by @briankeefe (preserved via cherry-pick + rebase). The third commit adds the regression guards.

Closes #360

## Verification
- \`bun test\` — 1238/1238 pass across 78 files
- \`bun run typecheck\` — clean
- regression check: temporarily broke the gate (\`trackFileChanges = false\`) and confirmed the two new pi-adapter integration tests fail as designed
- regression check: temporarily added \`shouldTrackFileChanges: () => false\` to piAdapter and confirmed the per-adapter unit guard fails as designed

## Test plan
- [x] Full suite green (1238/1238)
- [x] Typecheck clean
- [x] Positive-path test catches gate regression
- [x] Unit guard catches accidental per-adapter opt-out