### PR TITLE
feat: Claude Code adapter with split SDK / client working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-Meridian bridges the Claude Code SDK to the standard Anthropic API. No OAuth interception. No binary patches. No hacks. Just pure, documented SDK calls. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, ForgeCode, Crush, Cline, Aider, Pi, Droid, Open WebUI — connects to Meridian and gets Claude, with session management, streaming, and prompt caching handled natively by the SDK.
+Meridian bridges the Claude Code SDK to the standard Anthropic API. No OAuth interception. No binary patches. No hacks. Just pure, documented SDK calls. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, ForgeCode, Crush, Cline, Aider, Pi, Droid, Open WebUI, Claude Code — connects to Meridian and gets Claude, with session management, streaming, and prompt caching handled natively by the SDK.
 
 > [!NOTE]
 > ### How Meridian works with Anthropic
@@ -483,6 +483,29 @@ Pi uses the `@mariozechner/pi-ai` library which supports a configurable `baseUrl
 
 Pi mimics Claude Code's User-Agent, so automatic detection isn't possible. The `x-meridian-agent: pi` header in the config above tells Meridian to use the Pi adapter. Alternatively, if Pi is your only agent, you can set `MERIDIAN_DEFAULT_AGENT=pi` as an env var instead.
 
+### Claude Code
+
+Claude Code can point at Meridian like any other Anthropic API client. The
+common use case is sharing a single Claude Max subscription from one host
+across other machines on your network — run Meridian on the box that is
+logged into Claude Max, then run Claude Code anywhere else against it.
+
+```bash
+# On another machine (or the same one)
+ANTHROPIC_AUTH_TOKEN=x ANTHROPIC_BASE_URL=http://meridian-host:3456 claude
+```
+
+> **Note:** Use `ANTHROPIC_AUTH_TOKEN` (or `ANTHROPIC_API_KEY`) — Claude Code
+> treats both as bearer credentials. Set the value to your `MERIDIAN_API_KEY`
+> if you've enabled authentication, otherwise any string works.
+
+Claude Code is detected automatically via its `claude-cli/*` User-Agent.
+Requests flow through the Claude Code adapter which:
+
+- Parses the client's real working directory from its `Primary working directory:` system-prompt line so Claude answers path-related questions with your local path, not the proxy host's.
+- Leaves the SDK subprocess cwd on the proxy host (Claude Code's local paths don't exist there).
+- Runs in passthrough mode by default — Claude Code executes its own tools on the machine it runs on; Meridian just forwards tool_use blocks.
+
 ### Any Anthropic-compatible tool
 
 ```bash
@@ -502,6 +525,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 | [Aider](https://github.com/paul-gauthier/aider) | ✅ Verified | Env vars — file editing, streaming; `--no-stream` broken (litellm bug) |
 | [Open WebUI](https://github.com/open-webui/open-webui) | ✅ Verified | OpenAI-compatible endpoints — set base URL to `http://127.0.0.1:3456` |
 | [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see above) — requires `MERIDIAN_DEFAULT_AGENT=pi` |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Verified | `ANTHROPIC_BASE_URL` — remote clients share a Max subscription over the network; client CWD preserved in system prompt |
 | [Continue](https://github.com/continuedev/continue) | 🔲 Untested | OpenAI-compatible endpoints should work — set `apiBase` to `http://127.0.0.1:3456` |
 
 Tested an agent or built a plugin? [Open an issue](https://github.com/rynfar/meridian/issues) and we'll add it.

--- a/README.md
+++ b/README.md
@@ -499,6 +499,12 @@ ANTHROPIC_AUTH_TOKEN=x ANTHROPIC_BASE_URL=http://meridian-host:3456 claude
 > treats both as bearer credentials. Set the value to your `MERIDIAN_API_KEY`
 > if you've enabled authentication, otherwise any string works.
 
+> ⚠️ **Security for multi-machine setups.** If you expose Meridian beyond
+> loopback (e.g. bind to `0.0.0.0` or a LAN IP), **set `MERIDIAN_API_KEY` to a
+> strong secret** and require it on clients. An unprotected network-accessible
+> proxy is a Claude Max credential leak — anyone who can reach the port can
+> burn your subscription.
+
 Claude Code is detected automatically via its `claude-cli/*` User-Agent.
 Requests flow through the Claude Code adapter which:
 

--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -13,6 +13,7 @@ import { crushAdapter } from "../proxy/adapters/crush"
 import { piAdapter } from "../proxy/adapters/pi"
 import { passthroughAdapter } from "../proxy/adapters/passthrough"
 import { forgeCodeAdapter } from "../proxy/adapters/forgecode"
+import { claudeCodeAdapter } from "../proxy/adapters/claudecode"
 
 function makeContext(userAgent: string, extraHeaders?: Record<string, string>): any {
   const allHeaders: Record<string, string> = {}
@@ -72,6 +73,25 @@ describe("detectAdapter — Crush detection", () => {
   it("returns crushAdapter for Charm-Crush with extra info", () => {
     const adapter = detectAdapter(makeContext("Charm-Crush/v0.51.2 (https://charm.land/crush)"))
     expect(adapter).toBe(crushAdapter)
+  })
+})
+
+describe("detectAdapter — Claude Code detection", () => {
+  it("returns claudeCodeAdapter for 'claude-cli/2.0.0'", () => {
+    const adapter = detectAdapter(makeContext("claude-cli/2.0.0"))
+    expect(adapter).toBe(claudeCodeAdapter)
+    expect(adapter.name).toBe("claude-code")
+  })
+
+  it("returns claudeCodeAdapter for any 'claude-cli/' prefix", () => {
+    expect(detectAdapter(makeContext("claude-cli/0.1.0")).name).toBe("claude-code")
+    expect(detectAdapter(makeContext("claude-cli/1.0.0")).name).toBe("claude-code")
+    expect(detectAdapter(makeContext("claude-cli/99.99.99")).name).toBe("claude-code")
+  })
+
+  it("returns claudeCodeAdapter for claude-cli with extra info", () => {
+    const adapter = detectAdapter(makeContext("claude-cli/2.0.0 (linux; x64)"))
+    expect(adapter).toBe(claudeCodeAdapter)
   })
 })
 
@@ -140,6 +160,15 @@ describe("detectAdapter — x-meridian-agent header override", () => {
   it("returns forgeCodeAdapter when x-meridian-agent is 'forgecode'", () => {
     expect(detectAdapter(makeContext("", { "x-meridian-agent": "forgecode" }))).toBe(forgeCodeAdapter)
     expect(forgeCodeAdapter.name).toBe("forgecode")
+  })
+
+  it("returns claudeCodeAdapter when x-meridian-agent is 'claude-code'", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "claude-code" }))).toBe(claudeCodeAdapter)
+    expect(claudeCodeAdapter.name).toBe("claude-code")
+  })
+
+  it("accepts 'claudecode' as an alias for 'claude-code'", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "claudecode" }))).toBe(claudeCodeAdapter)
   })
 
   it("is case-insensitive on header value", () => {

--- a/src/__tests__/claude-code-adapter.test.ts
+++ b/src/__tests__/claude-code-adapter.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for the Claude Code CLI adapter.
+ *
+ * Claude Code's request shape differs from the other adapters in two ways
+ * that this adapter handles:
+ *  - It usually runs on a different host than the proxy, so its local CWD
+ *    must not be used as the SDK subprocess cwd.
+ *  - It embeds working-directory info as `Primary working directory: …`
+ *    inside a `# Environment` section rather than the `<env>…</env>` block
+ *    OpenCode uses.
+ */
+import { describe, it, expect } from "bun:test"
+import { claudeCodeAdapter } from "../proxy/adapters/claudecode"
+
+describe("claudeCodeAdapter — identity", () => {
+  it("has name 'claude-code'", () => {
+    expect(claudeCodeAdapter.name).toBe("claude-code")
+  })
+})
+
+describe("claudeCodeAdapter.getSessionId", () => {
+  it("always returns undefined — Claude Code sends no session header", () => {
+    const ctx = {
+      req: { header: () => "any-value" },
+    }
+    expect(claudeCodeAdapter.getSessionId(ctx as any)).toBeUndefined()
+  })
+
+  it("returns undefined even when x-opencode-session is present", () => {
+    const ctx = {
+      req: {
+        header: (name: string) =>
+          name === "x-opencode-session" ? "sess-abc" : undefined,
+      },
+    }
+    expect(claudeCodeAdapter.getSessionId(ctx as any)).toBeUndefined()
+  })
+})
+
+describe("claudeCodeAdapter.extractWorkingDirectory", () => {
+  it("always returns undefined so the SDK falls back to a valid host path", () => {
+    expect(
+      claudeCodeAdapter.extractWorkingDirectory({
+        system:
+          "# Environment\n - Primary working directory: /Users/alice/projects/app",
+      })
+    ).toBeUndefined()
+  })
+
+  it("returns undefined for array system prompts too", () => {
+    expect(
+      claudeCodeAdapter.extractWorkingDirectory({
+        system: [
+          { type: "text", text: "# Environment" },
+          { type: "text", text: " - Primary working directory: /tmp/demo" },
+        ],
+      })
+    ).toBeUndefined()
+  })
+
+  it("returns undefined when no system prompt is present", () => {
+    expect(claudeCodeAdapter.extractWorkingDirectory({})).toBeUndefined()
+  })
+})
+
+describe("claudeCodeAdapter.extractClientWorkingDirectory", () => {
+  it("extracts CWD from a string system prompt", () => {
+    const body = {
+      system:
+        "# Environment\nYou have been invoked in the following environment:\n - Primary working directory: /Users/alice/projects/app\n - Is directory a git repo: Yes",
+    }
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!(body)
+    ).toBe("/Users/alice/projects/app")
+  })
+
+  it("extracts CWD from an array system prompt", () => {
+    const body = {
+      system: [
+        { type: "text", text: "# Environment" },
+        { type: "text", text: " - Primary working directory: /tmp/my-repo" },
+        { type: "text", text: " - Platform: linux" },
+      ],
+    }
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!(body)
+    ).toBe("/tmp/my-repo")
+  })
+
+  it("is case-insensitive on the 'Primary working directory:' label", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({
+        system: "primary working directory: /home/user/project",
+      })
+    ).toBe("/home/user/project")
+  })
+
+  it("trims trailing whitespace from the captured path", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({
+        system: "Primary working directory:    /path/with/padding   \n",
+      })
+    ).toBe("/path/with/padding")
+  })
+
+  it("returns undefined when the system prompt is missing", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({})
+    ).toBeUndefined()
+  })
+
+  it("returns undefined when the label is absent", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({
+        system: "You are a helpful assistant. No working directory line.",
+      })
+    ).toBeUndefined()
+  })
+
+  it("returns undefined for empty string system prompt", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({ system: "" })
+    ).toBeUndefined()
+  })
+
+  it("returns undefined for empty array system prompt", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({ system: [] })
+    ).toBeUndefined()
+  })
+
+  it("handles a system array with non-text blocks", () => {
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!({
+        system: [
+          { type: "image", source: {} },
+          { type: "text", text: " - Primary working directory: /opt/app" },
+        ],
+      })
+    ).toBe("/opt/app")
+  })
+
+  it("returns the first match when multiple Primary working directory lines exist", () => {
+    const body = {
+      system:
+        "Primary working directory: /first\nsome other text\nPrimary working directory: /second",
+    }
+    expect(
+      claudeCodeAdapter.extractClientWorkingDirectory!(body)
+    ).toBe("/first")
+  })
+})
+
+describe("claudeCodeAdapter — basic configuration surface", () => {
+  it("exposes MCP config like the other passthrough-capable adapters", () => {
+    expect(typeof claudeCodeAdapter.getMcpServerName()).toBe("string")
+    expect(Array.isArray(claudeCodeAdapter.getAllowedMcpTools())).toBe(true)
+    expect(Array.isArray(claudeCodeAdapter.getBlockedBuiltinTools())).toBe(true)
+    expect(Array.isArray(claudeCodeAdapter.getAgentIncompatibleTools())).toBe(true)
+  })
+
+  it("lists Claude Code's PascalCase core tools so they're not deferred", () => {
+    const core = claudeCodeAdapter.getCoreToolNames!()
+    expect(core).toContain("Read")
+    expect(core).toContain("Write")
+    expect(core).toContain("Edit")
+    expect(core).toContain("Bash")
+  })
+
+  it("defaults to passthrough mode and honors the disable flags", () => {
+    const original = process.env.MERIDIAN_PASSTHROUGH
+    try {
+      delete process.env.MERIDIAN_PASSTHROUGH
+      expect(claudeCodeAdapter.usesPassthrough!()).toBe(true)
+
+      process.env.MERIDIAN_PASSTHROUGH = "0"
+      expect(claudeCodeAdapter.usesPassthrough!()).toBe(false)
+
+      process.env.MERIDIAN_PASSTHROUGH = "false"
+      expect(claudeCodeAdapter.usesPassthrough!()).toBe(false)
+    } finally {
+      if (original === undefined) {
+        delete process.env.MERIDIAN_PASSTHROUGH
+      } else {
+        process.env.MERIDIAN_PASSTHROUGH = original
+      }
+    }
+  })
+
+  it("skips meridian's synthetic file-change tracker (Claude Code shows its own edits)", () => {
+    expect(claudeCodeAdapter.shouldTrackFileChanges!()).toBe(false)
+  })
+})
+
+describe("claudeCodeAdapter.extractFileChangesFromToolUse", () => {
+  it("flags Write tool uses as 'wrote'", () => {
+    const result = claudeCodeAdapter.extractFileChangesFromToolUse!("Write", {
+      file_path: "/tmp/a.txt",
+      content: "hi",
+    })
+    expect(result).toEqual([{ operation: "wrote", path: "/tmp/a.txt" }])
+  })
+
+  it("flags Edit and MultiEdit tool uses as 'edited'", () => {
+    expect(
+      claudeCodeAdapter.extractFileChangesFromToolUse!("Edit", {
+        file_path: "/tmp/b.ts",
+      })
+    ).toEqual([{ operation: "edited", path: "/tmp/b.ts" }])
+
+    expect(
+      claudeCodeAdapter.extractFileChangesFromToolUse!("MultiEdit", {
+        file_path: "/tmp/c.ts",
+      })
+    ).toEqual([{ operation: "edited", path: "/tmp/c.ts" }])
+  })
+
+  it("parses redirect writes from Bash commands", () => {
+    const changes = claudeCodeAdapter.extractFileChangesFromToolUse!("Bash", {
+      command: "echo hello > /tmp/out.txt",
+    })
+    expect(changes.length).toBeGreaterThan(0)
+    expect(changes[0]!.path).toBe("/tmp/out.txt")
+  })
+
+  it("returns an empty array for tools it doesn't track", () => {
+    expect(
+      claudeCodeAdapter.extractFileChangesFromToolUse!("Grep", {
+        pattern: "foo",
+      })
+    ).toEqual([])
+  })
+})

--- a/src/__tests__/query-cwd-note.test.ts
+++ b/src/__tests__/query-cwd-note.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for buildCwdNote — the helper that emits an `<env>` addendum so the
+ * model reports the client's real working directory, not the SDK subprocess'
+ * cwd on the proxy host. This bridges the gap for remote clients whose CWDs
+ * don't exist on the proxy box.
+ */
+import { describe, it, expect } from "bun:test"
+import { buildCwdNote } from "../proxy/query"
+
+describe("buildCwdNote", () => {
+  it("returns an empty string when clientCwd is undefined", () => {
+    expect(buildCwdNote("/srv/proxy")).toBe("")
+  })
+
+  it("returns an empty string when both sides match (same-host client)", () => {
+    expect(buildCwdNote("/same/path", "/same/path")).toBe("")
+  })
+
+  it("emits an <env> block with the client's path when they differ", () => {
+    const note = buildCwdNote("/srv/proxy", "/Users/alice/app")
+    expect(note).toContain("<env>")
+    expect(note).toContain("Working directory: /Users/alice/app")
+    expect(note).toContain("</env>")
+  })
+
+  it("includes a follow-up note identifying the proxy path", () => {
+    const note = buildCwdNote("/srv/proxy", "/Users/alice/app")
+    expect(note).toContain("<meridian-note>")
+    expect(note).toContain("/srv/proxy")
+    expect(note).toContain("/Users/alice/app")
+    expect(note).toContain("</meridian-note>")
+  })
+
+  it("places the <env> override before the meridian-note so the subprocess sees it first", () => {
+    const note = buildCwdNote("/srv/proxy", "/Users/alice/app")
+    const envIdx = note.indexOf("<env>")
+    const noteIdx = note.indexOf("<meridian-note>")
+    expect(envIdx).toBeGreaterThanOrEqual(0)
+    expect(noteIdx).toBeGreaterThan(envIdx)
+  })
+
+  it("handles paths containing spaces or special characters", () => {
+    const note = buildCwdNote("/srv", "/Users/alice/My Projects/app (v2)")
+    expect(note).toContain("Working directory: /Users/alice/My Projects/app (v2)")
+  })
+
+  it("treats an empty clientCwd as no-op", () => {
+    expect(buildCwdNote("/srv/proxy", "")).toBe("")
+  })
+})

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -24,10 +24,37 @@ export interface AgentIdentity {
   getSessionId(c: Context): string | undefined
 
   /**
-   * Extract the client's working directory from the request body.
-   * Returns undefined to fall back to CLAUDE_PROXY_WORKDIR or process.cwd().
+   * Extract the SDK subprocess working directory from the request body.
+   *
+   * This path must exist on the proxy host because it becomes the SDK
+   * child_process cwd (passed through as the `cwd` option to the Claude
+   * Agent SDK's query() call). If it doesn't exist, the subprocess spawn
+   * fails or chdirs misbehave.
+   *
+   * Adapters that assume the client runs on the same host as the proxy
+   * (OpenCode, Crush) can return the client-local path here.
+   * Adapters for remote clients pointing at a network-exposed proxy
+   * (Claude Code) should return undefined and override
+   * extractClientWorkingDirectory instead.
+   *
+   * Returns undefined to fall back to MERIDIAN_WORKDIR / CLAUDE_PROXY_WORKDIR
+   * env vars, then process.cwd().
    */
   extractWorkingDirectory(body: any): string | undefined
+
+  /**
+   * Optional: extract the client-local working directory (which may not
+   * exist on the proxy host). This is used for:
+   *  - Conversation fingerprinting (per-client-project bucketing so two
+   *    unrelated projects don't collide on identical first-message hashes).
+   *  - A system prompt addendum so the model reports the correct path
+   *    when asked and uses it for file path references.
+   *
+   * Return undefined to default to the SDK working directory (same machine
+   * assumption). Adapters for remote clients should implement this to parse
+   * the client's own "working directory" hint from the request body.
+   */
+  extractClientWorkingDirectory?(body: any): string | undefined
 
   /**
    * Content normalization — convert message content to a stable string

--- a/src/proxy/adapters/claudecode.ts
+++ b/src/proxy/adapters/claudecode.ts
@@ -1,0 +1,147 @@
+/**
+ * Claude Code agent adapter.
+ *
+ * Claude Code (claude-cli) is unusual among meridian clients in two ways:
+ *   1. It typically runs on a different machine than the proxy (pointing at
+ *      ANTHROPIC_BASE_URL over the network), so its CWD doesn't exist on the
+ *      proxy host.
+ *   2. Its system prompt embeds working-directory info using the
+ *      `Primary working directory: <path>` format inside a `# Environment`
+ *      block — different from OpenCode's `<env>Working directory: <path></env>`.
+ *
+ * Consequently this adapter:
+ *   - Returns `undefined` from extractWorkingDirectory so the SDK subprocess
+ *     chdirs into `process.cwd()` (a valid server path) rather than the
+ *     client's local filesystem layout.
+ *   - Parses the client's local CWD via extractClientWorkingDirectory for
+ *     fingerprinting and a system-prompt hint (see server.ts + query.ts).
+ */
+
+import type { Context } from "hono"
+import type { AgentAdapter } from "../adapter"
+import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
+import { normalizeContent } from "../messages"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../tools"
+
+/**
+ * Extract Claude Code's client-local working directory from the request's
+ * system prompt. Claude Code injects a block like:
+ *
+ *   # Environment
+ *   You have been invoked in the following environment:
+ *    - Primary working directory: /Users/alice/projects/myapp
+ *    - ...
+ *
+ * Returns the path if found, or undefined to fall back to the SDK CWD.
+ */
+function extractClaudeCodeClientCwd(body: any): string | undefined {
+  let systemText = ""
+  if (typeof body.system === "string") {
+    systemText = body.system
+  } else if (Array.isArray(body.system)) {
+    systemText = body.system
+      .filter((b: any) => b.type === "text" && b.text)
+      .map((b: any) => b.text)
+      .join("\n")
+  }
+  if (!systemText) return undefined
+
+  const match = systemText.match(/Primary working directory:\s*([^\n<]+)/i)
+  return match?.[1]?.trim() || undefined
+}
+
+export const claudeCodeAdapter: AgentAdapter = {
+  name: "claude-code",
+
+  /**
+   * Claude Code doesn't send a session-affinity header, so fall through to
+   * fingerprint-based resume (first-user-message + clientCwd).
+   */
+  getSessionId(_c: Context): string | undefined {
+    return undefined
+  },
+
+  /**
+   * Claude Code is remote relative to the proxy. Do not use its local path
+   * as the SDK subprocess cwd — return undefined so the resolver falls back
+   * to MERIDIAN_WORKDIR / process.cwd() (a valid path on the proxy host).
+   */
+  extractWorkingDirectory(_body: any): string | undefined {
+    return undefined
+  },
+
+  /**
+   * Used for fingerprint bucketing and the system-prompt CWD hint.
+   */
+  extractClientWorkingDirectory(body: any): string | undefined {
+    return extractClaudeCodeClientCwd(body)
+  },
+
+  normalizeContent(content: any): string {
+    return normalizeContent(content)
+  },
+
+  getBlockedBuiltinTools(): readonly string[] {
+    return BLOCKED_BUILTIN_TOOLS
+  },
+
+  getAgentIncompatibleTools(): readonly string[] {
+    return CLAUDE_CODE_ONLY_TOOLS
+  },
+
+  getMcpServerName(): string {
+    return MCP_SERVER_NAME
+  },
+
+  getAllowedMcpTools(): readonly string[] {
+    return ALLOWED_MCP_TOOLS
+  },
+
+  getCoreToolNames(): readonly string[] {
+    // Claude Code ships a Read/Write/Bash/etc. toolkit much like OpenCode.
+    return ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+  },
+
+  usesPassthrough(): boolean {
+    // Claude Code owns its own tool execution client-side; default to
+    // passthrough so tool_use blocks flow back to the CLI.
+    const envVal = process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH
+    if (envVal === "0" || envVal === "false" || envVal === "no") {
+      return false
+    }
+    return true
+  },
+
+  supportsThinking(): boolean {
+    return true
+  },
+
+  /**
+   * Claude Code surfaces its own file edits in its UI; suppress meridian's
+   * synthetic "Files changed:" block to avoid duplication.
+   */
+  shouldTrackFileChanges(): boolean {
+    return false
+  },
+
+  /**
+   * Map Claude Code tool_use blocks to file changes. Claude Code uses
+   * PascalCase tool names (Read, Write, Edit, Bash) with file_path input.
+   */
+  extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
+    const input = toolInput as Record<string, unknown> | null | undefined
+    const filePath = input?.file_path ?? input?.filePath ?? input?.path
+
+    const lowerName = toolName.toLowerCase()
+    if (lowerName === "write" && filePath) {
+      return [{ operation: "wrote", path: String(filePath) }]
+    }
+    if ((lowerName === "edit" || lowerName === "multiedit") && filePath) {
+      return [{ operation: "edited", path: String(filePath) }]
+    }
+    if (lowerName === "bash" && input?.command) {
+      return extractFileChangesFromBash(String(input.command))
+    }
+    return []
+  },
+}

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -13,6 +13,7 @@ import { crushAdapter } from "./crush"
 import { passthroughAdapter } from "./passthrough"
 import { piAdapter } from "./pi"
 import { forgeCodeAdapter } from "./forgecode"
+import { claudeCodeAdapter } from "./claudecode"
 
 const ADAPTER_MAP: Record<string, AgentAdapter> = {
   opencode: openCodeAdapter,
@@ -21,6 +22,8 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   passthrough: passthroughAdapter,
   pi: piAdapter,
   forgecode: forgeCodeAdapter,
+  "claude-code": claudeCodeAdapter,
+  claudecode: claudeCodeAdapter,
 }
 
 const envDefault = process.env.MERIDIAN_DEFAULT_AGENT || ""
@@ -54,8 +57,9 @@ function isLiteLLMRequest(c: Context): boolean {
  * 3. User-Agent starts with "opencode/"     → OpenCode adapter
  * 4. User-Agent starts with "factory-cli/"  → Droid adapter
  * 5. User-Agent starts with "Charm-Crush/"  → Crush adapter
- * 6. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
- * 7. Default                                → MERIDIAN_DEFAULT_AGENT env var, or OpenCode
+ * 6. User-Agent starts with "claude-cli/"  → Claude Code adapter
+ * 7. litellm/* UA or x-litellm-* headers   → LiteLLM passthrough adapter
+ * 8. Default                                → MERIDIAN_DEFAULT_AGENT env var, or OpenCode
  */
 export function detectAdapter(c: Context): AgentAdapter {
   const agentOverride = c.req.header("x-meridian-agent")?.toLowerCase()
@@ -81,6 +85,13 @@ export function detectAdapter(c: Context): AgentAdapter {
 
   if (userAgent.startsWith("Charm-Crush/")) {
     return crushAdapter
+  }
+
+  // Claude Code CLI — `claude-cli/<version>`. Pi mimics this User-Agent so
+  // Pi users must explicitly select via x-meridian-agent header or
+  // MERIDIAN_DEFAULT_AGENT env var (those are matched earlier).
+  if (userAgent.startsWith("claude-cli/")) {
+    return claudeCodeAdapter
   }
 
   if (isLiteLLMRequest(c)) {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -16,8 +16,15 @@ export interface QueryContext {
   prompt: string | AsyncIterable<any>
   /** Resolved Claude model name */
   model: string
-  /** Client working directory */
+  /** SDK subprocess working directory — must exist on the proxy host. */
   workingDirectory: string
+  /**
+   * Client-local working directory (as reported in the request). May not
+   * exist on the proxy host. When this differs from workingDirectory the
+   * system prompt is augmented with a note directing the model to refer
+   * to file paths using the client's path rather than the proxy's.
+   */
+  clientWorkingDirectory?: string
   /** System context text (may be empty) */
   systemContext: string
   /** Path to Claude executable */
@@ -119,36 +126,67 @@ function computePassthroughMaxTurns(
   return base + advisorBump
 }
 
+/**
+ * Build an addendum that tells the model which path belongs to the real user.
+ * Applied when the SDK subprocess runs in one directory on the proxy host but
+ * the client is working in a different directory on their own machine
+ * (typical of a remote Claude Code → network-proxy setup). Without this note
+ * the SDK's env block leaks `sdkCwd` into the model's context and Claude
+ * reports that as its working directory.
+ */
+export function buildCwdNote(sdkCwd: string, clientCwd?: string): string {
+  if (!clientCwd || clientCwd === sdkCwd) return ""
+  // Emit in the `<env>Working directory: …</env>` shape the Claude Code
+  // subprocess uses itself, so it doesn't auto-inject a second env block
+  // pointing at its own process.cwd() (which would be the proxy host path).
+  // Placed at the top of the append so it's the first env block the model
+  // sees. The subsequent notice tells the model to prefer this over any
+  // contradictory path that might slip through later in the context.
+  return (
+    `\n\n<env>\n` +
+    `Working directory: ${clientCwd}\n` +
+    `</env>\n` +
+    `<meridian-note>\n` +
+    `You are reached through a proxy. The subprocess running you resides at ` +
+    `"${sdkCwd}" on the proxy host, but that is not the user's working directory. ` +
+    `Always treat "${clientCwd}" as the working directory when referring to files or paths.\n` +
+    `</meridian-note>`
+  )
+}
+
 function resolveSystemPrompt(
   systemContext: string | undefined,
   passthrough: boolean,
   settingSources: SettingSource[] | undefined,
-  codeSystemPrompt?: boolean,
-  clientSystemPrompt?: boolean,
+  codeSystemPrompt: boolean | undefined,
+  clientSystemPrompt: boolean | undefined,
+  cwdNote: string,
 ): { systemPrompt?: string | { type: "preset"; preset: "claude_code"; append?: string } } {
   const hasSettings = settingSources != null && settingSources.length > 0
   const usePreset = codeSystemPrompt ?? (hasSettings || (!passthrough && !!systemContext))
   const includeClient = clientSystemPrompt ?? true
   const clientContext = includeClient ? systemContext : undefined
+  const append = [clientContext, cwdNote].filter(Boolean).join("") || undefined
 
   if (usePreset) {
-    return clientContext
-      ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append: clientContext } }
+    return append
+      ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append } }
       : { systemPrompt: { type: "preset" as const, preset: "claude_code" as const } }
   }
-  if (clientContext) return { systemPrompt: clientContext }
+  if (append) return { systemPrompt: append }
   return {}
 }
 
 export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
   const {
-    prompt, model, workingDirectory, systemContext, claudeExecutable,
+    prompt, model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv, hasDeferredTools,
     resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools, incompatibleTools,
     mcpServerName, allowedMcpTools, onStderr,
     effort, thinking, taskBudget, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
     memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
   } = ctx
+  const cwdNote = buildCwdNote(workingDirectory, clientWorkingDirectory)
 
   const allBlockedTools = [...blockedTools, ...incompatibleTools]
 
@@ -169,7 +207,7 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       ...(stream ? { includePartialMessages: true } : {}),
       permissionMode: "bypassPermissions" as const,
       allowDangerouslySkipPermissions: true,
-      ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt),
+      ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt, cwdNote),
       ...(passthrough
         ? {
             disallowedTools: [...allBlockedTools],

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -417,7 +417,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // Examples: "main", "fork-memory-extract", "subagent-scout".
         const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
         let model = mapModelToClaudeModel(body.model || "sonnet", authStatus?.subscriptionType, agentMode)
+        // workingDirectory = SDK subprocess cwd (must exist on the proxy host).
+        // clientWorkingDirectory = the client's local path (may not exist here);
+        // used for per-project fingerprint bucketing and a system-prompt hint
+        // so the model reports the user's real path. For same-host clients
+        // (OpenCode, Crush) the adapter can leave extractClientWorkingDirectory
+        // undefined and the two collapse to the same value.
         const workingDirectory = (process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR) || adapter.extractWorkingDirectory(body) || process.cwd()
+        const clientWorkingDirectory = adapter.extractClientWorkingDirectory?.(body) || workingDirectory
 
         // Strip env vars that would cause the SDK subprocess to loop back through
         // the proxy instead of using its native Claude Max auth. Also strip vars
@@ -532,8 +539,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // For agents without (Pi): pass profile-scoped workingDirectory to fingerprint lookup.
         const profileSessionId = profile.id !== "default" && agentSessionId
           ? `${profile.id}:${agentSessionId}` : agentSessionId
+        // Use the client-local CWD for fingerprint bucketing so that two
+        // independent client projects don't collide on the same first-user-
+        // message hash even when they share an SDK cwd on the proxy host.
         const profileScopedCwd = profile.id !== "default"
-          ? `${workingDirectory}::profile=${profile.id}` : workingDirectory
+          ? `${clientWorkingDirectory}::profile=${profile.id}` : clientWorkingDirectory
         // Clients that run concurrent sub-request flows in the same conversation
         // (e.g. pylon's memory-extract fork or subagent children) share the same
         // (firstUserMessage, cwd) fingerprint as the parent — so meridian's
@@ -898,7 +908,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 let didYieldContent = false
                 try {
                   for await (const event of query(buildQueryOptions({
-                    prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
+                    prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                     resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, betas, settingSources,
@@ -939,7 +949,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                     yield* query(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
-                      model, workingDirectory, systemContext, claudeExecutable,
+                      model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                       resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, betas, settingSources,
@@ -1339,7 +1349,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   let didYieldClientEvent = false
                   try {
                     for await (const event of query(buildQueryOptions({
-                      prompt: makePrompt(), model, workingDirectory, systemContext, claudeExecutable,
+                      prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                       resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, betas, settingSources,
@@ -1377,7 +1387,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                       yield* query(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
-                        model, workingDirectory, systemContext, claudeExecutable,
+                        model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, hasDeferredTools,
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, betas, settingSources,


### PR DESCRIPTION
Supersedes #401.

## Summary

Picks up @davetha's Claude Code CLI adapter from #401 with authorship preserved, rebased onto current `main` and with a small docs follow-up.

## Commits

1. `356e6e9c` — **@davetha** — Claude Code adapter + split SDK/client cwd
2. `e6e8d74b` — **docs** — LAN security warning for multi-machine setups

## What the adapter does

Until now \`workingDirectory\` served two incompatible roles: SDK subprocess cwd (must exist on the proxy host) **and** fingerprint key / system-prompt env hint (should reflect the client's real project). Same-host clients collapsed these; remote clients (Claude Code over LAN) cannot.

- New optional \`AgentAdapter.extractClientWorkingDirectory()\` returns the client-local path.
- \`server.ts\` resolves both \`workingDirectory\` and \`clientWorkingDirectory\` independently; fingerprint bucketing switches to \`clientWorkingDirectory\`.
- \`query.ts\` gets a \`buildCwdNote()\` helper that emits an \`<env>Working directory: X</env>\` block using the same format the Claude Code subprocess uses for its own env injection, so the subprocess sees the env is already present and doesn't double-inject with its proxy-host path.
- New \`claudeCodeAdapter\` parses \`Primary working directory:\` from the Claude Code system prompt, returns \`undefined\` from \`extractWorkingDirectory\` (SDK stays on the proxy host).
- \`claude-cli/*\` UA detection + \`x-meridian-agent: claude-code\`/\`claudecode\` header aliases.

## Rebase notes

The original PR conflicted with \`query.ts\` (advisor #413, maxTurns #420, refactor #425) and \`server.ts\` (passthrough normalization #425). Resolution kept both \`computePassthroughMaxTurns\` and \`buildCwdNote\` side-by-side; \`resolveSystemPrompt\` now takes a \`cwdNote\` argument threaded through \`buildQueryOptions\`.

## Security follow-up

Added an explicit warning to the README Claude Code section: non-loopback setups should set \`MERIDIAN_API_KEY\` to a strong secret. The original text ("any string works") was literally true but dangerous when binding to a LAN IP — anyone who can reach the port burns the subscription.

## Test plan

- [x] \`bun test\` — **1431/1431 pass** (36 new from @davetha + all prior)
  - \`claude-code-adapter.test.ts\` (24 tests)
  - \`query-cwd-note.test.ts\` (7 tests)
  - \`adapter-detection.test.ts\` additions (5 tests)
- [x] **Live E2E** via launchd-respawned proxy on this branch:
  - \`User-Agent: claude-cli/2.0.0\` routes to \`adapter=claude-code\` (verified in proxy log) ✅
  - System prompt with \`Primary working directory: /Users/alice/my-project\` → model reports that exact path when asked ✅
  - Confirms the full chain: UA → adapter detection → \`extractClientWorkingDirectory\` → \`buildCwdNote\` → model context