### PR TITLE
feat: register OAuth token as profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ meridian profile add ci --oauth-token
 meridian profile add ci --oauth-token sk-ant-oat01-...
 ```
 
-OAuth-token profiles store nothing on disk besides the token in `profiles.json` — there's no per-profile config dir, no Keychain entry, no browser handshake. The Claude Code SDK reads the token from `CLAUDE_CODE_OAUTH_TOKEN` for any request routed to that profile.
+OAuth-token profiles store the token in `profiles.json` and feed it to the SDK via `CLAUDE_CODE_OAUTH_TOKEN` — no Keychain entry, no browser handshake. To prevent the SDK's 401-recovery from silently falling back to the host's `~/.claude` credentials, OAuth-token profiles also pin `CLAUDE_CONFIG_DIR` to an isolated per-profile directory under `~/.config/meridian/profiles/<name>/`. That directory holds only SDK state (sessions, settings) — never `.credentials.json`, since the token is delivered through the env.
 
 ### Switching profiles
 
@@ -278,7 +278,7 @@ You can also switch profiles from the web UI at `http://127.0.0.1:3456/profiles`
 
 ### How it works
 
-Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. OAuth-token profiles are the exception — they live entirely in `~/.config/meridian/profiles.json` and feed the SDK via `CLAUDE_CODE_OAUTH_TOKEN` directly. When a request arrives, Meridian resolves the profile in priority order:
+Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. OAuth-token profiles use the same isolated directory layout — but the token itself lives in `~/.config/meridian/profiles.json` and is fed to the SDK via `CLAUDE_CODE_OAUTH_TOKEN`, so the per-profile dir holds only SDK state (sessions, settings) and never the credential. When a request arrives, Meridian resolves the profile in priority order:
 
 1. `x-meridian-profile` request header (per-request override)
 2. Active profile (set via `meridian profile switch` or the web UI)

--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ meridian profile add work
 
 > **⚠ Important:** Claude's OAuth reuses your browser session. Before adding a second account, sign out of claude.ai and sign into the other account first.
 
+#### Headless / CI: register an OAuth token
+
+When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:
+
+```bash
+# Prompt for the token (input is hidden — paste the value from `claude setup-token`)
+meridian profile add ci --oauth-token
+
+# Or pass it inline
+meridian profile add ci --oauth-token sk-ant-oat01-...
+```
+
+OAuth-token profiles store nothing on disk besides the token in `profiles.json` — there's no per-profile config dir, no Keychain entry, no browser handshake. The Claude Code SDK reads the token from `CLAUDE_CODE_OAUTH_TOKEN` for any request routed to that profile.
+
 ### Switching profiles
 
 ```bash
@@ -256,14 +270,15 @@ You can also switch profiles from the web UI at `http://127.0.0.1:3456/profiles`
 | Command | Description |
 |---------|-------------|
 | `meridian profile add <name>` | Add a profile and authenticate via browser |
+| `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |
 | `meridian profile list` | List profiles and auth status |
 | `meridian profile switch <name>` | Switch the active profile (requires running proxy) |
-| `meridian profile login <name>` | Re-authenticate an expired profile |
+| `meridian profile login <name>` | Re-authenticate an expired profile (browser-login profiles only) |
 | `meridian profile remove <name>` | Remove a profile and its credentials |
 
 ### How it works
 
-Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. When a request arrives, Meridian resolves the profile in priority order:
+Each profile stores its credentials in an isolated `CLAUDE_CONFIG_DIR` under `~/.config/meridian/profiles/<name>/`. OAuth-token profiles are the exception — they live entirely in `~/.config/meridian/profiles.json` and feed the SDK via `CLAUDE_CODE_OAUTH_TOKEN` directly. When a request arrives, Meridian resolves the profile in priority order:
 
 1. `x-meridian-profile` request header (per-request override)
 2. Active profile (set via `meridian profile switch` or the web UI)
@@ -276,10 +291,20 @@ Session state is scoped per profile — switching accounts won't cross-contamina
 For advanced setups (CI, Docker), profiles can also be provided via environment variable:
 
 ```bash
-export MERIDIAN_PROFILES='[{"id":"personal","claudeConfigDir":"/path/to/config1"},{"id":"work","claudeConfigDir":"/path/to/config2"}]'
+export MERIDIAN_PROFILES='[
+  {"id":"personal","claudeConfigDir":"/path/to/config1"},
+  {"id":"work","claudeConfigDir":"/path/to/config2"},
+  {"id":"ci","oauthToken":"sk-ant-oat01-..."}
+]'
 export MERIDIAN_DEFAULT_PROFILE=personal
 meridian
 ```
+
+Profile shapes:
+
+- `claudeConfigDir` — points at a `~/.claude`-style directory; uses Claude Max OAuth from that dir
+- `apiKey` (with optional `baseUrl`) — direct Anthropic API access; sets `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`
+- `oauthToken` — long-lived token from `claude setup-token`; sets `CLAUDE_CODE_OAUTH_TOKEN`, no config dir needed
 
 When `MERIDIAN_PROFILES` is set, it takes precedence over disk-configured profiles. When unset, Meridian auto-discovers profiles from `~/.config/meridian/profiles.json` on each request.
 
@@ -710,9 +735,10 @@ export default {
 | `meridian` | Start the proxy server |
 | `meridian setup` | Configure the OpenCode plugin in `~/.config/opencode/opencode.json` |
 | `meridian profile add <name>` | Add a profile and authenticate via browser |
+| `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |
 | `meridian profile list` | List all profiles and their auth status |
 | `meridian profile switch <name>` | Switch the active profile (requires running proxy) |
-| `meridian profile login <name>` | Re-authenticate an expired profile |
+| `meridian profile login <name>` | Re-authenticate an expired profile (browser-login profiles only) |
 | `meridian profile remove <name>` | Remove a profile and its credentials |
 | `meridian refresh-token` | Manually refresh the Claude OAuth token (exits 0/1) |
 
@@ -766,6 +792,19 @@ docker run \
 ```
 
 Switch profiles at runtime via the `x-meridian-profile` header or `meridian profile switch` (see [Multi-Profile Support](#multi-profile-support)).
+
+### OAuth-token profiles in Docker (no volume mount)
+
+If you'd rather not mount a credential directory, generate a long-lived OAuth token on the host with `claude setup-token` and pass it as a profile. There's nothing to mount — the token alone is the credential:
+
+```bash
+docker run \
+  -e 'MERIDIAN_PROFILES=[{"id":"ci","oauthToken":"sk-ant-oat01-..."}]' \
+  -e MERIDIAN_DEFAULT_PROFILE=ci \
+  -p 3456:3456 meridian
+```
+
+This is the recommended path for CI runners, ephemeral containers, and cross-host deployments where browser-based login isn't reachable. Treat the token like any other secret — inject it via your platform's secret store rather than committing it to your image or compose file.
 
 ## Testing
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -43,11 +43,19 @@ See https://github.com/rynfar/meridian for full documentation.`)
 }
 
 if (args[0] === "profile") {
-  const { profileAdd, profileList, profileRemove, profileSwitch, profileLogin, profileHelp } = await import("../src/proxy/profileCli")
+  const { profileAdd, profileAddOauthToken, profileList, profileRemove, profileSwitch, profileLogin, profileHelp } = await import("../src/proxy/profileCli")
   const subcommand = args[1]
   const profileId = args[2]
 
-  if (subcommand === "add" && profileId) profileAdd(profileId)
+  if (subcommand === "add" && profileId) {
+    const oauthFlagIdx = args.indexOf("--oauth-token", 3)
+    if (oauthFlagIdx >= 0) {
+      const tokenArg = args[oauthFlagIdx + 1]
+      await profileAddOauthToken(profileId, tokenArg)
+    } else {
+      profileAdd(profileId)
+    }
+  }
   else if (subcommand === "list" || subcommand === "ls") profileList()
   else if (subcommand === "remove" && profileId) profileRemove(profileId)
   else if (subcommand === "switch" && profileId) await profileSwitch(profileId)

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -2,6 +2,8 @@
  * Unit tests for profiles.ts — pure function tests (no mocks needed).
  */
 import { describe, test, expect, beforeEach } from "bun:test"
+import { join } from "node:path"
+import { homedir } from "node:os"
 import {
   resolveProfile,
   listProfiles,
@@ -103,24 +105,33 @@ describe("resolveProfile", () => {
     )
     expect(result.id).toBe("ci")
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-foo" })
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-foo")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
   })
 
   test("infers oauth-token type from oauthToken field alone", () => {
     const result = resolveProfile([{ id: "ci", oauthToken: "sk-ant-oat01-bar" }], undefined)
     expect(result.id).toBe("ci")
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-bar" })
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-bar")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
   })
 
-  test("oauthToken takes precedence over claudeConfigDir on the same profile", () => {
+  test("oauthToken overrides claudeConfigDir with isolated profile dir", () => {
     const result = resolveProfile(
       [{ id: "ci", oauthToken: "sk-ant-oat01-baz", claudeConfigDir: "/ignored" }],
       undefined,
     )
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-baz" })
-    expect(result.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-baz")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
+    expect(result.env.CLAUDE_CONFIG_DIR).not.toBe("/ignored")
   })
 
   test("oauth-token type without oauthToken returns empty env", () => {
@@ -128,6 +139,14 @@ describe("resolveProfile", () => {
     expect(result.id).toBe("bare-oauth")
     expect(result.type).toBe("oauth-token")
     expect(result.env).toEqual({})
+  })
+
+  test("oauth-token isolation dir uses profile id, not 'default'", () => {
+    const result = resolveProfile(
+      [{ id: "my-special-ci", oauthToken: "sk-ant-oat01-aaa" }],
+      undefined,
+    )
+    expect(result.env.CLAUDE_CONFIG_DIR).toContain("/my-special-ci")
   })
 
   test("header selects oauth-token profile when active points elsewhere", () => {
@@ -139,7 +158,10 @@ describe("resolveProfile", () => {
     const result = resolveProfile(mixed, undefined, "ci")
     expect(result.id).toBe("ci")
     expect(result.type).toBe("oauth-token")
-    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-qux" })
+    expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-qux")
+    expect(result.env.CLAUDE_CONFIG_DIR).toBe(
+      join(homedir(), ".config", "meridian", "profiles", "ci"),
+    )
   })
 })
 

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -95,6 +95,52 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("api")
     expect(result.env).toEqual({})
   })
+
+  test("resolves oauth-token profile via explicit type", () => {
+    const result = resolveProfile(
+      [{ id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-foo" }],
+      undefined,
+    )
+    expect(result.id).toBe("ci")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-foo" })
+  })
+
+  test("infers oauth-token type from oauthToken field alone", () => {
+    const result = resolveProfile([{ id: "ci", oauthToken: "sk-ant-oat01-bar" }], undefined)
+    expect(result.id).toBe("ci")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-bar" })
+  })
+
+  test("oauthToken takes precedence over claudeConfigDir on the same profile", () => {
+    const result = resolveProfile(
+      [{ id: "ci", oauthToken: "sk-ant-oat01-baz", claudeConfigDir: "/ignored" }],
+      undefined,
+    )
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-baz" })
+    expect(result.env.CLAUDE_CONFIG_DIR).toBeUndefined()
+  })
+
+  test("oauth-token type without oauthToken returns empty env", () => {
+    const result = resolveProfile([{ id: "bare-oauth", type: "oauth-token" }], undefined)
+    expect(result.id).toBe("bare-oauth")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({})
+  })
+
+  test("header selects oauth-token profile when active points elsewhere", () => {
+    const mixed: ProfileConfig[] = [
+      { id: "personal", claudeConfigDir: "/c1" },
+      { id: "ci", oauthToken: "sk-ant-oat01-qux" },
+    ]
+    setActiveProfile("personal")
+    const result = resolveProfile(mixed, undefined, "ci")
+    expect(result.id).toBe("ci")
+    expect(result.type).toBe("oauth-token")
+    expect(result.env).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-qux" })
+  })
 })
 
 describe("listProfiles", () => {
@@ -131,6 +177,14 @@ describe("listProfiles", () => {
   test("defaults type to claude-max when unset", () => {
     const result = listProfiles([{ id: "bare" }], undefined)
     expect(result[0]!.type).toBe("claude-max")
+  })
+
+  test("preserves oauth-token type when explicitly set", () => {
+    const result = listProfiles(
+      [{ id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-foo" }],
+      undefined,
+    )
+    expect(result[0]).toEqual({ id: "ci", type: "oauth-token", isActive: true })
   })
 })
 

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -276,3 +276,59 @@ describe("profile-scoped session isolation", () => {
     expect(result.env.CLAUDE_CONFIG_DIR).toBe("/home/.claude")
   })
 })
+
+// ---------------------------------------------------------------------------
+// dirsToRemoveOnProfileRemove — pure helper covering the cleanup paths.
+//
+// Regression target: oauth-token profiles store no `claudeConfigDir` on the
+// profile itself, so the original profileRemove bypassed any dir cleanup and
+// left the SDK-populated isolation dir at PROFILES_DIR/<id> orphaned forever.
+// ---------------------------------------------------------------------------
+describe("dirsToRemoveOnProfileRemove", () => {
+  const PROFILES_DIR = "/tmp/test-profiles-dir"
+
+  test("browser-login profile drops its claudeConfigDir when under PROFILES_DIR", async () => {
+    const { dirsToRemoveOnProfileRemove } = await import("../proxy/profileCli")
+    const dirs = dirsToRemoveOnProfileRemove(
+      { id: "personal", claudeConfigDir: `${PROFILES_DIR}/personal` },
+      PROFILES_DIR,
+    )
+    expect(dirs).toEqual([`${PROFILES_DIR}/personal`])
+  })
+
+  test("never returns a claudeConfigDir outside PROFILES_DIR (refuses to rm-rf foreign paths)", async () => {
+    const { dirsToRemoveOnProfileRemove } = await import("../proxy/profileCli")
+    const dirs = dirsToRemoveOnProfileRemove(
+      { id: "wild", claudeConfigDir: "/home/user/.claude" },
+      PROFILES_DIR,
+    )
+    expect(dirs).toEqual([])
+  })
+
+  test("oauth-token profile drops the pinned isolation dir at PROFILES_DIR/<id>", async () => {
+    const { dirsToRemoveOnProfileRemove } = await import("../proxy/profileCli")
+    const dirs = dirsToRemoveOnProfileRemove(
+      { id: "ci", oauthToken: "sk-ant-oat01-xxx" },
+      PROFILES_DIR,
+    )
+    expect(dirs).toEqual([`${PROFILES_DIR}/ci`])
+  })
+
+  test("explicit type='oauth-token' without oauthToken still drops the isolation dir", async () => {
+    const { dirsToRemoveOnProfileRemove } = await import("../proxy/profileCli")
+    const dirs = dirsToRemoveOnProfileRemove(
+      { id: "bare-ci", type: "oauth-token" },
+      PROFILES_DIR,
+    )
+    expect(dirs).toEqual([`${PROFILES_DIR}/bare-ci`])
+  })
+
+  test("api profile returns no dirs (token lives in profiles.json, no on-disk state)", async () => {
+    const { dirsToRemoveOnProfileRemove } = await import("../proxy/profileCli")
+    const dirs = dirsToRemoveOnProfileRemove(
+      { id: "direct-api", type: "api", apiKey: "sk-ant-api03-..." },
+      PROFILES_DIR,
+    )
+    expect(dirs).toEqual([])
+  })
+})

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -326,6 +326,28 @@ describe("buildQueryOptions", () => {
     expect(env.CLAUDE_CONFIG_DIR).toBeUndefined()
   })
 
+  // sharedMemory must NOT strip CLAUDE_CONFIG_DIR when the profile carries an
+  // explicit CLAUDE_CODE_OAUTH_TOKEN. Stripping it lets the SDK's 401-recovery
+  // silently fall back to host ~/.claude credentials and swap a refreshed
+  // token in for the env-provided one — making the oauth-token profile a
+  // no-op against any host with an active claude login.
+  // The whole point of pinning the per-profile isolation dir (see
+  // buildResolvedProfile in profiles.ts) is to prevent that fallback.
+  it("preserves CLAUDE_CONFIG_DIR with sharedMemory=true when CLAUDE_CODE_OAUTH_TOKEN is present", () => {
+    const result = buildQueryOptions(makeContext({
+      sharedMemory: true,
+      cleanEnv: {
+        CLAUDE_CONFIG_DIR: "/Users/me/.config/meridian/profiles/ci",
+        CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-test",
+        SOMETHING_ELSE: "keep-me",
+      },
+    }))
+    const env = (result.options as any).env
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/Users/me/.config/meridian/profiles/ci")
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-test")
+    expect(env.SOMETHING_ELSE).toBe("keep-me")
+  })
+
   // ── codeSystemPrompt / clientSystemPrompt controls ────────────────
 
   it("forces preset when codeSystemPrompt is true even in passthrough", () => {

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -1,8 +1,10 @@
 /**
  * CLI commands for profile management.
  *
- * Profiles are stored under ~/.config/meridian/profiles/{id}/ — each
- * directory is a standalone CLAUDE_CONFIG_DIR with its own OAuth tokens.
+ * Browser-login profiles are stored under ~/.config/meridian/profiles/{id}/
+ * — each directory is a standalone CLAUDE_CONFIG_DIR with its own OAuth
+ * tokens. OAuth-token profiles (added via `--oauth-token`) live entirely in
+ * profiles.json — no per-profile config dir.
  *
  * This is a leaf module — no imports from server.ts or session/.
  */
@@ -143,6 +145,38 @@ export function profileAdd(id: string): void {
   printEnvHint(profiles)
 }
 
+export async function profileAddOauthToken(id: string, tokenArg: string | undefined): Promise<void> {
+  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+    console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
+    process.exit(1)
+  }
+
+  const profiles = loadProfileConfig()
+  if (profiles.find(p => p.id === id)) {
+    console.error(`\x1b[31m✗ Profile "${id}" already exists.\x1b[0m`)
+    console.error(`  Run: meridian profile list`)
+    process.exit(1)
+  }
+
+  let token = tokenArg?.trim() ?? ""
+  if (!token) {
+    console.log(`\x1b[36mAdding profile: ${id} (OAuth token)\x1b[0m`)
+    console.log(`  Generate a token with: \x1b[1mclaude setup-token\x1b[0m`)
+    console.log()
+    token = promptToken(`Paste OAuth token for "${id}" (input hidden):`)
+  }
+
+  if (!token) {
+    console.error("\x1b[31m✗ Empty token. Aborted.\x1b[0m")
+    process.exit(1)
+  }
+
+  profiles.push({ id, type: "oauth-token", oauthToken: token })
+  saveProfileConfig(profiles)
+  console.log(`\x1b[32m✓ Profile "${id}" added (OAuth token).\x1b[0m`)
+  printEnvHint(profiles)
+}
+
 export function profileList(): void {
   const profiles = loadProfileConfig()
   if (profiles.length === 0) {
@@ -153,6 +187,10 @@ export function profileList(): void {
 
   console.log("Profiles:\n")
   for (const p of profiles) {
+    if (p.oauthToken || p.type === "oauth-token") {
+      console.log(`  ${p.id.padEnd(20)} \x1b[32m✓ OAuth token\x1b[0m`)
+      continue
+    }
     const auth = getAuthStatus(p.claudeConfigDir ?? "")
     const status = auth.loggedIn
       ? `\x1b[32m✓ ${auth.email} (${auth.subscriptionType || "unknown"})\x1b[0m`
@@ -220,6 +258,12 @@ export function profileLogin(id: string): void {
     process.exit(1)
   }
 
+  if (profile.oauthToken || profile.type === "oauth-token") {
+    console.error(`\x1b[31m✗ Profile "${id}" uses an OAuth token; \`claude auth login\` does not apply.\x1b[0m`)
+    console.error(`  To replace the token: meridian profile remove ${id} && meridian profile add ${id} --oauth-token`)
+    process.exit(1)
+  }
+
   console.log(`\x1b[36mRe-authenticating profile: ${id}\x1b[0m`)
   console.log()
   console.log("\x1b[33m⚠ Make sure you're signed into the correct Claude account in your browser.\x1b[0m")
@@ -256,6 +300,42 @@ function promptYesNo(question: string): boolean {
   return answer !== "n" && answer !== "no"
 }
 
+/** Synchronous secret prompt. Reads one line from stdin without echoing typed
+ *  characters (TTY). Falls back to a piped read when stdin is not a TTY so
+ *  `echo $TOKEN | meridian profile add ci --oauth-token` keeps working. */
+function promptToken(question: string): string {
+  process.stderr.write(`${question}\n> `)
+  const script = [
+    `const stdin = process.stdin;`,
+    `if (!stdin.isTTY) {`,
+    `  let buf = "";`,
+    `  stdin.setEncoding("utf8");`,
+    `  stdin.on("data", (c) => { buf += c; });`,
+    `  stdin.on("end", () => { process.stdout.write(buf.split(/\\r?\\n/)[0] || ""); process.exit(0); });`,
+    `} else {`,
+    `  stdin.setRawMode(true); stdin.resume(); stdin.setEncoding("utf8");`,
+    `  let input = "";`,
+    `  stdin.on("data", (key) => {`,
+    `    if (key === "\\u0003") { process.stderr.write("\\n"); process.exit(1); }`,
+    `    else if (key === "\\r" || key === "\\n") {`,
+    `      stdin.setRawMode(false); process.stderr.write("\\n");`,
+    `      process.stdout.write(input); process.exit(0);`,
+    `    }`,
+    `    else if (key === "\\u007f" || key === "\\b") {`,
+    `      if (input.length > 0) input = input.slice(0, -1);`,
+    `    }`,
+    `    else { input += key; }`,
+    `  });`,
+    `}`,
+  ].join("\n")
+  const result = spawnSync("node", ["-e", script], { stdio: ["inherit", "pipe", "inherit"] })
+  if (result.status !== 0) {
+    process.stderr.write("\n")
+    process.exit(1)
+  }
+  return (result.stdout?.toString() ?? "").trim()
+}
+
 function printEnvHint(_profiles: ProfileConfig[]): void {
   console.log(`\x1b[90mConfig: ${CONFIG_FILE}\x1b[0m`)
   console.log("\x1b[90mProfiles are picked up automatically — no restart needed.\x1b[0m")
@@ -265,15 +345,20 @@ export function profileHelp(): void {
   console.log(`meridian profile — manage Claude account profiles
 
 Commands:
-  meridian profile add <name>       Add a profile and authenticate
-  meridian profile list             List profiles and auth status
-  meridian profile remove <name>    Remove a profile
-  meridian profile switch <name>    Switch the active profile (requires running proxy)
-  meridian profile login <name>     Re-authenticate an existing profile
+  meridian profile add <name>                       Add a profile via browser login
+  meridian profile add <name> --oauth-token [TOKEN] Add a profile from a \`claude setup-token\` value
+                                                    (if TOKEN is omitted, you will be prompted; input is hidden)
+  meridian profile list                             List profiles and auth status
+  meridian profile remove <name>                    Remove a profile
+  meridian profile switch <name>                    Switch the active profile (requires running proxy)
+  meridian profile login <name>                     Re-authenticate an existing profile (claude-max only)
 
 Examples:
-  meridian profile add personal     # Add personal account
-  meridian profile add work         # Add work account
-  meridian profile switch work      # Switch to work account
-  meridian profile list             # Show all profiles`)
+  meridian profile add personal                     # Add personal account (browser login)
+  meridian profile add work                         # Add work account
+  meridian profile add ci --oauth-token             # Add headless CI profile (prompted, no echo)
+  meridian profile add ci --oauth-token sk-ant-oat01-...
+                                                    # Add headless CI profile (token from CLI argument)
+  meridian profile switch work                      # Switch to work account
+  meridian profile list                             # Show all profiles`)
 }

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -201,6 +201,27 @@ export function profileList(): void {
   printEnvHint(profiles)
 }
 
+/**
+ * Pure: resolve which on-disk directories should be removed when this profile
+ * is deleted. Browser-login profiles drop their explicit `claudeConfigDir`
+ * (provided it lives under `profilesDir`); oauth-token profiles drop the
+ * pinned isolation dir at `profilesDir/<id>` (created by the SDK during use,
+ * not stored on the profile itself).
+ *
+ * Caller is responsible for the actual `rmSync` — this returns paths only.
+ */
+export function dirsToRemoveOnProfileRemove(profile: ProfileConfig, profilesDir: string): string[] {
+  const dirs: string[] = []
+  if (profile.claudeConfigDir && profile.claudeConfigDir.startsWith(profilesDir)) {
+    dirs.push(profile.claudeConfigDir)
+  }
+  if (profile.oauthToken || profile.type === "oauth-token") {
+    const isolationDir = join(profilesDir, profile.id)
+    if (!dirs.includes(isolationDir)) dirs.push(isolationDir)
+  }
+  return dirs
+}
+
 export function profileRemove(id: string): void {
   const profiles = loadProfileConfig()
   const idx = profiles.findIndex(p => p.id === id)
@@ -209,13 +230,13 @@ export function profileRemove(id: string): void {
     process.exit(1)
   }
 
-  const configDir = profiles[idx]!.claudeConfigDir ?? ""
+  const removed = profiles[idx]!
+  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, PROFILES_DIR)
   profiles.splice(idx, 1)
   saveProfileConfig(profiles)
 
-  // Remove the config directory
-  if (configDir && existsSync(configDir) && configDir.startsWith(PROFILES_DIR)) {
-    rmSync(configDir, { recursive: true, force: true })
+  for (const dir of dirsToRemove) {
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
   }
 
   console.log(`\x1b[32m✓ Profile "${id}" removed.\x1b[0m`)

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -192,7 +192,14 @@ export function resolveProfile(
 function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
   if (profile.oauthToken || profile.type === "oauth-token") {
     const env: Record<string, string> = {}
-    if (profile.oauthToken) env.CLAUDE_CODE_OAUTH_TOKEN = profile.oauthToken
+    if (profile.oauthToken) {
+      env.CLAUDE_CODE_OAUTH_TOKEN = profile.oauthToken
+      // Isolate from host ~/.claude. Without this, the SDK's 401-recovery
+      // silently reads host creds from disk and swaps a refreshed token in
+      // for our env value, masking token failures. Path must not collapse
+      // to ~/.claude — see query.ts re: upstream claude-code#20553.
+      env.CLAUDE_CONFIG_DIR = join(homedir(), ".config", "meridian", "profiles", profile.id)
+    }
     return { id: profile.id, type: "oauth-token", env }
   }
 

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -2,8 +2,9 @@
  * Multi-profile support.
  *
  * Allows a single Meridian instance to route requests to different Claude
- * accounts. Each profile is a named auth context (a CLAUDE_CONFIG_DIR for
- * Max subscriptions, or an API key for direct API access).
+ * accounts. Each profile is a named auth context — a CLAUDE_CONFIG_DIR for
+ * Max subscriptions, an Anthropic API key for direct API access, or a
+ * long-lived OAuth token minted by `claude setup-token`.
  *
  * Profile selection priority:
  *   1. x-meridian-profile request header (per-request override)
@@ -50,12 +51,17 @@ export function loadProfilesFromDisk(): ProfileConfig[] {
   }
 }
 
-export type ProfileType = "claude-max" | "api"
+export type ProfileType = "claude-max" | "api" | "oauth-token"
 
 export interface ProfileConfig {
   /** Unique profile identifier (e.g. "personal", "work") */
   id: string
-  /** Auth type — "claude-max" uses CLAUDE_CONFIG_DIR, "api" uses ANTHROPIC_API_KEY */
+  /**
+   * Auth type. Inferred from the populated credential field when omitted:
+   *   - `oauthToken`        → "oauth-token" (CLAUDE_CODE_OAUTH_TOKEN)
+   *   - `apiKey`/`baseUrl`  → must be combined with explicit `type: "api"`
+   *   - `claudeConfigDir`   → "claude-max" (CLAUDE_CONFIG_DIR)
+   */
   type?: ProfileType
   /** Path to .claude config directory (claude-max profiles) */
   claudeConfigDir?: string
@@ -63,6 +69,8 @@ export interface ProfileConfig {
   apiKey?: string
   /** Anthropic base URL override (api profiles) */
   baseUrl?: string
+  /** Long-lived OAuth token from `claude setup-token` (oauth-token profiles) */
+  oauthToken?: string
 }
 
 export interface ResolvedProfile {
@@ -182,6 +190,12 @@ export function resolveProfile(
  * Build env overrides for a profile config.
  */
 function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
+  if (profile.oauthToken || profile.type === "oauth-token") {
+    const env: Record<string, string> = {}
+    if (profile.oauthToken) env.CLAUDE_CODE_OAUTH_TOKEN = profile.oauthToken
+    return { id: profile.id, type: "oauth-token", env }
+  }
+
   const type = profile.type ?? "claude-max"
 
   if (type === "api") {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -14,10 +14,17 @@ import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughT
  * Return a copy of `env` with `CLAUDE_CONFIG_DIR` removed. Used by the
  * sharedMemory branch — see the comment at the env construction site.
  *
+ * Skips the strip when `CLAUDE_CODE_OAUTH_TOKEN` is present: oauth-token
+ * profiles deliberately pin a per-profile config dir so the SDK's
+ * 401-recovery cannot silently fall back to host `~/.claude` credentials
+ * and swap a refreshed token in for the env-provided one (closes #446).
+ * Stripping the pin would defeat that isolation.
+ *
  * Pure function: never mutates the input.
  */
 function stripConfigDir(env: Record<string, string | undefined>): Record<string, string | undefined> {
   if (!("CLAUDE_CONFIG_DIR" in env)) return env
+  if (env.CLAUDE_CODE_OAUTH_TOKEN) return env
   const out = { ...env }
   delete out.CLAUDE_CONFIG_DIR
   return out


### PR DESCRIPTION
## What this is

This PR fully accepts the work from #474 by @isac322 (Byeonghoon Yoo) — both original commits are cherry-picked here with his authorship preserved — and adds **two** small follow-up fixes on top.

Closes #446. Closes #474.

## Original work (Byeonghoon Yoo, unchanged)

| Commit | What |
|--------|------|
| `28aa720e` | feat: register OAuth token as profile — `oauth-token` profile type, `--oauth-token` CLI flag, secure prompt, `CLAUDE_CODE_OAUTH_TOKEN` env wiring |
| `bce93141` | fix: isolate oauth-token profile from host `~/.claude` by pinning `CLAUDE_CONFIG_DIR` to `~/.config/meridian/profiles/<id>/` so the SDK's 401-recovery can't silently swap host creds in for the env token |

The full motivation, design, CLI examples, and Docker recipe in #474 carry over verbatim — that PR's body is the right context for this work. None of his code or reasoning was altered; the rest of this PR builds on it.

## What I added on top

`842943ac fix(query): preserve CLAUDE_CONFIG_DIR for oauth-token profiles under sharedMemory`

`stripConfigDir` in `query.ts` was unconditionally removing `CLAUDE_CONFIG_DIR` when `sharedMemory: true` (the existing fix for #453 / upstream claude-code#20553). For oauth-token profiles, this silently undoes the isolation pin Byeonghoon introduced — the SDK's 401-recovery falls back to host `~/.claude` and the env token becomes a no-op against any host with an active `claude login`.

Fix: skip the strip when `CLAUDE_CODE_OAUTH_TOKEN` is present in env. Latent today (`sharedMemory` is per-adapter and defaults off), but anyone who flips it on for an adapter that resolves to an oauth-token profile silently regresses without this guard.

`06eaf7d5 fix(profiles): clean oauth-token isolation dir on profile remove`

`profileRemove` only deletes `profile.claudeConfigDir`, which is unset for oauth-token profiles. The SDK still populates state at `~/.config/meridian/profiles/<id>/` during use (the pinned isolation dir), so `meridian profile remove ci` left that directory orphaned forever — counter to the user's expectation of "remove cleans up."

Extracted a pure `dirsToRemoveOnProfileRemove(profile, profilesDir)` helper that returns the list of dirs to clean for a given profile shape:
- browser-login → its explicit `claudeConfigDir` (only when under `PROFILES_DIR`, so a malformed config can't trigger `rm -rf` on a foreign path)
- oauth-token → `PROFILES_DIR/<id>`
- api → no on-disk state, returns empty

`profileRemove` iterates the helper's output. Foreign-path safety is preserved by the existing `startsWith(PROFILES_DIR)` check, now centralized.

## Tests

- **`query.test.ts`**: 1 new regression test — fails on unfixed code with `Expected: "/Users/me/.config/meridian/profiles/ci"` / `Received: undefined`, passes with the strip gate.
- **`profiles-unit.test.ts`**: 5 new unit tests for `dirsToRemoveOnProfileRemove` covering browser-login, oauth-token (inferred), oauth-token (explicit `type` only), api, and the foreign-path refusal.

Full suite: **1708 pass / 0 fail** (1702 from #474 baseline + 6 new).

## Local verification

- Cherry-picked both of Byeonghoon's commits cleanly off his PR head, authorship preserved.
- Built clean (`npm run build`).
- Typechecked clean (`tsc --noEmit`).
- Booted on `:3500` against the live default keychain — `/health` healthy, no startup regressions.
- Confirmed prod proxy on `:3456` undisturbed throughout.

## Merge strategy

Recommend **rebase merge** (not squash) so all 4 commits land on `main` with their original authorship — Byeonghoon's `git log` and contribution graph entries reflect his work correctly.

## Out of scope (calling out for follow-up only)

The review of #474 also flagged two items I did **not** address here, since they're cosmetic/separate concerns:
- Asymmetric type inference (`oauthToken` infers, `apiKey` does not) — at most a one-line JSDoc clarification
- `promptToken` shells out to `node -e` for raw-mode TTY — works, but worth a refactor to a Bun-native readline later

These are worth a follow-up issue, not a hold on this PR.