### PR TITLE
fix(resolver): Windows + broken-postinstall fallbacks (closes #417, mitigates #445)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,74 @@ jobs:
       - run: npm run typecheck
       - run: npm test
       - run: bun run build
+
+  # Windows smoke test — catches platform-specific regressions in:
+  #   - claude-code postinstall on Windows (issue #445 class)
+  #   - the resolver picking up the bundled binary or platform-package binary (#417)
+  #   - cross-platform path handling in TS code
+  #   - bundle output spawning under node on Windows
+  # We don't run the full unit suite here — that's covered by the Linux job
+  # above and the resolver's logic is mock-driven so platform doesn't matter
+  # for unit-level coverage. This job exercises the REAL install + start flow.
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: oven-sh/setup-bun@v2
+
+      # Install — this also runs claude-code's postinstall, which is the
+      # single most common source of Windows install-time bugs.
+      - run: bun install
+
+      # Run only the resolver tests on Windows. Useful even though they use
+      # mocked deps, because the test runner itself exercises path joining,
+      # file URL parsing, etc., on the real Windows runtime.
+      - run: bun test src/__tests__/claude-executable-resolver.test.ts
+        shell: bash
+
+      # Build the bundle.
+      - run: bun run build
+        shell: bash
+
+      # Smoke-start: launch the bundled CLI in the background, hit /health,
+      # verify it responds with a body. We don't have Claude auth in CI, so
+      # the auth check inside /health may report loggedIn:false — that's
+      # fine; what we're verifying is the resolver finds the executable
+      # and the proxy boots without throwing.
+      - name: smoke start + /health probe
+        shell: pwsh
+        run: |
+          $env:MERIDIAN_PORT = "3458"
+          $env:MERIDIAN_HOST = "127.0.0.1"
+          # Start meridian in the background.
+          $proc = Start-Process -FilePath "node" -ArgumentList "dist/cli.js" -PassThru -RedirectStandardOutput "meridian.out.log" -RedirectStandardError "meridian.err.log" -WindowStyle Hidden
+          try {
+            # Poll /health up to 30s.
+            $ok = $false
+            for ($i = 0; $i -lt 30; $i++) {
+              Start-Sleep -Seconds 1
+              try {
+                $r = Invoke-WebRequest -Uri "http://127.0.0.1:3458/health" -UseBasicParsing -TimeoutSec 2
+                if ($r.StatusCode -eq 200) { $ok = $true; break }
+              } catch { }
+            }
+            if (-not $ok) {
+              Write-Host "===== meridian.out.log ====="
+              if (Test-Path "meridian.out.log") { Get-Content "meridian.out.log" }
+              Write-Host "===== meridian.err.log ====="
+              if (Test-Path "meridian.err.log") { Get-Content "meridian.err.log" }
+              throw "Meridian did not respond on /health within 30s — resolver or startup likely failed on Windows"
+            }
+            $body = Invoke-RestMethod -Uri "http://127.0.0.1:3458/health" -TimeoutSec 5
+            Write-Host "/health response: $($body | ConvertTo-Json -Compress)"
+            if (-not $body.version) { throw "/health missing version field" }
+            Write-Host "OK — meridian booted on Windows and /health returned a version."
+          }
+          finally {
+            try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch { }
+          }

--- a/src/__tests__/claude-executable-resolver.test.ts
+++ b/src/__tests__/claude-executable-resolver.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for `resolveClaudeExecutable` — the pure resolver underlying
+ * `resolveClaudeExecutableAsync`. These tests inject mock dependencies so
+ * we can simulate Windows behavior, missing binaries, broken stubs, and
+ * various PATH-lookup edge cases without touching the real filesystem.
+ *
+ * Covers the issue space documented in #417 (Windows resolver) and #445
+ * (postinstall-broken stub).
+ */
+import { describe, it, expect } from "bun:test"
+import { resolveClaudeExecutable } from "../proxy/models"
+
+type Deps = Parameters<typeof resolveClaudeExecutable>[0]
+
+/**
+ * Builds a minimal-deps stub for a single test case. Each filesystem
+ * predicate / package resolution / exec call is configurable; defaults
+ * mimic an empty environment where everything misses.
+ */
+function makeDeps(overrides: Partial<NonNullable<Deps>> = {}): NonNullable<Deps> {
+  return {
+    existsSync: () => false,
+    statSync: () => ({ size: 0 }),
+    exec: async () => ({ stdout: "" }),
+    resolvePackage: (specifier) => {
+      throw new Error(`mock: not configured to resolve ${specifier}`)
+    },
+    envGet: () => undefined,
+    platform: "darwin",
+    arch: "arm64",
+    isBun: false,
+    ...overrides,
+  }
+}
+
+describe("resolveClaudeExecutable: env override", () => {
+  it("returns MERIDIAN_CLAUDE_PATH when set and the file exists", async () => {
+    const deps = makeDeps({
+      envGet: (n) => (n === "MERIDIAN_CLAUDE_PATH" ? "/custom/claude" : undefined),
+      existsSync: (p) => p === "/custom/claude",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/custom/claude")
+  })
+
+  it("falls through when MERIDIAN_CLAUDE_PATH is set but the file is missing", async () => {
+    const deps = makeDeps({
+      envGet: (n) => (n === "MERIDIAN_CLAUDE_PATH" ? "/nope" : undefined),
+      existsSync: () => false,
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+
+  it("ignores empty string env value", async () => {
+    const deps = makeDeps({
+      envGet: (n) => (n === "MERIDIAN_CLAUDE_PATH" ? "" : undefined),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})
+
+describe("resolveClaudeExecutable: bundled binary with stub-size guard", () => {
+  it("returns the bundled binary when it exists and is the real ~200 MB binary", async () => {
+    const deps = makeDeps({
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/lib/node_modules/@anthropic-ai/claude-code/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
+      statSync: () => ({ size: 213_404_000 }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe(
+      "/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
+    )
+  })
+
+  it("skips the bundled binary when it is the ~500 byte stub (postinstall failed)", async () => {
+    // This is the issue #445 scenario: install.cjs threw, the stub was
+    // never replaced. Resolver must NOT hand back the broken stub.
+    const deps = makeDeps({
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-code/bin/claude.exe",
+      statSync: () => ({ size: 512 }), // stub
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+
+  it("treats files at the 4 KB threshold as a stub (boundary check)", async () => {
+    // Only the bundled package resolves; subsequent steps must miss so
+    // the test isolates the stub-guard behavior.
+    const deps = makeDeps({
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-code/bin/claude.exe",
+      statSync: () => ({ size: 4096 }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+
+  it("treats files just above 4 KB as a real binary", async () => {
+    const deps = makeDeps({
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-code/bin/claude.exe",
+      statSync: () => ({ size: 4097 }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/m/claude-code/bin/claude.exe")
+  })
+
+  it("falls through when the package itself can't be resolved", async () => {
+    const deps = makeDeps({
+      resolvePackage: () => {
+        throw new Error("not found")
+      },
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})
+
+describe("resolveClaudeExecutable: platform-specific peer package", () => {
+  it("falls back to claude-code-darwin-arm64 when bundled stub is broken", async () => {
+    // Simulates issue #445 on macOS: bundled stub is 500 bytes (skipped),
+    // but the platform-specific package binary is intact (~200 MB).
+    const deps = makeDeps({
+      platform: "darwin",
+      arch: "arm64",
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return "/m/claude-code-darwin-arm64/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => {
+        if (p === "/m/claude-code/bin/claude.exe") return true // stub exists
+        if (p === "/m/claude-code-darwin-arm64/claude") return true // real binary
+        return false
+      },
+      statSync: () => ({ size: 500 }), // bundled is stub
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe(
+      "/m/claude-code-darwin-arm64/claude",
+    )
+  })
+
+  it("uses claude.exe filename on win32-x64", async () => {
+    const deps = makeDeps({
+      platform: "win32",
+      arch: "x64",
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code-win32-x64/package.json") return "/m/claude-code-win32-x64/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-code-win32-x64/claude.exe",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe(
+      "/m/claude-code-win32-x64/claude.exe",
+    )
+  })
+
+  it("works on win32-arm64 too", async () => {
+    const deps = makeDeps({
+      platform: "win32",
+      arch: "arm64",
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code-win32-arm64/package.json") return "/m/claude-code-win32-arm64/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-code-win32-arm64/claude.exe",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe(
+      "/m/claude-code-win32-arm64/claude.exe",
+    )
+  })
+
+  it("on linux, also tries the -musl variant", async () => {
+    const deps = makeDeps({
+      platform: "linux",
+      arch: "x64",
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code-linux-x64/package.json") throw new Error("not installed")
+        if (s === "@anthropic-ai/claude-code-linux-x64-musl/package.json") return "/m/claude-code-linux-x64-musl/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-code-linux-x64-musl/claude",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe(
+      "/m/claude-code-linux-x64-musl/claude",
+    )
+  })
+
+  it("returns null when no platform package resolves", async () => {
+    const deps = makeDeps({
+      platform: "darwin",
+      arch: "arm64",
+      resolvePackage: () => { throw new Error("not installed") },
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})
+
+describe("resolveClaudeExecutable: PATH lookup", () => {
+  it("uses `where` on Windows", async () => {
+    let capturedCmd = ""
+    const deps = makeDeps({
+      platform: "win32",
+      arch: "x64",
+      exec: async (cmd) => {
+        capturedCmd = cmd
+        return { stdout: "C:\\Users\\me\\nodejs\\claude.exe\r\n" }
+      },
+      existsSync: (p) => p === "C:\\Users\\me\\nodejs\\claude.exe",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("C:\\Users\\me\\nodejs\\claude.exe")
+    expect(capturedCmd).toBe("where claude")
+  })
+
+  it("uses `which` on POSIX", async () => {
+    let capturedCmd = ""
+    const deps = makeDeps({
+      platform: "darwin",
+      exec: async (cmd) => {
+        capturedCmd = cmd
+        return { stdout: "/usr/local/bin/claude\n" }
+      },
+      existsSync: (p) => p === "/usr/local/bin/claude",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/usr/local/bin/claude")
+    expect(capturedCmd).toBe("which claude")
+  })
+
+  it("on Windows, picks the first existing path from a multi-line `where` output", async () => {
+    const deps = makeDeps({
+      platform: "win32",
+      exec: async () => ({
+        stdout:
+          "C:\\Old\\nodejs\\claude.exe\r\n" +
+          "C:\\Users\\me\\nodejs\\claude.exe\r\n" +
+          "C:\\Other\\claude.exe\r\n",
+      }),
+      existsSync: (p) =>
+        p === "C:\\Users\\me\\nodejs\\claude.exe" || p === "C:\\Other\\claude.exe",
+    })
+    // First match-and-exists wins.
+    expect(await resolveClaudeExecutable(deps)).toBe("C:\\Users\\me\\nodejs\\claude.exe")
+  })
+
+  it("on Windows, filters out mingw-style paths emitted by Git-for-Windows `which.exe`", async () => {
+    // This is the exact #417 reporter-described case: Git Bash's `which`
+    // emits `/c/...` style paths that Node's `existsSync` rejects.
+    // Our implementation uses `where` (cmd builtin), but ALSO defends
+    // against ever feeding a /-prefixed path to existsSync on Windows.
+    const deps = makeDeps({
+      platform: "win32",
+      exec: async () => ({ stdout: "/c/nvm4w/nodejs/claude\r\n" }),
+      // existsSync would return false for the mingw path anyway, but
+      // assert we never try it.
+      existsSync: (p) => {
+        if (p.startsWith("/c/")) {
+          throw new Error("must not call existsSync with mingw-style path on Windows")
+        }
+        return false
+      },
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+
+  it("returns null when the lookup command throws", async () => {
+    const deps = makeDeps({
+      exec: async () => {
+        throw new Error("which: command not found")
+      },
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+
+  it("returns null when stdout is empty", async () => {
+    const deps = makeDeps({
+      exec: async () => ({ stdout: "" }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+
+  it("returns null when stdout has only whitespace", async () => {
+    const deps = makeDeps({
+      exec: async () => ({ stdout: "\n   \r\n  \n" }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})
+
+describe("resolveClaudeExecutable: legacy SDK cli.js (bun only)", () => {
+  it("returns the SDK cli.js when running under bun", async () => {
+    const deps = makeDeps({
+      isBun: true,
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-agent-sdk") return "/m/claude-agent-sdk/index.js"
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === "/m/claude-agent-sdk/cli.js",
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/m/claude-agent-sdk/cli.js")
+  })
+
+  it("skips the SDK cli.js when not under bun (won't exec js as binary)", async () => {
+    const deps = makeDeps({
+      isBun: false,
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-agent-sdk") return "/m/claude-agent-sdk/index.js"
+        throw new Error("not configured")
+      },
+      existsSync: () => true, // even if file exists, skip it on non-bun
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})
+
+describe("resolveClaudeExecutable: priority ordering", () => {
+  it("env override beats every other source", async () => {
+    const deps = makeDeps({
+      envGet: (n) => (n === "MERIDIAN_CLAUDE_PATH" ? "/explicit/claude" : undefined),
+      existsSync: () => true, // every other source would also "succeed"
+      resolvePackage: () => "/some/other/path/package.json",
+      statSync: () => ({ size: 213_404_000 }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/explicit/claude")
+  })
+
+  it("bundled real binary beats platform package and PATH lookup", async () => {
+    const deps = makeDeps({
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/m/cc/package.json"
+        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return "/m/cc-d-a/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: () => true,
+      statSync: () => ({ size: 213_404_000 }), // bundled is real
+      exec: async () => ({ stdout: "/usr/local/bin/claude\n" }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/m/cc/bin/claude.exe")
+  })
+
+  it("platform package beats PATH lookup when bundled is a stub", async () => {
+    const deps = makeDeps({
+      platform: "darwin",
+      arch: "arm64",
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return "/m/cc/package.json"
+        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return "/m/cc-d-a/package.json"
+        throw new Error("not configured")
+      },
+      existsSync: () => true,
+      statSync: () => ({ size: 500 }), // stub
+      exec: async () => ({ stdout: "/usr/local/bin/claude\n" }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBe("/m/cc-d-a/claude")
+  })
+
+  it("returns null when ALL sources miss", async () => {
+    const deps = makeDeps({
+      envGet: () => undefined,
+      resolvePackage: () => { throw new Error("nope") },
+      existsSync: () => false,
+      exec: async () => ({ stdout: "" }),
+    })
+    expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})

--- a/src/__tests__/claude-executable-resolver.test.ts
+++ b/src/__tests__/claude-executable-resolver.test.ts
@@ -8,7 +8,16 @@
  * (postinstall-broken stub).
  */
 import { describe, it, expect } from "bun:test"
+import { join, dirname } from "path"
 import { resolveClaudeExecutable } from "../proxy/models"
+
+// `path.join` produces backslashed paths on Windows and slash-separated paths
+// on POSIX. Tests use `J(...)` and `BIN(pkgJson, ...rest)` everywhere a path
+// is constructed so expected values match exactly what the resolver builds via
+// the host's `path.join`, regardless of platform. (Capital names avoid
+// shadowing the common `p =>` arg name.)
+const J = (...parts: string[]) => join(...parts)
+const BIN = (pkgJson: string, ...rest: string[]) => join(dirname(pkgJson), ...rest)
 
 type Deps = Parameters<typeof resolveClaudeExecutable>[0]
 
@@ -60,28 +69,30 @@ describe("resolveClaudeExecutable: env override", () => {
 
 describe("resolveClaudeExecutable: bundled binary with stub-size guard", () => {
   it("returns the bundled binary when it exists and is the real ~200 MB binary", async () => {
+    const pkgJson = "/lib/node_modules/@anthropic-ai/claude-code/package.json"
+    const expectedBin = BIN(pkgJson, "bin", "claude.exe")
     const deps = makeDeps({
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/lib/node_modules/@anthropic-ai/claude-code/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return pkgJson
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
+      existsSync: (p) => p === expectedBin,
       statSync: () => ({ size: 213_404_000 }),
     })
-    expect(await resolveClaudeExecutable(deps)).toBe(
-      "/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
-    )
+    expect(await resolveClaudeExecutable(deps)).toBe(expectedBin)
   })
 
   it("skips the bundled binary when it is the ~500 byte stub (postinstall failed)", async () => {
     // This is the issue #445 scenario: install.cjs threw, the stub was
     // never replaced. Resolver must NOT hand back the broken stub.
+    const pkgJson = "/m/claude-code/package.json"
+    const expectedBin = BIN(pkgJson, "bin", "claude.exe")
     const deps = makeDeps({
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return pkgJson
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-code/bin/claude.exe",
+      existsSync: (p) => p === expectedBin,
       statSync: () => ({ size: 512 }), // stub
     })
     expect(await resolveClaudeExecutable(deps)).toBeNull()
@@ -90,27 +101,31 @@ describe("resolveClaudeExecutable: bundled binary with stub-size guard", () => {
   it("treats files at the 4 KB threshold as a stub (boundary check)", async () => {
     // Only the bundled package resolves; subsequent steps must miss so
     // the test isolates the stub-guard behavior.
+    const pkgJson = "/m/claude-code/package.json"
+    const expectedBin = BIN(pkgJson, "bin", "claude.exe")
     const deps = makeDeps({
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return pkgJson
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-code/bin/claude.exe",
+      existsSync: (p) => p === expectedBin,
       statSync: () => ({ size: 4096 }),
     })
     expect(await resolveClaudeExecutable(deps)).toBeNull()
   })
 
   it("treats files just above 4 KB as a real binary", async () => {
+    const pkgJson = "/m/claude-code/package.json"
+    const expectedBin = BIN(pkgJson, "bin", "claude.exe")
     const deps = makeDeps({
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return pkgJson
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-code/bin/claude.exe",
+      existsSync: (p) => p === expectedBin,
       statSync: () => ({ size: 4097 }),
     })
-    expect(await resolveClaudeExecutable(deps)).toBe("/m/claude-code/bin/claude.exe")
+    expect(await resolveClaudeExecutable(deps)).toBe(expectedBin)
   })
 
   it("falls through when the package itself can't be resolved", async () => {
@@ -127,70 +142,68 @@ describe("resolveClaudeExecutable: platform-specific peer package", () => {
   it("falls back to claude-code-darwin-arm64 when bundled stub is broken", async () => {
     // Simulates issue #445 on macOS: bundled stub is 500 bytes (skipped),
     // but the platform-specific package binary is intact (~200 MB).
+    const bundledPkg = "/m/claude-code/package.json"
+    const platformPkg = "/m/claude-code-darwin-arm64/package.json"
+    const stubPath = BIN(bundledPkg, "bin", "claude.exe")
+    const platformBin = BIN(platformPkg, "claude")
     const deps = makeDeps({
       platform: "darwin",
       arch: "arm64",
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/m/claude-code/package.json"
-        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return "/m/claude-code-darwin-arm64/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return bundledPkg
+        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return platformPkg
         throw new Error("not configured")
       },
-      existsSync: (p) => {
-        if (p === "/m/claude-code/bin/claude.exe") return true // stub exists
-        if (p === "/m/claude-code-darwin-arm64/claude") return true // real binary
-        return false
-      },
+      existsSync: (p) => p === stubPath || p === platformBin,
       statSync: () => ({ size: 500 }), // bundled is stub
     })
-    expect(await resolveClaudeExecutable(deps)).toBe(
-      "/m/claude-code-darwin-arm64/claude",
-    )
+    expect(await resolveClaudeExecutable(deps)).toBe(platformBin)
   })
 
   it("uses claude.exe filename on win32-x64", async () => {
+    const platformPkg = "/m/claude-code-win32-x64/package.json"
+    const platformBin = BIN(platformPkg, "claude.exe")
     const deps = makeDeps({
       platform: "win32",
       arch: "x64",
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code-win32-x64/package.json") return "/m/claude-code-win32-x64/package.json"
+        if (s === "@anthropic-ai/claude-code-win32-x64/package.json") return platformPkg
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-code-win32-x64/claude.exe",
+      existsSync: (p) => p === platformBin,
     })
-    expect(await resolveClaudeExecutable(deps)).toBe(
-      "/m/claude-code-win32-x64/claude.exe",
-    )
+    expect(await resolveClaudeExecutable(deps)).toBe(platformBin)
   })
 
   it("works on win32-arm64 too", async () => {
+    const platformPkg = "/m/claude-code-win32-arm64/package.json"
+    const platformBin = BIN(platformPkg, "claude.exe")
     const deps = makeDeps({
       platform: "win32",
       arch: "arm64",
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code-win32-arm64/package.json") return "/m/claude-code-win32-arm64/package.json"
+        if (s === "@anthropic-ai/claude-code-win32-arm64/package.json") return platformPkg
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-code-win32-arm64/claude.exe",
+      existsSync: (p) => p === platformBin,
     })
-    expect(await resolveClaudeExecutable(deps)).toBe(
-      "/m/claude-code-win32-arm64/claude.exe",
-    )
+    expect(await resolveClaudeExecutable(deps)).toBe(platformBin)
   })
 
   it("on linux, also tries the -musl variant", async () => {
+    const muslPkg = "/m/claude-code-linux-x64-musl/package.json"
+    const muslBin = BIN(muslPkg, "claude")
     const deps = makeDeps({
       platform: "linux",
       arch: "x64",
       resolvePackage: (s) => {
         if (s === "@anthropic-ai/claude-code-linux-x64/package.json") throw new Error("not installed")
-        if (s === "@anthropic-ai/claude-code-linux-x64-musl/package.json") return "/m/claude-code-linux-x64-musl/package.json"
+        if (s === "@anthropic-ai/claude-code-linux-x64-musl/package.json") return muslPkg
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-code-linux-x64-musl/claude",
+      existsSync: (p) => p === muslBin,
     })
-    expect(await resolveClaudeExecutable(deps)).toBe(
-      "/m/claude-code-linux-x64-musl/claude",
-    )
+    expect(await resolveClaudeExecutable(deps)).toBe(muslBin)
   })
 
   it("returns null when no platform package resolves", async () => {
@@ -295,15 +308,17 @@ describe("resolveClaudeExecutable: PATH lookup", () => {
 
 describe("resolveClaudeExecutable: legacy SDK cli.js (bun only)", () => {
   it("returns the SDK cli.js when running under bun", async () => {
+    const sdkIndex = "/m/claude-agent-sdk/index.js"
+    const expectedCli = J(dirname(sdkIndex), "cli.js")
     const deps = makeDeps({
       isBun: true,
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-agent-sdk") return "/m/claude-agent-sdk/index.js"
+        if (s === "@anthropic-ai/claude-agent-sdk") return sdkIndex
         throw new Error("not configured")
       },
-      existsSync: (p) => p === "/m/claude-agent-sdk/cli.js",
+      existsSync: (p) => p === expectedCli,
     })
-    expect(await resolveClaudeExecutable(deps)).toBe("/m/claude-agent-sdk/cli.js")
+    expect(await resolveClaudeExecutable(deps)).toBe(expectedCli)
   })
 
   it("skips the SDK cli.js when not under bun (won't exec js as binary)", async () => {
@@ -331,9 +346,11 @@ describe("resolveClaudeExecutable: priority ordering", () => {
   })
 
   it("bundled real binary beats platform package and PATH lookup", async () => {
+    const bundledPkg = "/m/cc/package.json"
+    const expectedBin = BIN(bundledPkg, "bin", "claude.exe")
     const deps = makeDeps({
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/m/cc/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return bundledPkg
         if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return "/m/cc-d-a/package.json"
         throw new Error("not configured")
       },
@@ -341,23 +358,26 @@ describe("resolveClaudeExecutable: priority ordering", () => {
       statSync: () => ({ size: 213_404_000 }), // bundled is real
       exec: async () => ({ stdout: "/usr/local/bin/claude\n" }),
     })
-    expect(await resolveClaudeExecutable(deps)).toBe("/m/cc/bin/claude.exe")
+    expect(await resolveClaudeExecutable(deps)).toBe(expectedBin)
   })
 
   it("platform package beats PATH lookup when bundled is a stub", async () => {
+    const bundledPkg = "/m/cc/package.json"
+    const platformPkg = "/m/cc-d-a/package.json"
+    const platformBin = BIN(platformPkg, "claude")
     const deps = makeDeps({
       platform: "darwin",
       arch: "arm64",
       resolvePackage: (s) => {
-        if (s === "@anthropic-ai/claude-code/package.json") return "/m/cc/package.json"
-        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return "/m/cc-d-a/package.json"
+        if (s === "@anthropic-ai/claude-code/package.json") return bundledPkg
+        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return platformPkg
         throw new Error("not configured")
       },
       existsSync: () => true,
       statSync: () => ({ size: 500 }), // stub
       exec: async () => ({ stdout: "/usr/local/bin/claude\n" }),
     })
-    expect(await resolveClaudeExecutable(deps)).toBe("/m/cc-d-a/claude")
+    expect(await resolveClaudeExecutable(deps)).toBe(platformBin)
   })
 
   it("returns null when ALL sources miss", async () => {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -3,12 +3,22 @@
  */
 
 import { exec as execCallback } from "child_process"
-import { existsSync } from "fs"
+import { existsSync, statSync } from "fs"
 import { fileURLToPath } from "url"
 import { join, dirname } from "path"
 import { promisify } from "util"
 
 const exec = promisify(execCallback)
+
+/**
+ * Files smaller than this are treated as the placeholder stub that
+ * `@anthropic-ai/claude-code/install.cjs` writes when the platform-specific
+ * binary fails to install. The real Claude Code binary is ~200 MB; the stub
+ * is ~500 bytes. Anything under 4 KB is the stub. Used in the bundled-binary
+ * resolver step to avoid handing the proxy a non-functional placeholder when
+ * upstream postinstall fails (see issue #445).
+ */
+const STUB_SIZE_THRESHOLD = 4096
 
 export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku"
 
@@ -267,56 +277,173 @@ let cachedClaudePathPromise: Promise<string> | null = null
  * The promise is cleared in `finally` to allow retry on failure while
  * cachedClaudePath prevents re-resolution on success.
  */
+/**
+ * Resolver step contract — each tries one source, returns a path on success
+ * or null on miss. Failures (thrown errors) are caught by the caller and
+ * treated as misses so unresolved sources never block subsequent steps.
+ */
+type ResolverDeps = {
+  existsSync: (p: string) => boolean
+  statSync: (p: string) => { size: number }
+  exec: (cmd: string) => Promise<{ stdout: string }>
+  resolvePackage: (specifier: string) => string
+  envGet: (name: string) => string | undefined
+  platform: NodeJS.Platform
+  arch: string
+  isBun: boolean
+}
+
+const DEFAULT_DEPS: ResolverDeps = {
+  existsSync,
+  statSync: (p) => statSync(p),
+  exec,
+  resolvePackage: (specifier) => fileURLToPath(import.meta.resolve(specifier)),
+  envGet: (name) => process.env[name],
+  platform: process.platform,
+  arch: process.arch,
+  isBun: typeof process.versions.bun !== "undefined",
+}
+
+/**
+ * Step 0: explicit env override. Non-empty MERIDIAN_CLAUDE_PATH wins
+ * unconditionally, so users with broken installs / unusual setups can
+ * always point at a known-good binary. Mirrors the escape-hatch
+ * convention used by other proxy env vars.
+ */
+function tryEnvOverride(deps: ResolverDeps): string | null {
+  const explicit = deps.envGet("MERIDIAN_CLAUDE_PATH")
+  if (!explicit) return null
+  return deps.existsSync(explicit) ? explicit : null
+}
+
+/**
+ * Step 1: bundled `@anthropic-ai/claude-code/bin/claude.exe`.
+ *
+ * Skips the placeholder stub (≤4 KB) so we don't return a non-functional
+ * file when the upstream postinstall failed (issue #445). The real
+ * platform binary is ~200 MB; the stub is ~500 bytes.
+ */
+function tryBundledBinary(deps: ResolverDeps): string | null {
+  try {
+    const pkgPath = deps.resolvePackage("@anthropic-ai/claude-code/package.json")
+    const bundled = join(dirname(pkgPath), "bin", "claude.exe")
+    if (!deps.existsSync(bundled)) return null
+    const size = deps.statSync(bundled).size
+    if (size <= STUB_SIZE_THRESHOLD) return null
+    return bundled
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Step 2: platform-specific peer package
+ * (`@anthropic-ai/claude-code-<platform>-<arch>`). This is where the
+ * actual binary lives in the SDK ≥ 0.2.x split layout — the wrapper at
+ * `claude-code/bin/claude.exe` is just a hardlink/copy from here.
+ *
+ * Bypasses the bundled-binary path entirely, so it works when the
+ * upstream postinstall failed to do the link (#445) AND when the
+ * bundled wrapper exists but fails to spawn on the host (#417 — Windows
+ * `spawn UNKNOWN` reported by BenIsLegit, where the wrapper failed but
+ * the platform-package binary worked).
+ */
+function tryPlatformPackage(deps: ResolverDeps): string | null {
+  const binName = deps.platform === "win32" ? "claude.exe" : "claude"
+  const candidates = [`@anthropic-ai/claude-code-${deps.platform}-${deps.arch}`]
+  // Linux musl variant — claude-code ships a separate package for Alpine
+  // and other musl-based distros.
+  if (deps.platform === "linux") {
+    candidates.push(`@anthropic-ai/claude-code-${deps.platform}-${deps.arch}-musl`)
+  }
+  for (const pkg of candidates) {
+    try {
+      const pkgJson = deps.resolvePackage(`${pkg}/package.json`)
+      const candidate = join(dirname(pkgJson), binName)
+      if (deps.existsSync(candidate)) return candidate
+    } catch {
+      // Package not installed for this arch — try the next candidate.
+    }
+  }
+  return null
+}
+
+/**
+ * Step 3: PATH lookup via `where claude` on Windows or `which claude` on POSIX.
+ *
+ * Windows nuances handled here:
+ *   - `where` returns multiple newline-separated paths when multiple
+ *     binaries match — pick the first one that exists.
+ *   - On systems with Git for Windows installed, plain `which claude`
+ *     would invoke `which.exe` from `usr/bin/` which emits mingw-style
+ *     paths like `/c/nvm4w/nodejs/claude` that `existsSync` rejects.
+ *     Using `where` (the cmd.exe builtin / PowerShell-equivalent)
+ *     avoids that whole class of bugs.
+ *
+ * Filtering: any path that starts with `/` on Windows is a mingw-style
+ * path (real Windows paths start with a drive letter); skip them rather
+ * than feed unusable strings to `existsSync`.
+ */
+async function tryPathLookup(deps: ResolverDeps): Promise<string | null> {
+  const cmd = deps.platform === "win32" ? "where claude" : "which claude"
+  try {
+    const { stdout } = await deps.exec(cmd)
+    const candidates = stdout.split(/\r?\n/).map((s) => s.trim()).filter(Boolean)
+    for (const candidate of candidates) {
+      if (deps.platform === "win32" && candidate.startsWith("/")) continue
+      if (deps.existsSync(candidate)) return candidate
+    }
+  } catch {
+    // No `claude` on PATH (or `where`/`which` not available).
+  }
+  return null
+}
+
+/**
+ * Step 4: legacy SDK bundled cli.js (SDK < 0.2.98 only — removed in
+ * 0.2.98+). Best-effort fallback for stale bun installs; no-op for
+ * fresh ones.
+ */
+function tryLegacySdkCliJs(deps: ResolverDeps): string | null {
+  if (!deps.isBun) return null
+  try {
+    const sdkPath = deps.resolvePackage("@anthropic-ai/claude-agent-sdk")
+    const cliJs = join(dirname(sdkPath), "cli.js")
+    return deps.existsSync(cliJs) ? cliJs : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Pure resolver — runs each step and returns the first hit, or null when
+ * all steps miss. Exported for unit tests; production callers use
+ * resolveClaudeExecutableAsync, which adds caching on top.
+ */
+export async function resolveClaudeExecutable(deps: ResolverDeps = DEFAULT_DEPS): Promise<string | null> {
+  return (
+    tryEnvOverride(deps) ??
+    tryBundledBinary(deps) ??
+    tryPlatformPackage(deps) ??
+    (await tryPathLookup(deps)) ??
+    tryLegacySdkCliJs(deps)
+  )
+}
+
 export async function resolveClaudeExecutableAsync(): Promise<string> {
   if (cachedClaudePath) return cachedClaudePath
   if (cachedClaudePathPromise) return cachedClaudePathPromise
 
   cachedClaudePathPromise = (async () => {
-    // Resolution order (tightened after SDK 0.2.98 removed the bundled cli.js):
-    //   1. Bundled @anthropic-ai/claude-code binary — ships with Meridian
-    //      via dependency; version-pinned, always current with the SDK.
-    //      Postinstall (package.json) invokes its install.cjs so the stub
-    //      in bin/claude.exe is replaced with the real platform binary.
-    //   2. System-installed claude binary (user or package manager put it
-    //      on PATH) — fallback for installs where postinstall didn't run.
-    //   3. Legacy SDK bundled cli.js — only exists for SDK < 0.2.98; kept
-    //      as a best-effort fallback for stale installs. Removed in
-    //      SDK ≥ 0.2.98, so this branch is a no-op going forward.
-    const runningUnderBun = typeof process.versions.bun !== "undefined"
-
-    // 1. Bundled @anthropic-ai/claude-code binary (preferred — version-pinned)
-    try {
-      const pkgPath = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-code/package.json"))
-      const bundledBinary = join(dirname(pkgPath), "bin", "claude.exe")
-      if (existsSync(bundledBinary)) {
-        cachedClaudePath = bundledBinary
-        return bundledBinary
-      }
-    } catch {}
-
-    // 2. System-installed claude binary (standalone — no runtime dependency)
-    try {
-      const { stdout } = await exec("which claude")
-      const claudePath = stdout.trim()
-      if (claudePath && existsSync(claudePath)) {
-        cachedClaudePath = claudePath
-        return claudePath
-      }
-    } catch {}
-
-    // 3. Legacy: SDK bundled cli.js (SDK < 0.2.98 only — removed in 0.2.98+)
-    if (runningUnderBun) {
-      try {
-        const sdkPath = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-agent-sdk"))
-        const sdkCliJs = join(dirname(sdkPath), "cli.js")
-        if (existsSync(sdkCliJs)) {
-          cachedClaudePath = sdkCliJs
-          return sdkCliJs
-        }
-      } catch {}
+    const resolved = await resolveClaudeExecutable()
+    if (resolved) {
+      cachedClaudePath = resolved
+      return resolved
     }
-
-    throw new Error("Could not find Claude Code executable. Install via: npm install -g @anthropic-ai/claude-code")
+    throw new Error(
+      "Could not find Claude Code executable. Install via: npm install -g @anthropic-ai/claude-code, " +
+      "or set MERIDIAN_CLAUDE_PATH=/path/to/claude to point at an existing binary.",
+    )
   })()
 
   try {


### PR DESCRIPTION
Fixes the Claude executable resolver to handle two unrelated failure modes that together leave Windows users (#417) and some macOS users (#445) unable to start the proxy.

## Root causes

**Issue #417** — Windows resolver bugs (analysis credit: @Macawls):
- `exec("which claude")` on Windows invokes Git for Windows' `which.exe`, which emits mingw-style paths (`/c/nvm4w/nodejs/claude`) that Node's `existsSync` rejects.
- No `MERIDIAN_CLAUDE_PATH` env escape hatch for users with unusual setups.
- @BenIsLegit's follow-up: even when the bundled binary exists, `bin/claude.exe` can fail with `spawn UNKNOWN` on Windows; the platform-specific peer package binary works.

**Issue #445** — broken upstream postinstall:
- `@anthropic-ai/claude-code`'s `install.cjs` can fail with ENOENT (e.g. on homebrew npm setups).
- When that fails, `bin/claude.exe` stays as a ~500-byte placeholder stub instead of being replaced with the ~200 MB real binary.
- The old resolver picked up the stub and handed it to the SDK, which then failed at runtime with a cryptic spawn error.

## Fix

Refactored `resolveClaudeExecutableAsync` into a pure `resolveClaudeExecutable(deps)` function with all I/O dependencies injected. Production caller `resolveClaudeExecutableAsync` wraps it with caching (unchanged contract). Tests inject mock deps to simulate Windows / broken-postinstall / etc. without touching the real filesystem.

New resolution order, each step pure and falling through on miss:

| # | Source | Solves |
|---|---|---|
| 0 | `MERIDIAN_CLAUDE_PATH` env var | Universal escape hatch (Macawls' suggestion) |
| 1 | `@anthropic-ai/claude-code/bin/claude.exe` **with stub-size guard** (skip files ≤ 4 KB) | #445 — broken postinstall stub no longer poisons the resolver |
| 2 | `@anthropic-ai/claude-code-<platform>-<arch>/claude[.exe]` (and `-musl` on Linux) | Bypasses bundled wrapper entirely; works for #445 (no postinstall needed) AND #417 BenIsLegit case (wrapper fails but platform binary works) |
| 3 | `where claude` on Windows / `which claude` on POSIX. Multi-line stdout parsed; mingw `/c/...` paths filtered out as defense-in-depth. | #417 main complaint |
| 4 | Legacy SDK cli.js (bun only, SDK < 0.2.98) | Existing fallback, kept |

## Tests

26 new unit tests in `claude-executable-resolver.test.ts` covering:
- Env override priority + presence/absence/empty handling
- Stub-size guard at the 4 KB boundary
- Each platform package variant (darwin-arm64, win32-x64, win32-arm64, linux-x64-musl fallback)
- `where` vs `which` command selection
- Multi-line stdout parsing + first-existing-path selection
- Mingw `/c/...` path filtering on Windows
- Bun-only legacy cli.js gate
- Full priority chain (env beats bundled, bundled real beats platform, platform beats PATH when bundled is stub)

**Result:** 1643 tests pass / 0 fail / typecheck clean.

## Windows CI smoke test

New `windows-smoke` job in `.github/workflows/ci.yml` that on `windows-latest`:
1. `bun install` — exercises claude-code's postinstall on real Windows
2. Runs the resolver tests on the real Windows runtime (path joining, file URLs, etc.)
3. Builds the bundle
4. Spawns `node dist/cli.js`, polls `/health` for 30s, verifies a 200 response with a `version` field

This is the real backstop — it catches Windows-specific regressions in the install + start flow that unit tests with mocks can't see, and runs on every PR.

## Honest verification disclosure

I'm developing on macOS arm64. The unit tests exhaustively cover the resolver's branching logic with mocked deps, but **I can't run a true Windows e2e test from this machine.** The Windows CI smoke job above will do that on this PR. **Please don't merge until that job passes** AND ideally one of the original reporters confirms it works on their setup.

Pinging the reporters who diagnosed this:
- @Macawls — does this match your earlier patch and unblock the install on Windows 10 + nvm4w + Git for Windows?
- @BenIsLegit — does the platform-package fallback resolve the `spawn UNKNOWN` you hit?
- @murrayju — once installed (with `--ignore-scripts` if needed), does the proxy boot for you on macOS? Note the upstream `claude-code` postinstall ENOENT is not directly fixable from meridian, but with this PR a broken postinstall no longer breaks startup.

## Test plan

- [x] `npm test` — 1643 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] macOS regression: `resolveClaudeExecutable()` returns the real bundled binary as before
- [ ] Windows CI smoke (will fire on push)
- [ ] Real-world verification by reporters before merge