### PR TITLE
fix: attribute replayed tool results to the calls that produced them (#552)

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser } from "../proxy/messages"
+import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall } from "../proxy/messages"
 
 const img = (id: string) => ({ type: "image", source: { type: "base64", media_type: "image/png", data: id } })
 function userMsg(content: unknown) {
@@ -262,5 +262,55 @@ describe("consolidateMultimodalOntoLastUser (#553)", () => {
     const snapshot = JSON.parse(JSON.stringify(input))
     consolidateMultimodalOntoLastUser(input)
     expect(input).toEqual(snapshot)
+  })
+})
+
+describe("buildToolUseIndex / tool-result attribution (#552)", () => {
+  const history = [
+    { role: "user", content: "create tmp/test2.txt" },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Creating it now." },
+        { type: "tool_use", id: "toolu_w", name: "write", input: { filePath: "tmp/test2.txt", content: "apple" } },
+      ],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_w", content: "Wrote file successfully" }],
+    },
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_r", name: "read", input: { path: "tmp/test1.txt" } }],
+    },
+  ]
+
+  it("indexes every assistant tool_use by id with name and target", () => {
+    const idx = buildToolUseIndex(history)
+    expect(idx.get("toolu_w")).toEqual({ name: "write", target: "tmp/test2.txt" })
+    expect(idx.get("toolu_r")).toEqual({ name: "read", target: "tmp/test1.txt" })
+  })
+
+  it("extracts common target keys and truncates long ones", () => {
+    const idx = buildToolUseIndex([
+      { role: "assistant", content: [
+        { type: "tool_use", id: "t1", name: "bash", input: { command: "echo hi" } },
+        { type: "tool_use", id: "t2", name: "grep", input: { pattern: "x".repeat(200) } },
+        { type: "tool_use", id: "t3", name: "custom", input: { weird: true } },
+      ] },
+    ])
+    expect(idx.get("t1")).toEqual({ name: "bash", target: "echo hi" })
+    expect(idx.get("t2")!.target!.length).toBeLessThanOrEqual(80)
+    expect(idx.get("t3")).toEqual({ name: "custom", target: undefined })
+  })
+
+  it("describeToolCall renders a compact attribution label", () => {
+    expect(describeToolCall({ name: "write", target: "tmp/test2.txt" })).toBe("[write tmp/test2.txt]")
+    expect(describeToolCall({ name: "custom", target: undefined })).toBe("[custom]")
+  })
+
+  it("returns an empty index for non-array and toolless content", () => {
+    expect(buildToolUseIndex([{ role: "user", content: "hi" }]).size).toBe(0)
+    expect(buildToolUseIndex([]).size).toBe(0)
   })
 })

--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -216,3 +216,54 @@ describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text",
     assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 })
+
+describe("tool-result attribution on full-history replay (#552)", () => {
+  // Fresh replay drops assistant tool_use blocks (per #111/#386), so without
+  // attribution the model sees raw tool outputs as bare user text and denies
+  // having made the calls ("a file I never created"). Each replayed
+  // tool_result must carry a compact [name target] attribution instead.
+  const toolLoopHistory = [
+    { role: "user", content: "create tmp/test2.txt then read tmp/test1.txt" },
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_w1", name: "write", input: { filePath: "tmp/test2.txt", content: "apple" } }],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_w1", content: "Wrote file successfully" }],
+    },
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_r1", name: "read", input: { filePath: "tmp/test1.txt" } }],
+    },
+    {
+      role: "user",
+      content: [
+        { type: "tool_result", tool_use_id: "toolu_r1", content: "line one\nline two" },
+        { type: "text", text: "what files did you create?" },
+      ],
+    },
+  ]
+
+  beforeEach(() => {
+    clearSessionCache()
+    clearSharedSessions()
+    capturedParams = null
+    mockMessages = [assistantMessage([{ type: "text", text: "You created tmp/test2.txt" }])]
+  })
+
+  it("attributes each replayed tool result to the call that produced it", async () => {
+    const app = createTestApp()
+    await postWithSession(app, "attribution-session-1", toolLoopHistory, "sdk-attr-1")
+
+    const prompt = promptToString(getCaptured()?.prompt)
+    // The write result must be attributed — the model must be able to see IT
+    // wrote tmp/test2.txt, not just an unexplained success string.
+    expect(prompt).toContain("[write tmp/test2.txt]")
+    expect(prompt).toContain("Wrote file successfully")
+    // The read result must be attributed to the right file.
+    expect(prompt).toContain("[read tmp/test1.txt]")
+    // And the banned verbose shapes must stay banned.
+    assertNoFlattenedToolBlocks(getCaptured()?.prompt)
+  })
+})

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -176,3 +176,59 @@ export function consolidateMultimodalOntoLastUser<
   }
   return result
 }
+
+/** A tool call the assistant made earlier in the conversation. */
+export interface ToolCallInfo {
+  name: string
+  /** Compact human-readable target (file path, command, pattern...), if any. */
+  target: string | undefined
+}
+
+/** Input keys that identify what a tool call operated on, in priority order. */
+const TOOL_TARGET_KEYS = ["filePath", "file_path", "path", "command", "pattern", "query", "url"] as const
+
+/**
+ * Index every assistant tool_use block in a conversation by id.
+ *
+ * Used to attribute tool_result blocks during full-history replay: the
+ * flattened replay drops assistant tool_use blocks (issues #111/#386 — verbose
+ * `[Tool Use: ...]` strings taught the model to imitate fake tool syntax), so
+ * without attribution the model sees raw tool outputs as bare user text with
+ * no cause — it then denies having made the calls at all ("a file I never
+ * created", #552).
+ */
+export function buildToolUseIndex(
+  messages: Array<{ role: string; content: any }>
+): Map<string, ToolCallInfo> {
+  const index = new Map<string, ToolCallInfo>()
+  for (const m of messages) {
+    if (m.role !== "assistant" || !Array.isArray(m.content)) continue
+    for (const block of m.content) {
+      if (block?.type !== "tool_use" || !block.id || typeof block.name !== "string") continue
+      let target: string | undefined
+      const input = block.input
+      if (input && typeof input === "object") {
+        for (const key of TOOL_TARGET_KEYS) {
+          const v = (input as Record<string, unknown>)[key]
+          if (typeof v === "string" && v) {
+            target = v.length > 80 ? v.slice(0, 77) + "..." : v
+            break
+          }
+        }
+      }
+      index.set(block.id, { name: block.name, target })
+    }
+  }
+  return index
+}
+
+/**
+ * Render a compact attribution label for a replayed tool result, e.g.
+ * `[write tmp/test2.txt]` or `[bash echo hi]`. Deliberately terse and
+ * bracket-formatted differently from the banned `[Tool Use: ...]` /
+ * `[Tool Result ...]` shapes (#111/#386) so the model reads it as context,
+ * not as tool-call syntax to imitate.
+ */
+export function describeToolCall(info: ToolCallInfo): string {
+  return info.target ? `[${info.name} ${info.target}]` : `[${info.name}]`
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -51,7 +51,7 @@ import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
-import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES } from "./messages"
+import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -190,13 +190,18 @@ function flattenAssistantContent(content: any): string {
 /**
  * Flatten a user message's content to plain text for replay.
  *
- * Unwraps tool_result blocks — emit just the raw result content so the
- * model sees a natural "here's the output" user turn instead of
- * `[Tool Result for toolu_xxx: ...]` noise (issue #111, #386).
+ * Unwraps tool_result blocks — emit the raw result content so the model sees
+ * a natural "here's the output" user turn instead of verbose
+ * `[Tool Result for toolu_xxx: ...]` noise (issue #111, #386). When a
+ * toolIndex is provided, each result is prefixed with a compact
+ * `[name target]` attribution: the replay drops assistant tool_use blocks,
+ * so without this the model sees raw outputs with no cause and denies having
+ * made the calls at all (#552 — "a file I never created").
  */
 function flattenUserContent(
   content: any,
-  sanitizeOpts: import("./sanitize").SanitizeOptions = {}
+  sanitizeOpts: import("./sanitize").SanitizeOptions = {},
+  toolIndex?: Map<string, import("./messages").ToolCallInfo>
 ): string {
   if (typeof content === "string") return sanitizeTextContent(content, sanitizeOpts)
   if (!Array.isArray(content)) return String(content ?? "")
@@ -204,15 +209,19 @@ function flattenUserContent(
     .map((b: any) => {
       if (b?.type === "text" && b.text) return sanitizeTextContent(b.text, sanitizeOpts)
       if (b?.type === "tool_result") {
+        const info = toolIndex?.get(b.tool_use_id)
+        const label = info ? describeToolCall(info) : undefined
         const inner = b.content
-        if (typeof inner === "string") return inner
-        if (Array.isArray(inner)) {
-          return inner
+        let flat = ""
+        if (typeof inner === "string") flat = inner
+        else if (Array.isArray(inner)) {
+          flat = inner
             .map((ib: any) => (ib?.type === "text" && ib.text ? ib.text : ""))
             .filter(Boolean)
             .join("\n")
         }
-        return ""
+        if (label) return flat ? `${label}:\n${flat}` : label
+        return flat
       }
       if (b?.type === "image") return "[Image attached]"
       if (b?.type === "document") return "[Document attached]"
@@ -233,6 +242,7 @@ function buildFreshPrompt(
   sanitizeOpts: import("./sanitize").SanitizeOptions = {}
 ): string | AsyncIterable<any> {
   const hasMultimodal = messages.some((m) => hasMultimodalContent(m.content))
+  const toolIndex = buildToolUseIndex(messages)
 
   if (hasMultimodal) {
     const structured: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> = []
@@ -266,7 +276,7 @@ function buildFreshPrompt(
       const role = m.role === "assistant" ? "Assistant" : "Human"
       const content = m.role === "assistant"
         ? flattenAssistantContent(m.content)
-        : flattenUserContent(m.content, sanitizeOpts)
+        : flattenUserContent(m.content, sanitizeOpts, toolIndex)
       return content ? `${role}: ${content}` : ""
     })
     .filter(Boolean)
@@ -879,12 +889,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // `<system-reminder>` is only stripped for adapters that leak CWD
         // through it (Droid) — preserved otherwise so that harness state
         // like oh-my-opencode's background-task IDs reaches the model.
+        // Tool-result attribution is indexed from the FULL history so ids
+        // resolve even when the originating call sits before a resume-delta
+        // boundary (#552).
+        const toolIndex = buildToolUseIndex(allMessages ?? messagesToConvert ?? [])
         textPrompt = messagesToConvert
           ?.map((m: { role: string; content: any }) => {
             const role = m.role === "assistant" ? "Assistant" : "Human"
             const content = m.role === "assistant"
               ? flattenAssistantContent(m.content)
-              : flattenUserContent(m.content, sanitizeOpts)
+              : flattenUserContent(m.content, sanitizeOpts, toolIndex)
             return content ? `${role}: ${content}` : ""
           })
           .filter(Boolean)


### PR DESCRIPTION
## Problem

kabo's retest on #552 (v1.45.2+) reported: *improved, but in build mode the model says calls are aborted and responses are out of order — it wrote test2.txt, then tried to read it, then claimed it never created that file.*

**Root cause:** fresh full-history replay is doubly lossy. `flattenAssistantContent` drops assistant `tool_use` blocks entirely (a deliberate #111/#386 decision — verbose `[Tool Use: ...]` strings taught the model to imitate fake tool syntax), and `flattenUserContent` unwraps `tool_result` to bare text. That was tolerable when **resume** was the primary path (the SDK session carried real history). Post-#580, single-step-aborted sessions are never resumed — **fresh replay IS the model's memory** in passthrough tool loops. The model therefore sees raw tool outputs as unexplained user text: file contents with no cause → "responses are out of order", a write success with no owner → "a file I never created".

## Fix

Attribute at the **result site** (conservative — doesn't reintroduce the banned verbose shapes):
- `buildToolUseIndex` (pure, `messages` leaf module): indexes every assistant `tool_use` by id with name + compact target (filePath/path/command/pattern/query/url, truncated).
- `flattenUserContent` prefixes each `tool_result` with `[name target]:` when the id resolves — e.g. `[write tmp/test2.txt]:\nWrote file successfully`.
- Wired into both replay sites: the main text-prompt build (index from **full** history so ids resolve across resume-delta boundaries) and `buildFreshPrompt`.
- The #111/#386 regression suite still passes — `[Tool Use:` / `[Tool Result` remain banned.

## Live A/B proof (real model, fresh sessions, same history)

History with file paths existing **only** in the tool_use inputs (so the model cannot infer from the user text), asked "which file did YOU create, which did you only read?":

| Build | Answer |
|---|---|
| v1.45.3 (deployed) | *"I haven't performed any file operations yet in this conversation"* — the literal #552 symptom |
| this branch | `CREATED=tmp/test2.txt READ=tmp/test1.txt` |

## Tests

- 4 unit tests on the pure helpers (indexing, target extraction/truncation, label rendering, empty cases).
- 1 integration test on the full replay path: each replayed result carries its attribution; banned shapes stay absent.

Full suite: 1865 pass, 0 fail; `tsc --noEmit` clean.