### PR TITLE
fix(models): list claude-opus-4-7 in /v1/models

### DIFF
--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -427,25 +427,35 @@ describe("translateAnthropicSseEvent", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 3 models", () => {
-    expect(buildModelList(true).length).toBe(3)
-    expect(buildModelList(false).length).toBe(3)
+  it("returns 4 models", () => {
+    expect(buildModelList(true).length).toBe(4)
+    expect(buildModelList(false).length).toBe(4)
   })
 
-  it("Max subscription gets 1M context for opus, 200k for sonnet", () => {
+  it("includes both opus-4-6 and opus-4-7 for UI pickers", () => {
+    const ids = buildModelList(true).map(m => m.id)
+    expect(ids).toContain("claude-opus-4-6")
+    expect(ids).toContain("claude-opus-4-7")
+  })
+
+  it("Max subscription gets 1M context for both opus variants, 200k for sonnet", () => {
     const models = buildModelList(true)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
-    const opus = models.find(m => m.id === "claude-opus-4-6")!
+    const opus46 = models.find(m => m.id === "claude-opus-4-6")!
+    const opus47 = models.find(m => m.id === "claude-opus-4-7")!
     expect(sonnet.context_window).toBe(200_000)
-    expect(opus.context_window).toBe(1_000_000)
+    expect(opus46.context_window).toBe(1_000_000)
+    expect(opus47.context_window).toBe(1_000_000)
   })
 
-  it("non-Max gets 200k context for sonnet and opus", () => {
+  it("non-Max gets 200k context for sonnet and both opus variants", () => {
     const models = buildModelList(false)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
-    const opus = models.find(m => m.id === "claude-opus-4-6")!
+    const opus46 = models.find(m => m.id === "claude-opus-4-6")!
+    const opus47 = models.find(m => m.id === "claude-opus-4-7")!
     expect(sonnet.context_window).toBe(200_000)
-    expect(opus.context_window).toBe(200_000)
+    expect(opus46.context_window).toBe(200_000)
+    expect(opus47.context_window).toBe(200_000)
   })
 
   it("haiku is always 200k regardless of subscription", () => {

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -423,6 +423,14 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       context_window: isMaxSubscription ? 1_000_000 : 200_000,
     },
     {
+      id: "claude-opus-4-7",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Opus 4.7",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+    },
+    {
       id: "claude-haiku-4-5",
       object: "model",
       created: now,


### PR DESCRIPTION
Partially addresses #419.

## Summary

UI pickers populate from \`GET /v1/models\`. The hardcoded list previously exposed only \`opus-4-6\`, so \`opus-4-7\` was invisible in OpenCode's model picker even though the \`/v1/messages\` endpoint accepts it.

Adds \`claude-opus-4-7\` to \`buildModelList()\` with the same 1M context entitlement as opus-4-6 for Max subscribers.

## Scope

This fixes the **surface symptom** in #419 (opus-4-7 missing from picker). The deeper bug in the same thread — every requested model self-identifies as sonnet-4 — is a separate, larger fix and will land in its own PR.

## Test plan

- [x] \`bun test\` — **1437/1437 pass** (existing buildModelList tests updated from 3→4 models, 1 new parity test for opus-4-7)
- [x] **Live E2E** against local proxy on this branch:
  \`\`\`
  $ curl -s http://127.0.0.1:3456/v1/models | jq '.data[] | .id'
  "claude-sonnet-4-6"
  "claude-opus-4-6"
  "claude-opus-4-7"
  "claude-haiku-4-5"
  \`\`\`
  With context_window=1_000_000 for both opus variants on Max subscription ✅