### PR TITLE
fix: align haiku model id with sonnet/opus short form

### DIFF
--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -449,8 +449,8 @@ describe("buildModelList", () => {
   })
 
   it("haiku is always 200k regardless of subscription", () => {
-    expect(buildModelList(true).find(m => m.id === "claude-haiku-4-5-20251001")!.context_window).toBe(200_000)
-    expect(buildModelList(false).find(m => m.id === "claude-haiku-4-5-20251001")!.context_window).toBe(200_000)
+    expect(buildModelList(true).find(m => m.id === "claude-haiku-4-5")!.context_window).toBe(200_000)
+    expect(buildModelList(false).find(m => m.id === "claude-haiku-4-5")!.context_window).toBe(200_000)
   })
 
   it("all models have correct object type", () => {

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -379,14 +379,14 @@ describe("GET /v1/models", () => {
     expect(data.length).toBeGreaterThan(0)
   })
 
-  it("includes claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5-20251001", async () => {
+  it("includes claude-sonnet-4-6, claude-opus-4-6, claude-haiku-4-5", async () => {
     const app = createTestApp()
     const res = await app.fetch(new Request("http://localhost/v1/models"))
     const body = await res.json() as Record<string, unknown>
     const ids = (body.data as Array<Record<string, unknown>>).map(m => m.id)
     expect(ids).toContain("claude-sonnet-4-6")
     expect(ids).toContain("claude-opus-4-6")
-    expect(ids).toContain("claude-haiku-4-5-20251001")
+    expect(ids).toContain("claude-haiku-4-5")
   })
 
   it("each model has required fields", async () => {

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -423,7 +423,7 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       context_window: isMaxSubscription ? 1_000_000 : 200_000,
     },
     {
-      id: "claude-haiku-4-5-20251001",
+      id: "claude-haiku-4-5",
       object: "model",
       created: now,
       owned_by: "anthropic",


### PR DESCRIPTION
## Summary

- `/v1/models` advertised `claude-haiku-4-5-20251001` while sonnet/opus used the dateless short form (`claude-sonnet-4-6`, `claude-opus-4-6`). Renames the haiku entry to `claude-haiku-4-5` for consistency.
- Closes #409 — clients that apply a version-normalization transform (e.g. oh-my-openagent's `claudeVersionDot`) pick up the dated suffix for haiku only and diverge. Aligning the short form resolves the mismatch.

Note: Meridian's model mapping is already lenient — `mapModelToClaudeModel` matches any string containing `haiku`/`opus`/`sonnet`. This is a surface-only change; requests still sending the old dated ID continue to work. Test coverage for both short and dated haiku inputs is retained.

## Test plan

- [x] `npm test` — full suite passes (no failing files)
- [x] `/v1/models` list test updated to assert `claude-haiku-4-5`
- [x] `buildModelList` context-window test updated
- [ ] Smoke test with oh-my-openagent after merge to confirm the downstream transform no longer produces an invalid ID