### PR TITLE
fix: preserve <system-reminder> for non-Droid adapters

### DIFF
--- a/src/__tests__/proxy-system-reminder-preservation.test.ts
+++ b/src/__tests__/proxy-system-reminder-preservation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration test for issue #368 — preservation of <system-reminder>
+ * content in user messages for non-Droid adapters.
+ *
+ * oh-my-opencode injects <system-reminder> blocks containing background-task
+ * IDs (`bg_*`) that Claude must see. Prior to the fix, Meridian's sanitizer
+ * stripped these blocks unconditionally, causing Claude to respond as if the
+ * user message was empty.
+ *
+ * This test posts the exact payload shape from the user report and asserts
+ * that the `bg_*` IDs reach the SDK prompt for OpenCode, but are still
+ * stripped for Droid (where <system-reminder> leaks CWD info).
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let mockMessages: any[] = []
+let capturedQueryParams: any = null
+let savedPassthrough: string | undefined
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParams = params
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }),
+  )
+}
+
+// The exact content shape that triggers #368: an OMO-injected system-reminder
+// announcing background-task completion with bg_* IDs the model needs.
+const OMO_SYSTEM_REMINDER = `<system-reminder>
+[ALL BACKGROUND TASKS COMPLETE]
+
+**Completed:**
+- \`bg_0aaa50b0\`: Find Activity entity and relations
+- \`bg_8ff9ed0f\`: Find Activity DB schema and migrations
+
+Use \`background_output(task_id="<id>")\` to retrieve each result.
+</system-reminder>
+<!-- OMO_INTERNAL_INITIATOR -->
+11:41 AM`
+
+function getPromptText(): string {
+  const p = capturedQueryParams?.prompt
+  if (typeof p === "string") return p
+  // AsyncIterable case — just coerce; this test uses a text prompt
+  return String(p)
+}
+
+describe("issue #368: <system-reminder> preservation by adapter", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedQueryParams = null
+    clearSessionCache()
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  it("OpenCode: preserves bg_* task IDs from <system-reminder> in the SDK prompt", async () => {
+    const app = createTestApp()
+    const body = {
+      model: "claude-sonnet-4-5-20250929",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: OMO_SYSTEM_REMINDER }],
+    }
+
+    await (await post(app, body)).json()
+
+    const prompt = getPromptText()
+    expect(prompt).toContain("bg_0aaa50b0")
+    expect(prompt).toContain("bg_8ff9ed0f")
+    expect(prompt).toContain("[ALL BACKGROUND TASKS COMPLETE]")
+    // OMO's unambiguous marker should still be stripped
+    expect(prompt).not.toContain("OMO_INTERNAL_INITIATOR")
+  })
+
+  it("OpenCode: preserves <system-reminder> when content is an array of blocks", async () => {
+    const app = createTestApp()
+    const body = {
+      model: "claude-sonnet-4-5-20250929",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: OMO_SYSTEM_REMINDER }],
+        },
+      ],
+    }
+
+    await (await post(app, body)).json()
+
+    const prompt = getPromptText()
+    expect(prompt).toContain("bg_0aaa50b0")
+    expect(prompt).toContain("bg_8ff9ed0f")
+  })
+
+  it("Droid: still strips <system-reminder> (CWD leakage)", async () => {
+    const app = createTestApp()
+    const DROID_UA = "factory-cli/0.89.0"
+    const body = {
+      model: "claude-sonnet-4-5-20250929",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `<system-reminder>\n% pwd\n/Users/dev/project\n</system-reminder>`,
+            },
+            { type: "text", text: "what does this repo do?" },
+          ],
+        },
+      ],
+      tools: [
+        { name: "Read", description: "Read a file", input_schema: { type: "object", properties: {} } },
+      ],
+    }
+
+    await (await post(app, body, { "User-Agent": DROID_UA })).json()
+
+    const prompt = getPromptText()
+    expect(prompt).not.toContain("% pwd")
+    expect(prompt).not.toContain("/Users/dev/project")
+    expect(prompt).toContain("what does this repo do?")
+  })
+})

--- a/src/__tests__/sanitize-unit.test.ts
+++ b/src/__tests__/sanitize-unit.test.ts
@@ -14,16 +14,25 @@ import { sanitizeTextContent } from "../proxy/sanitize"
 // ── Orchestration tag stripping ──
 
 describe("sanitizeTextContent", () => {
-  // --- Droid ---
+  // --- Droid: <system-reminder> stripping is opt-in ---
 
-  it("strips <system-reminder> blocks (Droid CWD injection)", () => {
+  it("strips <system-reminder> blocks when stripSystemReminder is enabled (Droid)", () => {
     const input = '<system-reminder>\nUser system info\n% pwd\n/home/user\n</system-reminder>\nactual question'
-    expect(sanitizeTextContent(input)).toBe("actual question")
+    expect(sanitizeTextContent(input, { stripSystemReminder: true })).toBe("actual question")
   })
 
-  it("strips multiline <system-reminder> with attributes", () => {
+  it("strips multiline <system-reminder> with attributes when enabled", () => {
     const input = 'hello\n<system-reminder id="sr-1">\nline one\nline two\n</system-reminder>\nworld'
-    expect(sanitizeTextContent(input)).toBe("hello\n\nworld")
+    expect(sanitizeTextContent(input, { stripSystemReminder: true })).toBe("hello\n\nworld")
+  })
+
+  it("PRESERVES <system-reminder> by default (issue #368)", () => {
+    // oh-my-opencode injects <system-reminder> blocks with bg_* task IDs
+    // that Claude must see. Default behavior must not strip them.
+    const input = '<system-reminder>\n[ALL BACKGROUND TASKS COMPLETE]\n- `bg_0aaa50b0`: Find X\n- `bg_8ff9ed0f`: Find Y\n</system-reminder>'
+    const result = sanitizeTextContent(input)
+    expect(result).toContain("bg_0aaa50b0")
+    expect(result).toContain("bg_8ff9ed0f")
   })
 
   // --- OpenCode / Crush ---
@@ -116,14 +125,14 @@ describe("sanitizeTextContent", () => {
 
   // --- Multiple patterns in one block ---
 
-  it("handles multiple patterns in one string", () => {
+  it("handles multiple patterns in one string (Droid mode)", () => {
     const input = '<system-reminder>x</system-reminder>\n<task_metadata>y</task_metadata>\nnormal content'
-    expect(sanitizeTextContent(input)).toBe("normal content")
+    expect(sanitizeTextContent(input, { stripSystemReminder: true })).toBe("normal content")
   })
 
-  it("returns empty string for all-wrapper input", () => {
+  it("returns empty string for all-wrapper input (Droid mode)", () => {
     const input = '<system-reminder>everything is internal</system-reminder>'
-    expect(sanitizeTextContent(input)).toBe("")
+    expect(sanitizeTextContent(input, { stripSystemReminder: true })).toBe("")
   })
 
   // --- False positive safety ---
@@ -179,7 +188,7 @@ describe("sanitizeTextContent", () => {
 
   // --- Regression: the exact scenario from issue #167 ---
 
-  it("strips the compound leakage pattern from #167", () => {
+  it("strips the compound leakage pattern from #167 (Droid mode)", () => {
     const input = [
       '<system-reminder>',
       '  Current dir: /home/user',
@@ -189,6 +198,30 @@ describe("sanitizeTextContent", () => {
       '<!-- OMO_INTERNAL_INITIATOR -->',
       'What is 2+2?',
     ].join("\n")
-    expect(sanitizeTextContent(input)).toBe("What is 2+2?")
+    expect(sanitizeTextContent(input, { stripSystemReminder: true })).toBe("What is 2+2?")
+  })
+
+  // --- Regression: issue #368 (OMO bg_* task IDs disappearing) ---
+
+  it("preserves bg_* task IDs in <system-reminder> by default (issue #368)", () => {
+    const input = [
+      '<system-reminder>',
+      '[ALL BACKGROUND TASKS COMPLETE]',
+      '',
+      '**Completed:**',
+      '- `bg_0aaa50b0`: Find Activity entity and relations',
+      '- `bg_8ff9ed0f`: Find Activity DB schema and migrations',
+      '',
+      'Use `background_output(task_id="<id>")` to retrieve each result.',
+      '</system-reminder>',
+      '<!-- OMO_INTERNAL_INITIATOR -->',
+      '11:41 AM',
+    ].join("\n")
+    const result = sanitizeTextContent(input)
+    expect(result).toContain("bg_0aaa50b0")
+    expect(result).toContain("bg_8ff9ed0f")
+    expect(result).toContain("[ALL BACKGROUND TASKS COMPLETE]")
+    // OMO comment still stripped (unambiguous orchestration marker)
+    expect(result).not.toContain("OMO_INTERNAL_INITIATOR")
   })
 })

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -145,6 +145,17 @@ export interface AgentAdapter {
   shouldTrackFileChanges?(): boolean
 
   /**
+   * Whether this agent leaks CWD/env info through `<system-reminder>` blocks
+   * in user messages (Droid). When true, the proxy strips those blocks before
+   * flattening to a text prompt so they don't echo back to the model.
+   *
+   * Most agents (OpenCode, Crush, ForgeCode) use `<system-reminder>` to surface
+   * harness state the model needs to see (e.g. oh-my-opencode background task
+   * IDs), so the default is false — preserve them.
+   */
+  leaksCwdViaSystemReminder?(): boolean
+
+  /**
    * Map a client-side tool_use block to file changes (passthrough mode).
    *
    * In passthrough mode the SDK doesn't execute tools, so PostToolUse

--- a/src/proxy/adapters/droid.ts
+++ b/src/proxy/adapters/droid.ts
@@ -75,6 +75,13 @@ export const droidAdapter: AgentAdapter = {
     return normalizeContent(content)
   },
 
+  leaksCwdViaSystemReminder(): boolean {
+    // Droid embeds CWD inside <system-reminder> blocks in user messages
+    // (see extractDroidCwd above). Those blocks must be stripped before the
+    // prompt is flattened, or they echo back to the model.
+    return true
+  },
+
   getBlockedBuiltinTools(): readonly string[] {
     // Reuse the same list as OpenCode — Droid sends its own Read/Write/Bash/etc.
     // tools and the SDK's built-ins would conflict.

--- a/src/proxy/sanitize.ts
+++ b/src/proxy/sanitize.ts
@@ -23,9 +23,12 @@
 // harnesses inject and that never appears in legitimate user content.
 // ---------------------------------------------------------------------------
 
+// Tags stripped unconditionally (every adapter).
+// `system-reminder` is NOT here — it is overloaded: Droid uses it to leak CWD
+// (should strip), but OpenCode's oh-my-opencode harness uses it to surface
+// background-task IDs and other orchestration state the model MUST see. So it
+// is only stripped when the caller opts in via { stripSystemReminder: true }.
 const ORCHESTRATION_TAGS = [
-  // Droid: CWD + env info injected into first user message
-  "system-reminder",
   // OpenCode / Crush: environment context blocks
   "env",
   // ForgeCode: system info wrapper and children
@@ -76,15 +79,32 @@ const ALL_PATTERNS = [
   ...NON_XML_PATTERNS,
 ]
 
+// Opt-in: only used when the adapter reports that it leaks CWD/env through
+// `<system-reminder>` blocks (Droid). Other adapters must preserve these
+// blocks — they carry model-visible harness state (see ORCHESTRATION_TAGS).
+const SYSTEM_REMINDER_PATTERNS: RegExp[] = [
+  /<system-reminder\b[^>]*>[\s\S]*?<\/system-reminder>/gi,
+  /<system-reminder\b[^>]*\/>/gi,
+]
+
+export interface SanitizeOptions {
+  /** Strip `<system-reminder>` blocks. Enable for adapters (Droid) that leak
+   *  CWD/env through this tag. */
+  stripSystemReminder?: boolean
+}
+
 /**
  * Strip orchestration wrappers from a single text string.
  *
  * Designed to be called on individual content blocks (not concatenated
  * prompt strings) to eliminate cross-block regex matching risk.
  */
-export function sanitizeTextContent(text: string): string {
+export function sanitizeTextContent(text: string, opts: SanitizeOptions = {}): string {
   let result = text
-  for (const pattern of ALL_PATTERNS) {
+  const patterns = opts.stripSystemReminder
+    ? [...ALL_PATTERNS, ...SYSTEM_REMINDER_PATTERNS]
+    : ALL_PATTERNS
+  for (const pattern of patterns) {
     // Reset lastIndex for stateful regexes (those with 'g' flag)
     pattern.lastIndex = 0
     result = result.replace(pattern, "")

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -68,7 +68,8 @@ let claudeExecutable = ""
  */
 function buildFreshPrompt(
   messages: Array<{ role: string; content: any }>,
-  stripCacheControl: (content: any) => any
+  stripCacheControl: (content: any) => any,
+  sanitizeOpts: import("./sanitize").SanitizeOptions = {}
 ): string | AsyncIterable<any> {
   const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
   const hasMultimodal = messages.some((m) =>
@@ -113,11 +114,11 @@ function buildFreshPrompt(
       const role = m.role === "assistant" ? "Assistant" : "Human"
       let content: string
       if (typeof m.content === "string") {
-        content = sanitizeTextContent(m.content)
+        content = sanitizeTextContent(m.content, sanitizeOpts)
       } else if (Array.isArray(m.content)) {
         content = m.content
           .map((block: any) => {
-            if (block.type === "text" && block.text) return sanitizeTextContent(block.text)
+            if (block.type === "text" && block.text) return sanitizeTextContent(block.text, sanitizeOpts)
             if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
             if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
             if (block.type === "image") return "[Image attached]"
@@ -449,6 +450,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
 
 
+      // Adapter-scoped sanitize options (see sanitize.ts).
+      const sanitizeOpts: import("./sanitize").SanitizeOptions = {
+        stripSystemReminder: adapter.leaksCwdViaSystemReminder?.() ?? false,
+      }
+
       // When resuming, only send new messages the SDK doesn't have.
       const allMessages = body.messages || []
       let messagesToConvert: typeof allMessages
@@ -550,18 +556,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       } else {
         // Text prompt — convert messages to string.
         // Sanitize each text block before flattening to strip orchestration
-        // wrappers (<system-reminder>, <env>, etc.) that harnesses inject.
-        // Per-block sanitization avoids cross-message regex collateral.
+        // wrappers (<env>, <task_metadata>, etc.) that harnesses inject.
+        // `<system-reminder>` is only stripped for adapters that leak CWD
+        // through it (Droid) — preserved otherwise so that harness state
+        // like oh-my-opencode's background-task IDs reaches the model.
         textPrompt = messagesToConvert
           ?.map((m: { role: string; content: string | Array<{ type: string; text?: string; content?: string; tool_use_id?: string; name?: string; input?: unknown; id?: string }> }) => {
             const role = m.role === "assistant" ? "Assistant" : "Human"
             let content: string
             if (typeof m.content === "string") {
-              content = sanitizeTextContent(m.content)
+              content = sanitizeTextContent(m.content, sanitizeOpts)
             } else if (Array.isArray(m.content)) {
               content = m.content
                 .map((block: any) => {
-                  if (block.type === "text" && block.text) return sanitizeTextContent(block.text)
+                  if (block.type === "text" && block.text) return sanitizeTextContent(block.text, sanitizeOpts)
                   if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
                   if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
                   if (block.type === "image") return "[Image attached]"
@@ -775,7 +783,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                     yield* query(buildQueryOptions({
-                      prompt: buildFreshPrompt(allMessages, stripCacheControl),
+                      prompt: buildFreshPrompt(allMessages, stripCacheControl, sanitizeOpts),
                       model, workingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                       resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,
@@ -1191,7 +1199,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                       yield* query(buildQueryOptions({
-                        prompt: buildFreshPrompt(allMessages, stripCacheControl),
+                        prompt: buildFreshPrompt(allMessages, stripCacheControl, sanitizeOpts),
                         model, workingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,


### PR DESCRIPTION
## Problem

Closes #368.

Meridian's sanitizer stripped `<system-reminder>...</system-reminder>` from every user message before flattening to the text prompt ([src/proxy/sanitize.ts:28](../blob/main/src/proxy/sanitize.ts#L28), added in #327 to stop Droid's CWD leakage / #167).

oh-my-opencode repurposes the same tag to surface background-task state to the model — for example the `bg_*` task IDs in the screenshot attached to #368. For OMO users the tag is the *entire* content of the injected message. Stripping it collapsed the turn to near-empty text, so Claude responded "I don't have the task IDs." The user's framing ("queued messages get ignored") was a symptom of the OMO injection pattern; timing wasn't the trigger.

### Repro (before this PR)

```
Input  (299 chars): <system-reminder>[ALL BACKGROUND TASKS COMPLETE] ... bg_0aaa50b0 ... </system-reminder>...
Output   (8 chars): "11:41 AM"
```

## Fix

Scope `<system-reminder>` stripping to adapters that actually leak CWD through the tag.

- `sanitize.ts` gains an optional `SanitizeOptions { stripSystemReminder?: boolean }` arg. Default is `false`, so the tag passes through.
- `AgentAdapter` gains an optional `leaksCwdViaSystemReminder()` hook.
- Droid returns `true` (its `extractCwd` already parses the same tag).
- `server.ts` derives `sanitizeOpts` from the adapter and threads it through both the main text prompt path and `buildFreshPrompt`.

## Tests

- **Unit** (`sanitize-unit.test.ts`): new case asserts `bg_*` IDs survive by default; existing Droid / #167 cases updated to pass `stripSystemReminder: true`.
- **Integration** (`proxy-system-reminder-preservation.test.ts`, new): posts the exact OMO payload from #368 via `/v1/messages`, captures the SDK `prompt`, and asserts:
  - OpenCode requests: `bg_0aaa50b0` and `bg_8ff9ed0f` reach the SDK.
  - Droid requests: `<system-reminder>` content is still stripped.

Full suite: 1243 tests, 0 failures. Typecheck clean.

## Test plan

- [x] `npm test`
- [x] `npx tsc --noEmit`
- [ ] E2E: run opencode + oh-my-opencode locally and confirm Claude now sees `bg_*` task IDs after a background-task completion injection.