### PR TITLE
fix: prevent cross-session context leakage via fingerprint cache for headerless OpenCode requests

### DIFF
--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -215,9 +215,10 @@ describe("Fingerprint resume: cross-project safety via lineage", () => {
       { role: "user", content: "list the project B files" },
     ], "sdk-project-b")
 
-    // Prefix overlap ("hello") → undo/branch detected → forks from project A
-    expect(getCaptured()?.options?.resume).toBe("sdk-project-a")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // OpenCode without session header: undo is downgraded to diverged to
+    // prevent cross-session fingerprint collisions (headerless requests
+    // from category-dispatched or title-generation flows).
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 
   it("resumes correctly after cross-project rejection creates new session", async () => {
@@ -322,9 +323,57 @@ describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
       { role: "user", content: "actually, delete that file instead" },
     ], "sdk-tools-undo-new")
 
-    // Prefix overlap ("create a file", "I'll create that file.") → undo → fork
-    expect(getCaptured()?.options?.resume).toBe("sdk-tools-undo")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // OpenCode without session header: undo is downgraded to diverged
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+  })
+})
+
+describe("Fingerprint isolation: headered sessions must not leak into fingerprint cache", () => {
+  /** Send a request WITH a session header (header-tracked path) */
+  async function postWithSession(
+    app: TestApp,
+    sessionHeader: string,
+    messages: Array<{ role: string; content: string }>,
+    sdkSessionId: string,
+  ) {
+    queuedSessionIds.push(sdkSessionId)
+    const response = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-opencode-session": sessionHeader,
+      },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages,
+      }),
+    }))
+    await response.json()
+  }
+
+  it("headerless request does not resume a headered session with the same fingerprint", async () => {
+    const app = createTestApp()
+
+    // Session A: tracked by header, builds up a 3-message conversation
+    await postWithSession(app, "sess-A", [
+      { role: "user", content: "ping" },
+    ], "sdk-A")
+    await postWithSession(app, "sess-A", [
+      { role: "user", content: "ping" },
+      { role: "assistant", content: "pong" },
+      { role: "user", content: "how are you?" },
+    ], "sdk-A")
+
+    // Session B: headerless (simulates OpenCode category-dispatched request),
+    // same first message → same fingerprint. Must NOT resume session A.
+    capturedQueryParams = null
+    await postNoSession(app, [
+      { role: "user", content: "ping" },
+    ], "sdk-B")
+
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 })
 

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -767,9 +767,8 @@ describe("Session lineage: fingerprint fallback", () => {
     }))
     await r2.json()
 
-    // Prefix overlap (Good evening, Hi!) → undo → fork via fingerprint
-    expect(getCaptured()?.options?.resume).toBe("sdk-fp1")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // OpenCode without session header: undo is downgraded to diverged
+    expect(getCaptured()?.options?.resume).toBeUndefined()
   })
 })
 

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -18,7 +18,7 @@ export const openCodeAdapter: AgentAdapter = {
   name: "opencode",
 
   getSessionId(c: Context): string | undefined {
-    return c.req.header("x-opencode-session")
+    return c.req.header("x-opencode-session") ?? c.req.header("x-session-affinity")
   },
 
   extractWorkingDirectory(body: any): string | undefined {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -424,9 +424,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // unaffected — behavior is byte-identical to today.
         const isIndependentSession =
           requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || false
-        const lineageResult = isIndependentSession
+        let lineageResult = isIndependentSession
           ? { type: "diverged" as const }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
+        // NOTE: agent-specific (opencode) — when OpenCode's chat.headers plugin
+        // hook doesn't fire (category-dispatched or title-generation requests),
+        // the request has no session header and falls through to fingerprint
+        // lookup. A new 1-message session can collide with a stored N-message
+        // session and be classified as "undo." Downgrade to "diverged" to
+        // prevent leaking the old session's conversation history.
+        if (lineageResult.type === "undo" && adapter.name === "opencode" && !agentSessionId) {
+          lineageResult = { type: "diverged" }
+        }
         const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -250,7 +250,12 @@ export function storeSession(
   // In-memory cache
   if (sessionId) sessionCache.set(sessionId, state)
   const fp = getConversationFingerprint(messages, workingDirectory)
-  if (fp) fingerprintCache.set(fp, state)
+  // Only populate the fingerprint cache for headerless requests. When a
+  // session header is present the session is already tracked by ID; writing
+  // to the fingerprint cache too causes cross-session collisions when a
+  // later headerless request (e.g. OpenCode category-dispatched or title
+  // generation) happens to share the same first-message fingerprint.
+  if (fp && !sessionId) fingerprintCache.set(fp, state)
   // Shared file store (cross-proxy resume)
   const key = sessionId || fp
   if (key) {


### PR DESCRIPTION
## Summary

Cherry-pick of @jhenderiks's fix from #378, rebased onto current `main` and conflict-resolved with the `isIndependentSession` guard from #376.

Closes #378

- **`cache.ts`** — stop dual-writing headered sessions to fingerprint cache (`!sessionId` guard)
- **`server.ts`** — downgrade "undo" to "diverged" for headerless OpenCode requests (prevents context leakage when plugin hook doesn't fire)
- **`opencode.ts`** — align `getSessionId` to also read `x-session-affinity`
- Added `NOTE:` marker on agent-specific guard per project conventions

Credit: original fix and root cause analysis by @jhenderiks. Commit preserves their authorship.

## Test plan

- [x] 1260/1260 tests pass locally (1259 existing + 1 new regression test)
- [x] Verified cherry-picked commit preserves original author
- [x] Conflict with `isIndependentSession` (PR #376) resolved — both guards coexist
- [x] Launchd service restarted and healthy on local