### PR TITLE
fix(passthrough): truthful deny reasons for dropped tool calls

### DIFF
--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -26,6 +26,7 @@ const PASSTHROUGH_PREFIX = "mcp__oc__"
 
 let mockTurns: any[] = []
 let capturedController: AbortController | undefined
+let capturedResume: string | undefined
 
 function toolTurn(toolId: string, toolName: string, input: Record<string, unknown>) {
   return {
@@ -74,6 +75,7 @@ function streamMessageStart() {
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedController = opts?.options?.abortController
+    capturedResume = opts?.options?.resume
     return (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
       for (const turn of mockTurns) {
@@ -119,15 +121,19 @@ const tool = (name: string) => ({
   input_schema: { type: "object", properties: {}, additionalProperties: true },
 })
 
-async function post(app: any, stream: boolean): Promise<Response> {
+async function post(
+  app: any,
+  stream: boolean,
+  messages: unknown[] = [{ role: "user", content: "Do the thing." }]
+): Promise<Response> {
   const req = new Request("http://localhost/v1/messages", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", "x-opencode-session": "deny-abort-session" },
     body: JSON.stringify(
       makeRequest({
         stream,
         tools: [tool("get_weather"), tool("get_time")],
-        messages: [{ role: "user", content: "Do the thing." }],
+        messages,
       })
     ),
   })
@@ -154,6 +160,7 @@ describe("Passthrough deny aborts the nested SDK session on loop detection", () 
     process.env.MERIDIAN_PASSTHROUGH = "1"
     mockTurns = []
     capturedController = undefined
+    capturedResume = undefined
     clearSessionCache()
   })
 
@@ -210,5 +217,30 @@ describe("Passthrough deny aborts the nested SDK session on loop detection", () 
       .filter((e: any) => e.event === "content_block_start" && e.data?.content_block?.type === "tool_use")
       .map((e: any) => e.data.content_block.id)
     expect(toolStartIds).toEqual(["toolu_s1"])
+  })
+
+  it("does not offer a single-step-aborted session for resume — the follow-up starts fresh (#552)", async () => {
+    mockTurns = [
+      toolTurn("toolu_1", "get_weather", { city: "SF" }),
+      toolTurn("toolu_2", "get_weather", { city: "LA" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const first = await post(app, false)
+    expect(first.status).toBe(200)
+    expect(capturedController!.signal.aborted).toBe(true)
+
+    // Follow-up turn: client executed the forwarded call and returns its
+    // result. The aborted session's history contains a dangling dropped call
+    // ("Stream closed") — resuming it hands the model diverged memory, the
+    // source of the "read tool is returning the wrong file" confusion.
+    mockTurns = [toolTurn("toolu_3", "get_time", { tz: "UTC" })]
+    const second = await post(app, false, [
+      { role: "user", content: "Do the thing." },
+      { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: "get_weather", input: { city: "SF" } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "72F" }] },
+    ])
+    expect(second.status).toBe(200)
+    expect(capturedResume).toBeUndefined()
   })
 })

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -399,3 +399,81 @@ describe("PreToolUse hook: passthrough ToolSearch", () => {
     expect(result.reason.toLowerCase()).toContain("end your turn")
   })
 })
+
+describe("PreToolUse hook: deny reasons must not promise delivery for dropped calls (#552)", () => {
+  // Root cause of the "read tool is returning the wrong file" confusion:
+  // dropped calls (same-tool repeat / forced single) received the same deny
+  // text as forwarded calls — "forwarded to the client ... result will be
+  // delivered in a future turn". That promise persists in the resumed SDK
+  // session's history, so next turn the model remembers a pending call whose
+  // result never arrives and misattributes the results it does receive.
+  beforeEach(() => {
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    mockMessages = [assistantMessage([{ type: "text", text: "Done" }])]
+    capturedQueryParams = null
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  async function getHook(body: Record<string, unknown> = {}) {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+      ...body,
+    })).json()
+    const allMatcher = capturedQueryParams.options.hooks.PreToolUse.find((h: any) => h.matcher === "")
+    return allMatcher.hooks[0]
+  }
+
+  const callHook = (hookFn: any, id: string, input: Record<string, unknown>) =>
+    hookFn({
+      hook_event_name: "PreToolUse",
+      tool_name: "read",
+      tool_input: input,
+      tool_use_id: id,
+    }, undefined, { signal: new AbortController().signal })
+
+  it("forwarded (captured) calls keep the delivery promise", async () => {
+    const hookFn = await getHook()
+    const result = await callHook(hookFn, "toolu_a", { file_path: "/a.txt" })
+    expect(result.decision).toBe("block")
+    expect(result.reason).toContain("forwarded to the client for execution")
+  })
+
+  it("same-tool re-calls with new args say NOT executed and to re-issue — no delivery promise", async () => {
+    const hookFn = await getHook()
+    await callHook(hookFn, "toolu_a", { file_path: "/a.txt" })
+    const result = await callHook(hookFn, "toolu_b", { file_path: "/b.txt" })
+    expect(result.decision).toBe("block")
+    expect(result.reason).not.toContain("forwarded to the client for execution")
+    expect(result.reason).not.toContain("will be delivered")
+    expect(result.reason.toLowerCase()).toContain("not executed")
+    expect(result.reason.toLowerCase()).toContain("re-issue")
+  })
+
+  it("exact duplicate re-emits say already forwarded — no second delivery promise", async () => {
+    const hookFn = await getHook()
+    await callHook(hookFn, "toolu_a", { file_path: "/a.txt" })
+    const result = await callHook(hookFn, "toolu_a2", { file_path: "/a.txt" })
+    expect(result.decision).toBe("block")
+    expect(result.reason.toLowerCase()).toContain("already")
+    expect(result.reason).not.toContain("will be delivered")
+  })
+
+  it("forced-single overflow says NOT executed — no delivery promise", async () => {
+    const hookFn = await getHook({ tool_choice: { type: "tool", name: "read" } })
+    await callHook(hookFn, "toolu_a", { file_path: "/a.txt" })
+    const result = await callHook(hookFn, "toolu_b", { file_path: "/b.txt" })
+    expect(result.decision).toBe("block")
+    expect(result.reason.toLowerCase()).toContain("not executed")
+    expect(result.reason).not.toContain("will be delivered")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1089,9 +1089,35 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // The reason text is read by the model as the "tool result" of
                 // a denied call. With a vague reason ("Forwarding to client for
                 // execution") modern Claude tends to retry with a different
-                // tool, burning the maxTurns budget. Be explicit that the call
-                // succeeded externally and that the model should stop here —
-                // see telemetry for the failure mode this addresses.
+                // tool, burning the maxTurns budget. Be explicit about what
+                // actually happened and that the model should stop here — see
+                // telemetry for the failure mode this addresses.
+                //
+                // The reason MUST match the call's fate (#552): dropped calls
+                // (same-tool repeat / forced single) are NOT forwarded, and a
+                // false "result will be delivered" promise persists in the
+                // resumed session's history — next turn the model remembers a
+                // pending call whose result never arrives and misattributes
+                // the results it does receive ("the read tool is returning
+                // the wrong file").
+                if (isExactDuplicate) {
+                  return {
+                    decision: "block" as const,
+                    reason:
+                      "This exact tool call has already been forwarded to the client — do not repeat it. " +
+                      "Do not call additional tools and do not generate further text — end your turn now.",
+                  }
+                }
+                if (isSameToolRepeat || exceedsForcedSingle) {
+                  return {
+                    decision: "block" as const,
+                    reason:
+                      "This tool call was NOT executed and was not forwarded. Your earlier tool call(s) " +
+                      "are being returned to the client now; their results arrive next turn. Re-issue this " +
+                      "call after that if it is still needed. Do not call additional tools and do not " +
+                      "generate further text — end your turn now.",
+                  }
+                }
                 return {
                   decision: "block" as const,
                   reason:

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1657,7 +1657,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // Store session for future resume.
           // Fork/subagent requests don't write to the cache — see lookupSession
           // block above for rationale (avoids polluting the parent's key).
-              if (currentSessionId && !isIndependentSession) {
+          // Single-step-aborted sessions are never offered for resume: the
+          // SIGTERM lands before the dropped call's deny is persisted, so the
+          // SDK-side history holds a dangling tool_use ("Stream closed") that
+          // diverges from the client's view — resuming it hands the model
+          // memory of a call whose result never arrives (#552). A fresh
+          // session rebuilt from client history is coherent by construction.
+              if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
 
@@ -2278,8 +2284,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               // Store session for future resume.
               // Fork/subagent requests don't write to the cache (see lookupSession
-              // block for rationale).
-              if (currentSessionId && !isIndependentSession) {
+              // block for rationale). Single-step-aborted sessions are never
+              // offered for resume — their history holds a dangling dropped
+              // call that diverges from the client's view (#552); see the
+              // non-stream store above.
+              if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
 


### PR DESCRIPTION
## Bug (#552, @kabo's v1.45.1 report)

After a passthrough single-step, the model resumes its SDK session remembering a tool call whose deny text promised "the result will be delivered in a future turn" — but for **dropped** calls (same-tool repeat / forced-single overflow) that promise is false: the call was never forwarded, so no result ever arrives. The model then misattributes the results it does receive: *"The read tool is returning the wrong file. Let me try a different approach…"*

Legit trigger: sequential same-tool use — read file A, then read file B. The single-step guard correctly returns only step 1 to the client, but B's deny lied about B's fate, and the lie lives on in the resumed session's history.

## Fix

Per-fate deny reasons in the PreToolUse hook:
- **Forwarded (captured):** unchanged — "forwarded to the client… result will be delivered".
- **Exact duplicate:** "already been forwarded — do not repeat it".
- **Dropped (repeat/forced-single):** "NOT executed and was not forwarded… re-issue this call after [the returned step's] results arrive".

No flow-control changes — capture, loop-break, and the #575 abort are untouched; only the text the model reads (and remembers on resume) changes.

## Validation

- TDD: 4 new hook-level tests (forwarded keeps promise; repeat/duplicate/forced-single get truthful reasons) — watched the 3 new-behavior ones fail first
- Full suite (1830 pass), typecheck, build

Refs #552