### PR TITLE
fix: support native structured output

### DIFF
--- a/src/__tests__/proxy-structured-output.test.ts
+++ b/src/__tests__/proxy-structured-output.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+let capturedOptions: Record<string, unknown> = {}
+let mockMessages: unknown[] = []
+let queryCalls = 0
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { options?: Record<string, unknown> }) => {
+    queryCalls += 1
+    capturedOptions = params.options ?? {}
+    return (async function* () {
+      for (const message of mockMessages) yield message
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+const schema = {
+  type: "object",
+  properties: { answer: { type: "string" } },
+  required: ["answer"],
+  additionalProperties: false,
+}
+
+function resultMessage(structuredOutput: unknown) {
+  return {
+    type: "result",
+    subtype: "success",
+    duration_ms: 10,
+    duration_api_ms: 8,
+    is_error: false,
+    num_turns: 1,
+    result: JSON.stringify(structuredOutput),
+    stop_reason: "end_turn",
+    total_cost_usd: 0,
+    usage: { input_tokens: 12, output_tokens: 7 },
+    modelUsage: {},
+    permission_denials: [],
+    errors: [],
+    uuid: crypto.randomUUID(),
+    session_id: "structured-session",
+    structured_output: structuredOutput,
+  }
+}
+
+function request(stream: boolean, outputConfig: unknown = { format: { type: "json_schema", schema } }) {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      max_tokens: 512,
+      stream,
+      messages: [{ role: "user", content: "Return an answer." }],
+      output_config: outputConfig,
+    }),
+  })
+}
+
+describe("native structured output", () => {
+  let originalPassthrough: string | undefined
+
+  beforeEach(() => {
+    originalPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    capturedOptions = {}
+    mockMessages = []
+    queryCalls = 0
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (originalPassthrough === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = originalPassthrough
+  })
+
+  it("maps output_config.format to the Agent SDK and returns authoritative JSON", async () => {
+    mockMessages = [resultMessage({ answer: "grounded" })]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await app.fetch(request(false))
+    const body = await response.json() as any
+
+    expect(response.status).toBe(200)
+    expect(capturedOptions.outputFormat).toEqual({ type: "json_schema", schema })
+    expect(body.stop_reason).toBe("end_turn")
+    expect(body.content).toEqual([{ type: "text", text: '{"answer":"grounded"}' }])
+    expect(body.usage).toEqual({ input_tokens: 12, output_tokens: 7 })
+  })
+
+  it("buffers structured streaming until validation and emits one valid SSE message", async () => {
+    mockMessages = [resultMessage({ answer: "streamed" })]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await app.fetch(request(true))
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("text/event-stream")
+    expect(capturedOptions.outputFormat).toEqual({ type: "json_schema", schema })
+    expect(body).toContain("event: message_start")
+    expect(body).toContain('"text":"{\\"answer\\":\\"streamed\\"}"')
+    expect(body).toContain('"stop_reason":"end_turn"')
+    expect(body).toContain("event: message_stop")
+  })
+
+  it("rejects malformed output formats before starting an SDK query", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await app.fetch(request(false, { format: { type: "xml", schema } }))
+    const body = await response.json() as any
+
+    expect(response.status).toBe(400)
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.message).toContain("Only 'json_schema' is supported")
+    expect(queryCalls).toBe(0)
+  })
+
+  it("fails instead of returning fallback prose when the SDK omits structured_output", async () => {
+    mockMessages = [{
+      type: "result",
+      subtype: "success",
+      session_id: "missing-structured-output",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await app.fetch(request(false))
+    const body = await response.json() as any
+
+    expect(response.status).toBeGreaterThanOrEqual(500)
+    expect(body.type).toBe("error")
+  })
+})

--- a/src/__tests__/proxy-structured-output.test.ts
+++ b/src/__tests__/proxy-structured-output.test.ts
@@ -55,7 +55,11 @@ function resultMessage(structuredOutput: unknown) {
   }
 }
 
-function request(stream: boolean, outputConfig: unknown = { format: { type: "json_schema", schema } }) {
+function request(
+  stream: boolean,
+  outputConfig: unknown = { format: { type: "json_schema", schema } },
+  extra: Record<string, unknown> = {}
+) {
   return new Request("http://localhost/v1/messages", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -65,6 +69,7 @@ function request(stream: boolean, outputConfig: unknown = { format: { type: "jso
       stream,
       messages: [{ role: "user", content: "Return an answer." }],
       output_config: outputConfig,
+      ...extra,
     }),
   })
 }
@@ -114,6 +119,23 @@ describe("native structured output", () => {
     expect(body).toContain('"text":"{\\"answer\\":\\"streamed\\"}"')
     expect(body).toContain('"stop_reason":"end_turn"')
     expect(body).toContain("event: message_stop")
+  })
+
+  it("rejects requests that combine tools with output_config.format", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const tools = [{
+      name: "get_weather",
+      description: "Get the weather",
+      input_schema: { type: "object", properties: {}, additionalProperties: false },
+    }]
+    const response = await app.fetch(request(false, undefined, { tools }))
+    const body = await response.json() as any
+
+    expect(response.status).toBe(400)
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.message).toContain("tools")
+    expect(queryCalls).toBe(0)
   })
 
   it("rejects malformed output formats before starting an SDK query", async () => {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -6,7 +6,7 @@
  */
 
 import { join } from "node:path"
-import type { Options, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
+import type { Options, OutputFormat, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
 import { envInt } from "../env"
@@ -88,6 +88,8 @@ export interface QueryContext {
   thinking?: { type: 'adaptive' } | { type: 'enabled'; budgetTokens?: number } | { type: 'disabled' }
   /** API-side task budget in tokens — model paces tool use within this limit */
   taskBudget?: { total: number }
+  /** Native JSON-schema output contract for the Claude Agent SDK */
+  outputFormat?: OutputFormat
   /** Beta features to enable */
   betas?: string[]
   /** SDK setting sources — controls CLAUDE.md and user settings loading */
@@ -226,7 +228,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv, hasDeferredTools,
     resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools, incompatibleTools,
     mcpServerName, allowedMcpTools, onStderr,
-    effort, thinking, taskBudget, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
+    effort, thinking, taskBudget, outputFormat, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
     memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
   } = ctx
   const cwdNote = buildCwdNote(workingDirectory, clientWorkingDirectory)
@@ -322,6 +324,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       ...(effort ? { effort } : {}),
       ...(thinking ? { thinking } : {}),
       ...(taskBudget ? { taskBudget } : {}),
+      ...(outputFormat ? { outputFormat } : {}),
       ...(betas && betas.length > 0 ? { betas: betas as SdkBeta[] } : {}),
       ...(maxBudgetUsd && maxBudgetUsd > 0 ? { maxBudgetUsd } : {}),
       ...(fallbackModel ? { fallbackModel } : {}),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -56,6 +56,7 @@ import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
 import { normalizeEffort } from "./effort"
+import { parseOutputFormat, structuredOutputText } from "./structuredOutput"
 import { runTransformHook, buildPipeline, createRequestContext } from "./transform"
 import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
@@ -464,6 +465,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           )
         }
 
+        const parsedOutputFormat = parseOutputFormat(body.output_config)
+        if (!parsedOutputFormat.ok) {
+          return c.json(
+            { type: "error", error: { type: "invalid_request_error", message: parsedOutputFormat.message } },
+            400
+          )
+        }
+        const outputFormat = parsedOutputFormat.value
+
         // Resolve profile: header > active > default > first configured
         const profile = resolveProfile(
           finalConfig.profiles,
@@ -579,7 +589,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const stream = pipelineCtx.prefersStreaming !== undefined ? pipelineCtx.prefersStreaming : (body.stream ?? false)
 
         // --- SDK parameter passthrough ---
-        // Extract effort, thinking, taskBudget from body (standard Anthropic API fields).
+        // Extract effort, thinking, taskBudget, and native structured output
+        // from standard Anthropic API fields.
         // Header overrides take precedence over body values.
         const effortHeader = c.req.header("x-opencode-effort")
         const thinkingHeader = c.req.header("x-opencode-thinking")
@@ -1082,6 +1093,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (!stream) {
           const contentBlocks: Array<Record<string, unknown>> = []
           let assistantMessages = 0
+          let hasStructuredOutput = false
+          let structuredOutput: unknown
           const upstreamStartAt = Date.now()
           let firstChunkAt: number | undefined
           let currentSessionId: string | undefined
@@ -1144,7 +1157,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                     resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
-                    effort, thinking, taskBudget, betas, settingSources,
+                    effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
@@ -1191,7 +1204,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                       resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
-                      effort, thinking, taskBudget, betas, settingSources,
+                      effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
@@ -1239,7 +1252,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                       resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
-                      effort, thinking, taskBudget, betas, settingSources,
+                      effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
@@ -1393,6 +1406,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (resultUsage) {
                   lastUsage = { ...lastUsage, ...resultUsage }
                 }
+                if (outputFormat && "structured_output" in message) {
+                  hasStructuredOutput = true
+                  structuredOutput = message.structured_output
+                }
               }
             }
 
@@ -1455,6 +1472,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               })
               throw error
             }
+          }
+
+          if (outputFormat) {
+            if (!hasStructuredOutput) {
+              throw new Error("Structured output was requested but the SDK returned no structured_output result")
+            }
+            contentBlocks.splice(0, contentBlocks.length, {
+              type: "text",
+              text: structuredOutputText(structuredOutput),
+            })
           }
 
           // In passthrough mode, merge captured tool_use blocks from the hook.
@@ -1654,6 +1681,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
             let messageStartEmitted = false
             let lastUsage: TokenUsage | undefined
+            let hasStructuredOutput = false
+            let structuredOutput: unknown
             // Hoisted out of the inner streaming loop so the outer catch can
             // dedupe captured tool_uses against what was already forwarded
             // when recovering gracefully from max_turns (see catch below).
@@ -1690,7 +1719,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                       resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
-                      effort, thinking, taskBudget, betas, settingSources,
+                      effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
@@ -1732,7 +1761,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
-                        effort, thinking, taskBudget, betas, settingSources,
+                        effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
@@ -1776,7 +1805,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                         resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
-                        effort, thinking, taskBudget, betas, settingSources,
+                        effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
@@ -1894,6 +1923,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   if (message.type === "assistant" && (message as any).uuid) {
                     sdkUuidMap.push((message as any).uuid)
                   }
+                  if (message.type === "result") {
+                    const resultUsage = (message as { usage?: unknown }).usage as TokenUsage | undefined
+                    if (resultUsage) lastUsage = { ...lastUsage, ...resultUsage }
+                    if (outputFormat && "structured_output" in message) {
+                      hasStructuredOutput = true
+                      structuredOutput = message.structured_output
+                    }
+                  }
 
                   if (message.type === "stream_event") {
                     streamEventsSeen += 1
@@ -1909,6 +1946,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     const event = message.event
                     const eventType = (event as any).type
                     const eventIndex = (event as any).index as number | undefined
+
+                    // Native structured output is validated only on the SDK's
+                    // final result message. Buffer its partial wire events and
+                    // emit one valid Anthropic SSE message after validation.
+                    if (outputFormat) {
+                      if (eventType === "message_start") {
+                        const startUsage = (event as unknown as { message?: { usage?: TokenUsage } }).message?.usage
+                        if (startUsage) lastUsage = { ...lastUsage, ...startUsage }
+                      } else if (eventType === "message_delta") {
+                        const deltaUsage = (event as unknown as { usage?: TokenUsage }).usage
+                        if (deltaUsage) lastUsage = { ...lastUsage, ...deltaUsage }
+                      }
+                      continue
+                    }
 
                     // Track MCP tool blocks (mcp__opencode__*) — these are internal tools
                     // that the SDK executes. Don't forward them to OpenCode.
@@ -2103,6 +2154,56 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
               } finally {
                 clearInterval(heartbeat)
+              }
+
+              if (outputFormat) {
+                if (!hasStructuredOutput) {
+                  throw new Error("Structured output was requested but the SDK returned no structured_output result")
+                }
+                const text = structuredOutputText(structuredOutput)
+                const messageId = `msg_${Date.now()}`
+                safeEnqueue(encoder.encode(
+                  `event: message_start\ndata: ${JSON.stringify({
+                    type: "message_start",
+                    message: {
+                      id: messageId,
+                      type: "message",
+                      role: "assistant",
+                      content: [],
+                      model: body.model,
+                      stop_reason: null,
+                      stop_sequence: null,
+                      usage: { input_tokens: lastUsage?.input_tokens ?? 0, output_tokens: 0 },
+                    },
+                  })}\n\n`
+                ), "structured_message_start")
+                safeEnqueue(encoder.encode(
+                  `event: content_block_start\ndata: ${JSON.stringify({
+                    type: "content_block_start",
+                    index: 0,
+                    content_block: { type: "text", text: "" },
+                  })}\n\n`
+                ), "structured_block_start")
+                safeEnqueue(encoder.encode(
+                  `event: content_block_delta\ndata: ${JSON.stringify({
+                    type: "content_block_delta",
+                    index: 0,
+                    delta: { type: "text_delta", text },
+                  })}\n\n`
+                ), "structured_text_delta")
+                safeEnqueue(encoder.encode(
+                  `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`
+                ), "structured_block_stop")
+                safeEnqueue(encoder.encode(
+                  `event: message_delta\ndata: ${JSON.stringify({
+                    type: "message_delta",
+                    delta: { stop_reason: "end_turn", stop_sequence: null },
+                    usage: { output_tokens: lastUsage?.output_tokens ?? 0 },
+                  })}\n\n`
+                ), "structured_message_delta")
+                messageStartEmitted = true
+                eventsForwarded += 5
+                textEventsForwarded += 1
               }
 
               claudeLog("upstream.completed", {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -465,7 +465,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           )
         }
 
-        const parsedOutputFormat = parseOutputFormat(body.output_config)
+        const parsedOutputFormat = parseOutputFormat(body.output_config, body.tools)
         if (!parsedOutputFormat.ok) {
           return c.json(
             { type: "error", error: { type: "invalid_request_error", message: parsedOutputFormat.message } },

--- a/src/proxy/structuredOutput.ts
+++ b/src/proxy/structuredOutput.ts
@@ -1,0 +1,42 @@
+import type { OutputFormat } from "@anthropic-ai/claude-agent-sdk"
+
+export type OutputFormatParseResult =
+  | { ok: true; value: OutputFormat | undefined }
+  | { ok: false; message: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+/**
+ * Parse Anthropic's `output_config.format` into the Claude Agent SDK's native
+ * structured-output option. Absence is a no-op; malformed or unsupported
+ * values are rejected at the HTTP boundary instead of failing in the SDK.
+ */
+export function parseOutputFormat(outputConfig: unknown): OutputFormatParseResult {
+  if (outputConfig === undefined) return { ok: true, value: undefined }
+  if (!isRecord(outputConfig)) {
+    return { ok: false, message: "output_config: Expected an object" }
+  }
+
+  const format = outputConfig.format
+  if (format === undefined) return { ok: true, value: undefined }
+  if (!isRecord(format)) {
+    return { ok: false, message: "output_config.format: Expected an object" }
+  }
+  if (format.type !== "json_schema") {
+    return { ok: false, message: "output_config.format.type: Only 'json_schema' is supported" }
+  }
+  if (!isRecord(format.schema)) {
+    return { ok: false, message: "output_config.format.schema: Expected a JSON Schema object" }
+  }
+
+  return {
+    ok: true,
+    value: { type: "json_schema", schema: format.schema },
+  }
+}
+
+export function structuredOutputText(value: unknown): string {
+  return JSON.stringify(value)
+}

--- a/src/proxy/structuredOutput.ts
+++ b/src/proxy/structuredOutput.ts
@@ -12,8 +12,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * Parse Anthropic's `output_config.format` into the Claude Agent SDK's native
  * structured-output option. Absence is a no-op; malformed or unsupported
  * values are rejected at the HTTP boundary instead of failing in the SDK.
+ *
+ * Combining `tools` with `output_config.format` is rejected: structured-output
+ * mode buffers the SDK's wire events and replaces the response content with the
+ * validated result, so a tool_use turn would be swallowed and the client-driven
+ * tool loop would never see it.
  */
-export function parseOutputFormat(outputConfig: unknown): OutputFormatParseResult {
+export function parseOutputFormat(outputConfig: unknown, tools?: unknown): OutputFormatParseResult {
   if (outputConfig === undefined) return { ok: true, value: undefined }
   if (!isRecord(outputConfig)) {
     return { ok: false, message: "output_config: Expected an object" }
@@ -29,6 +34,9 @@ export function parseOutputFormat(outputConfig: unknown): OutputFormatParseResul
   }
   if (!isRecord(format.schema)) {
     return { ok: false, message: "output_config.format.schema: Expected a JSON Schema object" }
+  }
+  if (Array.isArray(tools) && tools.length > 0) {
+    return { ok: false, message: "output_config.format: Cannot be combined with tools" }
   }
 
   return {


### PR DESCRIPTION
## What changed

- validates Anthropic `output_config.format` requests at the HTTP boundary
- forwards JSON Schema contracts through the Claude Agent SDK native `outputFormat` option
- returns the authoritative `structured_output` value for non-streaming calls
- buffers streaming output until schema validation and then emits a valid Anthropic SSE message
- fails clearly when the SDK omits a requested structured result

## Why

AI SDK structured generation can send `output_config.format`, but Meridian only forwarded `output_config.effort`. The ignored format forced clients onto the synthetic JSON-tool path, which could loop, exceed client timeouts, and produce unparseable output for complex schemas.

## Impact

Clients can use native JSON-schema output without custom submit-result tools or application-side parsing workarounds. Existing requests without `output_config.format` are unchanged.

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run build`
- focused structured-output, SDK-parameter, and query-option suites: 50 passed