### PR TITLE
fix: forward sonnet/haiku model requests via ANTHROPIC_DEFAULT_*_MODEL overrides

### DIFF
--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -216,7 +216,8 @@ describe("SDK model pin injection (fixes #419)", () => {
 
   it("injects Meridian's canonical model pins when no shell env is set", async () => {
     const app = createTestApp()
-    await post(app, BASIC_REQUEST)
+    // Bare alias: no envOverride kicks in, so the canonical pin is exercised.
+    await post(app, { ...BASIC_REQUEST, model: "sonnet" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
@@ -235,6 +236,22 @@ describe("SDK model pin injection (fixes #419)", () => {
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
   })
 
+  // Regression: requesting a specific claude-sonnet-* version was silently
+  // collapsed to the generic "sonnet" alias and resolved to Meridian's
+  // canonical pin (claude-sonnet-4-6) instead of the requested version,
+  // because envOverrides only special-cased opus/fable requests.
+  it("explicit claude-sonnet-5 requests pin the SDK env to sonnet-5", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-sonnet-5" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+
+  it("explicit claude-haiku-4-5 requests pin the SDK env to haiku-4-5", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-haiku-4-5" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
+  })
+
   it("explicit claude-opus-4-7 requests beat inherited env pins", async () => {
     process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-6"
     const app = createTestApp()
@@ -249,12 +266,36 @@ describe("SDK model pin injection (fixes #419)", () => {
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
   })
 
+  it("explicit claude-sonnet-5 requests beat inherited env pins", async () => {
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-6"
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-sonnet-5" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+
+  it("explicit claude-haiku-4-5 requests beat inherited env pins", async () => {
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-1"
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-haiku-4-5" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
+  })
+
+  // Bare aliases ("sonnet", "opus", "haiku") must still fall back to
+  // Meridian's canonical pins — only explicit claude-<family>-* requests
+  // should set an override.
+  it("bare 'sonnet' alias requests do not set an envOverride, falling back to the canonical pin", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "sonnet" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
+  })
+
   it("shell ANTHROPIC_DEFAULT_* values win over Meridian's pins", async () => {
     process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-1-20250805"
     process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-20250514"
     process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-custom"
     const app = createTestApp()
-    await post(app, BASIC_REQUEST)
+    // Bare alias: no envOverride kicks in, so the shell-set pin is exercised.
+    await post(app, { ...BASIC_REQUEST, model: "sonnet" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-1-20250805")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-20250514")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-custom")

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -484,7 +484,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? { ANTHROPIC_DEFAULT_OPUS_MODEL: requestedModel }
           : requestedModel.startsWith("claude-fable-")
             ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
-            : undefined
+            : requestedModel.startsWith("claude-sonnet-")
+              ? { ANTHROPIC_DEFAULT_SONNET_MODEL: requestedModel }
+              : requestedModel.startsWith("claude-haiku-")
+                ? { ANTHROPIC_DEFAULT_HAIKU_MODEL: requestedModel }
+                : undefined
         // workingDirectory = SDK subprocess cwd (must exist on the proxy host).
         // clientWorkingDirectory = the client's local path (may not exist here);
         // used for per-project fingerprint bucketing and a system-prompt hint


### PR DESCRIPTION
## Bug

Requesting an explicit sonnet or haiku model (e.g. `claude-sonnet-5`) via the proxy does not actually route to that model. Meridian logs success with the intended model (`adapter=... model=sonnet`), but Claude Code reports itself as a different, older version at runtime. Using `claude` directly with the same model ID works correctly.

## Root cause

In `src/proxy/server.ts`, the `envOverrides` block that pins `ANTHROPIC_DEFAULT_{TYPE}_MODEL` for the SDK subprocess only special-cases `claude-opus-` and `claude-fable-` prefixes:

```js
const envOverrides = requestedModel.startsWith("claude-opus-")
  ? { ANTHROPIC_DEFAULT_OPUS_MODEL: requestedModel }
  : requestedModel.startsWith("claude-fable-")
    ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
    : undefined
```

`mapModelToClaudeModel` (`src/proxy/models.ts`) collapses any `claude-sonnet-*`/`claude-haiku-*` request down to the generic `"sonnet"`/`"haiku"` SDK alias, and `resolveSdkModelDefaults()` fills in `ANTHROPIC_DEFAULT_SONNET_MODEL`/`ANTHROPIC_DEFAULT_HAIKU_MODEL` with Meridian's hardcoded canonical pin whenever no override wins. Since sonnet/haiku never produced an override, an explicit request (e.g. `claude-sonnet-5`) was silently downgraded to the canonical pin (`claude-sonnet-4-6`) at the SDK subprocess boundary.

This is the same class of bug fixed for opus/fable — just not extended to sonnet/haiku at the time.

## Fix

Extends the existing `envOverrides` branch to `claude-sonnet-` and `claude-haiku-` prefixes, mirroring the opus/fable pattern exactly. Opus/fable behavior is unchanged.

## Tests

- Added: explicit `claude-sonnet-5`/`claude-haiku-4-5` requests set their respective `ANTHROPIC_DEFAULT_*_MODEL` override, including beating an inherited shell env pin (mirrors existing opus coverage).
- Added: bare `"sonnet"` alias still falls through to the canonical/shell pin (no change to alias behavior).
- Adjusted two existing tests that asserted canonical-pin/shell-pin fallback using a request model (`claude-sonnet-4-5`) that, with this fix, now legitimately triggers an override — switched those specifically to the bare `sonnet` alias, which is what they intended to exercise.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `npm test` — full suite green, including new/adjusted cases in `proxy-env-stripping.test.ts`
- [x] `bun run build` — clean

## Closes

https://github.com/rynfar/meridian/issues/558