### PR TITLE
fix: normalize context-usage to last iteration

### DIFF
--- a/src/__tests__/proxy-context-usage-store.test.ts
+++ b/src/__tests__/proxy-context-usage-store.test.ts
@@ -74,4 +74,55 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage — shared store", () 
     expect(usage.input_tokens).toBe(77)
     expect(usage.output_tokens).toBe(11)
   })
+
+  it("returns the last usage iteration from the shared session store", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const claudeSessionId = "sess_shared_usage_iterations_001"
+
+    storeSharedSession(
+      "shared-key-usage-iterations",
+      claudeSessionId,
+      1,
+      "lineage",
+      ["msg-hash"],
+      [null],
+      {
+        input_tokens: 9000,
+        cache_creation_input_tokens: 250000,
+        cache_read_input_tokens: 700000,
+        output_tokens: 1200,
+        iterations: [
+          {
+            input_tokens: 9000,
+            cache_creation_input_tokens: 250000,
+            cache_read_input_tokens: 700000,
+            output_tokens: 1200,
+            type: "message",
+          },
+          {
+            input_tokens: 1200,
+            cache_creation_input_tokens: 800,
+            cache_read_input_tokens: 3400,
+            output_tokens: 80,
+            type: "message",
+          },
+        ],
+      }
+    )
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    const usage = body.context_usage as Record<string, unknown>
+    expect(body.session_id).toBe(claudeSessionId)
+    expect(usage.input_tokens).toBe(1200)
+    expect(usage.cache_creation_input_tokens).toBe(800)
+    expect(usage.cache_read_input_tokens).toBe(3400)
+    expect(usage.output_tokens).toBe(80)
+    expect(usage.type).toBe("message")
+    expect(usage.iterations).toBeUndefined()
+  })
 })

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -462,6 +462,65 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
     expect(usage.output_tokens).toBe(6)
   })
 
+  it("returns the last usage iteration when the SDK reports cumulative top-level usage", async () => {
+    const claudeSessionId = "sess_usage_iterations_001"
+    mockMessages = [{
+      type: "assistant",
+      message: {
+        id: "msg_iterations",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-haiku-4-5-20251001",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 5000,
+          cache_creation_input_tokens: 150000,
+          cache_read_input_tokens: 600000,
+          output_tokens: 1000,
+          iterations: [
+            {
+              input_tokens: 5000,
+              cache_creation_input_tokens: 150000,
+              cache_read_input_tokens: 600000,
+              output_tokens: 1000,
+              type: "message",
+            },
+            {
+              input_tokens: 3000,
+              cache_creation_input_tokens: 2000,
+              cache_read_input_tokens: 4000,
+              output_tokens: 200,
+              type: "message",
+            },
+          ],
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: claudeSessionId,
+    }]
+
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, "x-opencode-session": "agent-session-iterations" }, {
+      "x-opencode-session": "agent-session-iterations",
+    })
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    const usage = body.context_usage as Record<string, unknown>
+    expect(body.session_id).toBe(claudeSessionId)
+    expect(usage.input_tokens).toBe(3000)
+    expect(usage.cache_creation_input_tokens).toBe(2000)
+    expect(usage.cache_read_input_tokens).toBe(4000)
+    expect(usage.output_tokens).toBe(200)
+    expect(usage.type).toBe("message")
+    expect(usage.iterations).toBeUndefined()
+  })
+
   it("returns 404 when session exists but has no usage data", async () => {
     // Sessions from before usage tracking was added won't have contextUsage
     const { storeSession } = await import("../proxy/session/cache")

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -38,6 +38,7 @@ import {
   hashMessage,
   computeMessageHashes,
   type LineageResult,
+  type TokenUsageIteration,
   type TokenUsage,
 } from "./session/lineage"
 // Re-export for backwards compatibility (existing tests import from here)
@@ -163,6 +164,11 @@ function flattenUserContent(
     })
     .filter(Boolean)
     .join("\n")
+}
+
+function normalizeContextUsage(usage: TokenUsage): TokenUsageIteration {
+  const lastIteration = usage.iterations?.at(-1)
+  return lastIteration ?? usage
 }
 
 /**
@@ -2159,7 +2165,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     if (!session.contextUsage) {
       return c.json({ error: "No usage data available for this session" }, 404)
     }
-    return c.json({ session_id: claudeSessionId, context_usage: session.contextUsage })
+    return c.json({ session_id: claudeSessionId, context_usage: normalizeContextUsage(session.contextUsage) })
   })
 
   // --- Session Recovery ---

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -12,11 +12,17 @@ import { diagnosticLog } from "../../telemetry"
 // --- Types ---
 
 /** Token usage counters from the SDK (subset of Anthropic usage object). */
-export interface TokenUsage {
+export interface TokenUsageIteration {
   input_tokens?: number
   output_tokens?: number
   cache_read_input_tokens?: number
   cache_creation_input_tokens?: number
+  type?: string
+}
+
+/** Token usage counters from the SDK, including optional iteration breakdowns. */
+export interface TokenUsage extends TokenUsageIteration {
+  iterations?: TokenUsageIteration[]
 }
 
 /** Minimum suffix overlap (stored messages found at the end of incoming)


### PR DESCRIPTION
## Problem

Meridian's `/v1/sessions/:claudeSessionId/context-usage` endpoint currently returns the raw `session.contextUsage` object that was last observed from the Claude Agent SDK.

That works for simple requests, but it can be wrong for long-running Claude Code / OpenCode sessions when the SDK includes an `iterations` breakdown. In those cases, the top-level usage fields can represent cumulative usage across internal iterations, while the current context-window snapshot is the **last iteration**.

The practical symptom is inflated context-usage reporting in clients that consume this compatibility endpoint. In real Meridian-backed Opus sessions, this showed up as context counters jumping far above the actual active context for a turn.

## Root cause

The endpoint was returning `session.contextUsage` verbatim:

- if `iterations` was absent, this was fine
- if `iterations` was present, the endpoint still returned the cumulative top-level usage instead of the last iteration

The Claude Agent SDK itself treats `result.usage` as cumulative query usage, while current context usage is surfaced separately. This compatibility endpoint is intended to report the **current active context snapshot**, not cumulative totals across internal iterations.

## Fix

- extend `TokenUsage` to model optional `iterations`
- normalize `/v1/sessions/:claudeSessionId/context-usage` to `usage.iterations.at(-1)` when present
- fall back to the original top-level usage object when `iterations` is absent

This keeps existing behavior unchanged for normal sessions while fixing inflated context reporting for iterative SDK runs.

This is also an intentional compatibility choice: the endpoint now returns the effective current usage view for clients, not the raw stored SDK payload (including `iterations`) when those two differ.

## Tests

Added regression coverage for both storage paths Meridian uses:

- in-memory session cache path in `src/__tests__/proxy-sdk-params.test.ts`
- shared session store path in `src/__tests__/proxy-context-usage-store.test.ts`

Both tests store a usage object where:
- the top-level fields are intentionally cumulative and very large
- the last `iterations[]` entry is smaller and represents the actual current context snapshot

They assert that the endpoint returns the last iteration, not the cumulative top-level object.

## Validation

- `bun test src/__tests__/proxy-sdk-params.test.ts`
- `bun test src/__tests__/proxy-context-usage-store.test.ts`
- `bun run typecheck`
- `bun run build`

## Notes

This PR only changes the compatibility endpoint response. It does **not** alter how usage is stored internally, so raw SDK usage data is still preserved in session state.