### PR TITLE
fix: strip Hermes Agent system-prompt boilerplate on the openai adapter

### DIFF
--- a/src/__tests__/openai-strip-hermes.test.ts
+++ b/src/__tests__/openai-strip-hermes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "bun:test"
+import {
+  runTransformHook,
+  createRequestContext,
+  type RequestContext,
+} from "../proxy/transform"
+import {
+  stripHermesBoilerplateTransform,
+  HERMES_BOILERPLATE_ANCHOR,
+  openAiTransforms,
+} from "../proxy/transforms/openai"
+import { getAdapterTransforms } from "../proxy/transforms/registry"
+
+function makeCtx(systemContext: string | undefined, adapter = "openai"): RequestContext {
+  return createRequestContext({
+    adapter,
+    body: {},
+    headers: new Headers(),
+    model: "opus",
+    messages: [],
+    systemContext,
+    stream: false,
+    workingDirectory: "/tmp",
+  })
+}
+
+const PERSONA = "# Bob — PublicAI CPO Agent\n\nYou are Bob, PublicAI's CPO.\n\n"
+const BOILERPLATE = `${HERMES_BOILERPLATE_ANCHOR} (by Nous Research). Load the hermes skill...\nYou are a CLI AI Agent.`
+
+describe("stripHermesBoilerplateTransform", () => {
+  it("truncates the system prompt at the Hermes boilerplate anchor", () => {
+    const out = stripHermesBoilerplateTransform.onRequest!(makeCtx(PERSONA + BOILERPLATE))
+    expect(out.systemContext).toBe(PERSONA.trimEnd())
+    expect(out.systemContext).not.toContain(HERMES_BOILERPLATE_ANCHOR)
+  })
+
+  it("keeps the persona/identity that precedes the anchor", () => {
+    const out = stripHermesBoilerplateTransform.onRequest!(makeCtx(PERSONA + BOILERPLATE))
+    expect(out.systemContext).toContain("You are Bob")
+  })
+
+  it("is a no-op when the anchor is absent", () => {
+    const sys = "# Alice\n\nYou are Alice, a personal advisor."
+    const out = stripHermesBoilerplateTransform.onRequest!(makeCtx(sys))
+    expect(out.systemContext).toBe(sys)
+  })
+
+  it("is a no-op when the anchor sits at the very start (no persona to keep)", () => {
+    const sys = BOILERPLATE
+    const out = stripHermesBoilerplateTransform.onRequest!(makeCtx(sys))
+    expect(out.systemContext).toBe(sys)
+  })
+
+  it("is a no-op when systemContext is undefined", () => {
+    const out = stripHermesBoilerplateTransform.onRequest!(makeCtx(undefined))
+    expect(out.systemContext).toBeUndefined()
+  })
+
+  it("only runs for the openai adapter (skipped for others)", () => {
+    const ctx = makeCtx(PERSONA + BOILERPLATE, "opencode")
+    const out = runTransformHook([stripHermesBoilerplateTransform], "onRequest", ctx, "opencode")
+    expect(out.systemContext).toBe(PERSONA + BOILERPLATE) // unchanged for opencode
+  })
+
+  it("runs via runTransformHook for the openai adapter", () => {
+    const ctx = makeCtx(PERSONA + BOILERPLATE, "openai")
+    const out = runTransformHook([stripHermesBoilerplateTransform], "onRequest", ctx, "openai")
+    expect(out.systemContext).toBe(PERSONA.trimEnd())
+  })
+})
+
+describe("openai transform registry wiring", () => {
+  it("registers the stripper for the openai adapter", () => {
+    const names = getAdapterTransforms("openai").map(t => t.name)
+    expect(names).toContain("openai-strip-hermes-boilerplate")
+  })
+
+  it("does not add the stripper to the opencode adapter", () => {
+    const names = getAdapterTransforms("opencode").map(t => t.name)
+    expect(names).not.toContain("openai-strip-hermes-boilerplate")
+  })
+
+  it("openAiTransforms includes the stripper last", () => {
+    expect(openAiTransforms[openAiTransforms.length - 1]).toBe(stripHermesBoilerplateTransform)
+  })
+})

--- a/src/proxy/transforms/openai.ts
+++ b/src/proxy/transforms/openai.ts
@@ -1,0 +1,53 @@
+import type { Transform, RequestContext } from "../transform"
+import { openCodeTransforms } from "./opencode"
+
+/**
+ * Anthropic's Claude Agent SDK silently aborts — returning an empty stream
+ * (`data: [DONE]` with no content blocks) — when the forwarded system prompt
+ * carries Hermes Agent's operational boilerplate (its self-description, tool
+ * and permission directives the SDK tries to interpret). The symptom is a
+ * client-visible "empty stream with no finish_reason" error and only reproduces
+ * with the real Hermes system prompt: generic text of the same size streams
+ * fine.
+ *
+ * The profile persona we actually want forwarded lives in the leading block of
+ * the system prompt, before Hermes' self-description. Everything from that
+ * boilerplate onward is operational text the SDK-backed model does not need
+ * (it has its own tool handling). Truncating at the anchor leaves a clean,
+ * profile-specific persona that the SDK accepts.
+ *
+ * Scoped to the `openai` adapter (Hermes talks to Meridian over
+ * /v1/chat/completions). No-op when the anchor is absent.
+ */
+export const HERMES_BOILERPLATE_ANCHOR = "You run on Hermes Agent"
+
+export const stripHermesBoilerplateTransform: Transform = {
+  name: "openai-strip-hermes-boilerplate",
+  adapters: ["openai"],
+
+  onRequest(ctx: RequestContext): RequestContext {
+    const sys = ctx.systemContext
+    if (typeof sys !== "string") return ctx
+
+    const idx = sys.indexOf(HERMES_BOILERPLATE_ANCHOR)
+    // idx <= 0 means: anchor absent, or it sits at the very start with no
+    // persona ahead of it. Either way there is nothing safe to keep, so leave
+    // the system prompt untouched.
+    if (idx <= 0) return ctx
+
+    const head = sys.slice(0, idx).trimEnd()
+    if (!head) return ctx
+
+    return { ...ctx, systemContext: head }
+  },
+}
+
+/**
+ * Transforms for the generic OpenAI-compatible endpoint. Mirrors the OpenCode
+ * transforms (tool/passthrough behaviour is identical) and adds the Hermes
+ * boilerplate stripper so forwarded system prompts don't trip the SDK.
+ */
+export const openAiTransforms: Transform[] = [
+  ...openCodeTransforms,
+  stripHermesBoilerplateTransform,
+]

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -5,6 +5,7 @@ import { droidTransforms } from "./droid"
 import { piTransforms } from "./pi"
 import { forgeCodeTransforms } from "./forgecode"
 import { passthroughTransforms } from "./passthrough"
+import { openAiTransforms } from "./openai"
 
 const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   opencode: openCodeTransforms,
@@ -13,10 +14,11 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   pi: piTransforms,
   forgecode: forgeCodeTransforms,
   passthrough: passthroughTransforms,
-  // The OpenAI-compatible endpoint reuses OpenCode's transforms verbatim so
-  // tool/passthrough behaviour is identical; only the preset default differs
-  // (see sdkFeatures.ADAPTER_DEFAULTS.openai).
-  openai: openCodeTransforms,
+  // The OpenAI-compatible endpoint reuses OpenCode's transforms (tool/passthrough
+  // behaviour is identical; only the preset default differs — see
+  // sdkFeatures.ADAPTER_DEFAULTS.openai) plus a stripper that removes Hermes
+  // Agent system-prompt boilerplate the SDK chokes on (see ./openai).
+  openai: openAiTransforms,
 }
 
 export function getAdapterTransforms(adapterName: string): readonly Transform[] {


### PR DESCRIPTION
## Problem

When a client forwards a system prompt that contains **Hermes Agent**'s
operational boilerplate (its self-description, tool/permission directives) over
`/v1/chat/completions` with `clientSystemPrompt: true`, the Claude Agent SDK
**silently returns an empty stream** — `data: [DONE]` with no content blocks —
which surfaces to the client as `empty stream with no finish_reason`.

The trigger is the **content**, not the size: generic filler text of the same
length (24 KB+) streams fine, while the real Hermes system prompt reliably
empty-streams. Bisection isolated it to a section of Hermes' boilerplate (the
SDK appears to try to parse directives embedded in it). The error is swallowed —
even with `sdkDebug` enabled, nothing is logged.

This forced operators onto `clientSystemPrompt: false` (dropping the persona
entirely), so the agent ran with no identity / language / behavior rules.

## Fix

Add an `openai`-adapter `onRequest` transform that truncates the forwarded
system prompt at the Hermes boilerplate anchor (`"You run on Hermes Agent"`),
keeping only the leading profile persona — which the SDK accepts and streams
normally. The persona we want lives in that leading block; everything after the
anchor is operational text the SDK-backed model doesn't need (it has its own
tool handling).

- Scoped to the `openai` adapter — `opencode` and other clients are untouched.
- No-op when the anchor is absent.

## Tests

`src/__tests__/openai-strip-hermes.test.ts` — 10 tests (truncation, persona
preservation, no-op cases, adapter scoping, registry wiring). Full transform/
openai suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)