### PR TITLE
fix(tokenRefresh): silence scheduled refresh log

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -442,6 +442,27 @@ describe("startBackgroundRefresh", () => {
     expect(fetchCalls).toBeGreaterThanOrEqual(2)
   })
 
+  it("does not write scheduled refresh status to stderr by default", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    const originalError = console.error
+    const stderr: unknown[][] = []
+    console.error = (...args: unknown[]) => { stderr.push(args) }
+    try {
+      mockFetch(() => Promise.resolve(makeSuccessResponse(MOCK_TOKEN_RESPONSE)))
+      const { store } = makeStore({
+        ...MOCK_CREDENTIALS,
+        claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 },
+      })
+
+      startBackgroundRefresh(store, 1000, 60_000)
+      await tick(50)
+
+      expect(stderr).toHaveLength(0)
+    } finally {
+      console.error = originalError
+    }
+  })
+
   it("is idempotent — second start() while running is a no-op", async () => {
     const { startBackgroundRefresh, isBackgroundRefreshActive } = await import("../proxy/tokenRefresh")
     let fetchCalls = 0

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -412,7 +412,6 @@ async function scheduleNext(
     const ok = await refreshOAuthToken(store)
     if (!scheduledRefreshActive || gen !== scheduledRefreshGeneration) return
     claudeLog("token_refresh.scheduled", { ok, immediate: true })
-    console.error(`[token_refresh] scheduled refresh (immediate) ok=${ok}`)
     armTimer(ok ? 0 : failureRetryMs, store, bufferMs, failureRetryMs, gen)
     return
   }


### PR DESCRIPTION
## Summary

- remove the unconditional scheduled token refresh `console.error` line
- keep the existing `claudeLog("token_refresh.scheduled", ...)` debug telemetry
- add a regression test covering the default no-stderr behavior

Closes #517.

## Why

The default stderr line can surface inside interactive TUI clients such as OpenCode when Meridian runs through `opencode-with-claude`, polluting the input line with:

```text
[token_refresh] scheduled refresh (immediate) ok=false
```

## Verification

- `bun test src/__tests__/token-refresh.test.ts`
- `bun run typecheck`
