### PR TITLE
fix: implement passthrough for the pi adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The system prompt controls are independent — any combination works:
 
 The core question is **who executes the tools** — the SDK or the client?
 
-- **Passthrough mode** (default for OpenCode) — Claude generates tool calls, but Meridian captures them and sends them back to the client for execution. The client runs the tool using its own implementation, with its own sandboxing, file tracking, and UI, then sends the result in the next request. This is how OpenCode, oh-my-opencagent (OMO), and most coding agents work — they have their own read/write/bash tools and need to stay in control of what runs on the user's machine.
+- **Passthrough mode** (default for OpenCode and Pi) — Claude generates tool calls, but Meridian captures them and sends them back to the client for execution. The client runs the tool using its own implementation, with its own sandboxing, file tracking, and UI, then sends the result in the next request. This is how OpenCode, oh-my-opencagent (OMO), and most coding agents work — they have their own read/write/bash tools and need to stay in control of what runs on the user's machine.
 - **Internal mode** — Claude Code handles everything. The SDK executes tools directly on the host, runs its full agent loop, and returns the final result. This is for clients that are purely chat interfaces (Open WebUI, simple API consumers) with no tool execution of their own.
 
 Most users don't need to configure anything — the adapter sets the right mode automatically. To override:
@@ -526,6 +526,8 @@ Pi uses the `@mariozechner/pi-ai` library which supports a configurable `baseUrl
 
 Pi mimics Claude Code's User-Agent, so automatic detection isn't possible. The `x-meridian-agent: pi` header in the config above tells Meridian to use the Pi adapter. Alternatively, if Pi is your only agent, you can set `MERIDIAN_DEFAULT_AGENT=pi` as an env var instead.
 
+Pi runs in passthrough mode by default — it executes its own tools and Meridian just forwards the `tool_use` blocks. Opt out with `MERIDIAN_PASSTHROUGH=0`.
+
 ### Claude Code
 
 Claude Code can point at Meridian like any other Anthropic API client. The
@@ -573,7 +575,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 | [Cline](https://github.com/cline/cline) | ✅ Verified | Config (see above) — full tool support, file read/write/edit, bash, session resume |
 | [Aider](https://github.com/paul-gauthier/aider) | ✅ Verified | Env vars — file editing, streaming; `--no-stream` broken (litellm bug) |
 | [Open WebUI](https://github.com/open-webui/open-webui) | ✅ Verified | OpenAI-compatible endpoints — set base URL to `http://127.0.0.1:3456` |
-| [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see above) — requires `MERIDIAN_DEFAULT_AGENT=pi` |
+| [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see above) — full tool support via passthrough; detected via `x-meridian-agent: pi` header |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Verified | `ANTHROPIC_BASE_URL` — remote clients share a Max subscription over the network; client CWD preserved in system prompt |
 | [Continue](https://github.com/continuedev/continue) | 🔲 Untested | OpenAI-compatible endpoints should work — set `apiBase` to `http://127.0.0.1:3456` |
 

--- a/src/__tests__/pi-adapter.test.ts
+++ b/src/__tests__/pi-adapter.test.ts
@@ -240,8 +240,24 @@ describe("piAdapter.buildSystemContextAddendum", () => {
 })
 
 describe("piAdapter.usesPassthrough", () => {
-  it("is not defined — defers to CLAUDE_PROXY_PASSTHROUGH env var", () => {
-    expect(piAdapter.usesPassthrough).toBeUndefined()
+  it("defaults to passthrough mode and honors the disable flags", () => {
+    const original = process.env.MERIDIAN_PASSTHROUGH
+    try {
+      delete process.env.MERIDIAN_PASSTHROUGH
+      expect(piAdapter.usesPassthrough!()).toBe(true)
+
+      process.env.MERIDIAN_PASSTHROUGH = "0"
+      expect(piAdapter.usesPassthrough!()).toBe(false)
+
+      process.env.MERIDIAN_PASSTHROUGH = "false"
+      expect(piAdapter.usesPassthrough!()).toBe(false)
+    } finally {
+      if (original === undefined) {
+        delete process.env.MERIDIAN_PASSTHROUGH
+      } else {
+        process.env.MERIDIAN_PASSTHROUGH = original
+      }
+    }
   })
 })
 

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -158,6 +158,11 @@ describe("Pi transform parity", () => {
     expect(ctx.extractFileChangesFromToolUse!("write", { filePath: "/a.ts" }))
       .toEqual(piAdapter.extractFileChangesFromToolUse!("write", { filePath: "/a.ts" }))
   })
+
+  it("matches passthrough resolution", () => {
+    const ctx = runTransformHook(piTransforms, "onRequest", makeCtx("pi"), "pi")
+    expect(ctx.passthrough).toBe(piAdapter.usesPassthrough!())
+  })
 })
 
 describe("ForgeCode transform parity", () => {

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -156,10 +156,22 @@ export const piAdapter: AgentAdapter = {
    * tool_result cycle). Passthrough mode is appropriate: the proxy returns
    * tool_use blocks to pi, which executes them and sends back tool_results.
    *
-   * Like Crush, defer to CLAUDE_PROXY_PASSTHROUGH env var so the same
-   * global setting controls both agents.
+   * Pi owns its tool execution loop, so passthrough is the correct default:
+   * the proxy returns tool_use blocks to pi and pi executes them. Without it,
+   * pi falls back to internal mode and only the hardcoded MCP tool set
+   * (read/write/edit/bash/glob/grep) is exposed — pi's own tools such as
+   * web_search/web_fetch/batch_web_fetch are silently dropped.
+   *
+   * Mirrors the claudecode/opencode adapters: default ON, opt out via
+   * MERIDIAN_PASSTHROUGH=0 (or CLAUDE_PROXY_PASSTHROUGH=0).
    */
-  // usesPassthrough not defined — defers to CLAUDE_PROXY_PASSTHROUGH env var
+  usesPassthrough(): boolean {
+    const envVal = process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH
+    if (envVal === "0" || envVal === "false" || envVal === "no") {
+      return false
+    }
+    return true
+  },
 
   /**
    * Pi uses lowercase tool names: read, write, edit, bash.

--- a/src/proxy/transforms/pi.ts
+++ b/src/proxy/transforms/pi.ts
@@ -12,6 +12,19 @@ const PI_ALLOWED_MCP_TOOLS: readonly string[] = [
   `mcp__${PI_MCP_SERVER_NAME}__grep`,
 ]
 
+/**
+ * Resolve passthrough mode for Pi from env. Mirrors the adapter's
+ * `usesPassthrough()` so the transform and adapter agree (transform-parity
+ * test enforces this). Default is ON — pi owns its tool execution loop, so
+ * tool_use blocks must flow back to pi. In internal mode only the hardcoded
+ * MCP tool set is exposed and pi's own tools (web_search/web_fetch/etc.) are
+ * dropped. Opt out via `MERIDIAN_PASSTHROUGH=0`.
+ */
+function resolvePiPassthrough(): boolean {
+  const envVal = process.env.MERIDIAN_PASSTHROUGH ?? process.env.CLAUDE_PROXY_PASSTHROUGH
+  return !(envVal === "0" || envVal === "false" || envVal === "no")
+}
+
 export const piTransforms: Transform[] = [
   {
     name: "pi-core",
@@ -32,6 +45,7 @@ export const piTransforms: Transform[] = [
         incompatibleTools: CLAUDE_CODE_ONLY_TOOLS,
         allowedMcpTools: PI_ALLOWED_MCP_TOOLS,
         sdkAgents: {},
+        passthrough: resolvePiPassthrough(),
         supportsThinking: true,
         extractFileChangesFromToolUse,
       }


### PR DESCRIPTION
## Description

Noticed pi wasn't making proper tool calls through Meridian. Digging in, the pi adapter's passthrough was never actually hooked up: the transform never set the flag, so pi silently ran in internal mode and only the six built-in tools (`read`, `write`, `edit`, `bash`, `glob`, `grep`) reached the model.

This PR implements passthrough for the pi adapter (defaulting on, mirroring `opencode`/`claudecode`; opt out with `MERIDIAN_PASSTHROUGH=0`) and fixes the tests. With it, pi's full tool set reaches the model.

## Steps to QA

### 1. Pull this branch, build, and run the proxy

```shell
git clone -b fix/pi-passthrough-default https://github.com/joematthews/meridian.git
cd meridian
bun install
bun run build
bun dist/cli.js
```

### 2. Install pi, some web tools, and the Meridian extension

```shell
npm install -g @earendil-works/pi-coding-agent
pi install npm:pi-meridian-extension
pi install npm:pi-smart-fetch
pi install npm:pi-smart-web-search
```

The `pi-meridian-extension` registers a `meridian` provider, sends the `x-meridian-agent: pi` header automatically, and rewrites pi's system prompt so Anthropic's backend does not misidentify it as automated abuse. No manual `models.json` configuration is needed.

### 3. Run pi against Meridian and try a prompt that needs the web

```shell
pi --model meridian/claude-sonnet-4-6
```

Then ask for something current, e.g.:

> What are the three most interesting open-source TUI coding agents right now? Search the web and give me a one-line take on each.

**Expected:** pi actually runs `web_search` (and likely `web_fetch`/`batch_web_fetch`), then answers from real results instead of from memory. Before this PR, those tools were silently dropped because the pi adapter ran in internal mode.

### 4. Verify passthrough opt-out (optional)

Stop Meridian, restart with passthrough disabled, and confirm pi falls back to internal mode (only `read/write/edit/bash/glob/grep` available):

```shell
MERIDIAN_PASSTHROUGH=0 bun dist/cli.js
```

---

> **Note:** The raw `models.json` approach (overriding pi's `anthropic` provider to point directly at Meridian) currently triggers 400 errors because pi's default system prompt is incorrectly flagged by Anthropic's backend as abuse. The `pi-meridian-extension` works around this by rewriting the prompt. The `models.json` path should work in the future if Anthropic relaxes prompt-based filtering for human-driven agentic tools.


## Docs

This PR also includes a few small README fixes the change touches:

- The passthrough section now lists Pi alongside OpenCode as passthrough-by-default.
- The Pi section notes it runs in passthrough by default, with the opt-out.
- Corrected the Tested Agents row for Pi — it said `requires MERIDIAN_DEFAULT_AGENT=pi`, but detection is via the `x-meridian-agent: pi` header (the env var is just an alternative).
