### PR TITLE
feat(effort): accept reasoning_effort end-to-end (OpenAI translation + validation)

### DIFF
--- a/src/__tests__/effort.test.ts
+++ b/src/__tests__/effort.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for effort normalization.
+ *
+ * The SDK `--effort` flag accepts a fixed vocabulary (low/medium/high/xhigh/max).
+ * Clients (especially OpenAI-compatible ones) may send values outside it —
+ * notably OpenAI's `"minimal"` — which the SDK rejects. normalizeEffort gates
+ * the value so an unknown effort falls back to the model default (undefined)
+ * instead of erroring the whole request.
+ */
+import { describe, it, expect } from "bun:test"
+import { normalizeEffort, VALID_EFFORTS } from "../proxy/effort"
+
+describe("normalizeEffort", () => {
+  it("passes through every valid Claude effort level", () => {
+    for (const level of VALID_EFFORTS) {
+      expect(normalizeEffort(level)).toBe(level)
+    }
+  })
+
+  it("accepts xhigh and max (beyond the legacy low/medium/high)", () => {
+    expect(normalizeEffort("xhigh")).toBe("xhigh")
+    expect(normalizeEffort("max")).toBe("max")
+  })
+
+  it("drops OpenAI's 'minimal' (not a valid Claude effort)", () => {
+    expect(normalizeEffort("minimal")).toBeUndefined()
+  })
+
+  it("drops unknown / malformed values rather than forwarding them", () => {
+    expect(normalizeEffort("super")).toBeUndefined()
+    expect(normalizeEffort("")).toBeUndefined()
+    expect(normalizeEffort("HIGH")).toBeUndefined() // case-sensitive: SDK wants lowercase
+    expect(normalizeEffort(undefined)).toBeUndefined()
+    expect(normalizeEffort(null)).toBeUndefined()
+    expect(normalizeEffort(3)).toBeUndefined()
+    expect(normalizeEffort({})).toBeUndefined()
+  })
+})

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -164,6 +164,22 @@ describe("POST /v1/chat/completions — non-streaming", () => {
     expect(res.status).toBe(200)
   })
 
+  it("carries reasoning_effort through translation to the SDK effort flag", async () => {
+    // OpenAI SDK clients send the reasoning level as `reasoning_effort`. It must
+    // survive the OpenAI->Anthropic translation and reach the SDK, not get
+    // dropped at the endpoint boundary.
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    await postChatCompletion(app, {
+      stream: false,
+      reasoning_effort: "high",
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(capturedOptions?.effort).toBe("high")
+  })
+
   it("sends the client system prompt verbatim, without the claude_code preset", async () => {
     // The OpenAI endpoint serves generic chat clients (Open WebUI, curl).
     // Their system prompt must reach the SDK as a plain string — NOT wrapped

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -107,6 +107,30 @@ describe("SDK param passthrough — body fields", () => {
     expect(capturedOptions.taskBudget).toBeUndefined()
     expect(capturedOptions.betas).toBeUndefined()
   })
+
+  it("forwards reasoning_effort from body (standard OpenAI field)", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, reasoning_effort: "high" })
+    expect(capturedOptions.effort).toBe("high")
+  })
+
+  it("forwards output_config.effort from body (Anthropic-style nesting)", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, output_config: { effort: "xhigh" } })
+    expect(capturedOptions.effort).toBe("xhigh")
+  })
+
+  it("body.effort wins over reasoning_effort", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, effort: "low", reasoning_effort: "max" })
+    expect(capturedOptions.effort).toBe("low")
+  })
+
+  it("drops an invalid reasoning_effort (OpenAI 'minimal') instead of forwarding a value the SDK rejects", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, reasoning_effort: "minimal" })
+    expect(capturedOptions.effort).toBeUndefined()
+  })
 })
 
 // ─── header overrides ─────────────────────────────────────────────────────────

--- a/src/proxy/effort.ts
+++ b/src/proxy/effort.ts
@@ -1,0 +1,27 @@
+/**
+ * Reasoning effort levels and normalization.
+ *
+ * The Claude Code SDK `--effort` flag accepts a fixed vocabulary. Clients send
+ * the effort under several keys (`effort`, `x-opencode-effort`, the standard
+ * OpenAI `reasoning_effort`, or an Anthropic-style `output_config.effort`), and
+ * not every value they send is valid for Claude — OpenAI notably offers
+ * `"minimal"`, which the SDK rejects. normalizeEffort gates the value so an
+ * unknown effort falls back to the model default (undefined) rather than
+ * erroring the whole request at the SDK boundary.
+ *
+ * Pure module — no I/O, no imports from server/session.
+ */
+
+export const VALID_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const
+
+export type Effort = (typeof VALID_EFFORTS)[number]
+
+/**
+ * Return the value if it is a valid Claude effort level, else undefined.
+ * Case-sensitive: the SDK expects lowercase.
+ */
+export function normalizeEffort(value: unknown): Effort | undefined {
+  return typeof value === "string" && (VALID_EFFORTS as readonly string[]).includes(value)
+    ? (value as Effort)
+    : undefined
+}

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -74,6 +74,10 @@ export interface OpenAiChatRequest {
   temperature?: number
   top_p?: number
   tools?: OpenAiChatTool[]
+  /** Standard OpenAI reasoning level (low/medium/high/…). */
+  reasoning_effort?: string
+  /** Anthropic-style nesting some clients use. */
+  output_config?: { effort?: string }
 }
 
 export interface AnthropicTextBlock {
@@ -111,6 +115,10 @@ export interface AnthropicRequestBody {
   temperature?: number
   top_p?: number
   tools?: AnthropicTool[]
+  /** Reasoning effort carried from the OpenAI request so the internal
+   *  /v1/messages hop forwards it to the SDK (value gated by normalizeEffort). */
+  reasoning_effort?: string
+  output_config?: { effort?: string }
 }
 
 export interface AnthropicUsage {
@@ -479,6 +487,12 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
   if (systemPrompt) result.system = systemPrompt
   if (body.temperature !== undefined) result.temperature = body.temperature
   if (body.top_p !== undefined) result.top_p = body.top_p
+  // Carry the reasoning level through so the internal /v1/messages hop can
+  // forward it to the SDK. Without this it's dropped at the endpoint boundary
+  // and OpenAI clients always run at the model default. Validation happens
+  // downstream via normalizeEffort.
+  if (body.reasoning_effort !== undefined) result.reasoning_effort = body.reasoning_effort
+  if (body.output_config?.effort !== undefined) result.output_config = { effort: body.output_config.effort }
 
   return result
 }

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -9,6 +9,7 @@ import { join } from "node:path"
 import type { Options, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
+import type { Effort } from "./effort"
 
 /**
  * Return a copy of `env` with `CLAUDE_CONFIG_DIR` removed. Used by the
@@ -80,8 +81,8 @@ export interface QueryContext {
   allowedMcpTools: readonly string[]
   /** Callback to receive stderr lines from the Claude subprocess */
   onStderr?: (line: string) => void
-  /** Effort level — controls thinking depth (low/medium/high/max) */
-  effort?: 'low' | 'medium' | 'high' | 'max'
+  /** Effort level — controls thinking depth (low/medium/high/xhigh/max) */
+  effort?: Effort
   /** Thinking configuration — adaptive, enabled with budget, or disabled */
   thinking?: { type: 'adaptive' } | { type: 'enabled'; budgetTokens?: number } | { type: 'disabled' }
   /** API-side task budget in tokens — model paces tool use within this limit */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -561,6 +561,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         const effort = effortHeader
           || body.effort
+          || body.reasoning_effort
+          || body.output_config?.effort
           || undefined
         let thinking: QueryContext['thinking'] | undefined = body.thinking || undefined
         if (thinkingHeader !== undefined) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -53,6 +53,7 @@ import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools } from "./me
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
+import { normalizeEffort } from "./effort"
 import { runTransformHook, buildPipeline, createRequestContext } from "./transform"
 import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
@@ -559,11 +560,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           console.error(`[PROXY] ${requestMeta.requestId} stripped anthropic-beta(s) for Max profile: ${betaFilter.stripped.join(", ")}`)
         }
 
-        const effort = effortHeader
+        // Effort can arrive as a header, the Anthropic `effort` field, the
+        // standard OpenAI `reasoning_effort`, or an Anthropic-style
+        // `output_config.effort`. normalizeEffort gates the value to Claude's
+        // vocabulary so an unknown level (e.g. OpenAI's "minimal") falls back to
+        // the model default instead of erroring at the SDK boundary.
+        const effort = normalizeEffort(
+          effortHeader
           || body.effort
           || body.reasoning_effort
           || body.output_config?.effort
-          || undefined
+        )
         let thinking: QueryContext['thinking'] | undefined = body.thinking || undefined
         if (thinkingHeader !== undefined) {
           try {


### PR DESCRIPTION
Builds on **#520** by @Blue-B (their commit is preserved at the base of this branch) and finishes it so it works end-to-end.

## What #520 did
Read the standard OpenAI `reasoning_effort` (and Anthropic-style `output_config.effort`) as effort sources on `/v1/messages`, in addition to `effort` / `x-opencode-effort`. Correct and useful for clients that POST those fields directly.

## The gap it left
OpenAI SDK clients hit **`/v1/chat/completions`**, which translates the body via `translateOpenAiToAnthropic` before re-routing to `/v1/messages`. That function returned only `{model, messages, max_tokens, tools, stream}` (+ system/temperature/top_p) — so `reasoning_effort` was **dropped at the endpoint boundary** and OpenAI SDK clients (the PR's headline use case) saw no effect. Separately, the raw value was forwarded unchecked: OpenAI's `"minimal"` isn't a valid Claude effort, so it would reach the SDK and **error the request** (regression vs. the previous drop-to-default).

## This PR adds
- **`openai.ts`** — carry `reasoning_effort` / `output_config.effort` through the OpenAI→Anthropic translation so the internal hop forwards them. *Now OpenAI SDK clients actually get effort.*
- **`effort.ts`** — new pure leaf module: `normalizeEffort` gates the value to Claude's vocabulary (`low/medium/high/xhigh/max`). Unknown values (e.g. `"minimal"`) fall back to the model default instead of erroring at the SDK.
- **`server.ts`** — route all effort sources through `normalizeEffort`.
- **`query.ts`** — `QueryContext.effort` uses the shared `Effort` type (adds the missing `xhigh`).

## Tests (TDD — red first)
- `effort.test.ts` — `normalizeEffort` vocabulary (valid pass-through, `minimal`/unknown → undefined).
- `proxy-sdk-params.test.ts` — `reasoning_effort` + `output_config.effort` forwarded, `effort` precedence, invalid `minimal` dropped.
- `proxy-openai-compat.test.ts` — `reasoning_effort` carried through `/v1/chat/completions` translation to the SDK options.
- Full suite green; build clean.
- Live smoke (real SDK): `reasoning_effort:"xhigh"` → 200; `reasoning_effort:"minimal"` → 200 (guard prevents the SDK error).

Supersedes #520. Original work by @Blue-B. 🙏

Co-authored-by: Blue-B <source_vs@naver.com>