### PR TITLE
feat(proxy): Tool call and thinking support for OpenAI proxy

### DIFF
--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -9,6 +9,7 @@ import {
   translateOpenAiToAnthropic,
   translateAnthropicToOpenAi,
   translateAnthropicSseEvent,
+  createSseTranslator,
   buildModelList,
 } from "../proxy/openai"
 
@@ -58,7 +59,7 @@ describe("translateOpenAiToAnthropic", () => {
       messages: [{ role: "user", content: "Hello" }],
     })
     expect(result).not.toBeNull()
-    expect(result!.messages).toEqual([{ role: "user", content: "Hello" }])
+    expect(result!.messages).toEqual([{ role: "user", content: [{ type: "text", text: "Hello" }] }])
     expect(result!.system).toBeUndefined()
   })
 
@@ -70,7 +71,7 @@ describe("translateOpenAiToAnthropic", () => {
       ],
     })
     expect(result!.system).toBe("You are helpful.")
-    expect(result!.messages).toEqual([{ role: "user", content: "Hi" }])
+    expect(result!.messages).toEqual([{ role: "user", content: [{ type: "text", text: "Hi" }] }])
   })
 
   it("concatenates multiple system messages", () => {
@@ -93,7 +94,7 @@ describe("translateOpenAiToAnthropic", () => {
       ],
     })
     // Only the last message is sent
-    expect(result!.messages).toEqual([{ role: "user", content: "And 3+3?" }])
+    expect(result!.messages).toEqual([{ role: "user", content: [{ type: "text", text: "And 3+3?" }] }])
     // Prior turns packed into system
     expect(result!.system).toContain("<conversation_history>")
     expect(result!.system).toContain("user: What is 2+2?")
@@ -202,7 +203,7 @@ describe("translateOpenAiToAnthropic", () => {
     })
 
     expect(result!.system).toContain('user: look[Image attached]')
-    expect(result!.messages).toEqual([{ role: 'user', content: 'now answer' }])
+    expect(result!.messages).toEqual([{ role: 'user', content: [{ type: "text", text: "now answer" }] }])
   })
 
   it("handles structured text content in messages", () => {
@@ -212,7 +213,7 @@ describe("translateOpenAiToAnthropic", () => {
         content: [{ type: "text", text: "structured" }],
       }],
     })
-    expect(result!.messages[0]!.content).toBe("structured")
+    expect(result!.messages[0]!.content).toEqual([{ type: "text", text: "structured" }])
   })
 
   it("preserves data-url image blocks in the last user message", () => {
@@ -275,6 +276,406 @@ describe("translateOpenAiToAnthropic", () => {
     })
     expect(result!.stream).toBe(false)
   })
+
+  // --- tool role (tool result) ---
+
+  it("tool role message → user message with tool_result block", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "What is the weather?" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "get_weather", arguments: '{"city":"NYC"}' } }],
+        },
+        { role: "tool", tool_call_id: "tu_1", content: "Sunny, 72°F" },
+        { role: "user", content: "Thanks" },
+      ],
+    })
+    // With 4 turns, prior 3 are packed into system; only last user message is sent directly.
+    // The tool result turn should appear in the conversation_history block.
+    expect(result!.system).toContain("<conversation_history>")
+    expect(result!.system).toContain("Sunny, 72°F")
+  })
+
+  it("tool role message with tool_call_id maps to tool_use_id", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "call tool" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_abc", function: { name: "fn", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "tu_abc", content: "result" },
+        { role: "user", content: "ok" },
+      ],
+    })
+    // packed into history — verify it round-tripped without crashing
+    expect(result).not.toBeNull()
+  })
+
+  it("tool role message without tool_call_id uses empty string for tool_use_id", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "use tool" },
+        { role: "tool", content: "result" },
+        { role: "user", content: "done" },
+      ],
+    })
+    expect(result).not.toBeNull()
+  })
+
+  // --- assistant message with tool_calls ---
+
+  it("assistant message with tool_calls → tool_use blocks appended to content", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "search", arguments: '{"q":"bun"}' } }],
+        },
+        { role: "user", content: "ok" },
+      ],
+    })
+    // Prior assistant turn is packed into system history
+    expect(result!.system).toContain("search")
+    expect(result!.system).toContain('"q"')
+  })
+
+  it("assistant message with text + tool_call → both preserved", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "Let me look that up.",
+          tool_calls: [{ type: "function", id: "tu_2", function: { name: "lookup", arguments: '{"id":1}' } }],
+        },
+        { role: "user", content: "ok" },
+      ],
+    })
+    expect(result!.system).toContain("Let me look that up.")
+    expect(result!.system).toContain("lookup")
+  })
+
+  it("assistant message with multiple tool_calls → multiple tool_use blocks", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { type: "function", id: "tu_a", function: { name: "fn_a", arguments: '{}' } },
+            { type: "function", id: "tu_b", function: { name: "fn_b", arguments: '{"x":1}' } },
+          ],
+        },
+        { role: "user", content: "continue" },
+      ],
+    })
+    expect(result!.system).toContain("fn_a")
+    expect(result!.system).toContain("fn_b")
+  })
+
+  // --- <think> block extraction ---
+
+  it("assistant content starting with <think>...</think> is split into thinking + text blocks", () => {
+    // The implementation slices at endOfThink+9 to skip "</think>\n" (8 chars + assumed newline).
+    // Use a newline after the closing tag to match that convention.
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>internal reasoning</think>\nactual answer" },
+        { role: "user", content: "noted" },
+      ],
+    })
+    // packed into system history — both parts should appear
+    expect(result!.system).toContain("internal reasoning")
+    expect(result!.system).toContain("actual answer")
+  })
+
+  it("assistant content with only <think> and no trailing text produces just a thinking block", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>just thinking</think>" },
+        { role: "user", content: "ok" },
+      ],
+    })
+    expect(result!.system).toContain("just thinking")
+    expect(result).not.toBeNull()
+  })
+
+  // --- tool definitions (body.tools) ---
+
+  it("function tool definition → AnthropicTool in result", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Returns current weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      }],
+    })
+    expect(result).not.toBeNull()
+    expect(result!.tools).toHaveLength(1)
+    expect(result!.tools![0]!.name).toBe("get_weather")
+    expect(result!.tools![0]!.description).toBe("Returns current weather")
+    expect(result!.tools![0]!.input_schema).toEqual({ type: "object", properties: { city: { type: "string" } } })
+  })
+
+  it("multiple function tool definitions are all translated", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [
+        { type: "function", function: { name: "fn_a", description: "a", parameters: {} } },
+        { type: "function", function: { name: "fn_b", description: "b", parameters: {} } },
+      ],
+    })
+    expect(result!.tools).toHaveLength(2)
+    expect(result!.tools!.map(t => t.name)).toEqual(["fn_a", "fn_b"])
+  })
+
+  it("function tool with strict flag preserves it", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{ type: "function", function: { name: "fn", description: "d", parameters: {}, strict: true } }],
+    })
+    expect(result!.tools![0]!.strict).toBe(true)
+  })
+
+  it("custom tool type → returns null (unsupported)", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+      tools: [{ type: "custom" }],
+    })
+    expect(result).toBeNull()
+  })
+
+  it("no tools provided → tools array is empty", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "Hi" }],
+    })
+    expect(result!.tools).toEqual([])
+  })
+
+  // --- summarizeAnthropicContent: exact marker formats in packed history ---
+
+  it("packs assistant tool_use into <tool_call name=...> markers", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn_a", arguments: '{"x":1}' } }],
+        },
+        { role: "user", content: "ok" },
+      ],
+    })
+    expect(result!.system).toContain('<tool_call name="fn_a">')
+    expect(result!.system).toContain("</tool_call>")
+    expect(result!.system).toContain('{"x":1}')
+  })
+
+  it("packs tool role string content into <tool_result> markers", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "go" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "tu_1", content: "Sunny, 72F" },
+        { role: "user", content: "thanks" },
+      ],
+    })
+    expect(result!.system).toContain("<tool_result>")
+    expect(result!.system).toContain("Sunny, 72F")
+    expect(result!.system).toContain("</tool_result>")
+  })
+
+  it("packs <think> assistant content into <think>...</think> markers", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>reasoning here</think>\nanswer" },
+        { role: "user", content: "ok" },
+      ],
+    })
+    expect(result!.system).toContain("<think>")
+    expect(result!.system).toContain("reasoning here")
+    expect(result!.system).toContain("</think>")
+  })
+
+  // --- tool role with structured array content ---
+
+  it("tool role with array content: text parts wrapped in <tool_result> markers", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "user", content: "go" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn", arguments: "{}" } }],
+        },
+        {
+          role: "tool",
+          tool_call_id: "tu_1",
+          content: [
+            { type: "text", text: "first" },
+            { type: "text", text: "second" },
+          ],
+        },
+        { role: "user", content: "thanks" },
+      ],
+    })
+    expect(result!.system).toContain("first")
+    expect(result!.system).toContain("second")
+    // Each text part gets its own <tool_result> wrapper in current implementation
+    const matches = result!.system!.match(/<tool_result>/g) ?? []
+    expect(matches.length).toBeGreaterThanOrEqual(2)
+  })
+
+  // --- assistant single text block flattens to string ---
+
+  it("assistant single text block flattens to string in turns", () => {
+    // With exactly 2 turns, only the last is packed into history; the first
+    // assistant turn becomes the sole message sent. We can inspect it directly.
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "plain text answer" },
+      ],
+    })
+    expect(result!.messages).toHaveLength(1)
+    expect(result!.messages[0]!.role).toBe("assistant")
+    expect(result!.messages[0]!.content).toBe("plain text answer")
+  })
+
+  it("assistant content with tool_calls keeps array form (not flattened)", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "let me check",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn", arguments: "{}" } }],
+        },
+      ],
+    })
+    expect(result!.messages).toHaveLength(1)
+    expect(Array.isArray(result!.messages[0]!.content)).toBe(true)
+    const blocks = result!.messages[0]!.content as Array<{ type: string }>
+    expect(blocks.map(b => b.type)).toEqual(["text", "tool_use"])
+  })
+
+  // --- <think> parsing edge cases ---
+
+  it("<think> without trailing newline preserves first character of answer", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>r</think>answer" },
+      ],
+    })
+    expect(result!.messages).toHaveLength(1)
+    const blocks = result!.messages[0]!.content as Array<{ type: string; text?: string; thinking?: string }>
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]!.type).toBe("thinking")
+    expect(blocks[0]!.thinking).toBe("r")
+    expect(blocks[1]!.type).toBe("text")
+    expect(blocks[1]!.text).toBe("answer")
+  })
+
+  it("<think> with trailing newline strips exactly one newline", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>r</think>\nanswer" },
+      ],
+    })
+    const blocks = result!.messages[0]!.content as Array<{ type: string; text?: string }>
+    // The newline after </think> is consumed; "answer" remains intact
+    expect(blocks[1]!.text).toBe("answer")
+  })
+
+  it("<think> with two trailing newlines keeps the second one", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>r</think>\n\nanswer" },
+      ],
+    })
+    const blocks = result!.messages[0]!.content as Array<{ type: string; text?: string }>
+    expect(blocks[1]!.text).toBe("\nanswer")
+  })
+
+  it("<think> without closing tag is treated as plain text (no thinking block)", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "assistant", content: "<think>unfinished reasoning and more" },
+      ],
+    })
+    expect(result!.messages).toHaveLength(1)
+    // No closing </think> → fall through to plain-text branch and flatten
+    expect(result!.messages[0]!.content).toBe("<think>unfinished reasoning and more")
+  })
+
+  // --- malformed tool_calls JSON arguments ---
+
+  it("malformed tool_call arguments do not crash; raw string preserved under __raw", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn", arguments: "not json {" } }],
+        },
+      ],
+    })
+    expect(result).not.toBeNull()
+    const blocks = result!.messages[0]!.content as Array<{ type: string; input?: Record<string, unknown> }>
+    const toolUse = blocks.find(b => b.type === "tool_use")!
+    expect(toolUse.input).toEqual({ __raw: "not json {" })
+  })
+
+  it("non-object JSON tool_call arguments fall back to __raw", () => {
+    // JSON.parse("[1,2]") succeeds but is an array, not a Record
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn", arguments: "[1,2]" } }],
+        },
+      ],
+    })
+    const blocks = result!.messages[0]!.content as Array<{ type: string; input?: Record<string, unknown> }>
+    const toolUse = blocks.find(b => b.type === "tool_use")!
+    expect(toolUse.input).toEqual({ __raw: "[1,2]" })
+  })
+
+  it("valid JSON object tool_call arguments parse normally", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ type: "function", id: "tu_1", function: { name: "fn", arguments: '{"a":1}' } }],
+        },
+      ],
+    })
+    const blocks = result!.messages[0]!.content as Array<{ type: string; input?: Record<string, unknown> }>
+    const toolUse = blocks.find(b => b.type === "tool_use")!
+    expect(toolUse.input).toEqual({ a: 1 })
+  })
+
+  // --- missing tool description ---
+
+  it("function tool definition without description defaults to empty string", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "hi" }],
+      tools: [{ type: "function", function: { name: "fn", parameters: {} } }],
+    })
+    expect(result!.tools).toHaveLength(1)
+    expect(result!.tools![0]!.description).toBe("")
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -315,7 +716,7 @@ describe("translateAnthropicToOpenAi", () => {
     const result = translateAnthropicToOpenAi(
       {
         content: [
-          { type: "thinking", text: "let me think..." },
+          { type: "thinking", thinking: "let me think..." },
           { type: "text", text: "actual answer" },
         ],
         stop_reason: "end_turn",
@@ -330,7 +731,7 @@ describe("translateAnthropicToOpenAi", () => {
       { content: [], stop_reason: "end_turn" },
       ID, MODEL, CREATED
     )
-    expect(result.choices[0]!.message.content).toBe("")
+    expect(result.choices[0]!.message.content).toBeNull()
   })
 
   it("handles missing usage", () => {
@@ -342,6 +743,97 @@ describe("translateAnthropicToOpenAi", () => {
     expect(result.usage.completion_tokens).toBe(0)
     expect(result.usage.total_tokens).toBe(0)
   })
+
+  // --- tool_use blocks ---
+
+  it("tool_use block → tool_calls on message", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [{ type: "tool_use", id: "tu_1", name: "get_weather", input: { city: "NYC" } }],
+        stop_reason: "tool_use",
+      },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.finish_reason).toBe("tool_calls")
+    expect(result.choices[0]!.message.tool_calls).toHaveLength(1)
+    const call = result.choices[0]!.message.tool_calls![0]! as { type: string; id: string; function: { name: string; arguments: string } }
+    expect(call.type).toBe("function")
+    expect(call.id).toBe("tu_1")
+    expect(call.function.name).toBe("get_weather")
+    expect(JSON.parse(call.function.arguments)).toEqual({ city: "NYC" })
+  })
+
+  it("multiple tool_use blocks → multiple tool_calls", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [
+          { type: "tool_use", id: "tu_a", name: "fn_a", input: {} },
+          { type: "tool_use", id: "tu_b", name: "fn_b", input: { x: 1 } },
+        ],
+        stop_reason: "tool_use",
+      },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.message.tool_calls).toHaveLength(2)
+    const names = result.choices[0]!.message.tool_calls!.map(c => (c as { function: { name: string } }).function.name)
+    expect(names).toEqual(["fn_a", "fn_b"])
+  })
+
+  it("no tool_use blocks → tool_calls is undefined on message", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [{ type: "text", text: "hello" }], stop_reason: "end_turn" },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.message.tool_calls).toBeUndefined()
+  })
+
+  // --- thinking blocks ---
+
+  it("thinking block → reasoning_content on message", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [
+          { type: "thinking", thinking: "my reasoning" },
+          { type: "text", text: "the answer" },
+        ],
+        stop_reason: "end_turn",
+      },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.message.reasoning_content).toBe("my reasoning")
+    expect(result.choices[0]!.message.content).toBe("the answer")
+  })
+
+  it("multiple thinking blocks → concatenated reasoning_content", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [
+          { type: "thinking", thinking: "part 1" },
+          { type: "thinking", thinking: "part 2" },
+          { type: "text", text: "done" },
+        ],
+        stop_reason: "end_turn",
+      },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.message.reasoning_content).toBe("part 1part 2")
+  })
+
+  it("no thinking blocks → reasoning_content is undefined", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [{ type: "text", text: "hi" }], stop_reason: "end_turn" },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.message.reasoning_content).toBeUndefined()
+  })
+
+  it("tool_use stop_reason → tool_calls finish_reason", () => {
+    const result = translateAnthropicToOpenAi(
+      { content: [{ type: "tool_use", id: "x", name: "fn", input: {} }], stop_reason: "tool_use" },
+      ID, MODEL, CREATED
+    )
+    expect(result.choices[0]!.finish_reason).toBe("tool_calls")
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -352,9 +844,10 @@ describe("translateAnthropicSseEvent", () => {
   const ID = "chatcmpl-test"
   const MODEL = "claude-sonnet-4-6"
   const CREATED = 1234567890
+  const NO_TOOL = 0 // sentinel: no tool call in progress
 
   it("message_start → role announcement chunk", () => {
-    const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED)
+    const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED, NO_TOOL)
     expect(chunk).not.toBeNull()
     expect(chunk!.choices[0]!.delta.role).toBe("assistant")
     expect(chunk!.choices[0]!.delta.content).toBe("")
@@ -364,7 +857,7 @@ describe("translateAnthropicSseEvent", () => {
   it("content_block_delta text_delta → content chunk", () => {
     const chunk = translateAnthropicSseEvent(
       { type: "content_block_delta", delta: { type: "text_delta", text: "hello" } },
-      ID, MODEL, CREATED
+      ID, MODEL, CREATED, NO_TOOL
     )
     expect(chunk).not.toBeNull()
     expect(chunk!.choices[0]!.delta.content).toBe("hello")
@@ -374,7 +867,7 @@ describe("translateAnthropicSseEvent", () => {
   it("content_block_delta thinking_delta → null (skipped)", () => {
     const chunk = translateAnthropicSseEvent(
       { type: "content_block_delta", delta: { type: "thinking_delta", text: "thinking..." } },
-      ID, MODEL, CREATED
+      ID, MODEL, CREATED, NO_TOOL
     )
     expect(chunk).toBeNull()
   })
@@ -382,7 +875,7 @@ describe("translateAnthropicSseEvent", () => {
   it("message_delta end_turn → finish chunk with stop", () => {
     const chunk = translateAnthropicSseEvent(
       { type: "message_delta", delta: { stop_reason: "end_turn" } },
-      ID, MODEL, CREATED
+      ID, MODEL, CREATED, NO_TOOL
     )
     expect(chunk).not.toBeNull()
     expect(chunk!.choices[0]!.finish_reason).toBe("stop")
@@ -392,33 +885,269 @@ describe("translateAnthropicSseEvent", () => {
   it("message_delta max_tokens → finish chunk with length", () => {
     const chunk = translateAnthropicSseEvent(
       { type: "message_delta", delta: { stop_reason: "max_tokens" } },
-      ID, MODEL, CREATED
+      ID, MODEL, CREATED, NO_TOOL
     )
     expect(chunk!.choices[0]!.finish_reason).toBe("length")
   })
 
   it("ping → null", () => {
-    expect(translateAnthropicSseEvent({ type: "ping" }, ID, MODEL, CREATED)).toBeNull()
+    expect(translateAnthropicSseEvent({ type: "ping" }, ID, MODEL, CREATED, NO_TOOL)).toBeNull()
   })
 
-  it("content_block_start → null", () => {
-    expect(translateAnthropicSseEvent({ type: "content_block_start" }, ID, MODEL, CREATED)).toBeNull()
+  it("content_block_start (non-tool) → null", () => {
+    expect(translateAnthropicSseEvent({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" }
+    }, ID, MODEL, CREATED, NO_TOOL)).toBeNull()
   })
 
   it("content_block_stop → null", () => {
-    expect(translateAnthropicSseEvent({ type: "content_block_stop" }, ID, MODEL, CREATED)).toBeNull()
+    expect(translateAnthropicSseEvent({ type: "content_block_stop" }, ID, MODEL, CREATED, NO_TOOL)).toBeNull()
   })
 
   it("message_stop → null", () => {
-    expect(translateAnthropicSseEvent({ type: "message_stop" }, ID, MODEL, CREATED)).toBeNull()
+    expect(translateAnthropicSseEvent({ type: "message_stop" }, ID, MODEL, CREATED, NO_TOOL)).toBeNull()
   })
 
   it("chunk carries correct id, model, created, object", () => {
-    const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED)
+    const chunk = translateAnthropicSseEvent({ type: "message_start" }, ID, MODEL, CREATED, NO_TOOL)
     expect(chunk!.id).toBe(ID)
     expect(chunk!.model).toBe(MODEL)
     expect(chunk!.created).toBe(CREATED)
     expect(chunk!.object).toBe("chat.completion.chunk")
+  })
+
+  // --- new: tool call streaming ---
+
+  it("content_block_start with tool_use → tool call start chunk at index 0 (first tool)", () => {
+    const chunk = translateAnthropicSseEvent(
+      {
+        type: "content_block_start",
+        content_block: { type: "tool_use", id: "tu_abc", name: "get_weather", input: {} },
+      },
+      ID, MODEL, CREATED, NO_TOOL // tool_call_num=-1, so index emitted is 0
+    )
+    expect(chunk).not.toBeNull()
+    const toolCall = chunk!.choices[0]!.delta.tool_calls![0]!
+    expect(toolCall.type).toBe("function")
+    expect((toolCall as { index: number }).index).toBe(0)
+    expect((toolCall as { id: string }).id).toBe("tu_abc")
+    expect((toolCall as { function: { name: string } }).function.name).toBe("get_weather")
+    expect(chunk!.choices[0]!.finish_reason).toBeNull()
+  })
+
+  it("content_block_start with tool_use → second tool uses index 1", () => {
+    const chunk = translateAnthropicSseEvent(
+      {
+        type: "content_block_start",
+        content_block: { type: "tool_use", id: "tu_def", name: "read_file", input: {} },
+      },
+      ID, MODEL, CREATED, 1
+    )
+    const toolCall = chunk!.choices[0]!.delta.tool_calls![0]! as { index: number }
+    expect(toolCall.index).toBe(1)
+  })
+
+  it("content_block_delta input_json_delta → tool call arguments chunk", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "content_block_delta", delta: { type: "input_json_delta", partial_json: '{"city":' } },
+      ID, MODEL, CREATED, 0
+    )
+    expect(chunk).not.toBeNull()
+    const toolCall = chunk!.choices[0]!.delta.tool_calls![0]! as { index: number; function: { arguments: string } }
+    expect(toolCall.index).toBe(0)
+    expect(toolCall.function.arguments).toBe('{"city":')
+    expect(chunk!.choices[0]!.finish_reason).toBeNull()
+  })
+
+  it("content_block_delta thinking_delta → reasoning_content chunk", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "content_block_delta", delta: { type: "thinking_delta", thinking: "let me think" } },
+      ID, MODEL, CREATED, NO_TOOL
+    )
+    expect(chunk).not.toBeNull()
+    expect(chunk!.choices[0]!.delta.reasoning_content).toBe("let me think")
+    expect(chunk!.choices[0]!.delta.content).toBeUndefined()
+    expect(chunk!.choices[0]!.finish_reason).toBeNull()
+  })
+
+  it("message_delta tool_use stop_reason → tool_calls finish_reason", () => {
+    const chunk = translateAnthropicSseEvent(
+      { type: "message_delta", delta: { stop_reason: "tool_use" } },
+      ID, MODEL, CREATED, NO_TOOL
+    )
+    expect(chunk!.choices[0]!.finish_reason).toBe("tool_calls")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createSseTranslator (stateful wrapper around translateAnthropicSseEvent)
+// ---------------------------------------------------------------------------
+
+describe("createSseTranslator", () => {
+  const CTX = { completionId: "chatcmpl-x", model: "claude-sonnet-4-6", created: 1234567890 }
+
+  it("first tool_use start emits index 0", () => {
+    const translate = createSseTranslator(CTX)
+    const chunk = translate({
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "tool_use", id: "tu_1", name: "fn_a", input: {} },
+    })
+    expect(chunk).not.toBeNull()
+    const tc = chunk!.choices[0]!.delta.tool_calls![0]!
+    expect(tc.index).toBe(0)
+    expect(tc.id).toBe("tu_1")
+    expect(tc.function!.name).toBe("fn_a")
+    expect(tc.function!.arguments).toBe("")
+  })
+
+  it("sequential tool_use starts emit ascending indexes 0, 1, 2", () => {
+    const translate = createSseTranslator(CTX)
+    const indexes: number[] = []
+    for (const name of ["fn_a", "fn_b", "fn_c"]) {
+      const chunk = translate({
+        type: "content_block_start",
+        content_block: { type: "tool_use", id: `tu_${name}`, name, input: {} },
+      })
+      indexes.push(chunk!.choices[0]!.delta.tool_calls![0]!.index)
+    }
+    expect(indexes).toEqual([0, 1, 2])
+  })
+
+  it("input_json_delta after tool start carries the same index as the start chunk", () => {
+    const translate = createSseTranslator(CTX)
+
+    const start = translate({
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "tu_1", name: "fn", input: {} },
+    })
+    const arg = translate({
+      type: "content_block_delta",
+      delta: { type: "input_json_delta", partial_json: '{"x":1}' },
+    })
+
+    const startIdx = start!.choices[0]!.delta.tool_calls![0]!.index
+    const argIdx = arg!.choices[0]!.delta.tool_calls![0]!.index
+    expect(startIdx).toBe(argIdx)
+    expect(startIdx).toBe(0)
+  })
+
+  it("text content_block_start does not advance the counter", () => {
+    const translate = createSseTranslator(CTX)
+    // A text block starts the stream
+    translate({
+      type: "content_block_start",
+      content_block: { type: "text", text: "" },
+    })
+    // ...then a tool_use block starts — should still be index 0, not 1
+    const chunk = translate({
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "tu_1", name: "fn", input: {} },
+    })
+    expect(chunk!.choices[0]!.delta.tool_calls![0]!.index).toBe(0)
+  })
+
+  it("malformed tool_use start (missing name) does not advance the counter", () => {
+    const translate = createSseTranslator(CTX)
+    // Malformed event: tool_use type but no `name` — pure function returns null,
+    // factory must not advance index either, otherwise the next valid tool would
+    // emit index 1 instead of 0.
+    translate({
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "tu_bad", input: {} } as never,
+    })
+    const chunk = translate({
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "tu_1", name: "fn", input: {} },
+    })
+    expect(chunk!.choices[0]!.delta.tool_calls![0]!.index).toBe(0)
+  })
+
+  it("two translator instances have independent state", () => {
+    const a = createSseTranslator(CTX)
+    const b = createSseTranslator(CTX)
+
+    // Advance instance `a` by two tool starts
+    a({ type: "content_block_start", content_block: { type: "tool_use", id: "1", name: "x", input: {} } })
+    a({ type: "content_block_start", content_block: { type: "tool_use", id: "2", name: "y", input: {} } })
+
+    // Instance `b` is fresh — first tool must still be index 0
+    const chunk = b({
+      type: "content_block_start",
+      content_block: { type: "tool_use", id: "3", name: "z", input: {} },
+    })
+    expect(chunk!.choices[0]!.delta.tool_calls![0]!.index).toBe(0)
+  })
+
+  it("non-tool events round-trip through the translator unchanged", () => {
+    const translate = createSseTranslator(CTX)
+
+    // message_start → role announcement
+    const start = translate({ type: "message_start" })
+    expect(start!.choices[0]!.delta.role).toBe("assistant")
+
+    // text delta
+    const text = translate({
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: "hi" },
+    })
+    expect(text!.choices[0]!.delta.content).toBe("hi")
+
+    // thinking delta
+    const thinking = translate({
+      type: "content_block_delta",
+      delta: { type: "thinking_delta", thinking: "reasoning" },
+    })
+    expect(thinking!.choices[0]!.delta.reasoning_content).toBe("reasoning")
+
+    // finish
+    const finish = translate({ type: "message_delta", delta: { stop_reason: "end_turn" } })
+    expect(finish!.choices[0]!.finish_reason).toBe("stop")
+  })
+
+  it("uses ctx fields for completionId, model, created on every chunk", () => {
+    const translate = createSseTranslator({
+      completionId: "chatcmpl-custom",
+      model: "claude-haiku-4-5",
+      created: 999,
+    })
+    const chunk = translate({ type: "message_start" })
+    expect(chunk!.id).toBe("chatcmpl-custom")
+    expect(chunk!.model).toBe("claude-haiku-4-5")
+    expect(chunk!.created).toBe(999)
+  })
+
+  it("realistic stream: thinking → text → tool with args → finish, in correct order", () => {
+    const translate = createSseTranslator(CTX)
+    const events: { type: string; [k: string]: unknown }[] = [
+      { type: "message_start" },
+      { type: "content_block_start", content_block: { type: "thinking" } },
+      { type: "content_block_delta", delta: { type: "thinking_delta", thinking: "think..." } },
+      { type: "content_block_stop" },
+      { type: "content_block_start", content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", delta: { type: "text_delta", text: "answer" } },
+      { type: "content_block_stop" },
+      { type: "content_block_start", content_block: { type: "tool_use", id: "tu_1", name: "fn", input: {} } },
+      { type: "content_block_delta", delta: { type: "input_json_delta", partial_json: '{"a":1}' } },
+      { type: "content_block_stop" },
+      { type: "message_delta", delta: { stop_reason: "tool_use" } },
+      { type: "message_stop" },
+    ]
+    const chunks = events
+      .map(e => translate(e))
+      .filter((c): c is NonNullable<typeof c> => c !== null)
+
+    // Order check: role → reasoning → text → tool_start → tool_args → finish
+    expect(chunks[0]!.choices[0]!.delta.role).toBe("assistant")
+    expect(chunks[1]!.choices[0]!.delta.reasoning_content).toBe("think...")
+    expect(chunks[2]!.choices[0]!.delta.content).toBe("answer")
+    expect(chunks[3]!.choices[0]!.delta.tool_calls![0]!.id).toBe("tu_1")
+    expect(chunks[3]!.choices[0]!.delta.tool_calls![0]!.index).toBe(0)
+    expect(chunks[4]!.choices[0]!.delta.tool_calls![0]!.function!.arguments).toBe('{"a":1}')
+    expect(chunks[4]!.choices[0]!.delta.tool_calls![0]!.index).toBe(0)
+    expect(chunks[5]!.choices[0]!.finish_reason).toBe("tool_calls")
   })
 })
 

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -21,6 +21,8 @@ import {
   messageStop,
   assistantMessage,
   parseSSE,
+  toolUseBlockStart,
+  inputJsonDelta,
 } from "./helpers"
 
 let mockMessages: unknown[] = []
@@ -359,6 +361,129 @@ describe("POST /v1/chat/completions — streaming", () => {
     const uniqueIds = new Set(ids)
     expect(uniqueIds.size).toBe(1)
     expect([...uniqueIds][0]).toMatch(/^chatcmpl-/)
+  })
+
+  // --- tool_call_counter increment behavior ---
+
+  type DeltaToolCall = {
+    type?: string
+    index?: number
+    id?: string
+    function?: { name?: string; arguments?: string }
+  }
+  type StreamChunk = {
+    choices: Array<{
+      delta: { tool_calls?: DeltaToolCall[]; content?: string; reasoning_content?: string }
+      finish_reason: string | null
+    }>
+  }
+
+  function streamChunks(text: string): StreamChunk[] {
+    return text.split("\n")
+      .filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+      .map(l => JSON.parse(l.slice(6)) as StreamChunk)
+  }
+
+  it("single tool_use stream emits tool_call with index 0", async () => {
+    mockMessages = [
+      messageStart("msg_1"),
+      toolUseBlockStart(0, "get_weather", "tu_1"),
+      inputJsonDelta(0, '{"city":'),
+      inputJsonDelta(0, '"NYC"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "weather?" }],
+    })
+
+    const chunks = streamChunks(await readStream(res))
+    const toolCallChunks = chunks
+      .map(c => c.choices[0]!.delta.tool_calls)
+      .filter((tc): tc is DeltaToolCall[] => Array.isArray(tc) && tc.length > 0)
+
+    expect(toolCallChunks.length).toBeGreaterThan(0)
+    // Every emitted tool_call delta for a single tool must use index 0
+    for (const tc of toolCallChunks) {
+      expect(tc[0]!.index).toBe(0)
+    }
+
+    // Final chunk has tool_calls finish_reason
+    const finishChunk = chunks.find(c => c.choices[0]!.finish_reason !== null)
+    expect(finishChunk?.choices[0]!.finish_reason).toBe("tool_calls")
+  })
+
+  it("multiple sequential tool_use blocks emit ascending indexes 0, 1, 2", async () => {
+    mockMessages = [
+      messageStart("msg_1"),
+      toolUseBlockStart(0, "fn_a", "tu_a"),
+      inputJsonDelta(0, '{"x":1}'),
+      blockStop(0),
+      toolUseBlockStart(1, "fn_b", "tu_b"),
+      inputJsonDelta(1, '{"y":2}'),
+      blockStop(1),
+      toolUseBlockStart(2, "fn_c", "tu_c"),
+      inputJsonDelta(2, '{"z":3}'),
+      blockStop(2),
+      messageDelta("tool_use"),
+      messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "do all three" }],
+    })
+
+    const chunks = streamChunks(await readStream(res))
+
+    // Tool starts are the chunks that carry id + name; collect their indexes in order
+    const startIndexes = chunks
+      .map(c => c.choices[0]!.delta.tool_calls?.[0])
+      .filter((tc): tc is DeltaToolCall => !!tc && tc.type === "function" && typeof tc.id === "string")
+      .map(tc => tc.index)
+    expect(startIndexes).toEqual([0, 1, 2])
+
+    // Argument-delta chunks for each tool should carry the matching index
+    const argChunks = chunks
+      .map(c => c.choices[0]!.delta.tool_calls?.[0])
+      .filter((tc): tc is DeltaToolCall =>
+        !!tc && !tc.id && typeof tc.function?.arguments === "string"
+      )
+    expect(argChunks.map(a => a.index)).toEqual([0, 1, 2])
+    expect(argChunks.map(a => a.function!.arguments)).toEqual(['{"x":1}', '{"y":2}', '{"z":3}'])
+  })
+
+  it("text-then-tool stream: tool indexes start at 0 (not affected by preceding text block)", async () => {
+    // tool_call_counter only increments on tool_use blocks, so a text block
+    // before a tool_use should still result in index 0 for the first tool.
+    mockMessages = [
+      messageStart("msg_1"),
+      textBlockStart(0), textDelta(0, "let me check"),
+      blockStop(0),
+      toolUseBlockStart(1, "search", "tu_1"),
+      inputJsonDelta(1, '{"q":"x"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "go" }],
+    })
+
+    const chunks = streamChunks(await readStream(res))
+    const startIndex = chunks
+      .map(c => c.choices[0]!.delta.tool_calls?.[0])
+      .find((tc): tc is DeltaToolCall => !!tc && tc.type === "function" && typeof tc.id === "string")
+      ?.index
+    expect(startIndex).toBe(0)
   })
 })
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -498,13 +498,17 @@ function toFinishReason(stopReason: string | undefined): "stop" | "length" | "to
 
 /**
  * Translate a complete Anthropic /v1/messages response to OpenAI format.
- * Currently supports only text, thinking and function call blocks
+ * Currently supports only text, thinking and function call blocks.
+ *
+ * When `thinkingPassthrough` is false, thinking blocks are not
+ * mapped to `reasoning_content` (stripped from the response).
  */
 export function translateAnthropicToOpenAi(
   response: AnthropicResponse,
   completionId: string,
   model: string,
-  created: number
+  created: number,
+  options?: { thinkingPassthrough?: boolean },
 ): OpenAiCompletion {
   const contentBlocks = response.content ?? []
 
@@ -524,10 +528,13 @@ export function translateAnthropicToOpenAi(
         }
       }))
 
-  const thinking = contentBlocks
-    .filter(b => b.type === "thinking")
-    .map(b => (b as AnthropicThinkingBlock).thinking!)
-    .join("")
+  const thinkingPassthrough = options?.thinkingPassthrough
+  const thinking = thinkingPassthrough !== false
+    ? contentBlocks
+        .filter(b => b.type === "thinking")
+        .map(b => (b as AnthropicThinkingBlock).thinking!)
+        .join("")
+    : ""
 
   const promptTokens = response.usage?.input_tokens ?? 0
   const completionTokens = response.usage?.output_tokens ?? 0
@@ -590,6 +597,8 @@ export interface SseTranslatorContext {
   completionId: string
   model: string
   created: number
+  /** When false, thinking blocks are stripped from the response */
+  thinkingPassthrough?: boolean
 }
 
 /**
@@ -624,6 +633,7 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
       ctx.model,
       ctx.created,
       toolCallIndex,
+      ctx.thinkingPassthrough,
     )
   }
 }
@@ -637,13 +647,17 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
  * chunks. Callers tracking multiple tools per stream must increment it on
  * each `content_block_start` with `type: "tool_use"` *before* calling this
  * function. Use `createSseTranslator` to handle this automatically.
+ *
+ * When `thinkingPassthrough` is false, thinking_delta events are skipped
+ * so the client does not receive reasoning_content.
  */
 export function translateAnthropicSseEvent(
   event: AnthropicSseEvent,
   completionId: string,
   model: string,
   created: number,
-  toolCallNum: number
+  toolCallNum: number,
+  thinkingPassthrough?: boolean
 ): OpenAiStreamChunk | null {
   // Initial chunk: role announcement
   if (event.type === "message_start") {
@@ -729,21 +743,27 @@ export function translateAnthropicSseEvent(
   // Reasoning
   if (
     event.type === "content_block_delta" &&
-    event.delta?.type === "thinking_delta" &&
-    typeof event.delta?.thinking === "string"
+    event.delta?.type === "thinking_delta"
   ) {
-    return {
-      id: completionId,
-      object: "chat.completion.chunk",
-      created,
-      model,
-      choices: [{
-        index: 0,
-        delta: {
-          reasoning_content: event.delta?.thinking
-        },
-        finish_reason: null
-      }],
+    // Skip thinking content only when passthrough is explicitly disabled.
+    // Default (undefined or true) passes thinking through for backward compatibility.
+    if (thinkingPassthrough === false) {
+      return null
+    }
+    if (typeof event.delta?.thinking === "string") {
+      return {
+        id: completionId,
+        object: "chat.completion.chunk",
+        created,
+        model,
+        choices: [{
+          index: 0,
+          delta: {
+            reasoning_content: event.delta?.thinking
+          },
+          finish_reason: null
+        }],
+      }
     }
   }
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -20,7 +20,7 @@
 // Types
 // ---------------------------------------------------------------------------
 
-export type OpenAiRole = "system" | "user" | "assistant"
+export type OpenAiRole = "system" | "user" | "assistant" | "tool"
 
 export interface OpenAiTextPart {
   type: "text"
@@ -44,8 +44,26 @@ export interface OpenAiContentPart {
 
 export interface OpenAiMessage {
   role: OpenAiRole
+  tool_call_id?: string
   content: string | OpenAiContentPart[]
+  tool_calls?: OpenAiCompletionToolCall[]
 }
+
+export interface OpenAiChatToolFunction {
+  type: "function"
+  function: {
+    name: string
+    description?: string
+    parameters: unknown // Any JSON schema
+    strict?: boolean
+  }
+}
+
+export interface OpenAiChatToolCustom {
+  type: "custom"
+}
+
+export type OpenAiChatTool = OpenAiChatToolFunction | OpenAiChatToolCustom
 
 export interface OpenAiChatRequest {
   model?: string
@@ -55,6 +73,7 @@ export interface OpenAiChatRequest {
   max_completion_tokens?: number
   temperature?: number
   top_p?: number
+  tools?: OpenAiChatTool[]
 }
 
 export interface AnthropicTextBlock {
@@ -71,11 +90,16 @@ export interface AnthropicImageBlock {
   }
 }
 
-export type AnthropicInputContentBlock = AnthropicTextBlock | AnthropicImageBlock
-
 export interface AnthropicMessage {
   role: "user" | "assistant"
-  content: string | AnthropicInputContentBlock[]
+  content: string | AnthropicContentBlock[]
+}
+
+export interface AnthropicTool {
+  name: string
+  description: string
+  input_schema: unknown // Any JSON schema
+  strict?: boolean
 }
 
 export interface AnthropicRequestBody {
@@ -86,6 +110,7 @@ export interface AnthropicRequestBody {
   system?: string
   temperature?: number
   top_p?: number
+  tools?: AnthropicTool[]
 }
 
 export interface AnthropicUsage {
@@ -93,15 +118,60 @@ export interface AnthropicUsage {
   output_tokens?: number
 }
 
-export interface AnthropicContentBlock {
-  type: string
+export interface AnthropicContentBlockText {
+  type: "text"
   text?: string
 }
+
+export interface AnthropicToolUseBlock {
+  type: "tool_use"
+  id: string
+  name: string
+  input: Record<string, unknown>
+}
+
+export interface AnthropicToolResultBlock {
+  type: "tool_result"
+  tool_use_id: string
+  content: string | AnthropicContentBlock[]
+}
+
+export interface AnthropicThinkingBlock {
+  type: "thinking"
+  thinking: string
+}
+
+export type AnthropicContentBlock =
+  AnthropicTextBlock |
+  AnthropicImageBlock |
+  AnthropicThinkingBlock |
+  AnthropicToolResultBlock |
+  AnthropicToolUseBlock
 
 export interface AnthropicResponse {
   content?: AnthropicContentBlock[]
   stop_reason?: string
   usage?: AnthropicUsage
+}
+
+/**
+ * Streaming tool-call delta as emitted in chat.completion.chunk events.
+ *
+ * The OpenAI streaming protocol splits a single tool call across multiple
+ * chunks: a "start" chunk announces the call (id + function name), and
+ * subsequent "args" chunks append `function.arguments` fragments. `index`
+ * correlates fragments back to their parent call. Fields are optional rather
+ * than `DeepPartial<OpenAiCompletionToolCall>` so the type can't represent
+ * nonsense like `{ function: { arguments: undefined } }`.
+ */
+export interface OpenAiStreamingToolCallDelta {
+  index: number
+  type?: "function"
+  id?: string
+  function?: {
+    name?: string
+    arguments?: string
+  }
 }
 
 export interface OpenAiStreamChunk {
@@ -111,10 +181,33 @@ export interface OpenAiStreamChunk {
   model: string
   choices: Array<{
     index: 0
-    delta: { role?: "assistant"; content?: string }
-    finish_reason: "stop" | "length" | null
+    delta: {
+      role?: "assistant"
+      content?: string
+      tool_calls?: OpenAiStreamingToolCallDelta[]
+      reasoning_content?: string
+    }
+    finish_reason: "stop" | "length" | "tool_calls" | null
   }>
 }
+
+export interface OpenAiCompletionFunctionToolCall {
+  type: "function"
+  index?: number
+  id: string
+  function: {
+    name: string
+    arguments: string
+  }
+}
+
+export interface OpenAiCompletionCustomToolCall {
+  type: "custom"
+}
+
+export type OpenAiCompletionToolCall = 
+  OpenAiCompletionFunctionToolCall |
+  OpenAiCompletionCustomToolCall
 
 export interface OpenAiCompletion {
   id: string
@@ -123,8 +216,13 @@ export interface OpenAiCompletion {
   model: string
   choices: Array<{
     index: 0
-    message: { role: "assistant"; content: string }
-    finish_reason: "stop" | "length"
+    message: {
+      role: "assistant"
+      content: string | null
+      reasoning_content?: string
+      tool_calls?: OpenAiCompletionToolCall[]
+    }
+    finish_reason: "stop" | "length" | "tool_calls"
   }>
   usage: {
     prompt_tokens: number
@@ -180,10 +278,10 @@ function parseDataUrlImage(url: string): AnthropicImageBlock | null {
   }
 }
 
-function translateOpenAiContentToAnthropic(content: string | OpenAiContentPart[]): string | AnthropicInputContentBlock[] {
-  if (typeof content === "string") return content
+function translateOpenAiContentToAnthropic(content: string | OpenAiContentPart[]): AnthropicContentBlock[] {
+  if (typeof content === "string") return [{ type: "text", text: content }]
 
-  const parts: AnthropicInputContentBlock[] = []
+  const parts: AnthropicContentBlock[] = []
 
   for (const part of content) {
     if (part.type === "text" && typeof part.text === "string") {
@@ -204,18 +302,25 @@ function translateOpenAiContentToAnthropic(content: string | OpenAiContentPart[]
     }
   }
 
-  if (parts.length === 1 && parts[0]?.type === "text") {
-    return parts[0].text
-  }
-
   return parts
 }
 
-function summarizeAnthropicContent(content: string | AnthropicInputContentBlock[]): string {
+function summarizeAnthropicContent(content: string | AnthropicContentBlock[]): string {
   if (typeof content === "string") return content
   return content
     .map((part) => {
       if (part.type === "text") return part.text
+      if (part.type === "thinking") return "\n<think>\n" + part.thinking + "\n</think>\n"
+      if (part.type === "tool_use")
+        return "\n<tool_call name=\"" + part.name + "\">\n" + JSON.stringify(part.input) + "\n</tool_call>\n"
+      if (part.type === "tool_result") {
+        if (typeof part.content === "string")
+          return "\n<tool_result>\n" + part.content + "\n</tool_result>\n"
+        else
+          return part.content
+            .map(c => c.type === "text" ? `\n<tool_result>\n${c.text}\n</tool_result>\n` : "")
+            .join("")
+      }
       if (part.type === "image") return "[Image attached]"
       return ""
     })
@@ -240,16 +345,107 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
   // Separate system messages from conversation turns
   const systemParts: string[] = []
   const turns: AnthropicMessage[] = []
+  const tools: AnthropicTool[] = []
 
   for (const msg of messages) {
     const text = extractOpenAiContent(msg.content ?? "")
     if (msg.role === "system") {
       if (text) systemParts.push(text)
+    } else if (msg.role === "tool") {
+      turns.push({
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: msg.tool_call_id ?? "",
+          content: translateOpenAiContentToAnthropic(msg.content ?? "")
+        }]
+      })
+    } else if (msg.role === "assistant") {
+      const msgContent = translateOpenAiContentToAnthropic(msg.content ?? "")
+      const content: AnthropicContentBlock[] = []
+      const toolCalls = msg.tool_calls ?? null
+
+      const firstBlock = msgContent[0]
+      const endOfThink = firstBlock?.type === "text" && firstBlock.text.startsWith("<think>")
+        ? firstBlock.text.indexOf("</think>")
+        : -1
+      if (firstBlock?.type === "text" && firstBlock.text.startsWith("<think>") && endOfThink !== -1) {
+        // Extract <think>...</think> to thinking block. Skip a single optional
+        // trailing newline after </think> for readability, but tolerate its
+        // absence rather than dropping the first character of the answer.
+        const thinking = firstBlock.text.substring("<think>".length, endOfThink)
+        let textStart = endOfThink + "</think>".length
+        if (firstBlock.text[textStart] === "\n") textStart += 1
+        const text = firstBlock.text.substring(textStart)
+        content.push({ type: "thinking", thinking })
+        if (text.length) content.push({ type: "text", text })
+        // Append remaining blocks (e.g. images) untouched
+        if (msgContent.length > 1) content.push(...msgContent.slice(1))
+      } else {
+        // No <think> block, or malformed (no closing tag) — keep as plain text
+        content.push(...msgContent)
+      }
+      if (toolCalls) {
+        const calls: AnthropicContentBlock[] = toolCalls
+          .filter(call => call.type === "function")
+          .map(call => {
+            // OpenAI clients sometimes resend partial/streamed tool-call
+            // arguments. Don't crash the request on malformed JSON — surface
+            // the original string under __raw so the model can still see it.
+            let input: Record<string, unknown>
+            try {
+              const parsed = JSON.parse(call.function.arguments) as unknown
+              input = (parsed && typeof parsed === "object" && !Array.isArray(parsed))
+                ? parsed as Record<string, unknown>
+                : { __raw: call.function.arguments }
+            } catch {
+              input = { __raw: call.function.arguments }
+            }
+            return {
+              type: "tool_use",
+              id: call.id,
+              name: call.function.name,
+              input,
+            }
+          })
+        content.push(...calls)
+      }
+
+      // Flatten content to single string if only one text block
+      let finalContent: string | AnthropicContentBlock[] = content
+      if (content.length === 1 && content[0]?.type === "text") {
+        finalContent = content[0].text
+      }
+
+      turns.push({
+        role: "assistant",
+        content: finalContent
+      })
     } else {
       turns.push({
-        role: msg.role === "assistant" ? "assistant" : "user",
+        role: "user",
         content: translateOpenAiContentToAnthropic(msg.content ?? ""),
       })
+    }
+  }
+
+  const reqTools = body.tools ?? []
+
+  // Convert OpenAI tool definitions to Anthropic format
+  for (const reqTool of reqTools) {
+    if (reqTool.type === "function") {
+      const tool = reqTool.function
+      tools.push({
+        name: tool.name,
+        // OpenAI's function.description is optional; default to empty string
+        // so AnthropicTool.description stays a non-undefined value.
+        description: tool.description ?? "",
+        input_schema: tool.parameters,
+        strict: tool.strict
+      })
+    } else {
+      // Other tool types than "function" not supported for now
+      return null
     }
   }
 
@@ -276,6 +472,7 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
     model: body.model ?? "claude-sonnet-4-6",
     messages: messagesToSend,
     max_tokens: body.max_tokens ?? body.max_completion_tokens ?? 8192,
+    tools: tools,
     stream: body.stream ?? false,
   }
 
@@ -293,14 +490,15 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
 /**
  * Map an Anthropic stop_reason to an OpenAI finish_reason.
  */
-function toFinishReason(stopReason: string | undefined): "stop" | "length" {
+function toFinishReason(stopReason: string | undefined): "stop" | "length" | "tool_calls" {
   if (stopReason === "max_tokens") return "length"
+  else if (stopReason === "tool_use") return "tool_calls"
   return "stop"
 }
 
 /**
  * Translate a complete Anthropic /v1/messages response to OpenAI format.
- * Thinking blocks are filtered out — only text blocks are included.
+ * Currently supports only text, thinking and function call blocks
  */
 export function translateAnthropicToOpenAi(
   response: AnthropicResponse,
@@ -308,9 +506,27 @@ export function translateAnthropicToOpenAi(
   model: string,
   created: number
 ): OpenAiCompletion {
-  const content = (response.content ?? [])
+  const contentBlocks = response.content ?? []
+
+  const content = contentBlocks
     .filter(b => b.type === "text" && typeof b.text === "string")
-    .map(b => b.text!)
+    .map(b  => (b as AnthropicContentBlockText).text!)
+    .join("")
+
+  const toolCalls: OpenAiCompletionToolCall[] = contentBlocks
+    .filter(b => b.type === "tool_use")
+    .map(b => ({
+        type: "function",
+        id: b.id,
+        function: {
+          name: b.name,
+          arguments: JSON.stringify(b.input)
+        }
+      }))
+
+  const thinking = contentBlocks
+    .filter(b => b.type === "thinking")
+    .map(b => (b as AnthropicThinkingBlock).thinking!)
     .join("")
 
   const promptTokens = response.usage?.input_tokens ?? 0
@@ -323,7 +539,12 @@ export function translateAnthropicToOpenAi(
     model,
     choices: [{
       index: 0,
-      message: { role: "assistant", content },
+      message: {
+        role: "assistant",
+        content: content || null,
+        reasoning_content: thinking.length ? thinking : undefined,
+        tool_calls: toolCalls.length ? toolCalls : undefined
+      },
       finish_reason: toFinishReason(response.stop_reason),
     }],
     usage: {
@@ -338,21 +559,91 @@ export function translateAnthropicToOpenAi(
 // Stream translation: Anthropic SSE event → OpenAI SSE chunk
 // ---------------------------------------------------------------------------
 
-interface AnthropicSseEvent {
+/**
+ * Wire-format SSE event from Anthropic's `/v1/messages` streaming API.
+ *
+ * `content_block` may describe a text block, a tool_use block, or a thinking
+ * block depending on the stream position — only `type` is guaranteed.
+ */
+export interface AnthropicSseEvent {
   type: string
-  delta?: { type?: string; text?: string; stop_reason?: string }
+  index?: number
+  delta?: {
+    type?: string
+    text?: string
+    stop_reason?: string
+    partial_json?: string
+    thinking?: string
+  }
+  content_block?:
+    | { type: "text"; text?: string }
+    | { type: "thinking"; thinking?: string }
+    | AnthropicToolUseBlock
   message?: { id?: string }
+}
+
+export interface SseTranslator {
+  (event: AnthropicSseEvent): OpenAiStreamChunk | null
+}
+
+export interface SseTranslatorContext {
+  completionId: string
+  model: string
+  created: number
+}
+
+/**
+ * A stateful translator for one OpenAI streaming response.
+ *
+ * Each completion stream gets its own translator instance to keep state out
+ * of server.ts. Internally tracks the current tool-call index so that
+ * `content_block_start` (tool_use) events are emitted as OpenAI tool_call
+ * deltas with monotonically increasing `index` values, matching how
+ * `function.arguments` fragments must correlate back to their parent call.
+ *
+ * Anthropic's wire format signals start/end of each content block; OpenAI's
+ * does not, so we manufacture an index per stream.
+ */
+export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
+  let toolCallIndex = -1 // -1 means "no tools used yet", becomes 0 on first block
+  return (event) => {
+    // Increment must use the same condition the pure translator uses to
+    // decide a tool-start chunk gets emitted, otherwise indexes drift if a
+    // malformed event is skipped.
+    if (
+      event.type === "content_block_start" &&
+      event.content_block?.type === "tool_use" &&
+      typeof event.content_block.name === "string"
+    ) {
+      toolCallIndex++
+    }
+
+    return translateAnthropicSseEvent(
+      event,
+      ctx.completionId,
+      ctx.model,
+      ctx.created,
+      toolCallIndex,
+    )
+  }
 }
 
 /**
  * Translate one parsed Anthropic SSE event into an OpenAI stream chunk.
- * Returns null for events that should be skipped (pings, block starts, etc).
+ * Returns null for events that should be skipped (pings, message_stop,
+ * content_block_stop, text-block content_block_start, etc).
+ *
+ * `toolCallNum` is the OpenAI `tool_calls[].index` value to emit on tool-call
+ * chunks. Callers tracking multiple tools per stream must increment it on
+ * each `content_block_start` with `type: "tool_use"` *before* calling this
+ * function. Use `createSseTranslator` to handle this automatically.
  */
 export function translateAnthropicSseEvent(
   event: AnthropicSseEvent,
   completionId: string,
   model: string,
-  created: number
+  created: number,
+  toolCallNum: number
 ): OpenAiStreamChunk | null {
   // Initial chunk: role announcement
   if (event.type === "message_start") {
@@ -377,6 +668,82 @@ export function translateAnthropicSseEvent(
       created,
       model,
       choices: [{ index: 0, delta: { content: event.delta.text }, finish_reason: null }],
+    }
+  }
+
+  // Tool call start
+  if (
+    event.type === "content_block_start" &&
+    event.content_block?.type === "tool_use" &&
+    typeof event.content_block?.name === "string"
+  ) {
+    return {
+      id: completionId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            type: "function",
+            index: toolCallNum,
+            id: event.content_block?.id,
+            function: {
+              name: event.content_block.name,
+              arguments: ""
+            }
+          }]
+        },
+        finish_reason: null
+      }],
+    }
+  }
+
+  // Tool call input
+  if (
+    event.type === "content_block_delta" &&
+    event.delta?.type === "input_json_delta" &&
+    typeof event.delta?.partial_json === "string"
+  ) {
+    return {
+      id: completionId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{
+        index: 0,
+        delta: {
+          tool_calls: [{
+            index: toolCallNum,
+            function: {
+              arguments: event.delta.partial_json
+            }
+          }]
+        },
+        finish_reason: null
+      }],
+    }
+  }
+
+  // Reasoning
+  if (
+    event.type === "content_block_delta" &&
+    event.delta?.type === "thinking_delta" &&
+    typeof event.delta?.thinking === "string"
+  ) {
+    return {
+      id: completionId,
+      object: "chat.completion.chunk",
+      created,
+      model,
+      choices: [{
+        index: 0,
+        delta: {
+          reasoning_content: event.delta?.thinking
+        },
+        finish_reason: null
+      }],
     }
   }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -45,7 +45,8 @@ import { classifyError, isStaleSessionError, isRateLimitError, isExtraUsageRequi
 import { refreshOAuthToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
-import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, translateAnthropicSseEvent, buildModelList } from "./openai"
+import type { AnthropicSseEvent } from "./openai"
+import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
@@ -2328,6 +2329,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let buffer = ""
         let streamError: Error | null = null
 
+        const translate = createSseTranslator({ completionId, model, created })
+
         try {
           while (true) {
             const { done, value } = await reader.read()
@@ -2347,7 +2350,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               catch { continue }
               if (typeof event.type !== "string") continue
 
-              const chunk = translateAnthropicSseEvent(event as { type: string } & Record<string, unknown>, completionId, model, created)
+              const chunk = translate(event as unknown as AnthropicSseEvent)
               if (chunk) controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
             }
           }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2313,9 +2313,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const created = Math.floor(Date.now() / 1000)
     const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : "claude-sonnet-4-6"
 
+    // Resolve SDK features for this request (thinking passthrough setting)
+    const { getFeaturesForAdapter } = require("./sdkFeatures") as typeof import("./sdkFeatures")
+    const adapter = detectAdapter(c)
+    const sdkFeatures = getFeaturesForAdapter(adapter.name)
+
     if (!anthropicBody.stream) {
       const anthropicRes = await internalRes.json() as Record<string, unknown>
-      return c.json(translateAnthropicToOpenAi(anthropicRes, completionId, model, created))
+      return c.json(translateAnthropicToOpenAi(anthropicRes, completionId, model, created, {
+        thinkingPassthrough: sdkFeatures.thinkingPassthrough
+      }))
     }
 
     // Streaming: translate Anthropic SSE events to OpenAI SSE chunks
@@ -2329,7 +2336,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let buffer = ""
         let streamError: Error | null = null
 
-        const translate = createSseTranslator({ completionId, model, created })
+        const translate = createSseTranslator({ completionId, model, created, thinkingPassthrough: sdkFeatures.thinkingPassthrough })
 
         try {
           while (true) {


### PR DESCRIPTION
## Summary

Adds support for tool calling via OpenAI request translator, both non-streaming and streaming. Allowing for use cases like agentic web search in Open WebUI.

`/v1/chat/completions` endpoint gained support for `tools` field with `type: "function"`, `role: "tool"` messages and `tool_calls` field in assistant's message. Likewise, response `thinking`, and `tool_use` blocks are now translated to OpenAI responses.

Conversation history is still summarized into system prompt, I didn't change anything there besides adding new block types. Current way it's done invalidates any prompt caching and has side effects on model's responses. I think proper way would be to get rid of this "summarizing" and maintain a claude code session if prefix matches (if I understand the issue from code comment correctly, correct me if I'm wrong), but that's out of scope, my goal was making it work at all. I think I can start working on that if this gets approved.

## Demo
[Nagranie ekranu_20260429_170317.webm](https://github.com/user-attachments/assets/619d6fbf-ddce-457d-95cd-07999010461a)

