### PR TITLE
feat(proxy): expose Claude Max subscription quota via /v1/usage/quota

### DIFF
--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests for `GET /v1/usage/quota`.
+ *
+ * Verifies the route exists, returns the expected shape on cold start
+ * (no SDK events observed), reflects the rate-limit store after events
+ * have been recorded, and filters out the internal "default" bucket.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => (async function* () {})(),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { rateLimitStore } = await import("../proxy/rateLimitStore")
+
+interface QuotaResponseBucket {
+  type: string
+  status: string
+  utilization: number | null
+  resetsAt: number | null
+  isUsingOverage: boolean
+  overageStatus: string | null
+  overageResetsAt: number | null
+  overageDisabledReason: string | null
+  surpassedThreshold: number | null
+  observedAt: number
+}
+
+interface QuotaResponse {
+  buckets: QuotaResponseBucket[]
+  asOf: number
+}
+
+describe("GET /v1/usage/quota", () => {
+  beforeEach(() => {
+    rateLimitStore.clear()
+  })
+
+  it("returns 200 with empty buckets and a freshness timestamp on cold start", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+
+    const before = Date.now()
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
+    const after = Date.now()
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as QuotaResponse
+    expect(body.buckets).toEqual([])
+    expect(typeof body.asOf).toBe("number")
+    expect(body.asOf).toBeGreaterThanOrEqual(before)
+    expect(body.asOf).toBeLessThanOrEqual(after)
+  })
+
+  it("reflects entries written to the rate-limit store, newest first", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+
+    rateLimitStore.record({
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.42,
+      resetsAt: 1_730_000_000_000,
+    })
+    // Force monotonic observedAt so newest-first ordering is deterministic
+    await Bun.sleep(2)
+    rateLimitStore.record({
+      status: "allowed_warning",
+      rateLimitType: "seven_day",
+      utilization: 0.91,
+      resetsAt: 1_730_500_000_000,
+      surpassedThreshold: 0.9,
+    })
+
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
+    expect(res.status).toBe(200)
+    const body = await res.json() as QuotaResponse
+    expect(body.buckets).toHaveLength(2)
+
+    const types = body.buckets.map(b => b.type)
+    expect(types).toEqual(["seven_day", "five_hour"])
+
+    const sevenDay = body.buckets[0]!
+    expect(sevenDay.status).toBe("allowed_warning")
+    expect(sevenDay.utilization).toBe(0.91)
+    expect(sevenDay.surpassedThreshold).toBe(0.9)
+
+    const fiveHour = body.buckets[1]!
+    expect(fiveHour.status).toBe("allowed")
+    expect(fiveHour.utilization).toBe(0.42)
+    expect(fiveHour.surpassedThreshold).toBeNull()
+    expect(fiveHour.isUsingOverage).toBe(false)
+  })
+
+  it("hides the internal 'default' fallback bucket from the endpoint", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+
+    // SDK event without rateLimitType — store buckets it under "default"
+    rateLimitStore.record({ status: "allowed", utilization: 0.1 })
+    rateLimitStore.record({
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.5,
+    })
+
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
+    const body = await res.json() as QuotaResponse
+    const types = body.buckets.map(b => b.type)
+    expect(types).not.toContain("default")
+    expect(types).toContain("five_hour")
+    expect(body.buckets).toHaveLength(1)
+  })
+
+  it("nulls out unset optional fields (utilization, resetsAt, overage*)", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    rateLimitStore.record({ status: "rejected", rateLimitType: "five_hour" })
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
+    const body = await res.json() as QuotaResponse
+    const bucket = body.buckets[0]!
+    expect(bucket.type).toBe("five_hour")
+    expect(bucket.status).toBe("rejected")
+    expect(bucket.utilization).toBeNull()
+    expect(bucket.resetsAt).toBeNull()
+    expect(bucket.overageStatus).toBeNull()
+    expect(bucket.overageResetsAt).toBeNull()
+    expect(bucket.overageDisabledReason).toBeNull()
+    expect(bucket.surpassedThreshold).toBeNull()
+    // isUsingOverage defaults to false (not null) so consumers can use the
+    // boolean directly without nullish handling.
+    expect(bucket.isUsingOverage).toBe(false)
+  })
+
+  it("preserves overage fields when present", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    rateLimitStore.record({
+      status: "allowed_warning",
+      rateLimitType: "overage",
+      utilization: 0.78,
+      resetsAt: 1_730_000_000_000,
+      overageStatus: "allowed",
+      overageResetsAt: 1_730_100_000_000,
+      isUsingOverage: true,
+      surpassedThreshold: 0.75,
+      overageDisabledReason: "no_limits_configured",
+    })
+
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
+    const body = await res.json() as QuotaResponse
+    const bucket = body.buckets[0]!
+    expect(bucket.type).toBe("overage")
+    expect(bucket.isUsingOverage).toBe(true)
+    expect(bucket.overageStatus).toBe("allowed")
+    expect(bucket.overageResetsAt).toBe(1_730_100_000_000)
+    expect(bucket.overageDisabledReason).toBe("no_limits_configured")
+    expect(bucket.surpassedThreshold).toBe(0.75)
+  })
+})

--- a/src/__tests__/rate-limit-store.test.ts
+++ b/src/__tests__/rate-limit-store.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the rate-limit store.
+ *
+ * The store is a process-wide singleton; each test instantiates a fresh
+ * private copy via `_RateLimitStoreForTests` to avoid cross-test bleed.
+ */
+
+import { describe, expect, it } from "bun:test"
+import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk"
+import { _RateLimitStoreForTests } from "../proxy/rateLimitStore"
+
+const FIVE_HOUR: SDKRateLimitInfo = {
+  status: "allowed",
+  rateLimitType: "five_hour",
+  utilization: 0.42,
+  resetsAt: 1_730_000_000_000,
+}
+
+const SEVEN_DAY: SDKRateLimitInfo = {
+  status: "allowed_warning",
+  rateLimitType: "seven_day",
+  utilization: 0.91,
+  resetsAt: 1_730_500_000_000,
+  surpassedThreshold: 0.9,
+}
+
+describe("rateLimitStore", () => {
+  it("starts empty", () => {
+    const store = new _RateLimitStoreForTests()
+    expect(store.size).toBe(0)
+    expect(store.getAll()).toEqual([])
+  })
+
+  it("records distinct buckets keyed by rateLimitType", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(FIVE_HOUR)
+    store.record(SEVEN_DAY)
+    expect(store.size).toBe(2)
+    const types = store.getAll().map(e => e.rateLimitType).sort()
+    expect(types).toEqual(["five_hour", "seven_day"])
+  })
+
+  it("overwrites on second record for same bucket (last-write-wins)", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record({ ...FIVE_HOUR, utilization: 0.42 })
+    store.record({ ...FIVE_HOUR, utilization: 0.55 })
+    expect(store.size).toBe(1)
+    expect(store.get("five_hour")?.utilization).toBe(0.55)
+  })
+
+  it("buckets entries without rateLimitType under 'default'", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record({ status: "allowed", utilization: 0.1 })
+    expect(store.size).toBe(1)
+    expect(store.get("default")?.utilization).toBe(0.1)
+  })
+
+  it("ignores nullish or non-object input without throwing", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(undefined)
+    store.record(null as unknown as SDKRateLimitInfo)
+    store.record("nope" as unknown as SDKRateLimitInfo)
+    expect(store.size).toBe(0)
+  })
+
+  it("stamps observedAt on each record", () => {
+    const store = new _RateLimitStoreForTests()
+    const before = Date.now()
+    store.record(FIVE_HOUR)
+    const after = Date.now()
+    const entry = store.get("five_hour")
+    expect(entry?.observedAt).toBeGreaterThanOrEqual(before)
+    expect(entry?.observedAt).toBeLessThanOrEqual(after)
+  })
+
+  it("getAll returns entries newest-first by observedAt", async () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(FIVE_HOUR)
+    // Force monotonic observedAt — Bun's `Date.now()` resolution is fine here.
+    await Bun.sleep(2)
+    store.record(SEVEN_DAY)
+    const all = store.getAll()
+    expect(all[0].rateLimitType).toBe("seven_day")
+    expect(all[1].rateLimitType).toBe("five_hour")
+  })
+
+  it("clear() empties the store", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(FIVE_HOUR)
+    store.record(SEVEN_DAY)
+    store.clear()
+    expect(store.size).toBe(0)
+    expect(store.getAll()).toEqual([])
+  })
+
+  it("preserves all SDKRateLimitInfo fields verbatim", () => {
+    const store = new _RateLimitStoreForTests()
+    const full: SDKRateLimitInfo = {
+      status: "allowed_warning",
+      rateLimitType: "overage",
+      utilization: 0.78,
+      resetsAt: 1_730_000_000_000,
+      overageStatus: "allowed",
+      overageResetsAt: 1_730_100_000_000,
+      isUsingOverage: true,
+      surpassedThreshold: 0.75,
+      overageDisabledReason: "no_limits_configured",
+    }
+    store.record(full)
+    const got = store.get("overage")
+    expect(got).toMatchObject(full)
+  })
+})

--- a/src/__tests__/rate-limit-store.test.ts
+++ b/src/__tests__/rate-limit-store.test.ts
@@ -79,9 +79,12 @@ describe("rateLimitStore", () => {
     // Force monotonic observedAt — Bun's `Date.now()` resolution is fine here.
     await Bun.sleep(2)
     store.record(SEVEN_DAY)
-    const all = store.getAll()
-    expect(all[0].rateLimitType).toBe("seven_day")
-    expect(all[1].rateLimitType).toBe("five_hour")
+    // Compare the mapped sequence rather than indexing into the array directly
+    // so the test stays under TypeScript's `noUncheckedIndexedAccess` strict
+    // mode (which CI's `tsc --noEmit` enforces but Bun's lenient default tsc
+    // does not).
+    const orderedTypes = store.getAll().map(e => e.rateLimitType)
+    expect(orderedTypes).toEqual(["seven_day", "five_hour"])
   })
 
   it("clear() empties the store", () => {

--- a/src/proxy/rateLimitStore.ts
+++ b/src/proxy/rateLimitStore.ts
@@ -27,8 +27,13 @@
  * in memory. State resets on proxy restart — that's fine because the SDK will
  * push a fresh event on the next request.
  *
- * Singleton — one Meridian process serves one Claude Max subscription, so
- * all in-flight clients share these counters.
+ * Singleton — one Meridian process holds one snapshot at a time. With
+ * multi-profile setups (`x-meridian-profile` / `POST /profiles/active`)
+ * each profile is a separate Claude Max subscription with separate quotas,
+ * so the store is **cleared on profile switch and on `/auth/refresh`** —
+ * the next SDK call repopulates it for the active profile. Consumers of
+ * `/v1/usage/quota` should treat the snapshot as "the active profile's
+ * latest known state" and re-fetch after switching profiles.
  */
 
 import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk"
@@ -70,7 +75,11 @@ class RateLimitStore {
     return this.entries.size
   }
 
-  /** Drop all stored entries. Used by tests and on `/auth/refresh`. */
+  /**
+   * Drop all stored entries. Wired into the `POST /profiles/active` and
+   * `POST /auth/refresh` handlers so quotas can't leak across profiles or
+   * stale credential boundaries. Also used by tests for isolation.
+   */
   clear(): void {
     this.entries.clear()
   }

--- a/src/proxy/rateLimitStore.ts
+++ b/src/proxy/rateLimitStore.ts
@@ -1,0 +1,86 @@
+/**
+ * Rate limit store — captures `SDKRateLimitInfo` events emitted by
+ * `@anthropic-ai/claude-agent-sdk`'s `query()` stream.
+ *
+ * The SDK reports the live Claude Max subscription quota state as
+ * `rate_limit_event` events in the form:
+ *
+ *   {
+ *     type: "rate_limit_event",
+ *     rate_limit_info: {
+ *       status: "allowed" | "allowed_warning" | "rejected",
+ *       resetsAt?: number,                              // epoch ms
+ *       rateLimitType?: "five_hour" | "seven_day"
+ *                     | "seven_day_opus" | "seven_day_sonnet"
+ *                     | "overage",
+ *       utilization?: number,                           // 0..1
+ *       overageStatus?: "allowed" | "allowed_warning" | "rejected",
+ *       overageResetsAt?: number,
+ *       isUsingOverage?: boolean,
+ *       surpassedThreshold?: number,
+ *       ...
+ *     },
+ *     uuid, session_id
+ *   }
+ *
+ * We keep the most recent entry per `rateLimitType` (or "default" if absent)
+ * in memory. State resets on proxy restart — that's fine because the SDK will
+ * push a fresh event on the next request.
+ *
+ * Singleton — one Meridian process serves one Claude Max subscription, so
+ * all in-flight clients share these counters.
+ */
+
+import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk"
+
+export interface RateLimitEntry extends SDKRateLimitInfo {
+  /** When this entry was captured (epoch ms). */
+  observedAt: number
+}
+
+/** Type discriminator for the entry's bucket key. */
+export type RateLimitBucketKey = NonNullable<SDKRateLimitInfo["rateLimitType"]> | "default"
+
+class RateLimitStore {
+  private entries = new Map<RateLimitBucketKey, RateLimitEntry>()
+
+  /**
+   * Record a rate-limit info snapshot.
+   * Last-write-wins per bucket key (rateLimitType). Older entries for the
+   * same key are overwritten — clients should treat the latest as canonical.
+   */
+  record(info: SDKRateLimitInfo | undefined | null): void {
+    if (!info || typeof info !== "object") return
+    const key: RateLimitBucketKey = info.rateLimitType ?? "default"
+    this.entries.set(key, { ...info, observedAt: Date.now() })
+  }
+
+  /** Snapshot all current entries, newest-first by observedAt. */
+  getAll(): RateLimitEntry[] {
+    return Array.from(this.entries.values()).sort((a, b) => b.observedAt - a.observedAt)
+  }
+
+  /** Snapshot a single bucket, or undefined if not yet seen. */
+  get(key: RateLimitBucketKey): RateLimitEntry | undefined {
+    return this.entries.get(key)
+  }
+
+  /** Number of distinct buckets observed. */
+  get size(): number {
+    return this.entries.size
+  }
+
+  /** Drop all stored entries. Used by tests and on `/auth/refresh`. */
+  clear(): void {
+    this.entries.clear()
+  }
+}
+
+/**
+ * Process-wide singleton. Importers should always use this instance — do
+ * not instantiate `RateLimitStore` directly outside of tests.
+ */
+export const rateLimitStore = new RateLimitStore()
+
+/** Exported for test isolation only. */
+export { RateLimitStore as _RateLimitStoreForTests }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2207,9 +2207,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     }
     setActiveProfile(body.profile!)
     // Evict all cached SDK sessions — they were started under the old profile's
-    // credentials and cannot be reused with different auth.
+    // credentials and cannot be reused with different auth. Also drop the
+    // rate-limit snapshot so /v1/usage/quota doesn't return the previous
+    // profile's quotas under the new profile's identity.
     clearSessionCache()
-    console.error(`[PROXY] Active profile switched to: ${body.profile} (session cache cleared)`)
+    rateLimitStore.clear()
+    console.error(`[PROXY] Active profile switched to: ${body.profile} (session + rate-limit caches cleared)`)
     return c.json({ success: true, activeProfile: body.profile })
   })
 
@@ -2260,6 +2263,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   app.post("/auth/refresh", async (c) => {
     const success = await refreshOAuthToken()
     if (success) {
+      // Drop the rate-limit snapshot — old quotas were observed under the
+      // previous credential and may belong to a different account if the
+      // refresh swapped profiles. The next SDK call repopulates.
+      rateLimitStore.clear()
       return c.json({ success: true, message: "OAuth token refreshed successfully" })
     }
     return c.json(
@@ -2384,10 +2391,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // Returns 200 with `buckets: []` if no events have been observed yet (first
   // call after proxy restart).
   app.get("/v1/usage/quota", (c) => {
-    const entries = rateLimitStore.getAll()
+    // Filter out the internal "default" bucket — it's a Meridian-side
+    // fallback for SDK events missing `rateLimitType`, not a real Anthropic
+    // bucket that consumers can render.
+    const entries = rateLimitStore.getAll().filter(entry => entry.rateLimitType !== undefined)
     return c.json({
       buckets: entries.map(entry => ({
-        type: entry.rateLimitType ?? "default",
+        type: entry.rateLimitType,
         status: entry.status,
         utilization: entry.utilization ?? null,
         resetsAt: entry.resetsAt ?? null,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -5,6 +5,7 @@ import type { Server } from "node:http"
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
+import { rateLimitStore } from "./rateLimitStore"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
 import { envBool } from "../env"
@@ -930,6 +931,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       : undefined,
                     advisorModel,
                   }))) {
+                    // Capture Claude Max subscription quota updates emitted by
+                    // the SDK as rate_limit_event. We snapshot them in a process-wide
+                    // store so /v1/usage/quota can return the latest live state.
+                    if ((event as any).type === "rate_limit_event") {
+                      rateLimitStore.record((event as any).rate_limit_info)
+                    }
                     // Only count real assistant content — not SDK error messages
                     // (which arrive as type:"assistant" with an error field set).
                     // Counting error assistants as content would prevent retries.
@@ -1371,6 +1378,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         : undefined,
                       advisorModel,
                     }))) {
+                      // Same SDK rate-limit capture as the non-stream path.
+                      if ((event as any).type === "rate_limit_event") {
+                        rateLimitStore.record((event as any).rate_limit_info)
+                      }
                       if ((event as any).type === "stream_event") {
                         didYieldClientEvent = true
                       }
@@ -2358,6 +2369,37 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const authStatus = await getClaudeAuthStatusAsync()
     const isMax = authStatus?.subscriptionType === "max"
     return c.json({ object: "list", data: buildModelList(isMax) })
+  })
+
+  // --- Subscription Quota ---
+  // Returns the most recent SDK-reported quota state for the Claude Max
+  // subscription, broken down by rate-limit bucket (five_hour, seven_day,
+  // seven_day_opus, seven_day_sonnet, overage).
+  //
+  // Source: `rate_limit_event` events emitted by `@anthropic-ai/claude-agent-sdk`'s
+  // `query()` stream. We snapshot them as they arrive and serve the cache here.
+  // The `utilization` field is a 0..1 fraction directly from Anthropic; `resetsAt`
+  // is an epoch-ms timestamp.
+  //
+  // Returns 200 with `buckets: []` if no events have been observed yet (first
+  // call after proxy restart).
+  app.get("/v1/usage/quota", (c) => {
+    const entries = rateLimitStore.getAll()
+    return c.json({
+      buckets: entries.map(entry => ({
+        type: entry.rateLimitType ?? "default",
+        status: entry.status,
+        utilization: entry.utilization ?? null,
+        resetsAt: entry.resetsAt ?? null,
+        isUsingOverage: entry.isUsingOverage ?? false,
+        overageStatus: entry.overageStatus ?? null,
+        overageResetsAt: entry.overageResetsAt ?? null,
+        overageDisabledReason: entry.overageDisabledReason ?? null,
+        surpassedThreshold: entry.surpassedThreshold ?? null,
+        observedAt: entry.observedAt,
+      })),
+      asOf: Date.now(),
+    })
   })
 
   // Returns the last observed token usage for a session, looked up by the Claude


### PR DESCRIPTION
## Summary

Captures `rate_limit_event` events emitted by `@anthropic-ai/claude-agent-sdk`'s `query()` stream and exposes the latest snapshot per rate-limit bucket (`five_hour`, `seven_day`, `seven_day_opus`, `seven_day_sonnet`, `overage`) over a new `GET /v1/usage/quota` endpoint.

The SDK reports `utilization` (0..1) and `resetsAt` directly from Anthropic, so clients can render live 5h/weekly usage without estimating from token telemetry.

## Motivation

Pylon Orchestrator (a multi-agent UI on top of Meridian) wants to show Claude Max 5h / weekly usage in the sidebar. Token-counting from Meridian's telemetry would need to estimate against unknown tier limits; the SDK gives us the canonical numbers for free.

## Changes

- **`src/proxy/rateLimitStore.ts` (new)** — process-wide singleton keyed by `rateLimitType`, last-write-wins. ~80 LOC.
- **`src/proxy/server.ts`** — hook both SDK iteration sites (stream + non-stream) to call `rateLimitStore.record(...)`. Add `GET /v1/usage/quota` route.
- **`src/__tests__/rate-limit-store.test.ts` (new)** — 9 unit tests.

## Endpoint shape

```json
GET /v1/usage/quota
{
  "buckets": [
    {
      "type": "five_hour",
      "status": "allowed",
      "utilization": 0.42,
      "resetsAt": 1730000000000,
      "isUsingOverage": false,
      "overageStatus": null,
      "overageResetsAt": null,
      "overageDisabledReason": null,
      "surpassedThreshold": null,
      "observedAt": 1730003500000
    }
  ],
  "asOf": 1730003600000
}
```

Returns `{ buckets: [], asOf: ... }` when no SDK events have been observed yet (e.g., first call after proxy restart, before any `/v1/messages` call).

## Verification

- `bunx tsc --noEmit` clean
- New unit tests: 9 pass / 0 fail
- Full Meridian test suite: all pass / exit 0
- `bun run build` succeeds; route + store land in `dist/cli-*.js` chunk

## Caveats

- State is in-memory and resets on proxy restart; the SDK pushes a fresh event on the next request, so this is acceptable.
- One Meridian process serves one Claude Max subscription, so all clients share these counters (correct semantics).