### PR TITLE
fix(security): require auth on /settings/api/* and /settings

### DIFF
--- a/src/__tests__/proxy-settings-auth.test.ts
+++ b/src/__tests__/proxy-settings-auth.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for issue #477.
+ *
+ * Before the fix, every route under `/settings/*` (including
+ * `PATCH /settings/api/features/:adapter` which mutates per-adapter SDK
+ * feature config — sharedMemory, additionalDirectories, maxBudgetUsd, etc.)
+ * was registered without going through `requireAuth`. With
+ * `MERIDIAN_API_KEY` set, every other prefix returned 401 to unauthenticated
+ * callers; `/settings/*` quietly served full read/write access. SilverResort
+ * reported it; this test pins the gate in place.
+ *
+ * The `audit` block walks every prefix the server registers and asserts an
+ * unauthenticated caller is rejected (or the prefix is on a small explicit
+ * public allowlist — `/`, `/health`). That makes the next "we forgot to
+ * protect /<new-feature>" mistake fail CI instead of waking up as a security
+ * report.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test"
+
+const SAVED_KEY = process.env.MERIDIAN_API_KEY
+const TEST_KEY = "test-meridian-api-key"
+
+beforeAll(() => {
+  process.env.MERIDIAN_API_KEY = TEST_KEY
+})
+
+afterAll(() => {
+  if (SAVED_KEY !== undefined) process.env.MERIDIAN_API_KEY = SAVED_KEY
+  else delete process.env.MERIDIAN_API_KEY
+})
+
+// Imported after env is set so auth middleware reads our test key on its
+// first invocation. requireAuth re-reads env per-call, but using `await
+// import()` here keeps the timing explicit and matches the rest of the
+// test suite's pattern for env-sensitive imports.
+const { createProxyServer } = await import("../proxy/server")
+
+describe("MERIDIAN_API_KEY — /settings/api/* (regression for #477)", () => {
+  it("rejects GET /settings/api/features without auth", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(new Request("http://localhost/settings/api/features"))
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects PATCH /settings/api/features/:adapter without auth", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(new Request("http://localhost/settings/api/features/opencode", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sharedMemory: true }),
+    }))
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects DELETE /settings/api/features/:adapter without auth", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(new Request("http://localhost/settings/api/features/opencode", {
+      method: "DELETE",
+    }))
+    expect(res.status).toBe(401)
+  })
+
+  it("rejects GET /settings (HTML dashboard) without auth — same protection as /profiles, /plugins", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(new Request("http://localhost/settings"))
+    expect(res.status).toBe(401)
+  })
+
+  it("accepts GET /settings/api/features with a matching x-api-key", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(new Request("http://localhost/settings/api/features", {
+      headers: { "x-api-key": TEST_KEY },
+    }))
+    expect(res.status).toBe(200)
+    const body = await res.json() as Record<string, unknown>
+    // Body shape is FeatureConfig — a record of adapter → partial features.
+    // We only assert it parses; exact contents depend on host config.
+    expect(typeof body).toBe("object")
+  })
+
+  it("accepts GET /settings/api/features with a matching Bearer token", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(new Request("http://localhost/settings/api/features", {
+      headers: { "authorization": `Bearer ${TEST_KEY}` },
+    }))
+    expect(res.status).toBe(200)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Audit: any sensitive route added in the future must go through requireAuth.
+// ---------------------------------------------------------------------------
+describe("auth audit: every registered prefix is protected when MERIDIAN_API_KEY is set", () => {
+  // Routes that are *intentionally* public. Both serve read-only,
+  // non-sensitive content (landing page; auth status). If you're adding to
+  // this list, that's a security review. When in doubt, gate it.
+  const PUBLIC_PREFIXES = new Set(["/", "/health"])
+
+  it("rejects unauthenticated requests to every non-public route prefix", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+
+    // Hono exposes the registered routes via `app.routes`. Each entry has
+    // { method, path, handler }. Middleware mounts (app.use) appear too but
+    // with method "ALL"; we want the actual route handlers (GET/POST/etc.)
+    // for paths to probe.
+    const routes = (app as unknown as { routes: Array<{ method: string; path: string }> }).routes
+    const prefixes = new Set<string>()
+    for (const r of routes) {
+      if (r.method === "ALL") continue
+      // Strip param placeholders so `/settings/api/features/:adapter`
+      // becomes `/settings/api/features/x` — a fetchable path.
+      const probePath = r.path.replace(/:\w+/g, "x")
+      prefixes.add(probePath)
+    }
+
+    const failures: string[] = []
+    for (const path of prefixes) {
+      if (PUBLIC_PREFIXES.has(path)) continue
+      const res = await app.fetch(new Request(`http://localhost${path}`))
+      // Non-401 → not gated. 401 → correctly gated. Any other status (404,
+      // 405) on a route the server registered would itself be surprising.
+      if (res.status !== 401) {
+        failures.push(`${path} returned ${res.status} (expected 401 — not protected by requireAuth)`)
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -332,6 +332,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
   // Optional API key auth — protects all routes except / and /health
   // when MERIDIAN_API_KEY is set. No-op when unset.
+  //
+  // When adding a new sensitive prefix, add it here. The audit test in
+  // proxy-settings-auth.test.ts walks every registered route and fails CI
+  // if any non-public path responds with anything other than 401 to an
+  // unauthenticated request. That's the safety net against the next "we
+  // forgot to gate it" mistake (issue #477 was the catalyst — `/settings/*`
+  // was registered without going through requireAuth, so unauthenticated
+  // callers could mutate adapter SDK feature config via PATCH).
   app.use("/v1/*", requireAuth)
   app.use("/messages", requireAuth)
   app.use("/telemetry/*", requireAuth)
@@ -341,6 +349,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   app.use("/profiles", requireAuth)
   app.use("/plugins/*", requireAuth)
   app.use("/plugins", requireAuth)
+  app.use("/settings/*", requireAuth)
+  app.use("/settings", requireAuth)
   app.use("/auth/*", requireAuth)
 
   app.get("/", (c) => {


### PR DESCRIPTION
Closes #477.

## What was wrong

The optional `MERIDIAN_API_KEY` gate listed every protected prefix explicitly:

```ts
app.use("/v1/*", requireAuth)
app.use("/messages", requireAuth)
app.use("/telemetry/*", requireAuth)
app.use("/telemetry", requireAuth)
app.use("/metrics", requireAuth)
app.use("/profiles/*", requireAuth)
app.use("/profiles", requireAuth)
app.use("/plugins/*", requireAuth)
app.use("/plugins", requireAuth)
app.use("/auth/*", requireAuth)
```

Conspicuously absent: `/settings`. Meanwhile the server registered four routes under that prefix:

| Route | Effect (before fix) |
|-------|---------------------|
| `GET /settings` | Serves the settings HTML dashboard |
| `GET /settings/api/features` | **Discloses** the full per-adapter feature config |
| `PATCH /settings/api/features/:adapter` | **Mutates** per-adapter feature config |
| `DELETE /settings/api/features/:adapter` | Resets feature config to defaults |

When `MERIDIAN_API_KEY` was set, every other route correctly returned 401 to unauthenticated callers. `/settings/*` quietly served full read/write access. The PATCH endpoint controls `AdapterFeatures` — `sharedMemory`, `additionalDirectories`, `maxBudgetUsd`, `fallbackModel`, `thinking`, `sdkDebug` — exactly the surface a defender turning on `MERIDIAN_API_KEY` expects to lock down. Reported by @SilverResort in #477.

## Fix

Add `/settings/*` and `/settings` to the `requireAuth` list in `src/proxy/server.ts:335` — two lines. `/profiles` and `/plugins` already followed this dashboard-plus-API pattern; `/settings` was the gap.

## Tests — `src/__tests__/proxy-settings-auth.test.ts`

Two layers of coverage so this exact mistake (and its cousins) can't repeat:

**1. Targeted regression tests** — five cases:
- `GET /settings/api/features` without auth → 401
- `PATCH /settings/api/features/:adapter` without auth → 401
- `DELETE /settings/api/features/:adapter` without auth → 401
- `GET /settings` (HTML dashboard) without auth → 401
- `GET /settings/api/features` with matching `x-api-key` → 200
- `GET /settings/api/features` with matching `Authorization: Bearer` → 200

All five fail on the unfixed code (received 200 / 200 / 200 / 200 — confirmed locally before applying the patch). All pass with the gate in place.

**2. Auth audit** — walks every prefix Hono has registered via `app.routes` and asserts an unauthenticated request returns 401, with an explicit allowlist of public routes (`/`, `/health`). Without the fix, this test reports:

```
[
  "/settings returned 200 (expected 401 — not protected by requireAuth)",
  "/settings/api/features returned 200 (expected 401 — not protected by requireAuth)",
  "/settings/api/features/x returned 404 (expected 401 — not protected by requireAuth)",
]
```

The audit is the load-bearing piece — it turns the next "we forgot to gate `/foo/api/*`" mistake into a CI failure instead of a security report.

## Verification

- `tsc --noEmit` — clean.
- `npm test` — **1721 pass / 0 fail**.
- `npm run build` — clean.
- Audit test confirmed to fail on unfixed code with the exact prefixes listed above.

## Severity assessment

Medium. Not RCE, not credential exfiltration. But unauthenticated mutation of proxy behavior — including widening file access via `additionalDirectories` and lifting `maxBudgetUsd` — in the exact scenario the user opted into auth to prevent. The threat model `MERIDIAN_API_KEY` exists for is defense in depth on a localhost-bound proxy (DNS rebinding from a malicious browser tab, compromised co-tenant process, etc.); leaving config mutation open while protecting message routes is the kind of split-brain bug that defeats that posture.

## Merge strategy

Single commit by @rynfar. Squash merge.