### PR TITLE
fix(passthrough): correct single-step semantics for client-driven tool loops

### DIFF
--- a/src/__tests__/proxy-passthrough-single-turn.test.ts
+++ b/src/__tests__/proxy-passthrough-single-turn.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Passthrough Mode: client-driven single-step semantics (non-streaming)
+ *
+ * A passthrough /v1/messages request must behave like the raw Anthropic API:
+ * return the tool calls the model makes for ONE logical step and hand them back
+ * so the CLIENT drives the tool loop. Claude Code's nested SDK session instead
+ * blocks each forwarded tool and lets the model keep going — fabricating results
+ * and looping — which broke client-driven loops (AI SDK generateText /
+ * generateObject, e.g. Anchor's workflow spine) two ways:
+ *
+ *   1. Turn budget: sequential loops / forced tool_choice keep the SDK looping
+ *      until it trips maxTurns → the non-stream path threw HTTP 500.
+ *   2. Concatenation / duplication: every internal turn's tool_use was merged
+ *      into the single response → multiple concatenated tool_use / JSON objects
+ *      (unparseable structured output; #528 parallel-call duplication).
+ *
+ * The capture path now distinguishes:
+ *   - genuine parallel calls (DISTINCT tool names)     → all forwarded
+ *   - an exact re-emit of a blocked call (same name+input, new id) → dropped
+ *   - the same tool re-called with NEW args (loop continuation) → stop
+ *   - a forced single tool (tool_choice:{type:"tool"})           → keep first
+ *
+ * This drives a hook-aware SDK mock that fires PreToolUse between turns — how
+ * the real SDK accumulates captures — and asserts each rule.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { makeRequest } from "./helpers"
+
+const PASSTHROUGH_PREFIX = "mcp__oc__"
+
+// Assistant turns the mocked SDK yields, in order. Each tool_use turn's hook is
+// fired after the turn is yielded, simulating the real SDK executing (and the
+// passthrough PreToolUse hook capturing + blocking) between turns.
+let mockTurns: any[] = []
+
+function toolTurn(toolId: string, toolName: string, input: Record<string, unknown>) {
+  return {
+    type: "assistant",
+    message: {
+      id: `msg_${toolId}`,
+      type: "message",
+      role: "assistant",
+      content: [{ type: "tool_use", id: toolId, name: `${PASSTHROUGH_PREFIX}${toolName}`, input }],
+      model: "claude-sonnet-4-5-20250929",
+      stop_reason: "tool_use",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: "test-session",
+  }
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) =>
+    (async function* () {
+      const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+      for (const turn of mockTurns) {
+        yield turn
+        // Simulate the SDK executing this turn's tool call: the passthrough
+        // PreToolUse hook fires (captures + blocks) BEFORE the next turn is
+        // produced. If the consumer has already broken, this never runs for
+        // later turns.
+        if (preHook && turn.type === "assistant") {
+          for (const block of turn.message.content) {
+            if (block.type === "tool_use") {
+              await preHook({ tool_name: block.name, tool_use_id: block.id, tool_input: block.input })
+            }
+          }
+        }
+      }
+    })(),
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+const tool = (name: string) => ({
+  name,
+  description: `${name} tool`,
+  input_schema: { type: "object", properties: {}, additionalProperties: true },
+})
+
+async function postNonStream(app: any, overrides: Record<string, unknown> = {}): Promise<Response> {
+  const req = new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      makeRequest({
+        stream: false,
+        tools: [tool("get_weather"), tool("get_time")],
+        messages: [{ role: "user", content: "Do the thing." }],
+        ...overrides,
+      })
+    ),
+  })
+  return app.fetch(req)
+}
+
+function toolBlocks(body: any): Array<{ name: string; id: string; input: any }> {
+  return body.content.filter((b: any) => b.type === "tool_use")
+}
+
+describe("Passthrough non-streaming: client-driven single-step semantics", () => {
+  let origEnv: string | undefined
+
+  beforeEach(() => {
+    mockTurns = []
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv !== undefined) process.env.MERIDIAN_PASSTHROUGH = origEnv
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    mockTurns = []
+  })
+
+  it("keeps DISTINCT parallel tool_use across internal turns (no truncation, no dup) — #528", async () => {
+    // The SDK serializes even a parallel request into separate turns. Both
+    // distinct tools must survive; neither may be dropped or duplicated.
+    mockTurns = [
+      toolTurn("toolu_w", "get_weather", { city: "Paris" }),
+      toolTurn("toolu_t", "get_time", { city: "Paris" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const body = (await (await postNonStream(app)).json()) as any
+
+    const tus = toolBlocks(body)
+    expect(tus.map(t => t.name).sort()).toEqual(["get_time", "get_weather"])
+    expect(body.stop_reason).toBe("tool_use")
+  })
+
+  it("drops an EXACT re-emit (same name+input, new id) but keeps a following distinct call — #528", async () => {
+    // Order: distinct, then a duplicate of the first, then another distinct.
+    // The duplicate is dropped without stopping collection of the distinct set.
+    mockTurns = [
+      toolTurn("toolu_w1", "get_weather", { city: "Paris" }),
+      toolTurn("toolu_w2", "get_weather", { city: "Paris" }), // exact re-emit → dropped
+      toolTurn("toolu_t1", "get_time", { city: "Paris" }),    // distinct → kept
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const body = (await (await postNonStream(app)).json()) as any
+
+    const tus = toolBlocks(body)
+    expect(tus.map(t => t.name).sort()).toEqual(["get_time", "get_weather"])
+    // The kept get_weather is the first occurrence.
+    expect(tus.find(t => t.name === "get_weather")!.id).toBe("toolu_w1")
+  })
+
+  it("stops at the first repeat of the SAME tool with new args (sequential loop)", async () => {
+    // A sequential-dependency loop: the model re-calls the same tool with a
+    // fabricated ack. Only the first call is the client's real next step.
+    mockTurns = [
+      toolTurn("toolu_1", "get_weather", { city: "Paris" }),
+      toolTurn("toolu_2", "get_weather", { city: "London" }), // same tool, new args → stop
+      toolTurn("toolu_3", "get_weather", { city: "Tokyo" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const body = (await (await postNonStream(app)).json()) as any
+
+    const tus = toolBlocks(body)
+    expect(tus.length).toBe(1)
+    expect(tus[0]!.id).toBe("toolu_1")
+  })
+
+  it("returns exactly one tool_use when tool_choice forces a single tool (structured output)", async () => {
+    // generateObject sends tool_choice:{type:"tool",...}. Even if the SDK loops
+    // and re-answers with different args, only the first structured call ships.
+    mockTurns = [
+      toolTurn("toolu_a", "json", { answer: "first" }),
+      toolTurn("toolu_b", "json", { answer: "second, different" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const body = (await (await postNonStream(app, {
+      tools: [tool("json")],
+      tool_choice: { type: "tool", name: "json", disable_parallel_tool_use: true },
+    })).json()) as any
+
+    const tus = toolBlocks(body)
+    expect(tus.length).toBe(1)
+    expect(tus[0]!.id).toBe("toolu_a")
+    expect(tus[0]!.input.answer).toBe("first")
+  })
+
+  it("preserves first-turn text alongside the tool_use", async () => {
+    mockTurns = [
+      {
+        type: "assistant",
+        message: {
+          id: "msg_mixed",
+          type: "message",
+          role: "assistant",
+          content: [
+            { type: "text", text: "Fetching the weather." },
+            { type: "tool_use", id: "toolu_a", name: `${PASSTHROUGH_PREFIX}get_weather`, input: { city: "Paris" } },
+          ],
+          model: "claude-sonnet-4-5-20250929",
+          stop_reason: "tool_use",
+          usage: { input_tokens: 10, output_tokens: 20 },
+        },
+        parent_tool_use_id: null,
+        uuid: crypto.randomUUID(),
+        session_id: "test-session",
+      },
+      toolTurn("toolu_b", "get_weather", { city: "London" }), // same tool repeat → stop
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const body = (await (await postNonStream(app)).json()) as any
+
+    const tus = toolBlocks(body)
+    const texts = body.content.filter((b: any) => b.type === "text")
+    expect(tus.length).toBe(1)
+    expect(tus[0]!.id).toBe("toolu_a")
+    expect(texts.some((b: any) => b.text.includes("Fetching the weather."))).toBe(true)
+  })
+})

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -182,6 +182,21 @@ function stableStringify(value: unknown): string {
 }
 
 /**
+ * Stable semantic signature for a forwarded tool_use: tool name + a
+ * key-order-independent serialization of its input. Two tool calls with the
+ * same name and the same arguments share a signature even if the SDK assigns
+ * them different tool_use ids.
+ *
+ * Used by the passthrough capture path to tell apart genuine parallel calls
+ * (distinct signatures — e.g. get_weather vs get_time) from an SDK internal
+ * continuation turn re-emitting a blocked call (identical signature, new id).
+ * The former are all forwarded; the latter is a duplicate and dropped.
+ */
+export function toolUseSignature(name: string, input: unknown): string {
+  return `${name}::${stableStringify(input ?? null)}`
+}
+
+/**
  * Strip the MCP prefix from a tool name to get the OpenCode tool name.
  * e.g., "mcp__oc__todowrite" → "todowrite"
  */

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -9,6 +9,7 @@ import { join } from "node:path"
 import type { Options, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
+import { envInt } from "../env"
 import type { Effort } from "./effort"
 
 /**
@@ -147,7 +148,16 @@ function computePassthroughMaxTurns(
   advisorModel: string | undefined,
 ): number {
   const hasResume = !!resumeSessionId
-  const base = hasResume && hasDeferredTools ? 4 : 3
+  const defaultBase = hasResume && hasDeferredTools ? 4 : 3
+  // The base is the SDK's internal-loop budget before it must return control.
+  // It's normally enough (the capture path drops re-emitted duplicates and
+  // stops the loop when the model starts repeating), but wide parallel tool
+  // calls — which the SDK surfaces one assistant turn each — can need more
+  // headroom, and orchestration clients hit it on deep chains (#494). Allow
+  // MERIDIAN_PASSTHROUGH_MAX_TURNS / CLAUDE_PROXY_PASSTHROUGH_MAX_TURNS to
+  // raise (or lower) the base; the resume/advisor bumps below are unchanged.
+  const configured = envInt("PASSTHROUGH_MAX_TURNS", defaultBase)
+  const base = configured > 0 ? configured : defaultBase
   const advisorBump = advisorModel ? 3 : 0
   return base + advisorBump
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -38,7 +38,7 @@ import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
-import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -687,8 +687,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         //
         // Opt-in via header value: clients that don't set the header are
         // unaffected — behavior is byte-identical to today.
+        // Client-driven passthrough loop: the last message is a tool_result,
+        // i.e. the client executed a forwarded tool and is sending the result
+        // back to continue its own loop. These requests are self-contained
+        // (each carries the full growing conversation), so they need no session
+        // resume — and, being headerless, they would otherwise all collide on
+        // the same (firstUserMessage, cwd) fingerprint when a workflow engine
+        // runs several loops concurrently, causing one run to resume another
+        // run's Claude session and corrupt the conversation (premature
+        // end_turn, dropped tool calls). Treat them as independent: no
+        // fingerprint resume, no cache write. Header-keyed sessions (OpenCode's
+        // x-opencode-session, LiteLLM's x-litellm-session-id) never reach the
+        // fingerprint path, so they are unaffected.
+        const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : undefined
+        const lastIsToolResult = Array.isArray(lastMessage?.content)
+          && lastMessage.content.some((b: any) => b?.type === "tool_result")
+        const isClientDrivenLoop = !agentSessionId && lastIsToolResult
         const isIndependentSession =
-          requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || false
+          requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || isClientDrivenLoop || false
         let lineageResult = isIndependentSession
           ? { type: "diverged" as const }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
@@ -875,7 +891,29 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             ? ["project"]
             : pipelineCtx.settingSources ?? []
 
+      // Passthrough tool_use capture. `capturedToolUses` holds the DISTINCT
+      // tool calls to forward to the client; `capturedSignatures` dedupes them
+      // by (name, input) so an SDK internal continuation turn re-emitting a
+      // blocked call (same args, new id) is dropped instead of concatenated
+      // into the response (fixes #528). `sawDuplicateToolUse` records that such
+      // a re-emit happened — the signal the model has stopped making progress
+      // and started repeating, which the non-streaming loop uses to return the
+      // distinct set immediately rather than burning the whole turn budget.
       const capturedToolUses: Array<{ id: string; name: string; input: any }> = []
+      const capturedSignatures = new Set<string>()
+      const capturedToolNames = new Set<string>()
+      let sawDuplicateToolUse = false
+      // Forced structured output: a `tool_choice` of {type:"tool",...} (or an
+      // explicit disable_parallel_tool_use) means the client — e.g. the AI
+      // SDK's generateObject — wants EXACTLY ONE call to that tool. Claude
+      // Code's nested loop, prodded by the forced choice, re-calls the tool
+      // across internal turns with slightly different arguments; those are
+      // distinct signatures, so signature-dedup alone wouldn't collapse them
+      // and the response would concatenate multiple JSON objects (unparseable).
+      // When the client forces a single tool, keep only the first capture.
+      const toolChoice = body.tool_choice
+      const forceSingleToolUse =
+        !!toolChoice && (toolChoice.type === "tool" || toolChoice.disable_parallel_tool_use === true)
       const fileChanges: FileChange[] = []
 
       // In passthrough mode, register OpenCode's tools as MCP tools so Claude
@@ -965,11 +1003,50 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (toolName.toLowerCase() === "task" && toolInput?.subagent_type && typeof toolInput.subagent_type === "string") {
                   toolInput = { ...toolInput, subagent_type: resolveAgentAlias(toolInput.subagent_type) }
                 }
-                capturedToolUses.push({
-                  id: input.tool_use_id,
-                  name: toolName,
-                  input: toolInput,
-                })
+                // Decide whether to forward this captured tool_use, or drop it
+                // as an artifact of the nested SDK's internal loop. In
+                // passthrough the CLIENT executes tools and returns real
+                // results, so the model should only emit ONE logical step of
+                // tool calls per request — but Claude Code blocks each call and
+                // lets the model keep going, so it fabricates results and loops.
+                // Three cases collapse that loop back to the client-facing set:
+                //   1. Exact re-emit (same name+input, fresh id): a blocked call
+                //      re-surfaced on a later internal turn. Drop it, but keep
+                //      collecting — a genuine parallel call to a DIFFERENT tool
+                //      may still follow (robust to duplicate-before-distinct
+                //      ordering). This is the #528 duplication.
+                //   2. Same tool re-called with NEW args: the model fabricated a
+                //      result for the blocked call and continued (a sequential-
+                //      dependency loop, e.g. fetch→fetch→fetch). Stop after the
+                //      distinct set — the client will supply the real result and
+                //      drive the next call. (Genuine parallel uses DISTINCT tool
+                //      names — get_weather + get_time — which are kept.)
+                //   3. Forced single tool (tool_choice:{type:"tool"} / structured
+                //      output): keep only the first call.
+                // Cases 2 and 3 set sawDuplicateToolUse, the signal the non-
+                // streaming loop uses to return the distinct set immediately
+                // instead of draining the whole turn budget.
+                const signature = toolUseSignature(toolName, toolInput)
+                const isExactDuplicate = capturedSignatures.has(signature)
+                const isSameToolRepeat = !isExactDuplicate && capturedToolNames.has(toolName)
+                const exceedsForcedSingle = forceSingleToolUse && capturedToolUses.length >= 1
+                if (isExactDuplicate) {
+                  claudeLog("passthrough.duplicate_tool_use_dropped", { name: toolName })
+                } else if (isSameToolRepeat || exceedsForcedSingle) {
+                  sawDuplicateToolUse = true
+                  claudeLog("passthrough.extra_tool_use_dropped", {
+                    name: toolName,
+                    reason: exceedsForcedSingle ? "forced_single" : "same_tool_repeat",
+                  })
+                } else {
+                  capturedSignatures.add(signature)
+                  capturedToolNames.add(toolName)
+                  capturedToolUses.push({
+                    id: input.tool_use_id,
+                    name: toolName,
+                    input: toolInput,
+                  })
+                }
                 // The reason text is read by the model as the "tool result" of
                 // a denied call. With a vague reason ("Forwarding to client for
                 // execution") modern Claude tends to retry with a different
@@ -1226,6 +1303,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               if ((message as any).session_id) {
                 currentSessionId = (message as any).session_id
               }
+              // Passthrough single-turn guard: once the model re-emits a call it
+              // already made (detected in the PreToolUse hook between turns), it
+              // has stopped making progress and is looping against the blocked
+              // tool. Every distinct tool_use for this exchange is already in
+              // capturedToolUses, so stop draining the SDK's internal loop —
+              // this returns the full parallel set while avoiding the maxTurns
+              // exhaustion that otherwise 500s a client-driven tool loop.
+              if (passthrough && sawDuplicateToolUse) {
+                claudeLog("passthrough.loop_break", { mode: "non_stream", assistantMessages, captured: capturedToolUses.length })
+                break
+              }
               if (message.type === "assistant") {
                 assistantMessages += 1
                 // Capture SDK assistant UUID for undo rollback
@@ -1326,14 +1414,44 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
               error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
             }
-            claudeLog("upstream.failed", {
-              mode: "non_stream",
-              model,
-              durationMs: Date.now() - upstreamStartAt,
-              error: error instanceof Error ? error.message : String(error),
-              ...(stderrOutput ? { stderr: stderrOutput } : {})
-            })
-            throw error
+            // Graceful recovery — the non-streaming counterpart of the streaming
+            // path's canRecoverAsToolUse branch. If the SDK hit its turn cap (or
+            // was aborted) but the PreToolUse hook already captured tool_use
+            // blocks, the client has everything it needs to run the tools and
+            // drive the next turn. Fall through to the merge + normal response
+            // build below instead of surfacing a 500. Distinct-only captures
+            // that never triggered the loop-break (e.g. wide parallel exceeding
+            // the turn budget) land here.
+            const sdkTerm = extractSdkTermination(error instanceof Error ? error.message : String(error))
+            const canRecoverAsToolUse =
+              passthrough &&
+              capturedToolUses.length > 0 &&
+              (sdkTerm.reason === "max_turns" || sdkTerm.reason === "aborted")
+            if (canRecoverAsToolUse) {
+              diagnosticLog.session(
+                `${requestMeta.requestId} sdk_termination_recovered ${formatSdkTermination(sdkTerm, {
+                  model, requestSource, isResume, hasDeferredTools, sdkSessionId: resumeSessionId,
+                })} captured=${capturedToolUses.length}`,
+                requestMeta.requestId,
+              )
+              claudeLog("passthrough.max_turns_recovered", {
+                mode: "non_stream",
+                reason: sdkTerm.reason,
+                captured: capturedToolUses.length,
+              })
+              // Do not rethrow — execution continues into the merge block, which
+              // backfills contentBlocks from capturedToolUses and builds a clean
+              // stop_reason:"tool_use" response.
+            } else {
+              claudeLog("upstream.failed", {
+                mode: "non_stream",
+                model,
+                durationMs: Date.now() - upstreamStartAt,
+                error: error instanceof Error ? error.message : String(error),
+                ...(stderrOutput ? { stderr: stderrOutput } : {})
+              })
+              throw error
+            }
           }
 
           // In passthrough mode, merge captured tool_use blocks from the hook.


### PR DESCRIPTION
## Summary

Passthrough (`MERIDIAN_PASSTHROUGH=1`) must behave like the raw Anthropic API: each `/v1/messages` returns the tool calls the model makes for **one logical step** and hands them back so the **client** drives the tool loop. Claude Code's nested SDK blocks each forwarded tool (PreToolUse) and lets the model keep going — fabricating results and looping — which broke client-driven loops (AI SDK `generateText`/`generateObject`, e.g. Anchor's concurrent spine) and also caused the non-streaming parallel duplication in #528.

> **History:** an earlier version of this PR stopped after the first tool_use turn. That truncated legitimate **parallel** tool calls (Claude Code serializes even parallel calls into separate turns), so it was replaced with the signature/name-based approach below.

## Root causes → fixes

1. **Duplicate / concatenated tool_use** (#528; structured concatenation). Every internal turn's tool_use was force-merged into the one response. The capture path now dedupes exact re-emits by `(name,input)` signature (new `toolUseSignature`), **keeps** genuine parallel calls to *distinct* tools, and **stops** once the model re-calls the *same* tool with new args (loop continuation) or the client forced one tool via `tool_choice:{type:"tool"}` / `disable_parallel_tool_use` (`generateObject`).
2. **`max_turns` 500 on non-streaming loops.** Added a graceful `max_turns`/`aborted` recovery to the non-streaming catch, mirroring the streaming `canRecoverAsToolUse` path.
3. **Concurrency corruption** (premature `end_turn`, dropped calls). Headerless client-driven requests (last message a `tool_result`) all shared the same `(firstUserMessage, cwd)` fingerprint, so concurrent loops resumed each other's Claude session. They're self-contained → treat as independent (no fingerprint resume/write), reusing the existing fork/subagent path. Header-keyed sessions (OpenCode/LiteLLM) are unaffected.
4. **Configurable turn budget** (#494). `computePassthroughMaxTurns` now honors `MERIDIAN_PASSTHROUGH_MAX_TURNS`.

Text-only passthrough is untouched (no tool_use → no dedup/stop), so OpenCode and other existing clients are byte-identical.

## Resolves
- **#528** — non-streaming parallel tool_use duplication (verified: parallel now returns 2 distinct, not 1, not 4).
- **#494** — configurable passthrough max turns (`MERIDIAN_PASSTHROUGH_MAX_TURNS`).

Overlaps the #567–#570 cluster (dedup / recover / interrupt / config) — this consolidates those ideas into one change plus the session-collision and forced-single fixes. Maintainer's call whether to prefer this or the cluster.

## Validation

- **Unit suite: 1804 pass / 0 fail**; `tsc --noEmit` clean. New hook-aware regression tests cover: distinct parallel kept, exact re-emit dropped, same-tool-repeat stop, forced-single, first-turn text preserved.
- **Live (patched build vs real Claude Max):** parallel #528 repro → 2 distinct ✔; forced `generateObject` → exactly 1 object ✔; Anchor sequential loop → no over-collection ✔; server logs confirm client-driven requests are now `lineage=new` with **zero** session-collision anomalies.
- ⚠️ **Final acceptance pending:** the repeated `--concurrent 4/8 ALL PASS` runs were interrupted when the test account hit its Claude Max **session limit** (the iterations that ran before it were clean 8/8). Needs a final repeated run after quota reset to confirm determinism.

> Committed with `--no-gpg-sign` (signing key passphrase-locked in this environment; `main` HEAD is itself unsigned).

https://claude.ai/code/session_01D85oU8HoFXukFpN7nC3pY6
