### PR TITLE
chore: gitignore local agent tooling dirs (.claude, .pylon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ context.md
 .omc/
 apps/desktop/src-tauri/target/
 apps/desktop/src-tauri/target/
+
+# Local agent tooling (per-developer; never commit)
+.claude/
+.pylon/


### PR DESCRIPTION
## Summary
- add \`.claude/\` and \`.pylon/\` to \`.gitignore\` — per-developer local state (Claude Code workspace, Pylon orchestrator data) that should never be committed
- currently showing up as untracked across multiple contributors' checkouts

## Test plan
- [x] \`git check-ignore -v .claude/ .pylon/\` confirms both match the new rules