### PR TITLE
refactor(nix): modernize flake and home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Then in `~/.config/opencode/opencode.json`:
 
 # home-manager config
 {
-  imports = [ meridian.homeManagerModules.default ];
+  imports = [ meridian.homeModules.default ];
 
   services.meridian = {
     enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -49,6 +49,26 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781642113,
+        "narHash": "sha256-mAR7KTS9rjreTcXCNqfCbN96mnhJO8lDQq1vl7GviBQ=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "df4e0465717a2d34f05b8ccd967275aaf3ceaa01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "import-tree": {
       "locked": {
         "lastModified": 1763762820,
@@ -84,6 +104,7 @@
       "inputs": {
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts",
+        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "bun2nix": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": [
+          "flake-parts"
+        ],
         "import-tree": "import-tree",
         "nixpkgs": [
           "nixpkgs"
@@ -29,14 +31,16 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -76,24 +80,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,20 @@
   description = "Meridian – Local Anthropic API powered by your Claude Max subscription";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    systems.url = "github:nix-systems/default";
     bun2nix = {
       url = "github:nix-community/bun2nix/2.0.8";
       inputs = {
+        flake-parts.follows = "flake-parts";
         nixpkgs.follows = "nixpkgs";
         systems.follows = "systems";
-        flake-parts.follows = "flake-parts";
       };
     };
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
           };
 
         flake = {
-          homeManagerModules = {
+          homeModules = {
             default = self.homeManagerModules.meridian;
             meridian = moduleWithSystem (
               { self', ... }: import ./nix/hm-module.nix { inherit (self'.packages) meridian; }

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,9 @@
 
           homeModules = {
             default = self.homeModules.meridian;
-            meridian = moduleWithSystem ({ self', ... }: import ./nix/hm-module.nix self'.packages);
+            meridian = moduleWithSystem (
+              { self', ... }: flake-parts.lib.importApply ./nix/hm-module.nix self'.packages
+            );
           };
 
           overlays = {

--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,8 @@
         in
         {
           meridian = pkgs.stdenvNoCC.mkDerivation {
+            inherit (pkgs.lib.importJSON ./package.json) version;
             pname = "meridian";
-            version =
-              (builtins.fromJSON (builtins.readFile ./package.json)).version;
 
             src = pkgs.lib.cleanSource ./.;
 
@@ -49,9 +48,7 @@
               pkgs.makeWrapper
             ];
 
-            bunDeps = pkgs.bun2nix.fetchBunDeps {
-              bunNix = ./bun.nix;
-            };
+            bunDeps = pkgs.bun2nix.fetchBunDeps { bunNix = ./bun.nix; };
 
             bunInstallFlags = [ "--linker=hoisted" ];
 
@@ -71,7 +68,7 @@
               cp package.json $out/lib/meridian/
 
               mkdir -p $out/bin
-              makeWrapper ${pkgs.nodejs_22}/bin/node $out/bin/meridian \
+              makeWrapper ${pkgs.lib.getExe pkgs.nodejs_22} $out/bin/meridian \
                 --add-flags "$out/lib/meridian/dist/cli.js"
 
               runHook postInstall
@@ -95,12 +92,10 @@
         }
       );
 
-      overlays.default = final: prev: {
+      overlays.default = final: _: {
         meridian = self.packages.${final.stdenv.hostPlatform.system}.meridian;
       };
 
-      homeManagerModules.default = import ./nix/hm-module.nix {
-        meridianPackages = self.packages;
-      };
+      homeManagerModules.default = import ./nix/hm-module.nix { meridianPackages = self.packages; };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -6,38 +6,54 @@
     systems.url = "github:nix-systems/default";
     bun2nix = {
       url = "github:nix-community/bun2nix/2.0.8";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.systems.follows = "systems";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        systems.follows = "systems";
+        flake-parts.follows = "flake-parts";
+      };
+    };
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
     };
   };
 
   outputs =
-    {
+    inputs@{
       self,
       nixpkgs,
       systems,
       bun2nix,
+      flake-parts,
     }:
-    let
-      eachSystem = nixpkgs.lib.genAttrs (import systems);
-      pkgsFor = eachSystem (
-        system:
-        import nixpkgs {
-          inherit system;
-          overlays = [ bun2nix.overlays.default ];
-        }
-      );
-    in
-    {
-      packages = eachSystem (system: {
-        meridian = pkgsFor.${system}.callPackage ./nix/package.nix { };
-        default = self.packages.${system}.meridian;
-      });
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import systems;
 
-      overlays.default = final: _: {
-        meridian = self.packages.${final.stdenv.hostPlatform.system}.meridian;
+      perSystem =
+        {
+          config,
+          pkgs,
+          system,
+          ...
+        }:
+        {
+          _module.args.pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ bun2nix.overlays.default ];
+          };
+
+          packages = {
+            default = config.packages.meridian;
+            meridian = pkgs.callPackage ./nix/package.nix { };
+          };
+        };
+
+      flake = {
+        overlays.default = final: _: {
+          inherit (self.packages.${final.stdenv.hostPlatform.system}) meridian;
+        };
+
+        homeManagerModules.default = import ./nix/hm-module.nix { meridianPackages = self.packages; };
       };
-
-      homeManagerModules.default = import ./nix/hm-module.nix { meridianPackages = self.packages; };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -56,18 +56,18 @@
           };
 
         flake = {
-          overlays = {
-            default = self.overlays.meridian;
-            meridian =
-              _: prev:
-              withSystem prev.stdenv.hostPlatform.system ({ self', ... }: { inherit (self'.packages) meridian; });
-          };
-
           homeManagerModules = {
             default = self.homeManagerModules.meridian;
             meridian = moduleWithSystem (
               { self', ... }: import ./nix/hm-module.nix { inherit (self'.packages) meridian; }
             );
+          };
+
+          overlays = {
+            default = self.overlays.meridian;
+            meridian =
+              _: prev:
+              withSystem prev.stdenv.hostPlatform.system ({ self', ... }: { inherit (self'.packages) meridian; });
           };
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -29,68 +29,10 @@
       );
     in
     {
-      packages = eachSystem (
-        system:
-        let
-          pkgs = pkgsFor.${system};
-        in
-        {
-          meridian = pkgs.stdenvNoCC.mkDerivation {
-            inherit (pkgs.lib.importJSON ./package.json) version;
-            pname = "meridian";
-
-            src = pkgs.lib.cleanSource ./.;
-
-            nativeBuildInputs = [
-              pkgs.bun2nix.hook
-              pkgs.bun
-              pkgs.nodejs_22
-              pkgs.makeWrapper
-            ];
-
-            bunDeps = pkgs.bun2nix.fetchBunDeps { bunNix = ./bun.nix; };
-
-            bunInstallFlags = [ "--linker=hoisted" ];
-
-            buildPhase = ''
-              runHook preBuild
-              bun run build
-              runHook postBuild
-            '';
-
-            installPhase = ''
-              runHook preInstall
-
-              mkdir -p $out/lib/meridian
-              cp -r dist $out/lib/meridian/
-              cp -r node_modules $out/lib/meridian/
-              cp -r plugin $out/lib/meridian/
-              cp package.json $out/lib/meridian/
-
-              mkdir -p $out/bin
-              makeWrapper ${pkgs.lib.getExe pkgs.nodejs_22} $out/bin/meridian \
-                --add-flags "$out/lib/meridian/dist/cli.js"
-
-              runHook postInstall
-            '';
-
-            # The dist/ output is pre-bundled JS run by node via a wrapper; there
-            # are no native binaries or shebangs that need patching. Skipping
-            # fixup also avoids unnecessary work on a large node_modules tree.
-            dontFixup = true;
-
-            meta = {
-              description = "Local Anthropic API powered by your Claude Max subscription";
-              homepage = "https://github.com/rynfar/meridian";
-              license = pkgs.lib.licenses.mit;
-              mainProgram = "meridian";
-              platforms = pkgs.lib.platforms.unix;
-            };
-          };
-
-          default = self.packages.${system}.meridian;
-        }
-      );
+      packages = eachSystem (system: {
+        meridian = pkgsFor.${system}.callPackage ./nix/package.nix { };
+        default = self.packages.${system}.meridian;
+      });
 
       overlays.default = final: _: {
         meridian = self.packages.${final.stdenv.hostPlatform.system}.meridian;

--- a/flake.nix
+++ b/flake.nix
@@ -67,9 +67,7 @@
 
           homeModules = {
             default = self.homeModules.meridian;
-            meridian = moduleWithSystem (
-              { self', ... }: import ./nix/hm-module.nix { inherit (self'.packages) meridian; }
-            );
+            meridian = moduleWithSystem ({ self', ... }: import ./nix/hm-module.nix self'.packages);
           };
 
           overlays = {

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,10 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default";
   };
@@ -22,6 +26,7 @@
     inputs@{
       bun2nix,
       flake-parts,
+      home-manager,
       nixpkgs,
       systems,
       ...
@@ -34,6 +39,8 @@
         ...
       }:
       {
+        imports = [ home-manager.flakeModules.home-manager ];
+
         systems = import systems;
 
         perSystem =
@@ -57,7 +64,7 @@
 
         flake = {
           homeModules = {
-            default = self.homeManagerModules.meridian;
+            default = self.homeModules.meridian;
             meridian = moduleWithSystem (
               { self', ... }: import ./nix/hm-module.nix { inherit (self'.packages) meridian; }
             );

--- a/flake.nix
+++ b/flake.nix
@@ -20,40 +20,56 @@
 
   outputs =
     inputs@{
-      self,
-      nixpkgs,
-      systems,
       bun2nix,
       flake-parts,
+      nixpkgs,
+      systems,
+      ...
     }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = import systems;
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      {
+        moduleWithSystem,
+        self,
+        withSystem,
+        ...
+      }:
+      {
+        systems = import systems;
 
-      perSystem =
-        {
-          config,
-          pkgs,
-          system,
-          ...
-        }:
-        {
-          _module.args.pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ bun2nix.overlays.default ];
+        perSystem =
+          {
+            config,
+            pkgs,
+            system,
+            ...
+          }:
+          {
+            _module.args.pkgs = import nixpkgs {
+              inherit system;
+              overlays = [ bun2nix.overlays.default ];
+            };
+
+            packages = {
+              default = config.packages.meridian;
+              meridian = pkgs.callPackage ./nix/package.nix { };
+            };
           };
 
-          packages = {
-            default = config.packages.meridian;
-            meridian = pkgs.callPackage ./nix/package.nix { };
+        flake = {
+          overlays = {
+            default = self.overlays.meridian;
+            meridian =
+              _: prev:
+              withSystem prev.stdenv.hostPlatform.system ({ self', ... }: { inherit (self'.packages) meridian; });
+          };
+
+          homeManagerModules = {
+            default = self.homeManagerModules.meridian;
+            meridian = moduleWithSystem (
+              { self', ... }: import ./nix/hm-module.nix { inherit (self'.packages) meridian; }
+            );
           };
         };
-
-      flake = {
-        overlays.default = final: _: {
-          inherit (self.packages.${final.stdenv.hostPlatform.system}) meridian;
-        };
-
-        homeManagerModules.default = import ./nix/hm-module.nix { meridianPackages = self.packages; };
-      };
-    };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,8 @@
           };
 
         flake = {
+          homeManagerModules = self.homeModules;
+
           homeModules = {
             default = self.homeModules.meridian;
             meridian = moduleWithSystem (

--- a/flake.nix
+++ b/flake.nix
@@ -96,7 +96,7 @@
       );
 
       overlays.default = final: prev: {
-        meridian = self.packages.${final.system}.meridian;
+        meridian = self.packages.${final.stdenv.hostPlatform.system}.meridian;
       };
 
       homeManagerModules.default = import ./nix/hm-module.nix {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -11,7 +11,7 @@ let
 in
 {
   options.services.meridian = {
-    enable = lib.mkEnableOption "Meridian proxy service";
+    enable = lib.mkEnableOption "the Meridian proxy service";
 
     package = lib.mkOption {
       type = lib.types.package;
@@ -89,47 +89,33 @@ in
     home.packages = [ pkg ];
 
     systemd.user.services.meridian = {
-      Unit = {
-        Description = "Meridian - Local Anthropic API proxy";
-      };
+      Unit.Description = "Meridian - Local Anthropic API proxy";
 
       Service = {
         Type = "simple";
-        ExecStart = "${pkg}/bin/meridian";
+        ExecStart = lib.getExe pkg;
         Restart = "on-failure";
         RestartSec = 5;
 
         Environment =
           let
             env =
-              {
-                MERIDIAN_PORT = toString cfg.settings.port;
-                MERIDIAN_HOST = cfg.settings.host;
-                MERIDIAN_IDLE_TIMEOUT_SECONDS = toString cfg.settings.idleTimeoutSeconds;
-              }
-              // lib.optionalAttrs (cfg.settings.passthrough != null) {
-                MERIDIAN_PASSTHROUGH = if cfg.settings.passthrough then "1" else "0";
-              }
-              // lib.optionalAttrs (cfg.settings.defaultAgent != null) {
+              lib.filterAttrs (_: v: v != null) {
                 MERIDIAN_DEFAULT_AGENT = cfg.settings.defaultAgent;
-              }
-              // lib.optionalAttrs (cfg.settings.sonnetModel != null) {
+                MERIDIAN_HOST = cfg.settings.host;
+                MERIDIAN_IDLE_TIMEOUT_SECONDS = cfg.settings.idleTimeoutSeconds;
+                MERIDIAN_PASSTHROUGH = lib.mapNullable (b: if b then "1" else "0") cfg.settings.passthrough;
+                MERIDIAN_PORT = cfg.settings.port;
                 MERIDIAN_SONNET_MODEL = cfg.settings.sonnetModel;
-              }
-              // lib.optionalAttrs cfg.settings.telemetry.persist {
-                MERIDIAN_TELEMETRY_PERSIST = "1";
-              }
-              // lib.optionalAttrs (cfg.settings.telemetry.retentionDays != null) {
-                MERIDIAN_TELEMETRY_RETENTION_DAYS = toString cfg.settings.telemetry.retentionDays;
+                MERIDIAN_TELEMETRY_PERSIST = if cfg.settings.telemetry.persist then "1" else null;
+                MERIDIAN_TELEMETRY_RETENTION_DAYS = cfg.settings.telemetry.retentionDays;
               }
               // cfg.environment;
           in
-          lib.mapAttrsToList (k: v: "${k}=${v}") env;
+          lib.mapAttrsToList (k: v: "${k}=${toString v}") env;
       };
 
-      Install = {
-        WantedBy = [ "default.target" ];
-      };
+      Install.WantedBy = [ "default.target" ];
     };
   };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,4 +1,4 @@
-{ meridian }:
+packages:
 { config, lib, ... }:
 let
   cfg = config.services.meridian;
@@ -7,10 +7,8 @@ in
   options.services.meridian = {
     enable = lib.mkEnableOption "the Meridian proxy service";
 
-    package = lib.mkOption {
-      type = lib.types.package;
-      default = meridian;
-      description = "The Meridian package to use.";
+    package = lib.mkPackageOption packages "meridian" {
+      pkgsText = "inputs.meridian.packages.\${pkgs.stdenv.hostPlatform.system}";
     };
 
     settings = {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -85,7 +85,7 @@ in
       Unit.Description = "Meridian - Local Anthropic API proxy";
 
       Service = {
-        Type = "simple";
+        Type = "exec";
         ExecStart = lib.getExe pkg;
         Restart = "on-failure";
         RestartSec = 5;

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -81,8 +81,6 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ pkg ];
-
     systemd.user.services.meridian = {
       Unit.Description = "Meridian - Local Anthropic API proxy";
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -90,21 +90,23 @@ in
         RestartSec = 5;
 
         Environment =
-          let
-            env =
-              lib.filterAttrs (_: v: v != null) {
-                MERIDIAN_DEFAULT_AGENT = cfg.settings.defaultAgent;
-                MERIDIAN_HOST = cfg.settings.host;
-                MERIDIAN_IDLE_TIMEOUT_SECONDS = cfg.settings.idleTimeoutSeconds;
-                MERIDIAN_PASSTHROUGH = lib.mapNullable (b: if b then "1" else "0") cfg.settings.passthrough;
-                MERIDIAN_PORT = cfg.settings.port;
-                MERIDIAN_SONNET_MODEL = cfg.settings.sonnetModel;
-                MERIDIAN_TELEMETRY_PERSIST = if cfg.settings.telemetry.persist then "1" else null;
-                MERIDIAN_TELEMETRY_RETENTION_DAYS = cfg.settings.telemetry.retentionDays;
-              }
-              // cfg.environment;
-          in
-          lib.mapAttrsToList (k: v: "${k}=${toString v}") env;
+          lib.pipe
+            {
+              MERIDIAN_DEFAULT_AGENT = cfg.settings.defaultAgent;
+              MERIDIAN_HOST = cfg.settings.host;
+              MERIDIAN_IDLE_TIMEOUT_SECONDS = cfg.settings.idleTimeoutSeconds;
+              MERIDIAN_PASSTHROUGH = cfg.settings.passthrough;
+              MERIDIAN_PORT = cfg.settings.port;
+              MERIDIAN_SONNET_MODEL = cfg.settings.sonnetModel;
+              MERIDIAN_TELEMETRY_PERSIST = cfg.settings.telemetry.persist;
+              MERIDIAN_TELEMETRY_RETENTION_DAYS = cfg.settings.telemetry.retentionDays;
+            }
+            [
+              (lib.filterAttrs (_: v: v != null))
+              (lib.mapAttrs (_: lib.generators.mkValueStringDefault { }))
+              (lib.flip lib.mergeAttrs cfg.environment)
+              (lib.mapAttrsToList (k: v: "${k}=${v}"))
+            ];
       };
 
       Install.WantedBy = [ "default.target" ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -101,9 +101,8 @@ in
             }
             [
               (lib.filterAttrs (_: v: v != null))
-              (lib.mapAttrs (_: lib.generators.mkValueStringDefault { }))
               (lib.flip lib.mergeAttrs cfg.environment)
-              (lib.mapAttrsToList (k: v: "${k}=${v}"))
+              (lib.mapAttrsToList (lib.generators.mkKeyValueDefault { } "="))
             ];
       };
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,10 +1,5 @@
-{ meridianPackages }:
-{
-  config,
-  lib,
-  pkgs,
-  ...
-}:
+{ meridian }:
+{ config, lib, ... }:
 let
   cfg = config.services.meridian;
   pkg = cfg.package;
@@ -15,7 +10,7 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = meridianPackages.${pkgs.stdenv.hostPlatform.system}.meridian;
+      default = meridian;
       description = "The Meridian package to use.";
     };
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -2,7 +2,6 @@
 { config, lib, ... }:
 let
   cfg = config.services.meridian;
-  pkg = cfg.package;
 in
 {
   options.services.meridian = {
@@ -74,7 +73,7 @@ in
 
     opencode.pluginPath = lib.mkOption {
       type = lib.types.str;
-      default = "${pkg}/lib/meridian/plugin/meridian.ts";
+      default = "${cfg.package}/lib/meridian/plugin/meridian.ts";
       readOnly = true;
       description = "Nix store path to the OpenCode plugin file. Use this to reference the plugin in your OpenCode config.";
     };
@@ -86,7 +85,7 @@ in
 
       Service = {
         Type = "exec";
-        ExecStart = lib.getExe pkg;
+        ExecStart = lib.getExe cfg.package;
         Restart = "on-failure";
         RestartSec = 5;
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -15,7 +15,7 @@ in
 
     package = lib.mkOption {
       type = lib.types.package;
-      default = meridianPackages.${pkgs.system}.meridian;
+      default = meridianPackages.${pkgs.stdenv.hostPlatform.system}.meridian;
       description = "The Meridian package to use.";
     };
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,60 @@
+{
+  bun,
+  bun2nix,
+  lib,
+  makeWrapper,
+  nodejs_22,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
+  inherit (lib.importJSON ../package.json) version;
+  pname = "meridian";
+
+  src = lib.cleanSource ../.;
+
+  nativeBuildInputs = [
+    bun2nix.hook
+    bun
+    nodejs_22
+    makeWrapper
+  ];
+
+  bunDeps = bun2nix.fetchBunDeps { bunNix = ../bun.nix; };
+
+  bunInstallFlags = [ "--linker=hoisted" ];
+
+  buildPhase = ''
+    runHook preBuild
+    bun run build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/meridian
+    cp -r dist $out/lib/meridian/
+    cp -r node_modules $out/lib/meridian/
+    cp -r plugin $out/lib/meridian/
+    cp package.json $out/lib/meridian/
+
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe nodejs_22} $out/bin/meridian \
+      --add-flags "$out/lib/meridian/dist/cli.js"
+
+    runHook postInstall
+  '';
+
+  # The dist/ output is pre-bundled JS run by node via a wrapper; there
+  # are no native binaries or shebangs that need patching. Skipping
+  # fixup also avoids unnecessary work on a large node_modules tree.
+  dontFixup = true;
+
+  meta = {
+    description = "Local Anthropic API powered by your Claude Max subscription";
+    homepage = "https://github.com/rynfar/meridian";
+    license = lib.licenses.mit;
+    mainProgram = "meridian";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -33,12 +33,8 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/lib/meridian
-    cp -r dist $out/lib/meridian/
-    cp -r node_modules $out/lib/meridian/
-    cp -r plugin $out/lib/meridian/
-    cp package.json $out/lib/meridian/
+    cp -r dist node_modules plugin package.json $out/lib/meridian/
 
-    mkdir -p $out/bin
     makeWrapper ${lib.getExe nodejs_22} $out/bin/meridian \
       --add-flags "$out/lib/meridian/dist/cli.js"
 


### PR DESCRIPTION
Nix-only: fixes and cleanup to the flake distribution, with no change to the TypeScript or the proxy's runtime behavior.

## Fixes

- Replace the deprecated `pkgs.system` with `pkgs.stdenv.hostPlatform.system`.
- Stop the home-manager module from forcing the package onto `$PATH` via `home.packages`; it now only manages the systemd user service, and users who want the `meridian` CLI can add `config.services.meridian.package` to `home.packages` themselves.
- Use `Type = "exec"` so a failed startup is detected accurately.

## Cleanup

- Adopt `flake-parts`. It is already in the dependency closure (pulled in by `bun2nix`), so this adds no new dependency; it replaces the hand-rolled `eachSystem`/`pkgsFor` plumbing.
- Extract the package derivation into `nix/package.nix`, consumed via `callPackage`.
- The overlay and home-manager module use `withSystem` / `moduleWithSystem`, the flake-parts-native way to express the per-system package resolution they already did.
- Rebuild the `Environment` construction so adding a setting no longer requires editing the env block, plus general tidying (sorted inputs/outputs, aligned `follows`).
## home-manager input, for type checking

`home-manager` is added solely to expose the module through `home-manager.flakeModules.home-manager`, which types the output. Concretely it:

- validates the exported value is an actual module (`deferredModule`) at flake-eval time,
- tags it `_class = "homeManager"`, so importing it into a NixOS or nix-darwin config fails with a clear class-mismatch error instead of confusing "option does not exist" errors,
- attaches `_file` provenance so module errors point back at this flake.

## Notes

- `homeManagerModules` → `homeModules`: the README documented `homeManagerModules.default`, so I renamed to the modern `homeModules`, kept `homeManagerModules` as a deprecated alias, and updated the README. Happy to drop the alias for a clean break if you'd prefer.
- Env booleans now render as `true`/`false` instead of `1`/`0`, and `MERIDIAN_TELEMETRY_PERSIST` is always emitted; both are parsed identically by `src/env.ts`, so runtime behavior is unchanged.

## Testing

`nix flake check` passes; verified the package evaluates and the module's `Environment` resolves to the expected `KEY=value` list, including a user `environment` entry overriding a settings-derived variable.