### PR TITLE
docs: add Opus 4.7/4.8 to example model configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,9 +361,11 @@ Add a provider to `~/.config/crush/crush.json`:
       "base_url": "http://127.0.0.1:3456",
       "api_key": "dummy",
       "models": [
-        { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (1M)", "context_window": 1000000, "default_max_tokens": 64000, "can_reason": true, "supports_attachments": true },
-        { "id": "claude-opus-4-6",   "name": "Claude Opus 4.6 (1M)",   "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
-        { "id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", "context_window": 200000, "default_max_tokens": 16384, "can_reason": true, "supports_attachments": true }
+        { "id": "claude-opus-4-8",   "name": "Claude Opus 4.8 (1M)",    "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
+        { "id": "claude-opus-4-7",   "name": "Claude Opus 4.7 (1M)",    "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
+        { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (1M)",  "context_window": 1000000, "default_max_tokens": 64000, "can_reason": true, "supports_attachments": true },
+        { "id": "claude-opus-4-6",   "name": "Claude Opus 4.6 (1M)",    "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
+        { "id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", "context_window": 200000,  "default_max_tokens": 16384, "can_reason": true, "supports_attachments": true }
       ]
     }
   }
@@ -384,6 +386,8 @@ Add Meridian as a custom model provider in `~/.factory/settings.json`:
 ```json
 {
   "customModels": [
+    { "model": "claude-opus-4-8",         "name": "Opus 4.8 (Meridian)",   "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
+    { "model": "claude-opus-4-7",         "name": "Opus 4.7 (Meridian)",   "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-sonnet-4-6",       "name": "Sonnet 4.6 (Meridian)", "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-opus-4-6",         "name": "Opus 4.6 (Meridian)",   "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-haiku-4-5-20251001", "name": "Haiku 4.5 (Meridian)", "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" }


### PR DESCRIPTION
Adds the current Opus 1M models — **Opus 4.8** and **Opus 4.7** — to the example **Crush** (`crush.json`) and **Droid/Factory** (`settings.json`) provider snippets in the README, so the copy-paste configs reflect what actually routes through Meridian today.

### Relationship to #531
This supersedes #531 (original work by @d-arken, authorship preserved on the commit). The only change from that PR: **the `claude-fable-5` rows are dropped.**

### Why Fable 5 was removed
Anthropic currently has Fable 5 disabled, and Meridian has **no `fable` routing** — `mapModelToClaudeModel` falls unknown ids through to `sonnet` (`src/proxy/models.ts`), and the explicit-pin env override only fires for `claude-opus-*` (`src/proxy/server.ts`). So a documented `claude-fable-5` entry would silently serve **Sonnet** under a Fable label. Fable docs should land alongside its routing support (see #527 / #530).

### Validation
- `npm test` — full suite green (0 failures)
- Live headless smoke against the running proxy (v1.43.0, Max): both `claude-opus-4-8` and `claude-opus-4-7` return valid `message` responses routing to `opus[1m]` — no Sonnet fallback
- Both example JSON blocks parse cleanly

Docs-only; no code changes.