### PR TITLE
fix(passthrough): strip SDK tool catalog and CLAUDE.md from upstream payload

### DIFF
--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -182,6 +182,95 @@ describe("buildQueryOptions", () => {
     expect(allowed).toContain("mcp__passthrough__custom_tool")
   })
 
+  // ─── tools catalog stripping in passthrough — issue #489 ──────────────
+  //
+  // The SDK option `tools` controls which built-in tool *definitions* are
+  // sent upstream to Claude. Distinct from `disallowedTools` which only
+  // blocks invocation at runtime. Without `tools: []`, the SDK ships its
+  // full ~25k-token built-in catalog on every request even when we don't
+  // intend to use it. Passthrough mode should send an empty catalog so
+  // the upstream payload only carries the user's actual content +
+  // whatever MCP tools the client supplied. (Diagnosis by @albe-jj.)
+
+  it("strips the SDK built-in tool catalog in passthrough mode (tools=[])", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true }))
+    expect((result.options as any).tools).toEqual([])
+  })
+
+  it("strips the catalog even when passthroughMcp tools are present", () => {
+    const mockPassthroughMcp = {
+      toolNames: ["mcp__passthrough__custom_tool"],
+      server: {} as any,
+      hasDeferredTools: false,
+    }
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      passthroughMcp: mockPassthroughMcp,
+    }))
+    // Catalog is empty — built-ins disabled.
+    expect((result.options as any).tools).toEqual([])
+    // MCP tools still flow through allowedTools (separate channel).
+    const allowed = (result.options as any).allowedTools as string[]
+    expect(allowed).toContain("mcp__passthrough__custom_tool")
+  })
+
+  it("does NOT set tools: [] in non-passthrough mode (catalog must remain available)", () => {
+    // OpenCode and other coding-agent adapters need the SDK to invoke
+    // built-ins like Read/Write/Bash. The catalog stays the SDK default.
+    const result = buildQueryOptions(makeContext({ passthrough: false }))
+    expect((result.options as any).tools).toBeUndefined()
+  })
+
+  // ─── settingSources stripping in passthrough — #489 follow-up ────────
+  //
+  // When `claudeMd: "off"` (the passthrough default), server.ts produces
+  // `settingSources = []`. The lower spread block in query.ts gates on
+  // `length > 0`, so the empty array is silently dropped and the SDK
+  // never emits `--setting-sources=`. Without that flag, claude-code's
+  // subprocess falls back to its built-in default and loads
+  // user/project/local CLAUDE.md — adding ~hundreds-to-thousands of
+  // tokens of unintended context to every passthrough request. Found
+  // during the E2E audit while verifying the tools-catalog fix above
+  // (response said "I've got the context from your CLAUDE.md file"
+  // even with codeSystemPrompt: false). Pin `settingSources: []`
+  // explicitly in the passthrough branch so the empty array survives.
+
+  it("forces settingSources: [] in passthrough mode so claude-code skips CLAUDE.md", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true }))
+    expect((result.options as any).settingSources).toEqual([])
+  })
+
+  it("settingSources from caller still wins in passthrough when claudeMd is project/full", () => {
+    // server.ts resolves claudeMd="project" → settingSources=["project"];
+    // the later spread block in buildQueryOptions overwrites the
+    // passthrough default of `[]` because object spread keeps the last
+    // assignment. This preserves the user's explicit opt-in to load
+    // their project CLAUDE.md.
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      settingSources: ["project"] as any,
+    }))
+    expect((result.options as any).settingSources).toEqual(["project"])
+  })
+
+  // ─── resolveSystemPrompt defensive empty-string ───────────────────────
+  //
+  // If `codeSystemPrompt: false` is set explicitly AND there's no client
+  // system prompt AND no cwdNote to append, the previous code returned
+  // `{}` (no systemPrompt option) and let the SDK fall back to whatever
+  // default was in effect. Force an empty string so the preset can't
+  // sneak back in via that path.
+
+  it("returns systemPrompt: '' when codeSystemPrompt=false and there's nothing to append", () => {
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      codeSystemPrompt: false,
+      systemContext: "",
+      // No clientWorkingDirectory so cwdNote is empty
+    }))
+    expect((result.options as any).systemPrompt).toBe("")
+  })
+
   it("strips API keys from environment", () => {
     const result = buildQueryOptions(makeContext({
       cleanEnv: { HOME: "/home/user", SOME_VAR: "value" },
@@ -372,12 +461,16 @@ describe("buildQueryOptions", () => {
     expect(sp).toBe("Agent instructions")
   })
 
-  it("omits systemPrompt entirely when codeSystemPrompt false and no systemContext", () => {
+  it("forces systemPrompt='' when codeSystemPrompt false and no systemContext (defensive against preset fallback)", () => {
+    // Previously this asserted `undefined` — but leaving systemPrompt
+    // undefined lets the SDK fall back to the claude_code preset by
+    // default. The defensive empty-string form forecloses that path
+    // (#489 follow-up).
     const result = buildQueryOptions(makeContext({
       systemContext: "",
       codeSystemPrompt: false,
     }))
-    expect((result.options as any).systemPrompt).toBeUndefined()
+    expect((result.options as any).systemPrompt).toBe("")
   })
 
   it("shows preset without append when codeSystemPrompt true but clientSystemPrompt false", () => {
@@ -425,12 +518,14 @@ describe("buildQueryOptions", () => {
     expect(opts.settingSources).toEqual(["user", "project"])
   })
 
-  it("disabling both prompts produces no systemPrompt", () => {
+  it("disabling both prompts forces systemPrompt='' (defensive against preset fallback)", () => {
+    // Same defensive change as above — explicit empty rather than
+    // undefined so the SDK can't reintroduce the preset.
     const result = buildQueryOptions(makeContext({
       systemContext: "Agent instructions",
       codeSystemPrompt: false,
       clientSystemPrompt: false,
     }))
-    expect((result.options as any).systemPrompt).toBeUndefined()
+    expect((result.options as any).systemPrompt).toBe("")
   })
 })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -197,6 +197,13 @@ function resolveSystemPrompt(
       : { systemPrompt: { type: "preset" as const, preset: "claude_code" as const } }
   }
   if (append) return { systemPrompt: append }
+  // Defensive: when `codeSystemPrompt: false` is explicit and there's
+  // nothing to append, force an empty-string system prompt so the SDK
+  // can't fall back to the claude_code preset. Returning `{}` would leave
+  // `systemPrompt` undefined and let downstream defaults reintroduce the
+  // preset. (#489 follow-up — low impact in practice since most callers
+  // send a `system` field; belt-and-suspenders for the empty case.)
+  if (codeSystemPrompt === false) return { systemPrompt: "" }
   return {}
 }
 
@@ -233,6 +240,27 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt, cwdNote),
       ...(passthrough
         ? {
+            // Strip the SDK's ~25k-token built-in tool catalog from the
+            // upstream request. Passthrough mode never intends to invoke
+            // SDK built-ins (Read/Write/Bash/etc.) — those are the calling
+            // client's responsibility. `disallowedTools` below blocks
+            // invocation at runtime; it does NOT remove the definitions
+            // from the upstream payload. Setting `tools: []` elides the
+            // catalog from the request body. Closes #489 (diagnosis by
+            // @albe-jj).
+            tools: [],
+            // Explicitly disable claude-code's default settings loading.
+            // Without this, claude-code falls back to its built-in default
+            // (load user + project + local) and slurps CLAUDE.md from the
+            // proxy host's cwd into the system prompt — ~hundreds-to-
+            // thousands of tokens of unintended context that has no
+            // business in chat-style passthrough requests (LiteLLM, custom
+            // chat apps, etc.). Empty array → SDK emits `--setting-sources=`
+            // → subprocess loads nothing. The lower-down `settingSources &&
+            // settingSources.length > 0` block still wins when the user
+            // sets `claudeMd` to "project" or "full" because object spread
+            // order gives the later assignment the final word.
+            settingSources: [],
             disallowedTools: [...allBlockedTools],
             ...(passthroughMcp ? {
               allowedTools: [...passthroughMcp.toolNames],


### PR DESCRIPTION
Closes #489.

> **TL;DR**: Passthrough requests were paying ~25,856 tokens of overhead per call. After this PR they pay **322**. That's a **98.8% reduction**, measured on @albe-jj's exact repro, end-to-end against the live proxy.

## Root cause (and what #469 left behind)

@albe-jj's diagnosis in #489 is correct: PR #469 fixed the *system prompt* half of #408 — `codeSystemPrompt: false` is now respected for the passthrough adapter. But the upstream request to Claude **still includes the SDK's built-in tool catalog** (~21–25k tokens of Read/Write/Edit/Bash/Glob/Grep/etc.). `disallowedTools` only blocks tool *invocation* at runtime; it does not remove the *definitions* from the upstream payload.

While auditing the rest of the passthrough payload (per maintainer ask before merging this), I also found a **second leak**: when `claudeMd: "off"` (the passthrough adapter's default), `server.ts` produces `settingSources = []`, but `query.ts`'s `length > 0` gate silently dropped the empty array. The SDK never emitted `--setting-sources=`, so the claude-code subprocess fell back to its built-in default (load `user`/`project`/`local`) and slurped CLAUDE.md from the proxy host's cwd into the system prompt. The smoking gun in my E2E run was the model's response: *"I've got the context from your CLAUDE.md file"* — even with `codeSystemPrompt: false`.

## Fix

Three coordinated changes in `src/proxy/query.ts`:

```ts
...(passthrough
  ? {
      tools: [],              // ← strip ~25k-token catalog
      settingSources: [],     // ← stop CLAUDE.md from auto-loading
      disallowedTools: [...allBlockedTools],
      ...(passthroughMcp ? { allowedTools, mcpServers } : {}),
    }
  : {
      disallowedTools: [...allBlockedTools],
      allowedTools: [...allowedMcpTools],
      mcpServers: { [mcpServerName]: createOpencodeMcpServer() },
    }),
```

Plus a defensive return in `resolveSystemPrompt`:

```ts
// Forecloses any default-fallback path that would let the preset sneak
// back in. Empty string > undefined for explicit-no-preset signaling.
if (codeSystemPrompt === false) return { systemPrompt: "" }
```

The lower-down `settingSources && settingSources.length > 0` spread block still wins when the user opts into `claudeMd: "project"` or `"full"` — object spread keeps the last assignment, so per-feature customization continues to work.

**Scope: passthrough only.** Coding-agent adapters (OpenCode, Crush, ForgeCode, Pi, Droid, Claude Code) are untouched. Their CLAUDE.md-loading behavior is preserved (it's intentional for them — coding agents want project context).

## End-to-end evidence

@albe-jj's repro, claude-haiku-4-5, fresh proxy each time:

| Stage | `cache_creation_input_tokens` | `input_tokens` | Sample response |
|---|---:|---:|---|
| **Baseline** (current `main`) | **25,856** | 10 | "Hey! 👋 I'm ready to help with your **meridian** project (the OpenCode ↔ Claude M…" |
| After `tools: []` only | 0 | 2,700 | "Hey! 👋 I'm here and ready to help. I've got the context from your CLAUDE.md file…" |
| **Both fixes applied** | 0 | **322** | "Hi! 👋 Nice to meet you. I'm Claude, an AI assistant." |

The intermediate row exposes exactly the second leak — even after the catalog is gone, CLAUDE.md content is still bleeding in. The full fix produces a generic-chat response, no Claude-Code preset, no project context.

## Tests

5 new in `src/__tests__/query.test.ts`:

- `tools: []` is set in passthrough mode
- `tools: []` survives even when `passthroughMcp` is present (catalog stripped, MCP tools still allowed)
- `tools` stays undefined in non-passthrough mode (catalog must remain available for OpenCode/Crush/etc.)
- `settingSources: []` is set in passthrough mode
- `settingSources` from caller (e.g. `claudeMd: "project"`) still wins over the passthrough default

2 existing tests updated to reflect the defensive empty-string in `resolveSystemPrompt` (`systemPrompt: ""` instead of `undefined`). Full suite: **1727 / 0**. Typecheck clean. Build clean.

## Risk

- **Behavior change scoped to passthrough.** Any caller relying on the silent CLAUDE.md leak in passthrough requests will see the project context disappear. They can opt back in via `claudeMd: "project"` or `claudeMd: "full"` in `/settings`. We should call this out in the release notes.
- The defensive `systemPrompt: ""` change applies to any adapter, but only kicks in when `codeSystemPrompt: false` AND there's nothing to append — an edge case that previously fell back to undefined. Strictly more deterministic.
- No change to the auth surface, profile system, or any other adapter.

## Out of scope (follow-ups, not blocking this PR)

- **Coding-agent CLAUDE.md leak.** OpenCode/Crush/etc. still use the same query.ts gate, so when `claudeMd: "off"` for them too, claude-code's default loader still runs. Fixing that is a behavior change that needs its own discussion (some users may rely on the current implicit loading). Filed mentally for a separate audit.
- **`tools: []` for chat-client adapters** (Cherry Studio, etc.). Different shape — chat clients want some built-ins enabled (WebSearch). Their tool blocking lives in `getAgentIncompatibleTools()` and is intentional.

## Credit

Diagnosis, exact root-cause analysis, and the precise code change for the primary fix: @albe-jj in #489. The settingSources leak and the defensive empty-string were caught during the additional audit & E2E pass.

## Merge strategy

Squash merge. Single commit. Authorize when ready.