### PR TITLE
test: harden two wall-clock-dependent timing tests against CI flakes

### DIFF
--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -82,21 +82,22 @@ describe("GET /v1/usage/quota", () => {
   it("reflects entries written to the rate-limit store, newest first", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
 
+    // Explicit, distinct observedAt values make newest-first ordering
+    // deterministic without racing the real wall clock (a short sleep does
+    // not guarantee a fresh millisecond timestamp under CI load).
     rateLimitStore.record({
       status: "allowed",
       rateLimitType: "five_hour",
       utilization: 0.42,
       resetsAt: 1_730_000_000_000,
-    })
-    // Force monotonic observedAt so newest-first ordering is deterministic
-    await Bun.sleep(2)
+    }, 1_000)
     rateLimitStore.record({
       status: "allowed_warning",
       rateLimitType: "seven_day",
       utilization: 0.91,
       resetsAt: 1_730_500_000_000,
       surpassedThreshold: 0.9,
-    })
+    }, 2_000)
 
     const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
     expect(res.status).toBe(200)

--- a/src/__tests__/stream-idle-guard.test.ts
+++ b/src/__tests__/stream-idle-guard.test.ts
@@ -1,6 +1,51 @@
 import { describe, expect, it } from "bun:test"
 
 const { guardUpstreamIdle, UpstreamIdleError } = await import("../proxy/streamIdleGuard")
+import type { IdleGuardClock } from "../proxy/streamIdleGuard"
+
+type IdleTimerHandle = ReturnType<typeof setTimeout> | number
+
+// A fully controllable clock for the guard: timers never fire on their own, so
+// real upstream chunks always win their race against the idle deadline. The
+// test fires the idle timer explicitly via advance(), making stall detection
+// deterministic instead of racing the wall clock.
+function makeFakeClock() {
+  let current = 0
+  let nextId = 1
+  let scheduledTotal = 0
+  const pending = new Map<IdleTimerHandle, { fireAt: number; fn: () => void }>()
+  const waiters: Array<{ n: number; resolve: () => void }> = []
+
+  const clock: IdleGuardClock = {
+    now: () => current,
+    setTimeout(fn, ms) {
+      const id = nextId++
+      pending.set(id, { fireAt: current + ms, fn })
+      scheduledTotal++
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (scheduledTotal >= waiters[i]!.n) { waiters[i]!.resolve(); waiters.splice(i, 1) }
+      }
+      return id
+    },
+    clearTimeout(handle) { pending.delete(handle) },
+  }
+
+  return {
+    clock,
+    /** Resolves once at least `n` timers have been scheduled in total. */
+    waitForScheduled(n: number): Promise<void> {
+      if (scheduledTotal >= n) return Promise.resolve()
+      return new Promise<void>((resolve) => { waiters.push({ n, resolve }) })
+    },
+    /** Advance time by `ms`, firing every timer whose deadline has passed. */
+    advance(ms: number) {
+      current += ms
+      for (const [id, t] of [...pending]) {
+        if (t.fireAt <= current) { pending.delete(id); t.fn() }
+      }
+    },
+  }
+}
 
 // A controllable async iterable: push() emits a value, stall() just waits.
 function makeSource<T>() {
@@ -38,8 +83,13 @@ describe("guardUpstreamIdle", () => {
   it("throws UpstreamIdleError when the source goes silent even if onStall throws", async () => {
     const src = makeSource<number>()
     const stalls: number[] = []
-    const p = (async () => { for await (const _ of guardUpstreamIdle(src.iterable, 30, (ms) => { stalls.push(ms); throw new Error("observer failed") })) { /* drain */ } })()
+    const clock = makeFakeClock()
+    const p = (async () => { for await (const _ of guardUpstreamIdle(src.iterable, 30, (ms) => { stalls.push(ms); throw new Error("observer failed") }, clock.clock)) { /* drain */ } })()
     src.push(1) // one real chunk, then silence
+    // Chunk 1 is delivered (its idle timer is cleared) and a fresh idle timer
+    // is armed for the silent gap — the second scheduled timer. Fire it.
+    await clock.waitForScheduled(2)
+    clock.advance(30)
     let err: unknown
     try { await p } catch (e) { err = e }
     expect(err).toBeInstanceOf(UpstreamIdleError)

--- a/src/proxy/rateLimitStore.ts
+++ b/src/proxy/rateLimitStore.ts
@@ -53,11 +53,15 @@ class RateLimitStore {
    * Record a rate-limit info snapshot.
    * Last-write-wins per bucket key (rateLimitType). Older entries for the
    * same key are overwritten — clients should treat the latest as canonical.
+   *
+   * `observedAt` defaults to the current wall clock but may be supplied
+   * explicitly so callers (and tests) can control the capture timestamp used
+   * for newest-first ordering in {@link getAll}.
    */
-  record(info: SDKRateLimitInfo | undefined | null): void {
+  record(info: SDKRateLimitInfo | undefined | null, observedAt: number = Date.now()): void {
     if (!info || typeof info !== "object") return
     const key: RateLimitBucketKey = info.rateLimitType ?? "default"
-    this.entries.set(key, { ...info, observedAt: Date.now() })
+    this.entries.set(key, { ...info, observedAt })
   }
 
   /** Snapshot all current entries, newest-first by observedAt. */

--- a/src/proxy/streamIdleGuard.ts
+++ b/src/proxy/streamIdleGuard.ts
@@ -30,17 +30,38 @@ export class UpstreamIdleError extends Error {
   }
 }
 
+/** Opaque handle returned by a clock's timer scheduler. */
+type IdleTimerHandle = ReturnType<typeof setTimeout> | number
+
+/**
+ * Time source the guard depends on. Injectable so tests can drive idle
+ * detection deterministically instead of racing the real wall clock. Defaults
+ * to the platform clock in production.
+ */
+export interface IdleGuardClock {
+  now(): number
+  setTimeout(fn: () => void, ms: number): IdleTimerHandle
+  clearTimeout(handle: IdleTimerHandle): void
+}
+
+const realClock: IdleGuardClock = {
+  now: () => Date.now(),
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+}
+
 export async function* guardUpstreamIdle<T>(
   source: AsyncIterable<T>,
   idleMs: number,
   onStall?: (sinceLastMs: number) => void,
+  clock: IdleGuardClock = realClock,
 ): AsyncGenerator<T> {
   if (idleMs <= 0) {
     yield* source
     return
   }
   const it = source[Symbol.asyncIterator]()
-  let lastAt = Date.now()
+  let lastAt = clock.now()
   try {
     while (true) {
       // Start the next pull and swallow any late rejection if we abandon it
@@ -48,11 +69,11 @@ export async function* guardUpstreamIdle<T>(
       const nextP = it.next()
       nextP.catch(() => {})
 
-      let timer: ReturnType<typeof setTimeout> | undefined
+      let timer: IdleTimerHandle | undefined
       const idle = new Promise<never>((_, reject) => {
-        const remaining = Math.max(0, idleMs - (Date.now() - lastAt))
-        timer = setTimeout(() => {
-          const sinceLastMs = Date.now() - lastAt
+        const remaining = Math.max(0, idleMs - (clock.now() - lastAt))
+        timer = clock.setTimeout(() => {
+          const sinceLastMs = clock.now() - lastAt
           try {
             onStall?.(sinceLastMs)
           } catch {
@@ -66,10 +87,10 @@ export async function* guardUpstreamIdle<T>(
       try {
         res = await Promise.race([nextP, idle])
       } finally {
-        if (timer) clearTimeout(timer)
+        if (timer !== undefined) clock.clearTimeout(timer)
       }
       if (res.done) return
-      lastAt = Date.now()
+      lastAt = clock.now()
       yield res.value
     }
   } finally {


### PR DESCRIPTION
## Problem

Two tests relied on real wall-clock timing and flaked on GitHub Actions under load. On #555 the `test` job failed twice on two *different* timing tests before passing green on a re-run with no code change, confirming they are flakes.

## Fixes

Preferred approach for both: inject a clock/timestamp instead of sleeping on the real clock. Assertions are preserved.

**1. `src/__tests__/stream-idle-guard.test.ts:38` — "throws UpstreamIdleError when the source goes silent even if onStall throws"**

`guardUpstreamIdle` now takes an optional `IdleGuardClock` (`now`/`setTimeout`/`clearTimeout`), defaulting to the platform clock — production behavior is unchanged. The test drives a deterministic fake clock: timers never auto-fire, so the real chunk always wins its race against the idle deadline; the test then fires the idle timer explicitly via `advance(30)`. This removes all real-time dependence. The `sinceLastMs >= 30`, `stalls.length === 1`, and `instanceof UpstreamIdleError` assertions are unchanged.

**2. `src/__tests__/proxy-usage-quota-route.test.ts:82` — "reflects entries written to the rate-limit store, newest first"**

`rateLimitStore.record()` now accepts an optional `observedAt` (default `Date.now()`), so production callers are unchanged. The test passes explicit distinct timestamps (`1_000`, `2_000`) instead of `await Bun.sleep(2)`, which did not guarantee a fresh-millisecond stamp under load. Newest-first ordering is now deterministic.

## Verification

- `npm test` — all pass (1683 in the main run + the isolated files, 0 fail)
- `npx tsc --noEmit` — clean (separate CI typecheck gate)
- Ran the idle-guard test in a 5× loop — deterministic, no flakes

No `as any`/`@ts-ignore`; module boundaries respected.