### PR TITLE
feat(proxy): SDK termination diagnostics + max_turns recovery

### DIFF
--- a/src/__tests__/deferred-tool-loading.test.ts
+++ b/src/__tests__/deferred-tool-loading.test.ts
@@ -258,7 +258,7 @@ describe("auto-defer — threshold-based deferral via HTTP", () => {
     expect(capturedQueryParams.options.maxTurns).toBe(3)
   })
 
-  it("sets maxTurns to 2 when no deferred tools", async () => {
+  it("sets maxTurns to 3 when no deferred tools (passthrough base budget)", async () => {
     mockMessages = [assistantMessage([{ type: "text", text: "Hello" }])]
 
     await app().fetch(new Request("http://localhost/v1/messages", {
@@ -271,7 +271,7 @@ describe("auto-defer — threshold-based deferral via HTTP", () => {
       })),
     }))
 
-    expect(capturedQueryParams.options.maxTurns).toBe(2)
+    expect(capturedQueryParams.options.maxTurns).toBe(3)
   })
 
   it("disables auto-defer when threshold is 0", async () => {

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, isStaleSessionError, isExtraUsageRequiredError } from "../proxy/errors"
+import { classifyError, isStaleSessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -220,5 +220,175 @@ describe("classifyError", () => {
       expect(result.status).toBe(500)
       expect(result.message).toBe("Unknown error")
     })
+  })
+})
+
+describe("extractSdkTermination", () => {
+  describe("max_turns", () => {
+    it("detects bare max_turns message", () => {
+      const t = extractSdkTermination("Reached maximum number of turns (3)")
+      expect(t.reason).toBe("max_turns")
+      expect(t.turns).toBe(3)
+    })
+
+    it("detects max_turns inside SDK wrapper", () => {
+      const t = extractSdkTermination("Claude Code returned an error result: Reached maximum number of turns (3)")
+      expect(t.reason).toBe("max_turns")
+      expect(t.turns).toBe(3)
+    })
+
+    it("captures any turn count, not just 3", () => {
+      const t = extractSdkTermination("Reached maximum number of turns (12)")
+      expect(t.reason).toBe("max_turns")
+      expect(t.turns).toBe(12)
+    })
+
+    it("returns max_turns reason even when turn count is malformed", () => {
+      const t = extractSdkTermination("Reached maximum number of turns")
+      expect(t.reason).toBe("max_turns")
+      expect(t.turns).toBeUndefined()
+    })
+
+    it("captures subprocess stderr tail when present", () => {
+      const msg =
+        "Claude Code returned an error result: Reached maximum number of turns (3)\n" +
+        "Subprocess stderr: Warning: Custom betas are only available for API key users. Ignoring provided betas."
+      const t = extractSdkTermination(msg)
+      expect(t.reason).toBe("max_turns")
+      expect(t.turns).toBe(3)
+      expect(t.stderrTail).toContain("Custom betas")
+    })
+  })
+
+  describe("process_exit", () => {
+    it("detects exit code", () => {
+      const t = extractSdkTermination("Claude Code process exited with code 137")
+      expect(t.reason).toBe("process_exit")
+      expect(t.exitCode).toBe(137)
+    })
+
+    it("captures stderr tail with exit code", () => {
+      const t = extractSdkTermination(
+        "process exited with code 1\nSubprocess stderr: --permission-mode invalid value"
+      )
+      expect(t.reason).toBe("process_exit")
+      expect(t.exitCode).toBe(1)
+      expect(t.stderrTail).toContain("permission-mode")
+    })
+
+    it("returns exit reason without code when code missing", () => {
+      const t = extractSdkTermination("process exited unexpectedly")
+      expect(t.reason).toBe("process_exit")
+      expect(t.exitCode).toBeUndefined()
+    })
+  })
+
+  describe("aborted", () => {
+    it("detects AbortError", () => {
+      const t = extractSdkTermination("AbortError: The operation was aborted")
+      expect(t.reason).toBe("aborted")
+    })
+
+    it("detects 'Aborted' message", () => {
+      const t = extractSdkTermination("Aborted")
+      expect(t.reason).toBe("aborted")
+    })
+  })
+
+  describe("unknown", () => {
+    it("returns 'unknown' for unrecognized messages", () => {
+      const t = extractSdkTermination("Something weird happened")
+      expect(t.reason).toBe("unknown")
+      expect(t.turns).toBeUndefined()
+      expect(t.exitCode).toBeUndefined()
+    })
+
+    it("handles empty string safely", () => {
+      const t = extractSdkTermination("")
+      expect(t.reason).toBe("unknown")
+      expect(t.rawTail).toBeUndefined()
+    })
+
+    it("captures raw error head when reason=unknown so the cause is debuggable", () => {
+      const t = extractSdkTermination("Some weird upstream failure: wibble")
+      expect(t.reason).toBe("unknown")
+      expect(t.rawTail).toBe("Some weird upstream failure: wibble")
+    })
+
+    it("strips the stderr appendix from rawTail (already in stderrTail)", () => {
+      const msg =
+        "Some weird upstream failure: wibble\n" +
+        "Subprocess stderr: Warning: Custom betas..."
+      const t = extractSdkTermination(msg)
+      expect(t.reason).toBe("unknown")
+      expect(t.rawTail).toBe("Some weird upstream failure: wibble")
+      expect(t.stderrTail).toContain("Custom betas")
+    })
+
+    it("truncates very long rawTail to a sensible bound", () => {
+      const longLine = "x".repeat(5000)
+      const t = extractSdkTermination(longLine)
+      expect(t.reason).toBe("unknown")
+      expect((t.rawTail ?? "").length).toBeLessThanOrEqual(300)
+    })
+
+    it("does NOT set rawTail when reason is recognized", () => {
+      const t = extractSdkTermination("Reached maximum number of turns (3)")
+      expect(t.reason).toBe("max_turns")
+      expect(t.rawTail).toBeUndefined()
+    })
+  })
+
+  describe("stderr tail truncation", () => {
+    it("truncates very long stderr to a sensible bound", () => {
+      const longLine = "x".repeat(10_000)
+      const t = extractSdkTermination(`Reached maximum number of turns (3)\nSubprocess stderr: ${longLine}`)
+      expect(t.reason).toBe("max_turns")
+      expect(t.stderrTail).toBeDefined()
+      expect((t.stderrTail ?? "").length).toBeLessThanOrEqual(500)
+    })
+  })
+})
+
+describe("formatSdkTermination", () => {
+  it("formats max_turns with full context", () => {
+    const line = formatSdkTermination(
+      { reason: "max_turns", turns: 3, stderrTail: "Warning: Custom betas..." },
+      { model: "opus[1m]", requestSource: "main", isResume: true, hasDeferredTools: false, sdkSessionId: "5fa9ec00-633c-4f00-b1c2-9e1b3c175ca4" },
+    )
+    expect(line).toContain("sdk_termination")
+    expect(line).toContain("reason=max_turns")
+    expect(line).toContain("turns=3")
+    expect(line).toContain("model=opus[1m]")
+    expect(line).toContain("source=main")
+    expect(line).toContain("resume=true")
+    expect(line).toContain("deferred=false")
+    expect(line).toContain("session=5fa9ec00")
+    expect(line).toContain("Custom betas")
+  })
+
+  it("formats process_exit with exit code and no stderr", () => {
+    const line = formatSdkTermination(
+      { reason: "process_exit", exitCode: 137 },
+      { model: "haiku", isResume: false, hasDeferredTools: false },
+    )
+    expect(line).toContain("reason=process_exit")
+    expect(line).toContain("exit=137")
+    expect(line).not.toContain("stderr=")
+  })
+
+  it("omits unset context fields", () => {
+    const line = formatSdkTermination({ reason: "unknown" }, {})
+    expect(line).toBe("sdk_termination reason=unknown")
+  })
+
+  it("includes raw=… when reason=unknown carries a rawTail", () => {
+    const line = formatSdkTermination(
+      { reason: "unknown", rawTail: "Some weird upstream failure" },
+      { requestSource: "main" },
+    )
+    expect(line).toContain("reason=unknown")
+    expect(line).toContain("source=main")
+    expect(line).toContain('raw="Some weird upstream failure"')
   })
 })

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -391,6 +391,11 @@ describe("PreToolUse hook: passthrough ToolSearch", () => {
     }, undefined, { signal: new AbortController().signal })
 
     expect(result.decision).toBe("block")
-    expect(result.reason).toBe("Forwarding to client for execution")
+    // Reason must explicitly tell the model NOT to retry or emit further
+    // tools — without this nudge, modern Claude treats the deny as "try
+    // something else" and burns the maxTurns budget on retries.
+    expect(result.reason).toContain("forwarded to the client for execution")
+    expect(result.reason.toLowerCase()).toContain("do not retry")
+    expect(result.reason.toLowerCase()).toContain("end your turn")
   })
 })

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -50,17 +50,17 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).includePartialMessages).toBe(true)
   })
 
-  it("sets maxTurns to 2 in passthrough mode (needs 2 turns for blocked-tool handoff)", () => {
+  it("sets maxTurns to 3 in passthrough mode (thinking + tool_use + handoff fits in 3 turns)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true }))
-    expect(result.options.maxTurns).toBe(2)
+    expect(result.options.maxTurns).toBe(3)
   })
 
-  it("sets maxTurns to 3 in passthrough mode with resume (extra turn for session rehydration)", () => {
+  it("sets maxTurns to 3 in passthrough mode with resume (rehydration fits within base budget)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, resumeSessionId: "sess-123" }))
     expect(result.options.maxTurns).toBe(3)
   })
 
-  it("sets maxTurns to 3 in passthrough mode with deferred tools (extra turn for ToolSearch)", () => {
+  it("sets maxTurns to 3 in passthrough mode with deferred tools (ToolSearch fits within base budget)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, hasDeferredTools: true }))
     expect(result.options.maxTurns).toBe(3)
   })
@@ -74,9 +74,9 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(4)
   })
 
-  it("sets maxTurns to 5 in passthrough mode with advisor (base 2 + 3 for advisor call/result/answer)", () => {
+  it("sets maxTurns to 6 in passthrough mode with advisor (base 3 + 3 for advisor call/result/answer)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7" }))
-    expect(result.options.maxTurns).toBe(5)
+    expect(result.options.maxTurns).toBe(6)
   })
 
   it("sets maxTurns to 6 in passthrough mode with advisor + resume", () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -171,3 +171,123 @@ export function isExtraUsageRequiredError(errMsg: string): boolean {
   const lower = errMsg.toLowerCase()
   return lower.includes("extra usage") && lower.includes("1m")
 }
+
+/**
+ * Structured SDK-termination metadata extracted from raw error text.
+ * Used by diagnosticLog to surface why the SDK subprocess ended (max_turns,
+ * exit, abort) plus the captured stderr tail — info that classifyError
+ * collapses into a generic api_error.
+ */
+export interface SdkTermination {
+  reason: "max_turns" | "process_exit" | "aborted" | "unknown"
+  /** Turn count when reason=max_turns and parseable. */
+  turns?: number
+  /** Exit code when reason=process_exit and parseable. */
+  exitCode?: number
+  /** Captured "Subprocess stderr: …" tail (truncated). */
+  stderrTail?: string
+  /** Truncated raw error message — set only when reason="unknown" so the log
+   *  line stays self-contained for unrecognized SDK errors (e.g. so we can
+   *  add a new pattern next time). */
+  rawTail?: string
+}
+
+const STDERR_TAIL_MAX = 500
+const RAW_TAIL_MAX = 300
+
+function extractStderrTail(errMsg: string): string | undefined {
+  const marker = "Subprocess stderr:"
+  const idx = errMsg.indexOf(marker)
+  if (idx < 0) return undefined
+  const tail = errMsg.slice(idx + marker.length).trim()
+  if (!tail) return undefined
+  return tail.length > STDERR_TAIL_MAX ? tail.slice(0, STDERR_TAIL_MAX) : tail
+}
+
+function makeRawTail(errMsg: string): string | undefined {
+  // Strip the stderr appendix; we already log it separately as stderrTail.
+  const marker = "Subprocess stderr:"
+  const idx = errMsg.indexOf(marker)
+  const head = (idx >= 0 ? errMsg.slice(0, idx) : errMsg).trim()
+  if (!head) return undefined
+  return head.length > RAW_TAIL_MAX ? head.slice(0, RAW_TAIL_MAX) : head
+}
+
+/**
+ * Parse the raw error message thrown by the Claude Agent SDK into structured
+ * termination metadata. Pure function — no I/O.
+ *
+ * Returns reason="unknown" when the message doesn't match any recognized
+ * pattern; callers can still log it with whatever surrounding context they have.
+ */
+export function extractSdkTermination(errMsg: string): SdkTermination {
+  const stderrTail = extractStderrTail(errMsg)
+
+  // Look at both the wrapper text and the stderr tail when classifying
+  // (the SDK sometimes emits the operative phrase only into stderr).
+  const haystack = `${errMsg}\n${stderrTail ?? ""}`
+  const lower = haystack.toLowerCase()
+
+  if (lower.includes("reached maximum number of turns")) {
+    const m = haystack.match(/Reached maximum number of turns \((\d+)\)/i)
+    return {
+      reason: "max_turns",
+      ...(m ? { turns: Number(m[1]) } : {}),
+      ...(stderrTail ? { stderrTail } : {}),
+    }
+  }
+
+  if (lower.includes("exited with code") || lower.includes("process exited")) {
+    const m = haystack.match(/exited with code (\d+)/i)
+    return {
+      reason: "process_exit",
+      ...(m ? { exitCode: Number(m[1]) } : {}),
+      ...(stderrTail ? { stderrTail } : {}),
+    }
+  }
+
+  if (lower.includes("aborterror") || /\baborted\b/.test(lower)) {
+    return {
+      reason: "aborted",
+      ...(stderrTail ? { stderrTail } : {}),
+    }
+  }
+
+  const rawTail = makeRawTail(errMsg)
+  return {
+    reason: "unknown",
+    ...(stderrTail ? { stderrTail } : {}),
+    ...(rawTail ? { rawTail } : {}),
+  }
+}
+
+/**
+ * Render an SdkTermination plus request context as a single greppable log line.
+ * Matches the key=value style used by token-health diagnostic messages so all
+ * /telemetry/logs entries are uniform.
+ *
+ * Session IDs are truncated to 8 chars to keep lines short — full IDs are
+ * already on the parent telemetry record.
+ */
+export function formatSdkTermination(
+  t: SdkTermination,
+  ctx: {
+    model?: string
+    requestSource?: string
+    isResume?: boolean
+    hasDeferredTools?: boolean
+    sdkSessionId?: string
+  },
+): string {
+  const parts: string[] = [`reason=${t.reason}`]
+  if (t.turns !== undefined) parts.push(`turns=${t.turns}`)
+  if (t.exitCode !== undefined) parts.push(`exit=${t.exitCode}`)
+  if (ctx.model) parts.push(`model=${ctx.model}`)
+  if (ctx.requestSource) parts.push(`source=${ctx.requestSource}`)
+  if (ctx.isResume !== undefined) parts.push(`resume=${ctx.isResume}`)
+  if (ctx.hasDeferredTools !== undefined) parts.push(`deferred=${ctx.hasDeferredTools}`)
+  if (ctx.sdkSessionId) parts.push(`session=${ctx.sdkSessionId.slice(0, 8)}`)
+  if (t.rawTail) parts.push(`raw=${JSON.stringify(t.rawTail)}`)
+  if (t.stderrTail) parts.push(`stderr=${JSON.stringify(t.stderrTail)}`)
+  return `sdk_termination ${parts.join(" ")}`
+}

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -106,13 +106,17 @@ export interface BuildQueryResult {
  *
  * Compute maxTurns based on which SDK features are active. Each phase the SDK
  * walks before returning control to the host costs a turn:
- *   - Base (2): turn 1 generates tool_use blocks (captured by PreToolUse hook),
- *     turn 2 processes the blocked-tool handoff. maxTurns: 1 throws "Reached
- *     maximum number of turns (1)" before the response completes → HTTP 500.
- *   - Resume (+1): SDK spends a turn rehydrating session state.
- *   - Deferred tools (+1): ToolSearch consumes a turn before the real tool call.
- *   - Both resume and deferred tools: each consumes its own turn, so the base
- *     budget becomes 4 rather than 3.
+ *   - Base (3): turn 1 generates content (extended thinking + tool_use blocks
+ *     captured by PreToolUse hook); turn 2 receives the deny and may emit a
+ *     follow-up (text or further tool_use); turn 3 wraps the stream cleanly.
+ *     Was 2 historically — bumped after telemetry showed opus[1m] requests with
+ *     thinking + tool_use exhausting the 2-turn budget mid-handoff and returning
+ *     500s on fresh (non-resume) requests. See errors.ts sdk_termination
+ *     diagnostic + telemetry.
+ *   - Resume / deferred (no extra turn over base): both fit within the 3-turn
+ *     budget. Resume rehydration and ToolSearch lookups complete inside turn 1.
+ *   - Both resume and deferred (+1): a second prelude phase pushes one phase
+ *     out, so budget becomes 4.
  *   - Advisor (+3): server-side advisor executes call + result + final answer.
  */
 function computePassthroughMaxTurns(
@@ -121,7 +125,7 @@ function computePassthroughMaxTurns(
   advisorModel: string | undefined,
 ): number {
   const hasResume = !!resumeSessionId
-  const base = hasResume && hasDeferredTools ? 4 : (hasResume || hasDeferredTools) ? 3 : 2
+  const base = hasResume && hasDeferredTools ? 4 : 3
   const advisorBump = advisorModel ? 3 : 0
   return base + advisorBump
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -41,7 +41,7 @@ import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
+import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
@@ -1969,6 +1969,53 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               const streamErr = classifyError(errMsg)
               claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })
 
+              // Surface the SDK termination reason (max_turns / process_exit / aborted)
+              // and stderr tail to /telemetry/logs?category=error so failures are
+              // visible without trawling raw log files.
+              const sdkTerm = extractSdkTermination(errMsg)
+              diagnosticLog.error(
+                `${requestMeta.requestId} ${formatSdkTermination(sdkTerm, {
+                  model,
+                  requestSource,
+                  isResume,
+                  hasDeferredTools,
+                  sdkSessionId: resumeSessionId,
+                })}`,
+                requestMeta.requestId,
+              )
+
+              // Record the failed request in the telemetry store. Without this,
+              // streaming errors would not appear in /telemetry/requests at all
+              // (the success path's record call never runs when this catch fires).
+              const streamErrTotalMs = Date.now() - requestStartAt
+              const streamErrQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+              telemetryStore.record({
+                requestId: requestMeta.requestId,
+                timestamp: Date.now(),
+                adapter: adapter.name,
+                requestSource,
+                model,
+                requestModel: body.model || undefined,
+                mode: "stream",
+                isResume,
+                isPassthrough: passthrough,
+                hasDeferredTools,
+                deferredToolCount: hasDeferredTools ? deferredToolCount : undefined,
+                toolCount,
+                lineageType,
+                messageCount: allMessages.length,
+                sdkSessionId: resumeSessionId,
+                status: streamErr.status,
+                queueWaitMs: streamErrQueueWaitMs,
+                proxyOverheadMs: upstreamStartAt - requestStartAt - streamErrQueueWaitMs,
+                ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
+                upstreamDurationMs: Date.now() - upstreamStartAt,
+                totalDurationMs: streamErrTotalMs,
+                contentBlocks: eventsForwarded,
+                textEvents: textEventsForwarded,
+                error: streamErr.type,
+              })
+
               // If we already emitted message_start, close the message cleanly so
               // clients that access usage.input_tokens don't crash on the incomplete response.
               if (messageStartEmitted) {
@@ -2016,6 +2063,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const classified = classifyError(errMsg)
 
         claudeLog("proxy.error", { error: errMsg, classified: classified.type })
+
+        // Surface the SDK termination reason. Outer-catch context is limited —
+        // model/isResume/etc. may not be assigned yet if the error fired early —
+        // so include only the request-source header (resolved before any work).
+        const sdkTerm = extractSdkTermination(errMsg)
+        diagnosticLog.error(
+          `${requestMeta.requestId} ${formatSdkTermination(sdkTerm, {
+            requestSource: c.req.header("x-meridian-source")?.slice(0, 64) || undefined,
+          })}`,
+          requestMeta.requestId,
+        )
 
         const errorQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
         telemetryStore.record({

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -851,9 +851,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   name: toolName,
                   input: toolInput,
                 })
+                // The reason text is read by the model as the "tool result" of
+                // a denied call. With a vague reason ("Forwarding to client for
+                // execution") modern Claude tends to retry with a different
+                // tool, burning the maxTurns budget. Be explicit that the call
+                // succeeded externally and that the model should stop here —
+                // see telemetry for the failure mode this addresses.
                 return {
                   decision: "block" as const,
-                  reason: "Forwarding to client for execution",
+                  reason:
+                    "This tool call has been forwarded to the client for execution. " +
+                    "The result will be delivered in a future turn. " +
+                    "Do not retry, do not call additional tools, and do not generate further text — end your turn now.",
                 }
               }],
             }],
@@ -1343,6 +1352,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
             let messageStartEmitted = false
             let lastUsage: TokenUsage | undefined
+            // Hoisted out of the inner streaming loop so the outer catch can
+            // dedupe captured tool_uses against what was already forwarded
+            // when recovering gracefully from max_turns (see catch below).
+            const streamedToolUseIds = new Set<string>()
 
             try {
               let currentSessionId: string | undefined
@@ -1512,7 +1525,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // the key-value pair may span multiple deltas, preventing regex match.
               const taskToolBlockIndices = new Set<number>()
               const taskToolJsonBuffer = new Map<number, string>()
-              const streamedToolUseIds = new Set<string>()
 
               // Block index remapping: the SDK resets indices on each turn, but
               // we skip intermediate message_start/stop so the client sees one
@@ -1973,6 +1985,111 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // and stderr tail to /telemetry/logs?category=error so failures are
               // visible without trawling raw log files.
               const sdkTerm = extractSdkTermination(errMsg)
+
+              // Graceful recovery: when max_turns hits in passthrough mode but
+              // we already captured tool_use blocks, the client has actionable
+              // content — they received the tool_use blocks via SSE before the
+              // budget was exhausted. Convert the failure into a clean
+              // stop_reason="tool_use" response so the client executes the
+              // tools and drives the next turn (the same outcome as a normal
+              // tool-use cycle). Without this, the client sees a 500 even
+              // though we already streamed everything it needs.
+              const canRecoverAsToolUse =
+                sdkTerm.reason === "max_turns" &&
+                passthrough &&
+                capturedToolUses.length > 0 &&
+                messageStartEmitted
+
+              if (canRecoverAsToolUse) {
+                // Log the recovery at session level (not error) — it's a
+                // notable flow control event but not a failure for the client.
+                diagnosticLog.session(
+                  `${requestMeta.requestId} sdk_termination_recovered ${formatSdkTermination(sdkTerm, {
+                    model,
+                    requestSource,
+                    isResume,
+                    hasDeferredTools,
+                    sdkSessionId: resumeSessionId,
+                  })} captured=${capturedToolUses.length}`,
+                  requestMeta.requestId,
+                )
+
+                // Mirror the success-path emission: send any unseen tool_uses
+                // (dedup against streamedToolUseIds), then a clean
+                // message_delta with stop_reason="tool_use" + message_stop.
+                const unseenToolUses = capturedToolUses.filter(tu => !streamedToolUseIds.has(tu.id))
+                for (let i = 0; i < unseenToolUses.length; i++) {
+                  const tu = unseenToolUses[i]!
+                  const blockIndex = eventsForwarded + i
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_start\ndata: ${JSON.stringify({
+                      type: "content_block_start",
+                      index: blockIndex,
+                      content_block: { type: "tool_use", id: tu.id, name: tu.name, input: {} }
+                    })}\n\n`
+                  ), "recover_tool_block_start")
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_delta\ndata: ${JSON.stringify({
+                      type: "content_block_delta",
+                      index: blockIndex,
+                      delta: { type: "input_json_delta", partial_json: JSON.stringify(tu.input) }
+                    })}\n\n`
+                  ), "recover_tool_input")
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_stop\ndata: ${JSON.stringify({
+                      type: "content_block_stop",
+                      index: blockIndex
+                    })}\n\n`
+                  ), "recover_tool_block_stop")
+                }
+                safeEnqueue(encoder.encode(
+                  `event: message_delta\ndata: ${JSON.stringify({
+                    type: "message_delta",
+                    delta: { stop_reason: "tool_use", stop_sequence: null },
+                    usage: { output_tokens: 0 }
+                  })}\n\n`
+                ), "recover_message_delta")
+                safeEnqueue(encoder.encode(
+                  `event: message_stop\ndata: {"type":"message_stop"}\n\n`
+                ), "recover_message_stop")
+
+                // Record as success — the client got a usable response.
+                const recoverTotalMs = Date.now() - requestStartAt
+                const recoverQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+                telemetryStore.record({
+                  requestId: requestMeta.requestId,
+                  timestamp: Date.now(),
+                  adapter: adapter.name,
+                  requestSource,
+                  model,
+                  requestModel: body.model || undefined,
+                  mode: "stream",
+                  isResume,
+                  isPassthrough: passthrough,
+                  hasDeferredTools,
+                  deferredToolCount: hasDeferredTools ? deferredToolCount : undefined,
+                  toolCount,
+                  lineageType,
+                  messageCount: allMessages.length,
+                  sdkSessionId: resumeSessionId,
+                  status: 200,
+                  queueWaitMs: recoverQueueWaitMs,
+                  proxyOverheadMs: upstreamStartAt - requestStartAt - recoverQueueWaitMs,
+                  ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
+                  upstreamDurationMs: Date.now() - upstreamStartAt,
+                  totalDurationMs: recoverTotalMs,
+                  contentBlocks: eventsForwarded + unseenToolUses.length,
+                  textEvents: textEventsForwarded,
+                  error: null,
+                })
+
+                if (!streamClosed) {
+                  try { controller.close() } catch {}
+                  streamClosed = true
+                }
+                return
+              }
+
               diagnosticLog.error(
                 `${requestMeta.requestId} ${formatSdkTermination(sdkTerm, {
                   model,


### PR DESCRIPTION
## Summary

Fixes recurring `Reached maximum number of turns` 500s in passthrough mode by:

1. **Adding structured SDK-termination diagnostics** so failures are observable instead of opaque
2. **Sharpening the PreToolUse deny reason** so the model stops looping on tool retries
3. **Gracefully recovering** when `max_turns` hits but tool_use blocks were already streamed — converting the failure into a clean `stop_reason: "tool_use"` response

Built up across two commits in response to live telemetry from real-world failures.

## Commit 1: structured diagnostics + maxTurns base bump

- `extractSdkTermination()` / `formatSdkTermination()` in `errors.ts` parse raw SDK error text into `{reason: max_turns | process_exit | aborted | unknown, turns?, exitCode?, stderrTail?, rawTail?}`. Pure functions, fully unit-tested.
- Wires the diagnostic into both the streaming and non-streaming error paths in `server.ts` so `/telemetry/logs?category=error` surfaces *why* the SDK ended.
- **Closes a telemetry gap**: streaming errors previously never called `telemetryStore.record`, so they vanished from `/telemetry/requests`. Now they're recorded.
- Bumps `computePassthroughMaxTurns` base from **2 to 3**. Telemetry showed fresh (non-resume) `opus[1m]` requests with extended thinking + tool_use exhausting the 2-turn budget mid-handoff. The resume and deferred-tools cases were already at 3, so this just unifies the simple-case ceiling.

## Commit 2: graceful max_turns recovery + sharper deny reason

- Replaces the vague `"Forwarding to client for execution"` deny reason with an explicit instruction telling the model the tool call succeeded externally and to end its turn. Modern Claude was treating the old reason as "try a different tool" and burning the budget on retries.
- When `max_turns` hits in passthrough mode AND `capturedToolUses` is non-empty AND `messageStartEmitted=true`, the streaming catch now emits any unseen tool_uses + `stop_reason: "tool_use"` + `message_stop` instead of an error event. The client already received the actionable content via SSE — recovery just suppresses the synthetic error.

## Production validation

After deploying both commits to my local launchd Meridian (~2 days):
- Pre-fix: many `max_turns` failures per day in real workloads
- Post-fix: 1 `max_turns` event in 2 days (`resume=false`, no captured tool_uses to recover with — different failure mode, separate concern)
- `sdk_termination_recovered` recoveries: 0 fired (Fix A made the precondition for Fix B rare, which is the better outcome)

## Tests

- 13 new `extractSdkTermination`/`formatSdkTermination` unit tests covering each reason, stderr capture, raw-tail truncation, and the format renderer
- Updated `query.test.ts` and `deferred-tool-loading.test.ts` for the new maxTurns base
- `proxy-pretooluse-hook.test.ts` updated to assert the deny reason explicitly tells the model not to retry
- All 1488 tests pass; typecheck clean

## Test plan

- [ ] Run `npm test` and confirm 1488 pass / 0 fail
- [ ] Run `npx tsc --noEmit` and confirm clean
- [ ] Spot-check `/telemetry/logs?category=error` after a `max_turns` failure to confirm it shows `sdk_termination reason=max_turns turns=N model=… stderr=…`
- [ ] Spot-check `/telemetry/logs?category=session` for `sdk_termination_recovered` after a max_turns-with-captured-tools event