### PR TITLE
fix: interrupt nested SDK session immediately on passthrough tool deny

### DIFF
--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -958,8 +958,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // tool, burning the maxTurns budget. Be explicit that the call
                 // succeeded externally and that the model should stop here —
                 // see telemetry for the failure mode this addresses.
+                //
+                // `interrupt: true` asks the SDK to end the nested session's
+                // turn immediately after this deny, instead of leaving the
+                // model free to keep retrying/talking until the (much
+                // larger) maxTurns cap kills the session. Without it, a
+                // passthrough call that's already forwarded to the client
+                // can burn many turns before the max_turns/aborted recovery
+                // path (see the non-stream/stream recovery code) even gets
+                // a chance to kick in.
                 return {
                   decision: "block" as const,
+                  interrupt: true,
                   reason:
                     "This tool call has been forwarded to the client for execution. " +
                     "The result will be delivered in a future turn. " +


### PR DESCRIPTION
## Bug

In passthrough mode, the `PreToolUse` hook's deny response for a
forwarded tool call is `{ decision: "block", reason: "..." }` with no
interrupt signal. The model is free to keep retrying or talking until the
(much larger) `maxTurns` cap eventually kills the session — recoverable
via the max_turns/aborted recovery paths, but slow, burning turns the
request didn't actually need.

## Fix

Add `interrupt: true` to the deny response in the `PreToolUse` hook
(`src/proxy/server.ts`) so the SDK ends the nested session's turn
immediately after the deny, letting recovery (streaming or
non-streaming) kick in on turn 1 instead of waiting for the turn cap.

## Caveat / composition note

This can change `extractSdkTermination()`'s inferred termination reason
from `"max_turns"` to an abort/interrupt shape (e.g. `"aborted"`). Both
recovery paths need to accept either reason for this to compose safely —
see the companion PR that adds `"max_turns" || "aborted"` acceptance to
the non-streaming recovery path (the streaming path already accepts
both). If a deployment's recovery path only checks for `"max_turns"`,
reverting this one file is safe — the max_turns-cap recovery path still
works, just slower.

## Validation

This fix has been running as a runtime monkey-patch against the built
bundle in a personal-assistant production deployment, alongside the
accepting recovery-path changes, with no regressions observed.