### PR TITLE
Preserve advisor semantics and reject unsupported advisor requests

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { normalizeContent, getLastUserMessage } from "../proxy/messages"
+import { extractAdvisorToolDefinition, getLastUserMessage, normalizeContent, summarizeContentBlockForPrompt } from "../proxy/messages"
 
 describe("normalizeContent", () => {
   it("returns string content as-is", () => {
@@ -32,6 +32,19 @@ describe("normalizeContent", () => {
     const result = normalizeContent(content)
     expect(result).toContain("tool_result:tu_1:")
     expect(result).toContain('"key":"val"')
+  })
+
+  it("handles server_tool_use blocks", () => {
+    const content = [{ type: "server_tool_use", id: "srv_1", name: "advisor", input: {} }]
+    const result = normalizeContent(content)
+    expect(result).toBe("server_tool_use:srv_1:advisor:{}")
+  })
+
+  it("handles advisor_tool_result blocks", () => {
+    const content = [{ type: "advisor_tool_result", content: [{ type: "advisor_result", text: "Plan first." }] }]
+    const result = normalizeContent(content)
+    expect(result).toContain("advisor_tool_result:")
+    expect(result).toContain("advisor_result")
   })
 
   it("handles mixed content blocks", () => {
@@ -71,6 +84,43 @@ describe("normalizeContent", () => {
     expect(normalizeContent(42)).toBe("42")
     expect(normalizeContent(null)).toBe("null")
     expect(normalizeContent(true)).toBe("true")
+  })
+})
+
+describe("summarizeContentBlockForPrompt", () => {
+  it("summarizes server tool use blocks", () => {
+    expect(
+      summarizeContentBlockForPrompt({ type: "server_tool_use", name: "advisor", input: {} })
+    ).toBe("[Server Tool Use: advisor({})]")
+  })
+
+  it("summarizes advisor tool results", () => {
+    expect(
+      summarizeContentBlockForPrompt({ type: "advisor_tool_result", content: [{ type: "advisor_result", text: "Think bigger" }] })
+    ).toContain("Advisor Tool Result")
+  })
+})
+
+describe("extractAdvisorToolDefinition", () => {
+  it("extracts a valid advisor tool definition", () => {
+    expect(extractAdvisorToolDefinition([
+      { type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7", max_uses: 2 },
+    ])).toEqual({
+      type: "advisor_20260301",
+      name: "advisor",
+      model: "claude-opus-4-7",
+      max_uses: 2,
+    })
+  })
+
+  it("returns undefined when no advisor tool is present", () => {
+    expect(extractAdvisorToolDefinition([{ name: "Read" }])).toBeUndefined()
+  })
+
+  it("rejects malformed advisor tool definitions", () => {
+    expect(() => extractAdvisorToolDefinition([
+      { type: "advisor_20260301", name: "not-advisor", model: "claude-opus-4-7" },
+    ])).toThrow("Advisor tool must be named 'advisor'")
   })
 })
 

--- a/src/__tests__/proxy-advisor-support.test.ts
+++ b/src/__tests__/proxy-advisor-support.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  assistantMessage,
+  blockStop,
+  messageDelta,
+  messageStart,
+  parseSSE,
+  streamEvent,
+  textBlockStart,
+  textDelta,
+} from "./helpers"
+
+let mockMessages: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => {
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function readStreamFull(response: Response): Promise<string> {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return result
+}
+
+describe("Advisor request handling", () => {
+  beforeEach(() => {
+    mockMessages = []
+    clearSessionCache()
+  })
+
+  it("rejects native advisor tool requests on /v1/messages", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 1024,
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7" }],
+      }),
+    }))
+
+    expect(res.status).toBe(400)
+    const body = await res.json() as any
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.message).toContain("advisor tool requests are not supported")
+  })
+
+  it("rejects native advisor tool requests on /v1/chat/completions", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        messages: [{ role: "user", content: "hi" }],
+        tools: [{ type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7" }],
+      }),
+    }))
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("Advisor response preservation", () => {
+  beforeEach(() => {
+    mockMessages = []
+    clearSessionCache()
+  })
+
+  it("preserves server_tool_use and advisor_tool_result in non-streaming responses", async () => {
+    mockMessages = [assistantMessage([
+      { type: "text", text: "Let me consult Opus." },
+      { type: "server_tool_use", id: "srvtoolu_1", name: "advisor", input: {} },
+      { type: "advisor_tool_result", content: [{ type: "advisor_result", text: "Plan first." }] },
+    ])]
+    mockMessages[0].message.stop_reason = "pause_turn"
+
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 1024,
+        stream: false,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }))
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.stop_reason).toBe("pause_turn")
+    expect(body.content[1]).toEqual({ type: "server_tool_use", id: "srvtoolu_1", name: "advisor", input: {} })
+    expect(body.content[2].type).toBe("advisor_tool_result")
+  })
+
+  it("forwards advisor stream events unchanged", async () => {
+    mockMessages = [
+      messageStart("msg_advisor"),
+      textBlockStart(0),
+      textDelta(0, "Consulting advisor."),
+      blockStop(0),
+      streamEvent({
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "advisor", input: {} },
+      }),
+      streamEvent({ type: "content_block_stop", index: 1 }),
+      streamEvent({
+        type: "content_block_start",
+        index: 2,
+        content_block: { type: "advisor_tool_result", content: [] },
+      }),
+      streamEvent({
+        type: "content_block_delta",
+        index: 2,
+        delta: { type: "text_delta", text: "Plan first." },
+      }),
+      streamEvent({ type: "content_block_stop", index: 2 }),
+      messageDelta("pause_turn"),
+      streamEvent({ type: "message_stop" }),
+    ]
+
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 1024,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }))
+
+    expect(res.status).toBe(200)
+    const events = parseSSE(await readStreamFull(res))
+    const serverToolStart = events.find((e) => e.event === "content_block_start" && (e.data as any).content_block?.type === "server_tool_use")
+    expect(serverToolStart).toBeDefined()
+    const advisorDelta = events.find((e) => e.event === "content_block_delta" && (e.data as any).index === 2)
+    expect((advisorDelta?.data as any).delta.text).toBe("Plan first.")
+    const msgDelta = events.find((e) => e.event === "message_delta")
+    expect((msgDelta?.data as any).delta.stop_reason).toBe("pause_turn")
+  })
+})

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -166,6 +166,12 @@ describe("SDK param passthrough — header overrides", () => {
     ])
   })
 
+  it("advisor-tool anthropic-beta header is forwarded for claude-max profiles", async () => {
+    const app = createTestApp()
+    await post(app, BASE_BODY, { "anthropic-beta": "advisor-tool-2026-03-01" })
+    expect(capturedOptions.betas).toEqual(["advisor-tool-2026-03-01"])
+  })
+
   it("billable anthropic-beta (extended-cache-ttl) IS stripped for claude-max", async () => {
     const app = createTestApp()
     await post(app, BASE_BODY, { "anthropic-beta": "extended-cache-ttl-2025-04-11" })

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -29,17 +29,92 @@ export function normalizeContent(content: any): string {
     return content.map((block: any) => {
       if (block.type === "text" && block.text) return block.text
       if (block.type === "tool_use") return `tool_use:${block.id}:${block.name}:${JSON.stringify(block.input)}`
+      if (block.type === "server_tool_use") return `server_tool_use:${block.id}:${block.name}:${JSON.stringify(stripCacheControlForHashing(block.input))}`
       if (block.type === "tool_result") {
         const inner = block.content
         if (typeof inner === "string") return `tool_result:${block.tool_use_id}:${inner}`
         // Strip cache_control from nested content blocks before serializing
         return `tool_result:${block.tool_use_id}:${JSON.stringify(stripCacheControlForHashing(inner))}`
       }
+      if (block.type === "advisor_tool_result") {
+        return `advisor_tool_result:${JSON.stringify(stripCacheControlForHashing(block.content))}`
+      }
       // Unknown block types: strip cache_control before serializing
       return JSON.stringify(stripCacheControlForHashing(block))
     }).join("\n")
   }
   return String(content)
+}
+
+function stringifyBlockValue(value: any): string {
+  if (typeof value === "string") return value
+  return JSON.stringify(stripCacheControlForHashing(value))
+}
+
+export function summarizeContentBlockForPrompt(block: any): string {
+  if (!block || typeof block !== "object") return String(block)
+  if (block.type === "text" && block.text) return String(block.text)
+  if (block.type === "tool_use") return `[Tool Use: ${block.name}(${JSON.stringify(block.input)})]`
+  if (block.type === "server_tool_use") return `[Server Tool Use: ${block.name}(${JSON.stringify(block.input ?? {})})]`
+  if (block.type === "tool_result") return `[Tool Result for ${block.tool_use_id}: ${stringifyBlockValue(block.content)}]`
+  if (block.type === "advisor_tool_result") return `[Advisor Tool Result: ${stringifyBlockValue(block.content)}]`
+  if (block.type === "image") return "[Image attached]"
+  if (block.type === "document") return "[Document attached]"
+  if (block.type === "file") return "[File attached]"
+  return stringifyBlockValue(block)
+}
+
+export interface AdvisorToolDefinition {
+  type: "advisor_20260301"
+  name: "advisor"
+  model: string
+  max_uses?: number
+  caching?: { type: "ephemeral"; ttl: "5m" | "1h" }
+}
+
+export function extractAdvisorToolDefinition(tools: unknown): AdvisorToolDefinition | undefined {
+  if (!Array.isArray(tools)) return undefined
+
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") continue
+    const candidate = tool as Record<string, unknown>
+    if (candidate.type !== "advisor_20260301") continue
+
+    if (candidate.name !== "advisor") {
+      throw new Error("Advisor tool must be named 'advisor'")
+    }
+    if (typeof candidate.model !== "string" || candidate.model.length === 0) {
+      throw new Error("Advisor tool requires a non-empty model")
+    }
+
+    const maxUses = candidate.max_uses
+    if (maxUses !== undefined && (!Number.isInteger(maxUses) || Number(maxUses) <= 0)) {
+      throw new Error("Advisor tool max_uses must be a positive integer")
+    }
+
+    const caching = candidate.caching
+    if (caching !== undefined) {
+      if (typeof caching !== "object" || caching == null) {
+        throw new Error("Advisor tool caching must be an object")
+      }
+      const ttl = (caching as Record<string, unknown>).ttl
+      if (ttl !== "5m" && ttl !== "1h") {
+        throw new Error("Advisor tool caching.ttl must be '5m' or '1h'")
+      }
+    }
+
+    return {
+      type: "advisor_20260301",
+      name: "advisor",
+      model: candidate.model,
+      ...(maxUses !== undefined ? { max_uses: Number(maxUses) } : {}),
+      ...(caching !== undefined
+        ? { caching: { type: "ephemeral", ttl: (caching as Record<string, unknown>).ttl as "5m" | "1h" } }
+        : {}),
+    }
+  }
+
+  return undefined
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -23,7 +23,7 @@ import { refreshOAuthToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, translateAnthropicSseEvent, buildModelList } from "./openai"
-import { getLastUserMessage } from "./messages"
+import { extractAdvisorToolDefinition, getLastUserMessage, summarizeContentBlockForPrompt } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -124,7 +124,14 @@ function flattenAssistantContent(content: any): string {
   if (typeof content === "string") return content
   if (!Array.isArray(content)) return String(content ?? "")
   return content
-    .map((b: any) => (b?.type === "text" && b.text ? b.text : ""))
+    .map((b: any) => {
+      if (b?.type === "text" && b.text) return b.text
+      if (b?.type === "tool_use") return ""
+      if (b?.type === "server_tool_use" || b?.type === "advisor_tool_result") {
+        return summarizeContentBlockForPrompt(b)
+      }
+      return ""
+    })
     .filter(Boolean)
     .join("\n")
 }
@@ -360,6 +367,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           return c.json(
             { type: "error", error: { type: "invalid_request_error", message: "messages: Field required" } },
             400
+          )
+        }
+
+        const advisorTool = extractAdvisorToolDefinition(body.tools)
+        if (advisorTool) {
+          return c.json(
+            {
+              type: "error",
+              error: {
+                type: "invalid_request_error",
+                message: "Anthropic advisor tool requests are not supported by Meridian's current Claude Agent SDK path yet.",
+              },
+            },
+            400,
           )
         }
 
@@ -789,6 +810,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           const upstreamStartAt = Date.now()
           let firstChunkAt: number | undefined
           let currentSessionId: string | undefined
+          let lastStopReason: string | undefined
 
           // Build SDK UUID map: start with previously stored UUIDs (if resuming),
           // then capture new ones from the response. Declared outside try so
@@ -1015,6 +1037,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // Capture token usage from the assistant message
                 const msgUsage = message.message.usage as TokenUsage | undefined
                 if (msgUsage) lastUsage = { ...lastUsage, ...msgUsage }
+                if (typeof message.message.stop_reason === "string") {
+                  lastStopReason = message.message.stop_reason
+                }
               }
             }
 
@@ -1067,7 +1092,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
           // Determine stop_reason based on content: tool_use if any tool blocks, else end_turn
           const hasToolUse = contentBlocks.some((b) => b.type === "tool_use")
-          const stopReason = hasToolUse ? "tool_use" : "end_turn"
+          const stopReason = lastStopReason ?? (hasToolUse ? "tool_use" : "end_turn")
 
           // Append file change summary:
           // - Internal mode: fileChanges populated by PostToolUse hook
@@ -2052,6 +2077,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // See src/proxy/openai.ts for the translation logic and design rationale.
   app.post("/v1/chat/completions", async (c) => {
     const rawBody = await c.req.json() as Record<string, unknown>
+    if (extractAdvisorToolDefinition(rawBody.tools)) {
+      return c.json(
+        {
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message: "Anthropic advisor tool requests are not supported on Meridian's OpenAI-compatible route.",
+          },
+        },
+        400,
+      )
+    }
     const anthropicBody = translateOpenAiToAnthropic(rawBody)
 
     if (!anthropicBody) {


### PR DESCRIPTION
## Summary
- preserve advisor-shaped response semantics when the Claude Agent SDK emits them
- reject native advisor tool requests that Meridian cannot safely execute through the current SDK path
- add regression coverage for advisor beta forwarding, response preservation, and request rejection

## Motivation
Meridian already forwards the `advisor-tool-2026-03-01` beta header, but its proxy behavior still assumes ordinary client tool flows.

That creates two problems:
- native advisor requests can look superficially supported even though Meridian cannot actually execute them through the current Claude Agent SDK boundary
- if upstream emits advisor-shaped response data like `server_tool_use`, `advisor_tool_result`, or `pause_turn`, Meridian can distort that behavior by flattening unknown blocks or recomputing stop reasons locally

This change makes Meridian more honest and safer:
- unsupported native advisor requests now fail explicitly instead of being silently misrouted
- advisor-related response semantics are preserved when they already exist in upstream SDK output

## What changed
### Request handling
- detect native Anthropic advisor tool definitions in `tools[]`
- reject those requests on `/v1/messages`
- reject those requests on `/v1/chat/completions`

### Response preservation
- preserve upstream non-stream `stop_reason` instead of always recomputing it from local heuristics
- keep advisor-related content blocks compatible with Meridian prompt rebuilding and hashing paths
- preserve `server_tool_use` and `advisor_tool_result` in response handling paths

### Continuity and replay
- add advisor-aware content normalization and prompt summarization helpers
- prevent replay and retry paths from flattening advisor/server-tool blocks into misleading text-only fallbacks

## Testing
Passed locally:
- `bun test src/__tests__/messages.test.ts src/__tests__/proxy-advisor-support.test.ts`
- `bun test src/__tests__/proxy-sdk-params.test.ts --test-name-pattern "advisor-tool anthropic-beta header is forwarded for claude-max profiles"`

## Limitations
This does not add full native advisor execution support.

Meridian runs through `@anthropic-ai/claude-agent-sdk`, and the current SDK path does not expose a safe request-side way to inject a native Anthropic advisor server tool into `query()`.

So the behavior in this PR is intentionally:
- preserve advisor semantics when upstream emits them
- reject unsupported native advisor requests instead of pretending they work