### PR TITLE
fix(tokenRefresh): close trigger gap + add traffic-independent refresh

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -246,6 +246,101 @@ describe("refreshOAuthToken", () => {
 })
 
 // ---------------------------------------------------------------------------
+// ensureFreshToken — proactive refresh before SDK call
+// ---------------------------------------------------------------------------
+
+describe("ensureFreshToken", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  function makeStoreWithExpiry(expiresAt: number) {
+    return makeStore({ ...MOCK_CREDENTIALS, claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt } })
+  }
+
+  it("returns true without refreshing when token is far from expiry", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.reject(new Error("fetch should not be called")))
+    mockFetch(fetchSpy)
+    const { store, writes } = makeStoreWithExpiry(Date.now() + 60 * 60 * 1000) // +1h, well outside default 5min buffer
+
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(true)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(writes).toHaveLength(0)
+  })
+
+  it("refreshes when token is inside the buffer (near-expiry)", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+    mockFetch(fetchSpy)
+    const { store, getStored } = makeStoreWithExpiry(Date.now() + 60 * 1000) // +1min, well inside default 5min buffer
+
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(getStored()?.claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+
+  it("refreshes when token is already expired", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+    mockFetch(fetchSpy)
+    const { store, getStored } = makeStoreWithExpiry(Date.now() - 60 * 60 * 1000) // -1h
+
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(getStored()?.claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+
+  it("returns false when no credentials stored", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.reject(new Error("fetch should not be called")))
+    mockFetch(fetchSpy)
+    const { store } = makeStore(null)
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns false when expiresAt missing", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.reject(new Error("fetch should not be called")))
+    mockFetch(fetchSpy)
+    // expiresAt = 0 is falsy via `!expiresAt`
+    const { store } = makeStoreWithExpiry(0)
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns false when refresh request fails", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    mockFetch(() => Promise.resolve(new Response("invalid_grant", { status: 400 })))
+    const { store } = makeStoreWithExpiry(Date.now() - 1000)
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(false)
+  })
+
+  it("respects custom bufferMs", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+    mockFetch(fetchSpy)
+    // Token expires in 2h. Default 5-min buffer → no refresh; 3-h buffer → refresh.
+    const { store } = makeStoreWithExpiry(Date.now() + 2 * 60 * 60 * 1000)
+    expect(await ensureFreshToken(store, 60 * 1000)).toBe(true)            // 1-min buffer: skip
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(await ensureFreshToken(store, 3 * 60 * 60 * 1000)).toBe(true)   // 3-h buffer: refresh
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // createPlatformCredentialStore
 // ---------------------------------------------------------------------------
 

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -283,12 +283,51 @@ describe("isExpiredTokenError", () => {
     )).toBe(true)
   })
 
-  it("returns false for unrelated auth errors", async () => {
+  it("returns false for unrelated errors that lack a 401 marker", async () => {
     const { isExpiredTokenError } = await import("../proxy/errors")
     expect(isExpiredTokenError("authentication failed")).toBe(false)
     expect(isExpiredTokenError("rate limit exceeded")).toBe(false)
     expect(isExpiredTokenError("invalid credentials")).toBe(false)
     expect(isExpiredTokenError("token refresh failed")).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Broadened triggers — generic 401s and RFC-6750 wording.
+  //
+  // Reason: Anthropic's API can return a 401 for an expired access token
+  // without echoing the CLI-specific "OAuth token has expired" string, so the
+  // narrow legacy matcher missed scheduled-expiry failures and the proxy
+  // never fired refresh-and-retry. Confirmed in production 2026-05-03 on two
+  // NAS instances that sat idle past expiry: credentials.json mtime never
+  // ticked, every request returned 401 to the client, no
+  // "token_refresh.retrying" ever logged.
+  // ---------------------------------------------------------------------------
+
+  it("detects generic 401 + authentication wording", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    expect(isExpiredTokenError("API Error: 401 authentication_error")).toBe(true)
+    expect(isExpiredTokenError("HTTP 401 Unauthorized")).toBe(true)
+    expect(isExpiredTokenError("401 invalid request")).toBe(true)
+  })
+
+  it("detects RFC-6750 token error codes", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    expect(isExpiredTokenError('error="invalid_token"')).toBe(true)
+    expect(isExpiredTokenError("token_expired")).toBe(true)
+  })
+
+  it("does not trigger on 401 without an auth keyword", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    // Hypothetical 401 without auth wording — leave as not-a-trigger to keep
+    // the false-positive surface narrow.
+    expect(isExpiredTokenError("API returned 401 over rate limit")).toBe(false)
+  })
+
+  it("does not trigger on non-401 errors that incidentally include auth words", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    expect(isExpiredTokenError("authentication failed")).toBe(false)
+    expect(isExpiredTokenError("invalid argument")).toBe(false)
+    expect(isExpiredTokenError("unauthorized scope")).toBe(false)
   })
 })
 

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -341,6 +341,149 @@ describe("ensureFreshToken", () => {
 })
 
 // ---------------------------------------------------------------------------
+// startBackgroundRefresh — traffic-independent scheduled refresh
+// ---------------------------------------------------------------------------
+
+describe("startBackgroundRefresh", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    const { stopBackgroundRefresh, resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    stopBackgroundRefresh()
+    resetInflightRefresh()
+    globalThis.fetch = originalFetch
+  })
+
+  // Wait for any pending timers + microtasks to flush. Real timers — keeps
+  // the test runner simple at the cost of slightly longer test runs.
+  const tick = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+  it("immediately refreshes when token is already expired", async () => {
+    const { startBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store, getStored } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 60_000 },
+    })
+
+    startBackgroundRefresh(store, 1000, 60_000)
+    expect(isBackgroundRefreshActive()).toBe(true)
+    await tick(50)
+
+    expect(fetchCalls).toBe(1)
+    expect(getStored()?.claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+
+  it("schedules — does not refresh — when token has time", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() + 60 * 60 * 1000 }, // +1h
+    })
+
+    startBackgroundRefresh(store, 1000, 60_000)
+    await tick(50)
+
+    expect(fetchCalls).toBe(0)
+  })
+
+  it("polls when no credentials are present, picks up new file on next tick", async () => {
+    const { startBackgroundRefresh, stopBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    let stored: typeof MOCK_CREDENTIALS | null = null
+    const store: CredentialStore = {
+      async read() { return stored ? JSON.parse(JSON.stringify(stored)) : null },
+      async write(c) { stored = c as typeof MOCK_CREDENTIALS; return true },
+    }
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+
+    startBackgroundRefresh(store, 1000, 30) // 30ms poll interval
+    await tick(50)
+    expect(fetchCalls).toBe(0) // no credentials yet — refresh skipped
+
+    // Operator "logs in" — credentials appear with an expired token
+    stored = {
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    }
+    await tick(60) // wait for next poll tick
+
+    expect(fetchCalls).toBeGreaterThanOrEqual(1)
+    stopBackgroundRefresh()
+  })
+
+  it("retries on refresh failure", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(new Response("invalid_grant", { status: 400 }))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    })
+
+    startBackgroundRefresh(store, 1000, 30) // 30ms retry interval
+    await tick(120) // let it retry a few times
+
+    expect(fetchCalls).toBeGreaterThanOrEqual(2)
+  })
+
+  it("is idempotent — second start() while running is a no-op", async () => {
+    const { startBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    })
+
+    startBackgroundRefresh(store, 1000, 60_000)
+    startBackgroundRefresh(store, 1000, 60_000) // second call — should be no-op
+    expect(isBackgroundRefreshActive()).toBe(true)
+    await tick(50)
+
+    expect(fetchCalls).toBe(1) // only one refresh, not two
+  })
+
+  it("stop() prevents the next scheduled refresh from firing", async () => {
+    const { startBackgroundRefresh, stopBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() + 1000 }, // 1s out, well past 100ms buffer
+    })
+
+    startBackgroundRefresh(store, 100, 60_000)
+    stopBackgroundRefresh()
+    expect(isBackgroundRefreshActive()).toBe(false)
+    await tick(1500) // would have fired by now
+
+    expect(fetchCalls).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // createPlatformCredentialStore
 // ---------------------------------------------------------------------------
 

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -129,14 +129,27 @@ export function classifyError(errMsg: string): ClassifiedError {
  * Detect errors caused by an expired or missing OAuth access token.
  * Triggers an inline token refresh + retry in server.ts.
  *
- * Two distinct messages from the Claude Code CLI:
- *   - "OAuth token has expired" — CLI sent the token, Anthropic API rejected it
- *   - "Not logged in"           — CLI checked expiresAt locally and refused to try
- * Both are resolved by refreshing the token.
+ * Patterns, in order of specificity:
+ *   - "OAuth token has expired" / "Not logged in" — CLI-emitted (subprocess
+ *     either got 401 with this wording from Anthropic or detected expiry
+ *     locally before sending).
+ *   - "invalid_token" / "token_expired" — RFC 6750 resource-server errors that
+ *     can appear in the API response body.
+ *   - "401" + ("authentication" | "unauthorized" | "invalid") — generic 401
+ *     wrapping. Anthropic's API does not always echo the CLI-specific wording,
+ *     so without this branch a stale access token returns a generic 401 to the
+ *     proxy and refresh-and-retry never fires (caller sees the 401).
+ *
+ * False positives only cost one OAuth round-trip — the refresh is single-shot
+ * per request (gated by `tokenRefreshed` in server.ts) and surfaces the
+ * original error if it doesn't help.
  */
 export function isExpiredTokenError(errMsg: string): boolean {
   const lower = errMsg.toLowerCase()
-  return lower.includes("oauth token has expired") || lower.includes("not logged in")
+  if (lower.includes("oauth token has expired") || lower.includes("not logged in")) return true
+  if (lower.includes("invalid_token") || lower.includes("token_expired")) return true
+  if (lower.includes("401") && (lower.includes("authentication") || lower.includes("unauthorized") || lower.includes("invalid"))) return true
+  return false
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
@@ -966,6 +966,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const response = (async function* () {
               let rateLimitRetries = 0
 
+              // Proactive: refresh the access token if it's within the buffer
+              // of expiry. Best-effort — the reactive 401 path below picks up
+              // anything this misses. Saves a round-trip on the common case
+              // where the previous request left the token close to expiry.
+              await ensureFreshToken().catch(() => { /* reactive path handles */ })
+
               let tokenRefreshed = false
               while (true) {
                 // Track whether response content was yielded.
@@ -1431,6 +1437,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               const response = (async function* () {
                 let rateLimitRetries = 0
+
+                // Proactive token refresh — see non-stream path above.
+                await ensureFreshToken().catch(() => { /* reactive path handles */ })
+
                 let tokenRefreshed = false
 
                 while (true) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken, ensureFreshToken } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
@@ -2944,6 +2944,12 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     }
   })
 
+  // Background OAuth token refresh: keeps the refresh chain warm even when
+  // the proxy sits idle. Without it, an unused refresh token can be
+  // invalidated server-side after sitting unused for an extended period.
+  // Idempotent — re-calling start() on a hot-reload is a no-op.
+  startBackgroundRefresh()
+
   // Background auth keepalive: periodically refresh auth status for all
   // configured profiles so switching is instant (no stale token delay).
   let authKeepaliveInterval: ReturnType<typeof setInterval> | undefined
@@ -2971,6 +2977,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     config: finalConfig,
     async close() {
       if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+      stopBackgroundRefresh()
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()))
       })

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -303,6 +303,32 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
   return true
 }
 
+/**
+ * Refresh the access token if it is within `bufferMs` of expiry.
+ *
+ * Cheap to call before every SDK request: when the token isn't due yet this
+ * is just one credential-store read. When it is due, the underlying
+ * `refreshOAuthToken()` call is in-flight-deduplicated so concurrent callers
+ * share one network round-trip.
+ *
+ * Returns true when the token is fresh after the call (already valid OR
+ * successfully refreshed), false on any failure (no credentials, no
+ * expiresAt, refresh request failed). False is non-fatal — the caller
+ * proceeds with whatever token is on disk and falls back to the reactive
+ * refresh-on-401 path if Anthropic rejects it.
+ */
+export async function ensureFreshToken(
+  store?: CredentialStore,
+  bufferMs = 5 * 60 * 1000,
+): Promise<boolean> {
+  const s = store ?? createPlatformCredentialStore()
+  const credentials = await s.read()
+  const expiresAt = credentials?.claudeAiOauth?.expiresAt
+  if (!expiresAt) return false
+  if (expiresAt - Date.now() > bufferMs) return true
+  return refreshOAuthToken(s)
+}
+
 /** Reset in-flight state — for testing only. */
 export function resetInflightRefresh(): void {
   inflightRefresh = null

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -398,6 +398,7 @@ async function scheduleNext(
     // new expiresAt (or retry in failureRetryMs if refresh failed).
     const ok = await refreshOAuthToken(store)
     claudeLog("token_refresh.scheduled", { ok, immediate: true })
+    console.error(`[token_refresh] scheduled refresh (immediate) ok=${ok}`)
     if (!scheduledRefreshActive) return
     armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs)
     return
@@ -414,10 +415,10 @@ function armTimer(
 ): void {
   scheduledRefreshTimer = setTimeout(async () => {
     if (!scheduledRefreshActive) return
-    // If the timer woke up exactly at the deadline (delayMs > 0 path), fire
-    // refresh first; if the timer was a "reschedule based on disk" tick
-    // (delayMs === 0 after a successful refresh), skip the refresh and just
-    // recompute. The dueIn re-check inside scheduleNext distinguishes them.
+    // The dueIn re-check inside scheduleNext distinguishes "fire-now" from
+    // "reschedule-only" ticks: when the disk-state recompute lands inside
+    // the buffer window, scheduleNext emits the immediate-refresh log line;
+    // otherwise it just arms the next timer silently.
     void scheduleNext(store, bufferMs, failureRetryMs)
   }, delayMs)
   if (scheduledRefreshTimer && (scheduledRefreshTimer as { unref?: () => void }).unref) {

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -329,6 +329,107 @@ export async function ensureFreshToken(
   return refreshOAuthToken(s)
 }
 
+// ---------------------------------------------------------------------------
+// Background refresh scheduler
+// ---------------------------------------------------------------------------
+
+let scheduledRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let scheduledRefreshActive = false
+
+/**
+ * Start a self-rescheduling timer that refreshes the access token shortly
+ * before each expiry — regardless of incoming traffic.
+ *
+ * Idempotent: a second call while one is already running is a no-op. Safe to
+ * call from any code path; returns synchronously and schedules in the
+ * background.
+ *
+ * Why traffic-independent matters: without this, an idle proxy never fires
+ * either the proactive (`ensureFreshToken`) or reactive (401-retry) refresh
+ * path. Anthropic's OAuth refresh tokens appear to be invalidated server-side
+ * after sitting unused for an extended period (observed 2026-05-03: two NAS
+ * instances idle past expiry both got `400 invalid_grant` on a manual refresh
+ * attempt; only fix was OAuth-flow re-login). Running a refresh every ~8h
+ * keeps the refresh chain warm.
+ *
+ * On `refreshOAuthToken()` failure (network, transient API error, refresh
+ * token rejected) we retry every `failureRetryMs` — gives operators a window
+ * to `claude login` and have the new tokens picked up automatically on the
+ * next tick.
+ */
+export function startBackgroundRefresh(
+  store?: CredentialStore,
+  bufferMs = 5 * 60 * 1000,
+  failureRetryMs = 5 * 60 * 1000,
+): void {
+  if (scheduledRefreshActive) return
+  scheduledRefreshActive = true
+  void scheduleNext(store ?? createPlatformCredentialStore(), bufferMs, failureRetryMs)
+}
+
+/** Stop the background scheduler. Idempotent. */
+export function stopBackgroundRefresh(): void {
+  scheduledRefreshActive = false
+  if (scheduledRefreshTimer) clearTimeout(scheduledRefreshTimer)
+  scheduledRefreshTimer = null
+}
+
+async function scheduleNext(
+  store: CredentialStore,
+  bufferMs: number,
+  failureRetryMs: number,
+): Promise<void> {
+  if (!scheduledRefreshActive) return
+
+  const credentials = await store.read().catch(() => null)
+  const expiresAt = credentials?.claudeAiOauth?.expiresAt
+
+  if (!expiresAt) {
+    // Operator hasn't logged in yet (no credentials) or credentials are
+    // missing the field. Re-poll periodically — once `claude login` writes
+    // the file, the next tick picks it up.
+    armTimer(failureRetryMs, store, bufferMs, failureRetryMs)
+    return
+  }
+
+  const dueIn = expiresAt - Date.now() - bufferMs
+  if (dueIn <= 0) {
+    // Already due (or past) — fire now, schedule the follow-up based on the
+    // new expiresAt (or retry in failureRetryMs if refresh failed).
+    const ok = await refreshOAuthToken(store)
+    claudeLog("token_refresh.scheduled", { ok, immediate: true })
+    if (!scheduledRefreshActive) return
+    armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs)
+    return
+  }
+
+  armTimer(dueIn, store, bufferMs, failureRetryMs)
+}
+
+function armTimer(
+  delayMs: number,
+  store: CredentialStore,
+  bufferMs: number,
+  failureRetryMs: number,
+): void {
+  scheduledRefreshTimer = setTimeout(async () => {
+    if (!scheduledRefreshActive) return
+    // If the timer woke up exactly at the deadline (delayMs > 0 path), fire
+    // refresh first; if the timer was a "reschedule based on disk" tick
+    // (delayMs === 0 after a successful refresh), skip the refresh and just
+    // recompute. The dueIn re-check inside scheduleNext distinguishes them.
+    void scheduleNext(store, bufferMs, failureRetryMs)
+  }, delayMs)
+  if (scheduledRefreshTimer && (scheduledRefreshTimer as { unref?: () => void }).unref) {
+    (scheduledRefreshTimer as { unref: () => void }).unref()
+  }
+}
+
+/** For testing only. */
+export function isBackgroundRefreshActive(): boolean {
+  return scheduledRefreshActive
+}
+
 /** Reset in-flight state — for testing only. */
 export function resetInflightRefresh(): void {
   inflightRefresh = null


### PR DESCRIPTION
## Problem

After deploying `meridian-v1.41.1` (with #464's compact-JSON fix in place) on two long-running NAS-hosted Meridian instances, both started returning 401 to clients silently after sitting idle:

```
{"type":"error","error":{"type":"authentication_error",
 "message":"Claude authentication expired or invalid. Run 'claude login' in your terminal to re-authenticate, then restart the proxy."}}
```

Symptoms when diagnosed (2026-05-03):

- `/health` reported `loggedIn: true` (the local `claude auth status` only reads `.credentials.json` and trusts `expiresAt` — it doesn't probe Anthropic).
- `.credentials.json` mtime had **not** ticked since the operator's last `claude login` — 25h+ on one instance, ~2 days on the other.
- `docker logs … | grep -E 'token_refresh|OAuth token expired'` was **empty** — neither the inline retry nor any refresh attempt had ever fired despite continuous traffic.
- A manual `POST https://platform.claude.com/v1/oauth/token` with the on-disk refresh_token returned `400 invalid_grant: Refresh token not found or invalid`. Anthropic had server-side invalidated the unused refresh token.

A dev-stack proxy on the *same image*, logged in to the same account 2 days earlier, had no problem refreshing the moment we sent it traffic — implication: the refresh path *can* succeed if exercised regularly. What kills it is letting the access token sit expired long enough that Anthropic GC's the underlying refresh token.

## Two gaps in the existing design

#230 made refresh **inline-on-401**, gated on `isExpiredTokenError(errMsg)` matching `"oauth token has expired"` or `"not logged in"`. That's the only refresh trigger today.

**Gap #1 — trigger surface is too narrow.** Anthropic's API can return a generic 401 for a stale access token without echoing the CLI-specific wording. Such errors fall through to `classifyError`'s broader auth branch (`401 | authentication | invalid auth | credentials`) and surface as `"Claude authentication expired or invalid"` to the client. Refresh is never even attempted. This is the proximate cause of the silent failure above.

**Gap #2 — there is no traffic-independent refresh path.** Even with a fully broadened trigger, an idle proxy that never receives a request never exercises the chain. Anthropic's GC of unused refresh tokens (timeline appears to be ~24-48h based on what we saw, exact policy unknown) eventually invalidates the chain entirely; once that happens, `claude login` is the only recovery.

## Changes (4 commits)

| # | Commit | Layer | What |
|---|--------|-------|------|
| 1 | `fix(errors): broaden isExpiredTokenError to catch generic 401s` | reactive | Adds matchers for RFC 6750 wording (`invalid_token`, `token_expired`) and `"401" + ("authentication" \| "unauthorized" \| "invalid")`. Existing positive cases still match; existing negative cases (rate-limit errors, unrelated auth errors without 401) still return false. False positives are bounded — the existing `tokenRefreshed` guard makes refresh single-shot per request; a misclassified error costs at most one OAuth round-trip and the original error still bubbles up. |
| 2 | `feat(tokenRefresh): proactive ensureFreshToken before SDK call` | proactive | New `ensureFreshToken(store?, bufferMs = 5min)` helper. Reads credentials cheaply; returns true when far from expiry, calls `refreshOAuthToken` when within buffer. Wired into both SDK call sites in `server.ts` (non-stream + stream) before the per-request retry loop. Best-effort `.catch(() => {})` — reactive 401-retry handles anything missed. |
| 3 | `feat(tokenRefresh): background scheduler keeps refresh chain warm` | **traffic-independent** | `startBackgroundRefresh()` arms a self-rescheduling `setTimeout` at `expiresAt - bufferMs`, fires `refreshOAuthToken` regardless of traffic, schedules the next call based on the new `expiresAt` on success, retries every `failureRetryMs` (default 5min) on failure. Booted from `startProxyServer()` after `serve()`; `stopBackgroundRefresh()` wired into the close path. Idempotent (`scheduledRefreshActive` flag), `.unref()`-ed timer so it doesn't hold the process. **This is the load-bearing fix** — the other two close the trigger gap, but this is what keeps the chain warm for unattended deployments. |
| 4 | `feat(tokenRefresh): make scheduler activity visible in default logs` | observability | `claudeLog()` is gated on `OPENCODE_CLAUDE_PROVIDER_DEBUG` (unset in prod), so scheduled-refresh events would have been silent. One `console.error('[token_refresh] scheduled refresh (immediate) ok=…')` line per immediate refresh — kept narrow so a healthy scheduler is mostly silent (logs only fire when refresh actually runs). |

## How this fits with existing patterns

- Builds on #230's platform-aware `CredentialStore` interface — the scheduler uses the same store, so it inherits Keychain-on-macOS / file-on-Linux without re-introducing #224's macOS bug.
- Co-exists with #279's per-profile `authKeepaliveInterval` (which does a *local* `claude auth status` poll). Different concern: that one keeps the local in-memory cache fresh; this one keeps the upstream OAuth chain warm. No overlap.
- Mirrors #439's "401 → refresh → retry" pattern as already implemented in `oauthUsage.ts` — same shape, applied to the `server.ts` refresh sites.
- No new env vars, no new CLI subcommands, no external scheduler required.

## Tests

`bun test src/__tests__/token-refresh.test.ts src/__tests__/errors.test.ts`: 99 pass / 0 fail. The new tests:

- 4 for the broadened `isExpiredTokenError` (new positive matches for generic 401s and RFC 6750 codes; new negative cases for non-401 incidental matches like `"unauthorized scope"`).
- 7 for `ensureFreshToken` (under/over buffer, no credentials, no `expiresAt`, refresh failure, custom buffer).
- 6 for `startBackgroundRefresh` (already-expired immediate refresh, scheduling without refresh, no-credentials polling, retry-on-failure, idempotency, stop() prevents future fires).

Real timers with short delays (50–120 ms) — the scheduler suite runs in ~2 s.

## Soak evidence

Branch deployed to two production NAS instances on 2026-05-03 18:00 UTC. ~21 hours in:

```
$ docker logs meridian-proxy-1 2>&1 | grep '\[token_refresh\]'
[token_refresh] scheduled refresh (immediate) ok=true
[token_refresh] scheduled refresh (immediate) ok=true

$ docker logs meridian-work-proxy-1 2>&1 | grep '\[token_refresh\]'
[token_refresh] scheduled refresh (immediate) ok=false
[token_refresh] scheduled refresh (immediate) ok=true
[token_refresh] scheduled refresh (immediate) ok=true
```

The single `ok=false` line on the work instance is the boot-time probe against an already-invalidated refresh token (the chain that triggered the original investigation) — operator did `claude login`, the next 5-min retry tick read the new credentials, fired a successful refresh, and the chain has been auto-refreshing ever since. `.credentials.json` mtimes are ticking on schedule on both instances; no client-visible 401s since deploy.

## Forced-expiry repro

Reproducible locally with the dev stack:

```bash
docker exec dev-proxy-1 node -e '
  const fs = require("fs"); const p = "/home/claude/.claude/.credentials.json";
  const c = JSON.parse(fs.readFileSync(p, "utf8"));
  c.claudeAiOauth.expiresAt = Date.now() - 3600000;
  fs.writeFileSync(p, JSON.stringify(c));'
docker restart dev-proxy-1
sleep 6
docker logs dev-proxy-1 2>&1 | grep '\[token_refresh\]'
# [token_refresh] scheduled refresh (immediate) ok=true
docker exec dev-proxy-1 stat -c '%y' /home/claude/.claude/.credentials.json
# (mtime ~3 seconds after restart)
```

No traffic involved — the scheduler fires at boot because `expiresAt` is in the past, refreshes successfully, persists, and arms a long-cycle timer.

## Known limitations (out of scope for this PR)

The new call sites in this PR call `refreshOAuthToken()` / `createPlatformCredentialStore()` without a `claudeConfigDir` argument. Under multi-profile setups with `CLAUDE_CONFIG_DIR` overlays, only the default credential store gets refreshed. This mirrors the *existing* upstream behavior at the already-merged refresh sites (`server.ts` ~1062, ~1520, ~2502) — this PR doesn't introduce the gap, but it does extend it to a few more sites. `inflightRefresh` and the scheduler state are also process-global, so two profiles in one process can't refresh independently.

The fix is to thread `claudeConfigDir` through the refresh helpers — `oauthUsage.ts` (#439) already shows the right pattern. Happy to follow up with a separate PR that retrofits all the refresh sites to be profile-aware if you'd like; kept it out of this PR to keep the diff focused on the trigger gap and the missing traffic-independent path.

## Compatibility with open work

#474 (open, oauth-token profile type) doesn't conflict — its tokens have ~1 yr TTL and bypass the refresh path entirely. If it merges, the scheduler should grow a `ProfileType !== "oauth-account"` skip so it doesn't try to refresh long-lived static tokens. One-line guard, easy follow-up.

---

Closes the silent-401 failure mode that #223 originally described and that #230 partially addressed. Tested locally + 21 h prod soak across two long-running unattended instances.
