### PR TITLE
fix: multimodal image handling for OpenAI chat completions and nested tool_result

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ The Claude Code SDK provides programmatic access to Claude. But your favorite co
 ## Features
 
 - **Standard Anthropic API** — drop-in compatible with any tool that supports a custom `base_url`
-- **OpenAI-compatible API** — `/v1/chat/completions` and `/v1/models` for tools that only speak the OpenAI protocol (Open WebUI, Continue, etc.) — no LiteLLM needed
+- **OpenAI-compatible API** — `/v1/chat/completions` and `/v1/models` for tools that only speak the OpenAI protocol (Open WebUI, Continue, etc.) — no LiteLLM needed, including `image_url` support for data URLs
 - **Session management** — conversations persist across requests, survive compaction and undo, resume after proxy restarts
 - **Streaming** — full SSE streaming with MCP tool filtering
 - **Concurrent sessions** — run parent and subagent requests in parallel
 - **Subagent model selection** — primary agents get 1M context; subagents get 200k, preserving rate-limit budget
 - **Auto token refresh** — expired OAuth tokens are refreshed automatically; requests continue without interruption
 - **Passthrough mode** — forward tool calls to the client instead of executing internally
-- **Multimodal** — images, documents, and file attachments pass through to Claude
+- **Multimodal** — images, documents, file attachments, and multimodal tool results pass through to Claude
 - **Multi-profile** — switch between Claude accounts instantly, no restart needed
 - **Telemetry dashboard** — real-time performance metrics at `/telemetry`, including token usage and prompt cache efficiency ([`MONITORING.md`](MONITORING.md))
 - **Telemetry persistence** — opt-in SQLite storage for telemetry data that survives proxy restarts, with configurable retention
@@ -408,6 +408,9 @@ ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://127.0.0.1:3456 \
 Meridian speaks the OpenAI protocol natively — no LiteLLM or translation proxy needed.
 
 **`POST /v1/chat/completions`** — accepts OpenAI chat format, returns OpenAI completion format (streaming and non-streaming)
+
+- `image_url` parts are supported when provided as **data URLs** (`data:image/...;base64,...`)
+- multimodal tool flows where a tool returns `tool_result.content = [text, image]` are preserved through the structured multimodal path instead of being flattened to text
 
 **`GET /v1/models`** — returns available Claude models in OpenAI format
 

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -28,11 +28,11 @@ describe("extractOpenAiContent", () => {
     ])).toBe("hello world")
   })
 
-  it("skips non-text content parts", () => {
+  it("summarizes image parts in text extraction", () => {
     expect(extractOpenAiContent([
-      { type: "image_url", text: undefined },
+      { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
       { type: "text", text: "only this" },
-    ])).toBe("only this")
+    ])).toBe("[Image attached]only this")
   })
 
   it("returns empty string for empty array", () => {
@@ -186,7 +186,26 @@ describe("translateOpenAiToAnthropic", () => {
     expect(result!.system).toContain("assistant: Hello")
   })
 
-  it("handles structured content in messages", () => {
+  it("keeps multimodal history as placeholders in packed system context", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "look" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,abc123" } },
+          ],
+        },
+        { role: "assistant", content: "I see it" },
+        { role: "user", content: "now answer" },
+      ],
+    })
+
+    expect(result!.system).toContain('user: look[Image attached]')
+    expect(result!.messages).toEqual([{ role: 'user', content: 'now answer' }])
+  })
+
+  it("handles structured text content in messages", () => {
     const result = translateOpenAiToAnthropic({
       messages: [{
         role: "user",
@@ -194,6 +213,46 @@ describe("translateOpenAiToAnthropic", () => {
       }],
     })
     expect(result!.messages[0]!.content).toBe("structured")
+  })
+
+  it("preserves data-url image blocks in the last user message", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,abc123" } },
+        ],
+      }],
+    })
+
+    expect(result!.messages).toEqual([{
+      role: "user",
+      content: [
+        { type: "text", text: "describe this" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "abc123" } },
+      ],
+    }])
+  })
+
+  it("adds an explicit placeholder for unsupported external image urls", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image_url", image_url: { url: "https://example.com/test.png" } },
+        ],
+      }],
+    })
+
+    expect(result!.messages).toEqual([{
+      role: "user",
+      content: [
+        { type: "text", text: "describe this" },
+        { type: "text", text: "[Unsupported image_url omitted: only data URLs are currently supported]" },
+      ],
+    }])
   })
 
   it("sets stream from body", () => {

--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -140,6 +140,56 @@ describe("Multimodal content", () => {
     expect(typeof capturedQueryParams.prompt).not.toBe("string")
   })
 
+  it("should use structured prompt for images nested inside tool_result content", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "toolu_123", name: "read", input: { path: "/tmp/test.png" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_123",
+              content: [
+                { type: "text", text: "Read image file [image/png]" },
+                { type: "image", source: { type: "base64", media_type: "image/png", data: "abc" } },
+              ],
+            },
+            { type: "text", text: "describe the image" },
+          ],
+        },
+      ],
+    })).json()
+
+    expect(typeof capturedQueryParams.prompt).not.toBe("string")
+
+    const messages: any[] = []
+    for await (const msg of capturedQueryParams.prompt) {
+      messages.push(msg)
+    }
+
+    expect(messages.some((m: any) =>
+      typeof m.message?.content === "string" && m.message.content.includes("Tool Use")
+    )).toBe(false)
+
+    const multimodalUserMsg = messages.find((m: any) =>
+      Array.isArray(m.message?.content) &&
+      m.message.content.some((b: any) => b.type === "image")
+    )
+    expect(multimodalUserMsg).toBeDefined()
+    expect(multimodalUserMsg.message.content.some((b: any) => b.type === "text" && b.text.includes("Read image file"))).toBe(true)
+    expect(multimodalUserMsg.message.content.some((b: any) => b.type === "image")).toBe(true)
+  })
+
   it("should include all message roles in structured messages", async () => {
     const app = createTestApp()
     await (await post(app, {

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -24,10 +24,19 @@ import {
 } from "./helpers"
 
 let mockMessages: unknown[] = []
+let capturedPromptMessages: unknown[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: ({ prompt }: { prompt: string | AsyncIterable<unknown> }) => {
     return (async function* () {
+      capturedPromptMessages = []
+      if (typeof prompt === "string") {
+        capturedPromptMessages.push(prompt)
+      } else {
+        for await (const msg of prompt) {
+          capturedPromptMessages.push(msg)
+        }
+      }
       for (const msg of mockMessages) yield msg
     })()
   },
@@ -66,6 +75,7 @@ async function postChatCompletion(app: ReturnType<typeof createTestApp>, body: R
 describe("POST /v1/chat/completions — non-streaming", () => {
   beforeEach(() => {
     mockMessages = []
+    capturedPromptMessages = []
     clearSessionCache()
   })
 
@@ -161,6 +171,35 @@ describe("POST /v1/chat/completions — non-streaming", () => {
 
     expect(res.headers.get("content-type")).toContain("application/json")
   })
+
+  it("preserves data-url image_url blocks for the SDK prompt", async () => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: false,
+      messages: [{
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,abc123" } },
+        ],
+      }],
+    })
+
+    expect(res.status).toBe(200)
+    expect(capturedPromptMessages).toEqual([{
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "abc123" } },
+        ],
+      },
+      parent_tool_use_id: null,
+    }])
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -170,6 +209,7 @@ describe("POST /v1/chat/completions — non-streaming", () => {
 describe("POST /v1/chat/completions — streaming", () => {
   beforeEach(() => {
     mockMessages = []
+    capturedPromptMessages = []
     clearSessionCache()
   })
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -22,9 +22,24 @@
 
 export type OpenAiRole = "system" | "user" | "assistant"
 
+export interface OpenAiTextPart {
+  type: "text"
+  text?: string
+}
+
+export interface OpenAiImageUrlPart {
+  type: "image_url"
+  image_url?: {
+    url?: string
+  }
+}
+
 export interface OpenAiContentPart {
   type: string
   text?: string
+  image_url?: {
+    url?: string
+  }
 }
 
 export interface OpenAiMessage {
@@ -42,9 +57,25 @@ export interface OpenAiChatRequest {
   top_p?: number
 }
 
+export interface AnthropicTextBlock {
+  type: "text"
+  text: string
+}
+
+export interface AnthropicImageBlock {
+  type: "image"
+  source: {
+    type: "base64"
+    media_type: string
+    data: string
+  }
+}
+
+export type AnthropicInputContentBlock = AnthropicTextBlock | AnthropicImageBlock
+
 export interface AnthropicMessage {
   role: "user" | "assistant"
-  content: string
+  content: string | AnthropicInputContentBlock[]
 }
 
 export interface AnthropicRequestBody {
@@ -118,12 +149,77 @@ export interface OpenAiModel {
 /**
  * Normalise an OpenAI message content field to a plain string.
  * Handles both string content and structured content arrays.
+ * Non-text blocks are summarized so history packing does not silently erase
+ * multimodal context.
  */
 export function extractOpenAiContent(content: string | OpenAiContentPart[]): string {
   if (typeof content === "string") return content
   return content
-    .filter(p => p.type === "text" && typeof p.text === "string")
-    .map(p => p.text!)
+    .map((p) => {
+      if (p.type === "text" && typeof p.text === "string") return p.text
+      if (p.type === "image_url") return "[Image attached]"
+      return ""
+    })
+    .filter(Boolean)
+    .join("")
+}
+
+function parseDataUrlImage(url: string): AnthropicImageBlock | null {
+  const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s.exec(url)
+  if (!match) return null
+  const mediaType = match[1]
+  const data = match[2]
+  if (!mediaType || !data) return null
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type: mediaType,
+      data,
+    },
+  }
+}
+
+function translateOpenAiContentToAnthropic(content: string | OpenAiContentPart[]): string | AnthropicInputContentBlock[] {
+  if (typeof content === "string") return content
+
+  const parts: AnthropicInputContentBlock[] = []
+
+  for (const part of content) {
+    if (part.type === "text" && typeof part.text === "string") {
+      parts.push({ type: "text", text: part.text })
+      continue
+    }
+
+    if (part.type === "image_url") {
+      const url = part.image_url?.url
+      if (typeof url === "string") {
+        const parsed = parseDataUrlImage(url)
+        if (parsed) {
+          parts.push(parsed)
+          continue
+        }
+      }
+      parts.push({ type: "text", text: "[Unsupported image_url omitted: only data URLs are currently supported]" })
+    }
+  }
+
+  if (parts.length === 1 && parts[0]?.type === "text") {
+    return parts[0].text
+  }
+
+  return parts
+}
+
+function summarizeAnthropicContent(content: string | AnthropicInputContentBlock[]): string {
+  if (typeof content === "string") return content
+  return content
+    .map((part) => {
+      if (part.type === "text") return part.text
+      if (part.type === "image") return "[Image attached]"
+      return ""
+    })
+    .filter(Boolean)
     .join("")
 }
 
@@ -152,7 +248,7 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
     } else {
       turns.push({
         role: msg.role === "assistant" ? "assistant" : "user",
-        content: text,
+        content: translateOpenAiContentToAnthropic(msg.content ?? ""),
       })
     }
   }
@@ -165,7 +261,7 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
 
   if (turns.length > 1) {
     const history = turns.slice(0, -1)
-      .map(m => `${m.role}: ${m.content}`)
+      .map(m => `${m.role}: ${summarizeAnthropicContent(m.content)}`)
       .join("\n")
     const historyBlock =
       `<conversation_history>\n${history}\n</conversation_history>\n\n` +

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -171,7 +171,6 @@ function flattenUserContent(
  */
 function buildFreshPrompt(
   messages: Array<{ role: string; content: any }>,
-  stripCacheControl: (content: any) => any,
   sanitizeOpts: import("./sanitize").SanitizeOptions = {}
 ): string | AsyncIterable<any> {
   const hasMultimodal = messages.some((m) => hasMultimodalContent(m.content))
@@ -182,7 +181,7 @@ function buildFreshPrompt(
       if (m.role === "user") {
         structured.push({
           type: "user" as const,
-          message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControl(m.content)) },
+          message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControlDeep(m.content)) },
           parent_tool_use_id: null,
         })
       } else {
@@ -597,12 +596,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // Check if any messages contain multimodal content (images, documents, files)
       const hasMultimodal = messagesToConvert?.some((m: any) => hasMultimodalContent(m.content))
 
-      // Strip cache_control from content blocks — the SDK manages its own caching
-      // and OpenCode's ttl='1h' blocks conflict with the SDK's ttl='5m' blocks
-      function stripCacheControl(content: any): any {
-        return stripCacheControlDeep(content)
-      }
-
       // Build the prompt — either structured (multimodal) or text.
       // Structured prompts are stored as arrays so they can be replayed on retry.
       let structuredMessages: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> | undefined
@@ -620,7 +613,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (m.role === "user") {
               structuredMessages.push({
                 type: "user" as const,
-                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControl(m.content)) },
+                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControlDeep(m.content)) },
                 parent_tool_use_id: null,
               })
             }
@@ -631,7 +624,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (m.role === "user") {
               structuredMessages.push({
                 type: "user" as const,
-                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControl(m.content)) },
+                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControlDeep(m.content)) },
                 parent_tool_use_id: null,
               })
             } else {
@@ -875,7 +868,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                     yield* query(buildQueryOptions({
-                      prompt: buildFreshPrompt(allMessages, stripCacheControl, sanitizeOpts),
+                      prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                       resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,
@@ -1293,7 +1286,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                       yield* query(buildQueryOptions({
-                        prompt: buildFreshPrompt(allMessages, stripCacheControl, sanitizeOpts),
+                        prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, adapter, onStderr,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -63,6 +63,54 @@ const exec = promisify(execCallback)
 
 let claudeExecutable = ""
 
+const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
+
+function hasMultimodalContent(content: any): boolean {
+  if (!Array.isArray(content)) return false
+  return content.some((block: any) => {
+    if (!block || typeof block !== "object") return false
+    if (MULTIMODAL_TYPES.has(block.type)) return true
+    if (block.type === "tool_result") return hasMultimodalContent(block.content)
+    return false
+  })
+}
+
+function stripCacheControlDeep(content: any): any {
+  if (!Array.isArray(content)) return content
+  return content.map((block: any) => {
+    if (!block || typeof block !== "object") return block
+    const { cache_control, ...rest } = block
+    if (block.type === "tool_result" && Array.isArray(block.content)) {
+      return {
+        ...rest,
+        content: stripCacheControlDeep(block.content),
+      }
+    }
+    return rest
+  })
+}
+
+function normalizeStructuredUserContent(content: any): any {
+  if (!Array.isArray(content)) return content
+  const normalized: any[] = []
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue
+    if (block.type === "tool_result" && Array.isArray(block.content) && hasMultimodalContent(block.content)) {
+      normalized.push(...normalizeStructuredUserContent(block.content))
+      continue
+    }
+    if (block.type === "tool_result" && Array.isArray(block.content)) {
+      normalized.push({
+        ...block,
+        content: normalizeStructuredUserContent(block.content),
+      })
+      continue
+    }
+    normalized.push(block)
+  }
+  return normalized
+}
+
 /**
  * Flatten an assistant message's content to plain text for replay.
  *
@@ -126,10 +174,7 @@ function buildFreshPrompt(
   stripCacheControl: (content: any) => any,
   sanitizeOpts: import("./sanitize").SanitizeOptions = {}
 ): string | AsyncIterable<any> {
-  const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
-  const hasMultimodal = messages.some((m) =>
-    Array.isArray(m.content) && m.content.some((b: any) => MULTIMODAL_TYPES.has(b.type))
-  )
+  const hasMultimodal = messages.some((m) => hasMultimodalContent(m.content))
 
   if (hasMultimodal) {
     const structured: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> = []
@@ -137,10 +182,12 @@ function buildFreshPrompt(
       if (m.role === "user") {
         structured.push({
           type: "user" as const,
-          message: { role: "user" as const, content: stripCacheControl(m.content) },
+          message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControl(m.content)) },
           parent_tool_use_id: null,
         })
       } else {
+        // Drops tool_use blocks and skips tool-use-only assistant messages
+        // (flattenAssistantContent returns "" for those).
         const assistantText = flattenAssistantContent(m.content)
         if (assistantText) {
           structured.push({
@@ -548,22 +595,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       }
 
       // Check if any messages contain multimodal content (images, documents, files)
-      const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
-      const hasMultimodal = messagesToConvert?.some((m: any) =>
-        Array.isArray(m.content) && m.content.some((b: any) => MULTIMODAL_TYPES.has(b.type))
-      )
+      const hasMultimodal = messagesToConvert?.some((m: any) => hasMultimodalContent(m.content))
 
       // Strip cache_control from content blocks — the SDK manages its own caching
       // and OpenCode's ttl='1h' blocks conflict with the SDK's ttl='5m' blocks
       function stripCacheControl(content: any): any {
-        if (!Array.isArray(content)) return content
-        return content.map((block: any) => {
-          if (block.cache_control) {
-            const { cache_control, ...rest } = block
-            return rest
-          }
-          return block
-        })
+        return stripCacheControlDeep(content)
       }
 
       // Build the prompt — either structured (multimodal) or text.
@@ -583,7 +620,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (m.role === "user") {
               structuredMessages.push({
                 type: "user" as const,
-                message: { role: "user" as const, content: stripCacheControl(m.content) },
+                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControl(m.content)) },
                 parent_tool_use_id: null,
               })
             }
@@ -594,12 +631,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (m.role === "user") {
               structuredMessages.push({
                 type: "user" as const,
-                message: { role: "user" as const, content: stripCacheControl(m.content) },
+                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControl(m.content)) },
                 parent_tool_use_id: null,
               })
             } else {
-              // Convert assistant messages to text summaries.
-              // Drop tool_use blocks — see flattenAssistantContent.
+              // Drops tool_use blocks and skips tool-use-only assistant messages
+              // (flattenAssistantContent returns "" for those).
               const assistantText = flattenAssistantContent(m.content)
               if (assistantText) {
                 structuredMessages.push({


### PR DESCRIPTION
Supersedes #390. Preserves @bardusco's authorship on all 3 substantive commits; adds a cleanup commit on top to remove redundancies that only existed because #390 was branched before #386 merged.

## Summary

Fixes two multimodal bugs (both verified live against real Claude):

1. **OpenAI `/v1/chat/completions` dropped `image_url` parts**
   Data URL images were filtered out by the text-only extractor.
2. **Images nested inside `tool_result.content[]` were flattened to JSON**
   The multimodal detector only checked top-level blocks.

## What came from @bardusco (preserved)

- `src/proxy/openai.ts` — full image_url translation stack (`parseDataUrlImage`, `translateOpenAiContentToAnthropic`, typed interfaces, unsupported-URL placeholder)
- `src/proxy/server.ts` helpers — `hasMultimodalContent` (recursive), `stripCacheControlDeep` (recursive), `normalizeStructuredUserContent` (unwraps multimodal tool_result)
- All tests (`openai.test.ts`, `proxy-multimodal.test.ts`, `proxy-openai-compat.test.ts`)
- README updates

## What I cleaned up (final commit)

- Dropped `isToolUseOnlyAssistantMessage` — redundant, `flattenAssistantContent` from #386 already returns `""` for tool-use-only messages
- Resolved the conflict in `server.ts` by keeping #386's `flattenAssistantContent` code path instead of the old `[Tool Use: ...]` text flattening #390 was still carrying
- Inlined the dead `stripCacheControl` stub and dropped its param from `buildFreshPrompt`

## Test plan

- [x] Typecheck clean
- [x] Full suite: 1269 pass, 0 fail
- [x] **Live E2E vs real Claude (haiku-4.5) on this branch:**
  - OpenAI `image_url` data URL → correctly identified color
  - Anthropic nested `tool_result` image → correctly identified color (vs hallucinated wrong color on unfixed v1.37.4)
  - #386 non-regression: multi-turn tool_use history → natural response, no `[Tool Use:` leakage
  - Basic smoke (text-only) → works

## Notes

- `image_url` support is limited to **data URLs**. Remote fetching intentionally out of scope.
- The multimodal `tool_result` unwrap is correct in this flow: `flattenAssistantContent` drops the preceding `tool_use`, so preserving the `tool_result` wrapper would produce an orphan `tool_use_id` error from the API. Unwrapping delivers the tool's output as direct user content.