### PR TITLE
fix: use correct release-please output key so publish auto-triggers

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,8 +21,15 @@ jobs:
     if: ${{ !inputs.publish_only }}
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs['meridian--release_created'] }}
-      tag_name: ${{ steps.release.outputs['meridian--tag_name'] }}
+      # Use the unprefixed boolean release-please-action v4 sets for any-path
+      # release. Previous attempts used 'meridian--release_created' (the
+      # component name) but release-please prefixes outputs by PATH, not
+      # component — for our root-path manifest that would be '.--release_created',
+      # not 'meridian--*'. The 'releases_created' boolean is the documented
+      # top-level output that's true whenever any release was created, which
+      # is exactly what we want for a single-package repo.
+      release_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs['.--tag_name'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release


### PR DESCRIPTION
## Follow-up to #395

With #395 merged, release-please now properly labels release PRs and auto-creates tags + GitHub releases on merge (verified in 1.37.7). But the \`publish\` job was still skipped every time — the workflow's output detection has been wrong all along.

## Root cause

The workflow checks \`outputs['meridian--release_created']\`, which was introduced in #357 on the theory that release-please v4 prefixes outputs by component name. It doesn't — it prefixes by **path**. For our root-path manifest (\`"."\`), the path-prefixed key would be \`.--release_created\`. \`meridian--release_created\` has always been empty, which is why the publish job skipped every single release cycle.

Confirmed by reading [release-please-action v4 source](https://github.com/googleapis/release-please-action/blob/main/src/outputs.ts):

\`\`\`ts
function setPathOutput(path, key, value) {
  core.setOutput(key, value);                    // unprefixed
  core.setOutput(\`\${path}--\${key}\`, value);  // path-prefixed
}
core.setOutput('releases_created', releases.length > 0);  // top-level boolean
\`\`\`

## Fix

Switch to the top-level \`releases_created\` boolean — it's explicitly documented and is the cleanest signal for a single-package repo. Also fix \`tag_name\` to use the path-prefixed \`.--tag_name\`.

## Why this wasn't caught before

Every release since #357 appeared "mostly working": release-please DID open release PRs and update the changelog, so it felt like the system was functional. The publish skip required the maintainer to either (a) recognize it and run \`publish_only\` manually, or (b) push the tag/release manually. Both were documented as "emergency escape hatches" but had become the default path.

## Test plan

Merging this is itself the test:
- [ ] Merge → release-please opens a clean release PR for 1.37.8
- [ ] Merge that release PR → tag + release auto-created (the part that started working with #395)
- [ ] **Publish job triggers automatically** (this is the new behavior this PR fixes)
- [ ] \`@rynfar/meridian@1.37.8\` lands on npm with no manual intervention