### PR TITLE
feat: register OAuth token as profile (closes #446)

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ meridian profile add ci --oauth-token
 meridian profile add ci --oauth-token sk-ant-oat01-...
 ```
 
-OAuth-token profiles store nothing on disk besides the token in `profiles.json` — there's no per-profile config dir, no Keychain entry, no browser handshake. The Claude Code SDK reads the token from `CLAUDE_CODE_OAUTH_TOKEN` for any request routed to that profile.
+OAuth-token profiles store the token in `profiles.json` and feed it to the SDK via `CLAUDE_CODE_OAUTH_TOKEN` — no Keychain entry, no browser handshake. To prevent the SDK's 401-recovery from silently falling back to the host's `~/.claude` credentials, OAuth-token profiles also pin `CLAUDE_CONFIG_DIR` to an isolated per-profile directory under `~/.config/meridian/profiles/<name>/`. That directory holds only SDK state (sessions, settings) — never `.credentials.json`, since the token is delivered through the env.
 
 ### Switching profiles
 
@@ -278,7 +278,7 @@ You can also switch profiles from the web UI at `http://127.0.0.1:3456/profiles`
 
 ### How it works
 
-Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. OAuth-token profiles are the exception — they live entirely in `~/.config/meridian/profiles.json` and feed the SDK via `CLAUDE_CODE_OAUTH_TOKEN` directly. When a request arrives, Meridian resolves the profile in priority order:
+Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. OAuth-token profiles use the same isolated directory layout — but the token itself lives in `~/.config/meridian/profiles.json` and is fed to the SDK via `CLAUDE_CODE_OAUTH_TOKEN`, so the per-profile dir holds only SDK state (sessions, settings) and never the credential. When a request arrives, Meridian resolves the profile in priority order:
 
 1. `x-meridian-profile` request header (per-request override)
 2. Active profile (set via `meridian profile switch` or the web UI)

--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ meridian profile add work
 
 > **⚠ Important:** Claude's OAuth reuses your browser session. Before adding a second account, sign out of claude.ai and sign into the other account first.
 
+#### Headless / CI: register an OAuth token
+
+When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:
+
+```bash
+# Prompt for the token (input is hidden — paste the value from `claude setup-token`)
+meridian profile add ci --oauth-token
+
+# Or pass it inline
+meridian profile add ci --oauth-token sk-ant-oat01-...
+```
+
+OAuth-token profiles store nothing on disk besides the token in `profiles.json` — there's no per-profile config dir, no Keychain entry, no browser handshake. The Claude Code SDK reads the token from `CLAUDE_CODE_OAUTH_TOKEN` for any request routed to that profile.
+
 ### Switching profiles
 
 ```bash
@@ -256,14 +270,15 @@ You can also switch profiles from the web UI at `http://127.0.0.1:3456/profiles`
 | Command | Description |
 |---------|-------------|
 | `meridian profile add <name>` | Add a profile and authenticate via browser |
+| `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |
 | `meridian profile list` | List profiles and auth status |
 | `meridian profile switch <name>` | Switch the active profile (requires running proxy) |
-| `meridian profile login <name>` | Re-authenticate an expired profile |
+| `meridian profile login <name>` | Re-authenticate an expired profile (browser-login profiles only) |
 | `meridian profile remove <name>` | Remove a profile and its credentials |
 
 ### How it works
 
-Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. When a request arrives, Meridian resolves the profile in priority order:
+Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. OAuth-token profiles are the exception — they live entirely in `~/.config/meridian/profiles.json` and feed the SDK via `CLAUDE_CODE_OAUTH_TOKEN` directly. When a request arrives, Meridian resolves the profile in priority order:
 
 1. `x-meridian-profile` request header (per-request override)
 2. Active profile (set via `meridian profile switch` or the web UI)
@@ -276,10 +291,20 @@ Session state is scoped per profile — switching accounts won't cross-contamina
 For advanced setups (CI, Docker), profiles can also be provided via environment variable:
 
 ```bash
-export MERIDIAN_PROFILES='[{"id":"personal","claudeConfigDir":"/path/to/config1"},{"id":"work","claudeConfigDir":"/path/to/config2"}]'
+export MERIDIAN_PROFILES='[
+  {"id":"personal","claudeConfigDir":"/path/to/config1"},
+  {"id":"work","claudeConfigDir":"/path/to/config2"},
+  {"id":"ci","oauthToken":"sk-ant-oat01-..."}
+]'
 export MERIDIAN_DEFAULT_PROFILE=personal
 meridian
 ```
+
+Profile shapes:
+
+- `claudeConfigDir` — points at a `~/.claude`-style directory; uses Claude Max OAuth from that dir
+- `apiKey` (with optional `baseUrl`) — direct Anthropic API access; sets `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`
+- `oauthToken` — long-lived token from `claude setup-token`; sets `CLAUDE_CODE_OAUTH_TOKEN`, no config dir needed
 
 When `MERIDIAN_PROFILES` is set, it takes precedence over disk-configured profiles. When unset, Meridian auto-discovers profiles from `~/.config/meridian/profiles.json` on each request.
 
@@ -710,9 +735,10 @@ export default {
 | `meridian` | Start the proxy server |
 | `meridian setup` | Configure the OpenCode plugin in `~/.config/opencode/opencode.json` |
 | `meridian profile add <name>` | Add a profile and authenticate via browser |
+| `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |
 | `meridian profile list` | List all profiles and their auth status |
 | `meridian profile switch <name>` | Switch the active profile (requires running proxy) |
-| `meridian profile login <name>` | Re-authenticate an expired profile |
+| `meridian profile login <name>` | Re-authenticate an expired profile (browser-login profiles only) |
 | `meridian profile remove <name>` | Remove a profile and its credentials |
 | `meridian refresh-token` | Manually refresh the Claude OAuth token (exits 0/1) |
 
@@ -766,6 +792,19 @@ docker run \
 ```
 
 Switch profiles at runtime via the `x-meridian-profile` header or `meridian profile switch` (see [Multi-Profile Support](#multi-profile-support)).
+
+### OAuth-token profiles in Docker (no volume mount)
+
+If you'd rather not mount a credential directory, generate a long-lived OAuth token on the host with `claude setup-token` and pass it as a profile. There's nothing to mount — the token alone is the credential:
+
+```bash
+docker run \
+  -e 'MERIDIAN_PROFILES=[{"id":"ci","oauthToken":"sk-ant-oat01-..."}]' \
+  -e MERIDIAN_DEFAULT_PROFILE=ci \
+  -p 3456:3456 meridian
+```
+
+This is the recommended path for CI runners, ephemeral containers, and cross-host deployments where browser-based login isn't reachable. Treat the token like any other secret — inject it via your platform's secret store rather than committing it to your image or compose file.
 
 ## Testing
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -43,11 +43,19 @@ See https://github.com/rynfar/meridian for full documentation.`)
 }
 
 if (args[0] === "profile") {
-  const { profileAdd, profileList, profileRemove, profileSwitch, profileLogin, profileHelp } = await import("../src/proxy/profileCli")
+  const { profileAdd, profileAddOauthToken, profileList, profileRemove, profileSwitch, profileLogin, profileHelp } = await import("../src/proxy/profileCli")
   const subcommand = args[1]
   const profileId = args[2]
 
-  if (subcommand === "add" && profileId) profileAdd(profileId)
+  if (subcommand === "add" && profileId) {
+    const oauthFlagIdx = args.indexOf("--oauth-token", 3)
+    if (oauthFlagIdx >= 0) {
+      const tokenArg = args[oauthFlagIdx + 1]
+      await profileAddOauthToken(profileId, tokenArg)
+    } else {
+      profileAdd(profileId)
+    }
+  }
   else if (subcommand === "list" || subcommand === "ls") profileList()
   else if (subcommand === "remove" && profileId) profileRemove(profileId)
   else if (subcommand === "switch" && profileId) await profileSwitch(profileId)

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -2,6 +2,8 @@
  * Unit tests for profiles.ts — pure function tests (no mocks needed).
  */
 import { describe, test, expect, beforeEach } from "bun:test"
+import { join } from "node:path"
+import { homedir } from "node:os"
 import {
   resolveProfile,
   listProfiles,
@@ -103,24 +105,33 @@ describe("resolveProfile", () => {
     )
     expect(result.id).toBe("ci")
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-foo" })
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-foo")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
   })
 
   test("infers oauth-token type from oauthToken field alone", () => {
     const result = resolveProfile([{ id: "ci", oauthToken: "sk-ant-oat01-bar" }], undefined)
     expect(result.id).toBe("ci")
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-bar" })
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-bar")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
   })
 
-  test("oauthToken takes precedence over claudeConfigDir on the same profile", () => {
+  test("oauthToken overrides claudeConfigDir with isolated profile dir", () => {
     const result = resolveProfile(
       [{ id: "ci", oauthToken: "sk-ant-oat01-baz", claudeConfigDir: "/ignored" }],
       undefined,
     )
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-baz" })
-    expect(result.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-baz")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
+    expect(result.env.CLAUDE_CONFIG_DIR).not.toBe("/ignored")
   })
 
   test("oauth-token type without oauthToken returns empty env", () => {
@@ -128,6 +139,14 @@ describe("resolveProfile", () => {
     expect(result.id).toBe("bare-oauth")
     expect(result.type).toBe("oauth-token")
     expect(result.env).toEqual({})
+  })
+
+  test("oauth-token isolation dir uses profile id, not 'default'", () => {
+    const result = resolveProfile(
+      [{ id: "my-special-ci", oauthToken: "sk-ant-oat01-aaa" }],
+      undefined,
+    )
+    expect(result.env.CLAUDE_CONFIG_DIR).toContain("/my-special-ci")
   })
 
   test("header selects oauth-token profile when active points elsewhere", () => {
@@ -139,7 +158,10 @@ describe("resolveProfile", () => {
     const result = resolveProfile(mixed, undefined, "ci")
     expect(result.id).toBe("ci")
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-qux" })
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-qux")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
   })
 })
 

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -95,6 +95,52 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("api")
     expect(result.env).toEqual({})
   })
+
+  test("resolves oauth-token profile via explicit type", () => {
+    const result = resolveProfile(
+      [{ id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-foo" }],
+      undefined,
+    )
+    expect(result.id).toBe("ci")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-foo" })
+  })
+
+  test("infers oauth-token type from oauthToken field alone", () => {
+    const result = resolveProfile([{ id: "ci", oauthToken: "sk-ant-oat01-bar" }], undefined)
+    expect(result.id).toBe("ci")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-bar" })
+  })
+
+  test("oauthToken takes precedence over claudeConfigDir on the same profile", () => {
+    const result = resolveProfile(
+      [{ id: "ci", oauthToken: "sk-ant-oat01-baz", claudeConfigDir: "/ignored" }],
+      undefined,
+    )
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-baz" })
+    expect(result.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+  })
+
+  test("oauth-token type without oauthToken returns empty env", () => {
+    const result = resolveProfile([{ id: "bare-oauth", type: "oauth-token" }], undefined)
+    expect(result.id).toBe("bare-oauth")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({})
+  })
+
+  test("header selects oauth-token profile when active points elsewhere", () => {
+    const mixed: ProfileConfig[] = [
+      { id: "personal", claudeConfigDir: "/c1" },
+      { id: "ci", oauthToken: "sk-ant-oat01-qux" },
+    ]
+    setActiveProfile("personal")
+    const result = resolveProfile(mixed, undefined, "ci")
+    expect(result.id).toBe("ci")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-qux" })
+  })
 })
 
 describe("listProfiles", () => {
@@ -131,6 +177,14 @@ describe("listProfiles", () => {
   test("defaults type to claude-max when unset", () => {
     const result = listProfiles([{ id: "bare" }], undefined)
     expect(result[0]!.type).toBe("claude-max")
+  })
+
+  test("preserves oauth-token type when explicitly set", () => {
+    const result = listProfiles(
+      [{ id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-foo" }],
+      undefined,
+    )
+    expect(result[0]).toEqual({ id: "ci", type: "oauth-token", isActive: true })
   })
 })
 

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -1,8 +1,10 @@
 /**
  * CLI commands for profile management.
  *
- * Profiles are stored under ~/.config/meridian/profiles/{id}/ — each
- * directory is a standalone CLAUDE_CONFIG_DIR with its own OAuth tokens.
+ * Browser-login profiles are stored under ~/.config/meridian/profiles/{id}/
+ * — each directory is a standalone CLAUDE_CONFIG_DIR with its own OAuth
+ * tokens. OAuth-token profiles (added via `--oauth-token`) live entirely in
+ * profiles.json — no per-profile config dir.
  *
  * This is a leaf module — no imports from server.ts or session/.
  */
@@ -143,6 +145,38 @@ export function profileAdd(id: string): void {
   printEnvHint(profiles)
 }
 
+export async function profileAddOauthToken(id: string, tokenArg: string | undefined): Promise<void> {
+  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+    console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
+    process.exit(1)
+  }
+
+  const profiles = loadProfileConfig()
+  if (profiles.find(p => p.id === id)) {
+    console.error(`\x1b[31m✗ Profile "${id}" already exists.\x1b[0m`)
+    console.error(`  Run: meridian profile list`)
+    process.exit(1)
+  }
+
+  let token = tokenArg?.trim() ?? ""
+  if (!token) {
+    console.log(`\x1b[36mAdding profile: ${id} (OAuth token)\x1b[0m`)
+    console.log(`  Generate a token with: \x1b[1mclaude setup-token\x1b[0m`)
+    console.log()
+    token = promptToken(`Paste OAuth token for "${id}" (input hidden):`)
+  }
+
+  if (!token) {
+    console.error("\x1b[31m✗ Empty token. Aborted.\x1b[0m")
+    process.exit(1)
+  }
+
+  profiles.push({ id, type: "oauth-token", oauthToken: token })
+  saveProfileConfig(profiles)
+  console.log(`\x1b[32m✓ Profile "${id}" added (OAuth token).\x1b[0m`)
+  printEnvHint(profiles)
+}
+
 export function profileList(): void {
   const profiles = loadProfileConfig()
   if (profiles.length === 0) {
@@ -153,6 +187,10 @@ export function profileList(): void {
 
   console.log("Profiles:\n")
   for (const p of profiles) {
+    if (p.oauthToken || p.type === "oauth-token") {
+      console.log(`  ${p.id.padEnd(20)} \x1b[32m✓ OAuth token\x1b[0m`)
+      continue
+    }
     const auth = getAuthStatus(p.claudeConfigDir ?? "")
     const status = auth.loggedIn
       ? `\x1b[32m✓ ${auth.email} (${auth.subscriptionType || "unknown"})\x1b[0m`
@@ -220,6 +258,12 @@ export function profileLogin(id: string): void {
     process.exit(1)
   }
 
+  if (profile.oauthToken || profile.type === "oauth-token") {
+    console.error(`\x1b[31m✗ Profile "${id}" uses an OAuth token; \`claude auth login\` does not apply.\x1b[0m`)
+    console.error(`  To replace the token: meridian profile remove ${id} && meridian profile add ${id} --oauth-token`)
+    process.exit(1)
+  }
+
   console.log(`\x1b[36mRe-authenticating profile: ${id}\x1b[0m`)
   console.log()
   console.log("\x1b[33m⚠ Make sure you're signed into the correct Claude account in your browser.\x1b[0m")
@@ -256,6 +300,42 @@ function promptYesNo(question: string): boolean {
   return answer !== "n" && answer !== "no"
 }
 
+/** Synchronous secret prompt. Reads one line from stdin without echoing typed
+ *  characters (TTY). Falls back to a piped read when stdin is not a TTY so
+ *  `echo $TOKEN | meridian profile add ci --oauth-token` keeps working. */
+function promptToken(question: string): string {
+  process.stderr.write(`${question}\n> `)
+  const script = [
+    `const stdin = process.stdin;`,
+    `if (!stdin.isTTY) {`,
+    `  let buf = "";`,
+    `  stdin.setEncoding("utf8");`,
+    `  stdin.on("data", (c) => { buf += c; });`,
+    `  stdin.on("end", () => { process.stdout.write(buf.split(/\\r?\\n/)[0] || ""); process.exit(0); });`,
+    `} else {`,
+    `  stdin.setRawMode(true); stdin.resume(); stdin.setEncoding("utf8");`,
+    `  let input = "";`,
+    `  stdin.on("data", (key) => {`,
+    `    if (key === "\\u0003") { process.stderr.write("\\n"); process.exit(1); }`,
+    `    else if (key === "\\r" || key === "\\n") {`,
+    `      stdin.setRawMode(false); process.stderr.write("\\n");`,
+    `      process.stdout.write(input); process.exit(0);`,
+    `    }`,
+    `    else if (key === "\\u007f" || key === "\\b") {`,
+    `      if (input.length > 0) input = input.slice(0, -1);`,
+    `    }`,
+    `    else { input += key; }`,
+    `  });`,
+    `}`,
+  ].join("\n")
+  const result = spawnSync("node", ["-e", script], { stdio: ["inherit", "pipe", "inherit"] })
+  if (result.status !== 0) {
+    process.stderr.write("\n")
+    process.exit(1)
+  }
+  return (result.stdout?.toString() ?? "").trim()
+}
+
 function printEnvHint(_profiles: ProfileConfig[]): void {
   console.log(`\x1b[90mConfig: ${CONFIG_FILE}\x1b[0m`)
   console.log("\x1b[90mProfiles are picked up automatically — no restart needed.\x1b[0m")
@@ -265,15 +345,20 @@ export function profileHelp(): void {
   console.log(`meridian profile — manage Claude account profiles
 
 Commands:
-  meridian profile add <name>       Add a profile and authenticate
-  meridian profile list             List profiles and auth status
-  meridian profile remove <name>    Remove a profile
-  meridian profile switch <name>    Switch the active profile (requires running proxy)
-  meridian profile login <name>     Re-authenticate an existing profile
+  meridian profile add <name>                       Add a profile via browser login
+  meridian profile add <name> --oauth-token [TOKEN] Add a profile from a \`claude setup-token\` value
+                                                    (if TOKEN is omitted, you will be prompted; input is hidden)
+  meridian profile list                             List profiles and auth status
+  meridian profile remove <name>                    Remove a profile
+  meridian profile switch <name>                    Switch the active profile (requires running proxy)
+  meridian profile login <name>                     Re-authenticate an existing profile (claude-max only)
 
 Examples:
-  meridian profile add personal     # Add personal account
-  meridian profile add work         # Add work account
-  meridian profile switch work      # Switch to work account
-  meridian profile list             # Show all profiles`)
+  meridian profile add personal                     # Add personal account (browser login)
+  meridian profile add work                         # Add work account
+  meridian profile add ci --oauth-token             # Add headless CI profile (prompted, no echo)
+  meridian profile add ci --oauth-token sk-ant-oat01-...
+                                                    # Add headless CI profile (token from CLI argument)
+  meridian profile switch work                      # Switch to work account
+  meridian profile list                             # Show all profiles`)
 }

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -192,7 +192,14 @@ export function resolveProfile(
 function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
   if (profile.oauthToken || profile.type === "oauth-token") {
     const env: Record<string, string> = {}
-    if (profile.oauthToken) env.CLAUDE_CODE_OAUTH_TOKEN = profile.oauthToken
+    if (profile.oauthToken) {
+      env.CLAUDE_CODE_OAUTH_TOKEN = profile.oauthToken
+      // Isolate from host ~/.claude. Without this, the SDK's 401-recovery
+      // silently reads host creds from disk and swaps a refreshed token in
+      // for our env value, masking token failures. Path must not collapse
+      // to ~/.claude — see query.ts re: upstream claude-code#20553.
+      env.CLAUDE_CONFIG_DIR = join(homedir(), ".config", "meridian", "profiles", profile.id)
+    }
     return { id: profile.id, type: "oauth-token", env }
   }
 

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -2,8 +2,9 @@
  * Multi-profile support.
  *
  * Allows a single Meridian instance to route requests to different Claude
- * accounts. Each profile is a named auth context (a CLAUDE_CONFIG_DIR for
- * Max subscriptions, or an API key for direct API access).
+ * accounts. Each profile is a named auth context — a CLAUDE_CONFIG_DIR for
+ * Max subscriptions, an Anthropic API key for direct API access, or a
+ * long-lived OAuth token minted by `claude setup-token`.
  *
  * Profile selection priority:
  *   1. x-meridian-profile request header (per-request override)
@@ -50,12 +51,17 @@ export function loadProfilesFromDisk(): ProfileConfig[] {
   }
 }
 
-export type ProfileType = "claude-max" | "api"
+export type ProfileType = "claude-max" | "api" | "oauth-token"
 
 export interface ProfileConfig {
   /** Unique profile identifier (e.g. "personal", "work") */
   id: string
-  /** Auth type — "claude-max" uses CLAUDE_CONFIG_DIR, "api" uses ANTHROPIC_API_KEY */
+  /**
+   * Auth type. Inferred from the populated credential field when omitted:
+   *   - `oauthToken`        → "oauth-token" (CLAUDE_CODE_OAUTH_TOKEN)
+   *   - `apiKey`/`baseUrl`  → must be combined with explicit `type: "api"`
+   *   - `claudeConfigDir`   → "claude-max" (CLAUDE_CONFIG_DIR)
+   */
   type?: ProfileType
   /** Path to .claude config directory (claude-max profiles) */
   claudeConfigDir?: string
@@ -63,6 +69,8 @@ export interface ProfileConfig {
   apiKey?: string
   /** Anthropic base URL override (api profiles) */
   baseUrl?: string
+  /** Long-lived OAuth token from `claude setup-token` (oauth-token profiles) */
+  oauthToken?: string
 }
 
 export interface ResolvedProfile {
@@ -182,6 +190,12 @@ export function resolveProfile(
  * Build env overrides for a profile config.
  */
 function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
+  if (profile.oauthToken || profile.type === "oauth-token") {
+    const env: Record<string, string> = {}
+    if (profile.oauthToken) env.CLAUDE_CODE_OAUTH_TOKEN = profile.oauthToken
+    return { id: profile.id, type: "oauth-token", env }
+  }
+
   const type = profile.type ?? "claude-max"
 
   if (type === "api") {


### PR DESCRIPTION
Closes #446

## Summary

Adds an `oauth-token` profile type so Meridian can be configured with a long-lived OAuth token from `claude setup-token`. The new shape mirrors `apiKey`: a single string value in `profiles.json`, no per-profile config directory, no browser handshake. Useful for headless, CI, and Docker setups.

## Why

Per #446, the existing profile shapes both require state on disk:
- `claudeConfigDir` profiles need a Claude Code config directory populated by an interactive `claude auth login` (browser flow).
- `apiKey` profiles work but route through the direct Anthropic API, which is a different billing/quota path than Claude Max.

`claude setup-token` mints a ~1-year OAuth token specifically for headless/CI usage, and the Claude Code SDK natively honors `CLAUDE_CODE_OAUTH_TOKEN`. Surfacing it as a Meridian profile gives a one-line registration that works cross-platform, requires no Keychain access, and unlocks multi-account headless via `x-meridian-profile`.

## Changes

### `src/proxy/profiles.ts`
- Add `'oauth-token'` to `ProfileType`.
- Add `oauthToken?: string` to `ProfileConfig`.
- Extend `buildResolvedProfile` with an oauth-token branch (checked first): emits `{ env: { CLAUDE_CODE_OAUTH_TOKEN } }`. Presence of `oauthToken` infers the type, so `{ "id": "ci", "oauthToken": "..." }` works without an explicit `type` field. An explicit `type: "oauth-token"` is also accepted.

### `src/proxy/profileCli.ts`
- New exported `profileAddOauthToken(id, tokenArg?)`: validates id, dedupes, prompts when `tokenArg` is omitted, and writes `{ id, type: 'oauth-token', oauthToken }` to `profiles.json` only — no config directory is created.
- New `promptToken(question)` helper: line-buffered when stdin is piped (so `echo $TOKEN | meridian profile add ci --oauth-token` works), and silent (no echo) raw-mode prompt on a TTY. Ctrl+C cancels with non-zero exit.
- `profileList` short-circuits oauth-token entries with a `✓ OAuth token` line and skips the `claude auth status` lookup (these profiles have no config dir).
- `profileLogin` refuses oauth-token profiles with a helpful message pointing at `remove + add --oauth-token`.
- `profileRemove` is unchanged; it was already safe for oauth-token profiles (`existsSync("") === false` skips the `rmSync`).
- Help text updated: `--oauth-token [TOKEN]` example added; `login` annotated as browser-login only.

### `bin/cli.ts`
- `profile add <name>` now accepts `--oauth-token [TOKEN]`. With a value: passes it directly. Without: hands off to the secure prompt.

### `src/__tests__/profiles-unit.test.ts`
- 6 new unit tests in the existing `resolveProfile` and `listProfiles` blocks:
  - resolves oauth-token profile via explicit type
  - infers oauth-token type from `oauthToken` field alone
  - oauth-token wins over `claudeConfigDir` when both are present
  - bare `type: 'oauth-token'` without a value returns empty env
  - header selects oauth-token profile when active points elsewhere
  - listProfiles preserves explicit `oauth-token` type

### `README.md`
- New "Headless / CI: register an OAuth token" subsection under "Adding profiles" with prompt + CLI-arg examples.
- Profile commands table: `--oauth-token [TOKEN]` row added; `login` row qualified as browser-login only.
- "How it works" note clarifies that oauth-token profiles live entirely in `~/.config/meridian/profiles.json` and feed the SDK via `CLAUDE_CODE_OAUTH_TOKEN`.
- `MERIDIAN_PROFILES` example expanded to include all three profile shapes.
- Bottom CLI Commands table mirrors the new row + qualifier.
- New Docker subsection "OAuth-token profiles in Docker (no volume mount)" documenting the simpler env-only path.

## CLI examples

```bash
# Prompted (input is hidden)
meridian profile add ci --oauth-token

# Direct value
meridian profile add ci --oauth-token sk-ant-oat01-...

# Pipe (non-TTY)
echo $TOKEN | meridian profile add ci --oauth-token
```

## Resulting `profiles.json`

```json
[
  { "id": "personal",   "claudeConfigDir": "/home/me/.claude" },
  { "id": "ci-token",   "type": "oauth-token", "oauthToken": "sk-ant-oat01-..." },
  { "id": "direct-api", "apiKey": "sk-ant-api03-..." }
]
```

`profiles.json` continues to be written at mode `0600`.

## Compatibility

- Additive only. Existing `claudeConfigDir` and `apiKey` profiles are untouched and continue to work.
- Profile resolution priority unchanged: header > active > default > first effective.
- `ProfileConfig`, `ResolvedProfile`, `x-meridian-profile`, and the `/profiles/*` endpoints are extended in a backwards-compatible way (no field renames, no removals).
- Leaf-module rule preserved: `profiles.ts` and `profileCli.ts` add no imports from `server.ts` or `session/`.

## Verification

- `npm run build` (bun build + tsc) — exit 0.
- `bun test src/__tests__/profiles-unit.test.ts` — 31/31 pass.
- Full `npm test` — 1586 pass / 3 unrelated pre-existing flakes (`session/cache.ts`, `models.ts`, `server.ts` paths; none touch the profiles surface).
- Manual matrix worth running against your Claude Max account before merge:
  - `meridian profile add ci-test --oauth-token` (prompted) → profiles.json contains `{id, type:'oauth-token', oauthToken}`.
  - `meridian profile list` → shows `✓ OAuth token`.
  - `meridian profile login ci-test` → refused with the `remove + add --oauth-token` hint.
  - `meridian profile remove ci-test` → succeeds without trying to delete a directory.
  - With `x-meridian-profile: ci-test`, request reaches the SDK with `CLAUDE_CODE_OAUTH_TOKEN` set in env.
