### PR TITLE
fix(tokenRefresh): close trigger gap + add traffic-independent refresh

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -246,6 +246,101 @@ describe("refreshOAuthToken", () => {
 })
 
 // ---------------------------------------------------------------------------
+// ensureFreshToken — proactive refresh before SDK call
+// ---------------------------------------------------------------------------
+
+describe("ensureFreshToken", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  function makeStoreWithExpiry(expiresAt: number) {
+    return makeStore({ ...MOCK_CREDENTIALS, claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt } })
+  }
+
+  it("returns true without refreshing when token is far from expiry", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.reject(new Error("fetch should not be called")))
+    mockFetch(fetchSpy)
+    const { store, writes } = makeStoreWithExpiry(Date.now() + 60 * 60 * 1000) // +1h, well outside default 5min buffer
+
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(true)
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(writes).toHaveLength(0)
+  })
+
+  it("refreshes when token is inside the buffer (near-expiry)", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+    mockFetch(fetchSpy)
+    const { store, getStored } = makeStoreWithExpiry(Date.now() + 60 * 1000) // +1min, well inside default 5min buffer
+
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(getStored()?.claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+
+  it("refreshes when token is already expired", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+    mockFetch(fetchSpy)
+    const { store, getStored } = makeStoreWithExpiry(Date.now() - 60 * 60 * 1000) // -1h
+
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(true)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(getStored()?.claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+
+  it("returns false when no credentials stored", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.reject(new Error("fetch should not be called")))
+    mockFetch(fetchSpy)
+    const { store } = makeStore(null)
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns false when expiresAt missing", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.reject(new Error("fetch should not be called")))
+    mockFetch(fetchSpy)
+    // expiresAt = 0 is falsy via `!expiresAt`
+    const { store } = makeStoreWithExpiry(0)
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(false)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns false when refresh request fails", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    mockFetch(() => Promise.resolve(new Response("invalid_grant", { status: 400 })))
+    const { store } = makeStoreWithExpiry(Date.now() - 1000)
+    const ok = await ensureFreshToken(store)
+    expect(ok).toBe(false)
+  })
+
+  it("respects custom bufferMs", async () => {
+    const { ensureFreshToken } = await import("../proxy/tokenRefresh")
+    const fetchSpy = mock(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+    mockFetch(fetchSpy)
+    // Token expires in 2h. Default 5-min buffer → no refresh; 3-h buffer → refresh.
+    const { store } = makeStoreWithExpiry(Date.now() + 2 * 60 * 60 * 1000)
+    expect(await ensureFreshToken(store, 60 * 1000)).toBe(true)            // 1-min buffer: skip
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(await ensureFreshToken(store, 3 * 60 * 60 * 1000)).toBe(true)   // 3-h buffer: refresh
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // createPlatformCredentialStore
 // ---------------------------------------------------------------------------
 

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -283,12 +283,51 @@ describe("isExpiredTokenError", () => {
     )).toBe(true)
   })
 
-  it("returns false for unrelated auth errors", async () => {
+  it("returns false for unrelated errors that lack a 401 marker", async () => {
     const { isExpiredTokenError } = await import("../proxy/errors")
     expect(isExpiredTokenError("authentication failed")).toBe(false)
     expect(isExpiredTokenError("rate limit exceeded")).toBe(false)
     expect(isExpiredTokenError("invalid credentials")).toBe(false)
     expect(isExpiredTokenError("token refresh failed")).toBe(false)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Broadened triggers — generic 401s and RFC-6750 wording.
+  //
+  // Reason: Anthropic's API can return a 401 for an expired access token
+  // without echoing the CLI-specific "OAuth token has expired" string, so the
+  // narrow legacy matcher missed scheduled-expiry failures and the proxy
+  // never fired refresh-and-retry. Confirmed in production 2026-05-03 on two
+  // NAS instances that sat idle past expiry: credentials.json mtime never
+  // ticked, every request returned 401 to the client, no
+  // "token_refresh.retrying" ever logged.
+  // ---------------------------------------------------------------------------
+
+  it("detects generic 401 + authentication wording", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    expect(isExpiredTokenError("API Error: 401 authentication_error")).toBe(true)
+    expect(isExpiredTokenError("HTTP 401 Unauthorized")).toBe(true)
+    expect(isExpiredTokenError("401 invalid request")).toBe(true)
+  })
+
+  it("detects RFC-6750 token error codes", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    expect(isExpiredTokenError('error="invalid_token"')).toBe(true)
+    expect(isExpiredTokenError("token_expired")).toBe(true)
+  })
+
+  it("does not trigger on 401 without an auth keyword", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    // Hypothetical 401 without auth wording — leave as not-a-trigger to keep
+    // the false-positive surface narrow.
+    expect(isExpiredTokenError("API returned 401 over rate limit")).toBe(false)
+  })
+
+  it("does not trigger on non-401 errors that incidentally include auth words", async () => {
+    const { isExpiredTokenError } = await import("../proxy/errors")
+    expect(isExpiredTokenError("authentication failed")).toBe(false)
+    expect(isExpiredTokenError("invalid argument")).toBe(false)
+    expect(isExpiredTokenError("unauthorized scope")).toBe(false)
   })
 })
 

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -341,6 +341,149 @@ describe("ensureFreshToken", () => {
 })
 
 // ---------------------------------------------------------------------------
+// startBackgroundRefresh — traffic-independent scheduled refresh
+// ---------------------------------------------------------------------------
+
+describe("startBackgroundRefresh", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    const { stopBackgroundRefresh, resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    stopBackgroundRefresh()
+    resetInflightRefresh()
+    globalThis.fetch = originalFetch
+  })
+
+  // Wait for any pending timers + microtasks to flush. Real timers — keeps
+  // the test runner simple at the cost of slightly longer test runs.
+  const tick = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+  it("immediately refreshes when token is already expired", async () => {
+    const { startBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store, getStored } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 60_000 },
+    })
+
+    startBackgroundRefresh(store, 1000, 60_000)
+    expect(isBackgroundRefreshActive()).toBe(true)
+    await tick(50)
+
+    expect(fetchCalls).toBe(1)
+    expect(getStored()?.claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+
+  it("schedules — does not refresh — when token has time", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() + 60 * 60 * 1000 }, // +1h
+    })
+
+    startBackgroundRefresh(store, 1000, 60_000)
+    await tick(50)
+
+    expect(fetchCalls).toBe(0)
+  })
+
+  it("polls when no credentials are present, picks up new file on next tick", async () => {
+    const { startBackgroundRefresh, stopBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    let stored: typeof MOCK_CREDENTIALS | null = null
+    const store: CredentialStore = {
+      async read() { return stored ? JSON.parse(JSON.stringify(stored)) : null },
+      async write(c) { stored = c as typeof MOCK_CREDENTIALS; return true },
+    }
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+
+    startBackgroundRefresh(store, 1000, 30) // 30ms poll interval
+    await tick(50)
+    expect(fetchCalls).toBe(0) // no credentials yet — refresh skipped
+
+    // Operator "logs in" — credentials appear with an expired token
+    stored = {
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    }
+    await tick(60) // wait for next poll tick
+
+    expect(fetchCalls).toBeGreaterThanOrEqual(1)
+    stopBackgroundRefresh()
+  })
+
+  it("retries on refresh failure", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(new Response("invalid_grant", { status: 400 }))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    })
+
+    startBackgroundRefresh(store, 1000, 30) // 30ms retry interval
+    await tick(120) // let it retry a few times
+
+    expect(fetchCalls).toBeGreaterThanOrEqual(2)
+  })
+
+  it("is idempotent — second start() while running is a no-op", async () => {
+    const { startBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    })
+
+    startBackgroundRefresh(store, 1000, 60_000)
+    startBackgroundRefresh(store, 1000, 60_000) // second call — should be no-op
+    expect(isBackgroundRefreshActive()).toBe(true)
+    await tick(50)
+
+    expect(fetchCalls).toBe(1) // only one refresh, not two
+  })
+
+  it("stop() prevents the next scheduled refresh from firing", async () => {
+    const { startBackgroundRefresh, stopBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
+    let fetchCalls = 0
+    mockFetch(() => {
+      fetchCalls++
+      return Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+    })
+    const { store } = makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() + 1000 }, // 1s out, well past 100ms buffer
+    })
+
+    startBackgroundRefresh(store, 100, 60_000)
+    stopBackgroundRefresh()
+    expect(isBackgroundRefreshActive()).toBe(false)
+    await tick(1500) // would have fired by now
+
+    expect(fetchCalls).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // createPlatformCredentialStore
 // ---------------------------------------------------------------------------
 

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -481,6 +481,81 @@ describe("startBackgroundRefresh", () => {
 
     expect(fetchCalls).toBe(0)
   })
+
+  // Regression: stop() + start() while a scheduleNext() is mid-await must
+  // not leave an orphan refresh chain behind. Without generation tracking
+  // the first chain's read resolves *after* the second start() bumps the
+  // active flag, both chains arm follow-up timers, only the latest is
+  // tracked in scheduledRefreshTimer, and the orphan keeps firing — every
+  // subsequent tick produces 2× the work.
+  it("does not leak a parallel refresh chain across stop/start while a read is in flight", async () => {
+    const { startBackgroundRefresh, stopBackgroundRefresh } = await import("../proxy/tokenRefresh")
+
+    // First two reads (one per generation's scheduleNext) park on a manual
+    // gate so we can force both chains to be in flight simultaneously.
+    // Subsequent reads (doRefresh's internal read, follow-up timer reads)
+    // resolve synchronously so the chains can run to completion.
+    const pendingReads: Array<(creds: typeof MOCK_CREDENTIALS) => void> = []
+    let readCalls = 0
+
+    let stored: typeof MOCK_CREDENTIALS = {
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+    }
+
+    mockFetch(() => Promise.resolve(makeSuccessResponse({
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+      expires_in: 3600,
+    })))
+
+    const store: CredentialStore = {
+      read: () => {
+        readCalls++
+        if (readCalls <= 2) {
+          return new Promise(resolve => pendingReads.push(resolve))
+        }
+        return Promise.resolve(JSON.parse(JSON.stringify(stored)))
+      },
+      async write(c) {
+        stored = c as typeof MOCK_CREDENTIALS
+        return true
+      },
+    }
+
+    // gen-1 begins, scheduleNext-1 hits await store.read() and parks.
+    startBackgroundRefresh(store, 100, 60_000)
+    await tick(10)
+    expect(readCalls).toBe(1)
+
+    // stop() while gen-1's read is still pending.
+    stopBackgroundRefresh()
+
+    // start() bumps a new generation; scheduleNext-2 also parks on read.
+    startBackgroundRefresh(store, 100, 60_000)
+    await tick(10)
+    expect(readCalls).toBe(2)
+
+    // Release both parked reads with the (still expired) credentials. Both
+    // chains advance into refreshOAuthToken (dedup'd to one fetch via
+    // inflightRefresh, which writes the new long-lived expiry into stored).
+    // Each chain that survives then arms a 0-delay timer; when the timer
+    // fires, scheduleNext re-runs and store.read() is called again.
+    pendingReads[0]({ ...stored, claudeAiOauth: { ...stored.claudeAiOauth } })
+    pendingReads[1]({ ...stored, claudeAiOauth: { ...stored.claudeAiOauth } })
+
+    await tick(80)
+
+    // Read accounting:
+    //   1, 2 — initial scheduleNext reads (one per generation, gated)
+    //   3    — doRefresh's read inside refreshOAuthToken (single, dedup'd)
+    //   4..  — one follow-up read per scheduleNext chain that armed a timer
+    // With the fix only the live generation arms a follow-up → 4 total.
+    // With the bug both chains arm follow-ups → 5 total.
+    expect(readCalls).toBe(4)
+
+    stopBackgroundRefresh()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -541,8 +541,8 @@ describe("startBackgroundRefresh", () => {
     // inflightRefresh, which writes the new long-lived expiry into stored).
     // Each chain that survives then arms a 0-delay timer; when the timer
     // fires, scheduleNext re-runs and store.read() is called again.
-    pendingReads[0]({ ...stored, claudeAiOauth: { ...stored.claudeAiOauth } })
-    pendingReads[1]({ ...stored, claudeAiOauth: { ...stored.claudeAiOauth } })
+    pendingReads[0]?.({ ...stored, claudeAiOauth: { ...stored.claudeAiOauth } })
+    pendingReads[1]?.({ ...stored, claudeAiOauth: { ...stored.claudeAiOauth } })
 
     await tick(80)
 

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -129,14 +129,27 @@ export function classifyError(errMsg: string): ClassifiedError {
  * Detect errors caused by an expired or missing OAuth access token.
  * Triggers an inline token refresh + retry in server.ts.
  *
- * Two distinct messages from the Claude Code CLI:
- *   - "OAuth token has expired" — CLI sent the token, Anthropic API rejected it
- *   - "Not logged in"           — CLI checked expiresAt locally and refused to try
- * Both are resolved by refreshing the token.
+ * Patterns, in order of specificity:
+ *   - "OAuth token has expired" / "Not logged in" — CLI-emitted (subprocess
+ *     either got 401 with this wording from Anthropic or detected expiry
+ *     locally before sending).
+ *   - "invalid_token" / "token_expired" — RFC 6750 resource-server errors that
+ *     can appear in the API response body.
+ *   - "401" + ("authentication" | "unauthorized" | "invalid") — generic 401
+ *     wrapping. Anthropic's API does not always echo the CLI-specific wording,
+ *     so without this branch a stale access token returns a generic 401 to the
+ *     proxy and refresh-and-retry never fires (caller sees the 401).
+ *
+ * False positives only cost one OAuth round-trip — the refresh is single-shot
+ * per request (gated by `tokenRefreshed` in server.ts) and surfaces the
+ * original error if it doesn't help.
  */
 export function isExpiredTokenError(errMsg: string): boolean {
   const lower = errMsg.toLowerCase()
-  return lower.includes("oauth token has expired") || lower.includes("not logged in")
+  if (lower.includes("oauth token has expired") || lower.includes("not logged in")) return true
+  if (lower.includes("invalid_token") || lower.includes("token_expired")) return true
+  if (lower.includes("401") && (lower.includes("authentication") || lower.includes("unauthorized") || lower.includes("invalid"))) return true
+  return false
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
@@ -966,6 +966,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const response = (async function* () {
               let rateLimitRetries = 0
 
+              // Proactive: refresh the access token if it's within the buffer
+              // of expiry. Best-effort — the reactive 401 path below picks up
+              // anything this misses. Saves a round-trip on the common case
+              // where the previous request left the token close to expiry.
+              await ensureFreshToken().catch(() => { /* reactive path handles */ })
+
               let tokenRefreshed = false
               while (true) {
                 // Track whether response content was yielded.
@@ -1431,6 +1437,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               const response = (async function* () {
                 let rateLimitRetries = 0
+
+                // Proactive token refresh — see non-stream path above.
+                await ensureFreshToken().catch(() => { /* reactive path handles */ })
+
                 let tokenRefreshed = false
 
                 while (true) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken, ensureFreshToken } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
@@ -2944,6 +2944,12 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     }
   })
 
+  // Background OAuth token refresh: keeps the refresh chain warm even when
+  // the proxy sits idle. Without it, an unused refresh token can be
+  // invalidated server-side after sitting unused for an extended period.
+  // Idempotent — re-calling start() on a hot-reload is a no-op.
+  startBackgroundRefresh()
+
   // Background auth keepalive: periodically refresh auth status for all
   // configured profiles so switching is instant (no stale token delay).
   let authKeepaliveInterval: ReturnType<typeof setInterval> | undefined
@@ -2971,6 +2977,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     config: finalConfig,
     async close() {
       if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+      stopBackgroundRefresh()
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()))
       })

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -303,6 +303,32 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
   return true
 }
 
+/**
+ * Refresh the access token if it is within `bufferMs` of expiry.
+ *
+ * Cheap to call before every SDK request: when the token isn't due yet this
+ * is just one credential-store read. When it is due, the underlying
+ * `refreshOAuthToken()` call is in-flight-deduplicated so concurrent callers
+ * share one network round-trip.
+ *
+ * Returns true when the token is fresh after the call (already valid OR
+ * successfully refreshed), false on any failure (no credentials, no
+ * expiresAt, refresh request failed). False is non-fatal — the caller
+ * proceeds with whatever token is on disk and falls back to the reactive
+ * refresh-on-401 path if Anthropic rejects it.
+ */
+export async function ensureFreshToken(
+  store?: CredentialStore,
+  bufferMs = 5 * 60 * 1000,
+): Promise<boolean> {
+  const s = store ?? createPlatformCredentialStore()
+  const credentials = await s.read()
+  const expiresAt = credentials?.claudeAiOauth?.expiresAt
+  if (!expiresAt) return false
+  if (expiresAt - Date.now() > bufferMs) return true
+  return refreshOAuthToken(s)
+}
+
 /** Reset in-flight state — for testing only. */
 export function resetInflightRefresh(): void {
   inflightRefresh = null

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -398,6 +398,7 @@ async function scheduleNext(
     // new expiresAt (or retry in failureRetryMs if refresh failed).
     const ok = await refreshOAuthToken(store)
     claudeLog("token_refresh.scheduled", { ok, immediate: true })
+    console.error(`[token_refresh] scheduled refresh (immediate) ok=${ok}`)
     if (!scheduledRefreshActive) return
     armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs)
     return
@@ -414,10 +415,10 @@ function armTimer(
 ): void {
   scheduledRefreshTimer = setTimeout(async () => {
     if (!scheduledRefreshActive) return
-    // If the timer woke up exactly at the deadline (delayMs > 0 path), fire
-    // refresh first; if the timer was a "reschedule based on disk" tick
-    // (delayMs === 0 after a successful refresh), skip the refresh and just
-    // recompute. The dueIn re-check inside scheduleNext distinguishes them.
+    // The dueIn re-check inside scheduleNext distinguishes "fire-now" from
+    // "reschedule-only" ticks: when the disk-state recompute lands inside
+    // the buffer window, scheduleNext emits the immediate-refresh log line;
+    // otherwise it just arms the next timer silently.
     void scheduleNext(store, bufferMs, failureRetryMs)
   }, delayMs)
   if (scheduledRefreshTimer && (scheduledRefreshTimer as { unref?: () => void }).unref) {

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -335,6 +335,14 @@ export async function ensureFreshToken(
 
 let scheduledRefreshTimer: ReturnType<typeof setTimeout> | null = null
 let scheduledRefreshActive = false
+// Generation counter — bumped on every start/stop. Each scheduleNext chain
+// captures the generation it began with and re-checks it after every await;
+// if the global generation has moved on, the chain has been superseded and
+// must bail rather than arm a follow-up timer. Without this, a stop()+start()
+// that interleaves with an in-flight read leaves the first chain alive,
+// arming a timer that overwrites scheduledRefreshTimer (so stop() can't
+// clear it) and keeps firing in parallel with the live chain.
+let scheduledRefreshGeneration = 0
 
 /**
  * Start a self-rescheduling timer that refreshes the access token shortly
@@ -364,12 +372,14 @@ export function startBackgroundRefresh(
 ): void {
   if (scheduledRefreshActive) return
   scheduledRefreshActive = true
-  void scheduleNext(store ?? createPlatformCredentialStore(), bufferMs, failureRetryMs)
+  const gen = ++scheduledRefreshGeneration
+  void scheduleNext(store ?? createPlatformCredentialStore(), bufferMs, failureRetryMs, gen)
 }
 
 /** Stop the background scheduler. Idempotent. */
 export function stopBackgroundRefresh(): void {
   scheduledRefreshActive = false
+  scheduledRefreshGeneration++
   if (scheduledRefreshTimer) clearTimeout(scheduledRefreshTimer)
   scheduledRefreshTimer = null
 }
@@ -378,17 +388,20 @@ async function scheduleNext(
   store: CredentialStore,
   bufferMs: number,
   failureRetryMs: number,
+  gen: number,
 ): Promise<void> {
-  if (!scheduledRefreshActive) return
+  if (!scheduledRefreshActive || gen !== scheduledRefreshGeneration) return
 
   const credentials = await store.read().catch(() => null)
+  if (!scheduledRefreshActive || gen !== scheduledRefreshGeneration) return
+
   const expiresAt = credentials?.claudeAiOauth?.expiresAt
 
   if (!expiresAt) {
     // Operator hasn't logged in yet (no credentials) or credentials are
     // missing the field. Re-poll periodically — once `claude login` writes
     // the file, the next tick picks it up.
-    armTimer(failureRetryMs, store, bufferMs, failureRetryMs)
+    armTimer(failureRetryMs, store, bufferMs, failureRetryMs, gen)
     return
   }
 
@@ -397,14 +410,14 @@ async function scheduleNext(
     // Already due (or past) — fire now, schedule the follow-up based on the
     // new expiresAt (or retry in failureRetryMs if refresh failed).
     const ok = await refreshOAuthToken(store)
+    if (!scheduledRefreshActive || gen !== scheduledRefreshGeneration) return
     claudeLog("token_refresh.scheduled", { ok, immediate: true })
     console.error(`[token_refresh] scheduled refresh (immediate) ok=${ok}`)
-    if (!scheduledRefreshActive) return
-    armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs)
+    armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs, gen)
     return
   }
 
-  armTimer(dueIn, store, bufferMs, failureRetryMs)
+  armTimer(dueIn, store, bufferMs, failureRetryMs, gen)
 }
 
 function armTimer(
@@ -412,14 +425,15 @@ function armTimer(
   store: CredentialStore,
   bufferMs: number,
   failureRetryMs: number,
+  gen: number,
 ): void {
   scheduledRefreshTimer = setTimeout(async () => {
-    if (!scheduledRefreshActive) return
+    if (!scheduledRefreshActive || gen !== scheduledRefreshGeneration) return
     // The dueIn re-check inside scheduleNext distinguishes "fire-now" from
     // "reschedule-only" ticks: when the disk-state recompute lands inside
     // the buffer window, scheduleNext emits the immediate-refresh log line;
     // otherwise it just arms the next timer silently.
-    void scheduleNext(store, bufferMs, failureRetryMs)
+    void scheduleNext(store, bufferMs, failureRetryMs, gen)
   }, delayMs)
   if (scheduledRefreshTimer && (scheduledRefreshTimer as { unref?: () => void }).unref) {
     (scheduledRefreshTimer as { unref: () => void }).unref()

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -329,6 +329,107 @@ export async function ensureFreshToken(
   return refreshOAuthToken(s)
 }
 
+// ---------------------------------------------------------------------------
+// Background refresh scheduler
+// ---------------------------------------------------------------------------
+
+let scheduledRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let scheduledRefreshActive = false
+
+/**
+ * Start a self-rescheduling timer that refreshes the access token shortly
+ * before each expiry — regardless of incoming traffic.
+ *
+ * Idempotent: a second call while one is already running is a no-op. Safe to
+ * call from any code path; returns synchronously and schedules in the
+ * background.
+ *
+ * Why traffic-independent matters: without this, an idle proxy never fires
+ * either the proactive (`ensureFreshToken`) or reactive (401-retry) refresh
+ * path. Anthropic's OAuth refresh tokens appear to be invalidated server-side
+ * after sitting unused for an extended period (observed 2026-05-03: two NAS
+ * instances idle past expiry both got `400 invalid_grant` on a manual refresh
+ * attempt; only fix was OAuth-flow re-login). Running a refresh every ~8h
+ * keeps the refresh chain warm.
+ *
+ * On `refreshOAuthToken()` failure (network, transient API error, refresh
+ * token rejected) we retry every `failureRetryMs` — gives operators a window
+ * to `claude login` and have the new tokens picked up automatically on the
+ * next tick.
+ */
+export function startBackgroundRefresh(
+  store?: CredentialStore,
+  bufferMs = 5 * 60 * 1000,
+  failureRetryMs = 5 * 60 * 1000,
+): void {
+  if (scheduledRefreshActive) return
+  scheduledRefreshActive = true
+  void scheduleNext(store ?? createPlatformCredentialStore(), bufferMs, failureRetryMs)
+}
+
+/** Stop the background scheduler. Idempotent. */
+export function stopBackgroundRefresh(): void {
+  scheduledRefreshActive = false
+  if (scheduledRefreshTimer) clearTimeout(scheduledRefreshTimer)
+  scheduledRefreshTimer = null
+}
+
+async function scheduleNext(
+  store: CredentialStore,
+  bufferMs: number,
+  failureRetryMs: number,
+): Promise<void> {
+  if (!scheduledRefreshActive) return
+
+  const credentials = await store.read().catch(() => null)
+  const expiresAt = credentials?.claudeAiOauth?.expiresAt
+
+  if (!expiresAt) {
+    // Operator hasn't logged in yet (no credentials) or credentials are
+    // missing the field. Re-poll periodically — once `claude login` writes
+    // the file, the next tick picks it up.
+    armTimer(failureRetryMs, store, bufferMs, failureRetryMs)
+    return
+  }
+
+  const dueIn = expiresAt - Date.now() - bufferMs
+  if (dueIn <= 0) {
+    // Already due (or past) — fire now, schedule the follow-up based on the
+    // new expiresAt (or retry in failureRetryMs if refresh failed).
+    const ok = await refreshOAuthToken(store)
+    claudeLog("token_refresh.scheduled", { ok, immediate: true })
+    if (!scheduledRefreshActive) return
+    armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs)
+    return
+  }
+
+  armTimer(dueIn, store, bufferMs, failureRetryMs)
+}
+
+function armTimer(
+  delayMs: number,
+  store: CredentialStore,
+  bufferMs: number,
+  failureRetryMs: number,
+): void {
+  scheduledRefreshTimer = setTimeout(async () => {
+    if (!scheduledRefreshActive) return
+    // If the timer woke up exactly at the deadline (delayMs > 0 path), fire
+    // refresh first; if the timer was a "reschedule based on disk" tick
+    // (delayMs === 0 after a successful refresh), skip the refresh and just
+    // recompute. The dueIn re-check inside scheduleNext distinguishes them.
+    void scheduleNext(store, bufferMs, failureRetryMs)
+  }, delayMs)
+  if (scheduledRefreshTimer && (scheduledRefreshTimer as { unref?: () => void }).unref) {
+    (scheduledRefreshTimer as { unref: () => void }).unref()
+  }
+}
+
+/** For testing only. */
+export function isBackgroundRefreshActive(): boolean {
+  return scheduledRefreshActive
+}
+
 /** Reset in-flight state — for testing only. */
 export function resetInflightRefresh(): void {
   inflightRefresh = null


### PR DESCRIPTION
## What this is

This PR fully accepts the work from #479 by @CrazyCoder (Serge Baranov) — the original 4 commits are cherry-picked here with his authorship preserved — and adds **one** small follow-up fix on top.

Closes #479.

## Original work (Serge Baranov, unchanged)

| Commit | Layer | What |
|--------|-------|------|
| `5b638cc4` | reactive | broaden `isExpiredTokenError` to catch generic 401s |
| `0fc8a4dc` | proactive | `ensureFreshToken` before each SDK call |
| `4ad10515` | **load-bearing** | background scheduler keeps refresh chain warm |
| `67ece966` | observability | `[token_refresh]` line in default logs |

The full problem analysis, soak evidence (21h on two prod NAS instances), and forced-expiry repro from #479 carry over verbatim — see that PR for context. All of Serge's reasoning still applies, none of it changed.

## What I added on top

`cce9d61b fix(tokenRefresh): generation-track scheduler to kill orphan chains`

During code review of #479 I found one race in the scheduler — minor but real. The background scheduler keyed liveness on a single boolean (`scheduledRefreshActive`). A `stop()` + `start()` that interleaved with a `scheduleNext()` mid-await left the first chain alive: when its read resolved it re-checked `active` (now `true` again from start #2) and armed a follow-up timer. That timer overwrote `scheduledRefreshTimer`, so the next `stop()` couldn't clear it, and the orphan ran forever in parallel — every tick produced 2× the work.

Edge case in practice (only triggers on rapid `start → stop → start` while a credential-store read is parked), but trivial to fix and worth it because the bug compounds silently.

The fix replaces the boolean with a generation counter. `start()` bumps the generation; `stop()` bumps it again and invalidates any in-flight chain. `scheduleNext` captures `gen` on entry and re-checks after every await; if the global generation moved on, the chain bails before arming a timer.

## Tests

Adds a regression test that hand-controls `store.read()` promises so both generations are simultaneously in flight, then asserts read accounting. **Failed** against the unfixed code with `Expected: 4 / Received: 5` — the orphan chain demonstrably arms a parallel follow-up timer. **Passes** against the fix.

Full suite: **1695 pass / 0 fail** (1694 from #479's existing tests + 1 new regression).

## Local verification

- Cherry-picked all 4 of Serge's commits cleanly off his PR head, authorship preserved
- Built clean (`npm run build`)
- Booted on `:3500` against a live keychain (token had 8h headroom — read-only path) — `/health` healthy, scheduler armed quietly
- Confirmed prod proxy on `:3456` undisturbed throughout

## Merge strategy

Recommend **rebase merge** here (not squash) so Serge's 4 commits land on `main` with his authorship intact — both `git log` and the contribution graph reflect his work correctly.