### PR TITLE
fix: forward token usage on OpenAI-format streaming responses

### DIFF
--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1149,6 +1149,34 @@ describe("createSseTranslator", () => {
     expect(chunks[4]!.choices[0]!.delta.tool_calls![0]!.index).toBe(0)
     expect(chunks[5]!.choices[0]!.finish_reason).toBe("tool_calls")
   })
+
+  it("buildUsageChunk returns null when includeUsage was not requested", () => {
+    const translate = createSseTranslator(CTX)
+    translate({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 10, output_tokens: 5 } })
+    expect(translate.buildUsageChunk()).toBeNull()
+  })
+
+  it("buildUsageChunk returns null when no message_delta.usage was observed", () => {
+    const translate = createSseTranslator({ ...CTX, includeUsage: true })
+    translate({ type: "message_delta", delta: { stop_reason: "end_turn" } })
+    expect(translate.buildUsageChunk()).toBeNull()
+  })
+
+  it("buildUsageChunk returns a populated trailing chunk with empty choices when requested", () => {
+    const translate = createSseTranslator({ ...CTX, includeUsage: true })
+    translate({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 132, output_tokens: 37 } })
+    const chunk = translate.buildUsageChunk()
+    expect(chunk).not.toBeNull()
+    expect(chunk!.choices).toEqual([])
+    expect(chunk!.usage).toEqual({ prompt_tokens: 132, completion_tokens: 37, total_tokens: 169 })
+  })
+
+  it("buildUsageChunk uses the latest message_delta.usage if multiple arrive", () => {
+    const translate = createSseTranslator({ ...CTX, includeUsage: true })
+    translate({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { input_tokens: 100, output_tokens: 10 } })
+    translate({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 100, output_tokens: 42 } })
+    expect(translate.buildUsageChunk()!.usage).toEqual({ prompt_tokens: 100, completion_tokens: 42, total_tokens: 142 })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -78,6 +78,7 @@ export interface OpenAiChatRequest {
   reasoning_effort?: string
   /** Anthropic-style nesting some clients use. */
   output_config?: { effort?: string }
+  stream_options?: { include_usage?: boolean }
 }
 
 export interface AnthropicTextBlock {
@@ -197,6 +198,7 @@ export interface OpenAiStreamChunk {
     }
     finish_reason: "stop" | "length" | "tool_calls" | null
   }>
+  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number }
 }
 
 export interface OpenAiCompletionFunctionToolCall {
@@ -601,10 +603,12 @@ export interface AnthropicSseEvent {
     | { type: "thinking"; thinking?: string }
     | AnthropicToolUseBlock
   message?: { id?: string }
+  usage?: AnthropicUsage
 }
 
 export interface SseTranslator {
   (event: AnthropicSseEvent): OpenAiStreamChunk | null
+  buildUsageChunk(): OpenAiStreamChunk | null
 }
 
 export interface SseTranslatorContext {
@@ -613,6 +617,7 @@ export interface SseTranslatorContext {
   created: number
   /** When false, thinking blocks are stripped from the response */
   thinkingPassthrough?: boolean
+  includeUsage?: boolean
 }
 
 /**
@@ -629,7 +634,9 @@ export interface SseTranslatorContext {
  */
 export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
   let toolCallIndex = -1 // -1 means "no tools used yet", becomes 0 on first block
-  return (event) => {
+  let lastUsage: AnthropicUsage | undefined
+
+  const translate = ((event: AnthropicSseEvent) => {
     // Increment must use the same condition the pure translator uses to
     // decide a tool-start chunk gets emitted, otherwise indexes drift if a
     // malformed event is skipped.
@@ -641,6 +648,10 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
       toolCallIndex++
     }
 
+    if (event.type === "message_delta" && event.usage) {
+      lastUsage = event.usage
+    }
+
     return translateAnthropicSseEvent(
       event,
       ctx.completionId,
@@ -649,7 +660,27 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
       toolCallIndex,
       ctx.thinkingPassthrough,
     )
+  }) as SseTranslator
+
+  translate.buildUsageChunk = () => {
+    if (!ctx.includeUsage || !lastUsage) return null
+    const promptTokens = lastUsage.input_tokens ?? 0
+    const completionTokens = lastUsage.output_tokens ?? 0
+    return {
+      id: ctx.completionId,
+      object: "chat.completion.chunk",
+      created: ctx.created,
+      model: ctx.model,
+      choices: [],
+      usage: {
+        prompt_tokens: promptTokens,
+        completion_tokens: completionTokens,
+        total_tokens: promptTokens + completionTokens,
+      },
+    }
   }
+
+  return translate
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2756,7 +2756,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let buffer = ""
         let streamError: Error | null = null
 
-        const translate = createSseTranslator({ completionId, model, created, thinkingPassthrough: sdkFeatures.thinkingPassthrough })
+        const streamOptions = rawBody.stream_options as { include_usage?: boolean } | undefined
+        const includeUsage = streamOptions?.include_usage === true
+
+        const translate = createSseTranslator({ completionId, model, created, thinkingPassthrough: sdkFeatures.thinkingPassthrough, includeUsage })
 
         try {
           while (true) {
@@ -2784,7 +2787,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         } catch (err) {
           streamError = err instanceof Error ? err : new Error(String(err))
         } finally {
-          if (!streamError) controller.enqueue(encoder.encode("data: [DONE]\n\n"))
+          if (!streamError) {
+            const usageChunk = translate.buildUsageChunk()
+            if (usageChunk) {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify(usageChunk)}\n\n`))
+            }
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"))
+          }
           controller.close()
         }
       },


### PR DESCRIPTION
## Problem

When a client requests `stream_options: { include_usage: true }` on `/v1/chat/completions` (standard OpenAI streaming spec), Meridian never emits the trailing usage-only chunk. The token counter in clients like Hermes Agent stays at 0.

The data is already available — Anthropic's `message_delta` SSE event includes a `usage` object with `input_tokens` and `output_tokens`, and Meridian's own `/v1/messages` endpoint emits it correctly. But `translateAnthropicSseEvent` never reads `event.usage`, and the route handler never parses `stream_options` from the request body. The `OpenAiChatRequest` type doesn't even declare the field.

Non-streaming works correctly because `translateAnthropicToOpenAi` already reads `response.usage` — this PR brings streaming to parity.

## Changes

- `src/proxy/openai.ts`: Add `stream_options` to `OpenAiChatRequest`, `usage` to `AnthropicSseEvent` and `OpenAiStreamChunk`, `includeUsage` to `SseTranslatorContext`. Modify `createSseTranslator` to capture `event.usage` from `message_delta` events and expose `buildUsageChunk()` (attached as a property on the returned function — fully backward-compatible, zero existing call sites change).
- `src/proxy/server.ts`: Parse `stream_options.include_usage` from the request, pass it to `createSseTranslator`, emit the trailing usage chunk before `[DONE]`.
- `src/__tests__/openai.test.ts`: 4 new tests covering include_usage not requested, no usage observed, populated chunk, and multiple message_delta events.

## Spec compliance

Per the [OpenAI streaming spec](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options):
- Usage chunk has `choices: []` (empty array)
- Fields: `prompt_tokens`, `completion_tokens`, `total_tokens`
- Emitted as the last data chunk before `data: [DONE]`
- Only emitted when `stream_options.include_usage` is explicitly `true`