### PR TITLE
feat: add Fable 5 (claude-fable-5) model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ src/proxy/
 │   └── passthrough.ts     ← LiteLLM passthrough adapter
 ├── query.ts               ← SDK query options builder
 ├── errors.ts              ← Error classification
-├── models.ts              ← Model mapping (sonnet/opus/haiku, agentMode)
+├── models.ts              ← Model mapping (fable/sonnet/opus/haiku, agentMode)
 ├── tokenRefresh.ts        ← Cross-platform OAuth token refresh
 ├── openai.ts              ← OpenAI ↔ Anthropic format translation (pure)
 ├── setup.ts               ← OpenCode plugin configuration

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "opencode-claude-code-provider",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-        "@anthropic-ai/claude-code": "^2.1.117",
+        "@anthropic-ai/claude-code": "^2.1.170",
         "libsql": "^0.5.29",
       },
       "devDependencies": {
@@ -39,23 +39,23 @@
 
     "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119", "", { "os": "win32", "cpu": "x64" }, "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA=="],
 
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.119", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.119", "@anthropic-ai/claude-code-darwin-x64": "2.1.119", "@anthropic-ai/claude-code-linux-arm64": "2.1.119", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.119", "@anthropic-ai/claude-code-linux-x64": "2.1.119", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.119", "@anthropic-ai/claude-code-win32-arm64": "2.1.119", "@anthropic-ai/claude-code-win32-x64": "2.1.119" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-gt9dxiIQU60eWcSM26fwu31vzLeL1NYwY3HDFby1TipzwF5lNY766DEqKLkGemZGxaAOXKe9nY3c8GQK/gQ7VA=="],
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.170", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.170", "@anthropic-ai/claude-code-darwin-x64": "2.1.170", "@anthropic-ai/claude-code-linux-arm64": "2.1.170", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.170", "@anthropic-ai/claude-code-linux-x64": "2.1.170", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.170", "@anthropic-ai/claude-code-win32-arm64": "2.1.170", "@anthropic-ai/claude-code-win32-x64": "2.1.170" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-/kMpp+fz72boi8KvAW4EZ1G8FWtPAR3vH1uKGlYpoZ2O9SU5XdaYCTvw5tPyYGDoB+eFiOnolfTiKPUK8vnP7g=="],
 
-    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.119", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+DC98VI72gZeuSz6VgEc+aAe5RlQGy4gdylf3moyypYPOGzY2eX099pXggdK1sAlFiHQ5xRXCq6QfBnw4/RvZQ=="],
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.170", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lnBfVVTO+Wk31IAh5KDOY+Cuu1vIHC3N3UjHY9SEroDat8XKqjFtckY50jPi50m5x0oWkeQiyDl4nPstgdkNwQ=="],
 
-    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.119", "", { "os": "darwin", "cpu": "x64" }, "sha512-4O848nP+ligPgfGKuuQ1MspbwY3eDSwpH0mWfr97HWs8T79Q22Ev291j0tTGJf0qYQ9YP0oCCvVfS93ThVn6zg=="],
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.170", "", { "os": "darwin", "cpu": "x64" }, "sha512-w2lZwSsKDVqrY8O6N65SSP309JJleWrUx9tltW2SIGaPRLybtrZf7q6KxDz3I/gEMBhpwnC2MHXYMU0sw6JXzg=="],
 
-    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.119", "", { "os": "linux", "cpu": "arm64" }, "sha512-b+ricBXcR7iiEmzelRcRjMGJgpazkvlJzcezFUK41kcJ6HKCPCHVCvGh/4yhoK74PACFA74oSWCp1PK68o0boQ=="],
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-J2682NcqJbDouDcmR8VeVDAB4UxWryDMUZfPYdvbwiG3sM6SyupBHPuXgwIEcaT1M1jlpBiWRdJ4ActHF5Drng=="],
 
-    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.119", "", { "os": "linux", "cpu": "arm64" }, "sha512-ALgp64QveCo9s/AR56CUJBDQT6Z7j5twRXFs2LGMvZfod+LxBp9LHCcVfCk0BpJx2edMw/2OOwXFosK5qlXtLA=="],
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-ClnCeAnKuOqyuEqU4jiEZSsdQfA8gzuEoiTCQtGEEYHWSwu341aZa35EmNl90JIXqIl5i8sNbA+ZMD+GEKGfUQ=="],
 
-    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.119", "", { "os": "linux", "cpu": "x64" }, "sha512-i6nqfRnvW0IaCTJSHADxX23ykQTlYsmHRja72W92HhjyG8fudaSH2f1XM/zSbaSOp5s33mZAZ3js5coiH6Ksdw=="],
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.170", "", { "os": "linux", "cpu": "x64" }, "sha512-SSQ6TsGbZJSC1s6R5pxlTZPq1bilSpoTR8JANOq8ALUkbRVhgVSl0PiSSNSnc3zNdDCA1iA3ywLmAuISuhlvKA=="],
 
-    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.119", "", { "os": "linux", "cpu": "x64" }, "sha512-GTUn2pFM2I+ZiN+bEmgnH59SQ4M0SOEqUUXw1bA75LVVVKMLarZsb52fBp/KU0ja3O9hx5AaXpT+/FMu5eGBKg=="],
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.170", "", { "os": "linux", "cpu": "x64" }, "sha512-mPwe4thBIj8nAbhzkKGmCLnqWuFxUI1wvrFai7TttlPMMeM2gelXaJnfgo9LEgEkp5KqqBFZRNeYQREiJsEqUQ=="],
 
-    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.119", "", { "os": "win32", "cpu": "arm64" }, "sha512-eoMd3ocujGELdMi2jLrMpDEtC2KLTK/NCO7+oVTAKfsBUo6X7V2GQVa4Vdejk0zhxo+o68Jb4oTKQHt/wlRO6g=="],
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.170", "", { "os": "win32", "cpu": "arm64" }, "sha512-c3coVcbv6Ea8UBM4EYPbW341AC691Z9bCMEIWn/7YogLzRbBrhBQiMfPXN0qnapUMF8Osii093239PmdgXAHrA=="],
 
-    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.119", "", { "os": "win32", "cpu": "x64" }, "sha512-vf8Zoqk1ysHsN+0zh/PTx75oVTLL/Tr3qXLnjewycM3lCYDDhtowTyCCkQGU587npHC3BG0FW9+eskaHKZBnzA=="],
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.170", "", { "os": "win32", "cpu": "x64" }, "sha512-wUcLJQuxirInc9mOqIY/z9i7eXxJFy7ShXtN+PZJpZRJJR8Evbx2ZbBwT/zcUNN1nyhHao34gwLp6LXHd3G9lg=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -49,41 +49,41 @@
     url = "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz";
     hash = "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==";
   };
-  "@anthropic-ai/claude-code-darwin-arm64@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.119.tgz";
-    hash = "sha512-+DC98VI72gZeuSz6VgEc+aAe5RlQGy4gdylf3moyypYPOGzY2eX099pXggdK1sAlFiHQ5xRXCq6QfBnw4/RvZQ==";
+  "@anthropic-ai/claude-code-darwin-arm64@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.170.tgz";
+    hash = "sha512-lnBfVVTO+Wk31IAh5KDOY+Cuu1vIHC3N3UjHY9SEroDat8XKqjFtckY50jPi50m5x0oWkeQiyDl4nPstgdkNwQ==";
   };
-  "@anthropic-ai/claude-code-darwin-x64@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.119.tgz";
-    hash = "sha512-4O848nP+ligPgfGKuuQ1MspbwY3eDSwpH0mWfr97HWs8T79Q22Ev291j0tTGJf0qYQ9YP0oCCvVfS93ThVn6zg==";
+  "@anthropic-ai/claude-code-darwin-x64@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.170.tgz";
+    hash = "sha512-w2lZwSsKDVqrY8O6N65SSP309JJleWrUx9tltW2SIGaPRLybtrZf7q6KxDz3I/gEMBhpwnC2MHXYMU0sw6JXzg==";
   };
-  "@anthropic-ai/claude-code-linux-arm64-musl@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.119.tgz";
-    hash = "sha512-ALgp64QveCo9s/AR56CUJBDQT6Z7j5twRXFs2LGMvZfod+LxBp9LHCcVfCk0BpJx2edMw/2OOwXFosK5qlXtLA==";
+  "@anthropic-ai/claude-code-linux-arm64-musl@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.170.tgz";
+    hash = "sha512-ClnCeAnKuOqyuEqU4jiEZSsdQfA8gzuEoiTCQtGEEYHWSwu341aZa35EmNl90JIXqIl5i8sNbA+ZMD+GEKGfUQ==";
   };
-  "@anthropic-ai/claude-code-linux-arm64@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.119.tgz";
-    hash = "sha512-b+ricBXcR7iiEmzelRcRjMGJgpazkvlJzcezFUK41kcJ6HKCPCHVCvGh/4yhoK74PACFA74oSWCp1PK68o0boQ==";
+  "@anthropic-ai/claude-code-linux-arm64@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.170.tgz";
+    hash = "sha512-J2682NcqJbDouDcmR8VeVDAB4UxWryDMUZfPYdvbwiG3sM6SyupBHPuXgwIEcaT1M1jlpBiWRdJ4ActHF5Drng==";
   };
-  "@anthropic-ai/claude-code-linux-x64-musl@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.119.tgz";
-    hash = "sha512-GTUn2pFM2I+ZiN+bEmgnH59SQ4M0SOEqUUXw1bA75LVVVKMLarZsb52fBp/KU0ja3O9hx5AaXpT+/FMu5eGBKg==";
+  "@anthropic-ai/claude-code-linux-x64-musl@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.170.tgz";
+    hash = "sha512-mPwe4thBIj8nAbhzkKGmCLnqWuFxUI1wvrFai7TttlPMMeM2gelXaJnfgo9LEgEkp5KqqBFZRNeYQREiJsEqUQ==";
   };
-  "@anthropic-ai/claude-code-linux-x64@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.119.tgz";
-    hash = "sha512-i6nqfRnvW0IaCTJSHADxX23ykQTlYsmHRja72W92HhjyG8fudaSH2f1XM/zSbaSOp5s33mZAZ3js5coiH6Ksdw==";
+  "@anthropic-ai/claude-code-linux-x64@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.170.tgz";
+    hash = "sha512-SSQ6TsGbZJSC1s6R5pxlTZPq1bilSpoTR8JANOq8ALUkbRVhgVSl0PiSSNSnc3zNdDCA1iA3ywLmAuISuhlvKA==";
   };
-  "@anthropic-ai/claude-code-win32-arm64@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.119.tgz";
-    hash = "sha512-eoMd3ocujGELdMi2jLrMpDEtC2KLTK/NCO7+oVTAKfsBUo6X7V2GQVa4Vdejk0zhxo+o68Jb4oTKQHt/wlRO6g==";
+  "@anthropic-ai/claude-code-win32-arm64@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.170.tgz";
+    hash = "sha512-c3coVcbv6Ea8UBM4EYPbW341AC691Z9bCMEIWn/7YogLzRbBrhBQiMfPXN0qnapUMF8Osii093239PmdgXAHrA==";
   };
-  "@anthropic-ai/claude-code-win32-x64@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.119.tgz";
-    hash = "sha512-vf8Zoqk1ysHsN+0zh/PTx75oVTLL/Tr3qXLnjewycM3lCYDDhtowTyCCkQGU587npHC3BG0FW9+eskaHKZBnzA==";
+  "@anthropic-ai/claude-code-win32-x64@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.170.tgz";
+    hash = "sha512-wUcLJQuxirInc9mOqIY/z9i7eXxJFy7ShXtN+PZJpZRJJR8Evbx2ZbBwT/zcUNN1nyhHao34gwLp6LXHd3G9lg==";
   };
-  "@anthropic-ai/claude-code@2.1.119" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.119.tgz";
-    hash = "sha512-gt9dxiIQU60eWcSM26fwu31vzLeL1NYwY3HDFby1TipzwF5lNY766DEqKLkGemZGxaAOXKe9nY3c8GQK/gQ7VA==";
+  "@anthropic-ai/claude-code@2.1.170" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.170.tgz";
+    hash = "sha512-/kMpp+fz72boi8KvAW4EZ1G8FWtPAR3vH1uKGlYpoZ2O9SU5XdaYCTvw5tPyYGDoB+eFiOnolfTiKPUK8vnP7g==";
   };
   "@anthropic-ai/sdk@0.81.0" = fetchurl {
     url = "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz";

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-    "@anthropic-ai/claude-code": "^2.1.117",
+    "@anthropic-ai/claude-code": "^2.1.170",
     "libsql": "^0.5.29"
   },
   "devDependencies": {

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -32,6 +32,11 @@ describe("mapModelToClaudeModel", () => {
     expect(mapModelToClaudeModel("haiku")).toBe("haiku")
   })
 
+  it("maps fable models to fable[1m]", () => {
+    expect(mapModelToClaudeModel("claude-fable-5")).toBe("fable[1m]")
+    expect(mapModelToClaudeModel("fable")).toBe("fable[1m]")
+  })
+
   it("maps sonnet 4.6 models to sonnet (200k) for max subscriptions by default", () => {
     // Sonnet [1m] requires Extra Usage on Max — default to 200k to avoid charges
     expect(mapModelToClaudeModel("claude-sonnet-4-6", "max")).toBe("sonnet")
@@ -84,6 +89,11 @@ describe("mapModelToClaudeModel", () => {
       expect(mapModelToClaudeModel("opus", "max", "subagent")).toBe("opus")
     })
 
+    it("gives subagents base fable regardless of subscription", () => {
+      expect(mapModelToClaudeModel("claude-fable-5", "max", "subagent")).toBe("fable")
+      expect(mapModelToClaudeModel("fable", "max", "subagent")).toBe("fable")
+    })
+
     it("haiku is unaffected by agent mode", () => {
       expect(mapModelToClaudeModel("claude-haiku-4-5", "max", "subagent")).toBe("haiku")
     })
@@ -122,6 +132,10 @@ describe("stripExtendedContext", () => {
     expect(stripExtendedContext("sonnet[1m]")).toBe("sonnet")
   })
 
+  it("strips [1m] from fable", () => {
+    expect(stripExtendedContext("fable[1m]")).toBe("fable")
+  })
+
   it("returns haiku unchanged", () => {
     expect(stripExtendedContext("haiku")).toBe("haiku")
   })
@@ -129,6 +143,7 @@ describe("stripExtendedContext", () => {
   it("returns base models unchanged", () => {
     expect(stripExtendedContext("opus")).toBe("opus")
     expect(stripExtendedContext("sonnet")).toBe("sonnet")
+    expect(stripExtendedContext("fable")).toBe("fable")
   })
 })
 
@@ -136,12 +151,14 @@ describe("hasExtendedContext", () => {
   it("returns true for [1m] models", () => {
     expect(hasExtendedContext("opus[1m]")).toBe(true)
     expect(hasExtendedContext("sonnet[1m]")).toBe(true)
+    expect(hasExtendedContext("fable[1m]")).toBe(true)
   })
 
   it("returns false for base models", () => {
     expect(hasExtendedContext("opus")).toBe(false)
     expect(hasExtendedContext("sonnet")).toBe(false)
     expect(hasExtendedContext("haiku")).toBe(false)
+    expect(hasExtendedContext("fable")).toBe(false)
   })
 })
 
@@ -161,6 +178,11 @@ describe("Extra Usage cooldown", () => {
   it("mapModelToClaudeModel returns sonnet (not [1m]) during cooldown", () => {
     recordExtendedContextUnavailable()
     expect(mapModelToClaudeModel("claude-sonnet-4-6", "max")).toBe("sonnet")
+  })
+
+  it("mapModelToClaudeModel returns fable (not [1m]) during cooldown", () => {
+    recordExtendedContextUnavailable()
+    expect(mapModelToClaudeModel("claude-fable-5", "max")).toBe("fable")
   })
 
   it("sonnet stays sonnet even when cooldown is cleared (default is 200k)", () => {

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test"
 
-import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resolveSdkModelDefaults, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resolveSdkModelDefaults, CANONICAL_FABLE_MODEL, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
   const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
@@ -257,9 +257,15 @@ describe("resolveSdkModelDefaults", () => {
   // runs files in parallel.
   it("returns canonical pins when no overrides set", () => {
     const pins = resolveSdkModelDefaults({})
+    expect(pins.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe(CANONICAL_FABLE_MODEL)
     expect(pins.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe(CANONICAL_OPUS_MODEL)
     expect(pins.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(CANONICAL_SONNET_MODEL)
     expect(pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe(CANONICAL_HAIKU_MODEL)
+  })
+
+  it("MERIDIAN_DEFAULT_FABLE_MODEL override wins over the canonical default", () => {
+    const pins = resolveSdkModelDefaults({ MERIDIAN_DEFAULT_FABLE_MODEL: "claude-fable-6" })
+    expect(pins.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-6")
   })
 
   it("MERIDIAN_DEFAULT_OPUS_MODEL override wins over the canonical default", () => {
@@ -277,9 +283,10 @@ describe("resolveSdkModelDefaults", () => {
     expect(pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-5-0")
   })
 
-  it("returns only the three ANTHROPIC_DEFAULT_* keys — nothing else", () => {
+  it("returns only the four ANTHROPIC_DEFAULT_* keys — nothing else", () => {
     const pins = resolveSdkModelDefaults({})
     expect(Object.keys(pins).sort()).toEqual([
+      "ANTHROPIC_DEFAULT_FABLE_MODEL",
       "ANTHROPIC_DEFAULT_HAIKU_MODEL",
       "ANTHROPIC_DEFAULT_OPUS_MODEL",
       "ANTHROPIC_DEFAULT_SONNET_MODEL",
@@ -290,6 +297,7 @@ describe("resolveSdkModelDefaults", () => {
     // Smoke test that the no-arg path still works — value is unspecified but
     // shape must be correct.
     const pins = resolveSdkModelDefaults()
+    expect(typeof pins.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("string")
     expect(typeof pins.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("string")
     expect(typeof pins.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("string")
     expect(typeof pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("string")

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1156,40 +1156,45 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 4 models", () => {
-    expect(buildModelList(true).length).toBe(5)
-    expect(buildModelList(false).length).toBe(5)
+  it("returns 6 models", () => {
+    expect(buildModelList(true).length).toBe(6)
+    expect(buildModelList(false).length).toBe(6)
   })
 
-  it("includes opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes opus-4-6, opus-4-7, opus-4-8, and fable-5 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")
     expect(ids).toContain("claude-opus-4-8")
+    expect(ids).toContain("claude-fable-5")
   })
 
-  it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {
+  it("Max subscription gets 1M context for all opus variants and fable, 200k for sonnet", () => {
     const models = buildModelList(true)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
     const opus46 = models.find(m => m.id === "claude-opus-4-6")!
     const opus47 = models.find(m => m.id === "claude-opus-4-7")!
     const opus48 = models.find(m => m.id === "claude-opus-4-8")!
+    const fable5 = models.find(m => m.id === "claude-fable-5")!
     expect(sonnet.context_window).toBe(200_000)
     expect(opus46.context_window).toBe(1_000_000)
     expect(opus47.context_window).toBe(1_000_000)
     expect(opus48.context_window).toBe(1_000_000)
+    expect(fable5.context_window).toBe(1_000_000)
   })
 
-  it("non-Max gets 200k context for sonnet and all opus variants", () => {
+  it("non-Max gets 200k context for sonnet, all opus variants, and fable", () => {
     const models = buildModelList(false)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
     const opus46 = models.find(m => m.id === "claude-opus-4-6")!
     const opus47 = models.find(m => m.id === "claude-opus-4-7")!
     const opus48 = models.find(m => m.id === "claude-opus-4-8")!
+    const fable5 = models.find(m => m.id === "claude-fable-5")!
     expect(sonnet.context_window).toBe(200_000)
     expect(opus46.context_window).toBe(200_000)
     expect(opus47.context_window).toBe(200_000)
     expect(opus48.context_window).toBe(200_000)
+    expect(fable5.context_window).toBe(200_000)
   })
 
   it("haiku is always 200k regardless of subscription", () => {

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -187,9 +187,11 @@ describe("Environment variable stripping", () => {
 
 describe("SDK model pin injection (fixes #419)", () => {
   const modelEnvKeys = [
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
     "ANTHROPIC_DEFAULT_OPUS_MODEL",
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "MERIDIAN_DEFAULT_FABLE_MODEL",
     "MERIDIAN_DEFAULT_OPUS_MODEL",
     "MERIDIAN_DEFAULT_SONNET_MODEL",
     "MERIDIAN_DEFAULT_HAIKU_MODEL",
@@ -215,6 +217,7 @@ describe("SDK model pin injection (fixes #419)", () => {
   it("injects Meridian's canonical model pins when no shell env is set", async () => {
     const app = createTestApp()
     await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
@@ -224,6 +227,13 @@ describe("SDK model pin injection (fixes #419)", () => {
     const app = createTestApp()
     await post(app, { ...BASIC_REQUEST, model: "claude-opus-4-6" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-6")
+  })
+
+  it("explicit claude-fable-* requests pin the SDK env to that version", async () => {
+    process.env.ANTHROPIC_DEFAULT_FABLE_MODEL = "claude-fable-5"
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-fable-5-20260601" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5-20260601")
   })
 
   it("explicit claude-opus-4-7 requests beat inherited env pins", async () => {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -39,6 +39,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * override via MERIDIAN_DEFAULT_{TYPE}_MODEL (proxy-side) or
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
+export const CANONICAL_FABLE_MODEL = "claude-fable-5"
 export const CANONICAL_OPUS_MODEL = "claude-opus-4-8"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-4-6"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
@@ -56,6 +57,7 @@ export function resolveSdkModelDefaults(
   env: NodeJS.ProcessEnv = process.env,
 ): Record<string, string> {
   return {
+    ANTHROPIC_DEFAULT_FABLE_MODEL: env.MERIDIAN_DEFAULT_FABLE_MODEL ?? CANONICAL_FABLE_MODEL,
     ANTHROPIC_DEFAULT_OPUS_MODEL: env.MERIDIAN_DEFAULT_OPUS_MODEL ?? CANONICAL_OPUS_MODEL,
     ANTHROPIC_DEFAULT_SONNET_MODEL: env.MERIDIAN_DEFAULT_SONNET_MODEL ?? CANONICAL_SONNET_MODEL,
     ANTHROPIC_DEFAULT_HAIKU_MODEL: env.MERIDIAN_DEFAULT_HAIKU_MODEL ?? CANONICAL_HAIKU_MODEL,

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -21,7 +21,7 @@ const execFile = promisify(execFileCallback)
  */
 const STUB_SIZE_THRESHOLD = 4096
 
-export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku"
+export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku" | "fable" | "fable[1m]"
 
 /**
  * Current canonical pins for the `sonnet`/`opus`/`haiku` SDK aliases.
@@ -99,6 +99,14 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
   // Using the base model preserves rate limit budget for the primary agent.
   const isSubagent = agentMode === "subagent"
 
+  // Fable [1m]: Fable 5 supports the 1M extended context window. Mirrors
+  // the opus handling — [1m] for primary agents, base model for subagents,
+  // honoring the Extra Usage cooldown.
+  if (model.includes("fable")) {
+    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable()) return "fable[1m]"
+    return "fable"
+  }
+
   // Opus [1m]: included with Max, Team, and Enterprise subscriptions per
   // Anthropic docs (https://code.claude.com/docs/en/model-config#extended-context).
   // Safe to default to [1m] for Max users — no Extra Usage charges.
@@ -165,6 +173,7 @@ export function resetExtendedContextUnavailable(): void {
 export function stripExtendedContext(model: ClaudeModel): ClaudeModel {
   if (model === "opus[1m]") return "opus"
   if (model === "sonnet[1m]") return "sonnet"
+  if (model === "fable[1m]") return "fable"
   return model
 }
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -826,6 +826,14 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       context_window: isMaxSubscription ? 1_000_000 : 200_000,
     },
     {
+      id: "claude-fable-5",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Fable 5",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+    },
+    {
       id: "claude-haiku-4-5",
       object: "model",
       created: now,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -445,7 +445,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode)
         const envOverrides = requestedModel.startsWith("claude-opus-")
           ? { ANTHROPIC_DEFAULT_OPUS_MODEL: requestedModel }
-          : undefined
+          : requestedModel.startsWith("claude-fable-")
+            ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
+            : undefined
         // workingDirectory = SDK subprocess cwd (must exist on the proxy host).
         // clientWorkingDirectory = the client's local path (may not exist here);
         // used for per-project fingerprint bucketing and a system-prompt hint
@@ -3004,7 +3006,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       console.log(`Meridian running at http://${finalConfig.host}:${info.port}`)
       console.log(`Telemetry dashboard: http://${finalConfig.host}:${info.port}/telemetry`)
       const pins = resolveSdkModelDefaults()
-      console.log(`Model pins: opus=${pins.ANTHROPIC_DEFAULT_OPUS_MODEL} sonnet=${pins.ANTHROPIC_DEFAULT_SONNET_MODEL} haiku=${pins.ANTHROPIC_DEFAULT_HAIKU_MODEL}`)
+      console.log(`Model pins: fable=${pins.ANTHROPIC_DEFAULT_FABLE_MODEL} opus=${pins.ANTHROPIC_DEFAULT_OPUS_MODEL} sonnet=${pins.ANTHROPIC_DEFAULT_SONNET_MODEL} haiku=${pins.ANTHROPIC_DEFAULT_HAIKU_MODEL}`)
       // Surface the resolved Claude executable + which step picked it.
       // When users hit "wrong claude got picked" failure modes (e.g. a
       // bun-shimmed `claude` on PATH, see #478), this single line is what


### PR DESCRIPTION
## Summary

Claude Fable 5 (`claude-fable-5`) launched after Meridian's last release, so `mapModelToClaudeModel` buckets fable requests into the default `sonnet` branch — requests for Fable silently answer as Sonnet, the same failure class as #419. This PR adds first-class fable routing, mirroring the existing opus handling.

## Changes

- **Model mapping** (`models.ts`): requests containing `fable` map to `fable[1m]` for primary agents and base `fable` for subagents, honoring the existing Extra-Usage cooldown — a structural mirror of the opus branch. `ClaudeModel` type and `stripExtendedContext` extended accordingly. Fable 5 supports the 1M context window (verified on a Max subscription — no Extra Usage error).
- **Model discovery** (`openai.ts`): `GET /v1/models` now advertises `claude-fable-5` (1M context for Max, 200k otherwise).
- **SDK default pin**: `ANTHROPIC_DEFAULT_FABLE_MODEL` is pinned to `claude-fable-5` at the SDK subprocess boundary alongside the existing opus/sonnet/haiku pins (claude-code ≥ 2.1.170 reads this env var — confirmed by inspecting the binary). Overridable via `MERIDIAN_DEFAULT_FABLE_MODEL` (proxy-side) or shell `ANTHROPIC_DEFAULT_FABLE_MODEL` (wins), and explicit `claude-fable-*` request IDs pin per-request, mirroring the `claude-opus-*` handling. Startup `Model pins:` log includes fable.
- **Dependency floor**: `@anthropic-ai/claude-code` raised `^2.1.117` → `^2.1.170`. The fable alias is rejected by earlier CLIs (2.1.119 returns "There's an issue with the selected model (fable[1m])"); 2.1.170 resolves it. `bun.nix` regenerated via `bun run nix:lock` for the bun-nix-sync workflow.
- **Docs**: README architecture map updated for `models.ts`.

## Verification

- `npm test`: 1750 pass / 0 fail, including new fable coverage mirroring the opus tests (mapping, subagent mode, cooldown, strip/has extended context, model list, pin injection, per-request pin, override precedence)
- `npm run typecheck`: clean
- E2E on a Claude Max subscription (2026-06-09): `POST /v1/messages` with `"model": "claude-fable-5"` returned a real Fable completion (`stop_reason: end_turn`); proxy log shows `model=fable[1m]`; `GET /v1/models` lists `claude-fable-5`; `Model pins: fable=claude-fable-5 opus=claude-opus-4-8 sonnet=claude-sonnet-4-6 haiku=claude-haiku-4-5` at startup

## Notes for review

- `MERIDIAN_DEFAULT_FABLE_MODEL` is intentionally not added to the README configuration table, since the existing `MERIDIAN_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` vars aren't documented there either.
- E2E.md's E14 (model routing) was exercised manually for fable; I left the doc's "Last Verified" dates untouched since those reflect the maintainer's runs.