### PR TITLE
feat(diagnostics): surface resolved Claude executable in /health + startup log

### DIFF
--- a/src/__tests__/claude-executable-resolver.test.ts
+++ b/src/__tests__/claude-executable-resolver.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from "bun:test"
 import { join, dirname } from "path"
-import { resolveClaudeExecutable } from "../proxy/models"
+import { resolveClaudeExecutable, resolveClaudeExecutableWithSource } from "../proxy/models"
 
 // `path.join` produces backslashed paths on Windows and slash-separated paths
 // on POSIX. Tests use `J(...)` and `BIN(pkgJson, ...rest)` everywhere a path
@@ -388,5 +388,100 @@ describe("resolveClaudeExecutable: priority ordering", () => {
       exec: async () => ({ stdout: "" }),
     })
     expect(await resolveClaudeExecutable(deps)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveClaudeExecutableWithSource — same resolver, but the result also
+// reports which step produced the hit. Used at startup logging and in /health
+// so users can self-diagnose "wrong claude got picked" without playing
+// detective on their PATH (closes diagnostic gap from issue #478).
+// ---------------------------------------------------------------------------
+
+describe("resolveClaudeExecutableWithSource", () => {
+  it("reports source 'env' when MERIDIAN_CLAUDE_PATH wins", async () => {
+    const deps = makeDeps({
+      envGet: (n) => (n === "MERIDIAN_CLAUDE_PATH" ? "/custom/claude" : undefined),
+      existsSync: (p) => p === "/custom/claude",
+    })
+    expect(await resolveClaudeExecutableWithSource(deps)).toEqual({
+      path: "/custom/claude",
+      source: "env",
+    })
+  })
+
+  it("reports source 'bundled' when claude-code/bin/claude.exe wins", async () => {
+    const pkgJson = "/m/cc/package.json"
+    const expectedBin = BIN(pkgJson, "bin", "claude.exe")
+    const deps = makeDeps({
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code/package.json") return pkgJson
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === expectedBin,
+      statSync: () => ({ size: 200_000_000 }), // real binary
+    })
+    expect(await resolveClaudeExecutableWithSource(deps)).toEqual({
+      path: expectedBin,
+      source: "bundled",
+    })
+  })
+
+  it("reports source 'platform-package' when peer pkg wins after bundled stub", async () => {
+    const platformPkg = "/m/cc-d-a/package.json"
+    const platformBin = BIN(platformPkg, "claude")
+    const deps = makeDeps({
+      platform: "darwin",
+      arch: "arm64",
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-code-darwin-arm64/package.json") return platformPkg
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === platformBin,
+    })
+    expect(await resolveClaudeExecutableWithSource(deps)).toEqual({
+      path: platformBin,
+      source: "platform-package",
+    })
+  })
+
+  it("reports source 'path-lookup' when which/where claude wins", async () => {
+    const deps = makeDeps({
+      platform: "linux",
+      resolvePackage: () => { throw new Error("not installed") },
+      existsSync: (p) => p === "/usr/local/bin/claude",
+      exec: async () => ({ stdout: "/usr/local/bin/claude\n" }),
+    })
+    expect(await resolveClaudeExecutableWithSource(deps)).toEqual({
+      path: "/usr/local/bin/claude",
+      source: "path-lookup",
+    })
+  })
+
+  it("reports source 'legacy-cli-js' when only the SDK cli.js fallback hits", async () => {
+    const sdkPkg = "/m/sdk/package.json"
+    const cliJs = BIN(sdkPkg, "cli.js")
+    const deps = makeDeps({
+      isBun: true,
+      resolvePackage: (s) => {
+        if (s === "@anthropic-ai/claude-agent-sdk") return sdkPkg
+        throw new Error("not configured")
+      },
+      existsSync: (p) => p === cliJs,
+    })
+    expect(await resolveClaudeExecutableWithSource(deps)).toEqual({
+      path: cliJs,
+      source: "legacy-cli-js",
+    })
+  })
+
+  it("returns null when every source misses (matches resolveClaudeExecutable)", async () => {
+    const deps = makeDeps({
+      envGet: () => undefined,
+      resolvePackage: () => { throw new Error("nope") },
+      existsSync: () => false,
+      exec: async () => ({ stdout: "" }),
+    })
+    expect(await resolveClaudeExecutableWithSource(deps)).toBeNull()
   })
 })

--- a/src/__tests__/proxy-async-ops.test.ts
+++ b/src/__tests__/proxy-async-ops.test.ts
@@ -28,7 +28,26 @@ describe("proxy async ops", () => {
     if (body.status === "healthy") {
       expect(typeof body.auth.loggedIn).toBe("boolean")
       expect(body.auth.loggedIn).toBe(true)
-      expect(Object.keys(body).sort()).toEqual(["auth", "mode", "plugin", "status", "version"])
+      // claudeExecutable is present when the resolver has run (lazy init —
+      // populated on the first SDK call or eager by startProxyServer). When
+      // present it carries the resolved path + which step produced it
+      // (added in #478 follow-up so users can self-diagnose "wrong claude
+      // got picked"). Accept either shape so this test is independent of
+      // whether a sibling test already triggered resolution in the same
+      // process.
+      const expectedKeys = ["auth", "mode", "plugin", "status", "version"]
+      if (body.claudeExecutable !== undefined) {
+        expect(typeof body.claudeExecutable.path).toBe("string")
+        expect([
+          "env",
+          "bundled",
+          "platform-package",
+          "path-lookup",
+          "legacy-cli-js",
+        ]).toContain(body.claudeExecutable.source)
+        expectedKeys.push("claudeExecutable")
+      }
+      expect(Object.keys(body).sort()).toEqual(expectedKeys.sort())
     }
 
     if (body.status === "unhealthy") {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -269,7 +269,26 @@ export async function getClaudeAuthStatusAsync(profileId?: string, envOverrides?
 
 // --- Claude Executable Resolution ---
 
-let cachedClaudePath: string | null = null
+/**
+ * Tag identifying which resolver step produced the path. Surfaced at startup
+ * and in `/health` so users can self-diagnose "wrong claude got picked"
+ * without having to inspect their PATH manually (closes the diagnostic gap
+ * from #478, where a Bun-shimmed `claude` on PATH led to silent failures
+ * that looked indistinguishable from any other SDK error).
+ */
+export type ClaudeExecutableSource =
+  | "env"               // MERIDIAN_CLAUDE_PATH override
+  | "bundled"           // node_modules/@anthropic-ai/claude-code/bin/claude.exe
+  | "platform-package"  // @anthropic-ai/claude-code-<platform>-<arch>/claude
+  | "path-lookup"       // `which`/`where claude` PATH lookup
+  | "legacy-cli-js"     // SDK cli.js fallback (Bun-only)
+
+export interface ClaudeExecutableInfo {
+  path: string
+  source: ClaudeExecutableSource
+}
+
+let cachedClaudeInfo: ClaudeExecutableInfo | null = null
 let cachedClaudePathPromise: Promise<string> | null = null
 
 /**
@@ -422,29 +441,60 @@ function tryLegacySdkCliJs(deps: ResolverDeps): string | null {
 }
 
 /**
- * Pure resolver — runs each step and returns the first hit, or null when
- * all steps miss. Exported for unit tests; production callers use
- * resolveClaudeExecutableAsync, which adds caching on top.
+ * Pure resolver, source-aware variant — runs each step and returns the
+ * first hit (path + source tag), or null when all steps miss.
+ *
+ * Order matters: `env` wins unconditionally (operator escape hatch), then
+ * `bundled` (the path the SDK expects), then `platform-package` (postinstall
+ * fallback), then `path-lookup` (system PATH — most likely to surface
+ * unintended shims, see #478), then `legacy-cli-js` (only matters on stale
+ * Bun installs of SDK < 0.2.98).
+ */
+export async function resolveClaudeExecutableWithSource(
+  deps: ResolverDeps = DEFAULT_DEPS,
+): Promise<ClaudeExecutableInfo | null> {
+  const env = tryEnvOverride(deps)
+  if (env) return { path: env, source: "env" }
+  const bundled = tryBundledBinary(deps)
+  if (bundled) return { path: bundled, source: "bundled" }
+  const platformPkg = tryPlatformPackage(deps)
+  if (platformPkg) return { path: platformPkg, source: "platform-package" }
+  const pathLookup = await tryPathLookup(deps)
+  if (pathLookup) return { path: pathLookup, source: "path-lookup" }
+  const legacy = tryLegacySdkCliJs(deps)
+  if (legacy) return { path: legacy, source: "legacy-cli-js" }
+  return null
+}
+
+/**
+ * Pure resolver — returns the path string only. Kept for callers that
+ * don't need the source tag (existing behavior; preserves the existing
+ * test surface in claude-executable-resolver.test.ts).
  */
 export async function resolveClaudeExecutable(deps: ResolverDeps = DEFAULT_DEPS): Promise<string | null> {
-  return (
-    tryEnvOverride(deps) ??
-    tryBundledBinary(deps) ??
-    tryPlatformPackage(deps) ??
-    (await tryPathLookup(deps)) ??
-    tryLegacySdkCliJs(deps)
-  )
+  const info = await resolveClaudeExecutableWithSource(deps)
+  return info?.path ?? null
+}
+
+/**
+ * Returns the cached resolved-executable info — `null` if
+ * `resolveClaudeExecutableAsync` hasn't run yet. Used by `/health` and the
+ * startup log so the resolver only runs once and both surfaces see the
+ * same answer.
+ */
+export function getResolvedClaudeExecutableInfo(): ClaudeExecutableInfo | null {
+  return cachedClaudeInfo
 }
 
 export async function resolveClaudeExecutableAsync(): Promise<string> {
-  if (cachedClaudePath) return cachedClaudePath
+  if (cachedClaudeInfo) return cachedClaudeInfo.path
   if (cachedClaudePathPromise) return cachedClaudePathPromise
 
   cachedClaudePathPromise = (async () => {
-    const resolved = await resolveClaudeExecutable()
+    const resolved = await resolveClaudeExecutableWithSource()
     if (resolved) {
-      cachedClaudePath = resolved
-      return resolved
+      cachedClaudeInfo = resolved
+      return resolved.path
     }
     throw new Error(
       "Could not find Claude Code executable. Install via: npm install -g @anthropic-ai/claude-code, " +
@@ -461,7 +511,7 @@ export async function resolveClaudeExecutableAsync(): Promise<string> {
 
 /** Reset cached path — for testing only */
 export function resetCachedClaudePath(): void {
-  cachedClaudePath = null
+  cachedClaudeInfo = null
   cachedClaudePathPromise = null
 }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -46,7 +46,7 @@ import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools } from "./messages"
@@ -2382,6 +2382,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           auth: { loggedIn: false }
         }, 503)
       }
+      // Resolved Claude executable + which step produced it. Diagnostic
+      // surface for "the SDK is spawning the wrong claude" issues (#478).
+      // Null when /health is hit before the first SDK call (resolution is
+      // lazy in createProxyServer); startProxyServer eagerly populates it.
+      const claudeExecutableInfo = getResolvedClaudeExecutableInfo()
+
       return c.json({
         status: "healthy",
         version: serverVersion,
@@ -2391,6 +2397,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           subscriptionType: auth.subscriptionType,
         },
         mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
+        ...(claudeExecutableInfo ? { claudeExecutable: claudeExecutableInfo } : {}),
         plugin: { opencode: checkPluginConfigured() ? "configured" : "not-configured" },
       })
     } catch {
@@ -2924,6 +2931,14 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       console.log(`Telemetry dashboard: http://${finalConfig.host}:${info.port}/telemetry`)
       const pins = resolveSdkModelDefaults()
       console.log(`Model pins: opus=${pins.ANTHROPIC_DEFAULT_OPUS_MODEL} sonnet=${pins.ANTHROPIC_DEFAULT_SONNET_MODEL} haiku=${pins.ANTHROPIC_DEFAULT_HAIKU_MODEL}`)
+      // Surface the resolved Claude executable + which step picked it.
+      // When users hit "wrong claude got picked" failure modes (e.g. a
+      // bun-shimmed `claude` on PATH, see #478), this single line is what
+      // turns a 30-message debugging thread into a one-look diagnosis.
+      const claudeInfo = getResolvedClaudeExecutableInfo()
+      if (claudeInfo) {
+        console.log(`Claude executable: ${claudeInfo.path} (resolved via ${claudeInfo.source})`)
+      }
       console.log(`\nPoint any Anthropic-compatible tool at this endpoint:`)
       console.log(`  ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://${finalConfig.host}:${info.port}`)
     }


### PR DESCRIPTION
## Why

Issue #478 (Stefan Partheymüller) reported `error: Script not found "stream-json"` on every request. After tracing it, the most likely root cause is the executable resolver picking up a bun-shimmed `claude` on his PATH instead of the bundled native binary — but Meridian's resolver runs *silently*. There's no log line, no `/health` field, no way for the user to know which of the five resolver steps produced the path the SDK is now spawning. Every report of this class turns into a 30-message thread asking the user to run `which claude`, `ls -la`, `file`, etc.

This change makes the resolver self-diagnosing.

## What

Add a `ClaudeExecutableSource` tag to the resolver result. Sources mirror the existing resolver step ordering:

| Tag | Step |
|-----|------|
| `env` | `MERIDIAN_CLAUDE_PATH` override |
| `bundled` | `node_modules/@anthropic-ai/claude-code/bin/claude.exe` |
| `platform-package` | `@anthropic-ai/claude-code-<platform>-<arch>/claude` |
| `path-lookup` | `which`/`where claude` PATH lookup |
| `legacy-cli-js` | SDK `cli.js` fallback (Bun-only) |

Wire to two surfaces:
- **Startup log**: `Claude executable: <path> (resolved via <source>)` — one line per process boot.
- **GET /health**: adds `claudeExecutable: { path, source }` field on healthy responses.

Now anyone reporting a #478-class bug can hit `/health` and the source tag points at the exact step to investigate. `path-lookup` → check the user's PATH. `env` → check their env var. `bundled` → the bundled binary itself is broken (rare but happens on partial installs). The diagnostic surface is the same whether the user is on macOS, Linux, Windows, Docker, or OpenCode-embedded Bun.

## API surface

New exports in `src/proxy/models.ts`:
- `resolveClaudeExecutableWithSource(deps)` — pure, returns `{ path, source } | null`
- `getResolvedClaudeExecutableInfo()` — cached accessor used by `/health`
- `ClaudeExecutableSource` / `ClaudeExecutableInfo` types

Existing `resolveClaudeExecutable(deps)` is preserved as a thin wrapper that returns just the path string. **Zero breakage to the 26 existing resolver tests** — they keep asserting `expect(...).toBe(path)` against the same surface.

## Tests

- 6 new tests in `claude-executable-resolver.test.ts`, one per source value (env, bundled, platform-package, path-lookup, legacy-cli-js) plus a null-on-all-miss case.
- `proxy-async-ops.test.ts` health-schema test updated to accept the new optional `claudeExecutable` field. The field is conditional because it's populated by the resolver cache — present after the first SDK call or after `startProxyServer` (eager), absent before. Test tolerates both.

Full suite: **1714 pass / 0 fail**. Typecheck clean. Build clean.

## Live evidence

Booted on `:3500` against the local install:

```
Meridian running at http://127.0.0.1:3500
Claude executable: /Users/.../node_modules/@anthropic-ai/claude-code/bin/claude.exe (resolved via bundled)
```

```json
{
  "status": "healthy",
  ...
  "claudeExecutable": {
    "path": "/Users/.../node_modules/@anthropic-ai/claude-code/bin/claude.exe",
    "source": "bundled"
  }
}
```

## Follow-up after merge

Will respond to #478 asking Stefan to upgrade and post the new `/health.claudeExecutable` field. The source tag should pin down his bug in one round trip.