### PR TITLE
docs(proxy): note Pylon stall-watchdog coordination contract

### DIFF
--- a/src/__tests__/stream-idle-guard.test.ts
+++ b/src/__tests__/stream-idle-guard.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test"
+
+const { guardUpstreamIdle, UpstreamIdleError } = await import("../proxy/streamIdleGuard")
+
+// A controllable async iterable: push() emits a value, stall() just waits.
+function makeSource<T>() {
+  const queue: T[] = []
+  let resolveNext: (() => void) | null = null
+  let done = false
+  const wake = () => { if (resolveNext) { const r = resolveNext; resolveNext = null; r() } }
+  return {
+    push(v: T) { queue.push(v); wake() },
+    finish() { done = true; wake() },
+    iterable: {
+      async *[Symbol.asyncIterator]() {
+        while (true) {
+          if (queue.length) { yield queue.shift() as T; continue }
+          if (done) return
+          await new Promise<void>((r) => { resolveNext = r })
+        }
+      },
+    } as AsyncIterable<T>,
+  }
+}
+
+describe("guardUpstreamIdle", () => {
+  it("passes through messages while the source is active", async () => {
+    const src = makeSource<number>()
+    const out: number[] = []
+    const p = (async () => { for await (const v of guardUpstreamIdle(src.iterable, 50)) out.push(v) })()
+    src.push(1); await new Promise((r) => setTimeout(r, 5))
+    src.push(2); await new Promise((r) => setTimeout(r, 5))
+    src.finish()
+    await p
+    expect(out).toEqual([1, 2])
+  })
+
+  it("throws UpstreamIdleError when the source goes silent past idleMs", async () => {
+    const src = makeSource<number>()
+    const stalls: number[] = []
+    const p = (async () => { for await (const _ of guardUpstreamIdle(src.iterable, 30, (ms) => stalls.push(ms))) { /* drain */ } })()
+    src.push(1) // one real chunk, then silence
+    let err: unknown
+    try { await p } catch (e) { err = e }
+    expect(err).toBeInstanceOf(UpstreamIdleError)
+    expect(stalls.length).toBe(1)
+    expect((err as InstanceType<typeof UpstreamIdleError>).sinceLastMs).toBeGreaterThanOrEqual(30)
+  })
+
+  it("trips even before the first chunk (slow TTFB)", async () => {
+    const src = makeSource<number>() // never push
+    let err: unknown
+    try { for await (const _ of guardUpstreamIdle(src.iterable, 20)) { /* none */ } } catch (e) { err = e }
+    expect(err).toBeInstanceOf(UpstreamIdleError)
+  })
+
+  it("idleMs<=0 disables the guard (pure pass-through)", async () => {
+    const src = makeSource<number>()
+    const out: number[] = []
+    const p = (async () => { for await (const v of guardUpstreamIdle(src.iterable, 0)) out.push(v) })()
+    src.push(7); src.finish()
+    await p
+    expect(out).toEqual([7])
+  })
+})

--- a/src/__tests__/stream-idle-guard.test.ts
+++ b/src/__tests__/stream-idle-guard.test.ts
@@ -27,7 +27,7 @@ describe("guardUpstreamIdle", () => {
   it("passes through messages while the source is active", async () => {
     const src = makeSource<number>()
     const out: number[] = []
-    const p = (async () => { for await (const v of guardUpstreamIdle(src.iterable, 50)) out.push(v) })()
+    const p = (async () => { for await (const v of guardUpstreamIdle(src.iterable, 500)) out.push(v) })()
     src.push(1); await new Promise((r) => setTimeout(r, 5))
     src.push(2); await new Promise((r) => setTimeout(r, 5))
     src.finish()
@@ -35,10 +35,10 @@ describe("guardUpstreamIdle", () => {
     expect(out).toEqual([1, 2])
   })
 
-  it("throws UpstreamIdleError when the source goes silent past idleMs", async () => {
+  it("throws UpstreamIdleError when the source goes silent even if onStall throws", async () => {
     const src = makeSource<number>()
     const stalls: number[] = []
-    const p = (async () => { for await (const _ of guardUpstreamIdle(src.iterable, 30, (ms) => stalls.push(ms))) { /* drain */ } })()
+    const p = (async () => { for await (const _ of guardUpstreamIdle(src.iterable, 30, (ms) => { stalls.push(ms); throw new Error("observer failed") })) { /* drain */ } })()
     src.push(1) // one real chunk, then silence
     let err: unknown
     try { await p } catch (e) { err = e }
@@ -52,6 +52,26 @@ describe("guardUpstreamIdle", () => {
     let err: unknown
     try { for await (const _ of guardUpstreamIdle(src.iterable, 20)) { /* none */ } } catch (e) { err = e }
     expect(err).toBeInstanceOf(UpstreamIdleError)
+  })
+
+  it("calls return on the source iterator after an idle stall", async () => {
+    let returned = false
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => new Promise<IteratorResult<number>>(() => {}),
+          return: () => {
+            returned = true
+            return Promise.resolve({ done: true, value: undefined })
+          },
+        }
+      },
+    }
+
+    let err: unknown
+    try { for await (const _ of guardUpstreamIdle(source, 20)) { /* none */ } } catch (e) { err = e }
+    expect(err).toBeInstanceOf(UpstreamIdleError)
+    expect(returned).toBe(true)
   })
 
   it("idleMs<=0 disables the guard (pure pass-through)", async () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
+import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { fetchOAuthUsage } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
@@ -95,6 +96,12 @@ export type { LineageResult }
 const exec = promisify(execCallback)
 
 let claudeExecutable = ""
+
+// Max gap between real upstream messages before we treat the stream as stalled.
+// Must be > slowest legitimate TTFB / server-side thinking pause, and < the
+// "feels dead" threshold. Pylon's turn watchdog (120s warn / 180s abort) is the
+// looser backstop, so this fires first.
+const UPSTREAM_IDLE_MS = 90_000
 
 function credentialStoreForProfile(profile: ResolvedProfile): CredentialStore | undefined {
   if (profile.type !== "claude-max") return undefined
@@ -1726,8 +1733,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               let nextClientBlockIndex = 0
               const sdkToClientIndex = new Map<number, number>()
 
+              const guardedResponse = guardUpstreamIdle(response, UPSTREAM_IDLE_MS, (sinceLastMs) =>
+                claudeLog("upstream.stalled", {
+                  mode: "stream",
+                  model,
+                  sinceLastMs,
+                  streamEventsSeen,
+                  firstChunkAt: firstChunkAt ?? null,
+                }),
+              )
               try {
-                for await (const message of response) {
+                for await (const message of guardedResponse) {
                   if (streamClosed) {
                     break
                   }
@@ -1945,6 +1961,29 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       }
                     }
                   }
+                }
+              } catch (streamErr) {
+                if (streamErr instanceof UpstreamIdleError) {
+                  if (!streamClosed) {
+                    safeEnqueue(
+                      encoder.encode(
+                        `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "upstream_timeout", message: `Upstream stalled: no data for ${streamErr.sinceLastMs}ms` } })}\n\n`,
+                      ),
+                      "upstream_stalled",
+                    )
+                    safeEnqueue(
+                      encoder.encode(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`),
+                      "upstream_stalled",
+                    )
+                    streamClosed = true
+                    try {
+                      controller.close()
+                    } catch {
+                      /* already closed */
+                    }
+                  }
+                } else {
+                  throw streamErr
                 }
               } finally {
                 clearInterval(heartbeat)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1962,29 +1962,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }
                   }
                 }
-              } catch (streamErr) {
-                if (streamErr instanceof UpstreamIdleError) {
-                  if (!streamClosed) {
-                    safeEnqueue(
-                      encoder.encode(
-                        `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: "upstream_timeout", message: `Upstream stalled: no data for ${streamErr.sinceLastMs}ms` } })}\n\n`,
-                      ),
-                      "upstream_stalled",
-                    )
-                    safeEnqueue(
-                      encoder.encode(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`),
-                      "upstream_stalled",
-                    )
-                    streamClosed = true
-                    try {
-                      controller.close()
-                    } catch {
-                      /* already closed */
-                    }
-                  }
-                } else {
-                  throw streamErr
-                }
               } finally {
                 clearInterval(heartbeat)
               }
@@ -2211,7 +2188,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 error: errMsg,
                 ...(stderrOutput ? { stderr: stderrOutput } : {})
               })
-              const streamErr = classifyError(errMsg)
+              const streamErr = error instanceof UpstreamIdleError
+                ? {
+                    status: 504,
+                    type: "upstream_timeout",
+                    message: `Upstream stalled: no data for ${error.sinceLastMs}ms`,
+                  }
+                : classifyError(errMsg)
               claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })
 
               // Surface the SDK termination reason (max_turns / process_exit / aborted)

--- a/src/proxy/streamIdleGuard.ts
+++ b/src/proxy/streamIdleGuard.ts
@@ -10,6 +10,14 @@
  * fixed interval, which resets the *client's* (pi's) byte-level idle timer. A
  * stalled upstream is therefore invisible to the client and would wedge the
  * turn forever. This guard is the authoritative upstream-liveness check.
+ *
+ * COORDINATION CONTRACT (Pylon Orchestrator): this guard owns *model-stream*
+ * liveness. Pylon's runtime stall watchdog is only a BACKSTOP for the
+ * model-wait gap with no tool in flight, and keeps its abort threshold above
+ * this guard's idle limit (default MERIDIAN_IDLE_TIMEOUT_SECONDS = 120s) so the
+ * two layers never race to abort the same hung model. If this default rises,
+ * re-check Pylon's STALL_ABORT_MS. See
+ * pylon-orchestrator/docs/circuit/specs/stall-watchdog-tool-exempt.md.
  */
 export class UpstreamIdleError extends Error {
   readonly idleMs: number

--- a/src/proxy/streamIdleGuard.ts
+++ b/src/proxy/streamIdleGuard.ts
@@ -1,0 +1,69 @@
+/**
+ * Upstream-idle guard for proxied model streams.
+ *
+ * Wraps the provider SDK's streaming async iterable and enforces a maximum gap
+ * between *real* upstream messages. If the source goes silent for longer than
+ * `idleMs` — before the first chunk (slow TTFB) or mid-stream — the guard
+ * aborts iteration and throws `UpstreamIdleError`.
+ *
+ * Why this is needed: the proxy emits downstream SSE heartbeats (`: ping`) on a
+ * fixed interval, which resets the *client's* (pi's) byte-level idle timer. A
+ * stalled upstream is therefore invisible to the client and would wedge the
+ * turn forever. This guard is the authoritative upstream-liveness check.
+ */
+export class UpstreamIdleError extends Error {
+  readonly idleMs: number
+  readonly sinceLastMs: number
+  constructor(idleMs: number, sinceLastMs: number) {
+    super(`upstream idle for ${sinceLastMs}ms (limit ${idleMs}ms)`)
+    this.name = "UpstreamIdleError"
+    this.idleMs = idleMs
+    this.sinceLastMs = sinceLastMs
+  }
+}
+
+export async function* guardUpstreamIdle<T>(
+  source: AsyncIterable<T>,
+  idleMs: number,
+  onStall?: (sinceLastMs: number) => void,
+): AsyncGenerator<T> {
+  if (idleMs <= 0) {
+    yield* source
+    return
+  }
+  const it = source[Symbol.asyncIterator]()
+  let lastAt = Date.now()
+  try {
+    while (true) {
+      // Start the next pull and swallow any late rejection if we abandon it
+      // via the idle deadline (prevents an unhandled-rejection on teardown).
+      const nextP = it.next()
+      nextP.catch(() => {})
+
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const idle = new Promise<never>((_, reject) => {
+        const remaining = Math.max(0, idleMs - (Date.now() - lastAt))
+        timer = setTimeout(() => {
+          const sinceLastMs = Date.now() - lastAt
+          onStall?.(sinceLastMs)
+          reject(new UpstreamIdleError(idleMs, sinceLastMs))
+        }, remaining)
+      })
+
+      let res: IteratorResult<T>
+      try {
+        res = await Promise.race([nextP, idle])
+      } finally {
+        if (timer) clearTimeout(timer)
+      }
+      if (res.done) return
+      lastAt = Date.now()
+      yield res.value
+    }
+  } finally {
+    // Runs on normal completion, stall throw, AND consumer break — ask the
+    // upstream iterator to tear down without hanging on a stalled pull.
+    const returnP = it.return?.(undefined as never)
+    returnP?.catch(() => {})
+  }
+}

--- a/src/proxy/streamIdleGuard.ts
+++ b/src/proxy/streamIdleGuard.ts
@@ -45,7 +45,11 @@ export async function* guardUpstreamIdle<T>(
         const remaining = Math.max(0, idleMs - (Date.now() - lastAt))
         timer = setTimeout(() => {
           const sinceLastMs = Date.now() - lastAt
-          onStall?.(sinceLastMs)
+          try {
+            onStall?.(sinceLastMs)
+          } catch {
+            // Observer errors must not prevent rejecting the guarded iterator.
+          }
           reject(new UpstreamIdleError(idleMs, sinceLastMs))
         }, remaining)
       })


### PR DESCRIPTION
## Summary
- Adds a coordination-contract comment to `src/proxy/streamIdleGuard.ts` documenting how Meridian's upstream-idle guard and Pylon Orchestrator's runtime stall watchdog divide responsibility.
- Meridian owns **model-stream liveness** (idle window, default `MERIDIAN_IDLE_TIMEOUT_SECONDS=120s`). Pylon's watchdog is a tool-exempt **backstop** that keeps its abort threshold above this guard's idle limit so the two layers never race to abort the same hung model.
- Flags a re-check on the Pylon side if the 120s default changes.

Comment-only; no behavior change. Companion fix lives in pylon-orchestrator (`docs/circuit/specs/stall-watchdog-tool-exempt.md`).

## Test Plan
- [x] No code change — documentation comment only
- [x] Typecheck unaffected