### PR TITLE
fix(proxy): allow 4 turns when passthrough has both resume and deferred tools

### DIFF
--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -65,6 +65,15 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(3)
   })
 
+  it("sets maxTurns to 4 in passthrough mode when resume AND deferred tools are both active", () => {
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      resumeSessionId: "sess-123",
+      hasDeferredTools: true,
+    }))
+    expect(result.options.maxTurns).toBe(4)
+  })
+
   it("includes system prompt as preset in normal mode", () => {
     const result = buildQueryOptions(makeContext({ systemContext: "Be helpful" }))
     const sp = (result.options as any).systemPrompt

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -142,7 +142,14 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       // the model responds, so allow 3 turns to prevent "max turns (2)" errors.
       // With deferred tools: ToolSearch consumes a turn before the actual tool
       // call, so allow 3 turns to give room for search + call + handoff.
-      maxTurns: passthrough ? ((resumeSessionId || hasDeferredTools) ? 3 : 2) : 200,
+      // With BOTH resume and deferred tools: rehydration + ToolSearch + call +
+      // handoff each need their own turn, so allow 4 turns to prevent
+      // "max turns (3)" errors when both extensions are active simultaneously.
+      maxTurns: passthrough
+        ? (resumeSessionId && hasDeferredTools
+            ? 4
+            : (resumeSessionId || hasDeferredTools) ? 3 : 2)
+        : 200,
       cwd: workingDirectory,
       model,
       pathToClaudeCodeExecutable: claudeExecutable,


### PR DESCRIPTION
## Problem

In passthrough mode, `buildQueryOptions` caps `maxTurns` with:

```ts
maxTurns: passthrough ? ((resumeSessionId || hasDeferredTools) ? 3 : 2) : 200
```

Either single extension (resume *or* deferred tools) gets 3 turns; plain passthrough gets 2. But when **both** are active simultaneously, the SDK walks four phases:

| Phase | Cost |
|---|---|
| Session rehydration (resume) | 1 turn |
| ToolSearch lookup (deferred tools) | 1 turn |
| Real tool call | 1 turn |
| Blocked-tool handoff | 1 turn |

The request blows past the ternary's 3-turn ceiling and `claude-agent-sdk` throws `Reached maximum number of turns (3)` from `QueryEngine`, which surfaces to callers as:

```json
{"type":"api_error","message":"Claude Code returned an error result: Reached maximum number of turns (3)"}
```

I hit this repeatedly running a resumed session with deferred MCP tools registered (the common setup when using `opencode-with-claude` + a plugin that surfaces deferred tools via `ToolSearch`).

## Fix

Raise the ceiling to 4 **only** when both flags are true. Single-extension (3) and plain passthrough (2) budgets are unchanged.

```ts
maxTurns: passthrough
  ? (resumeSessionId && hasDeferredTools
      ? 4
      : (resumeSessionId || hasDeferredTools) ? 3 : 2)
  : 200
```

## Test coverage

Added a new case to `src/__tests__/query.test.ts`:

```ts
it("sets maxTurns to 4 in passthrough mode when resume AND deferred tools are both active", ...)
```

Existing tests for `maxTurns = 2 | 3 | 200` still pass unchanged. The existing test matrix (`proxy-droid-integration`, `proxy-transparent-tools`, `proxy-passthrough-tool-use`, `proxy-passthrough-concept`, `proxy-passthrough-thinking`, `deferred-tool-loading`) was missing the both-true case, which is why the regression slipped through.

## Verification

- `bun test src/__tests__/query.test.ts` — 40/40 pass
- `bun test` on related suites (`deferred-tool-loading`, `proxy-transparent-tools`, `proxy-passthrough-tool-use`, `proxy-droid-integration`, `proxy-passthrough-concept`, `proxy-passthrough-thinking`) — 62/62 pass
- `bun run typecheck` — no new errors on the modified files (pre-existing `bun:test` resolution issues across the suite are unchanged)

## Scope

Narrow fix: a single ternary branch plus one unit test. No behavior change for any other code path.