### PR TITLE
fix: pass include-component-in-tag on the release-please action input

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,11 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           skip-labeling: true
+          # Must be set on the action input (not just per-package config) so the
+          # previous-release LOOKUP side matches our `meridian-v<version>` tags.
+          # Without this the action looks for `v<version>`, can't find the last
+          # release, and recomputes every cycle from full history (#371).
+          include-component-in-tag: true
 
   publish:
     needs: release-please


### PR DESCRIPTION
## Problem

After #371 set \`include-component-in-tag: true\` inside \`release-please-config.json\`, the next release cycle *still* proposed \`1.38.0\` with the full-history changelog (#373), and merging #372 (the \`1.37.4\` release PR) did not cut a tag, GitHub release, or npm publish — \`release_created\` output was empty and the publish job was skipped.

Release-please run log still shows:

\`\`\`
include-component-in-tag: false
⚠ Found release tag with component '', but not configured in manifest
\`\`\`

The config-file setting only governs how the package's release is generated. The **previous-release lookup** uses the action input, which defaults to \`false\`, and doesn't read from the config file. So the lookup still searches for \`v<version>\` tags, can't match our \`meridian-v<version>\` tags, and recomputes from scratch every run.

## Fix

Set \`include-component-in-tag: true\` on the action \`with:\` block so both the lookup and release paths agree on the tag format.

## Post-merge repair

Merging #372 already bumped \`package.json\`, \`CHANGELOG.md\`, and the manifest to \`1.37.4\` on main, but no tag was created and nothing was published. After this PR merges I'll:

1. Close the bogus \`1.38.0\` PR #373.
2. Create the \`meridian-v1.37.4\` tag + GitHub release manually.
3. Trigger the \`publish_only\` workflow dispatch to publish \`@rynfar/meridian@1.37.4\` to npm.

Future releases will cut tags/releases/npm automatically.