### PR TITLE
fix(query): honour clientContext when codeSystemPrompt=false

### DIFF
--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -205,7 +205,7 @@ function resolveSystemPrompt(
   // `systemPrompt` undefined and let downstream defaults reintroduce the
   // preset. (#489 follow-up — low impact in practice since most callers
   // send a `system` field; belt-and-suspenders for the empty case.)
-  if (codeSystemPrompt === false) return { systemPrompt: "" }
+  if (codeSystemPrompt === false) return { systemPrompt: clientContext ?? "" }
   return {}
 }
 


### PR DESCRIPTION
## Problem

When `codeSystemPrompt` is explicitly set to `false` via
`PATCH /settings/api/features/:adapter`, the function `resolveSystemPrompt()`
returns `{ systemPrompt: "" }` unconditionally at line 208, discarding the
client's own system prompt before it is used.

Any non-coding API client (Open WebUI, curl, any OpenAI-compatible tool) that
disables the Claude Code preset via the settings API gets an empty system prompt —
the model ignores their instructions and falls back to the Claude Code persona
from Anthropic's prompt cache.

## Root Cause

The defensive empty-string return added in #489 fires before `clientContext`
is evaluated:

```typescript
// Before — clientContext is computed but never used in this branch
if (codeSystemPrompt === false) return { systemPrompt: "" }
```

## Fix

```typescript
// After — passes client system prompt through when present
if (codeSystemPrompt === false) return { systemPrompt: clientContext ?? "" }
```

The `?? ""` preserves the original defensive behaviour: when no system prompt
is provided, an explicit empty string prevents the SDK from reintroducing the
`claude_code` preset downstream.

## Test Results

All 55 existing assertions in `query.test.ts` pass with no modifications:

```
55 pass / 0 fail / 86 expect() calls
```

The existing test `forces systemPrompt='' when codeSystemPrompt false and no
systemContext` continues to pass because `clientContext ?? ""` evaluates to
`""` when `clientContext` is `undefined`.

## Reproduction

1. `PATCH /settings/api/features/opencode` with `{"codeSystemPrompt": false}`
2. Send any `/v1/chat/completions` request with a `system` message
3. Observe: `prompt_tokens: 3` (system prompt not counted), response reflects
   Claude Code persona instead of your system prompt