### PR TITLE
fix: close dangling content blocks before recovery frames (#552 red reads)

### DIFF
--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -219,6 +219,65 @@ describe("Passthrough deny aborts the nested SDK session on loop detection", () 
     expect(toolStartIds).toEqual(["toolu_s1"])
   })
 
+  it("closes a dangling tool_use content block before the recovery message_stop (#552 red reads)", async () => {
+    // Real SDK sequence captured live: with two parallel same-tool calls in
+    // one assistant turn, call 2's block_start + input deltas stream to the
+    // client, then the same-tool-repeat deny aborts the subprocess BEFORE
+    // call 2's content_block_stop arrives. Without an explicit close the
+    // client is left with an unterminated tool_use block — OpenCode renders
+    // it as an argument-less aborted ("red") tool call.
+    const streamEvent = (event: any) => ({
+      type: "stream_event",
+      event,
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: "test-session",
+    })
+    const twoCallTurn = toolTurn("toolu_p1", "read", { filePath: "a.txt" })
+    // Both tool calls live in ONE assistant message, mirroring the real SDK.
+    ;(twoCallTurn as any).message.content = [
+      { type: "tool_use", id: "toolu_p1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      { type: "tool_use", id: "toolu_p2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "b.txt" } },
+    ]
+    mockTurns = [
+      streamMessageStart(),
+      streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_p1", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+      streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"filePath":"a.txt"}' } }),
+      streamEvent({ type: "content_block_stop", index: 1 }),
+      streamEvent({ type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "toolu_p2", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+      streamEvent({ type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '{"filePath":"b.txt"}' } }),
+      // No content_block_stop for index 2 — the abort cuts it off here. The
+      // assistant turn below fires the PreToolUse hooks: call 1 captured,
+      // call 2 (same tool, new args) triggers the loop-break abort.
+      twoCallTurn,
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await post(app, true)
+    const events = await readSSE(response)
+    const eventTypes = events.map((e: any) => e.event)
+
+    expect(capturedController!.signal.aborted).toBe(true)
+    expect(eventTypes).not.toContain("error")
+
+    // Every forwarded content_block_start must have a matching stop.
+    const startIdxs = events
+      .filter((e: any) => e.event === "content_block_start")
+      .map((e: any) => e.data.index)
+    const stopIdxs = events
+      .filter((e: any) => e.event === "content_block_stop")
+      .map((e: any) => e.data.index)
+    for (const idx of startIdxs) {
+      expect(stopIdxs).toContain(idx)
+    }
+
+    // And the dangling block's stop must precede message_stop.
+    const lastStopPos = eventTypes.lastIndexOf("content_block_stop")
+    const messageStopPos = eventTypes.indexOf("message_stop")
+    expect(lastStopPos).toBeGreaterThan(-1)
+    expect(lastStopPos).toBeLessThan(messageStopPos)
+  })
+
   it("does not offer a single-step-aborted session for resume — the follow-up starts fresh (#552)", async () => {
     mockTurns = [
       toolTurn("toolu_1", "get_weather", { city: "SF" }),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1766,6 +1766,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // dedupe captured tool_uses against what was already forwarded
             // when recovering gracefully from max_turns (see catch below).
             const streamedToolUseIds = new Set<string>()
+            // Client block indices whose content_block_start was forwarded but
+            // whose content_block_stop hasn't been yet. The single-step abort
+            // (#575) can SIGTERM the subprocess mid-block, leaving the client
+            // with an unterminated tool_use block that renders as an
+            // argument-less aborted call (#552 "red reads") — the recovery
+            // path closes these explicitly before its final frames.
+            const openClientBlocks = new Set<number>()
 
             try {
               let currentSessionId: string | undefined
@@ -2206,6 +2213,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }
                     eventsForwarded += 1
 
+                    // Track envelope integrity: which forwarded blocks are open.
+                    if (eventType === "content_block_start") {
+                      const idx = (event as any).index
+                      if (typeof idx === "number") openClientBlocks.add(idx)
+                    } else if (eventType === "content_block_stop") {
+                      const idx = (event as any).index
+                      if (typeof idx === "number") openClientBlocks.delete(idx)
+                    }
+
                     // NOTE: agent-specific (passthrough mode) — break immediately when
                     // the model stops for tool_use so the client can execute the tools
                     // and send results back. Without this the SDK executes the passthrough
@@ -2558,6 +2574,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   })} captured=${capturedToolUses.length}`,
                   requestMeta.requestId,
                 )
+
+                // Close any content block whose start was forwarded but whose
+                // stop was lost to the abort (SIGTERM can cut the stream after
+                // a tool_use block's input deltas but before its stop) — an
+                // unterminated block renders client-side as an argument-less
+                // aborted call (#552 "red reads").
+                for (const idx of openClientBlocks) {
+                  safeEnqueue(encoder.encode(
+                    `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: idx })}\n\n`
+                  ), "recover_close_dangling_block")
+                }
+                openClientBlocks.clear()
 
                 // Mirror the success-path emission: send any unseen tool_uses
                 // (dedup against streamedToolUseIds), then a clean


### PR DESCRIPTION
## Problem

Second half of kabo's #552 retest: OpenCode shows **red, argument-less tool calls** ("red Reads") alongside each successful one.

**Root cause, reproduced live:** when the model issues two parallel same-tool calls in one assistant turn, call 2's `content_block_start` + all its `input_json_delta`s stream to the client — then the same-tool-repeat deny fires the #575 abort, SIGTERMing the subprocess **before call 2's `content_block_stop` arrives**. The recovery path emitted its `message_delta` + `message_stop` around the unterminated block. OpenCode can't finalize the call's arguments → renders an argument-less aborted call.

## Fix

Track which forwarded `content_block_start`s haven't seen their `content_block_stop`, and close them explicitly in the recovery path before the synthesized final frames. Envelope integrity: every started block is now stopped.

## Live A/B (real model, parallel reads, streaming)

| Build | Stream tail |
|---|---|
| v1.45.3 (deployed) | `block_start idx=2` → deltas → **no stop** → `message_stop` (the red read) |
| this branch | `block_start idx=2` → deltas → `block_stop idx=2` → `message_delta` → `message_stop` |

## Tests

New case in `proxy-passthrough-deny-abort.test.ts` replaying the exact captured SDK sequence (raw stream events, two same-tool calls, stop cut off by the abort): asserts every forwarded `content_block_start` has a matching stop, ordered before `message_stop`. Red before the fix, green after. Full suite: 1866 pass, 0 fail; `tsc --noEmit` clean.

## Note / follow-up

The non-stream path still returns only the first of two parallel calls, and the same-tool-repeat deny text says "not forwarded" while in streaming the call now IS fully delivered. That semantic inconsistency in the single-step machinery deserves its own careful issue rather than a rushed change here — this PR fixes the protocol violation only.