### PR TITLE
feat: support Claude Opus 4.8

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -19,6 +19,10 @@ describe("mapModelToClaudeModel", () => {
     expect(mapModelToClaudeModel("opus")).toBe("opus[1m]")
   })
 
+  it("maps opus 4.8 models to opus[1m]", () => {
+    expect(mapModelToClaudeModel("claude-opus-4-8")).toBe("opus[1m]")
+  })
+
   it("maps opus 4.5 models to opus (no 1M)", () => {
     expect(mapModelToClaudeModel("claude-opus-4-5")).toBe("opus")
   })

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1157,34 +1157,39 @@ describe("createSseTranslator", () => {
 
 describe("buildModelList", () => {
   it("returns 4 models", () => {
-    expect(buildModelList(true).length).toBe(4)
-    expect(buildModelList(false).length).toBe(4)
+    expect(buildModelList(true).length).toBe(5)
+    expect(buildModelList(false).length).toBe(5)
   })
 
-  it("includes both opus-4-6 and opus-4-7 for UI pickers", () => {
+  it("includes opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")
+    expect(ids).toContain("claude-opus-4-8")
   })
 
-  it("Max subscription gets 1M context for both opus variants, 200k for sonnet", () => {
+  it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {
     const models = buildModelList(true)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
     const opus46 = models.find(m => m.id === "claude-opus-4-6")!
     const opus47 = models.find(m => m.id === "claude-opus-4-7")!
+    const opus48 = models.find(m => m.id === "claude-opus-4-8")!
     expect(sonnet.context_window).toBe(200_000)
     expect(opus46.context_window).toBe(1_000_000)
     expect(opus47.context_window).toBe(1_000_000)
+    expect(opus48.context_window).toBe(1_000_000)
   })
 
-  it("non-Max gets 200k context for sonnet and both opus variants", () => {
+  it("non-Max gets 200k context for sonnet and all opus variants", () => {
     const models = buildModelList(false)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
     const opus46 = models.find(m => m.id === "claude-opus-4-6")!
     const opus47 = models.find(m => m.id === "claude-opus-4-7")!
+    const opus48 = models.find(m => m.id === "claude-opus-4-8")!
     expect(sonnet.context_window).toBe(200_000)
     expect(opus46.context_window).toBe(200_000)
     expect(opus47.context_window).toBe(200_000)
+    expect(opus48.context_window).toBe(200_000)
   })
 
   it("haiku is always 200k regardless of subscription", () => {

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -215,7 +215,7 @@ describe("SDK model pin injection (fixes #419)", () => {
   it("injects Meridian's canonical model pins when no shell env is set", async () => {
     const app = createTestApp()
     await post(app, BASIC_REQUEST)
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-7")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
   })
@@ -231,6 +231,13 @@ describe("SDK model pin injection (fixes #419)", () => {
     const app = createTestApp()
     await post(app, { ...BASIC_REQUEST, model: "claude-opus-4-7" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-7")
+  })
+
+  it("explicit claude-opus-4-8 requests beat inherited env pins", async () => {
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-7"
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-opus-4-8" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
   })
 
   it("shell ANTHROPIC_DEFAULT_* values win over Meridian's pins", async () => {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -39,7 +39,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * override via MERIDIAN_DEFAULT_{TYPE}_MODEL (proxy-side) or
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
-export const CANONICAL_OPUS_MODEL = "claude-opus-4-7"
+export const CANONICAL_OPUS_MODEL = "claude-opus-4-8"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-4-6"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -818,6 +818,14 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       context_window: isMaxSubscription ? 1_000_000 : 200_000,
     },
     {
+      id: "claude-opus-4-8",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Opus 4.8",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+    },
+    {
       id: "claude-haiku-4-5",
       object: "model",
       created: now,


### PR DESCRIPTION
## Summary
- Bump `CANONICAL_OPUS_MODEL` to `claude-opus-4-8` so fresh installs default to Opus 4.8 for `opus`/`claude-opus-*` requests
- List `claude-opus-4-8` (Claude Opus 4.8, 1M context on Max) in `/v1/models`
- Explicit `claude-opus-4-8` requests are pinned automatically via the existing `claude-opus-*` envOverride path (#497); the `supports1mContext` mapping already routes 4.8 to `opus[1m]`

## Test plan
- [x] `npm test` passes
- [x] Added: canonical pin defaults to 4.8 (`proxy-env-stripping`)
- [x] Added: explicit `claude-opus-4-8` beats inherited env pin (`proxy-env-stripping`)
- [x] Added: `claude-opus-4-8` maps to `opus[1m]` (`models`)
- [x] Added: `/v1/models` lists 4.8 with correct context window (`openai`)