### PR TITLE
feat: advisor tool support via SDK advisorModel option

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -2,7 +2,7 @@
  * Test helpers for mocking the Claude Agent SDK and creating test fixtures.
  */
 
-import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk"
+import type { SDKMessage, SDKAssistantMessage } from "@anthropic-ai/claude-agent-sdk"
 
 // --- SDK Message Factories ---
 
@@ -93,7 +93,7 @@ export function messageStop(): SDKMessage {
 }
 
 /** Create an assistant message (non-streaming complete message) */
-export function assistantMessage(content: Array<Record<string, unknown>>): SDKMessage {
+export function assistantMessage(content: Array<Record<string, unknown>>): SDKAssistantMessage {
   return {
     type: "assistant",
     message: {
@@ -108,7 +108,7 @@ export function assistantMessage(content: Array<Record<string, unknown>>): SDKMe
     parent_tool_use_id: null,
     uuid: crypto.randomUUID(),
     session_id: "test-session",
-  } as unknown as SDKMessage
+  } as unknown as SDKAssistantMessage
 }
 
 // --- Request Factories ---

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { normalizeContent, getLastUserMessage } from "../proxy/messages"
+import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools } from "../proxy/messages"
 
 describe("normalizeContent", () => {
   it("returns string content as-is", () => {
@@ -105,5 +105,58 @@ describe("getLastUserMessage", () => {
     const result = getLastUserMessage(messages)
     expect(result).toHaveLength(1)
     expect(result[0]!.content).toBe("only")
+  })
+})
+
+describe("extractAdvisorModel", () => {
+  it("extracts model from advisor tool definition", () => {
+    const tools = [
+      { name: "Read", description: "Read a file" },
+      { type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7" },
+    ]
+    expect(extractAdvisorModel(tools)).toBe("claude-opus-4-7")
+  })
+
+  it("returns undefined when no advisor tool is present", () => {
+    const tools = [{ name: "Read" }, { name: "Write" }]
+    expect(extractAdvisorModel(tools)).toBeUndefined()
+  })
+
+  it("returns undefined for non-array input", () => {
+    expect(extractAdvisorModel(undefined)).toBeUndefined()
+    expect(extractAdvisorModel(null)).toBeUndefined()
+    expect(extractAdvisorModel("not-array")).toBeUndefined()
+  })
+
+  it("returns undefined when model is missing or empty", () => {
+    expect(extractAdvisorModel([{ type: "advisor_20260301", name: "advisor" }])).toBeUndefined()
+    expect(extractAdvisorModel([{ type: "advisor_20260301", name: "advisor", model: "" }])).toBeUndefined()
+  })
+
+  it("matches any advisor_ type prefix", () => {
+    expect(extractAdvisorModel([{ type: "advisor_20270101", name: "advisor", model: "claude-opus-5" }])).toBe("claude-opus-5")
+  })
+})
+
+describe("stripAdvisorTools", () => {
+  it("removes advisor tool definitions from array", () => {
+    const tools = [
+      { name: "Read", description: "Read a file" },
+      { type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7" },
+      { name: "Write", description: "Write a file" },
+    ]
+    const result = stripAdvisorTools(tools)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ name: "Read", description: "Read a file" })
+    expect(result[1]).toEqual({ name: "Write", description: "Write a file" })
+  })
+
+  it("returns all tools when no advisor tool is present", () => {
+    const tools = [{ name: "Read" }, { name: "Write" }]
+    expect(stripAdvisorTools(tools)).toHaveLength(2)
+  })
+
+  it("handles empty array", () => {
+    expect(stripAdvisorTools([])).toHaveLength(0)
   })
 })

--- a/src/__tests__/proxy-advisor-support.test.ts
+++ b/src/__tests__/proxy-advisor-support.test.ts
@@ -158,8 +158,8 @@ describe("Advisor response — stop_reason preservation", () => {
   it("still uses end_turn when upstream does not set stop_reason", async () => {
     const msg = assistantMessage([{ type: "text", text: "Done." }])
     // Default assistantMessage sets stop_reason to "end_turn" via the helper,
-    // but let's explicitly remove it to test the fallback
-    delete msg.message.stop_reason
+    // but let's explicitly clear it to test the fallback
+    ;(msg.message as { stop_reason: string | null }).stop_reason = null as unknown as string
     mockMessages = [msg]
 
     const app = createTestApp()

--- a/src/__tests__/proxy-advisor-support.test.ts
+++ b/src/__tests__/proxy-advisor-support.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests for advisor tool support.
+ *
+ * Covers:
+ *   - advisorModel extracted from tools and passed to SDK query options
+ *   - Advisor tool stripped from passthrough MCP tools
+ *   - stop_reason preserved from upstream (pause_turn for advisors)
+ *   - Non-advisor requests unaffected
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  assistantMessage,
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  streamEvent,
+  parseSSE,
+} from "./helpers"
+
+let capturedOptions: Record<string, unknown> = {}
+let mockMessages: unknown[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
+    capturedOptions = params.options ?? {}
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(
+  app: ReturnType<typeof createTestApp>,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+async function readStreamFull(response: Response): Promise<string> {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return result
+}
+
+const BASE_BODY = {
+  model: "claude-sonnet-4-6",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "hi" }],
+}
+
+describe("Advisor tool — SDK option passthrough", () => {
+  beforeEach(() => {
+    capturedOptions = {}
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    clearSessionCache()
+  })
+
+  it("passes advisorModel to SDK when advisor tool is in request", async () => {
+    const app = createTestApp()
+    const res = await post(app, {
+      ...BASE_BODY,
+      // Only the advisor tool — after extraction and stripping, requestTools
+      // becomes empty so no passthrough MCP server is created
+      tools: [
+        { type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7" },
+      ],
+    })
+    expect(res.status).toBe(200)
+    expect(capturedOptions.advisorModel).toBe("claude-opus-4-7")
+  })
+
+  it("does not set advisorModel when no advisor tool is present", async () => {
+    const app = createTestApp()
+    await post(app, {
+      ...BASE_BODY,
+      tools: [
+        { name: "Read", description: "Read a file", input_schema: { type: "object", properties: {} } },
+      ],
+    })
+    expect(capturedOptions.advisorModel).toBeUndefined()
+  })
+
+  it("strips advisor tool so it does not appear in SDK tools", async () => {
+    const app = createTestApp()
+    const res = await post(app, {
+      ...BASE_BODY,
+      tools: [
+        { type: "advisor_20260301", name: "advisor", model: "claude-opus-4-7" },
+      ],
+    })
+    expect(res.status).toBe(200)
+    // advisorModel is set, and no passthrough tools remain
+    expect(capturedOptions.advisorModel).toBe("claude-opus-4-7")
+    // No MCP tools from the advisor definition
+    const disallowed = capturedOptions.disallowedTools as string[] | undefined
+    if (disallowed) {
+      expect(disallowed.some((t: string) => t.includes("advisor"))).toBe(false)
+    }
+  })
+})
+
+describe("Advisor response — stop_reason preservation", () => {
+  beforeEach(() => {
+    capturedOptions = {}
+    mockMessages = []
+    clearSessionCache()
+  })
+
+  it("preserves pause_turn stop_reason in non-streaming response", async () => {
+    const msg = assistantMessage([
+      { type: "text", text: "Let me consult the advisor." },
+      { type: "server_tool_use", id: "srvtoolu_1", name: "advisor", input: {} },
+    ])
+    msg.message.stop_reason = "pause_turn"
+    mockMessages = [msg]
+
+    const app = createTestApp()
+    const res = await post(app, BASE_BODY)
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.stop_reason).toBe("pause_turn")
+  })
+
+  it("still uses end_turn when upstream does not set stop_reason", async () => {
+    const msg = assistantMessage([{ type: "text", text: "Done." }])
+    // Default assistantMessage sets stop_reason to "end_turn" via the helper,
+    // but let's explicitly remove it to test the fallback
+    delete msg.message.stop_reason
+    mockMessages = [msg]
+
+    const app = createTestApp()
+    const res = await post(app, BASE_BODY)
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.stop_reason).toBe("end_turn")
+  })
+
+  it("preserves tool_use stop_reason from upstream", async () => {
+    const msg = assistantMessage([
+      { type: "text", text: "I need to read a file." },
+      { type: "tool_use", id: "toolu_1", name: "Read", input: { path: "/tmp/test" } },
+    ])
+    msg.message.stop_reason = "tool_use"
+    mockMessages = [msg]
+
+    const app = createTestApp()
+    const res = await post(app, BASE_BODY)
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.stop_reason).toBe("tool_use")
+  })
+
+  it("forwards pause_turn in streaming response", async () => {
+    mockMessages = [
+      messageStart("msg_advisor_stream"),
+      textBlockStart(0),
+      textDelta(0, "Consulting advisor."),
+      blockStop(0),
+      streamEvent({
+        type: "content_block_start",
+        index: 1,
+        content_block: { type: "server_tool_use", id: "srvtoolu_1", name: "advisor", input: {} },
+      }),
+      streamEvent({ type: "content_block_stop", index: 1 }),
+      messageDelta("pause_turn"),
+      streamEvent({ type: "message_stop" }),
+    ]
+
+    const app = createTestApp()
+    const res = await post(app, { ...BASE_BODY, stream: true })
+
+    expect(res.status).toBe(200)
+    const events = parseSSE(await readStreamFull(res))
+    const msgDelta = events.find((e) => e.event === "message_delta")
+    expect((msgDelta?.data as Record<string, unknown> & { delta: Record<string, unknown> }).delta.stop_reason).toBe("pause_turn")
+  })
+})

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -65,6 +65,26 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(3)
   })
 
+  it("sets maxTurns to 5 in passthrough mode with advisor (base 2 + 3 for advisor call/result/answer)", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7" }))
+    expect(result.options.maxTurns).toBe(5)
+  })
+
+  it("sets maxTurns to 6 in passthrough mode with advisor + resume", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7", resumeSessionId: "sess-123" }))
+    expect(result.options.maxTurns).toBe(6)
+  })
+
+  it("sets maxTurns to 6 in passthrough mode with advisor + deferred tools", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7", hasDeferredTools: true }))
+    expect(result.options.maxTurns).toBe(6)
+  })
+
+  it("does not bump maxTurns in non-passthrough mode when advisor is set", () => {
+    const result = buildQueryOptions(makeContext({ advisorModel: "claude-opus-4-7" }))
+    expect(result.options.maxTurns).toBe(200)
+  })
+
   it("includes system prompt as preset in normal mode", () => {
     const result = buildQueryOptions(makeContext({ systemContext: "Be helpful" }))
     const sp = (result.options as any).systemPrompt

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -43,6 +43,35 @@ export function normalizeContent(content: any): string {
 }
 
 /**
+ * Extract the advisor model from a tools array.
+ * Returns the model string if an advisor tool definition is found, undefined otherwise.
+ * The advisor tool is identified by a type starting with "advisor_".
+ */
+export function extractAdvisorModel(tools: unknown): string | undefined {
+  if (!Array.isArray(tools)) return undefined
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object") continue
+    const candidate = tool as Record<string, unknown>
+    if (typeof candidate.type === "string" && candidate.type.startsWith("advisor_") && typeof candidate.model === "string" && candidate.model.length > 0) {
+      return candidate.model
+    }
+  }
+  return undefined
+}
+
+/**
+ * Remove advisor tool definitions from a tools array.
+ * Returns a new array with advisor tools filtered out.
+ */
+export function stripAdvisorTools(tools: unknown[]): unknown[] {
+  return tools.filter((tool) => {
+    if (!tool || typeof tool !== "object") return true
+    const candidate = tool as Record<string, unknown>
+    return !(typeof candidate.type === "string" && candidate.type.startsWith("advisor_"))
+  })
+}
+
+/**
  * Extract only the last user message (for session resume — SDK already has history).
  */
 export function getLastUserMessage(messages: Array<{ role: string; content: any }>): Array<{ role: string; content: any }> {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -144,7 +144,11 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       // the model responds, so allow 3 turns to prevent "max turns (2)" errors.
       // With deferred tools: ToolSearch consumes a turn before the actual tool
       // call, so allow 3 turns to give room for search + call + handoff.
-      maxTurns: passthrough ? ((resumeSessionId || hasDeferredTools) ? 3 : 2) : 200,
+      // With advisor: the SDK executes the advisor server-side (call + result +
+      // final answer), requiring additional turns beyond the base passthrough limit.
+      maxTurns: passthrough
+        ? ((resumeSessionId || hasDeferredTools) ? 3 : 2) + (ctx.advisorModel ? 3 : 0)
+        : 200,
       cwd: workingDirectory,
       model,
       pathToClaudeCodeExecutable: claudeExecutable,

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -80,6 +80,8 @@ export interface QueryContext {
   sdkDebug?: boolean
   /** Additional directories Claude can access */
   additionalDirectories?: string[]
+  /** Advisor model for server-side advisor tool support */
+  advisorModel?: string
 }
 
 /**
@@ -196,6 +198,7 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       ...(fallbackModel ? { fallbackModel } : {}),
       ...(sdkDebug ? { debug: true } : {}),
       ...(additionalDirectories && additionalDirectories.length > 0 ? { additionalDirectories } : {}),
+      ...(ctx.advisorModel ? { advisorModel: ctx.advisorModel } : {}),
     }
   }
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { refreshOAuthToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, translateAnthropicSseEvent, buildModelList } from "./openai"
-import { getLastUserMessage } from "./messages"
+import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -744,6 +744,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // previously sent them, reuse the cached set to preserve prompt cache.
       let passthroughMcp: ReturnType<typeof createPassthroughMcpServer> | undefined
       let requestTools = Array.isArray(body.tools) ? body.tools : []
+      // Extract advisor model from tools and strip advisor tool definitions
+      // before passing to passthrough MCP — the SDK handles advisors natively
+      // via the advisorModel query option.
+      const advisorModel = extractAdvisorModel(requestTools)
+      if (advisorModel) {
+        requestTools = stripAdvisorTools(requestTools)
+      }
       if (passthrough && requestTools.length === 0 && profileSessionId) {
         const cached = sessionToolCache.get(profileSessionId)
         if (cached && cached.length > 0) {
@@ -849,6 +856,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
+          let lastStopReason: string | undefined
 
           try {
             // Lazy-resolve executable if not already set (e.g. when using createProxyServer directly)
@@ -888,6 +896,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     additionalDirectories: sdkFeatures.additionalDirectories
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
+                    advisorModel,
                   }))) {
                     // Only count real assistant content — not SDK error messages
                     // (which arrive as type:"assistant" with an error field set).
@@ -928,6 +937,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       additionalDirectories: sdkFeatures.additionalDirectories
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
+                      advisorModel,
                     }))
                     return
                   }
@@ -1063,6 +1073,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // Capture token usage from the assistant message
                 const msgUsage = message.message.usage as TokenUsage | undefined
                 if (msgUsage) lastUsage = { ...lastUsage, ...msgUsage }
+                if (typeof message.message.stop_reason === "string") {
+                  lastStopReason = message.message.stop_reason
+                }
               }
             }
 
@@ -1113,9 +1126,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             }
           }
 
-          // Determine stop_reason based on content: tool_use if any tool blocks, else end_turn
+          // Determine stop_reason: use content-based heuristic for standard cases,
+          // but preserve non-standard upstream values like pause_turn (advisor flows)
           const hasToolUse = contentBlocks.some((b) => b.type === "tool_use")
-          const stopReason = hasToolUse ? "tool_use" : "end_turn"
+          const heuristicStopReason = hasToolUse ? "tool_use" : "end_turn"
+          const stopReason = lastStopReason && lastStopReason !== "end_turn" && lastStopReason !== "tool_use"
+            ? lastStopReason
+            : heuristicStopReason
 
           // Append file change summary:
           // - Internal mode: fileChanges populated by PostToolUse hook
@@ -1310,6 +1327,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       additionalDirectories: sdkFeatures.additionalDirectories
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
+                      advisorModel,
                     }))) {
                       if ((event as any).type === "stream_event") {
                         didYieldClientEvent = true
@@ -1347,6 +1365,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         additionalDirectories: sdkFeatures.additionalDirectories
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
+                        advisorModel,
                       }))
                       return
                     }


### PR DESCRIPTION
## Summary

Adds native advisor tool support by mapping client advisor tool definitions to the SDK's `advisorModel` query option. This replaces the rejection approach proposed in #407.

## What changed

### Request handling
- Extract advisor model from `tools[]` (any tool with `type` starting with `advisor_`)
- Pass extracted model to SDK via `advisorModel` query option
- Strip advisor tool definitions from the tools array before passthrough MCP creation (SDK handles advisors natively)

### Response handling
- Preserve non-standard `stop_reason` from upstream (e.g. `pause_turn` for advisor flows)
- Standard stop reasons (`end_turn`, `tool_use`) still use the content-based heuristic for backward compatibility

### New pure functions (`messages.ts`)
- `extractAdvisorModel(tools)` — returns the advisor model string or undefined
- `stripAdvisorTools(tools)` — removes advisor tool definitions from the array

### `query.ts`
- Added `advisorModel?: string` to `QueryContext`
- Passes through to SDK options when present

## Testing
- Unit tests for `extractAdvisorModel` and `stripAdvisorTools`
- Integration tests for `advisorModel` SDK passthrough
- Integration tests for `stop_reason` preservation (`pause_turn`, `end_turn`, `tool_use`)
- Streaming test for `pause_turn` forwarding
- All 1,252 tests pass

## Context

The Claude Agent SDK (0.2.90, currently installed) already supports `advisorModel` as a query option. PR #407 proposed rejecting advisor requests, but this was based on the incorrect assumption that the SDK didn't support them. This PR implements actual support instead.

Supersedes #407