### PR TITLE
fix: strip SDK-only context_management from forwarded stream events (#525)

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools } from "../proxy/messages"
+import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields } from "../proxy/messages"
 
 describe("normalizeContent", () => {
   it("returns string content as-is", () => {
@@ -158,5 +158,48 @@ describe("stripAdvisorTools", () => {
 
   it("handles empty array", () => {
     expect(stripAdvisorTools([])).toHaveLength(0)
+  })
+})
+
+describe("stripNonStandardStreamFields (#525)", () => {
+  it("removes context_management from a message_delta event", () => {
+    const event = {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 12 },
+      context_management: { applied_edits: [{ type: "clear_tool_uses_20250919" }] },
+    }
+    const out = stripNonStandardStreamFields(event) as Record<string, unknown>
+    expect(out).not.toHaveProperty("context_management")
+    // Everything else must survive untouched.
+    expect(out.delta).toEqual({ stop_reason: "end_turn", stop_sequence: null })
+    expect(out.usage).toEqual({ output_tokens: 12 })
+  })
+
+  it("removes context_management nested inside delta", () => {
+    const event = {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", context_management: { foo: 1 } },
+    }
+    const out = stripNonStandardStreamFields(event) as { delta: Record<string, unknown> }
+    expect(out.delta).not.toHaveProperty("context_management")
+    expect(out.delta.stop_reason).toBe("end_turn")
+  })
+
+  it("is a no-op on events without the field (content_block_delta)", () => {
+    const event = { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } }
+    const out = stripNonStandardStreamFields(event)
+    expect(out).toEqual({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hi" } })
+  })
+
+  it("returns non-object inputs unchanged", () => {
+    expect(stripNonStandardStreamFields(null)).toBeNull()
+    expect(stripNonStandardStreamFields("x" as unknown)).toBe("x")
+  })
+
+  it("mutates and returns the same reference (for inline use)", () => {
+    const event = { type: "message_delta", context_management: {} }
+    expect(stripNonStandardStreamFields(event)).toBe(event)
+    expect(event).not.toHaveProperty("context_management")
   })
 })

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -80,3 +80,29 @@ export function getLastUserMessage(messages: Array<{ role: string; content: any 
   }
   return messages.slice(-1)
 }
+
+/**
+ * Remove fields the Claude Agent SDK attaches to streamed events that are not
+ * part of the public Anthropic streaming schema.
+ *
+ * The SDK adds `context_management` (advisory metadata about upstream context
+ * edits) to `message_delta`. The real Anthropic API does not return it on a
+ * normal (non-beta) request, and stock clients — e.g. langchain-anthropic —
+ * assume any present field is a typed SDK model and call `.model_dump()` on it,
+ * crashing on the raw dict (#525). The context edit already happened upstream,
+ * so the field is safe to drop.
+ *
+ * Mutates and returns the event for convenient inline use in the SSE forward
+ * path; a no-op when the field is absent, so it is safe to call on every event.
+ */
+export function stripNonStandardStreamFields<T>(event: T): T {
+  if (event && typeof event === "object") {
+    const e = event as Record<string, unknown>
+    delete e.context_management
+    const delta = e.delta
+    if (delta && typeof delta === "object") {
+      delete (delta as Record<string, unknown>).context_management
+    }
+  }
+  return event
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -51,7 +51,7 @@ import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
-import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools } from "./messages"
+import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -2174,7 +2174,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       }
                     }
 
-                    // Forward all other events (text, non-MCP tool_use like Task, message events)
+                    // Forward all other events (text, non-MCP tool_use like Task, message events).
+                    // Strip SDK-only fields (context_management on message_delta) that stock
+                    // Anthropic clients crash on — the real API never returns them (#525).
+                    stripNonStandardStreamFields(event)
                     const payload = encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify(event)}\n\n`)
                     if (!safeEnqueue(payload, `stream_event:${eventType}`)) {
                       break


### PR DESCRIPTION
## Problem

Closes #525. Stock `langchain-anthropic` streaming clients crash at the end of every turn with:

```
AttributeError: 'dict' object has no attribute 'model_dump'
  ...langchain_anthropic/chat_models.py, in _make_message_chunk_from_anthropic_event
    context_management.model_dump()
```

The Claude Agent SDK attaches a `context_management` field to `message_delta` events and Meridian forwards it verbatim. The real Anthropic API doesn't return it on a normal (non-beta) request, so `langchain-anthropic` stores it as a raw `dict` and then calls `.model_dump()` on it, which raw dicts don't have.

## Fix

Strip `context_management` (top-level and nested under `delta`) from streamed events before forwarding, via a pure `stripNonStandardStreamFields` helper added to the `messages` leaf module (keeping `server.ts` orchestration-only per the module rules). The context edit already happened upstream, so the advisory field is safe to drop; usage, prompt caching, and extended-thinking metadata are untouched.

## Tests

5 unit tests for the pure helper (message_delta field removal, nested-delta removal, no-op on other events, non-object safety, mutate-and-return). Full suite: 1845 pass, 0 fail; `tsc --noEmit` clean.