### PR TITLE
feat: add MERIDIAN_FORCE_TOOL_SEARCH to force deferred tool loading

### DIFF
--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -8,6 +8,7 @@
 import { join } from "node:path"
 import type { Options, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
+import { envBool } from "../env"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
 
 /**
@@ -294,7 +295,14 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
         // the "share memory with Claude Code" intent without poisoning
         // Keychain auth.
         ...(sharedMemory ? stripConfigDir(cleanEnv) : cleanEnv),
-        ENABLE_TOOL_SEARCH: hasDeferredTools ? "true" : "false",
+        // MERIDIAN_FORCE_TOOL_SEARCH=1 forces the SDK's deferred tool loading
+        // on regardless of the auto-defer heuristic. Useful when many MCP tools
+        // are connected on the non-passthrough path: inlining every tool schema
+        // can add tens of thousands of tokens to each request's cached prefix,
+        // and forcing tool-search defers them (fetched on demand) for a large
+        // token reduction with no loss of capability.
+        ENABLE_TOOL_SEARCH:
+          envBool("FORCE_TOOL_SEARCH") || hasDeferredTools ? "true" : "false",
         ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
         // When running as root (Docker, Unraid, NAS), set IS_SANDBOX=1 to
         // bypass the SDK's root check. Without this, the SDK exits with:


### PR DESCRIPTION
## Summary

Adds an env var, `MERIDIAN_FORCE_TOOL_SEARCH` (legacy alias `CLAUDE_PROXY_FORCE_TOOL_SEARCH`), that forces the spawned SDK's deferred tool loading on (`ENABLE_TOOL_SEARCH=true`) regardless of the auto-defer heuristic. Default off — no behavior change unless set.

## Motivation

On the non-passthrough path, `ENABLE_TOOL_SEARCH` is only enabled when `hasDeferredTools` is true (a tool has `defer_loading`, or passthrough auto-defer fires above `MERIDIAN_DEFER_TOOL_THRESHOLD`). When a client connects many MCP servers directly (no passthrough), `hasDeferredTools` stays false, so Meridian sets `ENABLE_TOOL_SEARCH=false` — and every MCP tool schema is inlined into each request's cached prefix.

With a large MCP surface this is the dominant token cost. Measured with a ~246-tool MCP server on Claude Opus:

| | inline tools | per-request base |
|---|--:|--:|
| before | 288 | ~62k tokens |
| with `MERIDIAN_FORCE_TOOL_SEARCH=1` | 4 | ~25k tokens (**−60%**) |

No loss of capability — the SDK fetches schemas on demand via ToolSearch.

## Change

`src/proxy/query.ts`:
```ts
ENABLE_TOOL_SEARCH:
  envBool("FORCE_TOOL_SEARCH") || hasDeferredTools ? "true" : "false",
```
Uses the existing `env()`/`envBool()` resolver, so it picks up `MERIDIAN_*` with the `CLAUDE_PROXY_*` fallback, matching `MERIDIAN_DEFER_TOOL_THRESHOLD` and friends.

## Tests

Added two cases to `src/__tests__/deferred-tool-loading.test.ts` (force-on without deferred tools; legacy alias). Full file passes (9/9); `tsc --noEmit` clean. README env table updated.