### PR TITLE
fix(query): strip CLAUDE_CONFIG_DIR for sharedMemory instead of setting (closes #453)

### DIFF
--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -281,14 +281,47 @@ describe("buildQueryOptions", () => {
     expect(opts.settings).toBeUndefined()
   })
 
-  it("sets CLAUDE_CONFIG_DIR when sharedMemory is true", () => {
-    const result = buildQueryOptions(makeContext({ sharedMemory: true }))
+  // sharedMemory env handling — see issue #453 (and upstream
+  // anthropics/claude-code#20553). Setting CLAUDE_CONFIG_DIR=$HOME/.claude
+  // explicitly — even though it's the default — changes the SDK's Keychain
+  // lookup key and breaks OAuth. So when sharedMemory is on, we DO NOT set
+  // CLAUDE_CONFIG_DIR; we instead strip any inherited custom value so the
+  // SDK falls back to its own default (which is ~/.claude).
+
+  it("does NOT set CLAUDE_CONFIG_DIR when sharedMemory=true and profile env is empty (regression #453)", () => {
+    const result = buildQueryOptions(makeContext({ sharedMemory: true, cleanEnv: {} }))
     const env = (result.options as any).env
-    expect(env.CLAUDE_CONFIG_DIR).toContain(".claude")
+    // Was the bug: previously this asserted env.CLAUDE_CONFIG_DIR contained
+    // ".claude". Setting it explicitly broke macOS Keychain auth.
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
   })
 
-  it("omits CLAUDE_CONFIG_DIR when sharedMemory is false", () => {
-    const result = buildQueryOptions(makeContext({ sharedMemory: false }))
+  it("strips inherited CLAUDE_CONFIG_DIR when sharedMemory=true (custom profile case)", () => {
+    // sharedMemory's intent is "use the SDK's default ~/.claude so memories
+    // sync with Claude Code". When a profile inherits a custom config dir,
+    // we need that custom path REMOVED — not overridden — so the SDK's own
+    // default takes over without the explicit-set bug.
+    const result = buildQueryOptions(makeContext({
+      sharedMemory: true,
+      cleanEnv: { CLAUDE_CONFIG_DIR: "/custom/profile/dir", SOMETHING_ELSE: "keep-me" },
+    }))
+    const env = (result.options as any).env
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
+    // Other inherited env vars are preserved.
+    expect(env.SOMETHING_ELSE).toBe("keep-me")
+  })
+
+  it("preserves CLAUDE_CONFIG_DIR from profile when sharedMemory=false", () => {
+    const result = buildQueryOptions(makeContext({
+      sharedMemory: false,
+      cleanEnv: { CLAUDE_CONFIG_DIR: "/custom/profile/dir" },
+    }))
+    const env = (result.options as any).env
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/custom/profile/dir")
+  })
+
+  it("omits CLAUDE_CONFIG_DIR when sharedMemory is false and profile env is empty", () => {
+    const result = buildQueryOptions(makeContext({ sharedMemory: false, cleanEnv: {} }))
     const env = (result.options as any).env
     expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
   })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -6,10 +6,22 @@
  */
 
 import { join } from "node:path"
-import { homedir } from "node:os"
 import type { Options, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
+
+/**
+ * Return a copy of `env` with `CLAUDE_CONFIG_DIR` removed. Used by the
+ * sharedMemory branch — see the comment at the env construction site.
+ *
+ * Pure function: never mutates the input.
+ */
+function stripConfigDir(env: Record<string, string | undefined>): Record<string, string | undefined> {
+  if (!("CLAUDE_CONFIG_DIR" in env)) return env
+  const out = { ...env }
+  delete out.CLAUDE_CONFIG_DIR
+  return out
+}
 
 export interface QueryContext {
   /** The prompt to send (text or async iterable for multimodal) */
@@ -235,11 +247,18 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       } : {}),
       ...(onStderr ? { stderr: onStderr } : {}),
       env: {
-        ...cleanEnv,
+        // sharedMemory: the user wants the SDK to use Claude Code's default
+        // config dir so memories sync. Counter-intuitively we DON'T set
+        // CLAUDE_CONFIG_DIR=$HOME/.claude here — explicitly setting it (even
+        // to the default value) changes the SDK's Keychain lookup key and
+        // breaks OAuth (issue #453, upstream anthropics/claude-code#20553).
+        // Instead, strip any inherited custom CLAUDE_CONFIG_DIR from the
+        // profile env so the SDK falls back to its own default. That achieves
+        // the "share memory with Claude Code" intent without poisoning
+        // Keychain auth.
+        ...(sharedMemory ? stripConfigDir(cleanEnv) : cleanEnv),
         ENABLE_TOOL_SEARCH: hasDeferredTools ? "true" : "false",
         ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
-        // Shared memory: point SDK at ~/.claude so memories are shared with Claude Code
-        ...(sharedMemory ? { CLAUDE_CONFIG_DIR: join(homedir(), ".claude") } : {}),
         // When running as root (Docker, Unraid, NAS), set IS_SANDBOX=1 to
         // bypass the SDK's root check. Without this, the SDK exits with:
         // "--dangerously-skip-permissions cannot be used with root/sudo"


### PR DESCRIPTION
Closes #453 — reported by @johanes-dev.

## Bug

`src/proxy/query.ts` was setting `CLAUDE_CONFIG_DIR=$HOME/.claude` whenever `sharedMemory` was true:

\`\`\`ts
...(sharedMemory ? { CLAUDE_CONFIG_DIR: join(homedir(), ".claude") } : {}),
\`\`\`

The intent was "make the SDK use Claude Code's default config dir so memories sync." Counter-intuitively, EXPLICITLY setting that env var to the default value changes the SDK's Keychain lookup key and breaks OAuth — even though the path string is identical to what the SDK would compute itself.

Reporter cites upstream documentation: [anthropics/claude-code#20553](https://github.com/anthropics/claude-code/issues/20553).

## Fix

When `sharedMemory` is on, **strip** any inherited `CLAUDE_CONFIG_DIR` from the profile env instead of setting one. The SDK then falls back to its own default (`~/.claude`) without the env-var poisoning the Keychain lookup.

This handles both cases the reporter's strict fix wouldn't:

| Scenario | Before | After |
|---|---|---|
| Default profile + sharedMemory | env explicitly set → Keychain breaks | env unset → SDK uses default ~/.claude ✓ |
| Custom profile + sharedMemory | env override (but Keychain still broken) | custom path stripped → SDK uses default ✓ |
| Default profile + no sharedMemory | env unset | env unset (unchanged) |
| Custom profile + no sharedMemory | env preserved | env preserved (unchanged) |

Implementation: small `stripConfigDir(env)` helper, conditionally swapped in for `cleanEnv` when `sharedMemory` is true.

## Tests

Replaced the two existing assertions that pinned the buggy "set to default" behavior with **4 tests covering the full matrix**:

- Default profile + sharedMemory=true: `CLAUDE_CONFIG_DIR` is undefined (regression-pinned to #453)
- Custom profile + sharedMemory=true: `CLAUDE_CONFIG_DIR` stripped, **other env vars preserved** (defends against accidental over-stripping)
- Custom profile + sharedMemory=false: custom value preserved
- Default profile + sharedMemory=false: env empty as before

All 1660 tests pass / 0 fail / typecheck clean.

Removed the now-unused `homedir` import.

## Verification request

@johanes-dev — would you confirm once this lands? You can install from the merged commit before the next release with:

\`\`\`bash
npm install -g github:rynfar/meridian#main
\`\`\`

Should resolve the "Not logged in" symptom when `sharedMemory` is enabled. Two of yours fixed today (#452 and now #453) — thanks for the precision on both.

## Test plan

- [x] `npm test` — 1660 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] Test matrix covers all 4 cases (default/custom × on/off)
- [ ] CI confirms (will fire on push)