### PR TITLE
fix(agentDefs): clone definitions when registering case variants and aliases (closes #448)

### DIFF
--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -445,4 +445,18 @@ describe("Case variant registration", () => {
     const defs = buildAgentDefinitions("No agents here")
     expect(Object.keys(defs)).toHaveLength(0)
   })
+
+  it("PascalCase variant must not share mutable references with base", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION, ["mcp__opencode__read"])
+    expect(defs["Explore"]).not.toBe(defs["explore"])
+    defs["Explore"]!.tools!.push("mcp__opencode__poison")
+    expect(defs["explore"]!.tools).not.toContain("mcp__opencode__poison")
+  })
+
+  it("'general-purpose' alias must not share mutable references with target", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION, ["mcp__opencode__read"])
+    expect(defs["general-purpose"]).not.toBe(defs["general"])
+    defs["general-purpose"]!.tools!.push("mcp__opencode__poison")
+    expect(defs["general"]!.tools).not.toContain("mcp__opencode__poison")
+  })
 })

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -144,6 +144,14 @@ function ensureDefaultAgents(
  *
  * Also registers common Claude-invented names like "general-purpose".
  */
+function cloneAgentDefinition(def: AgentDefinition): AgentDefinition {
+  return {
+    ...def,
+    ...(def.tools ? { tools: [...def.tools] } : {}),
+    ...(def.disallowedTools ? { disallowedTools: [...def.disallowedTools] } : {}),
+  }
+}
+
 function addCaseVariants(agents: Record<string, AgentDefinition>): void {
   // Snapshot keys before mutating (avoids iterating newly-added entries)
   const baseNames = Object.keys(agents)
@@ -155,7 +163,7 @@ function addCaseVariants(agents: Record<string, AgentDefinition>): void {
       sep + ch.toUpperCase()
     )
     if (titleCase !== name && !agents[titleCase]) {
-      agents[titleCase] = def
+      agents[titleCase] = cloneAgentDefinition(def)
     }
   }
 
@@ -166,7 +174,7 @@ function addCaseVariants(agents: Record<string, AgentDefinition>): void {
   }
   for (const [alias, target] of Object.entries(ALIASES)) {
     if (!agents[alias] && agents[target]) {
-      agents[alias] = agents[target]!
+      agents[alias] = cloneAgentDefinition(agents[target]!)
     }
   }
 }


### PR DESCRIPTION
Carries forward #448 by @WarGloom — defensive fix for a latent shared-reference bug in `addCaseVariants`.

## Summary

Before this fix, `addCaseVariants` assigned PascalCase variants and `general-purpose`/`General-Purpose` aliases by **reference**:

\`\`\`ts
defs["Explore"].tools.push("poison")
// defs["explore"].tools is also corrupted ← latent bug
\`\`\`

Adds `cloneAgentDefinition()` — shallow clone with `tools`/`disallowedTools` array duplication — and uses it at both assignment sites. **No behavior change for current call sites** — output structure stays identical.

## Verification

Cherry-picked WarGloom's commit onto current `main` (5 PRs landed since this PR was opened, including #457 which also touched `agentDefs.ts`):

- ✅ Auto-merged cleanly with #457's changes — no conflicts
- ✅ Full suite: 1559 pass / 0 fail
- ✅ Typecheck clean
- ✅ The PR's own tests are equivalent to a runtime smoke test — they mutate `defs["Explore"].tools` and assert `defs["explore"].tools` is unchanged. If those pass, the bug can't recur.

## Why it matters

Bug is latent today (no production code mutates these values). But it's a footgun — any future SDK update or downstream consumer that legitimately tweaks per-variant config would silently corrupt the base.

## Authorship

Cherry-picked the original commit by @WarGloom (`95be25da`) so their authorship is preserved in `git log`. No fixup commits needed.

Closes #448.