### PR TITLE
fix(tokenRefresh): write compact JSON for credentials (closes #452)

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 import type { CredentialStore } from "../proxy/tokenRefresh"
+import { serializeCredentials } from "../proxy/tokenRefresh"
 
 /** Assign a mock to globalThis.fetch without TS complaining about missing `preconnect` */
 function mockFetch(fn: (...args: unknown[]) => Promise<Response | never>): void {
@@ -288,5 +289,60 @@ describe("isExpiredTokenError", () => {
     expect(isExpiredTokenError("rate limit exceeded")).toBe(false)
     expect(isExpiredTokenError("invalid credentials")).toBe(false)
     expect(isExpiredTokenError("token refresh failed")).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: issue #452 — credentials must be written compact (no whitespace)
+// ---------------------------------------------------------------------------
+//
+// `JSON.stringify(credentials, null, 2)` would pretty-print, which Claude
+// Code's credential parser cannot read. Result: silent logout after Meridian
+// refreshed the token. This test pins the output format so a future commit
+// can't accidentally re-introduce indentation.
+
+describe("serializeCredentials", () => {
+  const FIXTURE = {
+    claudeAiOauth: {
+      accessToken: "tok-abc",
+      refreshToken: "ref-xyz",
+      expiresAt: 1700000000000,
+      scopes: ["openid", "profile"],
+      subscriptionType: "max",
+      rateLimitTier: "standard",
+    },
+  }
+
+  it("emits compact JSON (no newlines)", () => {
+    expect(serializeCredentials(FIXTURE)).not.toContain("\n")
+  })
+
+  it("emits compact JSON (no two-space indent)", () => {
+    expect(serializeCredentials(FIXTURE)).not.toContain("  ")
+  })
+
+  it("emits valid JSON that round-trips through JSON.parse", () => {
+    const out = serializeCredentials(FIXTURE)
+    expect(JSON.parse(out)).toEqual(FIXTURE)
+  })
+
+  it("matches what JSON.stringify(x) would produce (drop-in equivalent)", () => {
+    expect(serializeCredentials(FIXTURE)).toBe(JSON.stringify(FIXTURE))
+  })
+
+  it("preserves arbitrary extra fields (does not strip user data)", () => {
+    const withExtras = { ...FIXTURE, customField: "value", nested: { a: 1 } }
+    const parsed = JSON.parse(serializeCredentials(withExtras))
+    expect(parsed.customField).toBe("value")
+    expect(parsed.nested).toEqual({ a: 1 })
+  })
+
+  it("never emits the pretty-printed form (regression #452)", () => {
+    const compact = serializeCredentials(FIXTURE)
+    const pretty = JSON.stringify(FIXTURE, null, 2)
+    expect(compact).not.toBe(pretty)
+    // pretty-printed always contains a newline between fields; compact never does.
+    expect(pretty).toContain("\n")
+    expect(compact).not.toContain("\n")
   })
 })

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -74,6 +74,20 @@ export interface CredentialStore {
   write(credentials: CredentialsFile): Promise<boolean>
 }
 
+/**
+ * Serialize a credentials object to the on-disk / Keychain format Claude Code
+ * expects.
+ *
+ * MUST be compact (no whitespace) — Claude Code's credential parser cannot
+ * read pretty-printed JSON and treats the user as logged out when it
+ * encounters one. See issue #452.
+ *
+ * Exported so the regression test can pin the output format directly.
+ */
+export function serializeCredentials(credentials: CredentialsFile): string {
+  return JSON.stringify(credentials)
+}
+
 // ---------------------------------------------------------------------------
 // macOS Keychain backend
 // ---------------------------------------------------------------------------
@@ -121,7 +135,7 @@ function buildMacosStore(serviceName: string): CredentialStore {
     },
 
     async write(credentials) {
-      const json = JSON.stringify(credentials, null, 2)
+      const json = serializeCredentials(credentials)
       const wasHex = keychainWasHexByService.get(serviceName) ?? false
       // Write back in the same encoding Claude Code expects — hex after `claude login`.
       const value = wasHex ? Buffer.from(json).toString("hex") : json
@@ -162,7 +176,7 @@ function buildFileStore(filePath: string): CredentialStore {
       try {
         // Ensure parent dir exists for non-default paths.
         mkdirSync(dirname(filePath), { recursive: true })
-        writeFileSync(filePath, JSON.stringify(credentials, null, 2), "utf-8")
+        writeFileSync(filePath, serializeCredentials(credentials), "utf-8")
         return true
       } catch (err) {
         claudeLog("token_refresh.file_write_failed", { path: filePath, error: String(err) })


### PR DESCRIPTION
Fixes #452 — reported by @johanes-dev.

## Bug

Both credential backends were calling `JSON.stringify(credentials, null, 2)`:

- `src/proxy/tokenRefresh.ts:124` — macOS Keychain backend
- `src/proxy/tokenRefresh.ts:165` — Linux file backend

Claude Code's credential parser cannot read pretty-printed JSON. After Meridian refreshed an OAuth token, Claude Code would silently treat the user as logged out, forcing re-login.

## Fix

Extract the format choice into `serializeCredentials()` (exported) and use it from both write paths. Compact output matches what Claude Code itself writes after `claude login`.

## Tests

6 new regression tests in `token-refresh.test.ts` pin the format:
- No newlines
- No two-space indent
- Round-trips through `JSON.parse`
- Drop-in equivalent to `JSON.stringify(x)`
- Preserves arbitrary extra fields (no data loss)
- Never produces the pretty-printed form (explicit regression check)

The "drop-in equivalent" test means a future commit can't subtly change the format and have the existing tests pass.

## Test plan

- [x] `npm test` — 1649 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [ ] CI confirms (will fire on push)

## Verification request

@johanes-dev — once this lands, would you confirm that re-login is no longer needed after Meridian's token refresh on your setup? You can install from the merged commit before the next release with:

\`\`\`bash
npm install -g github:rynfar/meridian#main
\`\`\`