### PR TITLE
fix(proxy): fall back to process.cwd() when SDK cwd doesn't exist (#381)

### DIFF
--- a/src/__tests__/cwd.test.ts
+++ b/src/__tests__/cwd.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for resolveSdkWorkingDirectory.
+ *
+ * Verifies the precedence chain (env > adapter > fallback) and the
+ * existsSync-based fallback that fixes the remote-host issue (#381).
+ */
+
+import { describe, it, expect } from "bun:test"
+import { resolveSdkWorkingDirectory } from "../proxy/cwd"
+
+describe("resolveSdkWorkingDirectory", () => {
+  it("uses env override when set and exists", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: "/env/path",
+      adapterCwd: "/adapter/path",
+      fallback: "/fallback",
+      exists: (p) => p === "/env/path",
+    })
+    expect(r.workingDirectory).toBe("/env/path")
+    expect(r.claimedWorkingDirectory).toBe("/env/path")
+    expect(r.fellBack).toBe(false)
+  })
+
+  it("uses adapter cwd when env is unset and adapter cwd exists", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: undefined,
+      adapterCwd: "/adapter/path",
+      fallback: "/fallback",
+      exists: (p) => p === "/adapter/path",
+    })
+    expect(r.workingDirectory).toBe("/adapter/path")
+    expect(r.claimedWorkingDirectory).toBe("/adapter/path")
+    expect(r.fellBack).toBe(false)
+  })
+
+  it("uses fallback when both env and adapter are unset", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: undefined,
+      adapterCwd: undefined,
+      fallback: "/fallback",
+      exists: () => true,
+    })
+    expect(r.workingDirectory).toBe("/fallback")
+    expect(r.claimedWorkingDirectory).toBe("/fallback")
+    expect(r.fellBack).toBe(false)
+  })
+
+  // Regression for #381 — when client supplies a working directory that
+  // doesn't exist on the proxy host (remote-host setup), we MUST fall back
+  // to the proxy's own cwd or the SDK spawn dies with ENOENT.
+  it("falls back to fallback when adapter cwd doesn't exist (remote-host case)", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: undefined,
+      adapterCwd: "/Users/clientmachine/proj",
+      fallback: "/home/proxy",
+      exists: (p) => p === "/home/proxy", // adapter path missing on proxy host
+    })
+    expect(r.workingDirectory).toBe("/home/proxy")
+    expect(r.claimedWorkingDirectory).toBe("/Users/clientmachine/proj")
+    expect(r.fellBack).toBe(true)
+  })
+
+  it("falls back when env override doesn't exist", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: "/missing",
+      adapterCwd: undefined,
+      fallback: "/home/proxy",
+      exists: (p) => p === "/home/proxy",
+    })
+    expect(r.workingDirectory).toBe("/home/proxy")
+    expect(r.claimedWorkingDirectory).toBe("/missing")
+    expect(r.fellBack).toBe(true)
+  })
+
+  it("env override beats adapter cwd even when adapter cwd exists", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: "/env/path",
+      adapterCwd: "/adapter/path",
+      fallback: "/fallback",
+      exists: () => true, // both exist
+    })
+    expect(r.workingDirectory).toBe("/env/path")
+    expect(r.fellBack).toBe(false)
+  })
+
+  it("treats empty string envOverride as unset", () => {
+    const r = resolveSdkWorkingDirectory({
+      envOverride: "",
+      adapterCwd: "/adapter/path",
+      fallback: "/fallback",
+      exists: () => true,
+    })
+    expect(r.workingDirectory).toBe("/adapter/path")
+  })
+})

--- a/src/__tests__/proxy-droid-integration.test.ts
+++ b/src/__tests__/proxy-droid-integration.test.ts
@@ -10,7 +10,18 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { mkdirSync } from "node:fs"
 import { assistantMessage } from "./helpers"
+
+// Use real, existent directories so server.ts:resolveSdkWorkingDirectory's
+// existsSync check passes — otherwise the SDK cwd silently falls back to
+// process.cwd() (the fix for issue #381).
+const DROID_PROJECT_DIR = join(tmpdir(), "meridian-test-droid-project")
+const OPENCODE_PROJECT_DIR = join(tmpdir(), "meridian-test-opencode-project")
+mkdirSync(DROID_PROJECT_DIR, { recursive: true })
+mkdirSync(OPENCODE_PROJECT_DIR, { recursive: true })
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -67,7 +78,7 @@ Model: claude-sonnet-4-5-20250514
 Today's date: 2026-03-29
 
 % pwd
-/Users/dev/my-project
+${DROID_PROJECT_DIR}
 
 % ls
 src package.json
@@ -102,7 +113,7 @@ const OPENCODE_BODY = {
   model: "claude-sonnet-4-5-20250929",
   max_tokens: 1024,
   stream: false,
-  system: "<env>\n  Working directory: /Users/dev/opencode-project\n</env>",
+  system: `<env>\n  Working directory: ${OPENCODE_PROJECT_DIR}\n</env>`,
   messages: [{ role: "user", content: "Hello" }],
   tools: [
     { name: "Read", description: "Read a file", input_schema: { type: "object", properties: {} } },
@@ -256,13 +267,13 @@ describe("Droid adapter: CWD extraction from system-reminder", () => {
     const app = createTestApp()
     await (await post(app, DROID_BODY, { "User-Agent": DROID_UA })).json()
     // The proxy passes cwd to the SDK options
-    expect(capturedQueryParams.options.cwd).toBe("/Users/dev/my-project")
+    expect(capturedQueryParams.options.cwd).toBe(DROID_PROJECT_DIR)
   })
 
   it("OpenCode uses CWD from env block in system prompt", async () => {
     const app = createTestApp()
     await (await post(app, OPENCODE_BODY)).json()
-    expect(capturedQueryParams.options.cwd).toBe("/Users/dev/opencode-project")
+    expect(capturedQueryParams.options.cwd).toBe(OPENCODE_PROJECT_DIR)
   })
 })
 

--- a/src/__tests__/proxy-forgecode-integration.test.ts
+++ b/src/__tests__/proxy-forgecode-integration.test.ts
@@ -8,7 +8,16 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { mkdirSync } from "node:fs"
 import { assistantMessage, textBlockStart, textDelta, blockStop, messageDelta, messageStop, messageStart } from "./helpers"
+
+// Use a real, existent directory so server.ts:resolveSdkWorkingDirectory's
+// existsSync check passes — otherwise the SDK cwd silently falls back to
+// process.cwd() (the fix for issue #381).
+const FORGECODE_PROJECT_DIR = join(tmpdir(), "meridian-test-forgecode-project")
+mkdirSync(FORGECODE_PROJECT_DIR, { recursive: true })
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -50,7 +59,7 @@ const FORGECODE_BODY = {
   system: [
     {
       type: "text",
-      text: "<system_information>\n<operating_system>Darwin</operating_system>\n<current_working_directory>/Users/dev/my-project</current_working_directory>\n<default_shell>/bin/zsh</default_shell>\n<home_directory>/Users/dev</home_directory>\n</system_information>",
+      text: `<system_information>\n<operating_system>Darwin</operating_system>\n<current_working_directory>${FORGECODE_PROJECT_DIR}</current_working_directory>\n<default_shell>/bin/zsh</default_shell>\n<home_directory>/Users/dev</home_directory>\n</system_information>`,
     },
   ],
   messages: [{
@@ -73,7 +82,7 @@ const OPENCODE_BODY = {
   model: "claude-sonnet-4-5-20250929",
   max_tokens: 1024,
   stream: false,
-  system: "<env>\n  Working directory: /Users/dev/my-project\n</env>",
+  system: `<env>\n  Working directory: ${FORGECODE_PROJECT_DIR}\n</env>`,
   messages: [{ role: "user", content: "Hello" }],
 }
 
@@ -408,7 +417,7 @@ describe("ForgeCode adapter: CWD extraction through proxy", () => {
     // The proxy extracts CWD from the adapter and uses it for fingerprinting
     // and as the working directory for the SDK query
     expect(capturedQueryParams).toBeDefined()
-    expect(capturedQueryParams.options.cwd).toBe("/Users/dev/my-project")
+    expect(capturedQueryParams.options.cwd).toBe(FORGECODE_PROJECT_DIR)
   })
 })
 

--- a/src/__tests__/proxy-working-directory.test.ts
+++ b/src/__tests__/proxy-working-directory.test.ts
@@ -5,10 +5,14 @@
  * so that Claude's system prompt shows the user's project directory,
  * not the proxy's installation directory.
  *
- * Configurable via CLAUDE_PROXY_WORKDIR env var.
+ * Configurable via CLAUDE_PROXY_WORKDIR env var. When the resolved cwd
+ * doesn't exist on the proxy host (remote-server case, issue #381) we
+ * fall back to process.cwd() to keep the SDK spawn from dying with
+ * ENOENT.
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { tmpdir } from "node:os"
 import { assistantMessage } from "./helpers"
 
 let mockMessages: any[] = []
@@ -71,9 +75,12 @@ describe("Working directory", () => {
     expect(typeof capturedQueryParams.options.cwd).toBe("string")
   })
 
-  it("should use CLAUDE_PROXY_WORKDIR when set", async () => {
+  it("should use CLAUDE_PROXY_WORKDIR when set and the path exists", async () => {
     const original = process.env.CLAUDE_PROXY_WORKDIR
-    process.env.CLAUDE_PROXY_WORKDIR = "/tmp/test-project"
+    // tmpdir() always exists; using a fake path triggers the existsSync
+    // fallback (covered separately below).
+    const realPath = tmpdir()
+    process.env.CLAUDE_PROXY_WORKDIR = realPath
 
     try {
       const app = createTestApp()
@@ -84,10 +91,76 @@ describe("Working directory", () => {
         messages: [{ role: "user", content: "hello" }],
       })).json()
 
-      expect(capturedQueryParams.options.cwd).toBe("/tmp/test-project")
+      expect(capturedQueryParams.options.cwd).toBe(realPath)
     } finally {
       if (original) process.env.CLAUDE_PROXY_WORKDIR = original
       else delete process.env.CLAUDE_PROXY_WORKDIR
+    }
+  })
+
+  it("should fall back to process.cwd() when CLAUDE_PROXY_WORKDIR points at a non-existent path (#381)", async () => {
+    const original = process.env.CLAUDE_PROXY_WORKDIR
+    process.env.CLAUDE_PROXY_WORKDIR = "/this/definitely/does/not/exist/zzz"
+
+    try {
+      const app = createTestApp()
+      await (await post(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 100,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })).json()
+
+      expect(capturedQueryParams.options.cwd).toBe(process.cwd())
+    } finally {
+      if (original) process.env.CLAUDE_PROXY_WORKDIR = original
+      else delete process.env.CLAUDE_PROXY_WORKDIR
+    }
+  })
+
+  it("should fall back to process.cwd() when client-supplied cwd doesn't exist (#381 remote-host case)", async () => {
+    const original = process.env.CLAUDE_PROXY_WORKDIR
+    delete process.env.CLAUDE_PROXY_WORKDIR
+    delete process.env.MERIDIAN_WORKDIR
+
+    try {
+      const app = createTestApp()
+      // Simulate OpenCode embedding a remote machine's path in <env>.
+      // The path doesn't exist on the proxy host — without the fallback,
+      // the SDK would fail with ENOENT (reported as "binary not found").
+      await (await post(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 100,
+        stream: false,
+        system: "<env>\nWorking directory: /Users/remoteclient/proj\nIs directory a git repo: yes\n</env>",
+        messages: [{ role: "user", content: "hello" }],
+      })).json()
+
+      expect(capturedQueryParams.options.cwd).toBe(process.cwd())
+    } finally {
+      if (original) process.env.CLAUDE_PROXY_WORKDIR = original
+    }
+  })
+
+  it("should use the client-supplied cwd when it exists on the proxy host (same-host case)", async () => {
+    const original = process.env.CLAUDE_PROXY_WORKDIR
+    delete process.env.CLAUDE_PROXY_WORKDIR
+    delete process.env.MERIDIAN_WORKDIR
+
+    try {
+      const realPath = tmpdir()
+      const app = createTestApp()
+      await (await post(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 100,
+        stream: false,
+        system: `<env>\nWorking directory: ${realPath}\nIs directory a git repo: yes\n</env>`,
+        messages: [{ role: "user", content: "hello" }],
+      })).json()
+
+      expect(capturedQueryParams.options.cwd).toBe(realPath)
+    } finally {
+      if (original) process.env.CLAUDE_PROXY_WORKDIR = original
     }
   })
 

--- a/src/proxy/cwd.ts
+++ b/src/proxy/cwd.ts
@@ -1,0 +1,53 @@
+/**
+ * Resolve the SDK subprocess `cwd:` option, falling back to a known-valid
+ * path on the proxy host when the resolved working directory doesn't exist.
+ *
+ * Background — issue #381:
+ *   When meridian runs on a remote machine (e.g. accessed over Tailscale)
+ *   and the client (OpenCode/Crush/etc.) runs on a different machine, the
+ *   adapter extracts the client's reported working directory and passes it
+ *   to the SDK as `cwd:`. That path doesn't exist on the proxy host, so
+ *   `child_process.spawn(claude, { cwd })` fails with ENOENT — which the
+ *   SDK then reports as the misleading "Claude Code native binary not
+ *   found at ..." error.
+ *
+ *   Falling back to the proxy's own `process.cwd()` lets the SDK spawn
+ *   succeed; `clientWorkingDirectory` is tracked separately (and emitted
+ *   into the model's context via buildCwdNote) so the model still hears
+ *   about the user's real working directory.
+ */
+
+import { existsSync } from "node:fs"
+
+export interface CwdResolution {
+  /** Path passed to the SDK as `cwd:`. Always exists on the proxy host. */
+  workingDirectory: string
+  /**
+   * The originally-resolved path before existence validation. May not
+   * exist on the proxy host. Used as `clientWorkingDirectory` for
+   * fingerprint bucketing and the system-prompt cwdNote.
+   */
+  claimedWorkingDirectory: string
+  /** True if `workingDirectory` differs from `claimedWorkingDirectory`. */
+  fellBack: boolean
+}
+
+export interface ResolveCwdOpts {
+  /** MERIDIAN_WORKDIR / CLAUDE_PROXY_WORKDIR (highest precedence). */
+  envOverride: string | undefined
+  /** Adapter's extracted client working directory. */
+  adapterCwd: string | undefined
+  /** Last-resort fallback. Must exist; typically `process.cwd()`. */
+  fallback: string
+  /** Injection point for tests. Defaults to `node:fs`'s existsSync. */
+  exists?: (path: string) => boolean
+}
+
+export function resolveSdkWorkingDirectory(opts: ResolveCwdOpts): CwdResolution {
+  const exists = opts.exists ?? existsSync
+  const claimed = opts.envOverride || opts.adapterCwd || opts.fallback
+  if (exists(claimed)) {
+    return { workingDirectory: claimed, claimedWorkingDirectory: claimed, fellBack: false }
+  }
+  return { workingDirectory: opts.fallback, claimedWorkingDirectory: claimed, fellBack: true }
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -7,6 +7,7 @@ import { join } from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { fetchOAuthUsage } from "./oauthUsage"
+import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
 import { envBool } from "../env"
@@ -437,8 +438,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // so the model reports the user's real path. For same-host clients
         // (OpenCode, Crush) the adapter can leave extractClientWorkingDirectory
         // undefined and the two collapse to the same value.
-        const workingDirectory = (process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR) || adapter.extractWorkingDirectory(body) || process.cwd()
-        const clientWorkingDirectory = adapter.extractClientWorkingDirectory?.(body) || workingDirectory
+        //
+        // Issue #381 — when meridian runs on a remote host and the client is
+        // on another machine, the claimed cwd may not exist locally; the SDK
+        // would otherwise fail with a misleading "binary not found" error.
+        // resolveSdkWorkingDirectory falls back to process.cwd() in that case.
+        const cwdResolution = resolveSdkWorkingDirectory({
+          envOverride: process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR,
+          adapterCwd: adapter.extractWorkingDirectory(body),
+          fallback: process.cwd(),
+        })
+        const workingDirectory = cwdResolution.workingDirectory
+        if (cwdResolution.fellBack) {
+          claudeLog("cwd_fallback", {
+            claimed: cwdResolution.claimedWorkingDirectory,
+            usedInstead: workingDirectory,
+          })
+        }
+        const clientWorkingDirectory = adapter.extractClientWorkingDirectory?.(body) || cwdResolution.claimedWorkingDirectory
 
         // Strip env vars that would cause the SDK subprocess to loop back through
         // the proxy instead of using its native Claude Max auth. Also strip vars


### PR DESCRIPTION
## Summary

Fixes #381 — when meridian runs on a remote host and the client (OpenCode/Crush/etc.) runs on another machine over the network, the adapter extracts the client's reported working directory and passes it to the SDK as `cwd:`. That path doesn't exist on the proxy host, so `child_process.spawn` fails with ENOENT, which the SDK then reports as the misleading **"Claude Code native binary not found at <path>"** error.

The fix validates the resolved cwd with `existsSync` before passing to the SDK and falls back to `process.cwd()` if missing. `clientWorkingDirectory` still tracks the claimed path so per-project session bucketing and the `buildCwdNote` system-prompt hint continue to work — the model still hears about the user's real working directory.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Local client (path exists on proxy host) | ✓ works | ✓ works (unchanged) |
| Remote client over Tailscale (path doesn't exist on proxy host) | ✗ "binary not found" | ✓ works, falls back to proxy's cwd |
| Explicit `MERIDIAN_WORKDIR=/foo/bar` (exists) | ✓ works | ✓ works (unchanged) |
| Explicit `MERIDIAN_WORKDIR=/typo/path` (missing) | ✗ "binary not found" | ✓ falls back, logs `cwd_fallback` |
| `clientWorkingDirectory` for fingerprint bucketing | claim | claim (unchanged) |
| `buildCwdNote` to model | claim | claim (unchanged — already handled the "they differ" case) |

Users on remote setups no longer need the `MERIDIAN_WORKDIR=... + MERIDIAN_PASSTHROUGH=1` workaround documented in the issue thread.

## Test plan

- [x] 7 unit tests on the pure `resolveSdkWorkingDirectory` helper (precedence chain, fallback paths, env vs adapter precedence, empty string handling)
- [x] 4 integration tests in `proxy-working-directory.test.ts`:
  - env-set-and-exists → SDK gets that path
  - env-set-and-missing → SDK gets `process.cwd()`
  - client-cwd-missing (the #381 remote-host case) → SDK gets `process.cwd()`
  - client-cwd-exists (same-host case) → SDK gets the client's path
- [x] Updated `proxy-droid-integration` and `proxy-forgecode-integration` fixtures to use real `tmpdir()`-based paths so their CWD-extraction assertions pass under the new validation
- [x] Full `npm test` green: 1677 / 0 fail
- [x] `npm run typecheck` green
- [x] No production behavior change for any existing local-host user

Closes #381