### PR TITLE
fix: propagate client request cancellation

### DIFF
--- a/src/__tests__/proxy-request-cancellation.test.ts
+++ b/src/__tests__/proxy-request-cancellation.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+
+type QueryMode = "complete" | "wait-for-abort"
+
+let mode: QueryMode = "complete"
+let capturedController: AbortController | undefined
+let notifyQueryStarted: (() => void) | undefined
+
+function assistantMessage() {
+  return {
+    type: "assistant",
+    message: {
+      id: "msg_abort_test",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: "ok" }],
+      model: "claude-sonnet-4-6",
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: "abort-test-session",
+  }
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { options?: { abortController?: AbortController } }) => {
+    capturedController = params.options?.abortController
+    notifyQueryStarted?.()
+    return (async function* () {
+      if (mode === "complete") {
+        yield assistantMessage()
+        return
+      }
+
+      const signal = capturedController?.signal
+      await new Promise<void>((_resolve, reject) => {
+        if (!signal) return reject(new Error("missing SDK abort controller"))
+        if (signal.aborted) return reject(new Error("SDK query aborted"))
+        signal.addEventListener("abort", () => reject(new Error("SDK query aborted")), { once: true })
+      })
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function makeRequest(stream: boolean, signal?: AbortSignal) {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      stream,
+      messages: [{ role: "user", content: "hello" }],
+    }),
+    signal,
+  })
+}
+
+function queryStarted(): Promise<void> {
+  return new Promise((resolve) => {
+    notifyQueryStarted = resolve
+  })
+}
+
+describe("request cancellation propagation", () => {
+  let originalPassthrough: string | undefined
+
+  beforeEach(() => {
+    originalPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    mode = "complete"
+    capturedController = undefined
+    notifyQueryStarted = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (originalPassthrough === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = originalPassthrough
+  })
+
+  it("aborts a running non-stream SDK query when the HTTP request aborts", async () => {
+    mode = "wait-for-abort"
+    const started = queryStarted()
+    const requestController = new AbortController()
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const responsePromise = app.fetch(makeRequest(false, requestController.signal))
+    await started
+    requestController.abort("client timeout")
+    const response = await responsePromise
+
+    expect(capturedController).toBeDefined()
+    expect(capturedController!.signal.aborted).toBe(true)
+    expect(capturedController!.signal.reason).toBe("client timeout")
+    expect(response.status).toBeGreaterThanOrEqual(500)
+  })
+
+  it("aborts a streaming SDK query when the response body is cancelled", async () => {
+    mode = "wait-for-abort"
+    const started = queryStarted()
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await app.fetch(makeRequest(true))
+    await started
+    await response.body!.cancel("reader closed")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(capturedController).toBeDefined()
+    expect(capturedController!.signal.aborted).toBe(true)
+    expect(capturedController!.signal.reason).toBe("reader closed")
+  })
+
+  it("detaches the request signal after a completed non-stream query", async () => {
+    const requestController = new AbortController()
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await app.fetch(makeRequest(false, requestController.signal))
+    expect(response.status).toBe(200)
+    expect(capturedController).toBeDefined()
+    expect(capturedController!.signal.aborted).toBe(false)
+
+    requestController.abort("too late")
+    expect(capturedController!.signal.aborted).toBe(false)
+  })
+})

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -220,7 +220,7 @@ function resolveSystemPrompt(
   return {}
 }
 
-export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
+export function buildQueryOptions(ctx: QueryContext, abortController?: AbortController): BuildQueryResult {
   const {
     prompt, model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv, hasDeferredTools,
@@ -247,6 +247,7 @@ export function buildQueryOptions(ctx: QueryContext): BuildQueryResult {
       cwd: workingDirectory,
       model,
       pathToClaudeCodeExecutable: claudeExecutable,
+      ...(abortController ? { abortController } : {}),
       ...(stream ? { includePartialMessages: true } : {}),
       permissionMode: "bypassPermissions" as const,
       allowDangerouslySkipPermissions: true,

--- a/src/proxy/requestAbort.ts
+++ b/src/proxy/requestAbort.ts
@@ -1,0 +1,33 @@
+export interface RequestAbortLink {
+  controller: AbortController
+  abort: (reason?: unknown) => void
+  detach: () => void
+}
+
+/** Forward an HTTP request abort into the SDK query lifecycle. */
+export function linkRequestAbort(signal: AbortSignal): RequestAbortLink {
+  const controller = new AbortController()
+  let attached = false
+
+  const abort = (reason?: unknown) => {
+    if (!controller.signal.aborted) controller.abort(reason)
+  }
+  const forwardAbort = () => abort(signal.reason)
+
+  if (signal.aborted) {
+    forwardAbort()
+  } else {
+    signal.addEventListener("abort", forwardAbort, { once: true })
+    attached = true
+  }
+
+  return {
+    controller,
+    abort,
+    detach: () => {
+      if (!attached) return
+      signal.removeEventListener("abort", forwardAbort)
+      attached = false
+    },
+  }
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -7,6 +7,7 @@ import { join } from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
+import { linkRequestAbort } from "./requestAbort"
 import { fetchOAuthUsage } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
@@ -435,6 +436,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     requestMeta: { requestId: string; endpoint: string; queueEnteredAt: number; queueStartedAt: number }
   ) => {
     const requestStartAt = Date.now()
+    const requestAbort = linkRequestAbort(c.req.raw.signal)
+    let streamOwnsAbortLink = false
 
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
       // Hoist adapter detection before try so it's available in the catch block for telemetry
@@ -1150,7 +1153,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
-                  }))) {
+                  }, requestAbort.controller))) {
                     // Capture Claude Max subscription quota updates emitted by
                     // the SDK as rate_limit_event. We snapshot them in a process-wide
                     // store so /v1/usage/quota can return the latest live state.
@@ -1197,7 +1200,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }))
+                    }, requestAbort.controller))
                     return
                   }
 
@@ -1245,7 +1248,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }))
+                    }, requestAbort.controller))
                     return
                   }
 
@@ -1696,7 +1699,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }))) {
+                    }, requestAbort.controller))) {
                       // Same SDK rate-limit capture as the non-stream path.
                       if ((event as any).type === "rate_limit_event") {
                         rateLimitStore.record((event as any).rate_limit_info)
@@ -1738,7 +1741,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
-                      }))
+                      }, requestAbort.controller))
                       return
                     }
 
@@ -1782,7 +1785,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
-                      }))
+                      }, requestAbort.controller))
                       return
                     }
 
@@ -2508,11 +2511,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 try { controller.close() } catch {}
                 streamClosed = true
               }
+            } finally {
+              requestAbort.detach()
             }
-          }
+          },
+          cancel(reason) {
+            requestAbort.abort(reason)
+            requestAbort.detach()
+          },
         })
 
         const streamSessionId = resumeSessionId || `session_${Date.now()}`
+        streamOwnsAbortLink = true
         return new Response(readable, {
           headers: {
             "Content-Type": "text/event-stream",
@@ -2575,6 +2585,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           JSON.stringify({ type: "error", error: { type: classified.type, message: classified.message } }),
           { status: classified.status, headers: { "Content-Type": "application/json" } }
         )
+      } finally {
+        if (!streamOwnsAbortLink) requestAbort.detach()
       }
     })
   }


### PR DESCRIPTION
## What changed

- links each HTTP request signal to a dedicated Claude Agent SDK `AbortController`
- forwards that controller through every initial and retry query path
- aborts streaming SDK work when the response reader is cancelled
- detaches listeners after non-stream and stream completion

## Why

Client timeouts stopped waiting for Meridian but did not stop the underlying SDK subprocess. Requests could continue generating and consuming resources after the caller had disconnected.

## Impact

Timed-out and disconnected clients now stop the associated SDK work promptly. Successful request behavior is unchanged.

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run build`
- focused cancellation, SDK-parameter, and query-option suites: 49 passed