### PR TITLE
fix(thinking): honor explicit "disabled" setting over client requests

### DIFF
--- a/src/__tests__/proxy-thinking-setting.test.ts
+++ b/src/__tests__/proxy-thinking-setting.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The per-adapter `thinking` setting (sdk-features.json / settings UI) must be
+ * respected at the SDK boundary.
+ *
+ * Bug: an explicit "disabled" choice was ignored. The setting was only ever
+ * consulted as a fallback default (inside `if (!thinking)`), and "disabled" had
+ * no branch — so a client sending its own `thinking` (body or x-opencode-thinking
+ * header) overrode it, and `effort` (which only tunes thinking depth) still flowed
+ * through. An explicit "disabled" must now hard-disable thinking and drop effort,
+ * while the *default* "disabled" stays a no-op so clients can request thinking
+ * per-request.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+// ─── controllable sdk-features state ──────────────────────────────────────────
+// `explicitThinking` = the raw, user-configured value (undefined = unset/default).
+// `defaultThinking`  = the merged value getFeaturesForAdapter() returns.
+let explicitThinking: "adaptive" | "enabled" | "disabled" | undefined = undefined
+let defaultThinking: "adaptive" | "enabled" | "disabled" = "disabled"
+
+// Self-contained feature object (no delegation to the real module — once mocked,
+// the namespace IS the mock, so delegating would recurse infinitely).
+const FEATURES = {
+  codeSystemPrompt: true,
+  clientSystemPrompt: true,
+  claudeMd: "off" as const,
+  memory: false,
+  dreaming: false,
+  thinking: "disabled" as const,
+  thinkingPassthrough: false,
+  sharedMemory: false,
+  maxBudgetUsd: 0,
+  fallbackModel: "",
+  sdkDebug: false,
+  additionalDirectories: "",
+}
+
+mock.module("../proxy/sdkFeatures", () => ({
+  getExplicitThinking: () => explicitThinking,
+  getFeaturesForAdapter: () => ({ ...FEATURES, thinking: defaultThinking }),
+}))
+
+// ─── captured query params ────────────────────────────────────────────────────
+let capturedOptions: Record<string, unknown> = {}
+let mockMessages: unknown[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
+    capturedOptions = params.options ?? {}
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(
+  app: ReturnType<typeof createTestApp>,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {}
+) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const BASE_BODY = {
+  model: "claude-haiku-4-5-20251001",
+  max_tokens: 50,
+  stream: false,
+  messages: [{ role: "user", content: "hi" }],
+}
+
+describe("per-adapter thinking setting — explicit \"disabled\" is authoritative", () => {
+  beforeEach(() => {
+    capturedOptions = {}
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    explicitThinking = undefined
+    defaultThinking = "disabled"
+    clearSessionCache()
+  })
+
+  it("overrides client body.thinking when explicitly disabled", async () => {
+    explicitThinking = "disabled"
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, thinking: { type: "enabled", budgetTokens: 4096 } })
+    expect(capturedOptions.thinking).toEqual({ type: "disabled" })
+  })
+
+  it("overrides x-opencode-thinking header when explicitly disabled", async () => {
+    explicitThinking = "disabled"
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY }, {
+      "x-opencode-thinking": JSON.stringify({ type: "enabled", budgetTokens: 8192 }),
+    })
+    expect(capturedOptions.thinking).toEqual({ type: "disabled" })
+  })
+
+  it("drops effort when explicitly disabled (effort only tunes thinking depth)", async () => {
+    explicitThinking = "disabled"
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, effort: "high", thinking: { type: "enabled" } })
+    expect(capturedOptions.thinking).toEqual({ type: "disabled" })
+    expect(capturedOptions.effort).toBeUndefined()
+  })
+
+  it("disables thinking even when the client sends nothing", async () => {
+    explicitThinking = "disabled"
+    const app = createTestApp()
+    await post(app, BASE_BODY)
+    expect(capturedOptions.thinking).toEqual({ type: "disabled" })
+  })
+
+  // ─── regression guard: the *default* "disabled" must NOT override ───────────
+  it("default \"disabled\" (unset) leaves client body.thinking untouched", async () => {
+    explicitThinking = undefined
+    defaultThinking = "disabled"
+    const thinking = { type: "enabled", budgetTokens: 2048 }
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, thinking })
+    expect(capturedOptions.thinking).toEqual(thinking)
+  })
+
+  it("default \"disabled\" (unset) leaves client effort untouched", async () => {
+    explicitThinking = undefined
+    defaultThinking = "disabled"
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, effort: "high" })
+    expect(capturedOptions.effort).toBe("high")
+  })
+
+  // ─── adaptive/enabled stay fallback-only (unchanged) ────────────────────────
+  it("explicit \"enabled\" still defers to a client-supplied thinking value", async () => {
+    explicitThinking = "enabled"
+    defaultThinking = "enabled"
+    const thinking = { type: "disabled" }
+    const app = createTestApp()
+    await post(app, { ...BASE_BODY, thinking })
+    expect(capturedOptions.thinking).toEqual(thinking)
+  })
+
+  it("\"adaptive\" applies as a default only when the client sent nothing", async () => {
+    explicitThinking = "adaptive"
+    defaultThinking = "adaptive"
+    const app = createTestApp()
+    await post(app, BASE_BODY)
+    expect(capturedOptions.thinking).toEqual({ type: "adaptive" })
+  })
+})

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -138,6 +138,24 @@ export function getFeaturesForAdapter(adapterName: string): AdapterFeatures {
 }
 
 /**
+ * Returns the thinking value the user has *explicitly* configured for an
+ * adapter, or undefined when none is set (i.e. it falls back to defaults).
+ *
+ * The merged result from getFeaturesForAdapter() can't tell an explicit
+ * "disabled" choice apart from the default "disabled" (DEFAULT_FEATURES.thinking
+ * is "disabled"). Those two cases must behave differently: an explicit
+ * "disabled" is an authoritative "no thinking" instruction that overrides client
+ * requests, whereas the default "disabled" is a no-op fallback so clients can
+ * still request thinking per-request. See the thinking resolution in server.ts.
+ */
+export function getExplicitThinking(adapterName: string): AdapterFeatures["thinking"] | undefined {
+  const explicit = readConfig()[adapterName]?.thinking
+  return typeof explicit === "string" && VALID_THINKING_VALUES.has(explicit)
+    ? (explicit as AdapterFeatures["thinking"])
+    : undefined
+}
+
+/**
  * Get the full config for all adapters (for the settings UI).
  */
 export function getAllFeatureConfigs(): Record<string, AdapterFeatures> {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -595,7 +595,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // `output_config.effort`. normalizeEffort gates the value to Claude's
         // vocabulary so an unknown level (e.g. OpenAI's "minimal") falls back to
         // the model default instead of erroring at the SDK boundary.
-        const effort = normalizeEffort(
+        let effort = normalizeEffort(
           effortHeader
           || body.effort
           || body.reasoning_effort
@@ -611,11 +611,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }
         // SDK feature toggles — resolved once per request for use in thinking
         // defaults, settingSources, and buildQueryOptions below.
-        const { getFeaturesForAdapter } = require("./sdkFeatures") as typeof import("./sdkFeatures")
+        const { getFeaturesForAdapter, getExplicitThinking } = require("./sdkFeatures") as typeof import("./sdkFeatures")
         const sdkFeatures = getFeaturesForAdapter(adapter.name)
 
-        // Default thinking from SDK features config when client didn't set it
-        if (!thinking) {
+        // Resolve thinking against the per-adapter setting.
+        //
+        // An *explicitly* configured "disabled" is authoritative: it overrides
+        // any client-supplied thinking (body.thinking / x-opencode-thinking) and
+        // drops effort, since effort only tunes thinking depth. This mirrors the
+        // beta-stripped hard-disable below. We check the raw setting (not the
+        // merged value) because the default is also "disabled" — and that default
+        // must stay a no-op so clients can still request thinking per-request.
+        // "adaptive"/"enabled" act as a default only when the client sent nothing.
+        if (getExplicitThinking(adapter.name) === "disabled") {
+          thinking = { type: "disabled" }
+          effort = undefined
+          plog(`[PROXY] ${requestMeta.requestId} thinking disabled (per-adapter setting)`)
+        } else if (!thinking) {
           if (sdkFeatures.thinking === "adaptive") thinking = { type: "adaptive" }
           else if (sdkFeatures.thinking === "enabled") thinking = { type: "enabled" }
         }


### PR DESCRIPTION
## Problem

Setting **Thinking → `disabled`** in the settings UI (`sdk-features.json`) is silently ignored whenever the client requests thinking itself.

In `server.ts`, the per-adapter `thinking` setting was only ever consulted as a *fallback default*:

```ts
if (!thinking) {
  if (sdkFeatures.thinking === "adaptive") thinking = { type: "adaptive" }
  else if (sdkFeatures.thinking === "enabled") thinking = { type: "enabled" }
  // no branch for "disabled"
}
```

Two consequences:

- **Anthropic `/v1/messages`:** a client `body.thinking` or `x-opencode-thinking` header makes `thinking` truthy *before* this block, so the setting is never consulted — "disabled" is overridden by the client (e.g. OpenCode's own thinking toggle).
- **`effort` is independent:** `effort` only tunes thinking depth but is forwarded to the SDK regardless of the thinking setting, so reasoning can still be triggered (notably via `reasoning_effort` on the OpenAI endpoint) even with thinking "disabled".

So the only thing that actually force-disabled thinking was the beta-stripped path; the UI setting did not.

## Fix

Make an **explicitly configured** `"disabled"` authoritative — it now hard-disables thinking and drops `effort` at the SDK boundary, mirroring the existing beta-stripped hard-disable:

```ts
if (getExplicitThinking(adapter.name) === "disabled") {
  thinking = { type: "disabled" }
  effort = undefined
} else if (!thinking) {
  ...adaptive/enabled defaults (unchanged)...
}
```

### Why a new `getExplicitThinking()` helper?

`DEFAULT_FEATURES.thinking` is itself `"disabled"`, so the *merged* value from `getFeaturesForAdapter()` can't distinguish "user explicitly chose disabled" from "default disabled". Those must behave differently:

- **explicit `"disabled"`** → authoritative, overrides the client.
- **default `"disabled"`** (user never touched it) → stays a no-op, so clients can still request thinking per-request (preserves current out-of-box behavior).

`getExplicitThinking()` reads the *raw* user config (key present vs absent) to tell them apart. `"adaptive"`/`"enabled"` remain fallback-only and are unchanged.

## Tests

New `src/__tests__/proxy-thinking-setting.test.ts`:

- explicit `"disabled"` overrides `body.thinking` and the `x-opencode-thinking` header
- explicit `"disabled"` drops `effort`
- explicit `"disabled"` disables thinking when the client sends nothing
- **regression guards:** default `"disabled"` (unset) leaves client `body.thinking` and `effort` untouched
- `"adaptive"`/`"enabled"` still defer to client-supplied thinking

Full suite (`npm test`) passes; `tsc --noEmit` clean.

## Notes

No existing issue tracked this. It's the same class as #408 (`passthrough` ignored `codeSystemPrompt: false`) — a settings toggle dropped at the resolution boundary.

One reviewer decision worth flagging: I made explicit `"disabled"` also drop `effort`, on the basis that effort's only documented role is thinking depth. If you'd rather keep `effort` independent of the thinking setting, that line is easy to remove.
