### PR TITLE
fix(detect): MERIDIAN_DEFAULT_AGENT wins over claude-cli/* UA tiebreaker

### DIFF
--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -5,7 +5,7 @@
  * Droid is identified by its User-Agent prefix.
  * Everything else defaults to OpenCode.
  */
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, afterEach } from "bun:test"
 import { detectAdapter } from "../proxy/adapters/detect"
 import { openCodeAdapter } from "../proxy/adapters/opencode"
 import { droidAdapter } from "../proxy/adapters/droid"
@@ -91,6 +91,64 @@ describe("detectAdapter — Claude Code detection", () => {
 
   it("returns claudeCodeAdapter for claude-cli with extra info", () => {
     const adapter = detectAdapter(makeContext("claude-cli/2.0.0 (linux; x64)"))
+    expect(adapter).toBe(claudeCodeAdapter)
+  })
+})
+
+describe("detectAdapter — claude-cli + MERIDIAN_DEFAULT_AGENT tiebreaker", () => {
+  // Pi (and downstream Pi-based harnesses like pylon) ship with a User-Agent
+  // of `claude-cli/<version>`. When the operator has explicitly set
+  // MERIDIAN_DEFAULT_AGENT, the env var should win for this ambiguous UA.
+  const originalEnv = process.env.MERIDIAN_DEFAULT_AGENT
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.MERIDIAN_DEFAULT_AGENT
+    else process.env.MERIDIAN_DEFAULT_AGENT = originalEnv
+  })
+
+  it("routes claude-cli/* to pi adapter when MERIDIAN_DEFAULT_AGENT=pi", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = "pi"
+    const adapter = detectAdapter(makeContext("claude-cli/2.0.0"))
+    expect(adapter).toBe(piAdapter)
+  })
+
+  it("is case-insensitive on the env value", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = "PI"
+    expect(detectAdapter(makeContext("claude-cli/2.0.0")).name).toBe("pi")
+  })
+
+  it("falls through to claudeCodeAdapter when env is unset", () => {
+    delete process.env.MERIDIAN_DEFAULT_AGENT
+    expect(detectAdapter(makeContext("claude-cli/2.0.0"))).toBe(claudeCodeAdapter)
+  })
+
+  it("falls through to claudeCodeAdapter when env is empty string", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = ""
+    expect(detectAdapter(makeContext("claude-cli/2.0.0"))).toBe(claudeCodeAdapter)
+  })
+
+  it("does NOT override when env is explicitly claude-code (no-op tiebreaker)", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = "claude-code"
+    expect(detectAdapter(makeContext("claude-cli/2.0.0"))).toBe(claudeCodeAdapter)
+    process.env.MERIDIAN_DEFAULT_AGENT = "claudecode"
+    expect(detectAdapter(makeContext("claude-cli/2.0.0"))).toBe(claudeCodeAdapter)
+  })
+
+  it("falls through to claudeCodeAdapter when env is an unknown adapter name", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = "nonsense-agent"
+    expect(detectAdapter(makeContext("claude-cli/2.0.0"))).toBe(claudeCodeAdapter)
+  })
+
+  it("does NOT affect other unambiguous UAs (opencode/ still wins over env=pi)", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = "pi"
+    expect(detectAdapter(makeContext("opencode/1.5.0"))).toBe(openCodeAdapter)
+    expect(detectAdapter(makeContext("factory-cli/0.89.0"))).toBe(droidAdapter)
+    expect(detectAdapter(makeContext("Charm-Crush/1.0.0"))).toBe(crushAdapter)
+  })
+
+  it("explicit x-meridian-agent header still wins over the env tiebreaker", () => {
+    process.env.MERIDIAN_DEFAULT_AGENT = "pi"
+    const adapter = detectAdapter(makeContext("claude-cli/2.0.0", { "x-meridian-agent": "claude-code" }))
     expect(adapter).toBe(claudeCodeAdapter)
   })
 })

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -87,10 +87,20 @@ export function detectAdapter(c: Context): AgentAdapter {
     return crushAdapter
   }
 
-  // Claude Code CLI — `claude-cli/<version>`. Pi mimics this User-Agent so
-  // Pi users must explicitly select via x-meridian-agent header or
-  // MERIDIAN_DEFAULT_AGENT env var (those are matched earlier).
+  // Claude Code CLI — `claude-cli/<version>`. Pi (and downstream Pi-based
+  // harnesses like pylon) mimic this User-Agent, so when the operator has
+  // declared a default via MERIDIAN_DEFAULT_AGENT we treat the env var as
+  // the tiebreaker for this ambiguous UA. Other unambiguous UAs
+  // (opencode/, factory-cli/, Charm-Crush/) still win over the env default
+  // — the env default only resolves the claude-cli collision. Without this,
+  // setting MERIDIAN_DEFAULT_AGENT=pi has no effect because the claude-cli
+  // matcher fires first for Pi traffic. (Read at call time, not module
+  // load, so tests can toggle the env between cases.)
   if (userAgent.startsWith("claude-cli/")) {
+    const claudeCliOverride = (process.env.MERIDIAN_DEFAULT_AGENT || "").toLowerCase()
+    if (claudeCliOverride && ADAPTER_MAP[claudeCliOverride] && claudeCliOverride !== "claude-code" && claudeCliOverride !== "claudecode") {
+      return ADAPTER_MAP[claudeCliOverride]!
+    }
     return claudeCodeAdapter
   }
 


### PR DESCRIPTION
Resolves a routing regression introduced in #426 / v1.38.0 (Claude Code adapter) and resurfaced when v1.39.0 made the model pin actually take effect.

## Bug

Pi ships with a User-Agent of `claude-cli/<version>`, which now collides with the Claude Code CLI matcher added in #426. The detect.ts comment claimed:

> Pi mimics this User-Agent so Pi users must explicitly select via x-meridian-agent header or MERIDIAN_DEFAULT_AGENT env var (those are matched earlier).

But `MERIDIAN_DEFAULT_AGENT` was **never** matched earlier — it's only consulted as the final fallback via `defaultAdapter`. So setting `MERIDIAN_DEFAULT_AGENT=pi` had no effect on Pi traffic; every request landed on the Claude Code adapter, where pi-scrub never ran, and Anthropic's billing layer flagged the un-scrubbed system prompt for Extra-Usage gating.

This is the routing regression @untitaker reported in #421.

## Fix

Treat `MERIDIAN_DEFAULT_AGENT` as the tiebreaker for this one ambiguous UA. Other unambiguous UAs (`opencode/`, `factory-cli/`, `Charm-Crush/`) still win over the env default — only the `claude-cli/` collision falls through to the env override. Env is read at call time (not module load) so tests can toggle it cleanly.

```ts
if (userAgent.startsWith("claude-cli/")) {
  const claudeCliOverride = (process.env.MERIDIAN_DEFAULT_AGENT || "").toLowerCase()
  if (claudeCliOverride && ADAPTER_MAP[claudeCliOverride] && claudeCliOverride !== "claude-code" && claudeCliOverride !== "claudecode") {
    return ADAPTER_MAP[claudeCliOverride]!
  }
  return claudeCodeAdapter
}
```

## Test plan

- [x] 7 new unit tests in `adapter-detection.test.ts` covering: env=pi → pi adapter, case-insensitivity, env unset / empty / unknown / explicitly `claude-code` → falls through to Claude Code, env doesn't affect other unambiguous UAs (`opencode/`, `factory-cli/`, `Charm-Crush/`), `x-meridian-agent` header still wins
- [x] `bun test` — all sub-suites pass locally
- [x] **Live verified** on a Pi-based harness against a launchd-respawned proxy: traffic was previously 400'ing with "out of extra usage" post-v1.39.0; with this patch it routes to `adapter=pi` (matching `MERIDIAN_DEFAULT_AGENT=pi`), pi-scrub runs, and traffic returns to working.

## Follow-up

Comment on #421 once this lands.