### PR TITLE
feat: add workspace authority control primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,8 @@ ANTHROPIC_API_KEY=your-secret-key ANTHROPIC_BASE_URL=http://meridian-host:3456 o
 | `MERIDIAN_MAX_STORED_SESSIONS` | `CLAUDE_PROXY_MAX_STORED_SESSIONS` | `10000` | File-based session store capacity |
 | `MERIDIAN_WORKDIR` | `CLAUDE_PROXY_WORKDIR` | `cwd()` | Default working directory for SDK |
 | `MERIDIAN_IDLE_TIMEOUT_SECONDS` | `CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS` | `120` | HTTP keep-alive timeout |
+| `MERIDIAN_WORKSPACE_AUTHORITY_SOCKET` | — | unset | Enable the private orchestrator workspace-authority control socket at this absolute path. Its parent directory must be owned by Meridian and mode `0700`. |
+| `MERIDIAN_WORKSPACE_AUTHORITY_CREDENTIAL_FILE` | — | `<socket>.credential` | Runtime credential file for the workspace-authority socket. Must be in the same private directory as the socket. |
 | `MERIDIAN_TELEMETRY_SIZE` | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
 | `MERIDIAN_NO_FILE_CHANGES` | `CLAUDE_PROXY_NO_FILE_CHANGES` | unset | Disable "Files changed" summary in responses |
 | `MERIDIAN_SONNET_MODEL` | `CLAUDE_PROXY_SONNET_MODEL` | `sonnet` | Sonnet context tier: `sonnet` (200k, default) or `sonnet[1m]` (1M, requires Extra Usage†) |

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -38,6 +38,7 @@ Environment variables:
   MERIDIAN_HOST                     Host to bind to (default: 127.0.0.1)
   MERIDIAN_PASSTHROUGH              Enable passthrough mode (tools forwarded to client)
   MERIDIAN_IDLE_TIMEOUT_SECONDS     Idle timeout in seconds (default: 120)
+  MERIDIAN_WORKSPACE_AUTHORITY_SOCKET  Enable the private orchestrator control socket
 
 See https://github.com/rynfar/meridian for full documentation.`)
   process.exit(0)
@@ -123,6 +124,11 @@ const execFile = promisify(execFileCallback)
 const port = parseInt(process.env.MERIDIAN_PORT ?? process.env.CLAUDE_PROXY_PORT ?? "3456", 10)
 const host = process.env.MERIDIAN_HOST ?? process.env.CLAUDE_PROXY_HOST ?? "127.0.0.1"
 const idleTimeoutSeconds = parseInt(process.env.MERIDIAN_IDLE_TIMEOUT_SECONDS ?? process.env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS ?? "120", 10)
+const workspaceAuthoritySocket = process.env.MERIDIAN_WORKSPACE_AUTHORITY_SOCKET
+const workspaceAuthority = workspaceAuthoritySocket ? {
+  socketPath: workspaceAuthoritySocket,
+  credentialPath: process.env.MERIDIAN_WORKSPACE_AUTHORITY_CREDENTIAL_FILE || undefined,
+} : undefined
 
 // Load profile configuration:
 //   1. MERIDIAN_PROFILES env var (JSON array) — takes precedence
@@ -200,7 +206,7 @@ export async function runCli(
     enableDiskProfileDiscovery()
   }
 
-  const proxy = await start({ port, host, idleTimeoutSeconds, profiles, defaultProfile, version, installProcessErrorHandlers: true })
+  const proxy = await start({ port, host, idleTimeoutSeconds, profiles, defaultProfile, version, installProcessErrorHandlers: true, workspaceAuthority })
 
   // Handle EADDRINUSE — preserve CLI behavior of exiting on port conflict
   proxy.server.on("error", (error: NodeJS.ErrnoException) => {

--- a/src/__tests__/workspace-authority.test.ts
+++ b/src/__tests__/workspace-authority.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, unlink } from "node:fs/promises"
+import { createConnection } from "node:net"
+import { createServer as createHttpServer } from "node:http"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  WorkspaceAuthorityRegistry,
+  startWorkspaceAuthorityServer,
+  type WorkspaceAuthorityRequest,
+  type WorkspaceAuthorityResponse,
+  type WorkspaceAuthorityServer,
+} from "../proxy/workspaceAuthority"
+import { createProxyServer, startProxyServer } from "../proxy/server"
+
+const tempPaths: string[] = []
+const servers: WorkspaceAuthorityServer[] = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close().catch(() => {})))
+  await Promise.all(tempPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+async function privateRuntimeDir(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "meridian-authority-"))
+  tempPaths.push(path)
+  await chmod(path, 0o700)
+  return path
+}
+
+async function startTestServer(options: Record<string, unknown> = {}) {
+  const runtimeDir = await privateRuntimeDir()
+  const server = await startWorkspaceAuthorityServer({
+    socketPath: join(runtimeDir, "control.sock"),
+    ...options,
+  })
+  servers.push(server)
+  const credential = (await readFile(server.credentialPath, "utf8")).trim()
+  return { server, credential, runtimeDir }
+}
+
+async function exchange(socketPath: string, requests: WorkspaceAuthorityRequest[]): Promise<WorkspaceAuthorityResponse[]> {
+  return await new Promise((resolve, reject) => {
+    const socket = createConnection(socketPath)
+    const responses: WorkspaceAuthorityResponse[] = []
+    let buffered = ""
+    socket.setEncoding("utf8")
+    socket.once("error", reject)
+    socket.on("data", (chunk) => {
+      buffered += chunk
+      let newline = buffered.indexOf("\n")
+      while (newline >= 0) {
+        responses.push(JSON.parse(buffered.slice(0, newline)))
+        buffered = buffered.slice(newline + 1)
+        if (responses.length === requests.length) {
+          socket.end()
+          resolve(responses)
+          return
+        }
+        newline = buffered.indexOf("\n")
+      }
+    })
+    socket.once("connect", () => {
+      socket.write(requests.map((request) => JSON.stringify(request)).join("\n") + "\n")
+    })
+  })
+}
+
+describe("WorkspaceAuthorityRegistry", () => {
+  it("binds opaque capabilities to owner, agent, cwd, and expiry", () => {
+    let now = 1_000
+    const registry = new WorkspaceAuthorityRegistry({ now: () => now, defaultTtlMs: 100, maxTtlMs: 1_000 })
+    const lease = registry.issue({ owner: "paseo", agentId: "agent-1", cwd: "/srv/worktree" })
+
+    expect(lease.capability).toMatch(/^[A-Za-z0-9_-]{43}$/)
+    expect(registry.resolve(lease.capability)).toEqual(lease)
+    expect(lease).toMatchObject({ owner: "paseo", agentId: "agent-1", cwd: "/srv/worktree", expiresAt: 1_100 })
+
+    now = 1_100
+    expect(registry.resolve(lease.capability)).toBeUndefined()
+    expect(registry.size).toBe(0)
+  })
+
+  it("fails closed for mismatched ownership and post-revoke replay", () => {
+    const registry = new WorkspaceAuthorityRegistry()
+    const lease = registry.issue({ owner: "paseo", agentId: "agent-1", cwd: "/srv/a" })
+
+    expect(registry.renew(lease.capability, "paseo", "agent-2")).toBeUndefined()
+    expect(registry.revoke(lease.capability, "other", "agent-1")).toBe(false)
+    expect(registry.revoke(lease.capability, "paseo", "agent-1")).toBe(true)
+    expect(registry.resolve(lease.capability)).toBeUndefined()
+    expect(registry.renew(lease.capability, "paseo", "agent-1")).toBeUndefined()
+  })
+
+  it("renews live leases without changing capability identity", () => {
+    let now = 10
+    const registry = new WorkspaceAuthorityRegistry({ now: () => now, defaultTtlMs: 20, maxTtlMs: 100 })
+    const lease = registry.issue({ owner: "paseo", agentId: "agent-1", cwd: "/srv/a" })
+    now = 15
+    const renewed = registry.renew(lease.capability, "paseo", "agent-1", 50)
+
+    expect(renewed).toMatchObject({ capability: lease.capability, expiresAt: 65 })
+  })
+
+  it("bounds live storage but prunes expired entries before rejecting", () => {
+    let now = 0
+    let sequence = 0
+    const registry = new WorkspaceAuthorityRegistry({
+      now: () => now,
+      defaultTtlMs: 10,
+      maxTtlMs: 10,
+      maxEntries: 2,
+      mintCapability: () => `capability-${++sequence}`,
+    })
+    registry.issue({ owner: "paseo", agentId: "a", cwd: "/srv/a" })
+    registry.issue({ owner: "paseo", agentId: "b", cwd: "/srv/b" })
+    expect(() => registry.issue({ owner: "paseo", agentId: "c", cwd: "/srv/c" })).toThrow("registry is full")
+
+    now = 10
+    expect(registry.issue({ owner: "paseo", agentId: "c", cwd: "/srv/c" })).toBeDefined()
+    expect(registry.size).toBe(1)
+  })
+
+  it("revokes every lease for a terminated agent without touching peers", () => {
+    const registry = new WorkspaceAuthorityRegistry()
+    const first = registry.issue({ owner: "paseo", agentId: "a", cwd: "/srv/a" })
+    registry.issue({ owner: "paseo", agentId: "a", cwd: "/srv/a" })
+    const peer = registry.issue({ owner: "paseo", agentId: "b", cwd: "/srv/b" })
+
+    expect(registry.revokeAgent("paseo", "a")).toBe(2)
+    expect(registry.resolve(first.capability)).toBeUndefined()
+    expect(registry.resolve(peer.capability)).toEqual(peer)
+  })
+
+  it("rejects malformed identity, cwd, and TTL inputs", () => {
+    const registry = new WorkspaceAuthorityRegistry()
+    expect(() => registry.issue({ owner: "", agentId: "a", cwd: "/srv/a" })).toThrow()
+    expect(() => registry.issue({ owner: "paseo", agentId: "a", cwd: "relative" })).toThrow()
+    expect(() => registry.issue({ owner: "paseo", agentId: "a", cwd: "/srv/a", ttlMs: 0 })).toThrow()
+  })
+})
+
+describe("workspace authority Unix control server", () => {
+  it("is absent unless explicitly configured", () => {
+    expect(createProxyServer().workspaceAuthorityRegistry).toBeUndefined()
+  })
+
+  it("is owned by the proxy lifecycle when explicitly configured", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    const socketPath = join(runtimeDir, "control.sock")
+    const proxy = await startProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      silent: true,
+      workspaceAuthority: { socketPath },
+    })
+    expect((await lstat(socketPath)).isSocket()).toBe(true)
+    expect((await lstat(`${socketPath}.credential`)).isFile()).toBe(true)
+
+    await proxy.close()
+    expect(lstat(socketPath)).rejects.toMatchObject({ code: "ENOENT" })
+    expect(lstat(`${socketPath}.credential`)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("releases the HTTP listener even when authority artifact cleanup fails", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    const socketPath = join(runtimeDir, "control.sock")
+    const proxy = await startProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      silent: true,
+      workspaceAuthority: { socketPath },
+    })
+    const port = (proxy.server.address() as { port: number }).port
+    await unlink(`${socketPath}.credential`)
+    await mkdir(`${socketPath}.credential`)
+
+    await expect(proxy.close()).rejects.toThrow("failed to close all Meridian resources")
+    const verifier = createHttpServer()
+    await new Promise<void>((resolve, reject) => {
+      verifier.once("error", reject)
+      verifier.listen(port, "127.0.0.1", resolve)
+    })
+    await new Promise<void>((resolve) => verifier.close(() => resolve()))
+  })
+
+  it("rolls back the HTTP server when control startup fails", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    const socketPath = join(runtimeDir, "control.sock")
+    await chmod(runtimeDir, 0o755)
+    const portProbe = createHttpServer()
+    await new Promise<void>((resolve) => portProbe.listen(0, "127.0.0.1", resolve))
+    const port = (portProbe.address() as { port: number }).port
+    await new Promise<void>((resolve) => portProbe.close(() => resolve()))
+    await expect(startProxyServer({
+      port,
+      host: "127.0.0.1",
+      silent: true,
+      workspaceAuthority: { socketPath },
+    })).rejects.toThrow("mode 0700")
+
+    expect(lstat(socketPath)).rejects.toMatchObject({ code: "ENOENT" })
+    expect(lstat(`${socketPath}.credential`)).rejects.toMatchObject({ code: "ENOENT" })
+    const verifier = createHttpServer()
+    await new Promise<void>((resolve, reject) => {
+      verifier.once("error", reject)
+      verifier.listen(port, "127.0.0.1", resolve)
+    })
+    await new Promise<void>((resolve) => verifier.close(() => resolve()))
+  })
+
+  it("does not start control authority when the HTTP listener cannot bind", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    const socketPath = join(runtimeDir, "control.sock")
+    const holder = createHttpServer()
+    await new Promise<void>((resolve) => holder.listen(0, "127.0.0.1", resolve))
+    const port = (holder.address() as { port: number }).port
+    try {
+      await expect(startProxyServer({
+        port,
+        host: "127.0.0.1",
+        silent: true,
+        workspaceAuthority: { socketPath },
+      })).rejects.toMatchObject({ code: "EADDRINUSE" })
+      expect(lstat(socketPath)).rejects.toMatchObject({ code: "ENOENT" })
+      expect(lstat(`${socketPath}.credential`)).rejects.toMatchObject({ code: "ENOENT" })
+    } finally {
+      await new Promise<void>((resolve) => holder.close(() => resolve()))
+    }
+  })
+
+  it("creates private runtime artifacts and removes them with all leases on close", async () => {
+    const { server } = await startTestServer()
+    const socketStat = await lstat(server.socketPath)
+    const credentialStat = await lstat(server.credentialPath)
+    expect(socketStat.mode & 0o777).toBe(0o600)
+    expect(credentialStat.mode & 0o777).toBe(0o600)
+
+    server.registry.issue({ owner: "paseo", agentId: "a", cwd: "/srv/a" })
+    await server.close()
+    servers.splice(servers.indexOf(server), 1)
+    expect(server.registry.size).toBe(0)
+    expect(lstat(server.socketPath)).rejects.toMatchObject({ code: "ENOENT" })
+    expect(lstat(server.credentialPath)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("handles independently framed operations on one connection", async () => {
+    const { server, credential } = await startTestServer()
+    const responses = await exchange(server.socketPath, [
+      { id: "one", credential, operation: "issue", owner: "paseo", agentId: "a", cwd: "/srv/a" },
+      { id: "two", credential, operation: "issue", owner: "paseo", agentId: "b", cwd: "/srv/b" },
+    ])
+
+    expect(responses.map((response) => response.id)).toEqual(["one", "two"])
+    expect(responses.every((response) => response.ok)).toBe(true)
+    expect(server.registry.size).toBe(2)
+  })
+
+  it("refuses a duplicate start without disrupting the live server", async () => {
+    const { server, credential } = await startTestServer()
+    await expect(startWorkspaceAuthorityServer({ socketPath: server.socketPath }))
+      .rejects.toThrow("already active")
+
+    const [response] = await exchange(server.socketPath, [{
+      id: "still-live",
+      credential,
+      operation: "issue",
+      owner: "paseo",
+      agentId: "agent",
+      cwd: "/srv/a",
+    }])
+    expect(response?.ok).toBe(true)
+    expect((await readFile(server.credentialPath, "utf8")).trim()).toBe(credential)
+  })
+
+  it("accepts a batch larger than the per-frame limit when each frame is valid", async () => {
+    const { server, credential } = await startTestServer({ maxFrameBytes: 256 })
+    const requests = Array.from({ length: 8 }, (_, index): WorkspaceAuthorityRequest => ({
+      id: `batch-${index}`,
+      credential,
+      operation: "issue",
+      owner: "paseo",
+      agentId: `agent-${index}`,
+      cwd: `/srv/${index}`,
+    }))
+    expect(Buffer.byteLength(requests.map((request) => JSON.stringify(request)).join("\n"))).toBeGreaterThan(256)
+    const responses = await exchange(server.socketPath, requests)
+    expect(responses).toHaveLength(8)
+    expect(responses.every((response) => response.ok)).toBe(true)
+  })
+
+  it("isolates concurrent clients and preserves request ids", async () => {
+    const { server, credential } = await startTestServer({ maxEntries: 64 })
+    const responses = await Promise.all(Array.from({ length: 32 }, async (_, index) => {
+      return (await exchange(server.socketPath, [{
+        id: `request-${index}`,
+        credential,
+        operation: "issue",
+        owner: "paseo",
+        agentId: `agent-${index}`,
+        cwd: `/srv/${index}`,
+      }]))[0]
+    }))
+
+    expect(new Set(responses.map((response) => response?.id)).size).toBe(32)
+    expect(responses.every((response) => response?.ok)).toBe(true)
+    expect(server.registry.size).toBe(32)
+  })
+
+  it("rejects invalid credentials without revealing registry state", async () => {
+    const { server } = await startTestServer()
+    const [response] = await exchange(server.socketPath, [{
+      id: "bad-auth",
+      credential: "not-the-credential",
+      operation: "issue",
+      owner: "paseo",
+      agentId: "agent",
+      cwd: "/srv/a",
+    }])
+    expect(response).toEqual({ id: "bad-auth", ok: false, error: "unauthorized" })
+    expect(server.registry.size).toBe(0)
+  })
+
+  it("supports owner-bound renew and cleanup operations", async () => {
+    const { server, credential } = await startTestServer()
+    const [issued] = await exchange(server.socketPath, [{
+      id: "issue",
+      credential,
+      operation: "issue",
+      owner: "paseo",
+      agentId: "agent",
+      cwd: "/srv/a",
+    }])
+    if (!issued?.ok || !issued.lease) throw new Error("expected issued lease")
+
+    const responses = await exchange(server.socketPath, [
+      { id: "wrong", credential, operation: "renew", owner: "paseo", agentId: "other", capability: issued.lease.capability },
+      { id: "cleanup", credential, operation: "revoke-agent", owner: "paseo", agentId: "agent" },
+      { id: "replay", credential, operation: "renew", owner: "paseo", agentId: "agent", capability: issued.lease.capability },
+    ])
+    expect(responses).toEqual([
+      { id: "wrong", ok: false, error: "not_found" },
+      { id: "cleanup", ok: true, revoked: 1 },
+      { id: "replay", ok: false, error: "not_found" },
+    ])
+  })
+
+  it("fails before binding when the configured runtime directory is not private", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    await chmod(runtimeDir, 0o755)
+    await expect(startWorkspaceAuthorityServer({ socketPath: join(runtimeDir, "control.sock") }))
+      .rejects.toThrow("mode 0700")
+  })
+
+  it("requires owner permissions to be exactly mode 0700", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    await chmod(runtimeDir, 0o500)
+    try {
+      await expect(startWorkspaceAuthorityServer({ socketPath: join(runtimeDir, "control.sock") }))
+        .rejects.toThrow("mode 0700")
+    } finally {
+      await chmod(runtimeDir, 0o700)
+    }
+  })
+
+  it("drops oversized frames", async () => {
+    const { server } = await startTestServer({ maxFrameBytes: 64 })
+    await new Promise<void>((resolve, reject) => {
+      const socket = createConnection(server.socketPath)
+      socket.once("error", (error) => {
+        if ((error as NodeJS.ErrnoException).code === "ECONNRESET") resolve()
+        else reject(error)
+      })
+      socket.once("close", () => resolve())
+      socket.once("connect", () => socket.write("x".repeat(65)))
+    })
+    expect(server.registry.size).toBe(0)
+  })
+
+  it("can restart cleanly after an orderly shutdown", async () => {
+    const runtimeDir = await privateRuntimeDir()
+    const socketPath = join(runtimeDir, "control.sock")
+    const first = await startWorkspaceAuthorityServer({ socketPath })
+    await first.close()
+    await mkdir(runtimeDir, { recursive: true })
+
+    const second = await startWorkspaceAuthorityServer({ socketPath })
+    servers.push(second)
+    expect(second.socketPath).toBe(socketPath)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -10,6 +10,7 @@ import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { linkRequestAbort } from "./requestAbort"
 import { fetchOAuthUsage } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
+import { startWorkspaceAuthorityServer, WorkspaceAuthorityRegistry } from "./workspaceAuthority"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
 import { envBool } from "../env"
@@ -354,6 +355,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   const finalConfig = { ...DEFAULT_PROXY_CONFIG, ...config }
   proxyLogSilent = finalConfig.silent
   const serverVersion = finalConfig.version ?? "unknown"
+  const workspaceAuthorityRegistry = finalConfig.workspaceAuthority
+    ? new WorkspaceAuthorityRegistry(finalConfig.workspaceAuthority)
+    : undefined
 
   // Restore persisted active profile from last session
   restoreActiveProfile(finalConfig.profiles)
@@ -3446,7 +3450,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     }
   }
 
-  return { app, config: finalConfig, initPlugins: initPluginsAsync }
+  return { app, config: finalConfig, initPlugins: initPluginsAsync, workspaceAuthorityRegistry }
 }
 
 /**
@@ -3475,13 +3479,19 @@ export function installProxyProcessErrorHandlers(): void {
 
 export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promise<ProxyInstance> {
   claudeExecutable = await resolveClaudeExecutableAsync()
-  const { app, config: finalConfig, initPlugins } = createProxyServer(config)
+  const { app, config: finalConfig, initPlugins, workspaceAuthorityRegistry } = createProxyServer(config)
   if (initPlugins) await initPlugins()
 
   if (finalConfig.installProcessErrorHandlers) {
     installProxyProcessErrorHandlers()
   }
 
+  let resolveListening!: () => void
+  let rejectListening!: (error: unknown) => void
+  const listening = new Promise<void>((resolve, reject) => {
+    resolveListening = resolve
+    rejectListening = reject
+  })
   const server = serve({
     fetch: app.fetch,
     port: finalConfig.port,
@@ -3504,7 +3514,18 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       console.log(`\nPoint any Anthropic-compatible tool at this endpoint:`)
       console.log(`  ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://${finalConfig.host}:${info.port}`)
     }
+    resolveListening()
   }) as Server
+
+  server.once("error", rejectListening)
+  try {
+    await listening
+  } catch (error) {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    throw error
+  } finally {
+    server.off("error", rejectListening)
+  }
 
   const idleMs = finalConfig.idleTimeoutSeconds * 1000
   server.keepAliveTimeout = idleMs
@@ -3521,14 +3542,8 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     }
   })
 
-  // Background OAuth token refresh: keeps the refresh chain warm even when
-  // the proxy sits idle. Without it, an unused refresh token can be
-  // invalidated server-side after sitting unused for an extended period.
-  // Idempotent — re-calling start() on a hot-reload is a no-op.
-  startBackgroundRefresh()
-
-  // Profile-scoped OAuth token refresh: the default scheduler above only
-  // watches the default Claude credential store. Multi-profile credentials
+  // Profile-scoped OAuth token refresh: the process-global default scheduler
+  // only watches the default Claude credential store. Multi-profile credentials
   // live under each profile's CLAUDE_CONFIG_DIR, so poll the discovered
   // profile list and refresh any browser-login profile that is near expiry.
   const PROFILE_TOKEN_REFRESH_MS = 45_000
@@ -3560,6 +3575,25 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     if (authKeepaliveInterval.unref) authKeepaliveInterval.unref()
   }
 
+  // Start the control plane last. If it cannot bind securely, roll back every
+  // proxy resource created above so embedders never receive a partial server.
+  let workspaceAuthority: Awaited<ReturnType<typeof startWorkspaceAuthorityServer>> | undefined
+  try {
+    workspaceAuthority = finalConfig.workspaceAuthority && workspaceAuthorityRegistry
+      ? await startWorkspaceAuthorityServer(finalConfig.workspaceAuthority, workspaceAuthorityRegistry)
+      : undefined
+  } catch (error) {
+    clearInterval(profileTokenRefreshInterval)
+    if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+    throw error
+  }
+
+  // Background OAuth token refresh is process-global and idempotent. Start it
+  // only after every fallible per-instance resource is ready so a failed
+  // secondary proxy cannot stop or perturb an already-running instance.
+  startBackgroundRefresh()
+
   return {
     server,
     config: finalConfig,
@@ -3567,9 +3601,16 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       clearInterval(profileTokenRefreshInterval)
       if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
       stopBackgroundRefresh()
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()))
-      })
+      const results = await Promise.allSettled([
+        workspaceAuthority?.close() ?? Promise.resolve(),
+        new Promise<void>((resolve, reject) => {
+          server.close((err) => (err ? reject(err) : resolve()))
+        }),
+      ])
+      const errors = results
+        .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+        .map((result) => result.reason)
+      if (errors.length > 0) throw new AggregateError(errors, "failed to close all Meridian resources")
     },
   }
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -1,5 +1,6 @@
 import type { Server } from "node:http"
 import type { ProfileConfig } from "./profiles"
+import type { WorkspaceAuthorityRegistry, WorkspaceAuthorityServerConfig } from "./workspaceAuthority"
 
 export interface ProxyConfig {
   port: number
@@ -24,6 +25,8 @@ export interface ProxyConfig {
    * library consumer has already installed; the bundled CLI passes `true`.
    */
   installProcessErrorHandlers?: boolean
+  /** Disabled unless an explicit private Unix control socket is configured. */
+  workspaceAuthority?: WorkspaceAuthorityServerConfig
 }
 
 export interface ProxyInstance {
@@ -43,6 +46,8 @@ export interface ProxyServer {
   config: ProxyConfig
   /** Load plugins from disk and wire them into the request pipeline */
   initPlugins?(): Promise<void>
+  /** Internal registry used by the optional workspace-authority control server. */
+  workspaceAuthorityRegistry?: WorkspaceAuthorityRegistry
 }
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {

--- a/src/proxy/workspaceAuthority.ts
+++ b/src/proxy/workspaceAuthority.ts
@@ -1,0 +1,388 @@
+import { randomBytes, timingSafeEqual } from "node:crypto"
+import { chmod, lstat, mkdir, readFile, realpath, unlink, writeFile } from "node:fs/promises"
+import { createConnection, createServer, type Server, type Socket } from "node:net"
+import { dirname, isAbsolute } from "node:path"
+
+const DEFAULT_TTL_MS = 5 * 60_000
+const MAX_TTL_MS = 60 * 60_000
+const DEFAULT_MAX_ENTRIES = 1_024
+const DEFAULT_MAX_FRAME_BYTES = 16 * 1_024
+const DEFAULT_SOCKET_TIMEOUT_MS = 10_000
+
+export interface WorkspaceAuthorityLease {
+  capability: string
+  owner: string
+  agentId: string
+  cwd: string
+  expiresAt: number
+}
+
+export interface WorkspaceAuthorityRegistryOptions {
+  defaultTtlMs?: number
+  maxTtlMs?: number
+  maxEntries?: number
+  now?: () => number
+  mintCapability?: () => string
+}
+
+export interface IssueWorkspaceAuthorityLease {
+  owner: string
+  agentId: string
+  cwd: string
+  ttlMs?: number
+}
+
+function requireIdentifier(value: string, name: string): string {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > 256) throw new Error(`${name} must be between 1 and 256 characters`)
+  return trimmed
+}
+
+/**
+ * In-memory authority leases. A capability is reusable while its owning
+ * agent is live, but becomes permanently invalid after revoke or expiry.
+ */
+export class WorkspaceAuthorityRegistry {
+  readonly #leases = new Map<string, WorkspaceAuthorityLease>()
+  readonly #defaultTtlMs: number
+  readonly #maxTtlMs: number
+  readonly #maxEntries: number
+  readonly #now: () => number
+  readonly #mintCapability: () => string
+
+  constructor(options: WorkspaceAuthorityRegistryOptions = {}) {
+    this.#defaultTtlMs = options.defaultTtlMs ?? DEFAULT_TTL_MS
+    this.#maxTtlMs = options.maxTtlMs ?? MAX_TTL_MS
+    this.#maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES
+    this.#now = options.now ?? Date.now
+    this.#mintCapability = options.mintCapability ?? (() => randomBytes(32).toString("base64url"))
+    if (this.#defaultTtlMs <= 0 || this.#maxTtlMs < this.#defaultTtlMs) {
+      throw new Error("workspace authority TTL bounds are invalid")
+    }
+    if (!Number.isSafeInteger(this.#maxEntries) || this.#maxEntries <= 0) {
+      throw new Error("workspace authority maxEntries must be a positive integer")
+    }
+  }
+
+  issue(input: IssueWorkspaceAuthorityLease): WorkspaceAuthorityLease {
+    this.pruneExpired()
+    if (this.#leases.size >= this.#maxEntries) throw new Error("workspace authority registry is full")
+    const owner = requireIdentifier(input.owner, "owner")
+    const agentId = requireIdentifier(input.agentId, "agentId")
+    if (!isAbsolute(input.cwd)) throw new Error("cwd must be absolute")
+    const ttlMs = input.ttlMs ?? this.#defaultTtlMs
+    this.#validateTtl(ttlMs)
+
+    let capability = ""
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const candidate = this.#mintCapability()
+      if (candidate && !this.#leases.has(candidate)) {
+        capability = candidate
+        break
+      }
+    }
+    if (!capability) throw new Error("failed to mint a unique workspace authority capability")
+
+    const lease = Object.freeze({ capability, owner, agentId, cwd: input.cwd, expiresAt: this.#now() + ttlMs })
+    this.#leases.set(capability, lease)
+    return lease
+  }
+
+  resolve(capability: string): WorkspaceAuthorityLease | undefined {
+    const lease = this.#leases.get(capability)
+    if (!lease) return undefined
+    if (lease.expiresAt <= this.#now()) {
+      this.#leases.delete(capability)
+      return undefined
+    }
+    return lease
+  }
+
+  renew(capability: string, owner: string, agentId: string, ttlMs?: number): WorkspaceAuthorityLease | undefined {
+    const lease = this.resolve(capability)
+    if (!lease || lease.owner !== owner || lease.agentId !== agentId) return undefined
+    const effectiveTtl = ttlMs ?? this.#defaultTtlMs
+    this.#validateTtl(effectiveTtl)
+    const renewed = Object.freeze({ ...lease, expiresAt: this.#now() + effectiveTtl })
+    this.#leases.set(capability, renewed)
+    return renewed
+  }
+
+  revoke(capability: string, owner: string, agentId: string): boolean {
+    const lease = this.resolve(capability)
+    if (!lease || lease.owner !== owner || lease.agentId !== agentId) return false
+    return this.#leases.delete(capability)
+  }
+
+  revokeAgent(owner: string, agentId: string): number {
+    let revoked = 0
+    for (const [capability, lease] of this.#leases) {
+      if (lease.owner === owner && lease.agentId === agentId) {
+        this.#leases.delete(capability)
+        revoked++
+      }
+    }
+    return revoked
+  }
+
+  pruneExpired(): number {
+    const now = this.#now()
+    let pruned = 0
+    for (const [capability, lease] of this.#leases) {
+      if (lease.expiresAt <= now) {
+        this.#leases.delete(capability)
+        pruned++
+      }
+    }
+    return pruned
+  }
+
+  clear(): void {
+    this.#leases.clear()
+  }
+
+  get size(): number {
+    this.pruneExpired()
+    return this.#leases.size
+  }
+
+  #validateTtl(ttlMs: number): void {
+    if (!Number.isSafeInteger(ttlMs) || ttlMs <= 0 || ttlMs > this.#maxTtlMs) {
+      throw new Error(`ttlMs must be a positive integer no greater than ${this.#maxTtlMs}`)
+    }
+  }
+}
+
+export interface WorkspaceAuthorityServerConfig extends WorkspaceAuthorityRegistryOptions {
+  socketPath: string
+  credentialPath?: string
+  maxFrameBytes?: number
+  socketTimeoutMs?: number
+}
+
+export type WorkspaceAuthorityRequest =
+  | { id: string; credential: string; operation: "issue"; owner: string; agentId: string; cwd: string; ttlMs?: number }
+  | { id: string; credential: string; operation: "renew"; owner: string; agentId: string; capability: string; ttlMs?: number }
+  | { id: string; credential: string; operation: "revoke"; owner: string; agentId: string; capability: string }
+  | { id: string; credential: string; operation: "revoke-agent"; owner: string; agentId: string }
+
+export type WorkspaceAuthorityResponse =
+  | { id: string; ok: true; lease?: WorkspaceAuthorityLease; revoked?: number }
+  | { id: string; ok: false; error: "unauthorized" | "invalid_request" | "not_found" | "registry_full" }
+
+export interface WorkspaceAuthorityServer {
+  registry: WorkspaceAuthorityRegistry
+  socketPath: string
+  credentialPath: string
+  close(): Promise<void>
+}
+
+async function removeOwnedRuntimeEntry(path: string, expected: "socket" | "file"): Promise<void> {
+  try {
+    const stat = await lstat(path)
+    const typeMatches = expected === "socket" ? stat.isSocket() : stat.isFile()
+    if (!typeMatches || stat.uid !== process.getuid?.()) {
+      throw new Error(`refusing to replace unsafe workspace authority ${expected}: ${path}`)
+    }
+    await unlink(path)
+  } catch (error: any) {
+    if (error?.code !== "ENOENT") throw error
+  }
+}
+
+async function preparePrivateRuntimeDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 })
+  const pathStat = await lstat(path)
+  if (pathStat.isSymbolicLink()) {
+    throw new Error(`workspace authority runtime directory must not be a symlink: ${path}`)
+  }
+  const canonical = await realpath(path)
+  const stat = await lstat(canonical)
+  if (!stat.isDirectory() || stat.isSymbolicLink() || stat.uid !== process.getuid?.() || (stat.mode & 0o777) !== 0o700) {
+    throw new Error(`workspace authority runtime directory must be owned by the current user and mode 0700: ${path}`)
+  }
+}
+
+async function removeStaleSocketOrThrow(path: string): Promise<void> {
+  let stat
+  try {
+    stat = await lstat(path)
+  } catch (error: any) {
+    if (error?.code === "ENOENT") return
+    throw error
+  }
+  if (!stat.isSocket() || stat.uid !== process.getuid?.()) {
+    throw new Error(`refusing to replace unsafe workspace authority socket: ${path}`)
+  }
+
+  const live = await new Promise<boolean>((resolve, reject) => {
+    const socket = createConnection(path)
+    const timeout = setTimeout(() => {
+      socket.destroy()
+      reject(new Error(`timed out probing workspace authority socket: ${path}`))
+    }, 1_000)
+    socket.once("connect", () => {
+      clearTimeout(timeout)
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once("error", (error: NodeJS.ErrnoException) => {
+      clearTimeout(timeout)
+      if (error.code === "ECONNREFUSED" || error.code === "ENOENT") resolve(false)
+      else reject(error)
+    })
+  })
+  if (live) throw new Error(`workspace authority socket is already active: ${path}`)
+  await unlink(path).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") throw error
+  })
+}
+
+function sameCredential(actual: unknown, expected: string): boolean {
+  if (typeof actual !== "string") return false
+  const actualBytes = Buffer.from(actual)
+  const expectedBytes = Buffer.from(expected)
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes)
+}
+
+function requestId(value: unknown): string {
+  return typeof value === "string" && value.length > 0 && value.length <= 128 ? value : "unknown"
+}
+
+function handleRequest(
+  registry: WorkspaceAuthorityRegistry,
+  expectedCredential: string,
+  raw: unknown,
+): WorkspaceAuthorityResponse {
+  const input = raw as Partial<WorkspaceAuthorityRequest> | null
+  const id = requestId(input?.id)
+  if (!input || !sameCredential(input.credential, expectedCredential)) return { id, ok: false, error: "unauthorized" }
+
+  try {
+    if (input.operation === "issue") {
+      const lease = registry.issue({ owner: input.owner!, agentId: input.agentId!, cwd: input.cwd!, ttlMs: input.ttlMs })
+      return { id, ok: true, lease }
+    }
+    if (input.operation === "renew") {
+      const lease = registry.renew(input.capability!, input.owner!, input.agentId!, input.ttlMs)
+      return lease ? { id, ok: true, lease } : { id, ok: false, error: "not_found" }
+    }
+    if (input.operation === "revoke") {
+      const revoked = registry.revoke(input.capability!, input.owner!, input.agentId!)
+      return revoked ? { id, ok: true, revoked: 1 } : { id, ok: false, error: "not_found" }
+    }
+    if (input.operation === "revoke-agent") {
+      return { id, ok: true, revoked: registry.revokeAgent(input.owner!, input.agentId!) }
+    }
+    return { id, ok: false, error: "invalid_request" }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : ""
+    return { id, ok: false, error: message.includes("registry is full") ? "registry_full" : "invalid_request" }
+  }
+}
+
+/**
+ * Start a private newline-delimited JSON control socket. This is never started
+ * unless a socket path is explicitly configured by the embedding process.
+ */
+export async function startWorkspaceAuthorityServer(
+  config: WorkspaceAuthorityServerConfig,
+  registry = new WorkspaceAuthorityRegistry(config),
+): Promise<WorkspaceAuthorityServer> {
+  if (!isAbsolute(config.socketPath)) throw new Error("workspace authority socketPath must be absolute")
+  const credentialPath = config.credentialPath ?? `${config.socketPath}.credential`
+  if (!isAbsolute(credentialPath)) throw new Error("workspace authority credentialPath must be absolute")
+  if (credentialPath === config.socketPath) throw new Error("workspace authority socket and credential paths must differ")
+  if (dirname(credentialPath) !== dirname(config.socketPath)) {
+    throw new Error("workspace authority socket and credential must share a runtime directory")
+  }
+
+  await preparePrivateRuntimeDirectory(dirname(config.socketPath))
+  await removeStaleSocketOrThrow(config.socketPath)
+
+  const credential = randomBytes(32).toString("base64url")
+  const maxFrameBytes = config.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES
+  const timeoutMs = config.socketTimeoutMs ?? DEFAULT_SOCKET_TIMEOUT_MS
+  const sockets = new Set<Socket>()
+  let server: Server | undefined
+  let bound = false
+  try {
+    server = createServer((socket) => {
+      sockets.add(socket)
+      socket.setEncoding("utf8")
+      socket.setTimeout(timeoutMs, () => socket.destroy())
+      socket.on("close", () => sockets.delete(socket))
+      let buffered = ""
+      socket.on("data", (chunk: string) => {
+        buffered += chunk
+        let newline = buffered.indexOf("\n")
+        while (newline >= 0) {
+          const frame = buffered.slice(0, newline)
+          buffered = buffered.slice(newline + 1)
+          if (Buffer.byteLength(frame) > maxFrameBytes) {
+            socket.destroy()
+            return
+          }
+          if (frame) {
+            let response: WorkspaceAuthorityResponse
+            try {
+              response = handleRequest(registry, credential, JSON.parse(frame))
+            } catch {
+              response = { id: "unknown", ok: false, error: "invalid_request" }
+            }
+            socket.write(`${JSON.stringify(response)}\n`)
+          }
+          newline = buffered.indexOf("\n")
+        }
+        if (Buffer.byteLength(buffered) > maxFrameBytes) socket.destroy()
+      })
+    })
+    await new Promise<void>((resolve, reject) => {
+      server!.once("error", reject)
+      server!.listen(config.socketPath, () => {
+        bound = true
+        server!.off("error", reject)
+        resolve()
+      })
+    })
+    await chmod(config.socketPath, 0o600)
+    await removeOwnedRuntimeEntry(credentialPath, "file")
+    await writeFile(credentialPath, `${credential}\n`, { encoding: "utf8", flag: "wx", mode: 0o600, flush: true })
+  } catch (error) {
+    if (server) await new Promise<void>((resolve) => server!.close(() => resolve()))
+    if (bound) {
+      await Promise.allSettled([
+        removeOwnedRuntimeEntry(config.socketPath, "socket"),
+        removeOwnedRuntimeEntry(credentialPath, "file"),
+      ])
+    }
+    throw error
+  }
+
+  let closePromise: Promise<void> | undefined
+  return {
+    registry,
+    socketPath: config.socketPath,
+    credentialPath,
+    close() {
+      closePromise ??= (async () => {
+        registry.clear()
+        for (const socket of sockets) socket.destroy()
+        const results = await Promise.allSettled([
+          new Promise<void>((resolve, reject) => server!.close((error) => error ? reject(error) : resolve())),
+          removeOwnedRuntimeEntry(config.socketPath, "socket"),
+          removeOwnedRuntimeEntry(credentialPath, "file"),
+        ])
+        const errors = results
+          .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+          .map((result) => result.reason)
+        if (errors.length > 0) throw new AggregateError(errors, "failed to close workspace authority resources")
+      })()
+      return closePromise
+    },
+  }
+}
+
+export async function readWorkspaceAuthorityCredential(path: string): Promise<string> {
+  return (await readFile(path, "utf8")).trim()
+}


### PR DESCRIPTION
## Summary

Add a disabled-by-default workspace authority primitive for trusted local orchestrators.

- add a bounded, expiring in-memory lease registry that mints opaque capabilities bound to owner, agent, and absolute cwd
- add an authenticated newline-framed Unix control socket for issue, renew, revoke, and agent cleanup operations
- use a Meridian-generated runtime credential, exact `0700` directory validation, and `0600` socket/credential permissions
- make startup and shutdown transactional across the HTTP and control listeners, including duplicate/live socket protection
- expose opt-in CLI configuration through `MERIDIAN_WORKSPACE_AUTHORITY_SOCKET`

This PR intentionally does **not** consult capabilities during request cwd resolution. With the feature unset, no registry or control socket exists; with it enabled, existing HTTP/cwd behavior is still unchanged. Capability enforcement is a separate follow-up.

## Security and lifecycle properties

- live sockets are probed and never unlinked by a duplicate starter
- stale runtime artifacts are replaced only when owned by the current user
- capabilities expire, cannot be renewed or revoked across owner/agent bindings, and cannot be replayed after revoke/expiry
- registry storage is bounded and expired entries are pruned before admission
- control frames are size-limited and concurrent clients remain isolated
- child sockets, leases, credential files, Unix sockets, and the HTTP listener are cleaned up on failure/shutdown paths
- credentials and capabilities are not logged or placed in process arguments/environment values

## Test plan

- `bun run typecheck`
- `bun test` (1888 pass, 1 pre-existing skip, 0 fail)
- `bun run build`
- independent Codex review loop completed with no remaining findings
