### PR TITLE
fix: stop leaking tool_use/tool_result blocks as text into the prompt (#386)

### DIFF
--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Regression test for issue #386 — "New version still shows the Tools message in the context"
+ *
+ * The bug: in certain scenarios (proxy restart, cache eviction, new session header on rehydration),
+ * meridian falls through to "diverged" lineage and replays the full conversation history. When that
+ * history contains tool_use / tool_result blocks, they get flattened to `[Tool Use: name(...)]` and
+ * `[Tool Result for toolu_...: ...]` strings in the text prompt sent to the SDK.
+ *
+ * This test reproduces the worst-case scenario that real users hit and verifies that the SDK
+ * never receives a prompt containing those flattened tool strings.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { assistantMessage } from "./helpers"
+
+type MockSdkMessage = Record<string, unknown>
+type TestApp = { fetch: (req: Request) => Promise<Response> }
+
+let mockMessages: MockSdkMessage[] = []
+interface CapturedParams {
+  prompt?: unknown
+  options?: { resume?: string; forkSession?: boolean }
+}
+let capturedParams: CapturedParams | null = null
+let queuedSessionIds: string[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: unknown) => {
+    capturedParams = params as any
+    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    return (async function* () {
+      for (const msg of mockMessages) {
+        yield { ...msg, session_id: sessionId }
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
+}))
+
+const tmpDir = mkdtempSync(join(tmpdir(), "tool-flatten-regression-"))
+process.env.CLAUDE_PROXY_SESSION_DIR = tmpDir
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { clearSharedSessions } = await import("../proxy/sessionStore")
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+  delete process.env.CLAUDE_PROXY_SESSION_DIR
+  mock.restore()
+})
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app as TestApp
+}
+
+async function postWithSession(
+  app: TestApp,
+  sessionHeader: string,
+  messages: Array<{ role: string; content: any }>,
+  sdkSessionId: string,
+) {
+  queuedSessionIds.push(sdkSessionId)
+  const response = await app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-opencode-session": sessionHeader,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-5",
+      max_tokens: 128,
+      stream: false,
+      messages,
+    }),
+  }))
+  await response.json()
+}
+
+function promptToString(prompt: unknown): string {
+  if (typeof prompt === "string") return prompt
+  return ""
+}
+
+/** Assert the SDK prompt contains no flattened tool-use strings */
+function assertNoFlattenedToolBlocks(prompt: unknown) {
+  const s = promptToString(prompt)
+  expect(s).not.toContain("[Tool Use:")
+  expect(s).not.toContain("[Tool Result")
+  expect(s).not.toContain("[Tool Result for")
+}
+
+const history = [
+  { role: "user", content: "write a hello.txt file" },
+  {
+    role: "assistant",
+    content: [
+      { type: "text", text: "I'll write that file." },
+      { type: "tool_use", id: "toolu_001", name: "write", input: { path: "hello.txt", content: "hello" } },
+    ],
+  },
+  {
+    role: "user",
+    content: [
+      { type: "tool_result", tool_use_id: "toolu_001", content: "File written successfully." },
+    ],
+  },
+  { role: "assistant", content: "Done! hello.txt has been created." },
+  { role: "user", content: "now read it back to me" },
+]
+
+beforeEach(() => {
+  mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+  capturedParams = null
+  queuedSessionIds = []
+  clearSessionCache()
+  clearSharedSessions()
+})
+
+describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text", () => {
+  it("headered session: continuation with tool_use history sends delta only (no flatten)", async () => {
+    const app = createTestApp()
+
+    // Turn 1 — establish session
+    await postWithSession(app, "sess-continue", [
+      { role: "user", content: "write a hello.txt file" },
+    ], "sdk-continue")
+
+    // Turn 2 — continuation with full history including tool_use/tool_result blocks
+    capturedParams = null
+    await postWithSession(app, "sess-continue", history, "sdk-continue")
+
+    // Must resume (lineage=continuation) and must not have flattened tool blocks into text
+    expect(capturedParams?.options?.resume).toBe("sdk-continue")
+    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+  })
+
+  it("headered session: proxy restart (cache cleared) must still rehydrate without flattening", async () => {
+    const app = createTestApp()
+
+    // Turn 1 — establish session
+    await postWithSession(app, "sess-rehydrate", [
+      { role: "user", content: "write a hello.txt file" },
+    ], "sdk-rehydrate")
+
+    // Simulate proxy restart: wipe in-memory cache (shared store remains)
+    clearSessionCache()
+
+    // Turn 2 — same session header, full history with tool_use blocks
+    capturedParams = null
+    await postWithSession(app, "sess-rehydrate", history, "sdk-rehydrate")
+
+    // After restart, shared-store lookup should find the session → continuation
+    // (delta only). Critically, tool_use/tool_result must NOT leak as text.
+    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+  })
+
+  it("headered session: new session header on rehydration (session lost) must not flatten", async () => {
+    const app = createTestApp()
+
+    // Turn 1 — original session header
+    await postWithSession(app, "sess-original", [
+      { role: "user", content: "write a hello.txt file" },
+    ], "sdk-original")
+
+    // Client restarts and generates a NEW session header, but sends full history
+    capturedParams = null
+    await postWithSession(app, "sess-brand-new", history, "sdk-brand-new")
+
+    // This is where fingerprint fallback would have saved us in the old code.
+    // Whatever the final lineage decision, tool_use blocks must not be flattened.
+    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+  })
+
+  it("headerless session: full rehydration path must not flatten tool_use blocks", async () => {
+    const app = createTestApp()
+
+    // Turn 1 — headerless (pi-style flow)
+    queuedSessionIds.push("sdk-headerless-1")
+    await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages: [{ role: "user", content: "write a hello.txt file" }],
+      }),
+    })).then(r => r.json())
+
+    // Turn 2 — headerless with full history (tool blocks)
+    capturedParams = null
+    queuedSessionIds.push("sdk-headerless-2")
+    await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages: history,
+      }),
+    })).then(r => r.json())
+
+    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+  })
+})

--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -26,6 +26,7 @@ interface CapturedParams {
 }
 let capturedParams: CapturedParams | null = null
 let queuedSessionIds: string[] = []
+function getCaptured(): CapturedParams | null { return capturedParams }
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
@@ -141,8 +142,8 @@ describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text",
     await postWithSession(app, "sess-continue", history, "sdk-continue")
 
     // Must resume (lineage=continuation) and must not have flattened tool blocks into text
-    expect(capturedParams?.options?.resume).toBe("sdk-continue")
-    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+    expect(getCaptured()?.options?.resume).toBe("sdk-continue")
+    assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 
   it("headered session: proxy restart (cache cleared) must still rehydrate without flattening", async () => {
@@ -162,7 +163,7 @@ describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text",
 
     // After restart, shared-store lookup should find the session → continuation
     // (delta only). Critically, tool_use/tool_result must NOT leak as text.
-    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+    assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 
   it("headered session: new session header on rehydration (session lost) must not flatten", async () => {
@@ -179,7 +180,7 @@ describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text",
 
     // This is where fingerprint fallback would have saved us in the old code.
     // Whatever the final lineage decision, tool_use blocks must not be flattened.
-    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+    assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 
   it("headerless session: full rehydration path must not flatten tool_use blocks", async () => {
@@ -212,6 +213,6 @@ describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text",
       }),
     })).then(r => r.json())
 
-    assertNoFlattenedToolBlocks(capturedParams?.prompt)
+    assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -64,6 +64,60 @@ const exec = promisify(execCallback)
 let claudeExecutable = ""
 
 /**
+ * Flatten an assistant message's content to plain text for replay.
+ *
+ * Drops tool_use blocks entirely. The SDK already has them from its own
+ * session state (on resume) or doesn't need them for text-only replay
+ * (on rehydration). Emitting `[Tool Use: name(args)]` strings pollutes
+ * the context — the model reads them as literal user input and starts
+ * inventing fake tool-call patterns back (issue #111, #386).
+ */
+function flattenAssistantContent(content: any): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return String(content ?? "")
+  return content
+    .map((b: any) => (b?.type === "text" && b.text ? b.text : ""))
+    .filter(Boolean)
+    .join("\n")
+}
+
+/**
+ * Flatten a user message's content to plain text for replay.
+ *
+ * Unwraps tool_result blocks — emit just the raw result content so the
+ * model sees a natural "here's the output" user turn instead of
+ * `[Tool Result for toolu_xxx: ...]` noise (issue #111, #386).
+ */
+function flattenUserContent(
+  content: any,
+  sanitizeOpts: import("./sanitize").SanitizeOptions = {}
+): string {
+  if (typeof content === "string") return sanitizeTextContent(content, sanitizeOpts)
+  if (!Array.isArray(content)) return String(content ?? "")
+  return content
+    .map((b: any) => {
+      if (b?.type === "text" && b.text) return sanitizeTextContent(b.text, sanitizeOpts)
+      if (b?.type === "tool_result") {
+        const inner = b.content
+        if (typeof inner === "string") return inner
+        if (Array.isArray(inner)) {
+          return inner
+            .map((ib: any) => (ib?.type === "text" && ib.text ? ib.text : ""))
+            .filter(Boolean)
+            .join("\n")
+        }
+        return ""
+      }
+      if (b?.type === "image") return "[Image attached]"
+      if (b?.type === "document") return "[Document attached]"
+      if (b?.type === "file") return "[File attached]"
+      return ""
+    })
+    .filter(Boolean)
+    .join("\n")
+}
+
+/**
  * Build a prompt from all messages for a fresh (non-resume) session.
  * Used when retrying after a stale session UUID error.
  */
@@ -87,24 +141,14 @@ function buildFreshPrompt(
           parent_tool_use_id: null,
         })
       } else {
-        let text: string
-        if (typeof m.content === "string") {
-          text = `[Assistant: ${m.content}]`
-        } else if (Array.isArray(m.content)) {
-          text = m.content.map((b: any) => {
-            if (b.type === "text" && b.text) return `[Assistant: ${b.text}]`
-            if (b.type === "tool_use") return `[Tool Use: ${b.name}(${JSON.stringify(b.input)})]`
-            if (b.type === "tool_result") return `[Tool Result: ${typeof b.content === "string" ? b.content : JSON.stringify(b.content)}]`
-            return ""
-          }).filter(Boolean).join("\n")
-        } else {
-          text = `[Assistant: ${String(m.content)}]`
+        const assistantText = flattenAssistantContent(m.content)
+        if (assistantText) {
+          structured.push({
+            type: "user" as const,
+            message: { role: "user" as const, content: `[Assistant: ${assistantText}]` },
+            parent_tool_use_id: null,
+          })
         }
-        structured.push({
-          type: "user" as const,
-          message: { role: "user" as const, content: text },
-          parent_tool_use_id: null,
-        })
       }
     }
     return (async function* () { for (const msg of structured) yield msg })()
@@ -113,27 +157,12 @@ function buildFreshPrompt(
   return messages
     .map((m) => {
       const role = m.role === "assistant" ? "Assistant" : "Human"
-      let content: string
-      if (typeof m.content === "string") {
-        content = sanitizeTextContent(m.content, sanitizeOpts)
-      } else if (Array.isArray(m.content)) {
-        content = m.content
-          .map((block: any) => {
-            if (block.type === "text" && block.text) return sanitizeTextContent(block.text, sanitizeOpts)
-            if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
-            if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
-            if (block.type === "image") return "[Image attached]"
-            if (block.type === "document") return "[Document attached]"
-            if (block.type === "file") return "[File attached]"
-            return ""
-          })
-          .filter(Boolean)
-          .join("\n")
-      } else {
-        content = String(m.content)
-      }
-      return `${role}: ${content}`
+      const content = m.role === "assistant"
+        ? flattenAssistantContent(m.content)
+        : flattenUserContent(m.content, sanitizeOpts)
+      return content ? `${role}: ${content}` : ""
     })
+    .filter(Boolean)
     .join("\n\n") || ""
 }
 
@@ -569,25 +598,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 parent_tool_use_id: null,
               })
             } else {
-              // Convert assistant messages to text summaries
-              let text: string
-              if (typeof m.content === "string") {
-                text = `[Assistant: ${m.content}]`
-              } else if (Array.isArray(m.content)) {
-                text = m.content.map((b: any) => {
-                  if (b.type === "text" && b.text) return `[Assistant: ${b.text}]`
-                  if (b.type === "tool_use") return `[Tool Use: ${b.name}(${JSON.stringify(b.input)})]`
-                  if (b.type === "tool_result") return `[Tool Result: ${typeof b.content === "string" ? b.content : JSON.stringify(b.content)}]`
-                  return ""
-                }).filter(Boolean).join("\n")
-              } else {
-                text = `[Assistant: ${String(m.content)}]`
+              // Convert assistant messages to text summaries.
+              // Drop tool_use blocks — see flattenAssistantContent.
+              const assistantText = flattenAssistantContent(m.content)
+              if (assistantText) {
+                structuredMessages.push({
+                  type: "user" as const,
+                  message: { role: "user" as const, content: `[Assistant: ${assistantText}]` },
+                  parent_tool_use_id: null,
+                })
               }
-              structuredMessages.push({
-                type: "user" as const,
-                message: { role: "user" as const, content: text },
-                parent_tool_use_id: null,
-              })
             }
           }
         }
@@ -599,29 +619,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // through it (Droid) — preserved otherwise so that harness state
         // like oh-my-opencode's background-task IDs reaches the model.
         textPrompt = messagesToConvert
-          ?.map((m: { role: string; content: string | Array<{ type: string; text?: string; content?: string; tool_use_id?: string; name?: string; input?: unknown; id?: string }> }) => {
+          ?.map((m: { role: string; content: any }) => {
             const role = m.role === "assistant" ? "Assistant" : "Human"
-            let content: string
-            if (typeof m.content === "string") {
-              content = sanitizeTextContent(m.content, sanitizeOpts)
-            } else if (Array.isArray(m.content)) {
-              content = m.content
-                .map((block: any) => {
-                  if (block.type === "text" && block.text) return sanitizeTextContent(block.text, sanitizeOpts)
-                  if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
-                  if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${typeof block.content === "string" ? block.content : JSON.stringify(block.content)}]`
-                  if (block.type === "image") return "[Image attached]"
-                  if (block.type === "document") return "[Document attached]"
-                  if (block.type === "file") return "[File attached]"
-                  return ""
-                })
-                .filter(Boolean)
-                .join("\n")
-            } else {
-              content = String(m.content)
-            }
-            return `${role}: ${content}`
+            const content = m.role === "assistant"
+              ? flattenAssistantContent(m.content)
+              : flattenUserContent(m.content, sanitizeOpts)
+            return content ? `${role}: ${content}` : ""
           })
+          .filter(Boolean)
           .join("\n\n") || ""
       }
 


### PR DESCRIPTION
## Summary

Fixes #386. The text-prompt flattener was emitting `[Tool Use: name(args)]` for assistant `tool_use` blocks and `[Tool Result for toolu_xxx: ...]` for user `tool_result` blocks whenever message history was serialized to the SDK. The model reads these as literal user input and starts inventing fake tool-call patterns back — same failure mode as #111.

**Root cause:** structural bug in the flattener (4 duplicated sites), not a recent regression. #382's fingerprint-cache change is unrelated and stays in place.

**Fix:**
- Two helpers (`flattenAssistantContent`, `flattenUserContent`) replace the 4 duplicated flattening sites.
- Assistant `tool_use` blocks: dropped (the SDK already has them via resume; text-only narrative is enough on rehydration).
- User `tool_result` blocks: unwrapped to raw content.

**#382 protection preserved:**
- `cache.ts` fingerprint guard untouched.
- OpenCode headerless undo→diverged downgrade untouched.
- `session-fingerprint-context.test.ts` and `proxy-source-skip-cache.test.ts` still green.

## Test plan

- [x] New `proxy-tool-flattening-regression.test.ts` — 4 scenarios (headered continuation, proxy-restart rehydration, new-session-header rehydration, headerless rehydration) — all verify prompt contains no `[Tool Use:` or `[Tool Result for` strings
- [x] Full suite: 1264 pass, 0 fail
- [x] E2E live test against real Claude (haiku-4.5) with 5-message tool_use history — responds naturally, no fake tool-syntax invention