### PR TITLE
fix(models): pin SDK model aliases via ANTHROPIC_DEFAULT_*_MODEL env

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test"
 
-import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable } from "../proxy/models"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resolveSdkModelDefaults, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
   const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
@@ -222,5 +222,59 @@ describe("isClosedControllerError", () => {
     expect(isClosedControllerError(null)).toBe(false)
     expect(isClosedControllerError(undefined)).toBe(false)
     expect(isClosedControllerError(42)).toBe(false)
+  })
+})
+
+describe("resolveSdkModelDefaults", () => {
+  const envKeys = [
+    "MERIDIAN_DEFAULT_OPUS_MODEL",
+    "MERIDIAN_DEFAULT_SONNET_MODEL",
+    "MERIDIAN_DEFAULT_HAIKU_MODEL",
+  ]
+  const originalValues: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const k of envKeys) {
+      originalValues[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (originalValues[k] === undefined) delete process.env[k]
+      else process.env[k] = originalValues[k]
+    }
+  })
+
+  it("returns canonical pins when no overrides set", () => {
+    const pins = resolveSdkModelDefaults()
+    expect(pins.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe(CANONICAL_OPUS_MODEL)
+    expect(pins.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(CANONICAL_SONNET_MODEL)
+    expect(pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe(CANONICAL_HAIKU_MODEL)
+  })
+
+  it("MERIDIAN_DEFAULT_OPUS_MODEL override wins over the canonical default", () => {
+    process.env.MERIDIAN_DEFAULT_OPUS_MODEL = "claude-opus-5-0"
+    expect(resolveSdkModelDefaults().ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5-0")
+  })
+
+  it("MERIDIAN_DEFAULT_SONNET_MODEL override wins over the canonical default", () => {
+    process.env.MERIDIAN_DEFAULT_SONNET_MODEL = "claude-sonnet-5-0"
+    expect(resolveSdkModelDefaults().ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5-0")
+  })
+
+  it("MERIDIAN_DEFAULT_HAIKU_MODEL override wins over the canonical default", () => {
+    process.env.MERIDIAN_DEFAULT_HAIKU_MODEL = "claude-haiku-5-0"
+    expect(resolveSdkModelDefaults().ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-5-0")
+  })
+
+  it("returns only the three ANTHROPIC_DEFAULT_* keys — nothing else", () => {
+    const pins = resolveSdkModelDefaults()
+    expect(Object.keys(pins).sort()).toEqual([
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+      "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    ])
   })
 })

--- a/src/__tests__/profile-switch-integration.test.ts
+++ b/src/__tests__/profile-switch-integration.test.ts
@@ -33,6 +33,7 @@ mock.module("../logger", () => ({
 mock.module("../proxy/models", () => ({
   mapModelToClaudeModel: () => "sonnet",
   resolveClaudeExecutableAsync: async () => "claude",
+  resolveSdkModelDefaults: () => ({}),
   getClaudeAuthStatusAsync: async () => ({ loggedIn: true, email: "test@test.com", subscriptionType: "max" }),
   getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
   hasExtendedContext: () => false,

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -161,3 +161,64 @@ describe("Environment variable stripping", () => {
     expect(capturedQueryOptions.env.ANTHROPIC_BASE_URL).toBeUndefined()
   })
 })
+
+describe("SDK model pin injection (fixes #419)", () => {
+  const modelEnvKeys = [
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "MERIDIAN_DEFAULT_OPUS_MODEL",
+    "MERIDIAN_DEFAULT_SONNET_MODEL",
+    "MERIDIAN_DEFAULT_HAIKU_MODEL",
+  ]
+  const savedModelEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    capturedQueryOptions = null
+    clearSessionCache()
+    for (const k of modelEnvKeys) {
+      savedModelEnv[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedModelEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  it("injects Meridian's canonical model pins when no shell env is set", async () => {
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-7")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
+  })
+
+  it("shell ANTHROPIC_DEFAULT_* values win over Meridian's pins", async () => {
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-1-20250805"
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-20250514"
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-custom"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-1-20250805")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-20250514")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-custom")
+  })
+
+  it("MERIDIAN_DEFAULT_OPUS_MODEL overrides the canonical pin but not a shell ANTHROPIC_DEFAULT_OPUS_MODEL", async () => {
+    process.env.MERIDIAN_DEFAULT_OPUS_MODEL = "claude-opus-custom"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-custom")
+
+    // Now add a shell env — it wins over MERIDIAN_ too.
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-shell-wins"
+    clearSessionCache()
+    const app2 = createTestApp()
+    await post(app2, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-shell-wins")
+  })
+})

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -31,6 +31,7 @@ const EXTRA_USAGE_ERROR = "Claude Code returned an error result: API Error: Extr
 mock.module("../proxy/models", () => ({
   mapModelToClaudeModel: () => "sonnet[1m]",
   resolveClaudeExecutableAsync: async () => "claude",
+  resolveSdkModelDefaults: () => ({}),
   getClaudeAuthStatusAsync: async () => ({ loggedIn: true, subscriptionType: "max" }),
   hasExtendedContext: (model: string) => model.endsWith("[1m]"),
   stripExtendedContext: (model: string) => model.replace("[1m]", ""),

--- a/src/__tests__/proxy-health-degraded.test.ts
+++ b/src/__tests__/proxy-health-degraded.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, mock } from "bun:test"
 mock.module("../proxy/models", () => ({
   getClaudeAuthStatusAsync: async () => null,
   resolveClaudeExecutableAsync: async () => "claude",
+  resolveSdkModelDefaults: () => ({}),
   mapModelToClaudeModel: (model: string) => {
     if (model.toLowerCase().includes("opus")) return "opus"
     if (model.toLowerCase().includes("haiku")) return "haiku"

--- a/src/__tests__/proxy-subagent-model-selection.test.ts
+++ b/src/__tests__/proxy-subagent-model-selection.test.ts
@@ -53,6 +53,7 @@ mock.module("../proxy/models", () => ({
     return "sonnet"
   },
   resolveClaudeExecutableAsync: async () => "claude",
+  resolveSdkModelDefaults: () => ({}),
   getClaudeAuthStatusAsync: async () => ({ loggedIn: true, subscriptionType: "max" }),
   getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
   hasExtendedContext: (m: string) => m.endsWith("[1m]"),

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -11,6 +11,39 @@ import { promisify } from "util"
 const exec = promisify(execCallback)
 
 export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku"
+
+/**
+ * Current canonical pins for the `sonnet`/`opus`/`haiku` SDK aliases.
+ *
+ * mapModelToClaudeModel collapses every requested model to one of these
+ * aliases; the Claude Agent SDK then resolves the alias to a concrete
+ * version via ANTHROPIC_DEFAULT_{TYPE}_MODEL env vars. When those env
+ * vars are unset the SDK falls back to its own bundled defaults, which
+ * lag real Claude Max availability — users end up routed to stale
+ * versions (this was the root cause of #419: opus-* requests silently
+ * answering as sonnet-4).
+ *
+ * Meridian now pins these defaults itself at the SDK subprocess boundary
+ * so fresh installs behave correctly out of the box. Users can still
+ * override via MERIDIAN_DEFAULT_{TYPE}_MODEL (proxy-side) or
+ * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
+ */
+export const CANONICAL_OPUS_MODEL = "claude-opus-4-7"
+export const CANONICAL_SONNET_MODEL = "claude-sonnet-4-6"
+export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
+
+/**
+ * Build the ANTHROPIC_DEFAULT_{TYPE}_MODEL env record to apply before the
+ * inherited process env, so user-set shell values still win but unset
+ * variables get Meridian's canonical pins.
+ */
+export function resolveSdkModelDefaults(): Record<string, string> {
+  return {
+    ANTHROPIC_DEFAULT_OPUS_MODEL: process.env.MERIDIAN_DEFAULT_OPUS_MODEL ?? CANONICAL_OPUS_MODEL,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: process.env.MERIDIAN_DEFAULT_SONNET_MODEL ?? CANONICAL_SONNET_MODEL,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: process.env.MERIDIAN_DEFAULT_HAIKU_MODEL ?? CANONICAL_HAIKU_MODEL,
+  }
+}
 export interface ClaudeAuthStatus {
   loggedIn?: boolean
   subscriptionType?: string

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -43,7 +43,7 @@ import type { RequestMetric } from "../telemetry"
 import { classifyError, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, translateAnthropicSseEvent, buildModelList } from "./openai"
 import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
@@ -437,8 +437,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ...cleanEnv
         } = process.env
 
+        // Pin ANTHROPIC_DEFAULT_{TYPE}_MODEL before the inherited env. The
+        // Claude Agent SDK resolves the "sonnet"/"opus"/"haiku" aliases
+        // (emitted by mapModelToClaudeModel) via these env vars; when unset
+        // it falls back to its own bundled defaults, which lag real
+        // availability and caused #419 (opus-* requests silently answering
+        // as sonnet-4). Spread order: modelDefaults first, then cleanEnv,
+        // so user-provided ANTHROPIC_DEFAULT_* values still win.
+        const sdkModelDefaults = resolveSdkModelDefaults()
+
         // Overlay profile-specific env vars (e.g. CLAUDE_CONFIG_DIR for multi-account)
-        const profileEnv = { ...cleanEnv, ...profile.env }
+        const profileEnv = { ...sdkModelDefaults, ...cleanEnv, ...profile.env }
 
         let systemContext = ""
         if (body.system) {
@@ -2448,6 +2457,8 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     if (!finalConfig.silent) {
       console.log(`Meridian running at http://${finalConfig.host}:${info.port}`)
       console.log(`Telemetry dashboard: http://${finalConfig.host}:${info.port}/telemetry`)
+      const pins = resolveSdkModelDefaults()
+      console.log(`Model pins: opus=${pins.ANTHROPIC_DEFAULT_OPUS_MODEL} sonnet=${pins.ANTHROPIC_DEFAULT_SONNET_MODEL} haiku=${pins.ANTHROPIC_DEFAULT_HAIKU_MODEL}`)
       console.log(`\nPoint any Anthropic-compatible tool at this endpoint:`)
       console.log(`  ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://${finalConfig.host}:${info.port}`)
     }


### PR DESCRIPTION
Main fix for #419.

## Summary

The deeper symptom in #419 — every requested model (opus-4-5 through opus-4-7) silently self-identifying as \`claude-sonnet-4-*\` — stems from stale SDK alias resolution.

\`mapModelToClaudeModel\` in \`src/proxy/models.ts\` collapses every requested model string into one of three aliases: \`sonnet\` / \`opus\` / \`haiku\`. These aliases are passed to the Claude Agent SDK, which resolves them to concrete versions via \`ANTHROPIC_DEFAULT_{TYPE}_MODEL\` env vars. When those env vars are unset, the SDK falls back to its own bundled defaults — which lag real Claude Max availability, so fresh installs route to outdated model pins.

@fbraza confirmed in #419 that setting these env vars by hand in \`.bashrc\` fixed the routing. This PR makes Meridian pin them automatically at the SDK subprocess boundary.

## Design

New \`resolveSdkModelDefaults()\` in \`models.ts\` emits canonical pins for all three aliases:

| Alias | Meridian-pinned default | Constant |
|---|---|---|
| opus | \`claude-opus-4-7\` | \`CANONICAL_OPUS_MODEL\` |
| sonnet | \`claude-sonnet-4-6\` | \`CANONICAL_SONNET_MODEL\` |
| haiku | \`claude-haiku-4-5\` | \`CANONICAL_HAIKU_MODEL\` |

\`server.ts\` spreads the defaults into \`profileEnv\` **before** the inherited \`cleanEnv\`:

\`\`\`ts
const profileEnv = { ...sdkModelDefaults, ...cleanEnv, ...profile.env }
\`\`\`

So the precedence is:
1. **Shell \`ANTHROPIC_DEFAULT_*_MODEL\`** (in \`cleanEnv\`) — always wins; power users can pin manually
2. **\`MERIDIAN_DEFAULT_*_MODEL\`** (proxy-side override) — wins over the canonical default
3. **Canonical pins** — Meridian's baked-in fallback

Also logs the active pins at startup so operators can verify without having to ask the model to self-identify:

\`\`\`
Model pins: opus=claude-opus-4-7 sonnet=claude-sonnet-4-6 haiku=claude-haiku-4-5
\`\`\`

## Scope note

This fix is **necessary but not sufficient** on setups using the bundled SDK cli.js (pre-0.2.117). That bundled cli.js is too old to recognize \`claude-opus-4-7\` regardless of env — it ignores the pin and falls through to its own hardcoded default. The full remedy requires upgrading the SDK to 0.2.117 and switching to the standalone \`@anthropic-ai/claude-code\` binary, which will land as a separate PR.

For all other setups (node-run Meridian using the system \`claude\` binary, which is usually current) this PR is the complete fix.

## Test plan

- [x] Unit tests in \`models.test.ts\` for \`resolveSdkModelDefaults\`:
  - Canonical pins returned when no overrides set
  - \`MERIDIAN_DEFAULT_{TYPE}_MODEL\` overrides win over canonicals
  - Returns only the three \`ANTHROPIC_DEFAULT_*\` keys
- [x] Integration tests in \`proxy-env-stripping.test.ts\` verifying \`capturedQueryOptions.env\`:
  - Canonical pins injected when no shell env set
  - Shell \`ANTHROPIC_DEFAULT_*_MODEL\` values win over Meridian's pins
  - \`MERIDIAN_DEFAULT_*_MODEL\` overrides canonical but not shell
- [x] \`bun test\` — **1444/1444 pass** (7 new)
- [x] **E2E:** launchd proxy respawned on this branch logs the pins correctly at startup:
  \`\`\`
  Model pins: opus=claude-opus-4-7 sonnet=claude-sonnet-4-6 haiku=claude-haiku-4-5
  \`\`\`
- [x] **E2E caveat:** Trevor's launchd runs under bun → uses the bundled cli.js (stale), so live self-identification for opus-4-7 still hits the stale-cli issue. Full self-identification verification blocked on SDK upgrade PR (PR C).

Supersedes fbraza's \`.bashrc\` workaround in #419. Preserves every escape hatch for users who want different pins.