### PR TITLE
ci: only publish when release-please cut a release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,7 +52,13 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ always() && (needs.release-please.outputs.release_created || inputs.publish_only) }}
+    # release-please's `releases_created` output is a STRING ("true"/"false"),
+    # so a bare truthy check fires on every push (even when no release was
+    # created) and ends in E403 trying to re-publish the existing version.
+    # Compare to the literal 'true' string to only publish when release-please
+    # actually cut a release. publish_only is a real boolean from
+    # workflow_dispatch input, so it can stay as-is.
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || inputs.publish_only == true) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Same fix as [meridian-plugin-opencode-scrub#4](https://github.com/rynfar/meridian-plugin-opencode-scrub/pull/4) and [meridian-plugin-pi-scrub#3](https://github.com/rynfar/meridian-plugin-pi-scrub/pull/3).

## Bug

\`releases_created\` is a STRING (\`"true"\`/\`"false"\`) emitted by release-please-action v4. The current guard:

\`\`\`yaml
if: \${{ always() && (needs.release-please.outputs.release_created || inputs.publish_only) }}
\`\`\`

bare-truthy-checks the string — and \`"false"\` is truthy. So every non-release push to main triggers the \`publish\` step, which 403s on npm trying to re-publish the existing version.

The actual release-merge runs succeed, so this has been hidden in the run history (every other run has been failing silently). \`gh run list --workflow=release-please.yml\` shows the pattern across multiple PR merges today.

## Fix

\`\`\`yaml
if: \${{ always() && (needs.release-please.outputs.release_created == 'true' || inputs.publish_only == true) }}
\`\`\`

\`publish_only\` is a real boolean from \`workflow_dispatch\` input — keeping the explicit \`== true\` for symmetry / clarity.

## Test plan

- One-line workflow change; nothing to unit-test.
- Already verified in the two plugin repos: the post-fix push runs show \`release-please\` succeeding (10s) and \`publish\` cleanly skipped — and the actual release-PR-merge still publishes successfully.