### PR TITLE
fix(proxy): forward auth headers on /v1/chat/completions internal hop

### DIFF
--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -580,3 +580,87 @@ describe("Regression: /v1/messages unaffected", () => {
     expect(res.status).toBe(400)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Auth (issue #415): forward caller's auth headers on the internal hop
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/chat/completions — MERIDIAN_API_KEY auth forwarding (#415)", () => {
+  const TEST_KEY = "test-key-415"
+  let savedKey: string | undefined
+
+  beforeEach(() => {
+    savedKey = process.env.MERIDIAN_API_KEY
+    process.env.MERIDIAN_API_KEY = TEST_KEY
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedPromptMessages = []
+    clearSessionCache()
+  })
+
+  // Manual restore — bun:test's afterEach isn't imported in this file's other suites,
+  // and we don't want to leak the env var into unrelated tests.
+  function restoreKey() {
+    if (savedKey === undefined) delete process.env.MERIDIAN_API_KEY
+    else process.env.MERIDIAN_API_KEY = savedKey
+  }
+
+  it("accepts a valid Authorization: Bearer header and reaches the SDK", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Authorization": `Bearer ${TEST_KEY}` },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }))
+    restoreKey()
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.object).toBe("chat.completion")
+  })
+
+  it("accepts a valid x-api-key header and reaches the SDK", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-api-key": TEST_KEY },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }))
+    restoreKey()
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    expect(body.object).toBe("chat.completion")
+  })
+
+  it("rejects requests with no auth header (regression guard against accidental bypass)", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }))
+    restoreKey()
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects requests with a wrong Bearer token", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Authorization": "Bearer wrong-key" },
+      body: JSON.stringify({
+        model: "claude-haiku-4-5-20251001",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    }))
+    restoreKey()
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2514,9 +2514,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
     // Route internally via app.fetch() — no network roundtrip.
     // Hono resolves the path in-process; the URL scheme/host are ignored.
+    // Forward the caller's auth headers so requireAuth on /v1/messages accepts
+    // the inner hop when MERIDIAN_API_KEY is set (issue #415).
+    const internalHeaders: Record<string, string> = { "Content-Type": "application/json" }
+    const xApiKey = c.req.header("x-api-key")
+    if (xApiKey) internalHeaders["x-api-key"] = xApiKey
+    const authz = c.req.header("authorization")
+    if (authz) internalHeaders["authorization"] = authz
     const internalReq = new Request("http://internal/v1/messages", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: internalHeaders,
       body: JSON.stringify(anthropicBody),
     })
     const internalRes = await app.fetch(internalReq)


### PR DESCRIPTION
## Summary

- Fixes #415 — `/v1/chat/completions` returned 401 when `MERIDIAN_API_KEY` was set, because the internal `app.fetch('/v1/messages')` hop only forwarded `Content-Type` and tripped its own `requireAuth` middleware.
- Forward the caller's `x-api-key` and `Authorization` headers onto the internal request so the inner hop authenticates successfully. The outer `/v1/chat/completions` request has already passed `requireAuth` (it's under `/v1/*`), so the caller is authenticated by the time we reach the handler — we just carry the same key forward.

## Test plan

- [x] 4 new unit tests in `proxy-openai-compat.test.ts`:
  - `Authorization: Bearer <key>` → 200 (reaches mocked SDK)
  - `x-api-key: <key>` → 200 (reaches mocked SDK)
  - no auth header → 401 (regression guard against accidental bypass)
  - wrong Bearer token → 401
- [x] 22 pre-existing openai-compat tests still pass
- [x] Full `npm test` green (1654 tests / 0 fail)
- [x] E2E against a real proxy (`MERIDIAN_PORT=3458 MERIDIAN_API_KEY=test-415-key`) hitting real Claude Max:
  - no auth → 401 ✓
  - wrong Bearer → 401 ✓
  - correct `Authorization: Bearer test-415-key` → 200, `chat.completion` shape ✓
  - correct `x-api-key: test-415-key` → 200, `chat.completion` shape ✓

Reproduces and verifies the fix per the reporter's exact repro steps.