### PR TITLE
fix: recover non-streaming passthrough requests from max_turns/aborted

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1315,7 +1315,35 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               error: error instanceof Error ? error.message : String(error),
               ...(stderrOutput ? { stderr: stderrOutput } : {})
             })
-            throw error
+
+            // Graceful recovery: give the non-streaming path the same
+            // max_turns/aborted recovery the streaming path already has.
+            // When the nested SDK session dies mid-passthrough-loop but we
+            // already captured tool_use blocks via the PreToolUse hook, the
+            // client has actionable content — synthesize a stop_reason:
+            // "tool_use" response instead of a bare 500, and let this fall
+            // through into the existing merge block below (`if (passthrough
+            // && capturedToolUses.length > 0)`) that already knows how to
+            // backfill tool_use content blocks and assemble a normal
+            // chat.completions response.
+            const nonStreamErrMsg = error instanceof Error ? error.message : String(error)
+            const nonStreamSdkTerm = extractSdkTermination(nonStreamErrMsg)
+            const canRecoverAsToolUseNonStream =
+              (nonStreamSdkTerm.reason === "max_turns" || nonStreamSdkTerm.reason === "aborted") &&
+              passthrough &&
+              capturedToolUses.length > 0
+            if (canRecoverAsToolUseNonStream) {
+              plog(`[PROXY] ${requestMeta.requestId} nonstream_toolcalls_recovery reason=${nonStreamSdkTerm.reason} captured=${capturedToolUses.length} — synthesizing tool_use response instead of 500`)
+              claudeLog("passthrough.nonstream_recovered", {
+                mode: "non_stream",
+                model,
+                reason: nonStreamSdkTerm.reason,
+                captured: capturedToolUses.length
+              })
+              lastStopReason = "tool_use"
+            } else {
+              throw error
+            }
           }
 
           // In passthrough mode, merge captured tool_use blocks from the hook.


### PR DESCRIPTION
## Bug

The streaming passthrough path has a graceful-recovery branch
(`canRecoverAsToolUse`) that converts a `max_turns` SDK termination into a
clean `stop_reason: "tool_use"` response when tool_use blocks were
already captured via the `PreToolUse` hook — but the **non-streaming**
path has no equivalent. Any `stream=false` passthrough request with tools
that runs the nested Claude Code SDK session to its turn cap gets a bare
500, even though the captured tool_use blocks are sitting right there in
`capturedToolUses`.

## Root cause

The non-streaming catch block in `src/proxy/server.ts` only logs via
`claudeLog("upstream.failed", ...)` and unconditionally rethrows — it
never checks `extractSdkTermination()` or `capturedToolUses` before
giving up, unlike its streaming counterpart.

## Fix

When the same recovery conditions the streaming path already checks
hold (recoverable SDK termination + passthrough mode + at least one
captured tool use), skip the rethrow and let execution fall through into
the existing post-catch merge block (`if (passthrough &&
capturedToolUses.length > 0)`) that already knows how to backfill
tool_use content blocks from `capturedToolUses` and build a normal
chat.completions response with `finish_reason: "tool_calls"` — no need
for a second response-assembly path.

Accepts *either* `"max_turns"` or `"aborted"` as the termination reason,
so it composes cleanly with any future change to the PreToolUse hook that
alters the nested session's termination shape from `max_turns` to an
abort/interrupt shape.

## Validation

This fix has been running as a runtime monkey-patch (applied directly to
the built `dist/` bundle at startup) in a personal-assistant production
deployment. Non-streaming passthrough requests that previously 500'd on
turn-cap exhaustion now return a normal `tool_calls` response instead.
This PR ports that same logic into the TypeScript source at the
equivalent location.