### PR TITLE
fix(proxy): passthrough agent type normalization and param name mapping

### DIFF
--- a/src/__tests__/adapter.test.ts
+++ b/src/__tests__/adapter.test.ts
@@ -101,7 +101,7 @@ describe("openCodeAdapter.buildSdkAgents", () => {
     const agents = openCodeAdapter.buildSdkAgents!(body, [])
     for (const [name, def] of Object.entries(agents)) {
       expect((def as any).description).toBeTruthy()
-      expect((def as any).prompt).toContain(name)
+      expect((def as any).prompt.toLowerCase()).toContain(name.toLowerCase())
       expect((def as any).model).toBe("inherit")
     }
   })

--- a/src/__tests__/passthrough-param-normalization.test.ts
+++ b/src/__tests__/passthrough-param-normalization.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test"
+import { normalizeToolInput } from "../proxy/passthroughTools"
+
+describe("normalizeToolInput", () => {
+  it("returns input unchanged when all required fields are present", () => {
+    const input = { filePath: "/src/app.ts", offset: 0 }
+    const schema = {
+      properties: { filePath: { type: "string" }, offset: { type: "number" } },
+      required: ["filePath"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual(input)
+  })
+
+  it("converts snake_case to camelCase when required field is missing", () => {
+    const input = { file_path: "/src/app.ts" }
+    const schema = {
+      properties: { filePath: { type: "string" } },
+      required: ["filePath"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual({ filePath: "/src/app.ts" })
+  })
+
+  it("converts camelCase to snake_case when required field is missing", () => {
+    const input = { filePath: "/src/app.ts" }
+    const schema = {
+      properties: { file_path: { type: "string" } },
+      required: ["file_path"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual({ file_path: "/src/app.ts" })
+  })
+
+  it("normalizes multiple parameters at once", () => {
+    const input = { file_path: "/src/app.ts", old_string: "foo", new_string: "bar" }
+    const schema = {
+      properties: {
+        filePath: { type: "string" },
+        oldString: { type: "string" },
+        newString: { type: "string" },
+      },
+      required: ["filePath", "oldString", "newString"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual({
+      filePath: "/src/app.ts",
+      oldString: "foo",
+      newString: "bar",
+    })
+  })
+
+  it("preserves fields that already match the schema", () => {
+    const input = { filePath: "/src/app.ts", limit: 100 }
+    const schema = {
+      properties: { filePath: { type: "string" }, limit: { type: "number" } },
+      required: ["filePath"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual(input)
+  })
+
+  it("does not overwrite existing fields during normalization", () => {
+    // Both file_path and filePath present — leave as-is
+    const input = { file_path: "/wrong", filePath: "/correct" }
+    const schema = {
+      properties: { filePath: { type: "string" } },
+      required: ["filePath"],
+    }
+    // filePath is already defined, so no normalization needed
+    expect(normalizeToolInput(input, schema)).toEqual(input)
+  })
+
+  it("returns undefined input unchanged", () => {
+    expect(normalizeToolInput(undefined, { properties: { x: {} } })).toBeUndefined()
+  })
+
+  it("returns input unchanged when schema has no properties", () => {
+    const input = { file_path: "/src/app.ts" }
+    expect(normalizeToolInput(input, {})).toEqual(input)
+    expect(normalizeToolInput(input, undefined)).toEqual(input)
+  })
+
+  it("returns input unchanged when schema has no required fields", () => {
+    const input = { file_path: "/src/app.ts" }
+    const schema = {
+      properties: { filePath: { type: "string" } },
+      // no required array — all optional
+    }
+    // All required fields are trivially present (there are none)
+    expect(normalizeToolInput(input, schema)).toEqual(input)
+  })
+
+  it("handles multi-segment snake_case names", () => {
+    const input = { replace_all: true }
+    const schema = {
+      properties: { replaceAll: { type: "boolean" } },
+      required: ["replaceAll"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual({ replaceAll: true })
+  })
+
+  it("leaves unknown keys that have no schema match", () => {
+    const input = { file_path: "/src/app.ts", unknown_key: "value" }
+    const schema = {
+      properties: { filePath: { type: "string" } },
+      required: ["filePath"],
+    }
+    expect(normalizeToolInput(input, schema)).toEqual({
+      filePath: "/src/app.ts",
+      unknown_key: "value",
+    })
+  })
+})

--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from "bun:test"
-import { parseAgentDescriptions, buildAgentDefinitions, mapModelTier } from "../proxy/agentDefs"
+import { parseAgentDescriptions, buildAgentDefinitions, mapModelTier, FALLBACK_AGENT_NAME } from "../proxy/agentDefs"
 
 const SAMPLE_TASK_DESCRIPTION = `Launch a new agent to handle complex, multistep tasks autonomously.
 
@@ -47,22 +47,33 @@ describe("parseAgentDescriptions", () => {
   })
 })
 
+/** Helper: get base agent names (lowercase, non-alias) from a definitions map */
+const KNOWN_ALIASES = new Set(["general-purpose"])
+function baseAgentNames(defs: Record<string, any>): string[] {
+  return Object.keys(defs).filter(k => k === k.toLowerCase() && !KNOWN_ALIASES.has(k))
+}
+
 describe("buildAgentDefinitions", () => {
-  it("should create AgentDefinition for each parsed agent", () => {
+  it("should create AgentDefinition for each parsed agent plus defaults", () => {
     const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION)
 
-    expect(Object.keys(defs)).toHaveLength(6)
+    // 6 parsed + 1 injected default ("general") = 7 base agents
+    const base = baseAgentNames(defs)
+    expect(base).toHaveLength(7)
     expect(defs["oracle"]).toBeDefined()
     expect(defs["explore"]).toBeDefined()
     expect(defs["build"]).toBeDefined()
+    expect(defs["general"]).toBeDefined()
   })
 
-  it("each agent should have description, prompt, and model", () => {
+  it("each base agent should have description, prompt, and model", () => {
     const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION)
 
-    for (const [name, def] of Object.entries(defs)) {
+    for (const name of baseAgentNames(defs)) {
+      const def = defs[name]!
       expect(def.description).toBeTruthy()
-      expect(def.prompt).toContain(name)
+      // Prompt references the original agent name (not aliases or variants)
+      expect(def.prompt).toContain(`"${name}" agent`)
       expect(def.model).toBe("inherit")
     }
   })
@@ -119,7 +130,7 @@ describe("mapModelTier", () => {
 })
 
 describe("Native OpenCode (no oh-my-opencode)", () => {
-  it("should handle minimal native agents (build + plan only)", () => {
+  it("should handle minimal native agents (build + plan only) with defaults injected", () => {
     const nativeDescription = `Launch a new agent to handle complex, multistep tasks autonomously.
 
 Available agent types and the tools they have access to:
@@ -130,9 +141,12 @@ When using the Task tool, you must specify a subagent_type parameter.`
 
     const agents = buildAgentDefinitions(nativeDescription)
 
-    expect(Object.keys(agents)).toHaveLength(2)
+    // 2 parsed + 2 injected defaults ("explore", "general") = 4 base agents
+    expect(baseAgentNames(agents)).toHaveLength(4)
     expect(agents["build"]).toBeDefined()
     expect(agents["plan"]).toBeDefined()
+    expect(agents["explore"]).toBeDefined()
+    expect(agents["general"]).toBeDefined()
     expect(agents["build"]!.description).toContain("default agent")
     expect(agents["plan"]!.description).toContain("Plan mode")
   })
@@ -150,9 +164,12 @@ When using the Task tool, you must specify a subagent_type parameter.`
 
     const agents = buildAgentDefinitions(customDescription)
 
-    expect(Object.keys(agents)).toHaveLength(3)
+    // 3 parsed + 2 injected defaults ("explore", "general") = 5 base agents
+    expect(baseAgentNames(agents)).toHaveLength(5)
     expect(agents["librarian"]).toBeDefined()
     expect(agents["librarian"]!.description).toContain("Documentation search")
+    expect(agents["explore"]).toBeDefined()
+    expect(agents["general"]).toBeDefined()
   })
 })
 
@@ -186,11 +203,13 @@ When using the Task tool, you must specify a subagent_type parameter.`
 
     const agents = buildAgentDefinitions(omooDescription, mcpTools)
 
-    // All 10 agents extracted
-    expect(Object.keys(agents)).toHaveLength(10)
+    // All 10 base agents extracted (all 4 defaults already present)
+    const base = baseAgentNames(agents)
+    expect(base).toHaveLength(10)
 
-    // Each agent has proper structure
-    for (const [name, def] of Object.entries(agents)) {
+    // Each base agent has proper structure
+    for (const name of base) {
+      const def = agents[name]!
       expect(def.description.length).toBeGreaterThan(10)
       expect(def.prompt).toContain(name)
       expect(def.model).toBe("inherit")
@@ -215,5 +234,89 @@ describe("No Task tool (no agents)", () => {
   it("should return empty when description has no agent section", () => {
     const agents = buildAgentDefinitions("Launch a new agent to handle tasks.")
     expect(Object.keys(agents)).toHaveLength(0)
+  })
+})
+
+describe("Default agent injection", () => {
+  it("should inject defaults when parsing yields results", () => {
+    const desc = `Available agent types and the tools they have access to:
+- oracle: Read-only consultation agent.`
+    const agents = buildAgentDefinitions(desc)
+
+    // 1 parsed + 4 defaults (build, plan, explore, general) = 5 base agents
+    expect(baseAgentNames(agents)).toHaveLength(5)
+    expect(agents["oracle"]).toBeDefined()
+    expect(agents["build"]).toBeDefined()
+    expect(agents["plan"]).toBeDefined()
+    expect(agents["explore"]).toBeDefined()
+    expect(agents["general"]).toBeDefined()
+  })
+
+  it("should NOT inject defaults when parsing yields nothing", () => {
+    const agents = buildAgentDefinitions("No agents here")
+    expect(Object.keys(agents)).toHaveLength(0)
+  })
+
+  it("user-defined agents take priority over defaults", () => {
+    const desc = `Available agent types and the tools they have access to:
+- build: My custom build agent with special powers.`
+    const agents = buildAgentDefinitions(desc)
+
+    // User's description should NOT be overwritten by the default
+    expect(agents["build"]!.description).toBe("My custom build agent with special powers.")
+  })
+
+  it("should include MCP tools in default agent definitions", () => {
+    const desc = `Available agent types and the tools they have access to:
+- oracle: Read-only consultation agent.`
+    const mcpTools = ["mcp__opencode__read", "mcp__opencode__bash"]
+    const agents = buildAgentDefinitions(desc, mcpTools)
+
+    // Injected defaults should also get MCP tools
+    expect(agents["general"]!.tools).toEqual(mcpTools)
+    expect(agents["explore"]!.tools).toEqual(mcpTools)
+  })
+
+  it("fallback agent name is always present when agents exist", () => {
+    const desc = `Available agent types and the tools they have access to:
+- build: The default agent.`
+    const agents = buildAgentDefinitions(desc)
+
+    expect(agents[FALLBACK_AGENT_NAME]).toBeDefined()
+  })
+})
+
+describe("Case variant registration", () => {
+  it("should register PascalCase variants for all agents", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION)
+
+    // PascalCase variants should exist
+    expect(defs["Explore"]).toBeDefined()
+    expect(defs["Build"]).toBeDefined()
+    expect(defs["Plan"]).toBeDefined()
+    expect(defs["Oracle"]).toBeDefined()
+    expect(defs["Librarian"]).toBeDefined()
+    expect(defs["General"]).toBeDefined()
+    expect(defs["Sisyphus-Junior"]).toBeDefined()
+  })
+
+  it("PascalCase variant should share the same definition as the base", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION)
+
+    expect(defs["Explore"]!.description).toBe(defs["explore"]!.description)
+    expect(defs["Oracle"]!.prompt).toBe(defs["oracle"]!.prompt)
+  })
+
+  it("should register 'general-purpose' alias", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION)
+
+    expect(defs["general-purpose"]).toBeDefined()
+    expect(defs["General-Purpose"]).toBeDefined()
+    expect(defs["general-purpose"]!.description).toBe(defs["general"]!.description)
+  })
+
+  it("should not add variants when no agents exist", () => {
+    const defs = buildAgentDefinitions("No agents here")
+    expect(Object.keys(defs)).toHaveLength(0)
   })
 })

--- a/src/__tests__/proxy-agent-fuzzy-match.test.ts
+++ b/src/__tests__/proxy-agent-fuzzy-match.test.ts
@@ -67,10 +67,11 @@ describe("fuzzyMatchAgentName", () => {
     expect(fuzzyMatchAgentName("build-agent", validAgents)).toBe("build")
   })
 
-  // --- No match → return original lowercased ---
-  it("should return lowercased original when no match found", () => {
-    expect(fuzzyMatchAgentName("nonexistent", validAgents)).toBe("nonexistent")
-    expect(fuzzyMatchAgentName("FooBar", validAgents)).toBe("foobar")
+  // --- No match → route to fallback agent ---
+  it("should route unknown names to 'general' when it exists in valid agents", () => {
+    expect(fuzzyMatchAgentName("nonexistent", validAgents)).toBe("general")
+    expect(fuzzyMatchAgentName("FooBar", validAgents)).toBe("general")
+    expect(fuzzyMatchAgentName("completely-made-up-agent", validAgents)).toBe("general")
   })
 
   // --- Edge cases ---
@@ -87,5 +88,27 @@ describe("fuzzyMatchAgentName", () => {
     expect(fuzzyMatchAgentName("search", validAgents)).toBe("explore")
     expect(fuzzyMatchAgentName("research", validAgents)).toBe("librarian")
     expect(fuzzyMatchAgentName("consult", validAgents)).toBe("oracle")
+  })
+})
+
+describe("Fallback to generic agent", () => {
+  it("should fall back to lowercased original when 'general' is NOT in valid agents", () => {
+    const agentsWithoutGeneral = ["build", "plan", "oracle"]
+    expect(fuzzyMatchAgentName("nonexistent", agentsWithoutGeneral)).toBe("nonexistent")
+    expect(fuzzyMatchAgentName("FooBar", agentsWithoutGeneral)).toBe("foobar")
+  })
+
+  it("should route completely unknown names to 'general' when it exists", () => {
+    const agentsWithGeneral = ["build", "plan", "general"]
+    expect(fuzzyMatchAgentName("xyzzy", agentsWithGeneral)).toBe("general")
+    expect(fuzzyMatchAgentName("ProviderModelNotFoundError", agentsWithGeneral)).toBe("general")
+  })
+
+  it("should still prefer real matches over fallback", () => {
+    const agents = ["build", "plan", "general", "explore"]
+    // Prefix match should still work before fallback
+    expect(fuzzyMatchAgentName("exp", agents)).toBe("explore")
+    // Alias should still work before fallback
+    expect(fuzzyMatchAgentName("planner", agents)).toBe("plan")
   })
 })

--- a/src/__tests__/proxy-agent-fuzzy-match.test.ts
+++ b/src/__tests__/proxy-agent-fuzzy-match.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from "bun:test"
 
 // Import the matching function directly
-import { fuzzyMatchAgentName } from "../proxy/agentMatch"
+import { fuzzyMatchAgentName, resolveAgentAlias } from "../proxy/agentMatch"
 
 describe("fuzzyMatchAgentName", () => {
   const validAgents = [
@@ -110,5 +110,25 @@ describe("Fallback to generic agent", () => {
     expect(fuzzyMatchAgentName("exp", agents)).toBe("explore")
     // Alias should still work before fallback
     expect(fuzzyMatchAgentName("planner", agents)).toBe("plan")
+  })
+})
+
+describe("resolveAgentAlias", () => {
+  it("returns the canonical target for known aliases", () => {
+    expect(resolveAgentAlias("general-purpose")).toBe("general")
+    expect(resolveAgentAlias("General-Purpose")).toBe("general")
+    expect(resolveAgentAlias("code-reviewer")).toBe("oracle")
+    expect(resolveAgentAlias("planner")).toBe("plan")
+  })
+
+  it("returns the lowercased input when no alias applies", () => {
+    expect(resolveAgentAlias("explore")).toBe("explore")
+    expect(resolveAgentAlias("Explore")).toBe("explore")
+    expect(resolveAgentAlias("custom-agent")).toBe("custom-agent")
+  })
+
+  it("is case-insensitive for alias lookup", () => {
+    expect(resolveAgentAlias("GENERAL-PURPOSE")).toBe("general")
+    expect(resolveAgentAlias("Code-Reviewer")).toBe("oracle")
   })
 })

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -165,7 +165,9 @@ describe("PreToolUse hook: agent name correction", () => {
       tool_input: { subagent_type: "general-purpose", description: "test", prompt: "test" },
       tool_use_id: "toolu_test1",
     }, undefined, { signal: new AbortController().signal })
-    expect(result1.hookSpecificOutput.updatedInput.subagent_type).toBe("general")
+    // "general-purpose" is registered as an alias agent pointing to the "general"
+    // definition, so the fuzzy matcher returns it as a valid exact match.
+    expect(result1.hookSpecificOutput.updatedInput.subagent_type).toBe("general-purpose")
 
     // code-reviewer → oracle
     const result2 = await hookFn({

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -11,6 +11,21 @@
  * model tiers, and tool access.
  */
 
+/** Fallback agent name used when no fuzzy match is found */
+export const FALLBACK_AGENT_NAME = "general"
+
+/**
+ * Well-known agent types that the SDK (or Claude) commonly references.
+ * These are injected as defaults when parsing yields user-defined agents
+ * but is missing one or more of these types.
+ */
+const DEFAULT_AGENT_TYPES: Record<string, string> = {
+  build: "The default agent. Executes tools based on configured permissions.",
+  plan: "Plan mode. Disallows all edit tools.",
+  explore: "Contextual grep for codebases. Answers 'Where is X?', 'Which file has Y?'.",
+  general: "General-purpose agent for researching complex questions and executing multi-step tasks.",
+}
+
 /** SDK-compatible agent definition */
 export interface AgentDefinition {
   description: string
@@ -89,7 +104,71 @@ export function buildAgentDefinitions(
     }
   }
 
+  // Inject defaults only when parsing yielded at least one agent.
+  // If parsing yielded nothing, leave empty so the SDK uses its built-in types.
+  if (descriptions.size > 0) {
+    ensureDefaultAgents(agents, mcpToolNames)
+    addCaseVariants(agents)
+  }
+
   return agents
+}
+
+/**
+ * Fill in any well-known default agents not already present in the agents map.
+ * User-defined agents always take priority (we never overwrite).
+ */
+function ensureDefaultAgents(
+  agents: Record<string, AgentDefinition>,
+  mcpToolNames?: string[]
+): void {
+  for (const [name, description] of Object.entries(DEFAULT_AGENT_TYPES)) {
+    if (!agents[name]) {
+      agents[name] = {
+        description,
+        prompt: buildAgentPrompt(name, description),
+        model: "inherit",
+        ...(mcpToolNames?.length ? { tools: [...mcpToolNames] } : {}),
+      }
+    }
+  }
+}
+
+/**
+ * Register PascalCase aliases for every agent.
+ *
+ * Claude frequently sends capitalized agent names (e.g., "Explore", "Plan").
+ * The SDK's Claude subprocess validates subagent_type against the registered
+ * agents map BEFORE our PreToolUse hook can rewrite it. By registering
+ * PascalCase variants we ensure they pass validation.
+ *
+ * Also registers common Claude-invented names like "general-purpose".
+ */
+function addCaseVariants(agents: Record<string, AgentDefinition>): void {
+  // Snapshot keys before mutating (avoids iterating newly-added entries)
+  const baseNames = Object.keys(agents)
+
+  for (const name of baseNames) {
+    const def = agents[name]!
+    // Title-case: "explore" → "Explore", "sisyphus-junior" → "Sisyphus-Junior"
+    const titleCase = name.replace(/(^|-)(\w)/g, (_m, sep: string, ch: string) =>
+      sep + ch.toUpperCase()
+    )
+    if (titleCase !== name && !agents[titleCase]) {
+      agents[titleCase] = def
+    }
+  }
+
+  // Common Claude-invented aliases that map to registered agents
+  const ALIASES: Record<string, string> = {
+    "general-purpose": "general",
+    "General-Purpose": "general",
+  }
+  for (const [alias, target] of Object.entries(ALIASES)) {
+    if (!agents[alias] && agents[target]) {
+      agents[alias] = agents[target]!
+    }
+  }
 }
 
 /**

--- a/src/proxy/agentMatch.ts
+++ b/src/proxy/agentMatch.ts
@@ -55,6 +55,20 @@ const KNOWN_ALIASES: Record<string, string> = {
 // Common suffixes to strip
 const STRIP_SUFFIXES = ["-agent", "-tool", "-worker", "-task", " agent", " tool"]
 
+/**
+ * Resolve an agent-name alias to its canonical target, or return the lowercased
+ * input unchanged if no alias applies.
+ *
+ * Used when normalizing a captured `subagent_type` for the client response:
+ * the SDK may validate against registered alias variants (e.g., "general-purpose"
+ * is registered by `addCaseVariants`), but the client expects the canonical
+ * agent name from its config ("general").
+ */
+export function resolveAgentAlias(input: string): string {
+  const lowered = input.toLowerCase()
+  return KNOWN_ALIASES[lowered] ?? lowered
+}
+
 export function fuzzyMatchAgentName(input: string, validAgents: string[]): string {
   if (!input) return input
   if (validAgents.length === 0) return input.toLowerCase()

--- a/src/proxy/agentMatch.ts
+++ b/src/proxy/agentMatch.ts
@@ -12,8 +12,10 @@
  * 4. Substring match (e.g., "junior" → "sisyphus-junior")
  * 5. Suffix-stripped match (e.g., "explore-agent" → "explore")
  * 6. Semantic aliases (e.g., "search" → "explore")
- * 7. Fallback: return lowercased original
+ * 7. Fallback: route to generic agent if registered, otherwise lowercased original
  */
+
+import { FALLBACK_AGENT_NAME } from "./agentDefs"
 
 // Known aliases for common SDK mistakes
 const KNOWN_ALIASES: Record<string, string> = {
@@ -88,6 +90,7 @@ export function fuzzyMatchAgentName(input: string, validAgents: string[]): strin
   const reverseMatch = validAgents.find(a => lowered.includes(a.toLowerCase()))
   if (reverseMatch) return reverseMatch
 
-  // 7. Fallback
+  // 7. Fallback: route to registered generic agent if available
+  if (validAgents.includes(FALLBACK_AGENT_NAME)) return FALLBACK_AGENT_NAME
   return lowered
 }

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -191,3 +191,62 @@ export function stripMcpPrefix(toolName: string): string {
   }
   return toolName
 }
+
+function toCamelCase(s: string): string {
+  return s.replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+}
+
+function toSnakeCase(s: string): string {
+  return s.replace(/[A-Z]/g, c => `_${c.toLowerCase()}`)
+}
+
+/**
+ * Normalize tool input parameter names to match the client's schema.
+ *
+ * The Claude Code SDK's system prompt references built-in tools with
+ * snake_case parameter names (e.g., file_path), but clients like OpenCode
+ * may use camelCase (e.g., filePath). When the model generates a tool call
+ * using the SDK's naming convention instead of the MCP schema's convention,
+ * required parameters appear undefined on the client side.
+ *
+ * This function detects unrecognized keys, tries snake_case ↔ camelCase
+ * conversion, and remaps them when a match exists in the client's schema.
+ * It only activates when at least one required parameter is missing, so
+ * well-formed tool calls pass through untouched.
+ */
+export function normalizeToolInput(
+  input: Record<string, unknown> | undefined,
+  clientSchema: { properties?: Record<string, unknown>; required?: string[] } | undefined,
+): Record<string, unknown> | undefined {
+  if (!input || !clientSchema?.properties) return input
+
+  const schemaKeys = new Set(Object.keys(clientSchema.properties))
+  const required = new Set(clientSchema.required ?? [])
+
+  // Fast path: all required fields are present, no normalization needed
+  const missingRequired = [...required].filter(k => input[k] === undefined)
+  if (missingRequired.length === 0) return input
+
+  const normalized = { ...input }
+
+  for (const key of Object.keys(normalized)) {
+    if (schemaKeys.has(key)) continue // Already matches
+
+    // Try camelCase: file_path → filePath
+    const camel = toCamelCase(key)
+    if (camel !== key && schemaKeys.has(camel) && normalized[camel] === undefined) {
+      normalized[camel] = normalized[key]
+      delete normalized[key]
+      continue
+    }
+
+    // Try snake_case: filePath → file_path
+    const snake = toSnakeCase(key)
+    if (snake !== key && schemaKeys.has(snake) && normalized[snake] === undefined) {
+      normalized[snake] = normalized[key]
+      delete normalized[key]
+    }
+  }
+
+  return normalized
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -35,6 +35,7 @@ import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
@@ -817,14 +818,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // built-in tools with snake_case params (file_path), but clients
                 // may use camelCase (filePath). Remap when required fields are missing.
                 const clientTool = requestTools.find((t: any) => t.name === toolName)
-                // NOTE: agent-specific — normalize subagent_type to lowercase.
-                // Claude often sends PascalCase (e.g., "Explore") but OpenCode
-                // validates agent types case-sensitively against its config.
+                // NOTE: agent-specific — normalize subagent_type for the client response.
+                // Claude often sends PascalCase (e.g., "Explore") and aliases
+                // (e.g., "general-purpose") that OpenCode rejects. We send the
+                // canonical lowercase agent name that OpenCode's config declares.
                 let toolInput = normalizeToolInput(input.tool_input, clientTool?.input_schema)
                 if (toolName.toLowerCase() === "task" && toolInput?.subagent_type && typeof toolInput.subagent_type === "string") {
-                  let mapped = toolInput.subagent_type.toLowerCase()
-                  if (mapped === "general-purpose") mapped = "general"
-                  toolInput = { ...toolInput, subagent_type: mapped }
+                  toolInput = { ...toolInput, subagent_type: resolveAgentAlias(toolInput.subagent_type) }
                 }
                 capturedToolUses.push({
                   id: input.tool_use_id,
@@ -1632,8 +1632,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // NOTE: agent-specific — buffer input_json_delta for Task tool blocks.
                     // Claude sends PascalCase subagent_type (e.g., "Explore") and aliases
                     // like "general-purpose" that OpenCode rejects. input_json_delta sends
-                    // JSON in chunks so we can't regex-replace individual deltas — buffer
-                    // all chunks and emit the fixed JSON at content_block_stop.
+                    // JSON in chunks so we can't normalize individual deltas — buffer
+                    // all chunks, parse the complete JSON, and emit the fixed version
+                    // at content_block_stop.
                     if (
                       passthrough &&
                       eventIndex !== undefined &&
@@ -1650,15 +1651,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       if (eventType === "content_block_stop") {
                         const buffered = taskToolJsonBuffer.get(eventIndex)
                         if (buffered) {
-                          const fixed = buffered.replace(
-                            /"subagent_type"\s*:\s*"([^"]+)"/,
-                            (_: string, v: string) => {
-                              let mapped = v.toLowerCase()
-                              // Map common Claude-invented aliases to valid OpenCode agents
-                              if (mapped === "general-purpose") mapped = "general"
-                              return `"subagent_type":"${mapped}"`
+                          let fixed = buffered
+                          try {
+                            const parsed = JSON.parse(buffered) as Record<string, unknown>
+                            if (typeof parsed.subagent_type === "string") {
+                              parsed.subagent_type = resolveAgentAlias(parsed.subagent_type)
                             }
-                          )
+                            fixed = JSON.stringify(parsed)
+                          } catch {
+                            // Malformed JSON — forward buffer unchanged rather than drop the block
+                          }
                           const clientIdx = sdkToClientIndex.get(eventIndex) ?? eventIndex
                           safeEnqueue(encoder.encode(
                             `event: content_block_delta\ndata: ${JSON.stringify({

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -34,7 +34,7 @@ import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
-import { createPassthroughMcpServer, stripMcpPrefix, computeToolSetKey, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
@@ -813,10 +813,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (hasDeferredTools && coreSet && !coreSet.has(toolName.toLowerCase())) {
                   discoveredTools.add(toolName)
                 }
+                // Normalize parameter names: the SDK system prompt references
+                // built-in tools with snake_case params (file_path), but clients
+                // may use camelCase (filePath). Remap when required fields are missing.
+                const clientTool = requestTools.find((t: any) => t.name === toolName)
                 capturedToolUses.push({
                   id: input.tool_use_id,
                   name: toolName,
-                  input: input.tool_input,
+                  input: normalizeToolInput(input.tool_input, clientTool?.input_schema),
                 })
                 return {
                   decision: "block" as const,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -817,10 +817,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // built-in tools with snake_case params (file_path), but clients
                 // may use camelCase (filePath). Remap when required fields are missing.
                 const clientTool = requestTools.find((t: any) => t.name === toolName)
+                // NOTE: agent-specific — normalize subagent_type to lowercase.
+                // Claude often sends PascalCase (e.g., "Explore") but OpenCode
+                // validates agent types case-sensitively against its config.
+                let toolInput = normalizeToolInput(input.tool_input, clientTool?.input_schema)
+                if (toolName.toLowerCase() === "task" && toolInput?.subagent_type && typeof toolInput.subagent_type === "string") {
+                  let mapped = toolInput.subagent_type.toLowerCase()
+                  if (mapped === "general-purpose") mapped = "general"
+                  toolInput = { ...toolInput, subagent_type: mapped }
+                }
                 capturedToolUses.push({
                   id: input.tool_use_id,
                   name: toolName,
-                  input: normalizeToolInput(input.tool_input, clientTool?.input_schema),
+                  input: toolInput,
                 })
                 return {
                   decision: "block" as const,
@@ -1114,19 +1123,29 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             throw error
           }
 
-          // In passthrough mode, add captured tool_use blocks from the hook
-          // (the SDK may not include them in content after blocking)
+          // In passthrough mode, merge captured tool_use blocks from the hook.
+          // The PreToolUse hook normalizes tool input (e.g., subagent_type casing,
+          // parameter name mapping). If the SDK already included the tool_use in
+          // its content blocks, replace the input with the normalized version.
+          // If the SDK omitted it (blocked tools may not appear), add it.
           if (passthrough && capturedToolUses.length > 0) {
-            for (const tu of capturedToolUses) {
-              // Only add if not already in contentBlocks
-              if (!contentBlocks.some((b) => b.type === "tool_use" && (b as any).id === tu.id)) {
-                contentBlocks.push({
-                  type: "tool_use",
-                  id: tu.id,
-                  name: tu.name,
-                  input: tu.input,
-                })
+            const capturedById = new Map(capturedToolUses.map(tu => [tu.id, tu]))
+            for (const block of contentBlocks) {
+              if (block.type === "tool_use" && capturedById.has((block as any).id)) {
+                const captured = capturedById.get((block as any).id)!
+                ;(block as any).name = captured.name
+                ;(block as any).input = captured.input
+                capturedById.delete((block as any).id)
               }
+            }
+            // Add any remaining captured tool_use blocks not in content
+            for (const tu of capturedById.values()) {
+              contentBlocks.push({
+                type: "tool_use",
+                id: tu.id,
+                name: tu.name,
+                input: tu.input,
+              })
             }
           }
 
@@ -1457,6 +1476,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }, 15_000)
 
               const skipBlockIndices = new Set<number>()
+              // NOTE: agent-specific — track block indices for "task" tool_use blocks
+              // so we can normalize subagent_type in streamed input_json_delta events.
+              // Deltas are buffered because input_json_delta sends JSON in chunks —
+              // the key-value pair may span multiple deltas, preventing regex match.
+              const taskToolBlockIndices = new Set<number>()
+              const taskToolJsonBuffer = new Map<number, string>()
               const streamedToolUseIds = new Set<string>()
 
               // Block index remapping: the SDK resets indices on each turn, but
@@ -1570,6 +1595,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           // condition fires correctly.
                           streamedToolUseIds.add(block.id)
                         }
+                        // NOTE: agent-specific — track "task" tool blocks so we can
+                        // normalize subagent_type in their streamed input_json_delta.
+                        if (passthrough && eventIndex !== undefined && block.name.toLowerCase() === "task") {
+                          taskToolBlockIndices.add(eventIndex)
+                        }
                       }
                       // Assign a monotonic client index for this forwarded block
                       if (eventIndex !== undefined) {
@@ -1596,6 +1626,50 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       if (stopReason === "tool_use" && skipBlockIndices.size > 0) {
                         // All tool_use blocks in this turn were MCP — skip this delta
                         continue
+                      }
+                    }
+
+                    // NOTE: agent-specific — buffer input_json_delta for Task tool blocks.
+                    // Claude sends PascalCase subagent_type (e.g., "Explore") and aliases
+                    // like "general-purpose" that OpenCode rejects. input_json_delta sends
+                    // JSON in chunks so we can't regex-replace individual deltas — buffer
+                    // all chunks and emit the fixed JSON at content_block_stop.
+                    if (
+                      passthrough &&
+                      eventIndex !== undefined &&
+                      taskToolBlockIndices.has(eventIndex)
+                    ) {
+                      if (eventType === "content_block_delta") {
+                        const delta = (event as any).delta
+                        if (delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
+                          const prev = taskToolJsonBuffer.get(eventIndex) ?? ""
+                          taskToolJsonBuffer.set(eventIndex, prev + delta.partial_json)
+                          continue // Don't forward — emit complete JSON at block_stop
+                        }
+                      }
+                      if (eventType === "content_block_stop") {
+                        const buffered = taskToolJsonBuffer.get(eventIndex)
+                        if (buffered) {
+                          const fixed = buffered.replace(
+                            /"subagent_type"\s*:\s*"([^"]+)"/,
+                            (_: string, v: string) => {
+                              let mapped = v.toLowerCase()
+                              // Map common Claude-invented aliases to valid OpenCode agents
+                              if (mapped === "general-purpose") mapped = "general"
+                              return `"subagent_type":"${mapped}"`
+                            }
+                          )
+                          const clientIdx = sdkToClientIndex.get(eventIndex) ?? eventIndex
+                          safeEnqueue(encoder.encode(
+                            `event: content_block_delta\ndata: ${JSON.stringify({
+                              type: "content_block_delta",
+                              index: clientIdx,
+                              delta: { type: "input_json_delta", partial_json: fixed }
+                            })}\n\n`
+                          ), "task_tool_fixed_delta")
+                          taskToolJsonBuffer.delete(eventIndex)
+                        }
+                        // Fall through to forward content_block_stop normally
                       }
                     }
 


### PR DESCRIPTION
Supersedes #418.

## Summary

Picks up @Alexander-Ollman's three fixes from #418 with authorship preserved, plus one cleanup commit on top. All four changes target the OpenCode passthrough pipeline where subagent spawning previously failed due to naming mismatches between the SDK, Claude, and the client.

## Commits

1. `ad6bd9c2` — **@Alexander-Ollman** — param name normalization (snake↔camel) via `normalizeToolInput`
2. `bcbce782` — **@Alexander-Ollman** — default agent type injection + PascalCase variants + `"general"` fallback routing
3. `253c301c` — **@Alexander-Ollman** — subagent_type normalization in both non-stream (capturedById merge) and stream (input_json_delta buffer) paths
4. `ae3c4680` — **refactor** — centralize `general-purpose → general` via `resolveAgentAlias()`, replace streaming regex with JSON.parse, add unit tests for the helper

## Why a new PR

#418 didn't have CI runs (branch protection blocked). This PR picks up the same three commits verbatim and adds a refactor pass that:
- Removes the duplicated `general-purpose → general` check from two places in `server.ts` (now shared via `KNOWN_ALIASES` in `agentMatch.ts`).
- Replaces the streaming regex with `JSON.parse` / `JSON.stringify` — the buffer is complete JSON at `content_block_stop`, so parsing is safe and sidesteps escape-handling edge cases.
- Gives the captured tool_use path access to every alias (not just the one that motivated the original fix).

## Verification

### Unit + integration tests
- `bun test`: **1395/1395 pass** (3 new tests for `resolveAgentAlias`)

### E2E (live proxy, OpenCode passthrough, claude-haiku-4-5)
1. Task tool + Read tool (camelCase schema) mixed — E19: processes without crash ✅
2. Force Task call with PascalCase: model emitted `subagent_type: "Explore"`, response shows `"explore"` ✅
3. Force Task call with alias (streaming): model wanted `"general-purpose"`, stream emitted `"general"` ✅
4. Force Read tool call: model emitted `file_path` per SDK prompt, response shows `filePath` matching client schema ✅

## Test plan

- [x] `bun test` — 1395/1395
- [x] E19 Task tool parsing
- [x] E2E non-stream subagent_type normalization
- [x] E2E stream subagent_type normalization (via JSON.parse path)
- [x] E2E Read tool param-name normalization