### PR TITLE
chore: improve nix opencode integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,29 @@ Then in `~/.config/opencode/opencode.json`:
 
 The service starts automatically on login. Manage it with `systemctl --user {start,stop,restart,status} meridian`.
 
-The plugin path is also available as `config.services.meridian.opencode.pluginPath` for use in your OpenCode config:
+**Session variables** -- set `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` globally so any Anthropic-compatible tool points at Meridian:
 
 ```nix
-xdg.configFile."opencode/opencode.json".text = builtins.toJSON {
-  plugin = [ config.services.meridian.opencode.pluginPath ];
+services.meridian = {
+  enable = true;
+  setSessionVariables = true;
 };
 ```
+
+**OpenCode integration** -- install the Meridian plugin into OpenCode's auto-loaded plugin directory:
+
+```nix
+services.meridian = {
+  enable = true;
+  setSessionVariables = true;
+  opencode.enable = true;
+  # Optional example plugins:
+  # opencode.claudeMaxHeaders = true;  # session tracking headers
+  # opencode.agentMode = true;         # subagent model selection
+};
+```
+
+The plugin paths are also available as read-only options (`pluginPath`, `claudeMaxHeadersPath`, `agentModePath`) if you need to reference them manually.
 
 ## Why Meridian?
 

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
               cp -r dist $out/lib/meridian/
               cp -r node_modules $out/lib/meridian/
               cp -r plugin $out/lib/meridian/
+              cp -r examples $out/lib/meridian/
               cp package.json $out/lib/meridian/
 
               mkdir -p $out/bin

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -77,16 +77,73 @@ in
       description = "Extra environment variables passed to the Meridian service.";
     };
 
-    opencode.pluginPath = lib.mkOption {
-      type = lib.types.str;
-      default = "${pkg}/lib/meridian/plugin/meridian.ts";
-      readOnly = true;
-      description = "Nix store path to the OpenCode plugin file. Use this to reference the plugin in your OpenCode config.";
+    setSessionVariables = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Set ANTHROPIC_API_KEY and ANTHROPIC_BASE_URL as session variables pointing to Meridian.";
+    };
+
+    opencode = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Install the Meridian OpenCode plugin into the OpenCode plugins directory.";
+      };
+
+      claudeMaxHeaders = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Install the claude-max-headers example plugin (session tracking headers).";
+      };
+
+      agentMode = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Install the meridian-agent-mode example plugin (subagent model selection headers).";
+      };
+
+      pluginPath = lib.mkOption {
+        type = lib.types.str;
+        default = "${pkg}/lib/meridian/plugin/meridian.ts";
+        readOnly = true;
+        description = "Nix store path to the OpenCode plugin file.";
+      };
+
+      claudeMaxHeadersPath = lib.mkOption {
+        type = lib.types.str;
+        default = "${pkg}/lib/meridian/examples/opencode-plugin/claude-max-headers.ts";
+        readOnly = true;
+        description = "Nix store path to the claude-max-headers example plugin.";
+      };
+
+      agentModePath = lib.mkOption {
+        type = lib.types.str;
+        default = "${pkg}/lib/meridian/examples/opencode-plugin/meridian-agent-mode.ts";
+        readOnly = true;
+        description = "Nix store path to the meridian-agent-mode example plugin.";
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
     home.packages = [ pkg ];
+
+    home.sessionVariables = lib.mkIf cfg.setSessionVariables {
+      ANTHROPIC_API_KEY = "x";
+      ANTHROPIC_BASE_URL = "http://${cfg.settings.host}:${toString cfg.settings.port}";
+    };
+
+    xdg.configFile = lib.mkMerge [
+      (lib.mkIf cfg.opencode.enable {
+        "opencode/plugins/meridian.ts".source = cfg.opencode.pluginPath;
+      })
+      (lib.mkIf cfg.opencode.claudeMaxHeaders {
+        "opencode/plugins/claude-max-headers.ts".source = cfg.opencode.claudeMaxHeadersPath;
+      })
+      (lib.mkIf cfg.opencode.agentMode {
+        "opencode/plugins/meridian-agent-mode.ts".source = cfg.opencode.agentModePath;
+      })
+    ];
 
     systemd.user.services.meridian = {
       Unit = {


### PR DESCRIPTION
This PR adds:

- A simple way to enable the Meridian plugins in OpenCode via `services.meridian.opencode.enable = true`, along with `services.meridian.opencode.agentMode` and `services.meridian.opencode.claudeMaxHeaders`
- A `setSessionVariables` option that sets `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` globally

Notes before merging:

`agentMode` and `claudeMaxHeaders` currently point to plugins inside the example folders, but I believe these plugins are useful enough that they should be moved out of the examples and treated as recommended plugins, since they are not really just examples.

Personally, I think they could even be merged into the main OpenCode plugin required for Meridian to work. I know there is already an OpenCode plugin that bundles everything together, but it also runs its own proxy. My use case is to have a single proxy on my machine that all apps can access, so that setup does not work for me.