### PR TITLE
fix: require a meaningful baseline before flagging a context spike (#496)

### DIFF
--- a/src/__tests__/token-health-unit.test.ts
+++ b/src/__tests__/token-health-unit.test.ts
@@ -31,6 +31,29 @@ describe("detectTokenAnomalies", () => {
     expect(anomalies.some(a => a.type === "context_spike")).toBe(true)
   })
 
+  // #496: in passthrough, nearly all input is cache-read, so raw inputTokens
+  // sits at 1-2 and any jitter reads as huge % growth ("grew 100% (1 -> 2)").
+  // A tiny baseline must not trip the alert.
+  it("does not flag a context spike when the baseline is tiny (1 -> 2)", () => {
+    const prev = makeSnapshot({ turnNumber: 1, inputTokens: 1 })
+    const curr = makeSnapshot({ turnNumber: 2, inputTokens: 2 })
+    expect(detectTokenAnomalies(curr, prev).some(a => a.type === "context_spike")).toBe(false)
+  })
+
+  it("does not flag a context spike for sub-threshold baselines (100 -> 400)", () => {
+    const prev = makeSnapshot({ turnNumber: 1, inputTokens: 100 })
+    const curr = makeSnapshot({ turnNumber: 2, inputTokens: 400 })
+    expect(detectTokenAnomalies(curr, prev).some(a => a.type === "context_spike")).toBe(false)
+  })
+
+  it("still flags a genuine spike from a meaningful baseline (5000 -> 50000)", () => {
+    const prev = makeSnapshot({ turnNumber: 1, inputTokens: 5000 })
+    const curr = makeSnapshot({ turnNumber: 2, inputTokens: 50000 })
+    const spike = detectTokenAnomalies(curr, prev).find(a => a.type === "context_spike")
+    expect(spike).toBeDefined()
+    expect(spike!.severity).toBe("critical")
+  })
+
   it("detects cache miss on resume as critical when previous metric exists", () => {
     const prev = makeSnapshot({ turnNumber: 1, cacheHitRate: 0.85 })
     const curr = makeSnapshot({

--- a/src/proxy/tokenHealth.ts
+++ b/src/proxy/tokenHealth.ts
@@ -26,6 +26,14 @@ export interface TokenAnomaly {
 /** Input token growth threshold (fraction) above which we flag a context spike. */
 const CONTEXT_SPIKE_THRESHOLD = 0.6  // >60% growth
 
+/**
+ * Minimum baseline input tokens before percentage growth is meaningful. In
+ * passthrough, nearly all input is cache-read, so raw inputTokens routinely
+ * sits at 1-2 and any jitter reads as huge % growth ("grew 100% (1 -> 2)").
+ * Only a baseline above this floor can trip the context-spike alert (#496).
+ */
+const CONTEXT_SPIKE_MIN_BASELINE = 1000
+
 /** Cache hit rate below which we flag a cache miss on resume requests. */
 const CACHE_MISS_THRESHOLD = 0.05
 
@@ -44,8 +52,9 @@ export function detectTokenAnomalies(
 ): TokenAnomaly[] {
   const anomalies: TokenAnomaly[] = []
 
-  // Context spike: input tokens grew more than CONTEXT_SPIKE_THRESHOLD
-  if (previous && previous.inputTokens > 0) {
+  // Context spike: input tokens grew more than CONTEXT_SPIKE_THRESHOLD from a
+  // baseline large enough for the percentage to be meaningful.
+  if (previous && previous.inputTokens >= CONTEXT_SPIKE_MIN_BASELINE) {
     const growth = (current.inputTokens - previous.inputTokens) / previous.inputTokens
     if (growth > CONTEXT_SPIKE_THRESHOLD) {
       const pct = Math.round(growth * 100)


### PR DESCRIPTION
## Problem

Users on #496 saw alarming log lines like:

```
context_spike: Input tokens grew 100% in one turn (1 -> 2). Possible context leak or full replay.
```

In passthrough mode nearly all input is cache-read, so raw `inputTokens` routinely sits at 1-2. Any jitter then reads as huge percentage growth and trips the `context_spike` anomaly — pure noise, no functional impact, but it reads as a warning.

## Fix

Gate the context-spike check on a baseline of `>= 1000` input tokens (`CONTEXT_SPIKE_MIN_BASELINE`). This mirrors the absolute-floor pattern the sibling `output_explosion` check already uses (`current.outputTokens > 2000`). Genuine spikes from real baselines still alert (verified: 5000 -> 50000 fires critical).

Pure function change in `detectTokenAnomalies` — affects only whether an advisory log line is emitted; no request/response behavior changes.

## Tests

3 cases added to `token-health-unit.test.ts`: tiny baseline (1 -> 2) and sub-threshold baseline (100 -> 400) produce no anomaly; a real spike (5000 -> 50000) still fires critical. Full suite: 1850 pass, 0 fail; `tsc --noEmit` clean.