### PR TITLE
fix(pi): implement extractClientWorkingDirectory for defense in depth

### DIFF
--- a/src/__tests__/pi-adapter.test.ts
+++ b/src/__tests__/pi-adapter.test.ts
@@ -91,6 +91,51 @@ describe("piAdapter.extractWorkingDirectory", () => {
   })
 })
 
+describe("piAdapter.extractClientWorkingDirectory", () => {
+  it("mirrors extractWorkingDirectory — returns the parsed CWD", () => {
+    const body = {
+      system: "You are an expert coding assistant.\nCurrent working directory: /Users/test/project",
+    }
+    expect(piAdapter.extractClientWorkingDirectory!(body)).toBe("/Users/test/project")
+  })
+
+  it("extracts from array system prompt", () => {
+    const body = {
+      system: [
+        { type: "text", text: "System intro." },
+        { type: "text", text: "Current working directory: /tmp/my-repo" },
+      ],
+    }
+    expect(piAdapter.extractClientWorkingDirectory!(body)).toBe("/tmp/my-repo")
+  })
+
+  it("returns undefined when system prompt lacks the CWD line", () => {
+    expect(
+      piAdapter.extractClientWorkingDirectory!({ system: "no cwd line here" })
+    ).toBeUndefined()
+  })
+
+  it("returns undefined when system prompt is missing", () => {
+    expect(piAdapter.extractClientWorkingDirectory!({})).toBeUndefined()
+  })
+
+  it("returns the same value as extractWorkingDirectory for any body", () => {
+    // This parity guarantee is load-bearing: the default resolution in
+    // server.ts collapses the two paths for same-host clients. If they
+    // diverged, buildCwdNote would emit a spurious <env> addendum.
+    const bodies = [
+      { system: "Current working directory: /a" },
+      { system: [{ type: "text", text: "Current working directory: /b" }] },
+      { system: "no directory here" },
+      {},
+    ]
+    for (const body of bodies) {
+      expect(piAdapter.extractClientWorkingDirectory!(body))
+        .toBe(piAdapter.extractWorkingDirectory(body))
+    }
+  })
+})
+
 describe("piAdapter.normalizeContent", () => {
   it("normalizes string content", () => {
     expect(piAdapter.normalizeContent("hello world")).toBe("hello world")

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -80,6 +80,19 @@ export const piAdapter: AgentAdapter = {
     return extractPiCwd(body)
   },
 
+  /**
+   * Pi normally runs on the same host as the proxy, so the SDK subprocess
+   * can chdir into the client's project (see extractWorkingDirectory).
+   * Still expose the parse as extractClientWorkingDirectory too — this
+   * decouples fingerprint bucketing from MERIDIAN_WORKDIR (so two unrelated
+   * Pi projects don't share a fingerprint namespace just because the proxy
+   * is pinned to one cwd) and leaves a hook for any future remote-Pi setups
+   * where client and proxy paths diverge.
+   */
+  extractClientWorkingDirectory(body: any): string | undefined {
+    return extractPiCwd(body)
+  },
+
   normalizeContent(content: any): string {
     return normalizeContent(content)
   },


### PR DESCRIPTION
Related to #421 (tangentially — see Scope below).

## Summary

The Pi adapter parses \`Current working directory:\` from its system prompt in \`extractWorkingDirectory\`, but doesn't expose the same parse via the new \`extractClientWorkingDirectory\` hook introduced in #426. Adds a mirror implementation so Pi participates in the split-cwd pattern.

## Why it matters

The resolution in \`server.ts\` is:

\`\`\`ts
const workingDirectory = (MERIDIAN_WORKDIR) || adapter.extractWorkingDirectory(body) || process.cwd()
const clientWorkingDirectory = adapter.extractClientWorkingDirectory?.(body) || workingDirectory
\`\`\`

When \`MERIDIAN_WORKDIR\` is unset, Pi works fine: both paths collapse to the parsed client CWD. But when the operator pins the proxy to a specific directory via \`MERIDIAN_WORKDIR\`:

- **Before:** \`workingDirectory\` = env override; \`clientWorkingDirectory\` falls back to \`workingDirectory\` (same). Fingerprint bucketing collapses across every Pi project (they all share the override's namespace), and \`buildCwdNote\` emits nothing — so the model has no signal that the real project differs from the proxy's cwd.
- **After:** \`clientWorkingDirectory\` parses the client's actual path. Fingerprint bucketing is per-project. \`buildCwdNote\` emits an \`<env>Working directory: X</env>\` addendum pointing the model at the real path.

This is the same pattern the Claude Code adapter uses (#426); Pi didn't get it at the time because the initial PR predated that infrastructure.

## Scope — does not fix #421 directly

Markus's specific symptom (\`pwd\` returns Meridian's cwd instead of Pi's project) is most likely caused by **agent-detection routing**: Pi's \`claude-cli/*\` User-Agent collides with Claude Code, so without \`x-meridian-agent: pi\` or \`MERIDIAN_DEFAULT_AGENT=pi\`, his requests don't route to the Pi adapter in the first place. This PR doesn't address that; the fix for Markus is still the env var / header.

This PR is a hygiene improvement that makes the Pi adapter robust in scenarios the \`extractClientWorkingDirectory\` split already covers for Claude Code.

## Test plan

- [x] Unit tests (5 new, \`src/__tests__/pi-adapter.test.ts\`):
  - String + array system prompts
  - Missing CWD line → undefined
  - Missing system prompt → undefined
  - Parity with \`extractWorkingDirectory\` across multiple body shapes
- [x] \`bun test\` — **1436/1436 pass** (5 new + all prior)
- [x] **Live E2E** against a test proxy with \`MERIDIAN_WORKDIR=/tmp/e2e-pi-override\` and \`x-meridian-agent: pi\`:
  - Request with \`Current working directory: /Users/alice/pi-project\` in system prompt
  - Proxy log: \`adapter=pi\` ✅
  - Model answers \`/Users/alice/pi-project\` when asked for its cwd — proving the addendum reached the model context ✅