### PR TITLE
fix: preserve structured output tool in passthrough

### DIFF
--- a/src/__tests__/proxy-structured-output.test.ts
+++ b/src/__tests__/proxy-structured-output.test.ts
@@ -100,6 +100,7 @@ describe("native structured output", () => {
 
     expect(response.status).toBe(200)
     expect(capturedOptions.outputFormat).toEqual({ type: "json_schema", schema })
+    expect(capturedOptions.tools).toEqual(["StructuredOutput"])
     expect(body.stop_reason).toBe("end_turn")
     expect(body.content).toEqual([{ type: "text", text: '{"answer":"grounded"}' }])
     expect(body.usage).toEqual({ input_tokens: 12, output_tokens: 7 })
@@ -115,6 +116,7 @@ describe("native structured output", () => {
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toContain("text/event-stream")
     expect(capturedOptions.outputFormat).toEqual({ type: "json_schema", schema })
+    expect(capturedOptions.tools).toEqual(["StructuredOutput"])
     expect(body).toContain("event: message_start")
     expect(body).toContain('"text":"{\\"answer\\":\\"streamed\\"}"')
     expect(body).toContain('"stop_reason":"end_turn"')

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -206,6 +206,17 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).tools).toEqual([])
   })
 
+  it("preserves only StructuredOutput when native schema output is requested", () => {
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      outputFormat: {
+        type: "json_schema",
+        schema: { type: "object", properties: { answer: { type: "string" } } },
+      },
+    }))
+    expect(result.options.tools).toEqual(["StructuredOutput"])
+  })
+
   it("strips the catalog even when passthroughMcp tools are present", () => {
     const mockPassthroughMcp = {
       toolNames: ["mcp__passthrough__custom_tool"],

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -261,10 +261,11 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
             // SDK built-ins (Read/Write/Bash/etc.) — those are the calling
             // client's responsibility. `disallowedTools` below blocks
             // invocation at runtime; it does NOT remove the definitions
-            // from the upstream payload. Setting `tools: []` elides the
-            // catalog from the request body. Closes #489 (diagnosis by
-            // @albe-jj).
-            tools: [],
+            // from the upstream payload. Native schema output is implemented
+            // by Claude Code's internal StructuredOutput tool, so preserve
+            // that one tool when outputFormat is active and elide the rest of
+            // the catalog. Closes #489 (diagnosis by @albe-jj).
+            tools: outputFormat ? ["StructuredOutput"] : [],
             // Explicitly disable claude-code's default settings loading.
             // Without this, claude-code falls back to its built-in default
             // (load user + project + local) and slurps CLAUDE.md from the


### PR DESCRIPTION
## What changed

- preserve Claude Code's internal `StructuredOutput` tool when native schema output is requested in passthrough mode
- continue removing every other built-in Claude Code tool from passthrough requests
- add query-level and HTTP-path regression coverage for non-streaming and streaming requests

## Root cause

Native structured output was forwarded to the Agent SDK through `outputFormat`, but passthrough mode also set `tools: []`. Claude Code implements schema output through its internal `StructuredOutput` tool, so the SDK completed without a `structured_output` result and Meridian returned HTTP 500.

## Impact

Anthropic-compatible clients can use `output_config.format` through Meridian without re-enabling the full built-in tool catalog.

## Validation

- targeted structured-output and query tests: 61 passed
- full test suite: passed
- `bun run typecheck`: passed
- `bun run build`: passed

No live model requests were made while developing this patch.
