### PR TITLE
feat: forward x-meridian-agent header to internal requests

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2565,6 +2565,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     if (xApiKey) internalHeaders["x-api-key"] = xApiKey
     const authz = c.req.header("authorization")
     if (authz) internalHeaders["authorization"] = authz
+    const xMeridianAgent = c.req.header("x-meridian-agent")
+    if (xMeridianAgent) internalHeaders["x-meridian-agent"] = xMeridianAgent
     const internalReq = new Request("http://internal/v1/messages", {
       method: "POST",
       headers: internalHeaders,


### PR DESCRIPTION
## Summary

Forward the `x-meridian-agent` header from incoming requests to internal proxy requests.

## Changes

- In `server.ts`: read `x-meridian-agent` from the incoming request and include it in `internalHeaders` when present

## Why

Allows downstream services and plugins to identify which agent initiated a request, enabling agent-specific routing or logging on the internal side.