### PR TITLE
fix: dedupe passthrough tool_use captures by (name, input) signature

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -947,11 +947,31 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (toolName.toLowerCase() === "task" && toolInput?.subagent_type && typeof toolInput.subagent_type === "string") {
                   toolInput = { ...toolInput, subagent_type: resolveAgentAlias(toolInput.subagent_type) }
                 }
-                capturedToolUses.push({
-                  id: input.tool_use_id,
-                  name: toolName,
-                  input: toolInput,
-                })
+                // Dedupe at the source: in passthrough mode, when the nested
+                // SDK session never sees a real tool result for a blocked
+                // call, it can re-emit the exact same semantic call (same
+                // name + same input) on a later turn with a BRAND NEW
+                // tool_use id. Every downstream consumer of capturedToolUses
+                // (the non-stream merge, and both stream normal-path and
+                // stream recovery-path unseenToolUses filters) keys off id,
+                // so a duplicate with a fresh id sails through as a second,
+                // distinct tool_call for an identical action. Guard here,
+                // at the single push site, so all consumers are fixed at
+                // once.
+                const dedupeSig = `${toolName}:${JSON.stringify(toolInput)}`
+                const isDuplicateToolUse = capturedToolUses.some(
+                  (tu) => `${tu.name}:${JSON.stringify(tu.input)}` === dedupeSig,
+                )
+                if (isDuplicateToolUse) {
+                  plog(`[PROXY] passthrough_toolcall_dedupe skipped duplicate name=${toolName} sig=${dedupeSig.slice(0, 120)}`)
+                  claudeLog("passthrough.toolcall_dedupe_skipped", { toolName, toolUseId: input.tool_use_id })
+                } else {
+                  capturedToolUses.push({
+                    id: input.tool_use_id,
+                    name: toolName,
+                    input: toolInput,
+                  })
+                }
                 // The reason text is read by the model as the "tool result" of
                 // a denied call. With a vague reason ("Forwarding to client for
                 // execution") modern Claude tends to retry with a different


### PR DESCRIPTION
## Bug

In passthrough mode, meridian delivers every assistant `tool_call` **twice**
from turn ~4 onward on the Claude -> chat-completions path. In one observed
session this produced 32 `read_file` calls for 16 real ones, plus duplicated
`run_command` calls, confusing downstream orchestration that expected each
tool call exactly once.

## Root cause

The nested Claude Code SDK session, running in passthrough mode, has each
tool call intercepted by the `PreToolUse` hook, which pushes it onto
`capturedToolUses` and then blocks+interrupts it so the *client* executes
the tool instead. Because the nested session never sees a real tool result,
on a later turn/resume it sometimes re-emits the exact same semantic call
(same name + same input) with a **brand new `tool_use` id**.

The existing turn-2 dedup logic (`isPassthroughTurn2` in non-stream,
`turn2_suppressed` in stream) only prevents the *skipped turn's raw content
blocks* from being appended to the response — but the merge/recovery code
paths that consume `capturedToolUses` (the non-stream merge around
`capturedToolUses.map`, and `unseenToolUses` in both the stream normal path
and the stream recovery path) unconditionally re-add every entry whose id
isn't already accounted for. Since the duplicate call has a *different* id,
it sails through and gets emitted as a second, distinct `tool_call` for an
identical action.

## Fix

Dedupe at the single source: the `PreToolUse` hook push site in
`src/proxy/server.ts`. Before pushing a newly-intercepted tool call onto
`capturedToolUses`, check whether an entry with the same
`(name, JSON.stringify(input))` signature is already present; if so, skip
the push (the hook still returns the same block+interrupt decision so the
nested SDK's turn ends normally). This fixes all three consumption sites at
once, since none of them can ever emit a duplicate that was never captured
in the first place.

## Validation

This fix has been running as a targeted runtime monkey-patch (applied
directly to the built `dist/` bundle at startup) in a personal-assistant
production deployment. The duplicate-tool-call defect was confirmed via
direct repro against a local meridian instance before the patch, and the
dup rate dropped to zero after. This PR ports that same logic into the
TypeScript source at the equivalent location.