### PR TITLE
feat(models): add Claude Fable 5 (claude-fable-5) support

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test"
 
-import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resolveSdkModelDefaults, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resolveSdkModelDefaults, CANONICAL_FABLE_MODEL, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
   const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
@@ -105,6 +105,41 @@ describe("mapModelToClaudeModel", () => {
     it("leaves 1M selection intact for other values", () => {
       process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "1"
       expect(mapModelToClaudeModel("claude-opus-4-6")).toBe("opus[1m]")
+    })
+  })
+
+  describe("fable 5", () => {
+    afterEach(() => {
+      resetExtendedContextUnavailable()
+      delete process.env.MERIDIAN_1M_CONTEXT_SUPPORT
+    })
+
+    it("maps fable to fable[1m] for primary agents (mirrors opus)", () => {
+      expect(mapModelToClaudeModel("claude-fable-5")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("fable")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("claude-fable-5", "max")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("claude-fable-5", "max", "primary")).toBe("fable[1m]")
+    })
+
+    it("gives subagents base fable regardless of subscription", () => {
+      expect(mapModelToClaudeModel("claude-fable-5", "max", "subagent")).toBe("fable")
+      expect(mapModelToClaudeModel("fable", "max", "subagent")).toBe("fable")
+    })
+
+    it("downgrades fable[1m] to fable during the Extra Usage cooldown", () => {
+      recordExtendedContextUnavailable()
+      expect(mapModelToClaudeModel("claude-fable-5", "max")).toBe("fable")
+    })
+
+    it("downgrades fable[1m] to fable when MERIDIAN_1M_CONTEXT_SUPPORT=0", () => {
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "0"
+      expect(mapModelToClaudeModel("claude-fable-5", "max")).toBe("fable")
+    })
+
+    it("stripExtendedContext and hasExtendedContext handle fable[1m]", () => {
+      expect(stripExtendedContext("fable[1m]")).toBe("fable")
+      expect(hasExtendedContext("fable[1m]")).toBe(true)
+      expect(hasExtendedContext("fable")).toBe(false)
     })
   })
 
@@ -270,6 +305,7 @@ describe("resolveSdkModelDefaults", () => {
   // runs files in parallel.
   it("returns canonical pins when no overrides set", () => {
     const pins = resolveSdkModelDefaults({})
+    expect(pins.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe(CANONICAL_FABLE_MODEL)
     expect(pins.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe(CANONICAL_OPUS_MODEL)
     expect(pins.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(CANONICAL_SONNET_MODEL)
     expect(pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe(CANONICAL_HAIKU_MODEL)
@@ -290,9 +326,15 @@ describe("resolveSdkModelDefaults", () => {
     expect(pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-5-0")
   })
 
-  it("returns only the three ANTHROPIC_DEFAULT_* keys — nothing else", () => {
+  it("MERIDIAN_DEFAULT_FABLE_MODEL override wins over the canonical default", () => {
+    const pins = resolveSdkModelDefaults({ MERIDIAN_DEFAULT_FABLE_MODEL: "claude-fable-6" })
+    expect(pins.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-6")
+  })
+
+  it("returns only the four ANTHROPIC_DEFAULT_* keys — nothing else", () => {
     const pins = resolveSdkModelDefaults({})
     expect(Object.keys(pins).sort()).toEqual([
+      "ANTHROPIC_DEFAULT_FABLE_MODEL",
       "ANTHROPIC_DEFAULT_HAIKU_MODEL",
       "ANTHROPIC_DEFAULT_OPUS_MODEL",
       "ANTHROPIC_DEFAULT_SONNET_MODEL",

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1156,16 +1156,24 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 4 models", () => {
-    expect(buildModelList(true).length).toBe(5)
-    expect(buildModelList(false).length).toBe(5)
+  it("returns 6 models", () => {
+    expect(buildModelList(true).length).toBe(6)
+    expect(buildModelList(false).length).toBe(6)
   })
 
-  it("includes opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes fable-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
+    expect(ids).toContain("claude-fable-5")
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")
     expect(ids).toContain("claude-opus-4-8")
+  })
+
+  it("Max subscription gets 1M context for fable, 200k otherwise", () => {
+    const fableMax = buildModelList(true).find(m => m.id === "claude-fable-5")!
+    const fableFree = buildModelList(false).find(m => m.id === "claude-fable-5")!
+    expect(fableMax.context_window).toBe(1_000_000)
+    expect(fableFree.context_window).toBe(200_000)
   })
 
   it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -187,9 +187,11 @@ describe("Environment variable stripping", () => {
 
 describe("SDK model pin injection (fixes #419)", () => {
   const modelEnvKeys = [
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
     "ANTHROPIC_DEFAULT_OPUS_MODEL",
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "MERIDIAN_DEFAULT_FABLE_MODEL",
     "MERIDIAN_DEFAULT_OPUS_MODEL",
     "MERIDIAN_DEFAULT_SONNET_MODEL",
     "MERIDIAN_DEFAULT_HAIKU_MODEL",
@@ -215,6 +217,7 @@ describe("SDK model pin injection (fixes #419)", () => {
   it("injects Meridian's canonical model pins when no shell env is set", async () => {
     const app = createTestApp()
     await post(app, BASIC_REQUEST)
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
@@ -224,6 +227,12 @@ describe("SDK model pin injection (fixes #419)", () => {
     const app = createTestApp()
     await post(app, { ...BASIC_REQUEST, model: "claude-opus-4-6" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-6")
+  })
+
+  it("explicit claude-fable-5 requests pin the SDK env to fable", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-fable-5" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
   })
 
   it("explicit claude-opus-4-7 requests beat inherited env pins", async () => {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -22,7 +22,7 @@ const execFile = promisify(execFileCallback)
  */
 const STUB_SIZE_THRESHOLD = 4096
 
-export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku"
+export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku" | "fable" | "fable[1m]"
 
 /**
  * Current canonical pins for the `sonnet`/`opus`/`haiku` SDK aliases.
@@ -40,6 +40,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * override via MERIDIAN_DEFAULT_{TYPE}_MODEL (proxy-side) or
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
+export const CANONICAL_FABLE_MODEL = "claude-fable-5"
 export const CANONICAL_OPUS_MODEL = "claude-opus-4-8"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-4-6"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
@@ -57,6 +58,7 @@ export function resolveSdkModelDefaults(
   env: NodeJS.ProcessEnv = process.env,
 ): Record<string, string> {
   return {
+    ANTHROPIC_DEFAULT_FABLE_MODEL: env.MERIDIAN_DEFAULT_FABLE_MODEL ?? CANONICAL_FABLE_MODEL,
     ANTHROPIC_DEFAULT_OPUS_MODEL: env.MERIDIAN_DEFAULT_OPUS_MODEL ?? CANONICAL_OPUS_MODEL,
     ANTHROPIC_DEFAULT_SONNET_MODEL: env.MERIDIAN_DEFAULT_SONNET_MODEL ?? CANONICAL_SONNET_MODEL,
     ANTHROPIC_DEFAULT_HAIKU_MODEL: env.MERIDIAN_DEFAULT_HAIKU_MODEL ?? CANONICAL_HAIKU_MODEL,
@@ -104,6 +106,16 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
   // Subagents handle focused subtasks and don't benefit from 1M context.
   // Using the base model preserves rate limit budget for the primary agent.
   const isSubagent = agentMode === "subagent"
+
+  // Fable [1m]: Fable 5 supports the 1M extended context window and, like Opus,
+  // is included on Max with no Extra Usage charge (verified on Max — a
+  // fable[1m] request returns normally, no Extra Usage error). Mirrors the opus
+  // handling: [1m] for primary agents, base model for subagents, honoring the
+  // shared Extra Usage cooldown so a future billing change auto-downgrades.
+  if (model.includes("fable")) {
+    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable()) return "fable[1m]"
+    return "fable"
+  }
 
   // Opus [1m]: included with Max, Team, and Enterprise subscriptions per
   // Anthropic docs (https://code.claude.com/docs/en/model-config#extended-context).
@@ -171,6 +183,7 @@ export function resetExtendedContextUnavailable(): void {
 export function stripExtendedContext(model: ClaudeModel): ClaudeModel {
   if (model === "opus[1m]") return "opus"
   if (model === "sonnet[1m]") return "sonnet"
+  if (model === "fable[1m]") return "fable"
   return model
 }
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -840,6 +840,14 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       context_window: isMaxSubscription ? 1_000_000 : 200_000,
     },
     {
+      id: "claude-fable-5",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Fable 5",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+    },
+    {
       id: "claude-haiku-4-5",
       object: "model",
       created: now,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -482,7 +482,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode)
         const envOverrides = requestedModel.startsWith("claude-opus-")
           ? { ANTHROPIC_DEFAULT_OPUS_MODEL: requestedModel }
-          : undefined
+          : requestedModel.startsWith("claude-fable-")
+            ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
+            : undefined
         // workingDirectory = SDK subprocess cwd (must exist on the proxy host).
         // clientWorkingDirectory = the client's local path (may not exist here);
         // used for per-project fingerprint bucketing and a system-prompt hint
@@ -3121,7 +3123,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       console.log(`Meridian running at http://${finalConfig.host}:${info.port}`)
       console.log(`Telemetry dashboard: http://${finalConfig.host}:${info.port}/telemetry`)
       const pins = resolveSdkModelDefaults()
-      console.log(`Model pins: opus=${pins.ANTHROPIC_DEFAULT_OPUS_MODEL} sonnet=${pins.ANTHROPIC_DEFAULT_SONNET_MODEL} haiku=${pins.ANTHROPIC_DEFAULT_HAIKU_MODEL}`)
+      console.log(`Model pins: fable=${pins.ANTHROPIC_DEFAULT_FABLE_MODEL} opus=${pins.ANTHROPIC_DEFAULT_OPUS_MODEL} sonnet=${pins.ANTHROPIC_DEFAULT_SONNET_MODEL} haiku=${pins.ANTHROPIC_DEFAULT_HAIKU_MODEL}`)
       // Surface the resolved Claude executable + which step picked it.
       // When users hit "wrong claude got picked" failure modes (e.g. a
       // bun-shimmed `claude` on PATH, see #478), this single line is what


### PR DESCRIPTION
Adds first-class **Claude Fable 5** (`claude-fable-5`) routing. Fable launched — and was re-enabled by Anthropic — after Meridian's last release, so `mapModelToClaudeModel` bucketed fable into the default `sonnet` branch: requests silently answered as Sonnet, and `claude-fable-5` never appeared on `/v1/models`. Same failure class as #419.

## Changes

- **`models.ts`** — `ClaudeModel` gains `fable`/`fable[1m]`. `mapModelToClaudeModel` maps `fable → fable[1m]` for primary agents and base `fable` for subagents, honoring the shared Extra-Usage cooldown (a structural mirror of the opus branch). Adds `CANONICAL_FABLE_MODEL` + the `ANTHROPIC_DEFAULT_FABLE_MODEL` pin in `resolveSdkModelDefaults` (overridable via `MERIDIAN_DEFAULT_FABLE_MODEL`). `stripExtendedContext` handles `fable[1m]`.
- **`openai.ts`** — `/v1/models` advertises `claude-fable-5` (1M context on Max, 200k otherwise).
- **`server.ts`** — explicit `claude-fable-*` requests pin `ANTHROPIC_DEFAULT_FABLE_MODEL` per-request (mirrors `claude-opus-*`); startup `Model pins:` log includes fable.

## Verification

- **Live Max probe:** `claude -p … --model 'fable[1m]'` and `--model 'claude-fable-5'` both return normally with **no Extra Usage error** and no "issue with the selected model" — confirming the alias resolves on Max on the current CLI. Defaulting to `[1m]` is safe; the existing cooldown auto-downgrades to base `fable` if a future request ever hits Extra Usage.
- **Tests:** 8 new fable-named tests (mapping, subagent downgrade, cooldown downgrade, `MERIDIAN_1M_CONTEXT_SUPPORT=0` downgrade, strip/has extended context, model-list entry + context window, pin injection, per-request pin). Full `npm test` green, `tsc --noEmit` clean.

## Depends on #560

Requires `@anthropic-ai/claude-code ≥ 2.1.170` for the `fable[1m]` alias (earlier CLIs reject it). **Merge #560 (CLI bump to 2.1.198) first.**

## Credit

Design adopted from @colto's #527 (the alias approach), rebased on current `main` with the dependency bump split into #560. Supersedes #527 and #530.