### PR TITLE
fix: stop bash redirect heuristic emitting non-path false positives (#564)

### DIFF
--- a/src/__tests__/file-changes-unit.test.ts
+++ b/src/__tests__/file-changes-unit.test.ts
@@ -177,6 +177,47 @@ describe("extractFileChangesFromBash", () => {
   it("should not capture >= comparison operator", () => {
     expect(extractFileChangesFromBash('if (count >= 10) echo done')).toEqual([])
   })
+
+  // #564: the redirect regex captured non-path fragments (bare words, HTML
+  // tags, timestamps, shell vars) because isLikelyFilePath was too permissive.
+  // A capture is only a path if it has a `/` or a dotted file extension.
+  it("should not capture a bare word from a jq filter redirect (#564)", () => {
+    expect(extractFileChangesFromBash('jq .model > model')).toEqual([])
+  })
+
+  it("should not capture an ISO-8601 timestamp target (#564)", () => {
+    expect(extractFileChangesFromBash('echo "x" >> 2026-07-02T20:14:00Z')).toEqual([])
+  })
+
+  it("should not capture an HTML closing tag (#564)", () => {
+    expect(extractFileChangesFromBash('cat foo | sed "s/a/b/" > </sub>')).toEqual([])
+  })
+
+  it("should not capture a shell variable from a test expression (#564)", () => {
+    expect(extractFileChangesFromBash('if [ $a > $b ]; then')).toEqual([])
+  })
+
+  it("should capture only the real redirect target amid HTML text (#564)", () => {
+    expect(extractFileChangesFromBash('echo "<sub>foo</sub>" > out.html'))
+      .toEqual([{ operation: "wrote", path: "out.html" }])
+  })
+
+  it("should still capture an extensionless target that has a path separator", () => {
+    expect(extractFileChangesFromBash('echo x > bin/tool'))
+      .toEqual([{ operation: "wrote", path: "bin/tool" }])
+  })
+
+  it("should still capture dotfiles with a dotted name", () => {
+    expect(extractFileChangesFromBash('echo x > .env'))
+      .toEqual([{ operation: "wrote", path: ".env" }])
+  })
+
+  it("does not report a bare extensionless redirect target (accepted trade-off, #564)", () => {
+    // `> Makefile` writes a file, but bare extensionless words are
+    // indistinguishable from shell fragments; real write-tool calls still
+    // surface these via the strict allowlist path.
+    expect(extractFileChangesFromBash('echo x > Makefile')).toEqual([])
+  })
 })
 
 describe("formatFileChangeSummary", () => {

--- a/src/proxy/fileChanges.ts
+++ b/src/proxy/fileChanges.ts
@@ -89,14 +89,24 @@ export function createFileChangeHook(
 
 /**
  * Returns true if the string looks like a real file path rather than a
- * comparison operand or code fragment captured by the redirect regex.
+ * comparison operand, HTML fragment, timestamp, or code fragment captured by
+ * the redirect regex.
+ *
+ * The redirect regex (`>{1,2}...`) captures far more than filenames — jq
+ * filters (`> model`), HTML tags (`> </sub>`), timestamps (`>> 2026-...Z`),
+ * and test expressions (`[ $a > $b ]`) all produce captures. We reject shell/
+ * code metacharacters and integers, then require positive evidence of a path:
+ * a `/` separator or a dotted file extension. Bare extensionless words are
+ * dropped (a known false-negative trade-off, #564) — real writes to such files
+ * still surface through the strict write/edit tool allowlist.
  */
 function isLikelyFilePath(s: string): boolean {
-  if (/[()[\]]/.test(s)) return false   // code expression
-  if (/^-?\d+$/.test(s)) return false   // integer or -N
-  if (/^[{}]$/.test(s)) return false    // bare brace
-  if (!/[\w/.]/.test(s)) return false   // must have at least one path-like char
-  return true
+  if (s.length > 4096) return false           // implausible as a path
+  if (/[<>$`\\()[\]{}=]/.test(s)) return false // HTML/shell/code metacharacters
+  if (/^-?\d+$/.test(s)) return false          // integer or -N
+  if (s.includes("/")) return true             // has a path separator
+  if (/\.[A-Za-z0-9]{1,16}$/.test(s)) return true // dotted file extension
+  return false
 }
 
 /**


### PR DESCRIPTION
## Problem

Closes #564. The `Files changed:` footer reported false-positive writes mined from bash command *text* — `wrote model`, `wrote </sub>`, `wrote 2026-07-02T20:14:00Z`, `wrote \$b`. The redirect regex captures far more than filenames, and `isLikelyFilePath` only rejected a handful of shapes (parens/brackets, integers, bare braces), so almost anything passed. In long agent sessions these accumulate every turn and leak into compaction summaries.

## Fix

Tighten `isLikelyFilePath` (`src/proxy/fileChanges.ts`) to require positive evidence that a capture is a path:

- reject HTML/shell/code metacharacters `< > $ ` \ ( ) [ ] { } =` and integers
- **require** a `/` separator **or** a dotted file extension (`\.[A-Za-z0-9]{1,16}$`)

This kills every repro from the issue while preserving genuine redirects (`> out.html`, `>> logs/run.log`, `> bin/tool`, `> .env`).

### Trade-off

Bare extensionless redirect targets (`> Makefile`) are no longer reported — they're indistinguishable from shell fragments. This is a deliberate precision bias: real writes to such files still surface through the strict write/edit tool allowlist (`extractFileChange`), which is unaffected. Documented with a test.

## Tests

Added 8 cases to `file-changes-unit.test.ts` (all 4 issue repros + HTML-amid-text, slashed-extensionless, dotfile, and the documented trade-off). Full suite: 1838 pass, 0 fail; `tsc --noEmit` clean.