### PR TITLE
fix(docker): install claude-code native binary in runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,15 @@ FROM oven/bun:1 AS build
 
 WORKDIR /app
 COPY package.json bun.lock* ./
+# --ignore-scripts: skip the package's postinstall (which runs
+# claude-code/install.cjs and downloads a platform-native binary). The
+# build stage runs on debian/glibc; the runtime stage runs on alpine/musl.
+# A binary downloaded for glibc cannot exec on musl (different dynamic
+# loader paths) — yields ENOENT despite the file being present. The
+# install is performed in the runtime stage instead so it matches the
+# runtime libc.
 RUN --mount=type=cache,target=/root/.bun \
-    bun install
+    bun install --ignore-scripts
 
 COPY tsconfig.json* ./
 COPY bin/ ./bin/
@@ -28,13 +35,19 @@ COPY --from=build --chown=claude:claude /app/node_modules ./node_modules
 COPY --from=build --chown=claude:claude /app/dist ./dist
 COPY --from=build --chown=claude:claude /app/package.json ./
 
-# Create a 'claude' wrapper that delegates to the SDK's cli.js.
-# This replaces the global @anthropic-ai/claude-code install which
-# ships a native binary that crashes under QEMU ARM emulation.
-# The SDK's cli.js supports all commands the proxy needs (auth status, etc.).
+# Run claude-code's install.cjs in the runtime stage so the native binary
+# matches the runtime libc (alpine/musl). The script is a no-op if the
+# binary at bin/claude.exe is already correct for this platform; on a
+# fresh build it replaces the 500-byte stub with the real binary.
+RUN node /app/node_modules/@anthropic-ai/claude-code/install.cjs
+
+# Make the installed binary visible on PATH as `claude` so PATH-based
+# lookups (e.g. `claude auth status`, the SDK's PATH-lookup fallback)
+# resolve to the same binary the SDK uses directly. Symlink rather than a
+# shell wrapper — the SDK's subprocess launcher rejects shell wrappers on
+# some code paths.
 RUN mkdir -p /app/bin/shims \
-    && printf '#!/bin/sh\nexec node /app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js "$@"\n' > /app/bin/shims/claude \
-    && chmod +x /app/bin/shims/claude
+    && ln -sf /app/node_modules/@anthropic-ai/claude-code/bin/claude.exe /app/bin/shims/claude
 ENV PATH="/app/bin/shims:$PATH"
 COPY --chown=claude:claude bin/docker-entrypoint.sh bin/claude-proxy-supervisor.sh ./bin/
 RUN chmod +x ./bin/docker-entrypoint.sh ./bin/claude-proxy-supervisor.sh


### PR DESCRIPTION
## Symptom

After deploying an image built from the upstream `Dockerfile` (any tag at SDK ≥ 0.2.117), `/health` reports `degraded` with `"Could not verify auth status"` and every `/v1/messages` request returns:

```json
{"type":"error","error":{"type":"api_error","message":"Claude Code native binary not found at /app/node_modules/@anthropic-ai/claude-code/bin/claude.exe. Please ensure Claude Code is installed via native installer or specify a valid path with options.pathToClaudeCodeExecutable."}}
```

The binary file *is* present (~245 MB), but exec returns ENOENT.

## Cause

The two Dockerfile stages use different libcs:

| Stage   | Image            | libc      | Loader                      |
|---------|------------------|-----------|-----------------------------|
| Build   | `oven/bun:1`     | glibc     | `/lib64/ld-linux-x86-64.so.2` |
| Runtime | `node:22-alpine` | musl      | `/lib/ld-musl-x86-64.so.1`    |

`bun install` in the build stage runs the `package.json` `postinstall`, which invokes `claude-code/install.cjs`. That script downloads the platform-native binary based on `process.platform` / `process.arch` — at this point we're in the **build** container, so it picks the **glibc** binary. `COPY --from=build node_modules` then carries the glibc-linked binary into the alpine runtime stage, where its dynamic loader doesn't exist. Exec returns ENOENT despite the file being present (a classic glibc-vs-musl symptom — the kernel's `ENOENT` on a missing interpreter is reported against the binary path, which is misleading).

`resolveClaudeExecutableAsync` prefers this binary, so every API request fails. The build-time shim at `/app/bin/shims/claude` is also stale — it `exec`s the legacy SDK `cli.js` path that hasn't shipped since SDK 0.2.98 — so the PATH-lookup fallback fails too.

This affects both `linux/amd64` and `linux/arm64` builds (the workflow targets both).

## Fix

1. **Skip the postinstall in the build stage.** Pass `--ignore-scripts` to `bun install` so we don't waste a build cycle downloading a binary for the wrong libc.
2. **Run `install.cjs` in the runtime stage** so the binary matches the runtime libc. `install.cjs` picks the artifact based on the *current* container's platform/libc, so this works correctly for both linux/amd64 and linux/arm64 builds (each runs with the matching alpine target).
3. **Replace the legacy shim with a symlink** to the freshly-installed binary. PATH-based `claude` lookups (e.g. `claude auth status`, the SDK's PATH-lookup fallback) now resolve to the same binary the SDK uses directly. Using a symlink rather than a shell wrapper because the SDK's subprocess launcher rejects shell wrappers on some code paths.

## Verification

Built `meridian-pr-test` from this branch on a Docker Desktop linux/amd64 host. Brought it up against an existing auth volume and ran the local test harness — all 9 cases pass (`opus`, `sonnet`, `haiku`, `thinking`, `effort-max`, `xhigh`, `dup-env`, `cc-remote-cwd`, `tool-camel`).

```
$ docker run --rm --entrypoint sh meridian-pr-test -c 'claude --version && readlink -f /app/bin/shims/claude'
2.1.119 (Claude Code)
/app/node_modules/@anthropic-ai/claude-code/bin/claude.exe
```

`/health` now returns `healthy` immediately on first boot — no entrypoint patch required.

## Side note: stale shim comment

The pre-fix shim block carried a comment that's no longer accurate post-SDK-0.2.98:

```
# Create a 'claude' wrapper that delegates to the SDK's cli.js.
# This replaces the global @anthropic-ai/claude-code install which
# ships a native binary that crashes under QEMU ARM emulation.
# The SDK's cli.js supports all commands the proxy needs (auth status, etc.).
```

The current architecture explicitly *relies* on the native binary (the SDK resolver's first-choice path), so the comment reflects an earlier design. If QEMU-ARM crashes on the native binary remain a concern, they would manifest at runtime, not at build time — `install.cjs` only writes the file, it doesn't exec it.