### PR TITLE
fix(openai): don't inject claude_code preset on /v1/chat/completions

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -85,6 +85,7 @@ kill $(lsof -ti :3456)
 | E29 | [Context Usage Endpoint](#e29-context-usage-endpoint) | `/v1/sessions/:claudeSessionId/context-usage` returns live token usage for a completed request | 2026-04-03 |
 | E30 | [Context Usage via Fingerprint + Restart](#e30-context-usage-via-fingerprint--restart) | Context usage lookup works for headerless sessions and survives proxy restart via shared store | 2026-04-03 |
 | E32 | [Tool-use leak (#416) — opencode + opus-4-7](#e32-tool-use-leak-416--opencode--opus-4-7) | Multi-turn opencode rehydration with prior tool_use blocks does not cause opus-4-7 to emit `[Tool Use:` / `H:` / `Human:` text in its response | 2026-04-26 |
+| E33 | [OpenAI Compat: system prompt, no preset](#e33-openai-compat-system-prompt-no-preset) | `/v1/chat/completions` honours the client's system prompt without injecting the claude_code preset (openai adapter default) | 2026-06-15 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3066,3 +3067,32 @@ rm -f /tmp/e2e-416-body.json /tmp/e2e-416-aggressive.json
 ### Why this isn't fully covered by unit tests
 
 The existing regression test in `src/__tests__/proxy-tool-flattening-regression.test.ts` (issue #386) verifies the SDK **prompt** contains no `[Tool Use:` strings. That's necessary but not sufficient for #416 — the symptom there was the **model's response** containing those strings, picked up from context patterns the model imitates. Only a live model can verify that opus-4-7 doesn't mimic the rehydration format. The unit test guards Meridian's prompt construction; this E2E guards the model's actual behavior on the user's stack.
+
+---
+
+## E33: OpenAI Compat: system prompt, no preset
+
+**Verifies:** A generic OpenAI client (Open WebUI, curl) hitting `POST /v1/chat/completions` with a `system` message has that prompt honoured directly, **without** the ~28KB `claude_code` preset being injected on top. The internal hop is tagged `x-meridian-agent: openai`, selecting the `openai` adapter whose `codeSystemPrompt` defaults OFF (mirrors the passthrough precedent, #190). Regression guard for the #526 investigation.
+
+```bash
+curl -s http://127.0.0.1:3456/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -d '{
+    "model": "claude-haiku-4-5-20251001",
+    "max_tokens": 40,
+    "messages": [
+      {"role": "system", "content": "You are Aristotle, a philosophy tutor. You are NOT a coding assistant. In one short sentence, state who you are."},
+      {"role": "user", "content": "Who are you?"}
+    ]
+  }' | python3 -m json.tool
+```
+
+**Pass criteria:**
+- Response reflects the client system prompt (e.g. "I am Aristotle, a philosophy tutor.")
+- Proxy log shows `adapter=openai` for the inner hop (not `adapter=opencode`)
+- No Claude Code persona / tool-instruction leakage in the reply
+
+**To confirm the preset is actually gone** (the deterministic check), set `codeSystemPrompt` for the `openai` adapter and observe the difference, or rely on the unit test `src/__tests__/proxy-openai-compat.test.ts` → "sends the client system prompt verbatim, without the claude_code preset", which asserts the SDK receives a plain-string `systemPrompt` rather than a `{type: "preset", preset: "claude_code"}` object.
+
+**What's being tested:** `openAiAdapter` (`adapters/openai.ts`), the `x-meridian-agent: openai` tag on the internal hop (`server.ts`), and `ADAPTER_DEFAULTS.openai = { codeSystemPrompt: false }` (`sdkFeatures.ts`).

--- a/src/__tests__/openai-adapter.test.ts
+++ b/src/__tests__/openai-adapter.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for the OpenAI-compatible endpoint adapter.
+ *
+ * `/v1/chat/completions` serves generic OpenAI chat clients (Open WebUI,
+ * LibreChat, curl). These are NOT coding agents, so the inner hop is tagged
+ * `x-meridian-agent: openai` to resolve a dedicated adapter whose system-prompt
+ * preset defaults OFF — mirroring the `passthrough` precedent (#190). The
+ * adapter otherwise behaves exactly like `opencode` (tools, MCP, passthrough).
+ */
+import { describe, it, expect } from "bun:test"
+import { detectAdapter } from "../proxy/adapters/detect"
+import { openAiAdapter } from "../proxy/adapters/openai"
+import { openCodeAdapter } from "../proxy/adapters/opencode"
+
+function makeContext(extraHeaders: Record<string, string> = {}): any {
+  const allHeaders: Record<string, string> = {}
+  for (const [k, v] of Object.entries(extraHeaders)) allHeaders[k.toLowerCase()] = v
+  return {
+    req: {
+      header: (name?: string) => (name ? allHeaders[name.toLowerCase()] : { ...allHeaders }),
+    },
+  }
+}
+
+describe("openAiAdapter", () => {
+  it("is named 'openai'", () => {
+    expect(openAiAdapter.name).toBe("openai")
+  })
+
+  it("is resolved via the x-meridian-agent: openai override", () => {
+    const adapter = detectAdapter(makeContext({ "x-meridian-agent": "openai" }))
+    expect(adapter).toBe(openAiAdapter)
+    expect(adapter.name).toBe("openai")
+  })
+
+  it("shares opencode's tool + MCP identity (no tool-execution regression)", () => {
+    expect(openAiAdapter.getMcpServerName()).toBe(openCodeAdapter.getMcpServerName())
+    expect(openAiAdapter.getCoreToolNames?.()).toEqual(openCodeAdapter.getCoreToolNames?.())
+    expect(openAiAdapter.getBlockedBuiltinTools()).toEqual(openCodeAdapter.getBlockedBuiltinTools())
+    expect(openAiAdapter.getAllowedMcpTools()).toEqual(openCodeAdapter.getAllowedMcpTools())
+  })
+})

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -27,9 +27,11 @@ import {
 
 let mockMessages: unknown[] = []
 let capturedPromptMessages: unknown[] = []
+let capturedOptions: Record<string, unknown> | null = null
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: ({ prompt }: { prompt: string | AsyncIterable<unknown> }) => {
+  query: ({ prompt, options }: { prompt: string | AsyncIterable<unknown>; options?: Record<string, unknown> }) => {
+    capturedOptions = options ?? null
     return (async function* () {
       capturedPromptMessages = []
       if (typeof prompt === "string") {
@@ -160,6 +162,25 @@ describe("POST /v1/chat/completions — non-streaming", () => {
     })
 
     expect(res.status).toBe(200)
+  })
+
+  it("sends the client system prompt verbatim, without the claude_code preset", async () => {
+    // The OpenAI endpoint serves generic chat clients (Open WebUI, curl).
+    // Their system prompt must reach the SDK as a plain string — NOT wrapped
+    // under the 28KB claude_code preset, which would hijack their intent with
+    // the Claude Code persona. Regression guard for the #526 investigation.
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    await postChatCompletion(app, {
+      stream: false,
+      messages: [
+        { role: "system", content: "You are TestBot. Reply with exactly: ZEBRA-7" },
+        { role: "user", content: "Hello" },
+      ],
+    })
+
+    expect(capturedOptions?.systemPrompt).toBe("You are TestBot. Reply with exactly: ZEBRA-7")
   })
 
   it("response has Content-Type application/json", async () => {

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -14,6 +14,7 @@ import { passthroughAdapter } from "./passthrough"
 import { piAdapter } from "./pi"
 import { forgeCodeAdapter } from "./forgecode"
 import { claudeCodeAdapter } from "./claudecode"
+import { openAiAdapter } from "./openai"
 
 const ADAPTER_MAP: Record<string, AgentAdapter> = {
   opencode: openCodeAdapter,
@@ -24,6 +25,9 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   forgecode: forgeCodeAdapter,
   "claude-code": claudeCodeAdapter,
   claudecode: claudeCodeAdapter,
+  // Generic OpenAI-compatible endpoint (/v1/chat/completions). Selected via
+  // the x-meridian-agent: openai tag the handler sets on the internal hop.
+  openai: openAiAdapter,
 }
 
 const envDefault = process.env.MERIDIAN_DEFAULT_AGENT || ""

--- a/src/proxy/adapters/openai.ts
+++ b/src/proxy/adapters/openai.ts
@@ -1,0 +1,28 @@
+/**
+ * OpenAI-compatible endpoint adapter.
+ *
+ * `/v1/chat/completions` serves generic OpenAI chat clients (Open WebUI,
+ * LibreChat, curl, any OpenAI-compatible tool). These are NOT coding agents:
+ * they bring their own system prompt and don't want the ~28KB claude_code
+ * preset injected on top of it (which would override their intent with the
+ * Claude Code persona — see the #526 investigation).
+ *
+ * The handler tags the internal hop with `x-meridian-agent: openai` so this
+ * adapter is selected deterministically instead of falling through to the
+ * default `opencode` adapter (whose preset defaults ON). Behaviour is
+ * otherwise identical to `opencode` — same tools, MCP server, passthrough,
+ * and transforms — the ONLY difference is the system-prompt preset default,
+ * which is set OFF in sdkFeatures.ADAPTER_DEFAULTS. This mirrors the
+ * `passthrough` adapter precedent (#190).
+ *
+ * NOTE: agent-specific. Keep this as a thin re-identification of the OpenCode
+ * adapter; do not fork behaviour here.
+ */
+
+import type { AgentAdapter } from "../adapter"
+import { openCodeAdapter } from "./opencode"
+
+export const openAiAdapter: AgentAdapter = {
+  ...openCodeAdapter,
+  name: "openai",
+}

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -70,6 +70,14 @@ const ADAPTER_DEFAULTS: Record<string, Partial<AdapterFeatures>> = {
   passthrough: {
     codeSystemPrompt: false,
   },
+  // The OpenAI-compatible endpoint (/v1/chat/completions) serves generic chat
+  // clients (Open WebUI, LibreChat, curl) that bring their own system prompt.
+  // Default the claude_code preset OFF so their prompt isn't overridden by the
+  // ~28KB Claude Code persona (same rationale as passthrough). Users can flip
+  // it on via the settings UI for explicit opt-in.
+  openai: {
+    codeSystemPrompt: false,
+  },
 }
 
 function getConfigPath(): string {
@@ -133,7 +141,7 @@ export function getFeaturesForAdapter(adapterName: string): AdapterFeatures {
  * Get the full config for all adapters (for the settings UI).
  */
 export function getAllFeatureConfigs(): Record<string, AdapterFeatures> {
-  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough"]
+  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough", "openai"]
   const result: Record<string, AdapterFeatures> = {}
   for (const name of adapters) {
     result[name] = getFeaturesForAdapter(name)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2624,7 +2624,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     // Hono resolves the path in-process; the URL scheme/host are ignored.
     // Forward the caller's auth headers so requireAuth on /v1/messages accepts
     // the inner hop when MERIDIAN_API_KEY is set (issue #415).
-    const internalHeaders: Record<string, string> = { "Content-Type": "application/json" }
+    // Tag the inner hop as the generic OpenAI endpoint. Without this the
+    // header-less internal request falls through detectAdapter to the default
+    // `opencode` adapter, whose claude_code preset defaults ON — hijacking the
+    // client's own system prompt with the Claude Code persona (#526). The
+    // `openai` adapter mirrors opencode but defaults the preset OFF.
+    const internalHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+      "x-meridian-agent": "openai",
+    }
     const xApiKey = c.req.header("x-api-key")
     if (xApiKey) internalHeaders["x-api-key"] = xApiKey
     const authz = c.req.header("authorization")
@@ -2648,10 +2656,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const created = Math.floor(Date.now() / 1000)
     const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : "claude-sonnet-4-6"
 
-    // Resolve SDK features for this request (thinking passthrough setting)
+    // Resolve SDK features for this request (thinking passthrough setting).
+    // The OpenAI endpoint is unambiguously the `openai` adapter — matching the
+    // x-meridian-agent tag set on the internal hop above — so resolve directly
+    // rather than re-detecting from the (generic) client User-Agent.
     const { getFeaturesForAdapter } = require("./sdkFeatures") as typeof import("./sdkFeatures")
-    const adapter = detectAdapter(c)
-    const sdkFeatures = getFeaturesForAdapter(adapter.name)
+    const sdkFeatures = getFeaturesForAdapter("openai")
 
     if (!anthropicBody.stream) {
       const anthropicRes = await internalRes.json() as Record<string, unknown>

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -13,6 +13,10 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   pi: piTransforms,
   forgecode: forgeCodeTransforms,
   passthrough: passthroughTransforms,
+  // The OpenAI-compatible endpoint reuses OpenCode's transforms verbatim so
+  // tool/passthrough behaviour is identical; only the preset default differs
+  // (see sdkFeatures.ADAPTER_DEFAULTS.openai).
+  openai: openCodeTransforms,
 }
 
 export function getAdapterTransforms(adapterName: string): readonly Transform[] {


### PR DESCRIPTION
## Problem

Generic OpenAI-compatible clients (Open WebUI, LibreChat, curl) hitting `/v1/chat/completions` with a `system` message got the **Claude Code persona** instead of their own instructions. Surfaced in #526.

## Root cause (not what #526 thought)

The client's system prompt is **never dropped**. The endpoint re-routes internally to `/v1/messages` with the User-Agent stripped (`server.ts`), so `detectAdapter` falls through to the default **`opencode`** adapter — whose `codeSystemPrompt` defaults **ON**. Result: the SDK receives `{type: "preset", preset: "claude_code", append: "<your prompt>"}` — the 28KB preset dominates and your prompt is demoted to an append. (`prompt_tokens: 3` was the preset being cache-hit, not a missing prompt.)

#526's edit to `resolveSystemPrompt` was a **no-op** — that line is only reachable when there's no client prompt at all. Closed with a full trace.

## Fix

Give the OpenAI endpoint its own adapter identity that defaults the preset **OFF** — same rationale/precedent as the `passthrough` adapter (#190: non-coding clients shouldn't be fed the coding preset):

- **`adapters/openai.ts`** — new `openai` adapter, a thin re-identification of `opencode` (identical tools, MCP, passthrough, transforms); only the name differs.
- **`server.ts`** — tag the internal hop with `x-meridian-agent: openai` so it resolves deterministically.
- **`sdkFeatures.ts`** — `ADAPTER_DEFAULTS.openai = { codeSystemPrompt: false }`, plus an `openai` row in the settings UI for explicit opt-in.
- **`detect.ts` / `transforms/registry.ts`** — register the adapter and reuse `openCodeTransforms` verbatim (zero tool/passthrough behaviour change).

## Tests (TDD — red first)

- **`proxy-openai-compat.test.ts`** — full HTTP layer + mocked SDK: asserts a `system` message reaches the SDK as a **plain string**, not a `claude_code` preset object. Failed before (`Received: {type: "preset", …}`), passes after.
- **`openai-adapter.test.ts`** — adapter resolves via the tag and shares opencode's tool/MCP identity (no regression).
- Full suite green (0 failures); build clean.
- Live smoke (real SDK): Open WebUI-style request with `"You are Aristotle…"` → `"I am Aristotle, a philosophy tutor."`, proxy log shows `adapter=openai`.
- Manual recipe documented as **E33** in `E2E.md`.

## Behaviour change

OpenAI-endpoint traffic no longer gets the claude_code preset by default. Anyone who wants it can enable `codeSystemPrompt` on the `openai` adapter in the settings UI. Other adapters (opencode, crush, droid, …) are unaffected.

Reported by @ilie-neacsu in #526. 🙏