### PR TITLE
feat+fix: x-meridian-source header — observability AND fingerprint cache skip for fork/subagent flows

### DIFF
--- a/src/__tests__/proxy-source-header.test.ts
+++ b/src/__tests__/proxy-source-header.test.ts
@@ -1,0 +1,135 @@
+/**
+ * `x-meridian-source` header tests.
+ *
+ * The source header is a client-supplied tag used by meridian purely for
+ * observability — distinguishing concurrent request flows from the same
+ * conversation (e.g., pylon's main chat vs. memory-extract fork vs. subagents).
+ *
+ * Verified:
+ *   - header value appears in the [PROXY] request summary log line
+ *   - absent header: no `source=` token appears
+ *   - long / untrusted values are truncated to 64 chars (crude DoS guard on log line)
+ *   - header does NOT affect routing, lineage detection, or caching
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let mockMessages: unknown[] = []
+let capturedQueryParams: any = null
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParams = params
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const BASE_BODY = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "hello" }],
+}
+
+describe("x-meridian-source header", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    clearSessionCache()
+  })
+
+  function getProxyLogLine(spy: ReturnType<typeof spyOn>): string | undefined {
+    // The summary log line is the one that contains adapter=<name> and msgCount=
+    return spy.mock.calls.map((c: any) => String(c[0])).find((msg: string) =>
+      msg.includes("[PROXY]") && msg.includes("adapter=") && msg.includes("msgCount=")
+    )
+  }
+
+  it("includes source=<value> in the [PROXY] summary line when header is present", async () => {
+    const logSpy = spyOn(console, "error")
+    const app = createTestApp()
+
+    await post(app, BASE_BODY, { "x-meridian-source": "fork-memory-extract" })
+
+    const line = getProxyLogLine(logSpy)
+    expect(line).toBeDefined()
+    expect(line!).toContain("source=fork-memory-extract")
+    // Sanity: adapter and other fields still present (not a regression)
+    expect(line!).toContain("adapter=")
+    expect(line!).toContain("msgCount=")
+    logSpy.mockRestore()
+  })
+
+  it("omits the source= token when header is absent", async () => {
+    const logSpy = spyOn(console, "error")
+    const app = createTestApp()
+
+    await post(app, BASE_BODY)
+
+    const line = getProxyLogLine(logSpy)
+    expect(line).toBeDefined()
+    expect(line!).not.toContain("source=")
+    logSpy.mockRestore()
+  })
+
+  it("truncates source values longer than 64 chars", async () => {
+    const logSpy = spyOn(console, "error")
+    const app = createTestApp()
+
+    const long = "a".repeat(200)
+    await post(app, BASE_BODY, { "x-meridian-source": long })
+
+    const line = getProxyLogLine(logSpy)
+    expect(line).toBeDefined()
+    // Should have at most 64 chars of the value after "source="
+    const match = line!.match(/source=(\S+)/)
+    expect(match).not.toBeNull()
+    expect(match![1]!.length).toBeLessThanOrEqual(64)
+    logSpy.mockRestore()
+  })
+
+  it("does not affect the SDK query (no source-derived routing)", async () => {
+    const app = createTestApp()
+
+    await post(app, BASE_BODY, { "x-meridian-source": "fork-memory-extract" })
+
+    // Sanity: request was processed normally by the same SDK call path
+    expect(capturedQueryParams).toBeDefined()
+    // None of the known query options should carry the source (it's log-only)
+    const serialized = JSON.stringify(capturedQueryParams.options ?? {})
+    expect(serialized).not.toContain("fork-memory-extract")
+  })
+})

--- a/src/__tests__/proxy-source-skip-cache.test.ts
+++ b/src/__tests__/proxy-source-skip-cache.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Fingerprint cache skip for fork/subagent requests.
+ *
+ * When `x-meridian-source` marks a request as an independent sub-flow
+ * (fork-memory-extract, subagent-scout, etc.), meridian must:
+ *
+ *   1. Skip fingerprint lookup — don't classify against the parent's cache
+ *      (which would bounce between undo / modified-continuation / diverged as
+ *      different flows write different hashes to the shared key)
+ *   2. Skip fingerprint write — don't pollute the parent's cache entry with
+ *      the fork's message hashes
+ *
+ * Requests without the header or with source=main retain today's behavior
+ * exactly. This test verifies both sides.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let mockMessages: unknown[] = []
+let capturedQueryParams: any = null
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParams = params
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { lookupSession } = await import("../proxy/session/cache")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const BASE_BODY = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "hello from pylon main" }],
+}
+
+describe("x-meridian-source: fingerprint cache skip for independent sessions", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    clearSessionCache()
+  })
+
+  /**
+   * To test "was the cache written," send request N, then call lookupSession
+   * with N+1 messages (same prefix + one new user message). If the cache was
+   * written after N, verifyLineage sees a prefix hash match + new suffix →
+   * "continuation". If cache wasn't written, lookup returns "diverged".
+   *
+   * We can't use the SAME messages for both post and lookup because
+   * verifyLineage intentionally treats `messages.length <= cached.messageCount`
+   * as a replay and classifies diverged (guards against duplicate request
+   * retries re-resuming the old SDK session).
+   */
+  const nextTurn = [
+    ...BASE_BODY.messages,
+    { role: "assistant", content: "ok" },
+    { role: "user", content: "another turn" },
+  ]
+
+  it("does NOT write to the fingerprint cache when source=fork-memory-extract", async () => {
+    const app = createTestApp()
+    const cwd = process.cwd()
+
+    await post(app, BASE_BODY, { "x-meridian-source": "fork-memory-extract" })
+
+    const result = lookupSession(undefined, nextTurn, cwd)
+    expect(result.type).toBe("diverged")
+  })
+
+  it("does NOT write to the fingerprint cache when source=subagent-<name>", async () => {
+    const app = createTestApp()
+    const cwd = process.cwd()
+    await post(app, BASE_BODY, { "x-meridian-source": "subagent-scout" })
+
+    const result = lookupSession(undefined, nextTurn, cwd)
+    expect(result.type).toBe("diverged")
+  })
+
+  it("DOES write to the fingerprint cache when source=main", async () => {
+    // Sanity: main requests (non-fork, non-subagent) must still populate the
+    // cache so the normal resume optimization works for regular chat turns.
+    const app = createTestApp()
+    const cwd = process.cwd()
+
+    await post(app, BASE_BODY, { "x-meridian-source": "main" })
+
+    const result = lookupSession(undefined, nextTurn, cwd)
+    expect(result.type).not.toBe("diverged")
+  })
+
+  it("DOES write to the fingerprint cache when no source header is set", async () => {
+    // Backward-compat: clients that don't send x-meridian-source must get
+    // today's behavior byte-for-byte.
+    const app = createTestApp()
+    const cwd = process.cwd()
+    await post(app, BASE_BODY)
+
+    const result = lookupSession(undefined, nextTurn, cwd)
+    expect(result.type).not.toBe("diverged")
+  })
+
+  it("fork with matching fingerprint does NOT overwrite parent's cache entry", async () => {
+    // Scenario: parent conversation writes its cache entry. Then a fork fires
+    // with the SAME fingerprint (same first user message + cwd — which is
+    // exactly why we needed this fix). The fork must not overwrite or
+    // invalidate the parent's cache.
+    const app = createTestApp()
+    const cwd = process.cwd()
+
+    // 1) Parent turn establishes cache.
+    await post(app, BASE_BODY, { "x-meridian-source": "main" })
+    const afterParent = lookupSession(undefined, nextTurn, cwd)
+    expect(afterParent.type).not.toBe("diverged")
+
+    // 2) Fork turn with matching fingerprint — should NOT touch parent's entry.
+    await post(app, BASE_BODY, { "x-meridian-source": "fork-memory-extract" })
+
+    // 3) Parent's cache entry should still resolve to non-diverged.
+    const afterFork = lookupSession(undefined, nextTurn, cwd)
+    expect(afterFork.type).not.toBe("diverged")
+  })
+
+  it("logs source=fork-... even for independent sessions (observability preserved)", async () => {
+    // When skipping the cache, we still want the source to appear in the
+    // [PROXY] summary log line so the operator can see that an independent
+    // session was handled.
+    const { spyOn } = await import("bun:test")
+    const logSpy = spyOn(console, "error")
+    const app = createTestApp()
+
+    await post(app, BASE_BODY, { "x-meridian-source": "fork-memory-extract" })
+
+    const calls = logSpy.mock.calls.map((c: any) => String(c[0]))
+    const summary = calls.find((msg: string) => msg.includes("[PROXY]") && msg.includes("adapter=") && msg.includes("msgCount="))
+    expect(summary).toBeDefined()
+    expect(summary).toContain("source=fork-memory-extract")
+    // Independent sessions always take the 'new' lineage path (since we skip
+    // the cache lookup, lineage result is diverged → logged as 'new').
+    expect(summary).toContain("lineage=new")
+    logSpy.mockRestore()
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -300,6 +300,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           Object.keys(profile.env).length > 0 ? profile.env : undefined
         )
         const agentMode = c.req.header("x-opencode-agent-mode") ?? null
+        // Opaque tag clients can send to distinguish concurrent request flows
+        // from the same conversation (e.g., pylon's main chat vs. memory-extract fork vs. subagent).
+        // Used only for observability — does not affect routing, caching, or session behavior.
+        // Examples: "main", "fork-memory-extract", "subagent-scout".
+        const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
         let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType, agentMode)
         // Allow adapter to override streaming preference (e.g. LiteLLM requires non-streaming)
         const adapterStreamPref = adapter.prefersStreaming?.(body)
@@ -421,7 +426,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
         const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
         const toolCount = body.tools?.length ?? 0
-        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
+        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
         console.error(`[PROXY] ${requestLogLine} msgs=${msgSummary}`)
         diagnosticLog.session(`${requestLogLine}`, requestMeta.requestId)
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -408,7 +408,25 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? `${profile.id}:${agentSessionId}` : agentSessionId
         const profileScopedCwd = profile.id !== "default"
           ? `${workingDirectory}::profile=${profile.id}` : workingDirectory
-        const lineageResult = lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
+        // Clients that run concurrent sub-request flows in the same conversation
+        // (e.g. pylon's memory-extract fork or subagent children) share the same
+        // (firstUserMessage, cwd) fingerprint as the parent — so meridian's
+        // fingerprint cache conflates them and bounces the parent through
+        // continuous undo/modified-continuation/diverged reclassifications as
+        // each flow writes different message hashes to the shared key.
+        //
+        // When x-meridian-source marks a request as an independent fork or
+        // subagent, skip fingerprint lookup (no reclassification) and skip the
+        // write at end of turn (no cache pollution). The main conversation
+        // keeps its cache entry intact across forks.
+        //
+        // Opt-in via header value: clients that don't set the header are
+        // unaffected — behavior is byte-identical to today.
+        const isIndependentSession =
+          requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || false
+        const lineageResult = isIndependentSession
+          ? { type: "diverged" as const }
+          : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
         const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
@@ -1091,8 +1109,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             cacheHitRate: computeCacheHitRate(lastUsage),
           })
 
-          // Store session for future resume
-              if (currentSessionId) {
+          // Store session for future resume.
+          // Fork/subagent requests don't write to the cache — see lookupSession
+          // block above for rationale (avoids polluting the parent's key).
+              if (currentSessionId && !isIndependentSession) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
 
@@ -1521,8 +1541,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 console.error(`[PROXY] ${requestMeta.requestId} discovered=${discoveredTools.size} (${newNames}) session_total=${allNames.length}`)
               }
 
-              // Store session for future resume
-              if (currentSessionId) {
+              // Store session for future resume.
+              // Fork/subagent requests don't write to the cache (see lookupSession
+              // block for rationale).
+              if (currentSessionId && !isIndependentSession) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -302,7 +302,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const agentMode = c.req.header("x-opencode-agent-mode") ?? null
         // Opaque tag clients can send to distinguish concurrent request flows
         // from the same conversation (e.g., pylon's main chat vs. memory-extract fork vs. subagent).
-        // Used only for observability — does not affect routing, caching, or session behavior.
+        // Logged for observability; fork-*/subagent-* values also skip fingerprint cache (see below).
         // Examples: "main", "fork-memory-extract", "subagent-scout".
         const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
         let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType, agentMode)
@@ -450,7 +450,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         // Recovery logging: when a session diverges, check if the store has a
         // previous session ID that the user can recover via `claude --resume`.
-        if (lineageResult.type === "diverged" && profileSessionId) {
+        if (lineageResult.type === "diverged" && profileSessionId && !isIndependentSession) {
           const recovery = lookupSessionRecovery(profileSessionId)
           if (recovery) {
             const prevId = recovery.previousClaudeSessionId || recovery.claudeSessionId


### PR DESCRIPTION
See latest commit. Two-commit PR: (1) observability header that logs x-meridian-source as source=<value>, (2) fingerprint cache skip for fork-*/subagent-* sources to fix the undo-loop/session-churn bug. Opt-in via header value — no change for adapters that don't send it. Tests: 10 new, 1259/1259 full-suite pass. Live-verified on local launchd. Companion pylon PRs: rynfar/pylon-orchestrator#1 (merged), #2 (open, live-tested working).