### PR TITLE
fix: normalize context-usage to last iteration

### DIFF
--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -10,6 +10,7 @@ import {
   measurePrefixOverlap,
   measureSuffixOverlap,
   verifyLineage,
+  normalizeContextUsage,
   MIN_SUFFIX_FOR_COMPACTION,
   type SessionState,
 } from "../proxy/session/lineage"
@@ -377,5 +378,41 @@ describe("verifyLineage", () => {
     // Must NOT be compaction — the suffix is at the wrong position
     expect(result.type).not.toBe("compaction")
     expect(result.type).toBe("diverged")
+  })
+})
+
+describe("normalizeContextUsage", () => {
+  it("returns the last iteration when iterations are present", () => {
+    const result = normalizeContextUsage({
+      input_tokens: 9000,
+      output_tokens: 1200,
+      iterations: [
+        { input_tokens: 9000, output_tokens: 1200, type: "message" },
+        { input_tokens: 1200, output_tokens: 80, type: "message" },
+      ],
+    })
+    expect(result.input_tokens).toBe(1200)
+    expect(result.output_tokens).toBe(80)
+    expect(result.type).toBe("message")
+  })
+
+  it("returns top-level usage when no iterations field", () => {
+    const result = normalizeContextUsage({
+      input_tokens: 500,
+      output_tokens: 50,
+    })
+    expect(result.input_tokens).toBe(500)
+    expect(result.output_tokens).toBe(50)
+  })
+
+  it("falls back to top-level usage when iterations is empty", () => {
+    const usage = {
+      input_tokens: 500,
+      output_tokens: 50,
+      iterations: [],
+    }
+    const result = normalizeContextUsage(usage)
+    expect(result.input_tokens).toBe(500)
+    expect(result.output_tokens).toBe(50)
   })
 })

--- a/src/__tests__/proxy-context-usage-store.test.ts
+++ b/src/__tests__/proxy-context-usage-store.test.ts
@@ -125,4 +125,36 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage — shared store", () 
     expect(usage.type).toBe("message")
     expect(usage.iterations).toBeUndefined()
   })
+
+  it("falls back to top-level usage when iterations is empty", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const claudeSessionId = "sess_shared_usage_empty_iterations_001"
+
+    storeSharedSession(
+      "shared-key-usage-empty-iterations",
+      claudeSessionId,
+      1,
+      "lineage",
+      ["msg-hash"],
+      [null],
+      {
+        input_tokens: 500,
+        cache_creation_input_tokens: 100,
+        cache_read_input_tokens: 200,
+        output_tokens: 50,
+        iterations: [],
+      }
+    )
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    const usage = body.context_usage as Record<string, unknown>
+    expect(body.session_id).toBe(claudeSessionId)
+    expect(usage.input_tokens).toBe(500)
+    expect(usage.output_tokens).toBe(50)
+  })
 })

--- a/src/__tests__/proxy-context-usage-store.test.ts
+++ b/src/__tests__/proxy-context-usage-store.test.ts
@@ -74,4 +74,55 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage — shared store", () 
     expect(usage.input_tokens).toBe(77)
     expect(usage.output_tokens).toBe(11)
   })
+
+  it("returns the last usage iteration from the shared session store", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const claudeSessionId = "sess_shared_usage_iterations_001"
+
+    storeSharedSession(
+      "shared-key-usage-iterations",
+      claudeSessionId,
+      1,
+      "lineage",
+      ["msg-hash"],
+      [null],
+      {
+        input_tokens: 9000,
+        cache_creation_input_tokens: 250000,
+        cache_read_input_tokens: 700000,
+        output_tokens: 1200,
+        iterations: [
+          {
+            input_tokens: 9000,
+            cache_creation_input_tokens: 250000,
+            cache_read_input_tokens: 700000,
+            output_tokens: 1200,
+            type: "message",
+          },
+          {
+            input_tokens: 1200,
+            cache_creation_input_tokens: 800,
+            cache_read_input_tokens: 3400,
+            output_tokens: 80,
+            type: "message",
+          },
+        ],
+      }
+    )
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    const usage = body.context_usage as Record<string, unknown>
+    expect(body.session_id).toBe(claudeSessionId)
+    expect(usage.input_tokens).toBe(1200)
+    expect(usage.cache_creation_input_tokens).toBe(800)
+    expect(usage.cache_read_input_tokens).toBe(3400)
+    expect(usage.output_tokens).toBe(80)
+    expect(usage.type).toBe("message")
+    expect(usage.iterations).toBeUndefined()
+  })
 })

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -462,6 +462,65 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
     expect(usage.output_tokens).toBe(6)
   })
 
+  it("returns the last usage iteration when the SDK reports cumulative top-level usage", async () => {
+    const claudeSessionId = "sess_usage_iterations_001"
+    mockMessages = [{
+      type: "assistant",
+      message: {
+        id: "msg_iterations",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-haiku-4-5-20251001",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 5000,
+          cache_creation_input_tokens: 150000,
+          cache_read_input_tokens: 600000,
+          output_tokens: 1000,
+          iterations: [
+            {
+              input_tokens: 5000,
+              cache_creation_input_tokens: 150000,
+              cache_read_input_tokens: 600000,
+              output_tokens: 1000,
+              type: "message",
+            },
+            {
+              input_tokens: 3000,
+              cache_creation_input_tokens: 2000,
+              cache_read_input_tokens: 4000,
+              output_tokens: 200,
+              type: "message",
+            },
+          ],
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: claudeSessionId,
+    }]
+
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, "x-opencode-session": "agent-session-iterations" }, {
+      "x-opencode-session": "agent-session-iterations",
+    })
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    const usage = body.context_usage as Record<string, unknown>
+    expect(body.session_id).toBe(claudeSessionId)
+    expect(usage.input_tokens).toBe(3000)
+    expect(usage.cache_creation_input_tokens).toBe(2000)
+    expect(usage.cache_read_input_tokens).toBe(4000)
+    expect(usage.output_tokens).toBe(200)
+    expect(usage.type).toBe("message")
+    expect(usage.iterations).toBeUndefined()
+  })
+
   it("returns 404 when session exists but has no usage data", async () => {
     // Sessions from before usage tracking was added won't have contextUsage
     const { storeSession } = await import("../proxy/session/cache")

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -521,6 +521,46 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
     expect(usage.iterations).toBeUndefined()
   })
 
+  it("falls back to top-level usage when iterations is empty", async () => {
+    const claudeSessionId = "sess_usage_empty_iterations_001"
+    mockMessages = [{
+      type: "assistant",
+      message: {
+        id: "msg_empty_iterations",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+        model: "claude-haiku-4-5-20251001",
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 500,
+          cache_creation_input_tokens: 100,
+          cache_read_input_tokens: 200,
+          output_tokens: 50,
+          iterations: [],
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: claudeSessionId,
+    }]
+
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, "x-opencode-session": "agent-session-empty-iterations" }, {
+      "x-opencode-session": "agent-session-empty-iterations",
+    })
+
+    const res = await app.fetch(
+      new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    const usage = body.context_usage as Record<string, unknown>
+    expect(body.session_id).toBe(claudeSessionId)
+    expect(usage.input_tokens).toBe(500)
+    expect(usage.output_tokens).toBe(50)
+  })
+
   it("returns 404 when session exists but has no usage data", async () => {
     // Sessions from before usage tracking was added won't have contextUsage
     const { storeSession } = await import("../proxy/session/cache")

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -63,6 +63,7 @@ import {
   hashMessage,
   computeMessageHashes,
   type LineageResult,
+  type TokenUsageIteration,
   type TokenUsage,
 } from "./session/lineage"
 // Re-export for backwards compatibility (existing tests import from here)
@@ -188,6 +189,11 @@ function flattenUserContent(
     })
     .filter(Boolean)
     .join("\n")
+}
+
+function normalizeContextUsage(usage: TokenUsage): TokenUsageIteration {
+  const lastIteration = usage.iterations?.at(-1)
+  return lastIteration ?? usage
 }
 
 /**
@@ -2250,7 +2256,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     if (!session.contextUsage) {
       return c.json({ error: "No usage data available for this session" }, 404)
     }
-    return c.json({ session_id: claudeSessionId, context_usage: session.contextUsage })
+    return c.json({ session_id: claudeSessionId, context_usage: normalizeContextUsage(session.contextUsage) })
   })
 
   // --- Session Recovery ---

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -62,6 +62,7 @@ import {
   computeLineageHash,
   hashMessage,
   computeMessageHashes,
+  normalizeContextUsage,
   type LineageResult,
   type TokenUsageIteration,
   type TokenUsage,
@@ -191,10 +192,6 @@ function flattenUserContent(
     .join("\n")
 }
 
-function normalizeContextUsage(usage: TokenUsage): TokenUsageIteration {
-  const lastIteration = usage.iterations?.at(-1)
-  return lastIteration ?? usage
-}
 
 /**
  * Build a prompt from all messages for a fresh (non-resume) session.

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -12,11 +12,17 @@ import { diagnosticLog } from "../../telemetry"
 // --- Types ---
 
 /** Token usage counters from the SDK (subset of Anthropic usage object). */
-export interface TokenUsage {
+export interface TokenUsageIteration {
   input_tokens?: number
   output_tokens?: number
   cache_read_input_tokens?: number
   cache_creation_input_tokens?: number
+  type?: string
+}
+
+/** Token usage counters from the SDK, including optional iteration breakdowns. */
+export interface TokenUsage extends TokenUsageIteration {
+  iterations?: TokenUsageIteration[]
 }
 
 /** Minimum suffix overlap (stored messages found at the end of incoming)

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -25,6 +25,14 @@ export interface TokenUsage extends TokenUsageIteration {
   iterations?: TokenUsageIteration[]
 }
 
+/** Return the effective current-context usage snapshot.
+ *  When `iterations` is present and non-empty, returns the last entry;
+ *  otherwise returns the original top-level usage object. */
+export function normalizeContextUsage(usage: TokenUsage): TokenUsageIteration {
+  const lastIteration = usage.iterations?.at(-1)
+  return lastIteration ?? usage
+}
+
 /** Minimum suffix overlap (stored messages found at the end of incoming)
  *  required to classify a mutation as compaction rather than a branch. */
 export const MIN_SUFFIX_FOR_COMPACTION = 2


### PR DESCRIPTION
## Summary

Cherry-pick of #396 by @jhenderiks with module boundary fixes.

### Original fix (credited to Justin Henderiks)
- Normalize `/v1/sessions/:id/context-usage` to return `usage.iterations.at(-1)` when present
- Fall back to top-level usage when `iterations` is absent
- Fixes inflated context-usage reporting for iterative SDK runs
- Add `TokenUsageIteration` type and extend `TokenUsage` with optional `iterations`
- Integration tests for both in-memory and shared store paths

### Refactor (this PR)
- Move `normalizeContextUsage` from `server.ts` to `session/lineage.ts` per module boundary rules (pure function, no I/O)
- Add direct unit tests in `lineage-unit.test.ts`
- Add empty `iterations: []` edge case coverage in all test files

Closes #396