### PR TITLE
fix(droid): respect MERIDIAN_PASSTHROUGH env (closes #440)

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -4,7 +4,7 @@ Live tests against the real proxy + Claude Max SDK. These verify the full reques
 
 **Prerequisites:** Claude Max subscription, `claude auth status` shows `loggedIn: true`, `opencode` installed.
 
-> **Droid tests (D1–D10)** additionally require `droid` installed (`droid --version` ≥ 0.89.0) and a Factory AI account for BYOK configuration.
+> **Droid tests (D1–D10)** additionally require `droid` installed (`droid --version` ≥ 0.89.0) and a Factory AI account for BYOK configuration. Tests D1–D10 cover internal mode (the default). Passthrough mode for Droid is opt-in via `MERIDIAN_PASSTHROUGH=1` and requires `droid` ≥ 0.109 — see "Droid passthrough mode" below.
 
 ## Quick Start
 
@@ -47,12 +47,12 @@ kill $(lsof -ti :3456)
 | E20 | [Env Stripping](#e20-env-stripping) | ANTHROPIC_* vars don't leak to SDK subprocess | 2026-03-24 |
 | E21 | [Session Store Pruning](#e21-session-store-pruning) | File store respects count cap, oldest entries evicted | 2026-03-24 |
 | D1 | [Droid: Basic Response](#d1-droid-basic-response) | Proxy accepts Droid User-Agent, routes via droid adapter, returns valid response | 2026-03-29 |
-| D2 | [Droid: MCP Server Name](#d2-droid-mcp-server-name) | Tools use `mcp__droid__` prefix, not `mcp__opencode__` | 2026-03-29 |
+| D2 | [Droid: MCP Server Name](#d2-droid-mcp-server-name) | Internal mode: tools use `mcp__droid__` prefix, not `mcp__opencode__` | 2026-03-29 |
 | D3 | [Droid: OpenCode Backward Compat](#d3-droid-opencode-backward-compat) | Requests without Droid UA still use opencode adapter | 2026-03-29 |
 | D4 | [Droid: CWD from system-reminder](#d4-droid-cwd-from-system-reminder) | Working directory extracted from `<system-reminder>` block | 2026-03-29 |
 | D5 | [Droid: Fingerprint Session Resume](#d5-droid-fingerprint-session-resume) | Session continues via fingerprint (no session header needed) | 2026-03-29 |
 | D6 | [Droid: Real Binary Basic](#d6-droid-real-binary-basic) | Live `droid exec` → proxy → Claude Max returns correct response | 2026-03-29 |
-| D7 | [Droid: Real Binary Tool Use](#d7-droid-real-binary-tool-use) | Live `droid exec` reads file via `mcp__droid__read` | 2026-03-29 |
+| D7 | [Droid: Real Binary Tool Use](#d7-droid-real-binary-tool-use) | Internal mode: live `droid exec` reads file via `mcp__droid__read` | 2026-03-29 |
 | D8 | [Droid: exec Session Isolation](#d8-droid-exec-session-isolation) | Each `droid exec` call is a fresh session (expected — no history passed) | 2026-03-29 |
 | D9 | [Droid: Streaming SSE](#d9-droid-streaming-sse) | SSE stream correct format with Droid User-Agent | 2026-03-29 |
 | D10 | [Droid: OpenCode Session Unaffected](#d10-droid-opencode-session-unaffected) | OpenCode header-based session tracking still works alongside Droid | 2026-03-29 |
@@ -1359,6 +1359,15 @@ Which proxy modules each E2E test exercises:
 ## Droid (Factory AI) Tests
 
 These tests verify the Droid adapter added in the Droid support release. They require `droid` CLI installed and a Factory AI account.
+
+### Droid passthrough mode
+
+Droid's passthrough behavior is **env-controlled, defaulting to OFF**:
+
+- **Without `MERIDIAN_PASSTHROUGH`** (default): Droid runs in internal mode. The proxy executes tools via the `mcp__droid__*` MCP server and Claude sees results via the SDK's internal tool loop. This is what tests D1–D10 cover.
+- **With `MERIDIAN_PASSTHROUGH=1`** (or `CLAUDE_PROXY_PASSTHROUGH=1`): the proxy forwards `tool_use` blocks to Droid, Droid executes the tools locally, and sends `tool_result` back. Requires Droid ≥ 0.109 (earlier versions had a BYOK loop bug where `tool_result` wasn't delivered).
+
+Historical note: this used to be hardcoded to internal mode for Droid because of the BYOK loop bug. Verified working on Droid 0.114.1 — `tool_use` → `tool_result` roundtrip completes correctly. See `src/__tests__/droid-adapter.test.ts` and `src/__tests__/proxy-droid-integration.test.ts` for the unit-level coverage of the env-controlled behavior.
 
 ### Droid BYOK Setup
 

--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -330,9 +330,25 @@ describe("detectAdapter — adapter contracts", () => {
     expect(adapter.getMcpServerName()).toBe("opencode")
   })
 
-  it("detected droid adapter always returns false for usesPassthrough", () => {
+  it("detected droid adapter respects env for usesPassthrough — opt-in default off", () => {
     const adapter = detectAdapter(makeContext("factory-cli/0.89.0"))
-    expect(adapter.usesPassthrough!()).toBe(false)
+    expect(typeof adapter.usesPassthrough).toBe("function")
+    const savedMP = process.env.MERIDIAN_PASSTHROUGH
+    const savedCP = process.env.CLAUDE_PROXY_PASSTHROUGH
+    try {
+      delete process.env.MERIDIAN_PASSTHROUGH
+      delete process.env.CLAUDE_PROXY_PASSTHROUGH
+      // Default: off (preserves prior behavior for users without the env var)
+      expect(adapter.usesPassthrough!()).toBe(false)
+      // Opt-in: on
+      process.env.MERIDIAN_PASSTHROUGH = "1"
+      expect(adapter.usesPassthrough!()).toBe(true)
+    } finally {
+      if (savedMP !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedMP
+      else delete process.env.MERIDIAN_PASSTHROUGH
+      if (savedCP !== undefined) process.env.CLAUDE_PROXY_PASSTHROUGH = savedCP
+      else delete process.env.CLAUDE_PROXY_PASSTHROUGH
+    }
   })
 
   it("detected opencode adapter has no usesPassthrough — defers to env var", () => {

--- a/src/__tests__/droid-adapter.test.ts
+++ b/src/__tests__/droid-adapter.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the Droid (Factory AI) agent adapter.
  */
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { droidAdapter } from "../proxy/adapters/droid"
 
 // Actual system-reminder content captured from a live Droid session
@@ -289,7 +289,43 @@ describe("droidAdapter.buildSystemContextAddendum", () => {
 })
 
 describe("droidAdapter.usesPassthrough", () => {
-  it("always returns false — Droid uses internal mode regardless of env var", () => {
+  // Save/restore env vars per test so global state doesn't leak.
+  let savedMP: string | undefined
+  let savedCP: string | undefined
+  beforeEach(() => {
+    savedMP = process.env.MERIDIAN_PASSTHROUGH
+    savedCP = process.env.CLAUDE_PROXY_PASSTHROUGH
+    delete process.env.MERIDIAN_PASSTHROUGH
+    delete process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+  afterEach(() => {
+    if (savedMP !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedMP
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    if (savedCP !== undefined) process.env.CLAUDE_PROXY_PASSTHROUGH = savedCP
+    else delete process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+
+  it("returns false by default (no env var) — internal mode is the safe default", () => {
+    expect(droidAdapter.usesPassthrough!()).toBe(false)
+  })
+
+  it("returns true when MERIDIAN_PASSTHROUGH=1 — opt-in unlock", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    expect(droidAdapter.usesPassthrough!()).toBe(true)
+  })
+
+  it("respects CLAUDE_PROXY_PASSTHROUGH as an alias", () => {
+    process.env.CLAUDE_PROXY_PASSTHROUGH = "true"
+    expect(droidAdapter.usesPassthrough!()).toBe(true)
+  })
+
+  it("returns false for explicit MERIDIAN_PASSTHROUGH=0", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+    expect(droidAdapter.usesPassthrough!()).toBe(false)
+  })
+
+  it("returns false for unrecognized env values", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "maybe"
     expect(droidAdapter.usesPassthrough!()).toBe(false)
   })
 })

--- a/src/__tests__/proxy-droid-integration.test.ts
+++ b/src/__tests__/proxy-droid-integration.test.ts
@@ -23,7 +23,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       for (const msg of mockMessages) yield msg
     })()
   },
-  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  // Provide tool()/registerTool() on the instance so passthrough-mode setup
+  // (which registers the dynamic mcp__droid__* tool surface) doesn't crash
+  // when the env var enables it.
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
   tool: () => ({}),
 }))
 
@@ -344,10 +351,10 @@ describe("Droid adapter: response format", () => {
   })
 })
 
-describe("Droid adapter: always internal mode (usesPassthrough=false)", () => {
+describe("Droid adapter: passthrough is env-controlled, defaults off", () => {
   beforeEach(() => {
     savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
-    process.env.MERIDIAN_PASSTHROUGH = "0"
+    delete process.env.MERIDIAN_PASSTHROUGH
     mockMessages = [assistantMessage([{ type: "text", text: "Done" }])]
     capturedQueryParams = null
     clearSessionCache()
@@ -358,39 +365,51 @@ describe("Droid adapter: always internal mode (usesPassthrough=false)", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
   })
 
-  it("Droid requests use internal MCP server even when CLAUDE_PROXY_PASSTHROUGH=1", async () => {
-    // Simulate the launchd environment where PASSTHROUGH is set globally
+  it("without env var, Droid uses internal mode — preserves prior default", async () => {
+    const app = createTestApp()
+    await (await post(app, DROID_BODY, { "User-Agent": DROID_UA })).json()
+
+    // Internal mode: allowedTools use mcp__droid__ prefix, maxTurns is 200.
+    const allowedTools: string[] = capturedQueryParams.options.allowedTools
+    expect(allowedTools).toBeDefined()
+    for (const tool of allowedTools) {
+      expect(tool).toStartWith("mcp__droid__")
+    }
+    expect(capturedQueryParams.options.maxTurns).toBe(200)
+  })
+
+  it("with MERIDIAN_PASSTHROUGH=1, Droid uses passthrough mode", async () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    const app = createTestApp()
+    await (await post(app, DROID_BODY, { "User-Agent": DROID_UA })).json()
+
+    // Passthrough mode: maxTurns drops out of the 200 internal default. Exact
+    // value depends on resume/deferred/advisor flags (see computePassthroughMaxTurns
+    // in query.ts), but it is always < 200 in passthrough mode.
+    expect(capturedQueryParams.options.maxTurns).toBeLessThan(200)
+  })
+
+  it("with CLAUDE_PROXY_PASSTHROUGH=1 (alias), Droid uses passthrough mode", async () => {
     const original = process.env.CLAUDE_PROXY_PASSTHROUGH
     process.env.CLAUDE_PROXY_PASSTHROUGH = "1"
-
     try {
       const app = createTestApp()
       await (await post(app, DROID_BODY, { "User-Agent": DROID_UA })).json()
-
-      // Droid adapter's usesPassthrough()=false overrides the env var:
-      // allowedTools use mcp__droid__ prefix (internal mode), not passthrough MCP
-      const allowedTools: string[] = capturedQueryParams.options.allowedTools
-      expect(allowedTools).toBeDefined()
-      for (const tool of allowedTools) {
-        expect(tool).toStartWith("mcp__droid__")
-      }
-      // maxTurns is 200 (internal), not 1 (passthrough)
-      expect(capturedQueryParams.options.maxTurns).toBe(200)
+      expect(capturedQueryParams.options.maxTurns).toBeLessThan(200)
     } finally {
       if (original === undefined) delete process.env.CLAUDE_PROXY_PASSTHROUGH
       else process.env.CLAUDE_PROXY_PASSTHROUGH = original
     }
   })
 
-  it("openCodeAdapter.usesPassthrough is undefined — verified at adapter unit level, not integration level", () => {
-    // The openCodeAdapter now implements usesPassthrough() and defaults to true
-    // (passthrough mode) unless MERIDIAN_PASSTHROUGH=0 is set.
-    // Full passthrough integration is covered by proxy-passthrough-concept.test.ts.
-    // Here we just confirm the adapter contract at the unit level.
+  it("openCodeAdapter.usesPassthrough is unaffected by Droid changes", () => {
+    // The openCodeAdapter independently implements usesPassthrough() and
+    // defaults to true (passthrough on) unless MERIDIAN_PASSTHROUGH=0 is set.
+    // Confirm we did not accidentally regress its contract while editing Droid.
     const { openCodeAdapter } = require("../proxy/adapters/opencode")
     expect(typeof openCodeAdapter.usesPassthrough).toBe("function")
-    // With MERIDIAN_PASSTHROUGH=0 set in beforeEach, it returns false
-    expect(openCodeAdapter.usesPassthrough()).toBe(false)
+    // With env unset (beforeEach cleared it), opencode default is true
+    expect(openCodeAdapter.usesPassthrough()).toBe(true)
   })
 })
 

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { createRequestContext, runTransformHook } from "../proxy/transform"
 import { openCodeTransforms } from "../proxy/transforms/opencode"
 import { crushTransforms } from "../proxy/transforms/crush"
@@ -112,9 +112,33 @@ describe("Crush transform parity", () => {
 })
 
 describe("Droid transform parity", () => {
-  it("matches passthrough (always false)", () => {
+  // Save/restore env so the parity assertion isn't sensitive to ambient state.
+  let savedMP: string | undefined
+  let savedCP: string | undefined
+  beforeEach(() => {
+    savedMP = process.env.MERIDIAN_PASSTHROUGH
+    savedCP = process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+  afterEach(() => {
+    if (savedMP !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedMP
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    if (savedCP !== undefined) process.env.CLAUDE_PROXY_PASSTHROUGH = savedCP
+    else delete process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+
+  it("matches passthrough (env off → false)", () => {
+    delete process.env.MERIDIAN_PASSTHROUGH
+    delete process.env.CLAUDE_PROXY_PASSTHROUGH
     const ctx = runTransformHook(droidTransforms, "onRequest", makeCtx("droid"), "droid")
     expect(ctx.passthrough).toBe(droidAdapter.usesPassthrough!())
+    expect(ctx.passthrough).toBe(false)
+  })
+
+  it("matches passthrough (env on → true)", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    const ctx = runTransformHook(droidTransforms, "onRequest", makeCtx("droid"), "droid")
+    expect(ctx.passthrough).toBe(droidAdapter.usesPassthrough!())
+    expect(ctx.passthrough).toBe(true)
   })
 
   it("matches leaksCwdViaSystemReminder", () => {

--- a/src/proxy/adapters/droid.ts
+++ b/src/proxy/adapters/droid.ts
@@ -123,16 +123,21 @@ export const droidAdapter: AgentAdapter = {
   },
 
   /**
-   * Droid always uses internal mode — the proxy executes tools via the
-   * mcp__droid__* MCP server rather than forwarding tool_use blocks back
-   * to Droid. This overrides CLAUDE_PROXY_PASSTHROUGH for Droid requests.
+   * Droid passthrough is env-controlled, defaulting to OFF.
    *
-   * Why: Droid's TUI via BYOK does not complete the passthrough tool
-   * execution loop (sending tool_results back), so Claude hallucinates
-   * from context instead of actually reading files.
+   * Set `MERIDIAN_PASSTHROUGH=1` (or `CLAUDE_PROXY_PASSTHROUGH=1`) to enable.
+   *
+   * History: this used to hardcode `false` because Droid's BYOK didn't close
+   * the tool execution loop — Claude would see no `tool_result` come back
+   * and hallucinate file contents. Verified working on Droid v0.114.1
+   * (tool_use → tool_result roundtrip completes correctly). Default stays
+   * OFF so existing users see no behavior change; explicit env opt-in
+   * unlocks passthrough for those who want it (better real-time TUI
+   * streaming, no internal SDK loop hallucination on long contexts).
    */
   usesPassthrough(): boolean {
-    return false
+    const envVal = process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH
+    return envVal === "1" || envVal === "true" || envVal === "yes"
   },
 }
 

--- a/src/proxy/transforms/droid.ts
+++ b/src/proxy/transforms/droid.ts
@@ -11,6 +11,22 @@ const DROID_ALLOWED_MCP_TOOLS: readonly string[] = [
   `mcp__${DROID_MCP_SERVER_NAME}__grep`,
 ]
 
+/**
+ * Resolve passthrough mode for Droid from env. Mirrors the adapter's
+ * `usesPassthrough()` so the transform and adapter agree (transform-parity
+ * test enforces this). Default is OFF — opt in via `MERIDIAN_PASSTHROUGH=1`.
+ *
+ * Historically this was hardcoded to `false` because Droid's BYOK didn't
+ * close the tool execution loop (Claude saw no tool_result). Verified
+ * working on Droid v0.114.1: tool_use → tool_result roundtrip completes
+ * correctly. Older Droid users on a buggy version can keep the default
+ * (no env var) or explicitly set `MERIDIAN_PASSTHROUGH=0`.
+ */
+function resolveDroidPassthrough(): boolean {
+  const envVal = process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH
+  return envVal === "1" || envVal === "true" || envVal === "yes"
+}
+
 export const droidTransforms: Transform[] = [
   {
     name: "droid-core",
@@ -22,7 +38,7 @@ export const droidTransforms: Transform[] = [
         incompatibleTools: CLAUDE_CODE_ONLY_TOOLS,
         allowedMcpTools: DROID_ALLOWED_MCP_TOOLS,
         sdkAgents: {},
-        passthrough: false,
+        passthrough: resolveDroidPassthrough(),
         leaksCwdViaSystemReminder: true,
       }
     },


### PR DESCRIPTION
Closes #440 — reporter @colding10 flagged that `transforms/droid.ts` was hardcoding `passthrough: false`, ignoring `MERIDIAN_PASSTHROUGH`.

## Background

Historically Droid's transform and adapter both forced internal mode because of a BYOK bug: Droid's TUI wouldn't send `tool_result` back, so Claude saw no tool output and would hallucinate file contents. The reporter says Droid v0.109+ fixed this; I verified on v0.114.1.

## What I tested before changing code

Cherry-picked a scratch branch with the fix on top of current `main`, ran a second meridian instance on port 3457 (zero disruption to my running pylon proxy), pointed Droid's BYOK at it, and used the proxy's diagnostic instrumentation to capture exactly what Droid sends:

| Test | Tool | Result content (verified via diag) | Outcome |
|---|---|---|---|
| Cold-start first read | `Read` | `"The magic number is 1112223."` | ✅ |
| Read with sonnet, repeated | `Read` | actual file bytes | ✅ |
| Execute (cat) | `Execute` | file content + Droid's `[Process exited with code 0]` footer | ✅ (Claude flagged the footer as "atypical format" but processed correctly) |
| Create then verify (multi-turn) | `Create` → `Read` | `"file created successfully"` then `"CONFIRMED-9988"` (real content) | ✅ — filesystem reflects the change |
| Same flow on opus[1m] | `Read` | actual file bytes | ✅ |

`tool_use_id` correlation works correctly. `tool_result.content` carries the real bytes. The original "first failed test" turned out to be non-reproducible across 5 subsequent attempts.

## Code change

Both transform and adapter read `MERIDIAN_PASSTHROUGH` (or `CLAUDE_PROXY_PASSTHROUGH` alias) from env, **defaulting to OFF**:

- `transforms/droid.ts`: `passthrough: false` → `passthrough: resolveDroidPassthrough()`
- `adapters/droid.ts`: `usesPassthrough()` reads env instead of always returning false

This means:
- **Users without the env var: zero behavior change.** Default stays internal mode.
- **Users with `MERIDIAN_PASSTHROUGH=1` set:** Droid now honors it (previously only OpenCode did).

## Tests

7 new test cases across 4 files, all updates to existing `usesPassthrough=false` assertions plus added env on/off coverage:

- `droid-adapter.test.ts` — default off, env on, alias, explicit zero, unrecognized
- `adapter-detection.test.ts` — detected adapter respects env
- `transform-parity.test.ts` — verified parity holds across both env states (off matches false, on matches true)
- `proxy-droid-integration.test.ts` — replaced "always internal" assertion with env-controlled integration coverage; added regression check that `openCodeAdapter` contract is unaffected by the Droid edits

**1617 tests pass / 0 fail / typecheck clean.**

## Docs

- `E2E.md` D-test prereq note flags the env-controlled behavior and the Droid ≥ 0.109 requirement for passthrough
- New "Droid passthrough mode" subsection under "Droid (Factory AI) Tests" explaining default-off / opt-in behavior

## What I deliberately didn't test

Honest disclosure of verification limits:
- Tool errors (`is_error: true` from Droid)
- Many parallel tool calls in a single turn
- Long-running tools / streaming output
- Haiku model (sonnet + opus tested)
- Droid interactive TUI mode (only `droid exec` non-interactive)

These are edge cases — the protocol layer is the same as what we did test. But worth noting we'd want users on older or unusual Droid setups to roll back via `MERIDIAN_PASSTHROUGH=0` if they hit something.

## Test plan

- [x] `npm test` — 1617 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] Live e2e on Droid 0.114.1 against patched proxy — 5+ runs across read/write/multi-turn/sonnet/opus
- [x] Verified default-off path preserves prior behavior (existing D-tests still pass)
- [ ] CI confirms (will fire on push)