### PR TITLE
fix(agentDefs): clone definitions when registering case variants and aliases

### DIFF
--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -319,4 +319,18 @@ describe("Case variant registration", () => {
     const defs = buildAgentDefinitions("No agents here")
     expect(Object.keys(defs)).toHaveLength(0)
   })
+
+  it("PascalCase variant must not share mutable references with base", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION, ["mcp__opencode__read"])
+    expect(defs["Explore"]).not.toBe(defs["explore"])
+    defs["Explore"]!.tools!.push("mcp__opencode__poison")
+    expect(defs["explore"]!.tools).not.toContain("mcp__opencode__poison")
+  })
+
+  it("'general-purpose' alias must not share mutable references with target", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION, ["mcp__opencode__read"])
+    expect(defs["general-purpose"]).not.toBe(defs["general"])
+    defs["general-purpose"]!.tools!.push("mcp__opencode__poison")
+    expect(defs["general"]!.tools).not.toContain("mcp__opencode__poison")
+  })
 })

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -144,6 +144,14 @@ function ensureDefaultAgents(
  *
  * Also registers common Claude-invented names like "general-purpose".
  */
+function cloneAgentDefinition(def: AgentDefinition): AgentDefinition {
+  return {
+    ...def,
+    ...(def.tools ? { tools: [...def.tools] } : {}),
+    ...(def.disallowedTools ? { disallowedTools: [...def.disallowedTools] } : {}),
+  }
+}
+
 function addCaseVariants(agents: Record<string, AgentDefinition>): void {
   // Snapshot keys before mutating (avoids iterating newly-added entries)
   const baseNames = Object.keys(agents)
@@ -155,7 +163,7 @@ function addCaseVariants(agents: Record<string, AgentDefinition>): void {
       sep + ch.toUpperCase()
     )
     if (titleCase !== name && !agents[titleCase]) {
-      agents[titleCase] = def
+      agents[titleCase] = cloneAgentDefinition(def)
     }
   }
 
@@ -166,7 +174,7 @@ function addCaseVariants(agents: Record<string, AgentDefinition>): void {
   }
   for (const [alias, target] of Object.entries(ALIASES)) {
     if (!agents[alias] && agents[target]) {
-      agents[alias] = agents[target]!
+      agents[alias] = cloneAgentDefinition(agents[target]!)
     }
   }
 }


### PR DESCRIPTION
## Summary

`addCaseVariants` (in `src/proxy/agentDefs.ts`) registers PascalCase variants and the `general-purpose` / `General-Purpose` aliases by **assigning the source `AgentDefinition` by reference**. Mutating any of those entries (e.g. pushing onto `tools`) silently mutates the lowercase base, and vice versa.

## Reproducing

```ts
const defs = buildAgentDefinitions(SAMPLE_DESCRIPTION, ["mcp__opencode__read"])
defs["Explore"].tools.push("mcp__opencode__poison")
console.log(defs["explore"].tools)
// → ["mcp__opencode__read", "mcp__opencode__poison"]
```

Today no production code path mutates these values, so the bug is latent. But:

- The SDK or future consumers may legitimately tweak per-variant `tools`, `model`, `prompt`, or `disallowedTools`, and would corrupt the base unexpectedly.
- It is the kind of footgun that surfaces months later and is hard to reproduce.

## Change

- New tiny helper `cloneAgentDefinition(def)` — shallow clone with `tools` / `disallowedTools` arrays duplicated.
- Variants and aliases now use `cloneAgentDefinition(...)` instead of direct assignment.
- No behavior change for current call sites: shape and contents of returned record stay identical.

## Tests

Two regression tests in `proxy-agent-definitions.test.ts`:

1. `defs["Explore"].tools.push(...)` does not leak to `defs["explore"]`.
2. `defs["general-purpose"].tools.push(...)` does not leak to `defs["general"]`.

```bash
bun test src/__tests__/proxy-agent-definitions.test.ts
# 30 pass, 0 fail
```

## Notes

- No public API change.
- No new env vars or feature flags.
- Pure defensive fix.
