### PR TITLE
fix: apply opencode transforms to the openai adapter (#546)

### DIFF
--- a/src/__tests__/plugin-validation.test.ts
+++ b/src/__tests__/plugin-validation.test.ts
@@ -64,4 +64,15 @@ describe("validateTransform", () => {
     expect(result.valid).toBe(true)
     expect(result.warnings).toContain("unknown-agent")
   })
+
+  // #546: openai is a real adapter; plugins targeting it must not warn.
+  it("accepts 'openai' as a known adapter without warning", () => {
+    const result = validateTransform({
+      name: "scoped",
+      adapters: ["openai"],
+      onRequest: () => {},
+    })
+    expect(result.valid).toBe(true)
+    expect(result.warnings ?? []).not.toContain("openai")
+  })
 })

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -88,6 +88,25 @@ describe("OpenCode transform parity", () => {
   })
 })
 
+// #546: the openai adapter (/v1/chat/completions) reuses openCodeTransforms via
+// registry.ts. Each transform re-filters by its own `adapters` array, so unless
+// "openai" is listed there the opencode-core transform is silently skipped —
+// leaving built-in tools UNBLOCKED and passthrough OFF for OpenAI clients (a
+// full Claude Code agent under bypassPermissions, the opposite of intent).
+describe("OpenAI adapter reuses the OpenCode pipeline (#546)", () => {
+  it("blocks built-in tools for adapterName 'openai' (same as opencode)", () => {
+    const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("openai"), "openai")
+    expect([...ctx.blockedTools]).toEqual([...openCodeAdapter.getBlockedBuiltinTools()])
+    expect(ctx.blockedTools.length).toBeGreaterThan(0)
+  })
+
+  it("applies the same incompatibleTools and allowedMcpTools as opencode", () => {
+    const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("openai"), "openai")
+    expect([...ctx.incompatibleTools]).toEqual([...openCodeAdapter.getAgentIncompatibleTools()])
+    expect([...ctx.allowedMcpTools]).toEqual([...openCodeAdapter.getAllowedMcpTools()])
+  })
+})
+
 describe("Crush transform parity", () => {
   it("matches blockedTools", () => {
     const ctx = runTransformHook(crushTransforms, "onRequest", makeCtx("crush"), "crush")

--- a/src/proxy/plugins/validation.ts
+++ b/src/proxy/plugins/validation.ts
@@ -1,4 +1,4 @@
-const KNOWN_ADAPTERS = ["opencode", "crush", "droid", "pi", "forgecode", "passthrough"]
+const KNOWN_ADAPTERS = ["opencode", "openai", "crush", "droid", "pi", "forgecode", "passthrough"]
 const KNOWN_HOOKS = ["onRequest", "onResponse", "onTelemetry", "onSession", "onToolUse", "onToolResult", "onError"]
 
 export interface ValidationResult {

--- a/src/proxy/transforms/opencode.ts
+++ b/src/proxy/transforms/opencode.ts
@@ -8,7 +8,10 @@ import { resolvePassthrough } from "../../env"
 export const openCodeTransforms: Transform[] = [
   {
     name: "opencode-core",
-    adapters: ["opencode"],
+    // "openai" (/v1/chat/completions) reuses this pipeline via the transform
+    // registry; it must be listed here or the transform is skipped and OpenAI
+    // clients get built-in tools unblocked + passthrough off (#546).
+    adapters: ["opencode", "openai"],
 
     onRequest(ctx: RequestContext): RequestContext {
       const body = ctx.body

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -128,6 +128,7 @@ const FEATURES = [
 
 const ADAPTER_LABELS = {
   opencode: 'OpenCode',
+  openai: 'OpenAI (/v1/chat/completions)',
   crush: 'Crush',
   forgecode: 'ForgeCode',
   pi: 'Pi',


### PR DESCRIPTION
## Problem

Closes #546. #533 added the `openai` adapter (`/v1/chat/completions`) by reusing `openCodeTransforms` via the registry. But each transform re-filters by its own `adapters` array, and `opencode-core` was scoped `adapters: ["opencode"]` — so `runTransformHook` skipped it for `openai`.

**Security-relevant effect:** OpenAI-format clients got `BLOCKED_BUILTIN_TOOLS` **not** blocked and passthrough **off** — i.e. a full Claude Code agent with `Bash`/`WebFetch` (and the profile's `claudeConfigDir`) under `bypassPermissions`, the opposite of the #526/#533 intent.

## Fix

Three additions so `openai` is a first-class alias of the opencode pipeline:
- `"openai"` → `opencode-core.adapters` (the actual regression — restores tool blocking + passthrough default)
- `"openai"` → `KNOWN_ADAPTERS` (`plugins/validation.ts`) so plugins can target it without a spurious warning
- `openai` entry in `ADAPTER_LABELS` (settings card now renders)

## Tests

- `transform-parity.test.ts`: running the pipeline with `adapterName: "openai"` now blocks built-in tools and applies the same incompatible/allowed-MCP tool sets as opencode.
- `plugin-validation.test.ts`: `adapters: ["openai"]` validates without warning.

Both red before the fix, green after. Full suite: 1853 pass, 0 fail; `tsc --noEmit` clean.

Note: the reporter also suggested a structural follow-up (a single adapter manifest / family-based matching to stop the list-duplication that let this half-land). Worth a separate behavior-preserving refactor, tracked separately.