### PR TITLE
fix(plugins): convert Windows paths to file:// URLs for ESM import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
       - run: bun test src/__tests__/claude-executable-resolver.test.ts
         shell: bash
 
+      # Plugin loader exercises `await import(absolutePath)` which on Windows
+      # rejects raw backslash paths with `Received protocol c:`. The test
+      # writes a real plugin file to a tempdir and loads it, so it actually
+      # round-trips the buggy code path on the Windows runtime — keeps regressions
+      # in `loader.ts`'s URL handling from sneaking back in. See PR #480.
+      - run: bun test src/__tests__/plugin-loader.test.ts
+        shell: bash
+
       # Build the bundle.
       - run: bun run build
         shell: bash

--- a/src/proxy/plugins/loader.ts
+++ b/src/proxy/plugins/loader.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, existsSync } from "fs"
 import { join, isAbsolute, extname } from "path"
+import { pathToFileURL } from "url"
 import type { Transform } from "../transform"
 import type { PluginEntry, PluginConfig, LoadedPlugin } from "./types"
 import { validateTransform } from "./validation"
@@ -93,7 +94,7 @@ export async function loadPlugins(
       // many times within the same millisecond (tests, hot iteration) the
       // timestamp alone collides and we serve the cached build.
       const cacheBuster = `?t=${Date.now()}-${++loadCounter}`
-      const mod = await import(filePath + cacheBuster)
+      const mod = await import(pathToFileURL(filePath).href + cacheBuster)
       const exported = mod.default ?? mod
 
       // Support single Transform or array of Transforms

--- a/src/proxy/plugins/loader.ts
+++ b/src/proxy/plugins/loader.ts
@@ -93,8 +93,22 @@ export async function loadPlugins(
       // Include a counter in addition to Date.now() — when reload fires
       // many times within the same millisecond (tests, hot iteration) the
       // timestamp alone collides and we serve the cached build.
+      //
+      // Specifier rules differ by platform:
+      //   - POSIX: pass the raw path + query. Bun keys the module cache off
+      //     the full specifier string, so `?t=...` busts the cache. Wrapping
+      //     the path in `pathToFileURL` here normalizes the URL and Bun
+      //     drops the query when computing the cache key — the reload no
+      //     longer takes effect.
+      //   - Windows: ESM rejects `import("C:\\...")` with `Received protocol c:`
+      //     because it parses `C:` as a URL scheme. We must hand it a
+      //     `file://` URL. The query stays meaningful as part of the
+      //     specifier (no normalization stripping observed there).
       const cacheBuster = `?t=${Date.now()}-${++loadCounter}`
-      const mod = await import(pathToFileURL(filePath).href + cacheBuster)
+      const specifier = process.platform === "win32"
+        ? pathToFileURL(filePath).href + cacheBuster
+        : filePath + cacheBuster
+      const mod = await import(specifier)
       const exported = mod.default ?? mod
 
       // Support single Transform or array of Transforms


### PR DESCRIPTION
## What this is

Accepts the work from #480 by @heckradr (André Heckrath) — the original commit is cherry-picked here with his authorship preserved — and adds **one** stacked fix that's required for the change to be merge-safe, plus a CI step that would have caught the regression.

Closes #480.

## Original commit (André Heckrath, unchanged)

`be1cbf04 fix(plugins): convert Windows paths to file:// URLs for ESM import`

Wraps `filePath` with `pathToFileURL(filePath).href` before dynamic import so Windows backslash paths (`C:\\Users\\…`) parse — without this they fail with `Received protocol c:`. Direct hit on a real Windows-only bug; the diagnosis is correct.

## Why a follow-up was needed

Applied unconditionally, the wrap **silently breaks `/plugins/reload` on POSIX.** Bun's module cache keys off the full specifier string when given a raw path (so `?t=…` evicts), but normalizes `file://` URLs and drops the query *before* computing the cache key. After the original PR's change, every reload kept serving the previously-loaded module — confirmed locally by the existing integration test:

```
(fail) Plugin integration — end-to-end via HTTP > POST /plugins/reload picks up changes without restart
  Expected: defined / Received: undefined
```

Plugin authors iterating with `/plugins/reload` would have stopped seeing their edits the moment this merged. Latent because the CI suite doesn't auto-run on fork PRs and the Linux job didn't catch it pre-merge.

## What I added on top

`e758882d fix(plugins): gate pathToFileURL on win32 + add loader to windows-smoke CI`

1. **Platform gate.** Use the `file://` URL only on `win32`; keep the raw-path-with-query on POSIX. Both produce a specifier `import()` accepts on the host platform; both keep the cache evictable. Inline comment in `loader.ts` explains the asymmetry.

2. **Wire `plugin-loader.test.ts` into `windows-smoke`.** The job currently only runs the resolver tests — it never exercised the buggy `await import(absolutePath)` line on the actual Windows runtime. With this step, any future regression in loader URL handling fails CI on Windows directly. The existing tests already build a real plugin in a tempdir and load it via `loadPlugins`, which is exactly the round-trip we need.

## Tests

- `plugin-loader.test.ts` — 11/11 pass on POSIX (covers basic import + auto-discovery + plugins.json paths). On the Windows runner this same file now exercises the `pathToFileURL` branch.
- `plugin-integration.test.ts` — 4/4 pass, including `POST /plugins/reload picks up changes without restart` which **failed** on the unmodified original commit and **passes** with the platform gate.
- Full suite: **1708 pass / 0 fail.**
- `tsc --noEmit` clean.

## Local verification

- Cherry-picked André's commit cleanly, authorship preserved.
- Built clean (`npm run build`).
- All plugin-* unit and integration tests green on macOS.

## Merge strategy

Recommend **rebase merge** so both commits land with their original authorship — André's `git log` and contribution graph entries reflect his work correctly.

## Note on commit attribution

André's commit was authored with a literal `[EMAIL]` placeholder in his git config (`Heckrath, Andre <[EMAIL]>`). GitHub will still link his PR contribution via the username (`heckradr`), but the commit's `Author:` email won't match a registered account. Worth flagging to him so future commits attribute correctly — not a blocker here.