### PR TITLE
feat(models): add Claude Fable 5 to model list and routing

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -55,6 +55,12 @@ describe("mapModelToClaudeModel", () => {
     expect(mapModelToClaudeModel("", undefined)).toBe("sonnet")
   })
 
+  it("passes the concrete fable model straight through (no alias collapse)", () => {
+    expect(mapModelToClaudeModel("claude-fable-5")).toBe("claude-fable-5")
+    expect(mapModelToClaudeModel("claude-fable-5", "max")).toBe("claude-fable-5")
+    expect(mapModelToClaudeModel("fable")).toBe("claude-fable-5")
+  })
+
   it("respects explicit sonnet[1m] override when opted in", () => {
     process.env.CLAUDE_PROXY_SONNET_MODEL = "sonnet[1m]"
     expect(mapModelToClaudeModel("sonnet", "team")).toBe("sonnet[1m]")

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1156,16 +1156,24 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 4 models", () => {
-    expect(buildModelList(true).length).toBe(5)
-    expect(buildModelList(false).length).toBe(5)
+  it("returns 6 models", () => {
+    expect(buildModelList(true).length).toBe(6)
+    expect(buildModelList(false).length).toBe(6)
   })
 
-  it("includes opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes fable-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
+    expect(ids).toContain("claude-fable-5")
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")
     expect(ids).toContain("claude-opus-4-8")
+  })
+
+  it("Max subscription gets 1M context for fable, 200k otherwise", () => {
+    const fableMax = buildModelList(true).find(m => m.id === "claude-fable-5")!
+    const fableFree = buildModelList(false).find(m => m.id === "claude-fable-5")!
+    expect(fableMax.context_window).toBe(1_000_000)
+    expect(fableFree.context_window).toBe(200_000)
   })
 
   it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -21,7 +21,9 @@ const execFile = promisify(execFileCallback)
  */
 const STUB_SIZE_THRESHOLD = 4096
 
-export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku"
+// Fable has no SDK alias (the alias system only covers sonnet/opus/haiku),
+// so it is carried as the concrete model id and passed straight to the SDK.
+export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku" | "claude-fable-5"
 
 /**
  * Current canonical pins for the `sonnet`/`opus`/`haiku` SDK aliases.
@@ -92,6 +94,11 @@ function supports1mContext(model: string): boolean {
 }
 
 export function mapModelToClaudeModel(model: string, subscriptionType?: string | null, agentMode?: string | null): ClaudeModel {
+  // Fable is the top tier above Opus and has no sonnet/opus/haiku SDK alias,
+  // so there is no ANTHROPIC_DEFAULT_*_MODEL slot to pin it through. Pass the
+  // concrete id straight to the SDK; the Claude CLI resolves it directly.
+  if (model.includes("fable")) return "claude-fable-5"
+
   if (model.includes("haiku")) return "haiku"
 
   const use1m = supports1mContext(model)

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -794,6 +794,14 @@ export function translateAnthropicSseEvent(
 export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date.now() / 1000)): OpenAiModel[] {
   return [
     {
+      id: "claude-fable-5",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Fable 5",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+    },
+    {
       id: "claude-sonnet-4-6",
       object: "model",
       created: now,


### PR DESCRIPTION
## What

Adds **Claude Fable 5** (`claude-fable-5`) to the proxy so OpenWebUI (and any OpenAI-compatible client) can list and use it.

## Why

Fable is the tier above Opus and has no `sonnet`/`opus`/`haiku` SDK alias, so the existing `mapModelToClaudeModel` collapse routes a `claude-fable-5` request to `sonnet` and it never appears on `/v1/models`. Max users on Fable currently can't reach it through Meridian.

## Changes

- `src/proxy/models.ts` — extend `ClaudeModel` with `claude-fable-5`; `mapModelToClaudeModel` passes the concrete id straight through (no alias to collapse to, so it's handed to the SDK directly — the Claude CLI resolves it).
- `src/proxy/openai.ts` — `buildModelList` advertises `claude-fable-5` (1M context on Max, 200k otherwise), matching the opus entries.
- Tests updated: model count 5→6, fable mapping + list assertions.

All `[1m]` rate-limit / extra-usage strip paths are no-ops for fable (`hasExtendedContext` is false), and `envOverrides` stays undefined (it only pins opus). No exhaustive `ClaudeModel` switches needed updating.

## Verification

Deployed on a Claude Max account and verified end-to-end: `claude-fable-5` lists on `/v1/models` and round-trips a chat completion (PONG), confirming Max serves Fable through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)