### PR TITLE
feat: add MERIDIAN_1M_CONTEXT_SUPPORT toggle to disable 1M auto-selection

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -73,6 +73,41 @@ describe("mapModelToClaudeModel", () => {
     resetExtendedContextUnavailable()
   })
 
+  describe("MERIDIAN_1M_CONTEXT_SUPPORT opt-out", () => {
+    afterEach(() => {
+      delete process.env.MERIDIAN_1M_CONTEXT_SUPPORT
+      delete process.env.CLAUDE_PROXY_1M_CONTEXT_SUPPORT
+      delete process.env.CLAUDE_PROXY_SONNET_MODEL
+    })
+
+    it("downgrades opus[1m] to opus when disabled", () => {
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "0"
+      expect(mapModelToClaudeModel("claude-opus-4-6")).toBe("opus")
+      expect(mapModelToClaudeModel("opus")).toBe("opus")
+    })
+
+    it("downgrades sonnet[1m] override to sonnet when disabled", () => {
+      process.env.CLAUDE_PROXY_SONNET_MODEL = "sonnet[1m]"
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "0"
+      expect(mapModelToClaudeModel("sonnet", "max")).toBe("sonnet")
+    })
+
+    it("accepts false/no spellings and the CLAUDE_PROXY_ alias", () => {
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "false"
+      expect(mapModelToClaudeModel("opus")).toBe("opus")
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "no"
+      expect(mapModelToClaudeModel("opus")).toBe("opus")
+      delete process.env.MERIDIAN_1M_CONTEXT_SUPPORT
+      process.env.CLAUDE_PROXY_1M_CONTEXT_SUPPORT = "0"
+      expect(mapModelToClaudeModel("opus")).toBe("opus")
+    })
+
+    it("leaves 1M selection intact for other values", () => {
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "1"
+      expect(mapModelToClaudeModel("claude-opus-4-6")).toBe("opus[1m]")
+    })
+  })
+
   describe("subagent mode", () => {
     it("gives subagents base sonnet regardless of subscription", () => {
       expect(mapModelToClaudeModel("claude-sonnet-4-6", "max", "subagent")).toBe("sonnet")

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -7,6 +7,7 @@ import { existsSync, statSync } from "fs"
 import { fileURLToPath } from "url"
 import { join, dirname } from "path"
 import { promisify } from "util"
+import { env } from "../env"
 
 const exec = promisify(execCallback)
 const execFile = promisify(execFileCallback)
@@ -85,6 +86,11 @@ let cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null = null
  * Older models (4.5 and earlier) do not.
  */
 function supports1mContext(model: string): boolean {
+  // Global opt-out: MERIDIAN_1M_CONTEXT_SUPPORT=0 (or false/no) disables 1M
+  // auto-selection entirely, downgrading every model to its base variant.
+  // Accepts the CLAUDE_PROXY_ alias and all falsy spellings via env().
+  const override = env("1M_CONTEXT_SUPPORT")
+  if (override === "0" || override === "false" || override === "no") return false
   // Explicit older versions (4-5, 4.5, etc.) do not support 1M
   if (model.includes("4-5") || model.includes("4.5")) return false
   // Everything else (bare names, 4-6, unknown) defaults to latest (1M capable)


### PR DESCRIPTION
Since the 1M context window no longer drains the Max/Pro token budget, operators may want to stop forcing the 1M model variants. This adds a global opt-out:

- `MERIDIAN_1M_CONTEXT_SUPPORT=0` (also `false` / `no`, and the legacy `CLAUDE_PROXY_1M_CONTEXT_SUPPORT` alias) makes `supports1mContext()` return `false`, downgrading every model to its base variant (`opus[1m]→opus`, `sonnet[1m]→sonnet`).

This builds on @EmrysMyrddin's #542. The difference: instead of reading `process.env` directly with a strict `=== '0'`, it routes through `env()` so it honors the `CLAUDE_PROXY_` legacy alias and all falsy spellings (`0`/`false`/`no`) — consistent with every other toggle in the proxy (`resolvePassthrough`, `envBool`). A user setting `=false` would silently no-op under the direct-read version.

Adds unit tests covering opus downgrade, sonnet[1m]-override downgrade, the `false`/`no`/alias spellings, and that other values leave 1M intact.

Closes #542. Related to #541.

Co-authored-by: Valentin Cocaud <v.cocaud@gmail.com>