### PR TITLE
fix: remove skip-labeling from release-please so releases auto-cut on merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,14 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          skip-labeling: true
+          # Labels ('autorelease: pending' / 'autorelease: tagged') are how
+          # release-please tracks which PR is the active release PR across
+          # runs. With skip-labeling=true release-please never recognized a
+          # merged release PR and never cut a release — every run opened a
+          # fresh release PR with the full history (the 1.37.5/1.37.6 manual
+          # recovery dances). skip-labeling was added to work around a
+          # transient GraphQL "stale PR node" error that no longer applies.
+          #
           # Must be set on the action input (not just per-package config) so the
           # previous-release LOOKUP side matches our `meridian-v<version>` tags.
           # Without this the action looks for `v<version>`, can't find the last


### PR DESCRIPTION
## Root cause

Release-please uses the \`autorelease: pending\` / \`autorelease: tagged\` labels to track which PR is the active release PR across workflow runs. Since 72123181 (4/7/26) we had \`skip-labeling: true\`, which meant release-please could **never** recognize a merged release PR → \`release_created\` stayed false → publish job always skipped.

**Visible symptom:**
- 1.37.5 and 1.37.6 both required the manual recovery dance: trigger \`publish_only\`, push tag manually, create GitHub release manually
- Every run after a release PR merge opened a fresh "1.38.0" release PR with the **entire commit history** in the changelog (because release-please couldn't find its own prior state)

## Fix

Remove \`skip-labeling: true\`. Labels are required for release-please's state machine. The original \`skip-labeling\` commit message referenced a "stale PR node error" that no longer applies.

## Verification

Next release PR merge should:
1. Apply \`autorelease: tagged\` label to the merged PR
2. Create the tag and GitHub release automatically
3. Set \`release_created=true\` → trigger the publish job
4. No manual recovery needed

## Test plan

- [ ] Merge → release-please opens a release PR with ONLY the label fix
- [ ] That release PR has \`autorelease: pending\` label applied
- [ ] Merging that PR creates the tag + GitHub release + triggers npm publish automatically
- [ ] No manual steps required