### PR TITLE
Accept standard reasoning_effort / output_config.effort as effort source

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -561,6 +561,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         const effort = effortHeader
           || body.effort
+          || body.reasoning_effort
+          || body.output_config?.effort
           || undefined
         let thinking: QueryContext['thinking'] | undefined = body.thinking || undefined
         if (thinkingHeader !== undefined) {


### PR DESCRIPTION
## What
Read the standard OpenAI `reasoning_effort` body field (and Anthropic-style `output_config.effort`) as an effort source, in addition to the existing `effort` / `x-opencode-effort`.

## Why
OpenAI-compatible clients (e.g. pi, and the OpenAI SDK generally) send the reasoning level as `reasoning_effort` in the request body. Meridian only read `effortHeader` (`x-opencode-effort`) and `body.effort`, so the effort coming from standard clients was silently dropped and never forwarded to the SDK — every request effectively ran at the model default regardless of the client's chosen level.

## Change
`src/proxy/server.ts`:
```ts
const effort = effortHeader
  || body.effort
  || body.reasoning_effort        // standard OpenAI field
  || body.output_config?.effort   // Anthropic-style nesting
  || undefined
```

## Notes
- Purely additive and backward compatible: existing `effort` / `x-opencode-effort` keep priority; the new fields are fallbacks.
- `body` is `any` (from `c.req.json()`), so no type changes are required.
- Verified end-to-end: with this change, a client sending `reasoning_effort: "xhigh"` (or `max`) reaches the Claude Code SDK `--effort` flag (confirmed by the SDK validating the value: `it must be one of: low, medium, high, xhigh, max`).