### PR TITLE
fix(thinking): drop effort when the thinking beta is stripped

### DIFF
--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -207,6 +207,24 @@ describe("SDK param passthrough — header overrides", () => {
     ])
   })
 
+  it("drops effort when the thinking beta is stripped (strip-all policy)", async () => {
+    // When interleaved-thinking is stripped, thinking is hard-disabled to keep
+    // thinking blocks out of session state. effort only tunes thinking depth, so
+    // it must be dropped too — otherwise it still reaches the SDK (query.ts) and
+    // can re-trigger reasoning, re-introducing the blocks the strip guards against.
+    process.env.MERIDIAN_BETA_POLICY = "strip-all"
+    try {
+      const app = createTestApp()
+      await post(app, { ...BASE_BODY, effort: "high" }, {
+        "anthropic-beta": "interleaved-thinking-2025-05-14",
+      })
+      expect(capturedOptions.thinking).toEqual({ type: "disabled" })
+      expect(capturedOptions.effort).toBeUndefined()
+    } finally {
+      delete process.env.MERIDIAN_BETA_POLICY
+    }
+  })
+
   it("anthropic-beta header is forwarded for api-type profiles", async () => {
     const { app } = createProxyServer({
       port: 0, host: "127.0.0.1",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -602,7 +602,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // `output_config.effort`. normalizeEffort gates the value to Claude's
         // vocabulary so an unknown level (e.g. OpenAI's "minimal") falls back to
         // the model default instead of erroring at the SDK boundary.
-        const effort = normalizeEffort(
+        let effort = normalizeEffort(
           effortHeader
           || body.effort
           || body.reasoning_effort
@@ -633,6 +633,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const thinkingBetaStripped = betaFilter.stripped.some(b => b.startsWith("interleaved-thinking"))
         if (thinkingBetaStripped) {
           thinking = { type: "disabled" }
+          // effort only tunes thinking depth and reaches the SDK independently
+          // (query.ts), so it can re-trigger reasoning even with thinking
+          // disabled — drop it too, keeping thinking blocks out of session state.
+          effort = undefined
           if (betaFilter.stripped.length > 0) {
             plog(`[PROXY] ${requestMeta.requestId} thinking disabled (thinking beta stripped by ${getBetaPolicyFromEnv()} policy)`)
           }


### PR DESCRIPTION
## Problem

The beta-stripped hard-disable in `server.ts` sets `thinking = { type: "disabled" }` to keep thinking blocks out of session state (otherwise a resumed session contains thinking blocks the API rejects once the `interleaved-thinking` beta is stripped). But it left `effort` untouched.

`effort` only tunes thinking depth and is forwarded to the SDK **independently** of `thinking` (`query.ts` spreads `...(effort ? { effort } : {})`). So under `MERIDIAN_BETA_POLICY=strip-all` (or any path that strips `interleaved-thinking`), a client sending `effort`/`reasoning_effort` still has it reach the SDK — which can re-trigger reasoning and re-introduce the exact thinking blocks the strip guards against.

## Fix

Drop `effort` in the `thinkingBetaStripped` branch, mirroring the explicit per-adapter `"disabled"` path in #548.

## Test

Adds an integration test to `proxy-sdk-params.test.ts`: under `strip-all` policy with `anthropic-beta: interleaved-thinking-*` and `effort: "high"`, asserts `capturedOptions.thinking === { type: "disabled" }` **and** `capturedOptions.effort === undefined`. Verified RED before the fix (effort came through as `"high"`), GREEN after. Full suite (1783 pass) and `tsc --noEmit` clean.

## Relationship to #548

Standalone bug (present on `main` independently), found while reviewing #548. The two overlap only on the trivial `const effort` → `let effort` change on the same line — an identical edit, so no merge conflict regardless of merge order. This is the beta-stripped counterpart to the explicit-`"disabled"` fix in #548.