### PR TITLE
fix: remove MultiEdit from BLOCKED_BUILTIN_TOOLS

### DIFF
--- a/src/__tests__/proxy-tool-blocking.test.ts
+++ b/src/__tests__/proxy-tool-blocking.test.ts
@@ -62,7 +62,7 @@ afterAll(() => {
 
 // The complete set of tools that must ALWAYS be blocked
 const BLOCKED_BUILTIN_TOOLS = [
-  "Read", "Write", "Edit", "MultiEdit",
+  "Read", "Write", "Edit",
   "Bash", "Glob", "Grep", "NotebookEdit",
   "WebFetch", "WebSearch", "TodoWrite"
 ]

--- a/src/proxy/tools.ts
+++ b/src/proxy/tools.ts
@@ -11,7 +11,7 @@
  * (which have correct param names for the calling agent).
  */
 export const BLOCKED_BUILTIN_TOOLS = [
-  "Read", "Write", "Edit", "MultiEdit",
+  "Read", "Write", "Edit",
   "Bash", "Glob", "Grep", "NotebookEdit",
   "WebFetch", "WebSearch", "TodoWrite"
 ]


### PR DESCRIPTION
## Problem

`MultiEdit` was merged into `Edit` in Claude Code 2.1.x and no longer exists as a distinct tool. Passing `--disallowedTools MultiEdit` to the Claude Code CLI now triggers:

```
Permission deny rule "MultiEdit" matches no known tool — check for typos.
```

This warning is harmless (does not block execution) but shows up on every proxied request that hits the tool-blocking path, adding log noise and occasionally surfacing in downstream error messages surfaced to users (e.g. mixed in with quota-exceeded errors, which is how I found it).

## Fix

Remove `MultiEdit` from `BLOCKED_BUILTIN_TOOLS` in `src/proxy/tools.ts` (and the mirrored list in the test file). `Edit` already covers multi-file/multi-edit operations in current Claude Code versions, so no functional blocking is lost.

## Testing

Verified against a live Meridian instance (v1.45.0) proxying Claude Code 2.1.202 — warning no longer appears after the fix.
