### PR TITLE
fix: make passthrough mode's turn cap configurable via env var

### DIFF
--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -10,6 +10,7 @@ import type { Options, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
 import type { Effort } from "./effort"
+import { envInt } from "../env"
 
 /**
  * Return a copy of `env` with `CLAUDE_CONFIG_DIR` removed. Used by the
@@ -140,6 +141,12 @@ export interface BuildQueryResult {
  *   - Both resume and deferred (+1): a second prelude phase pushes one phase
  *     out, so budget becomes 4.
  *   - Advisor (+3): server-side advisor executes call + result + final answer.
+ *
+ * The computed base is only a default — it's configurable via
+ * MERIDIAN_PASSTHROUGH_MAX_TURNS (or the legacy CLAUDE_PROXY_PASSTHROUGH_
+ * MAX_TURNS alias) for deployments whose nested-session turn shape doesn't
+ * match the assumptions above (e.g. an agent-side hook that needs more than
+ * one deny-and-retry round trip before ending its turn).
  */
 function computePassthroughMaxTurns(
   resumeSessionId: string | undefined,
@@ -147,7 +154,8 @@ function computePassthroughMaxTurns(
   advisorModel: string | undefined,
 ): number {
   const hasResume = !!resumeSessionId
-  const base = hasResume && hasDeferredTools ? 4 : 3
+  const defaultBase = hasResume && hasDeferredTools ? 4 : 3
+  const base = envInt("PASSTHROUGH_MAX_TURNS", defaultBase)
   const advisorBump = advisorModel ? 3 : 0
   return base + advisorBump
 }


### PR DESCRIPTION
## Bug

`computePassthroughMaxTurns()` in `src/proxy/query.ts` hardcodes the
passthrough-mode turn budget to 3 (4 when both resume and deferred tools
are active), with no config surface at all. Deployments whose nested
Claude Code SDK session needs more headroom before the PreToolUse hook's
deny-and-retry cycle ends the turn cleanly have no way to raise the cap
without patching source — they either get premature `max_turns` aborts
on deeper tool-call chains, or have to fork the file.

## Root cause

The turn budget is derived purely from `resumeSessionId` /
`hasDeferredTools` / `advisorModel` flags inside the function body; there
is no env var or config field consulted anywhere in the computation.

## Fix

Resolve the base turn count through `envInt("PASSTHROUGH_MAX_TURNS",
defaultBase)` (using the existing `env.ts` helper and its
`MERIDIAN_*`/`CLAUDE_PROXY_*` alias convention), falling back to the
current computed default when the var is unset. The resume/deferred/
advisor bump logic is unchanged — this only makes the *base* overridable.

## Validation

This fix has been running as a runtime monkey-patch (applied directly to
the built `dist/` bundle at startup, driven by
`MERIDIAN_PASSTHROUGH_MAX_TURNS`) in a personal-assistant production
deployment. Raising the cap via the env var — with zero code changes —
eliminated premature `max_turns` aborts on passthrough requests with
deeper tool-call chains. This PR ports that same override mechanism into
the TypeScript source at the equivalent location.