### PR TITLE
fix: resume Claude Code sessions after tool results

### DIFF
--- a/src/__tests__/claude-code-adapter.test.ts
+++ b/src/__tests__/claude-code-adapter.test.ts
@@ -19,21 +19,47 @@ describe("claudeCodeAdapter — identity", () => {
 })
 
 describe("claudeCodeAdapter.getSessionId", () => {
-  it("always returns undefined — Claude Code sends no session header", () => {
+  it("extracts a session ID from Claude Code's JSON-string metadata", () => {
     const ctx = {
       req: { header: () => "any-value" },
     }
-    expect(claudeCodeAdapter.getSessionId(ctx as any)).toBeUndefined()
+    const body = {
+      metadata: {
+        user_id: JSON.stringify({
+          device_id: "device-1",
+          account_uuid: "",
+          session_id: "session-from-metadata",
+        }),
+      },
+    }
+    expect(claudeCodeAdapter.getSessionId(ctx as any, body)).toBe("session-from-metadata")
   })
 
-  it("returns undefined even when x-opencode-session is present", () => {
+  it("accepts object-form metadata for compatible gateways", () => {
+    const ctx = { req: { header: () => undefined } }
+    const body = { metadata: { user_id: { session_id: "object-session" } } }
+    expect(claudeCodeAdapter.getSessionId(ctx as any, body)).toBe("object-session")
+  })
+
+  it("falls back to fingerprinting when metadata is absent or malformed", () => {
+    const ctx = { req: { header: () => undefined } }
+    expect(claudeCodeAdapter.getSessionId(ctx as any, {})).toBeUndefined()
+    expect(claudeCodeAdapter.getSessionId(ctx as any, {
+      metadata: { user_id: "not-json" },
+    })).toBeUndefined()
+    expect(claudeCodeAdapter.getSessionId(ctx as any, {
+      metadata: { user_id: JSON.stringify({ device_id: "device-1" }) },
+    })).toBeUndefined()
+  })
+
+  it("ignores unrelated session headers", () => {
     const ctx = {
       req: {
         header: (name: string) =>
           name === "x-opencode-session" ? "sess-abc" : undefined,
       },
     }
-    expect(claudeCodeAdapter.getSessionId(ctx as any)).toBeUndefined()
+    expect(claudeCodeAdapter.getSessionId(ctx as any, {})).toBeUndefined()
   })
 })
 

--- a/src/__tests__/proxy-session-resume.test.ts
+++ b/src/__tests__/proxy-session-resume.test.ts
@@ -199,6 +199,47 @@ describe("Session resume: session ID tracking", () => {
     // Should NOT have resume set (different session)
     expect(capturedQueryParams.options.resume).toBeUndefined()
   })
+
+  it("resumes Claude Code after a tool_result using metadata session ID", async () => {
+    const app = createTestApp()
+    const metadata = {
+      user_id: JSON.stringify({
+        device_id: "device-1",
+        account_uuid: "",
+        session_id: "claude-code-session-1",
+      }),
+    }
+    const headers = { "user-agent": "claude-cli/2.1.207" }
+
+    await (await post(app, {
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      stream: false,
+      metadata,
+      messages: [{ role: "user", content: "Run the tests" }],
+    }, headers)).json()
+
+    mockMessages = [assistantMessage([{ type: "text", text: "The test failed." }])]
+    await (await post(app, {
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      stream: false,
+      metadata,
+      messages: [
+        { role: "user", content: "Run the tests" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "npm test" } }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "Exit code 1" }],
+        },
+      ],
+    }, headers)).json()
+
+    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+  })
 })
 
 // ============================================================
@@ -241,6 +282,37 @@ describe("Session resume: fingerprint fallback", () => {
         { role: "user", content: "Tell me more" },
       ],
     })).json()
+
+    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+  })
+
+  it("keeps Claude Code fingerprint resume for tool_result without metadata", async () => {
+    const app = createTestApp()
+    const headers = { "user-agent": "claude-cli/2.1.207" }
+
+    await (await post(app, {
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "Check the build" }],
+    }, headers)).json()
+
+    await (await post(app, {
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        { role: "user", content: "Check the build" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "toolu_2", name: "Bash", input: { command: "npm run build" } }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "Build complete" }],
+        },
+      ],
+    }, headers)).json()
 
     expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
   })

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -21,7 +21,7 @@ export interface AgentIdentity {
    * Extract a session ID from the request.
    * Returns undefined if the agent doesn't provide session tracking.
    */
-  getSessionId(c: Context): string | undefined
+  getSessionId(c: Context, body?: unknown): string | undefined
 
   /**
    * Extract the SDK subprocess working directory from the request body.

--- a/src/proxy/adapters/claudecode.ts
+++ b/src/proxy/adapters/claudecode.ts
@@ -51,15 +51,38 @@ function extractClaudeCodeClientCwd(body: any): string | undefined {
   return match?.[1]?.trim() || undefined
 }
 
+/** Extract the stable conversation ID embedded by Claude Code in metadata.user_id. */
+export function extractClaudeCodeSessionId(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined
+
+  const metadata = (body as { metadata?: unknown }).metadata
+  if (!metadata || typeof metadata !== "object") return undefined
+
+  const rawUserId = (metadata as { user_id?: unknown }).user_id
+  let userMetadata: unknown = rawUserId
+
+  if (typeof rawUserId === "string") {
+    try {
+      userMetadata = JSON.parse(rawUserId)
+    } catch {
+      return undefined
+    }
+  }
+
+  if (!userMetadata || typeof userMetadata !== "object") return undefined
+  const sessionId = (userMetadata as { session_id?: unknown }).session_id
+  return typeof sessionId === "string" && sessionId.length > 0 ? sessionId : undefined
+}
+
 export const claudeCodeAdapter: AgentAdapter = {
   name: "claude-code",
 
   /**
-   * Claude Code doesn't send a session-affinity header, so fall through to
-   * fingerprint-based resume (first-user-message + clientCwd).
+   * Claude Code embeds its conversation ID in metadata.user_id rather than a
+   * session-affinity header. Fall back to fingerprint resume when absent.
    */
-  getSessionId(_c: Context): string | undefined {
-    return undefined
+  getSessionId(_c: Context, body?: unknown): string | undefined {
+    return extractClaudeCodeSessionId(body)
   },
 
   /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -690,7 +690,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const betas = betaFilter.forwarded
 
         // Session resume: look up cached Claude SDK session and classify mutation
-        const agentSessionId = adapter.getSessionId(c)
+        const agentSessionId = adapter.getSessionId(c, body)
         // Scope session keys by profile to isolate resume state across accounts.
         // For agents with session IDs (OpenCode): prefix the key.
         // For agents without (Pi): pass profile-scoped workingDirectory to fingerprint lookup.
@@ -730,7 +730,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const lastMessage = Array.isArray(body.messages) ? body.messages[body.messages.length - 1] : undefined
         const lastIsToolResult = Array.isArray(lastMessage?.content)
           && lastMessage.content.some((b: any) => b?.type === "tool_result")
-        const isClientDrivenLoop = !agentSessionId && lastIsToolResult
+        // NOTE: Claude Code owns its tool loop but also expects Meridian to
+        // resume the backing SDK session. Older clients may omit metadata, so
+        // preserve fingerprint resume instead of treating their tool results
+        // as unrelated headerless workflow requests.
+        const isClientDrivenLoop = adapter.name !== "claude-code" && !agentSessionId && lastIsToolResult
         const isIndependentSession =
           requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || isClientDrivenLoop || false
         let lineageResult = isIndependentSession


### PR DESCRIPTION
## Summary

- extract Claude Code's conversation ID from `metadata.user_id`
- resume the backing Claude SDK session after client-executed tool results
- preserve fingerprint resume when older Claude Code clients omit metadata
- keep the headerless client-loop behavior introduced by #571 for other adapters

## Root cause

Claude Code does not send a session-affinity header. Its session ID is embedded
as JSON in `metadata.user_id`, but the Claude Code adapter always returned
`undefined` from `getSessionId()`.

Since #571, requests whose final message contains `tool_result` and have no
recognized session ID are treated as independent. This caused normal Claude
Code tool-result turns to skip session lookup and start a new SDK session.

## Fix

The Claude Code adapter now extracts `session_id` from both supported
`metadata.user_id` shapes:

- JSON-encoded string
- object form

Claude Code tool-result requests are also excluded from the generic headerless
independent-session rule, preserving fingerprint resume for clients that omit
metadata.

## Validation

A real two-request Claude Code flow was tested against Meridian 1.45.3:

1. the first request returned `stop_reason=tool_use`
2. the second request returned the tool result with the same metadata session ID
3. Meridian logged `lineage=continuation`
4. the original Claude SDK session was resumed
5. the resumed request achieved a 99% cache hit rate

Tests:

- TypeScript typecheck passed
- production build passed
- 1765 main-suite tests passed
- metadata session resume regression passed
- fingerprint fallback regression passed
- existing passthrough single-turn tests passed
