### PR TITLE
fix(docker): install claude-code native binary in runtime stage (closes #438)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,15 @@ FROM oven/bun:1 AS build
 
 WORKDIR /app
 COPY package.json bun.lock* ./
+# --ignore-scripts: skip the package's postinstall (which runs
+# claude-code/install.cjs and downloads a platform-native binary). The
+# build stage runs on debian/glibc; the runtime stage runs on alpine/musl.
+# A binary downloaded for glibc cannot exec on musl (different dynamic
+# loader paths) — yields ENOENT despite the file being present. The
+# install is performed in the runtime stage instead so it matches the
+# runtime libc.
 RUN --mount=type=cache,target=/root/.bun \
-    bun install
+    bun install --ignore-scripts
 
 COPY tsconfig.json* ./
 COPY bin/ ./bin/
@@ -28,13 +35,19 @@ COPY --from=build --chown=claude:claude /app/node_modules ./node_modules
 COPY --from=build --chown=claude:claude /app/dist ./dist
 COPY --from=build --chown=claude:claude /app/package.json ./
 
-# Create a 'claude' wrapper that delegates to the SDK's cli.js.
-# This replaces the global @anthropic-ai/claude-code install which
-# ships a native binary that crashes under QEMU ARM emulation.
-# The SDK's cli.js supports all commands the proxy needs (auth status, etc.).
+# Run claude-code's install.cjs in the runtime stage so the native binary
+# matches the runtime libc (alpine/musl). The script is a no-op if the
+# binary at bin/claude.exe is already correct for this platform; on a
+# fresh build it replaces the 500-byte stub with the real binary.
+RUN node /app/node_modules/@anthropic-ai/claude-code/install.cjs
+
+# Make the installed binary visible on PATH as `claude` so PATH-based
+# lookups (e.g. `claude auth status`, the SDK's PATH-lookup fallback)
+# resolve to the same binary the SDK uses directly. Symlink rather than a
+# shell wrapper — the SDK's subprocess launcher rejects shell wrappers on
+# some code paths.
 RUN mkdir -p /app/bin/shims \
-    && printf '#!/bin/sh\nexec node /app/node_modules/@anthropic-ai/claude-agent-sdk/cli.js "$@"\n' > /app/bin/shims/claude \
-    && chmod +x /app/bin/shims/claude
+    && ln -sf /app/node_modules/@anthropic-ai/claude-code/bin/claude.exe /app/bin/shims/claude
 ENV PATH="/app/bin/shims:$PATH"
 COPY --chown=claude:claude bin/docker-entrypoint.sh bin/claude-proxy-supervisor.sh ./bin/
 RUN chmod +x ./bin/docker-entrypoint.sh ./bin/claude-proxy-supervisor.sh


### PR DESCRIPTION
Carries forward #438 by @CrazyCoder — fixes a real Docker breakage that's been live since SDK 0.2.117.

## Bug summary (per author's analysis)

Two-stage Dockerfile mismatch:

| Stage | Image | libc | Loader |
|---|---|---|---|
| Build | `oven/bun:1` | glibc | `/lib64/ld-linux-x86-64.so.2` |
| Runtime | `node:22-alpine` | musl | `/lib/ld-musl-x86-64.so.1` |

`bun install`'s postinstall runs `claude-code/install.cjs` in the **build** stage → downloads a **glibc**-linked native binary → `COPY --from=build` carries it into the **musl** runtime → exec fails with ENOENT (no glibc dynamic loader). The 245 MB binary is present but unrunnable.

`resolveClaudeExecutableAsync` prefers this binary, so every API request fails with `Claude Code native binary not found...`. The legacy shim fallback is also broken (`exec`s a `cli.js` path that hasn't shipped since SDK 0.2.98).

Net effect: every Docker user has been broken since SDK 0.2.117 was adopted.

## Fix

1. `bun install --ignore-scripts` in build stage — don't waste cycles downloading wrong-libc binary
2. `node install.cjs` in runtime stage — picks the alpine/musl binary correctly per current container's platform/arch (works for both linux/amd64 and linux/arm64)
3. `ln -sf` symlink in `/app/bin/shims/claude` to the runtime-installed binary, replacing the stale shell wrapper

## Verification

- ✅ Cherry-picked onto current `main` cleanly (no conflicts with today's 7 merges — Dockerfile wasn't touched)
- ✅ Full TS suite still passes: 1610 / 0 fail; typecheck clean
- ✅ Author verified locally: built `meridian-pr-test`, ran 9-case test harness, confirmed `/health` returns healthy on first boot, confirmed symlink resolves to real binary
- ⏳ CI `build-push` will run `docker build` for both linux/amd64 and linux/arm64 — that's the meaningful verification

Tests don't exercise the Docker change directly (it's outside the TS surface), so the CI Docker build is the load-bearing check here.

## Authorship

Cherry-picked the original commit by @CrazyCoder (`2a19e37b`) so their authorship is preserved in `git log`. No fixup commits needed.

Closes #438.