### PR TITLE
Allow to disable 1M context models automatic selection

### DIFF
--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -85,6 +85,7 @@ let cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null = null
  * Older models (4.5 and earlier) do not.
  */
 function supports1mContext(model: string): boolean {
+  if (process.env.MERIDIAN_1M_CONTEXT_SUPPORT === '0') return false
   // Explicit older versions (4-5, 4.5, etc.) do not support 1M
   if (model.includes("4-5") || model.includes("4.5")) return false
   // Everything else (bare names, 4-6, unknown) defaults to latest (1M capable)


### PR DESCRIPTION
Since 1M context window is no-longer draining from the Max/Pro token budget, we shouldn't force the selection of the 1M context window model variants.

This PR is a quick fix to just entirely disable the 1M automatic selection.

A proper fix could be done later to add both 1M and 200k models to the advertised model list.

Related to #541 