### PR TITLE
fix: consolidate mid-history multimodal onto the final user turn (#553)

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,12 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields } from "../proxy/messages"
+import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser } from "../proxy/messages"
+
+const img = (id: string) => ({ type: "image", source: { type: "base64", media_type: "image/png", data: id } })
+function userMsg(content: unknown) {
+  return { type: "user" as const, message: { role: "user" as const, content }, parent_tool_use_id: null }
+}
 
 describe("normalizeContent", () => {
   it("returns string content as-is", () => {
@@ -201,5 +206,61 @@ describe("stripNonStandardStreamFields (#525)", () => {
     const event = { type: "message_delta", context_management: {} }
     expect(stripNonStandardStreamFields(event)).toBe(event)
     expect(event).not.toHaveProperty("context_management")
+  })
+})
+
+describe("consolidateMultimodalOntoLastUser (#553)", () => {
+  it("moves an image from an earlier user turn onto the last user turn", () => {
+    const out = consolidateMultimodalOntoLastUser([
+      userMsg([{ type: "text", text: "here is the file" }, img("A")]),
+      userMsg([{ type: "text", text: "describe it" }]),
+    ])
+    // Earlier turn keeps its text, loses the image.
+    expect(out[0]!.message.content).toEqual([{ type: "text", text: "here is the file" }])
+    // Last turn gains the image, keeps its text.
+    expect(out[1]!.message.content).toEqual([{ type: "text", text: "describe it" }, img("A")])
+  })
+
+  it("targets the last ARRAY-content user turn, not a flattened assistant string", () => {
+    const out = consolidateMultimodalOntoLastUser([
+      userMsg([img("A")]),
+      userMsg([{ type: "text", text: "look" }]),
+      userMsg("[Assistant: sure]"), // flattened assistant turn — string content
+    ])
+    // Image must land on the real user turn (index 1), never appended to a string.
+    expect(out[1]!.message.content).toContainEqual(img("A"))
+    expect(out[2]!.message.content).toBe("[Assistant: sure]")
+    expect(out[0]!.message.content).toEqual([])
+  })
+
+  it("does not duplicate an image already present on the last user turn", () => {
+    const out = consolidateMultimodalOntoLastUser([
+      userMsg([img("A")]),
+      userMsg([{ type: "text", text: "again" }, img("A")]),
+    ])
+    const imgs = (out[1]!.message.content as any[]).filter((b) => b.type === "image")
+    expect(imgs).toHaveLength(1)
+  })
+
+  it("preserves the order of multiple carried images", () => {
+    const out = consolidateMultimodalOntoLastUser([
+      userMsg([img("A")]),
+      userMsg([img("B")]),
+      userMsg([{ type: "text", text: "compare" }]),
+    ])
+    const imgs = (out[2]!.message.content as any[]).filter((b) => b.type === "image").map((b) => b.source.data)
+    expect(imgs).toEqual(["A", "B"])
+  })
+
+  it("is a no-op with fewer than two array-content user turns", () => {
+    const input = [userMsg([{ type: "text", text: "hi" }, img("A")])]
+    expect(consolidateMultimodalOntoLastUser(input)).toEqual(input)
+  })
+
+  it("does not mutate the input array or its messages", () => {
+    const input = [userMsg([img("A")]), userMsg([{ type: "text", text: "x" }])]
+    const snapshot = JSON.parse(JSON.stringify(input))
+    consolidateMultimodalOntoLastUser(input)
+    expect(input).toEqual(snapshot)
   })
 })

--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -190,6 +190,42 @@ describe("Multimodal content", () => {
     expect(multimodalUserMsg.message.content.some((b: any) => b.type === "image")).toBe(true)
   })
 
+  it("consolidates a mid-history image onto the final user turn so the SDK sees it (#553)", async () => {
+    const app = createTestApp()
+    await (await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "read /tmp/test.png" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "/tmp/test.png" } }] },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_1", content: [
+              { type: "text", text: "Read image file [image/png]" },
+              { type: "image", source: { type: "base64", media_type: "image/png", data: "IMGDATA" } },
+            ] },
+          ],
+        },
+        { role: "assistant", content: [{ type: "text", text: "Got it." }] },
+        { role: "user", content: [{ type: "text", text: "describe the image" }] },
+      ],
+    })).json()
+
+    const messages: any[] = []
+    for await (const msg of capturedQueryParams.prompt) messages.push(msg)
+
+    const arrayUserTurns = messages.filter((m: any) => Array.isArray(m.message?.content))
+    const lastArrayTurn = arrayUserTurns[arrayUserTurns.length - 1]
+    // The image must ride on the final user turn (what the SDK surfaces), not
+    // the mid-history tool_result turn where it originally sat.
+    expect(lastArrayTurn.message.content.some((b: any) => b.type === "image" && b.source?.data === "IMGDATA")).toBe(true)
+    // And it must not remain on the earlier turn (no duplication / stranding).
+    const midTurns = arrayUserTurns.slice(0, -1)
+    expect(midTurns.some((m: any) => m.message.content.some((b: any) => b.type === "image"))).toBe(false)
+  })
+
   it("should include all message roles in structured messages", async () => {
     const app = createTestApp()
     await (await post(app, {

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -106,3 +106,73 @@ export function stripNonStandardStreamFields<T>(event: T): T {
   }
   return event
 }
+
+/** Content block types that carry non-text data the model must "see". */
+export const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
+
+/**
+ * Consolidate multimodal blocks (image/document/file) from earlier user turns
+ * onto the final user turn of a structured (AsyncIterable) prompt.
+ *
+ * When the Claude Agent SDK is handed multiple user messages as a streaming
+ * iterable, it only surfaces multimodal blocks from the LAST user turn to the
+ * model — images sitting in earlier turns (e.g. an image a `read` tool returned
+ * mid-conversation) are silently dropped, and the model answers "I cannot see
+ * the image" (#553). Moving those blocks onto the final array-content user turn
+ * makes them visible; accompanying text is left in place.
+ *
+ * Notes:
+ *  - The target is the last entry whose `message.content` is an ARRAY. Flattened
+ *    assistant turns are string content and can never hold image blocks, so a
+ *    conversation ending on an assistant turn still lands images on the last
+ *    real user turn.
+ *  - Blocks structurally identical to ones already on the target are not
+ *    re-appended (avoids duplicating a client-re-attached image).
+ *
+ * Pure: returns a new array; the input and its messages are not mutated. No-op
+ * when there are fewer than two array-content user turns or nothing to carry.
+ */
+export function consolidateMultimodalOntoLastUser<
+  T extends { message: { content: unknown } }
+>(structured: T[]): T[] {
+  let targetIdx = -1
+  for (let i = structured.length - 1; i >= 0; i--) {
+    if (Array.isArray(structured[i]!.message.content)) {
+      targetIdx = i
+      break
+    }
+  }
+  if (targetIdx < 0) return structured
+
+  const carried: unknown[] = []
+  const result = structured.map((entry, i) => {
+    const content = entry.message.content
+    if (i === targetIdx || !Array.isArray(content)) return entry
+    const kept = content.filter((block: any) => {
+      if (block && typeof block === "object" && MULTIMODAL_TYPES.has(block.type)) {
+        carried.push(block)
+        return false
+      }
+      return true
+    })
+    if (kept.length === content.length) return entry
+    return { ...entry, message: { ...entry.message, content: kept } }
+  })
+
+  if (carried.length === 0) return structured
+
+  const target = result[targetIdx]!
+  const existing = target.message.content as unknown[]
+  const seen = new Set(existing.map((b) => JSON.stringify(b)))
+  const toAppend = carried.filter((b) => {
+    const key = JSON.stringify(b)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+  result[targetIdx] = {
+    ...target,
+    message: { ...target.message, content: [...existing, ...toAppend] },
+  }
+  return result
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -51,7 +51,7 @@ import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
-import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields } from "./messages"
+import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -122,8 +122,6 @@ async function ensureFreshTokenForProfiles(config: ProxyConfig): Promise<void> {
     if (store) await ensureFreshToken(store).catch(() => {})
   }
 }
-
-const MULTIMODAL_TYPES = new Set(["image", "document", "file"])
 
 function hasMultimodalContent(content: any): boolean {
   if (!Array.isArray(content)) return false
@@ -258,7 +256,9 @@ function buildFreshPrompt(
         }
       }
     }
-    return (async function* () { for (const msg of structured) yield msg })()
+    // See #553 — consolidate earlier-turn multimodal onto the final user turn.
+    const prompt = structured.length > 1 ? consolidateMultimodalOntoLastUser(structured) : structured
+    return (async function* () { for (const msg of prompt) yield msg })()
   }
 
   return messages
@@ -863,6 +863,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }
             }
           }
+        }
+
+        // The SDK only surfaces multimodal blocks from the LAST user turn of a
+        // streamed prompt; images sitting in earlier turns (e.g. a read-tool
+        // result mid-conversation) are otherwise dropped and the model replies
+        // "I cannot see the image" (#553). Move them onto the final user turn.
+        if (structuredMessages.length > 1) {
+          structuredMessages = consolidateMultimodalOntoLastUser(structuredMessages)
         }
       } else {
         // Text prompt — convert messages to string.


### PR DESCRIPTION
## Problem

Closes #553. In passthrough mode, images/documents/files sitting in **earlier** conversation turns are invisible to the model — it replies *"I cannot see the image"*. This is the default flow for any tool-using harness that returns images via a tool: the image arrives inside a `tool_result` block mid-history, the model reasons on for a few turns, and by replay time the image is no longer on the last message.

**Root cause** (verified by investigation): Meridian *correctly* preserves every earlier-message image in the structured stream — the drop is downstream, in how the SDK flattens an `AsyncIterable` of multiple user messages (it only surfaces multimodal from the **last** user turn). The reporter isolated it decisively: re-attaching the same image block onto the last user message makes the model describe it correctly.

## Fix

Add a pure `consolidateMultimodalOntoLastUser` helper (in the `messages` leaf module) that moves multimodal blocks from earlier user turns onto the **last array-content user turn** before the prompt is handed to the SDK:
- Targets the last *array-content* user turn — never a flattened `[Assistant: …]` string wrapper.
- Dedups against blocks already on the target (no double-attach when a client re-sends).
- Leaves accompanying text in place; pure (no input mutation).

Applied at **both** structured-prompt sites: the primary path and `buildFreshPrompt` (the stale-session retry path had the same latent drop).

**Safety:** strictly monotonic — it moves an otherwise-dropped image to a later turn, or no-ops when there's no later array-content turn. It cannot regress non-multimodal flows (gated behind `hasMultimodal`) and doesn't touch tool pairing (pairing is already flattened away before consolidation runs).

## Tests

- 6 direct unit tests on the pure helper (move, target-last-array-turn, dedup, order, no-op, no-mutation).
- 1 end-to-end integration test: a `tool_result` image mid-history lands on the final user turn the SDK surfaces, with no stranding on the earlier turn.

Full suite: 1860 pass, 0 fail; `tsc --noEmit` clean.

Note: the SDK-side last-message-only behavior was confirmed via the reporter's reproduction (I can't drive the real subprocess in CI); the fix is strictly-improving regardless of the exact SDK mechanism.