### PR TITLE
fix(env): strip CLAUDE_CODE_USE_POWERSHELL_TOOL from SDK env (closes #441)

### DIFF
--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -149,6 +149,29 @@ describe("Environment variable stripping", () => {
     delete process.env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
   })
 
+  // Regression: #441 — Claude calls SDK-only `PowerShell` tool that OpenCode
+  // can't execute. Triggered by `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` inherited
+  // from settings.json or shell env. Setting to "0" doesn't help — the var
+  // must be removed entirely.
+  it("should strip CLAUDE_CODE_USE_POWERSHELL_TOOL=1 (regression #441)", async () => {
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = "1"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.CLAUDE_CODE_USE_POWERSHELL_TOOL).toBeUndefined()
+    delete process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL
+  })
+
+  it("should strip CLAUDE_CODE_USE_POWERSHELL_TOOL=0 too (full removal, not just disable)", async () => {
+    // Per the upstream behavior the reporter documented: even setting it to
+    // "0" can leak the PowerShell tool to the model. Belt-and-suspenders:
+    // we strip the var entirely regardless of value.
+    process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL = "0"
+    const app = createTestApp()
+    await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.CLAUDE_CODE_USE_POWERSHELL_TOOL).toBeUndefined()
+    delete process.env.CLAUDE_CODE_USE_POWERSHELL_TOOL
+  })
+
   it("should work in streaming mode too", async () => {
     process.env.ANTHROPIC_API_KEY = "dummy"
     process.env.ANTHROPIC_BASE_URL = "http://127.0.0.1:3456"

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -442,12 +442,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         // Strip env vars that would cause the SDK subprocess to loop back through
         // the proxy instead of using its native Claude Max auth. Also strip vars
-        // that cause unwanted SDK plugin/feature loading.
+        // that cause unwanted SDK plugin/feature loading or expose Claude-Code-
+        // host-only tools that downstream agents (OpenCode, Crush, Droid, etc.)
+        // cannot execute.
         const {
-          CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,
+          // Strips infinite loop / wrong-auth conditions:
           ANTHROPIC_API_KEY: _dropApiKey,
           ANTHROPIC_BASE_URL: _dropBaseUrl,
           ANTHROPIC_AUTH_TOKEN: _dropAuthToken,
+          // Strips unwanted SDK plugin/feature loading:
+          CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,
+          // Strips Claude-Code-only tools that other agents can't execute.
+          // CLAUDE_CODE_USE_POWERSHELL_TOOL=1 makes the SDK register a
+          // `PowerShell` tool the model can call. OpenCode (and other clients)
+          // expose `bash` instead and reject `PowerShell` as an unavailable
+          // tool. Setting it to "0" doesn't help — the var has to be removed
+          // entirely. See issue #441.
+          CLAUDE_CODE_USE_POWERSHELL_TOOL: _dropUsePowershell,
           ...cleanEnv
         } = process.env
 


### PR DESCRIPTION
Closes #441 — reported by @BenIsLegit.

## Bug

When meridian acts as the Claude provider for OpenCode on Windows, Claude can attempt to call the SDK's `PowerShell` tool. OpenCode rejects it as unavailable:

\`\`\`
invalid [tool=PowerShell, error=Model tried to call unavailable tool 'PowerShell'.
Available tools: invalid, question, bash, read, glob, grep, edit, write, task, webfetch, todowrite, skill, quota_status.]
\`\`\`

Triggered by `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` inherited from the user's Claude Code `settings.json` or shell env. Meridian was passing it through to the SDK subprocess unchanged.

## Fix

Add `CLAUDE_CODE_USE_POWERSHELL_TOOL` to meridian's existing env-strip destructure in `server.ts`. The reporter documented that **setting the var to "0" doesn't fully disable** the tool — the variable has to be **removed entirely**, which the destructure pattern already does for any value.

Strips universally rather than per-adapter. The PowerShell tool is a Claude-Code-host feature; agents going through meridian (OpenCode, Crush, Droid, Pi, Forgecode, custom) all expose `bash` instead. If a future client ever needs PowerShell support, we can add a per-adapter opt-in then.

## Tests

2 new regression cases in `proxy-env-stripping.test.ts`, mirroring the existing pattern:
- Strips when value is `"1"` (the documented trigger)
- Strips when value is `"0"` too (per the reporter, "0" can still leak)

All 1662 tests pass / 0 fail / typecheck clean.

## Verification request

@BenIsLegit — would you confirm once this lands? You can install from the merged commit before the next release with:

\`\`\`bash
npm install -g github:rynfar/meridian#main
\`\`\`

Two of yours fixed today (this one + the Windows resolver work in #463) — thanks for the precision on both reports. The OpenCode tool-resolution trace in the body was particularly helpful.

## Test plan

- [x] `npm test` — 1662 pass / 0 fail
- [x] `npx tsc --noEmit` — clean
- [x] Tests cover both "1" and "0" cases (full removal regardless of value)
- [ ] CI confirms (will fire on push)