### PR TITLE
fix: prevent cross-session context leakage via fingerprint cache for headerless OpenCode requests

### DIFF
--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -215,9 +215,10 @@ describe("Fingerprint resume: cross-project safety via lineage", () => {
       { role: "user", content: "list the project B files" },
     ], "sdk-project-b")
 
-    // Prefix overlap ("hello") → undo/branch detected → forks from project A
-    expect(getCaptured()?.options?.resume).toBe("sdk-project-a")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // OpenCode without session header: undo is downgraded to diverged to
+    // prevent cross-session fingerprint collisions (headerless requests
+    // from category-dispatched or title-generation flows).
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 
   it("resumes correctly after cross-project rejection creates new session", async () => {
@@ -322,9 +323,57 @@ describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
       { role: "user", content: "actually, delete that file instead" },
     ], "sdk-tools-undo-new")
 
-    // Prefix overlap ("create a file", "I'll create that file.") → undo → fork
-    expect(getCaptured()?.options?.resume).toBe("sdk-tools-undo")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // OpenCode without session header: undo is downgraded to diverged
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+  })
+})
+
+describe("Fingerprint isolation: headered sessions must not leak into fingerprint cache", () => {
+  /** Send a request WITH a session header (header-tracked path) */
+  async function postWithSession(
+    app: TestApp,
+    sessionHeader: string,
+    messages: Array<{ role: string; content: string }>,
+    sdkSessionId: string,
+  ) {
+    queuedSessionIds.push(sdkSessionId)
+    const response = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-opencode-session": sessionHeader,
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages,
+      }),
+    }))
+    await response.json()
+  }
+
+  it("headerless request does not resume a headered session with the same fingerprint", async () => {
+    const app = createTestApp()
+
+    // Session A: tracked by header, builds up a 3-message conversation
+    await postWithSession(app, "sess-A", [
+      { role: "user", content: "ping" },
+    ], "sdk-A")
+    await postWithSession(app, "sess-A", [
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "pong" },
+      { role: "user", content: "how are you?" },
+    ], "sdk-A")
+
+    // Session B: headerless (simulates OpenCode category-dispatched request),
+    // same first message → same fingerprint. Must NOT resume session A.
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "ping" },
+    ], "sdk-B")
+
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 })
 

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -767,9 +767,8 @@ describe("Session lineage: fingerprint fallback", () => {
     }))
     await r2.json()
 
-    // Prefix overlap (Good evening, Hi!) → undo → fork via fingerprint
-    expect(getCaptured()?.options?.resume).toBe("sdk-fp1")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // OpenCode without session header: undo is downgraded to diverged
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 })
 

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -18,7 +18,7 @@ export const openCodeAdapter: AgentAdapter = {
   name: "opencode",
 
   getSessionId(c: Context): string | undefined {
-    return c.req.header("x-opencode-session")
+    return c.req.header("x-opencode-session") ?? c.req.header("x-session-affinity")
   },
 
   extractWorkingDirectory(body: any): string | undefined {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -403,7 +403,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? `${profile.id}:${agentSessionId}` : agentSessionId
         const profileScopedCwd = profile.id !== "default"
           ? `${workingDirectory}::profile=${profile.id}` : workingDirectory
-        const lineageResult = lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
+        let lineageResult = lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
+        // Guard: when OpenCode's chat.headers plugin hook doesn't fire (e.g.
+        // category-dispatched or title-generation requests), the request has
+        // no session header and falls through to fingerprint lookup.  A new
+        // 1-message session can collide with a stored N-message session and
+        // be classified as "undo."  Downgrade to "diverged" to prevent
+        // leaking the old session's conversation history.
+        if (lineageResult.type === "undo" && adapter.name === "opencode" && !agentSessionId) {
+          lineageResult = { type: "diverged" }
+        }
         const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -250,7 +250,12 @@ export function storeSession(
   // In-memory cache
   if (sessionId) sessionCache.set(sessionId, state)
   const fp = getConversationFingerprint(messages, workingDirectory)
-  if (fp) fingerprintCache.set(fp, state)
+  // Only populate the fingerprint cache for headerless requests. When a
+  // session header is present the session is already tracked by ID; writing
+  // to the fingerprint cache too causes cross-session collisions when a
+  // later headerless request (e.g. OpenCode category-dispatched or title
+  // generation) happens to share the same first-message fingerprint.
+  if (fp && !sessionId) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = sessionId || fp
   if (key) {


### PR DESCRIPTION
## Problem

When OpenCode dispatches requests through plugin-less code paths (OMO category routing, title generation), the Meridian plugin's `chat.headers` hook does not fire. These requests arrive at Meridian **without** an `x-opencode-session` header and fall through to fingerprint-based session lookup.

Because `storeSession()` dual-writes to both `sessionCache` (keyed by header) and `fingerprintCache` (keyed by content hash), a header-tracked session pollutes the fingerprint namespace. A subsequent headerless request with the same `SHA256(cwd + "\n" + firstUserMessage)` fingerprint matches the stored session. `verifyLineage` then classifies the new 1-message request as an "undo" of the stored N-message session and **resumes the old Claude SDK session with its full conversation history**, leaking context across independent OpenCode sessions.

## Root cause

Two independent issues combine:

1. **`storeSession` dual-write**: sessions tracked by header are also written to `fingerprintCache`, creating a collision surface for later headerless requests.
2. **Fingerprint "undo" false positive**: when a headerless OpenCode request (always a new session) has fewer messages than a stored session with the same fingerprint, `verifyLineage` classifies it as "undo" and resumes the old session.

## Fix

### 1. `storeSession` guard (`src/proxy/session/cache.ts`)

Only populate the fingerprint cache when no session header is present. Header-tracked sessions are already keyed by ID in `sessionCache`; dual-writing to `fingerprintCache` creates the cross-session collision surface.

```diff
- if (fp) fingerprintCache.set(fp, state)
+ if (fp && !sessionId) fingerprintCache.set(fp, state)
```

### 2. Undo→diverged guard for headerless OpenCode (`src/proxy/server.ts`)

When the OpenCode adapter has no session header, downgrade "undo" classification to "diverged" (fresh session). Headerless OpenCode requests are always new sessions (category-dispatched or title-generation flows where the plugin hook didn't fire), never legitimate undos.

```diff
- const lineageResult = lookupSession(...)
+ let lineageResult = lookupSession(...)
+ if (lineageResult.type === "undo" && adapter.name === "opencode" && !agentSessionId) {
+   lineageResult = { type: "diverged" }
+ }
```

### 3. `getSessionId` alignment (`src/proxy/adapters/opencode.ts`)

`detectAdapter()` already recognizes both `x-opencode-session` and `x-session-affinity` as OpenCode signals, but `getSessionId()` only read the former. Without this fix, a request detected as OpenCode via `x-session-affinity` would have `agentSessionId === undefined`, causing the undo→diverged guard to fire incorrectly.

```diff
- return c.req.header("x-opencode-session")
+ return c.req.header("x-opencode-session") ?? c.req.header("x-session-affinity")
```

## Trade-off

Legitimate fingerprint-based undo is sacrificed for headerless OpenCode requests. This is acceptable because:

- OpenCode is designed to work with the Meridian plugin which provides session headers
- When the plugin hook doesn't fire, the request is always a new session, never an undo
- OpenCode's own undo mechanism works at the application level (modifies the message array), not through SDK session forking

## Tests

- Updated 3 existing tests (2 in `session-fingerprint-context.test.ts`, 1 in `session-lineage.test.ts`) to expect diverged behavior instead of fork for headerless OpenCode undo — the updated assertions are more consistent with the test names (e.g. "does NOT resume wrong project")
- Added 1 new regression test: headered session stored → headerless request with same fingerprint → must not resume or fork
- Full suite: **1224 pass, 26 fail** (main: 1223 pass, 26 fail — net +1 from the new regression test, 26 pre-existing failures unchanged)