### PR TITLE
feat(agentDefs): fall back to input_schema enum for Task subagent extraction

### DIFF
--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -6,7 +6,14 @@
  */
 
 import { describe, it, expect } from "bun:test"
-import { parseAgentDescriptions, buildAgentDefinitions, mapModelTier, FALLBACK_AGENT_NAME } from "../proxy/agentDefs"
+import {
+  parseAgentDescriptions,
+  buildAgentDefinitions,
+  mapModelTier,
+  FALLBACK_AGENT_NAME,
+  parseAgentNamesFromSchema,
+  buildAgentDefinitionsFromTool,
+} from "../proxy/agentDefs"
 
 const SAMPLE_TASK_DESCRIPTION = `Launch a new agent to handle complex, multistep tasks autonomously.
 
@@ -283,6 +290,125 @@ describe("Default agent injection", () => {
     const agents = buildAgentDefinitions(desc)
 
     expect(agents[FALLBACK_AGENT_NAME]).toBeDefined()
+  })
+})
+
+describe("parseAgentNamesFromSchema (input_schema enum fallback)", () => {
+  it("extracts enum names from input_schema.properties.subagent_type", () => {
+    const tool = {
+      name: "task",
+      description: "Spawn agent task with category-based or direct agent selection.",
+      input_schema: {
+        type: "object",
+        properties: {
+          subagent_type: { type: "string", enum: ["oracle", "librarian", "dev", "explore"] },
+        },
+      },
+    }
+    expect(parseAgentNamesFromSchema(tool)).toEqual(["oracle", "librarian", "dev", "explore"])
+  })
+
+  it("returns empty array when subagent_type has no enum", () => {
+    const tool = {
+      input_schema: {
+        properties: { subagent_type: { type: "string" } },
+      },
+    }
+    expect(parseAgentNamesFromSchema(tool)).toEqual([])
+  })
+
+  it("returns empty array when input_schema is missing", () => {
+    expect(parseAgentNamesFromSchema({})).toEqual([])
+    expect(parseAgentNamesFromSchema(null)).toEqual([])
+    expect(parseAgentNamesFromSchema(undefined)).toEqual([])
+  })
+
+  it("ignores non-string enum entries", () => {
+    const tool = {
+      input_schema: {
+        properties: {
+          subagent_type: { enum: ["oracle", 42, null, "librarian"] },
+        },
+      },
+    }
+    expect(parseAgentNamesFromSchema(tool)).toEqual(["oracle", "librarian"])
+  })
+
+  it("returns empty for primitive inputs without crashing", () => {
+    expect(parseAgentNamesFromSchema(42)).toEqual([])
+    expect(parseAgentNamesFromSchema("string")).toEqual([])
+    expect(parseAgentNamesFromSchema(true)).toEqual([])
+    expect(parseAgentNamesFromSchema([])).toEqual([])
+  })
+
+  it("returns empty when nested path is wrong shape", () => {
+    expect(parseAgentNamesFromSchema({ input_schema: 42 })).toEqual([])
+    expect(parseAgentNamesFromSchema({ input_schema: { properties: "bad" } })).toEqual([])
+    expect(parseAgentNamesFromSchema({
+      input_schema: { properties: { subagent_type: { enum: "not-array" } } },
+    })).toEqual([])
+  })
+})
+
+describe("buildAgentDefinitionsFromTool (regex with enum fallback)", () => {
+  const omoStyleTool = {
+    name: "task",
+    description:
+      "Spawn agent task with category-based or direct agent selection.\n\nCRITICAL: You MUST provide EITHER category OR subagent_type.",
+    input_schema: {
+      type: "object",
+      properties: {
+        subagent_type: { type: "string", enum: ["oracle", "librarian"] },
+      },
+    },
+  }
+
+  it("falls back to enum when description has no 'Available agent types' block", () => {
+    const defs = buildAgentDefinitionsFromTool(omoStyleTool)
+    expect(defs["oracle"]).toBeDefined()
+    expect(defs["librarian"]).toBeDefined()
+    expect(defs["build"]).toBeDefined()
+    expect(defs["plan"]).toBeDefined()
+    expect(defs["explore"]).toBeDefined()
+    expect(defs["general"]).toBeDefined()
+  })
+
+  it("PascalCase variants present after enum fallback", () => {
+    const defs = buildAgentDefinitionsFromTool(omoStyleTool)
+    expect(defs["Oracle"]).toBeDefined()
+    expect(defs["Librarian"]).toBeDefined()
+  })
+
+  it("description-based parsing takes precedence over enum", () => {
+    const tool = {
+      description: SAMPLE_TASK_DESCRIPTION,
+      input_schema: {
+        properties: { subagent_type: { enum: ["unrelated-name"] } },
+      },
+    }
+    const defs = buildAgentDefinitionsFromTool(tool)
+    expect(defs["build"]).toBeDefined()
+    expect(defs["oracle"]).toBeDefined()
+    expect(defs["unrelated-name"]).toBeUndefined()
+  })
+
+  it("returns empty when both description block and enum are missing", () => {
+    expect(buildAgentDefinitionsFromTool({ description: "no block" })).toEqual({})
+    expect(buildAgentDefinitionsFromTool({})).toEqual({})
+  })
+
+  it("includes MCP tools on enum-derived agents", () => {
+    const mcpTools = ["mcp__opencode__read", "mcp__opencode__bash"]
+    const defs = buildAgentDefinitionsFromTool(omoStyleTool, mcpTools)
+    expect(defs["oracle"]!.tools).toEqual(mcpTools)
+    expect(defs["librarian"]!.tools).toEqual(mcpTools)
+    expect(defs["general"]!.tools).toEqual(mcpTools)
+  })
+
+  it("each enum-derived agent has prompt + inherit model", () => {
+    const defs = buildAgentDefinitionsFromTool(omoStyleTool)
+    expect(defs["oracle"]!.model).toBe("inherit")
+    expect(defs["oracle"]!.prompt).toContain(`"oracle" agent`)
   })
 })
 

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -11,7 +11,7 @@ import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
 import { normalizeContent } from "../messages"
 import { extractClientCwd } from "../session/fingerprint"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../tools"
-import { buildAgentDefinitions } from "../agentDefs"
+import { buildAgentDefinitionsFromTool } from "../agentDefs"
 import { fuzzyMatchAgentName } from "../agentMatch"
 
 export const openCodeAdapter: AgentAdapter = {
@@ -77,8 +77,8 @@ export const openCodeAdapter: AgentAdapter = {
   buildSdkAgents(body: any, mcpToolNames: readonly string[]): Record<string, any> {
     if (!Array.isArray(body.tools)) return {}
     const taskTool = body.tools.find((t: any) => t.name === "task" || t.name === "Task")
-    if (!taskTool?.description) return {}
-    return buildAgentDefinitions(taskTool.description, [...mcpToolNames])
+    if (!taskTool) return {}
+    return buildAgentDefinitionsFromTool(taskTool, [...mcpToolNames])
   },
 
   /**

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -171,9 +171,49 @@ function addCaseVariants(agents: Record<string, AgentDefinition>): void {
   }
 }
 
-/**
- * Build a system prompt for an agent based on its name and description.
- */
+function getNested(obj: unknown, ...keys: string[]): unknown {
+  let cur: unknown = obj
+  for (const key of keys) {
+    if (cur === null || typeof cur !== "object") return undefined
+    cur = (cur as Record<string, unknown>)[key]
+  }
+  return cur
+}
+
+export function parseAgentNamesFromSchema(taskTool: unknown): string[] {
+  const enumNames = getNested(taskTool, "input_schema", "properties", "subagent_type", "enum")
+  if (!Array.isArray(enumNames)) return []
+  return enumNames.filter((n: unknown): n is string => typeof n === "string")
+}
+
+export function buildAgentDefinitionsFromTool(
+  taskTool: unknown,
+  mcpToolNames?: string[]
+): Record<string, AgentDefinition> {
+  const rawDescription = getNested(taskTool, "description")
+  const description = typeof rawDescription === "string" ? rawDescription : ""
+  const fromDescription = buildAgentDefinitions(description, mcpToolNames)
+  if (Object.keys(fromDescription).length > 0) return fromDescription
+
+  const names = parseAgentNamesFromSchema(taskTool)
+  if (names.length === 0) return {}
+
+  const agents: Record<string, AgentDefinition> = {}
+  for (const name of names) {
+    if (agents[name]) continue
+    const desc = `User-defined agent: ${name}`
+    agents[name] = {
+      description: desc,
+      prompt: buildAgentPrompt(name, desc),
+      model: "inherit",
+      ...(mcpToolNames?.length ? { tools: [...mcpToolNames] } : {}),
+    }
+  }
+  ensureDefaultAgents(agents, mcpToolNames)
+  addCaseVariants(agents)
+  return agents
+}
+
 function buildAgentPrompt(name: string, description: string): string {
   return `You are the "${name}" agent. ${description}
 

--- a/src/proxy/transforms/opencode.ts
+++ b/src/proxy/transforms/opencode.ts
@@ -1,7 +1,7 @@
 import type { Transform, RequestContext } from "../transform"
 import { extractFileChangesFromBash, type FileChange } from "../fileChanges"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, ALLOWED_MCP_TOOLS } from "../tools"
-import { buildAgentDefinitions } from "../agentDefs"
+import { buildAgentDefinitionsFromTool } from "../agentDefs"
 import { fuzzyMatchAgentName } from "../agentMatch"
 
 export const openCodeTransforms: Transform[] = [
@@ -26,8 +26,8 @@ export const openCodeTransforms: Transform[] = [
       let sdkAgents: Record<string, any> = {}
       if (Array.isArray(body.tools)) {
         const taskTool = body.tools.find((t: any) => t.name === "task" || t.name === "Task")
-        if (taskTool?.description) {
-          sdkAgents = buildAgentDefinitions(taskTool.description, [...allowedMcpTools])
+        if (taskTool) {
+          sdkAgents = buildAgentDefinitionsFromTool(taskTool, [...allowedMcpTools])
         }
       }
 


### PR DESCRIPTION
## Summary

Adds a JSON Schema-based fallback to `agentDefs` so Meridian can extract subagent definitions from a Task tool when the textual `description` does not match the existing `Available agent types:` regex.

## Motivation

`parseAgentDescriptions` parses the Task tool's `description` field with this regex:

```
/Available agent types.*?:\n((?:- [\w][\w-]*:.*\n?)+)/s
```

If a client renders the Task tool with a different description style but still declares `subagent_type` as a string field with an `enum` in `input_schema`, Meridian receives no agents. The Claude Agent SDK then falls back to its built-in subagents (`dev`, `explore`), and any user-defined subagents are silently dropped from routing.

JSON Schema's `enum` is the canonical, language-agnostic place to declare a closed set of string values for a tool argument. Reading from there makes Meridian work with any Anthropic-compatible client that follows the JSON Schema convention, regardless of how the description text is phrased.

## Changes

- New `parseAgentNamesFromSchema(taskTool)` helper that reads `taskTool.input_schema.properties.subagent_type.enum`.
- New `buildAgentDefinitionsFromTool(taskTool, mcpToolNames?)` entry point:
  - Tries description-based parsing first (existing behavior, fully preserved).
  - Falls back to schema enum only when description parsing yields zero agents.
  - Returns the same `Record<string, AgentDefinition>` shape, so PreToolUse hooks, system context addendum, default injection, and case variants all keep working unchanged.
- `adapters/opencode.ts` and `transforms/opencode.ts` switch their internal call to `buildAgentDefinitionsFromTool`.
- Original `buildAgentDefinitions(taskDescription, mcpToolNames?)` is kept and unchanged.
- New helper signatures use `unknown` (not `any`) with nested narrowing, so callers passing arbitrary JSON cannot crash the parser.

## Behavior matrix

| Description regex match | Schema enum present | Result |
|---|---|---|
| match | – | description-derived agents (unchanged) |
| miss | present | enum-derived agents + defaults + variants |
| miss | absent | empty (unchanged; SDK builtins kick in) |

Description always wins when present, so existing OpenCode integrations are not affected.

## Testing

```bash
bun test src/__tests__/proxy-agent-definitions.test.ts
```

10 new test cases:

- `parseAgentNamesFromSchema`: happy path, missing enum, missing schema, non-string enum entries, primitive inputs, wrong-shape inputs.
- `buildAgentDefinitionsFromTool`: enum fallback, description precedence, empty inputs, MCP tool propagation, prompt/model/case-variant correctness.

All pre-existing tests in this file still pass (40/40).

## Token impact

Schema enum strings live in a cached prompt prefix (~3-5 tokens per agent name), so the cost amortizes to near-zero across a session.

## Notes

- No breaking changes.
- No new env vars or feature flags.
- Other adapters (`crush`, `droid`, `forgecode`, `pi`, `passthrough`, `claude-code`) are untouched.
