### PR TITLE
fix: clamp token-refresh timer delay to 32-bit max (Node 26 overflow loop, #515)

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -763,3 +763,61 @@ describe("serializeCredentials", () => {
     expect(compact).not.toContain("\n")
   })
 })
+
+describe("startBackgroundRefresh timer clamping (#515)", () => {
+  // Node clamps setTimeout delays above 2^31-1 ms to 1ms (with a warning). A
+  // token whose expiresAt is >~24.8 days out produces such a delay; without a
+  // clamp the 1ms timer re-fires, recomputes the same huge delay, and loops.
+  const MAX_32BIT = 2_147_483_647
+  let realSetTimeout: typeof globalThis.setTimeout
+  let recordedDelays: number[]
+
+  beforeEach(async () => {
+    const { stopBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    stopBackgroundRefresh()
+    realSetTimeout = globalThis.setTimeout
+    recordedDelays = []
+    globalThis.setTimeout = ((_fn: unknown, delay?: number) => {
+      recordedDelays.push(delay ?? 0)
+      // Do not actually schedule — just record the requested delay.
+      return { unref() {} } as unknown as ReturnType<typeof setTimeout>
+    }) as typeof globalThis.setTimeout
+  })
+
+  afterEach(async () => {
+    globalThis.setTimeout = realSetTimeout
+    const { stopBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    stopBackgroundRefresh()
+  })
+
+  // Let scheduleNext's awaited store.read() settle. Uses the real timer.
+  function flush(): Promise<void> {
+    return new Promise((resolve) => realSetTimeout(resolve, 5))
+  }
+
+  function storeWithExpiry(expiresAt: number) {
+    return makeStore({
+      ...MOCK_CREDENTIALS,
+      claudeAiOauth: { ...MOCK_CREDENTIALS.claudeAiOauth, expiresAt },
+    }).store
+  }
+
+  it("clamps a >24.8-day delay to the 32-bit max instead of overflowing to 1ms", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    const far = Date.now() + 40 * 24 * 60 * 60 * 1000 // 40 days out
+    startBackgroundRefresh(storeWithExpiry(far))
+    await flush()
+    expect(recordedDelays.length).toBeGreaterThan(0)
+    expect(recordedDelays[recordedDelays.length - 1]).toBe(MAX_32BIT)
+  })
+
+  it("does not clamp a normal ~8h delay", async () => {
+    const { startBackgroundRefresh } = await import("../proxy/tokenRefresh")
+    const soon = Date.now() + 8 * 60 * 60 * 1000 // 8h out
+    startBackgroundRefresh(storeWithExpiry(soon))
+    await flush()
+    const d = recordedDelays[recordedDelays.length - 1]!
+    expect(d).toBeGreaterThan(0)
+    expect(d).toBeLessThan(MAX_32BIT)
+  })
+})

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -441,6 +441,9 @@ async function scheduleNext(
   armTimer(dueIn, store, bufferMs, failureRetryMs, gen)
 }
 
+/** Largest delay setTimeout accepts before Node clamps it to 1ms (2^31 - 1). */
+const MAX_TIMEOUT_MS = 2_147_483_647
+
 function armTimer(
   delayMs: number,
   store: CredentialStore,
@@ -448,6 +451,12 @@ function armTimer(
   failureRetryMs: number,
   gen: number,
 ): void {
+  // A token lifetime beyond ~24.8 days produces a delay above the 32-bit
+  // signed max. Node then clamps it to 1ms and emits TimeoutOverflowWarning;
+  // the 1ms timer fires, scheduleNext recomputes the same huge delay, and it
+  // loops forever (#515). Cap the delay — the callback re-runs scheduleNext,
+  // which recomputes the remaining time and arms the next (also-capped) timer.
+  const safeDelayMs = delayMs > MAX_TIMEOUT_MS ? MAX_TIMEOUT_MS : delayMs
   scheduledRefreshTimer = setTimeout(async () => {
     if (!scheduledRefreshActive || gen !== scheduledRefreshGeneration) return
     // The dueIn re-check inside scheduleNext distinguishes "fire-now" from
@@ -457,7 +466,7 @@ function armTimer(
     // timer. Neither path writes to stderr (the unconditional log was removed
     // in #518 to stop polluting embedded TUI hosts).
     void scheduleNext(store, bufferMs, failureRetryMs, gen)
-  }, delayMs)
+  }, safeDelayMs)
   if (scheduledRefreshTimer && (scheduledRefreshTimer as { unref?: () => void }).unref) {
     (scheduledRefreshTimer as { unref: () => void }).unref()
   }


### PR DESCRIPTION
## Problem

Closes #515. When a token's `expiresAt` is more than ~24.8 days out, `scheduleNext` computes a `dueIn` above 2^31-1 ms and passes it to `setTimeout`. **Node.js v26** clamps such delays to 1ms and emits `TimeoutOverflowWarning`; the 1ms timer fires, `scheduleNext` recomputes the same huge `dueIn`, and it loops forever — flooding the console:

```
TimeoutOverflowWarning: 31532726366 does not fit into a 32-bit signed integer. Timeout duration was set to 1.
```

## Fix

Clamp the delay in `armTimer` to `MAX_TIMEOUT_MS` (2^31-1). The timer then fires after a real ~24.8-day wait, the callback re-runs `scheduleNext`, which recomputes the remaining time and arms the next (also-capped) timer — no warning, no loop. Normal ~8h token lifetimes are unaffected.

## Tests

Added two cases to `token-refresh.test.ts` (spying on `setTimeout` through the exported `startBackgroundRefresh`): a 40-day expiry is clamped to exactly the 32-bit max; a normal 8h expiry is scheduled unclamped. Full suite: 1838 pass, 0 fail; `tsc --noEmit` clean.