### PR TITLE
fix(proxy): allow 4 turns when passthrough has both resume and deferred tools

### DIFF
--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -89,6 +89,16 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(6)
   })
 
+  it("sets maxTurns to 7 in passthrough mode with advisor + resume + deferred tools (all three active)", () => {
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      advisorModel: "claude-opus-4-7",
+      resumeSessionId: "sess-123",
+      hasDeferredTools: true,
+    }))
+    expect(result.options.maxTurns).toBe(7)
+  })
+
   it("does not bump maxTurns in non-passthrough mode when advisor is set", () => {
     const result = buildQueryOptions(makeContext({ advisorModel: "claude-opus-4-7" }))
     expect(result.options.maxTurns).toBe(200)

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -65,6 +65,15 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(3)
   })
 
+  it("sets maxTurns to 4 in passthrough mode when resume AND deferred tools are both active", () => {
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      resumeSessionId: "sess-123",
+      hasDeferredTools: true,
+    }))
+    expect(result.options.maxTurns).toBe(4)
+  })
+
   it("sets maxTurns to 5 in passthrough mode with advisor (base 2 + 3 for advisor call/result/answer)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7" }))
     expect(result.options.maxTurns).toBe(5)

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -94,6 +94,31 @@ export interface BuildQueryResult {
   options: Options
 }
 
+/**
+ * NOTE: agent-specific (passthrough mode).
+ *
+ * Compute maxTurns based on which SDK features are active. Each phase the SDK
+ * walks before returning control to the host costs a turn:
+ *   - Base (2): turn 1 generates tool_use blocks (captured by PreToolUse hook),
+ *     turn 2 processes the blocked-tool handoff. maxTurns: 1 throws "Reached
+ *     maximum number of turns (1)" before the response completes → HTTP 500.
+ *   - Resume (+1): SDK spends a turn rehydrating session state.
+ *   - Deferred tools (+1): ToolSearch consumes a turn before the real tool call.
+ *   - Both resume and deferred tools: each consumes its own turn, so the base
+ *     budget becomes 4 rather than 3.
+ *   - Advisor (+3): server-side advisor executes call + result + final answer.
+ */
+function computePassthroughMaxTurns(
+  resumeSessionId: string | undefined,
+  hasDeferredTools: boolean,
+  advisorModel: string | undefined,
+): number {
+  const hasResume = !!resumeSessionId
+  const base = hasResume && hasDeferredTools ? 4 : (hasResume || hasDeferredTools) ? 3 : 2
+  const advisorBump = advisorModel ? 3 : 0
+  return base + advisorBump
+}
+
 function resolveSystemPrompt(
   systemContext: string | undefined,
   passthrough: boolean,
@@ -135,24 +160,8 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       // Hosts like OpenCode embed Bun, so the check fires even when `bun`
       // is not in PATH — causing subprocess spawns to fail.
       executable: "node" as const,
-      // NOTE: agent-specific (passthrough mode) — 2 turns minimum, not 1.
-      // Turn 1: model generates tool_use blocks (captured by PreToolUse hook).
-      // Turn 2: SDK processes the blocked-tool handoff before the generator
-      //         returns. maxTurns: 1 throws "Reached maximum number of turns (1)"
-      //         before the response is complete, causing HTTP 500s.
-      // On resume: the SDK may spend a turn rehydrating session state before
-      // the model responds, so allow 3 turns to prevent "max turns (2)" errors.
-      // With deferred tools: ToolSearch consumes a turn before the actual tool
-      // call, so allow 3 turns to give room for search + call + handoff.
-      // With BOTH resume and deferred tools: rehydration + ToolSearch + call +
-      // handoff each need their own turn, so allow 4 turns to prevent
-      // "max turns (3)" errors when both extensions are active simultaneously.
-      // With advisor: the SDK executes the advisor server-side (call + result +
-      // final answer), requiring additional turns beyond the base passthrough limit.
       maxTurns: passthrough
-        ? (resumeSessionId && hasDeferredTools
-            ? 4
-            : (resumeSessionId || hasDeferredTools) ? 3 : 2) + (ctx.advisorModel ? 3 : 0)
+        ? computePassthroughMaxTurns(resumeSessionId, hasDeferredTools, ctx.advisorModel)
         : 200,
       cwd: workingDirectory,
       model,

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -144,10 +144,15 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       // the model responds, so allow 3 turns to prevent "max turns (2)" errors.
       // With deferred tools: ToolSearch consumes a turn before the actual tool
       // call, so allow 3 turns to give room for search + call + handoff.
+      // With BOTH resume and deferred tools: rehydration + ToolSearch + call +
+      // handoff each need their own turn, so allow 4 turns to prevent
+      // "max turns (3)" errors when both extensions are active simultaneously.
       // With advisor: the SDK executes the advisor server-side (call + result +
       // final answer), requiring additional turns beyond the base passthrough limit.
       maxTurns: passthrough
-        ? ((resumeSessionId || hasDeferredTools) ? 3 : 2) + (ctx.advisorModel ? 3 : 0)
+        ? (resumeSessionId && hasDeferredTools
+            ? 4
+            : (resumeSessionId || hasDeferredTools) ? 3 : 2) + (ctx.advisorModel ? 3 : 0)
         : 200,
       cwd: workingDirectory,
       model,


### PR DESCRIPTION
Supersedes #420.

## Summary

- Picks up @WarGloom's fix from #420 with authorship preserved (commit `fb137b2d`) — raises the passthrough `maxTurns` ceiling to 4 when both `resumeSessionId` and `hasDeferredTools` are active, so sessions with resume + deferred tools no longer hit `Reached maximum number of turns (3)` from the SDK's `QueryEngine`.
- Adds a follow-up refactor: extracts `computePassthroughMaxTurns` so the formula now accommodates resume, deferred tools, and advisor (merged from #413) in a single readable function with a JSDoc table, rather than a triply-nested ternary.
- Covers the all-three-active case (advisor + resume + deferred tools → 7 turns) that the previous test matrix left out.

## Why a new PR

#420 was based on `main` before #413 (advisor support) merged, so it conflicted on the exact ternary it modified. Rebase + the combined refactor is captured here as two commits with authorship preserved for both contributors.

## Test plan

- [x] `bun test src/__tests__/query.test.ts` — 45/45 pass
- [x] `bun test` — 1369/1369 pass
- [x] Existing tests for `maxTurns = 2 | 3 | 4 | 5 | 6 | 200` unchanged
- [x] New test: `maxTurns = 7` when all three features active