### PR TITLE
fix(passthrough): abort nested SDK session once single-step capture completes

### DIFF
--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Passthrough deny → SDK abort (supersedes the approach in PR #570)
+ *
+ * When the PreToolUse hook detects that the model has stopped making progress
+ * against blocked passthrough tools (same tool re-called with new args, or a
+ * forced-single tool exceeded), every distinct tool_use for this exchange is
+ * already captured. Returning `interrupt: true` or `continue: false` from the
+ * hook does NOT stop the nested session — both keys are absent from the CLI's
+ * hook-output schema and are stripped by its Zod validation (verified
+ * empirically against the real SDK + bundled CLI). The only reliable way to
+ * end the nested session immediately is to abort the SDK query's
+ * AbortController from the proxy side.
+ *
+ * These tests assert:
+ *   1. Non-stream: the loop-detection deny aborts the SDK controller, and the
+ *      response still recovers as a clean stop_reason:"tool_use" message.
+ *   2. Stream: an abort-shaped SDK termination with captured tool_uses
+ *      recovers to tool_use + message_stop (not an error event) — the stream
+ *      gate must accept "aborted" like the non-stream gate does.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { makeRequest, parseSSE } from "./helpers"
+
+const PASSTHROUGH_PREFIX = "mcp__oc__"
+
+let mockTurns: any[] = []
+let capturedController: AbortController | undefined
+
+function toolTurn(toolId: string, toolName: string, input: Record<string, unknown>) {
+  return {
+    type: "assistant",
+    message: {
+      id: `msg_${toolId}`,
+      type: "message",
+      role: "assistant",
+      content: [{ type: "tool_use", id: toolId, name: `${PASSTHROUGH_PREFIX}${toolName}`, input }],
+      model: "claude-sonnet-4-5-20250929",
+      stop_reason: "tool_use",
+      usage: { input_tokens: 10, output_tokens: 20 },
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: "test-session",
+  }
+}
+
+function streamMessageStart() {
+  return {
+    type: "stream_event",
+    event: {
+      type: "message_start",
+      message: {
+        id: "msg_stream_1",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: "claude-sonnet-4-5-20250929",
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 0 },
+      },
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: "test-session",
+  }
+}
+
+// Hook-aware, abort-aware SDK mock. Mirrors the real SDK: each assistant
+// turn's PreToolUse hook fires after the turn is yielded, and an aborted
+// controller terminates the query with an abort-shaped error (the real
+// subprocess is SIGTERMed and surfaces "aborted by user").
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    capturedController = opts?.options?.abortController
+    return (async function* () {
+      const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+      for (const turn of mockTurns) {
+        if (capturedController?.signal.aborted) {
+          throw new Error("Claude Code process aborted by user")
+        }
+        yield turn
+        if (preHook && turn.type === "assistant") {
+          for (const block of turn.message.content) {
+            if (block.type === "tool_use") {
+              await preHook({ tool_name: block.name, tool_use_id: block.id, tool_input: block.input })
+            }
+          }
+        }
+        if (capturedController?.signal.aborted) {
+          throw new Error("Claude Code process aborted by user")
+        }
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+const tool = (name: string) => ({
+  name,
+  description: `${name} tool`,
+  input_schema: { type: "object", properties: {}, additionalProperties: true },
+})
+
+async function post(app: any, stream: boolean): Promise<Response> {
+  const req = new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(
+      makeRequest({
+        stream,
+        tools: [tool("get_weather"), tool("get_time")],
+        messages: [{ role: "user", content: "Do the thing." }],
+      })
+    ),
+  })
+  return app.fetch(req)
+}
+
+async function readSSE(response: Response) {
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let result = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    result += decoder.decode(value, { stream: true })
+  }
+  return parseSSE(result)
+}
+
+describe("Passthrough deny aborts the nested SDK session on loop detection", () => {
+  let origEnv: string | undefined
+
+  beforeEach(() => {
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    mockTurns = []
+    capturedController = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origEnv
+  })
+
+  it("non-stream: aborts the SDK query when a same-tool repeat is detected and still returns the distinct tool_use", async () => {
+    mockTurns = [
+      toolTurn("toolu_1", "get_weather", { city: "SF" }),
+      // Same tool, NEW args — the loop-continuation signal. The hook should
+      // abort here; the mock then terminates with an abort-shaped error.
+      toolTurn("toolu_2", "get_weather", { city: "LA" }),
+      // Must never be reached once the abort fires.
+      toolTurn("toolu_3", "get_weather", { city: "NYC" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await post(app, false)
+    const body = await response.json() as any
+
+    expect(capturedController).toBeDefined()
+    expect(capturedController!.signal.aborted).toBe(true)
+    expect(response.status).toBe(200)
+    expect(body.stop_reason).toBe("tool_use")
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.length).toBe(1)
+    expect(toolUses[0].id).toBe("toolu_1")
+  })
+
+  it("stream: recovers an abort-shaped termination as tool_use + message_stop instead of an error event", async () => {
+    mockTurns = [
+      streamMessageStart(),
+      toolTurn("toolu_s1", "get_weather", { city: "SF" }),
+      toolTurn("toolu_s2", "get_weather", { city: "LA" }),
+      toolTurn("toolu_s3", "get_weather", { city: "NYC" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await post(app, true)
+    const events = await readSSE(response)
+    const eventTypes = events.map((e: any) => e.event)
+
+    expect(capturedController).toBeDefined()
+    expect(capturedController!.signal.aborted).toBe(true)
+    expect(eventTypes).not.toContain("error")
+    expect(eventTypes).toContain("message_stop")
+    const deltas = events.filter((e: any) => e.event === "message_delta")
+    const stopReasons = deltas.map((e: any) => e.data?.delta?.stop_reason).filter(Boolean)
+    expect(stopReasons).toContain("tool_use")
+    // The distinct captured tool_use must reach the client exactly once.
+    const toolStartIds = events
+      .filter((e: any) => e.event === "content_block_start" && e.data?.content_block?.type === "tool_use")
+      .map((e: any) => e.data.content_block.id)
+    expect(toolStartIds).toEqual(["toolu_s1"])
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1052,6 +1052,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     name: toolName,
                     reason: exceedsForcedSingle ? "forced_single" : "same_tool_repeat",
                   })
+                  // Every distinct tool_use for this exchange is captured and the
+                  // model is now looping against blocked tools — kill the nested
+                  // SDK session immediately instead of letting it generate denied
+                  // retries until the turn budget runs out (#570). Hook-level
+                  // `interrupt: true` / `continue: false` cannot do this: neither
+                  // key exists in the CLI's hook-output schema, so both are
+                  // stripped before the deny is processed (verified against the
+                  // real SDK). Aborting the query's controller SIGTERMs the
+                  // subprocess; the abort-shaped termination is converted into a
+                  // clean stop_reason:"tool_use" response by the recovery paths.
+                  requestAbort.abort("passthrough single-step complete")
                 } else {
                   capturedSignatures.add(signature)
                   capturedToolNames.add(toolName)
@@ -2450,8 +2461,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // tools and drives the next turn (the same outcome as a normal
               // tool-use cycle). Without this, the client sees a 500 even
               // though we already streamed everything it needs.
+              // "aborted" is accepted only for the proxy's own single-step
+              // abort (sawDuplicateToolUse) — a client-disconnect abort must
+              // not be recorded as a recovered success.
               const canRecoverAsToolUse =
-                sdkTerm.reason === "max_turns" &&
+                (sdkTerm.reason === "max_turns" ||
+                  (sdkTerm.reason === "aborted" && sawDuplicateToolUse)) &&
                 passthrough &&
                 capturedToolUses.length > 0 &&
                 messageStartEmitted


### PR DESCRIPTION
## Bug

In passthrough mode, once the PreToolUse deny hook has captured every distinct tool_use for the exchange and detects the model looping against blocked tools (same tool re-called with new args, or a forced-single tool exceeded), the nested SDK session keeps generating denied retries until the turn budget ends it. @shanemmattner identified this turn-burning behavior in #570 — thanks Shane, the diagnosis was right on.

## Why not `interrupt: true` (#570's approach)

We verified empirically against the real SDK + bundled CLI that neither `interrupt: true` nor `continue: false` on the PreToolUse hook's flat JSON output has any effect: the CLI's hook-output Zod schema contains neither key, so both are silently stripped before the deny is processed. (`interrupt` is only honored on `canUseTool` / PermissionRequest deny shapes.) Three A/B runs through the real SDK produced turn-for-turn identical traces for baseline, `interrupt: true`, and `continue: false`.

## Fix

The proxy holds the SDK query's `AbortController` (since #574), so it can do what the hook cannot: when the loop-detection flag (`sawDuplicateToolUse`) is set, abort the controller immediately. The subprocess is SIGTERMed mid-generation instead of draining the remaining turn budget.

The streaming recovery gate now also accepts the proxy's own abort-shaped termination (the non-streaming gate already accepted "aborted" since #571), converting it into a clean `stop_reason: "tool_use"` response. Client-disconnect aborts are excluded from stream recovery so a cancelled stream isn't recorded as a recovered success.

## Validation

- New integration tests (hook-aware, abort-aware SDK mock): non-stream abort + recovery, stream abort + recovery
- `bun test` (1814 pass), `bun run typecheck`, `bun run build`
- Empirical hook-mechanism A/B against the real SDK + bundled CLI (baseline / interrupt / continue-false, single and chained-tool scenarios)

Closes #570

Reported-by: Shane Mattner (@shanemmattner)