### PR TITLE
feat(models): route Claude Mythos 5 (claude-mythos-*) through the fable tier

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -143,6 +143,33 @@ describe("mapModelToClaudeModel", () => {
     })
   })
 
+  describe("mythos 5 (rides the fable tier)", () => {
+    afterEach(() => {
+      resetExtendedContextUnavailable()
+      delete process.env.MERIDIAN_1M_CONTEXT_SUPPORT
+    })
+
+    it("maps mythos to fable[1m] for primary agents instead of falling through to sonnet", () => {
+      expect(mapModelToClaudeModel("claude-mythos-5")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("mythos")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("claude-mythos-5", "max", "primary")).toBe("fable[1m]")
+    })
+
+    it("gives subagents base fable", () => {
+      expect(mapModelToClaudeModel("claude-mythos-5", "max", "subagent")).toBe("fable")
+    })
+
+    it("downgrades to base fable during the Extra Usage cooldown", () => {
+      recordExtendedContextUnavailable()
+      expect(mapModelToClaudeModel("claude-mythos-5", "max")).toBe("fable")
+    })
+
+    it("downgrades to base fable when MERIDIAN_1M_CONTEXT_SUPPORT=0", () => {
+      process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "0"
+      expect(mapModelToClaudeModel("claude-mythos-5", "max")).toBe("fable")
+    })
+  })
+
   describe("subagent mode", () => {
     it("gives subagents base sonnet regardless of subscription", () => {
       expect(mapModelToClaudeModel("claude-sonnet-4-6", "max", "subagent")).toBe("sonnet")

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -236,6 +236,15 @@ describe("SDK model pin injection (fixes #419)", () => {
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
   })
 
+  // Mythos has no SDK alias of its own — it resolves through the fable alias,
+  // so an explicit claude-mythos-* request must pin ANTHROPIC_DEFAULT_FABLE_MODEL
+  // to the requested id (not Meridian's canonical claude-fable-5 pin).
+  it("explicit claude-mythos-5 requests pin the SDK env to mythos via the fable alias", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-mythos-5" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-mythos-5")
+  })
+
   // Regression: requesting a specific claude-sonnet-* version was silently
   // collapsed to the generic "sonnet" alias and resolved to Meridian's
   // canonical pin (claude-sonnet-4-6) instead of the requested version,

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -112,7 +112,14 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
   // fable[1m] request returns normally, no Extra Usage error). Mirrors the opus
   // handling: [1m] for primary agents, base model for subagents, honoring the
   // shared Extra Usage cooldown so a future billing change auto-downgrades.
-  if (model.includes("fable")) {
+  //
+  // Mythos rides the fable tier: Claude Mythos 5 (claude-mythos-5, Project
+  // Glasswing) shares Fable 5's underlying model, context window, and API
+  // surface, and the Claude Agent SDK has no separate "mythos" alias. Routing
+  // it here (instead of the sonnet fallthrough) keeps explicit mythos requests
+  // on the right tier; server.ts pins ANTHROPIC_DEFAULT_FABLE_MODEL to the
+  // requested claude-mythos-* id so the concrete model passes through verbatim.
+  if (model.includes("fable") || model.includes("mythos")) {
     if (use1m && !isSubagent && !isExtendedContextKnownUnavailable()) return "fable[1m]"
     return "fable"
   }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -507,11 +507,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? { ANTHROPIC_DEFAULT_OPUS_MODEL: requestedModel }
           : requestedModel.startsWith("claude-fable-")
             ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
-            : requestedModel.startsWith("claude-sonnet-")
-              ? { ANTHROPIC_DEFAULT_SONNET_MODEL: requestedModel }
-              : requestedModel.startsWith("claude-haiku-")
-                ? { ANTHROPIC_DEFAULT_HAIKU_MODEL: requestedModel }
-                : undefined
+            // Mythos shares the fable SDK alias (no separate mythos alias
+            // exists), so an explicit claude-mythos-* id resolves through
+            // ANTHROPIC_DEFAULT_FABLE_MODEL and reaches the API verbatim.
+            : requestedModel.startsWith("claude-mythos-")
+              ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
+              : requestedModel.startsWith("claude-sonnet-")
+                ? { ANTHROPIC_DEFAULT_SONNET_MODEL: requestedModel }
+                : requestedModel.startsWith("claude-haiku-")
+                  ? { ANTHROPIC_DEFAULT_HAIKU_MODEL: requestedModel }
+                  : undefined
         // workingDirectory = SDK subprocess cwd (must exist on the proxy host).
         // clientWorkingDirectory = the client's local path (may not exist here);
         // used for per-project fingerprint bucketing and a system-prompt hint


### PR DESCRIPTION
## Problem

`mapModelToClaudeModel` recognizes `haiku`/`fable`/`opus` substrings and defaults everything else to the sonnet tier. Since #561 added Fable 5, the one remaining current-generation id that still falls through is **Claude Mythos 5** (`claude-mythos-5`, Project Glasswing — same underlying model, context window, and API surface as `claude-fable-5`, different id). A client configured with a mythos id today is silently answered by sonnet — the same failure mode as #419 (opus-* requests silently answering as sonnet-4), just for a different tier.

## Fix

Mythos rides the fable tier, since the Claude Agent SDK has no separate `mythos` alias:

- **`src/proxy/models.ts`** — `mapModelToClaudeModel` now treats `mythos` like `fable`: primary agents get `fable[1m]`, subagents get base `fable`, and the shared Extra Usage cooldown / `MERIDIAN_1M_CONTEXT_SUPPORT` downgrade logic applies unchanged.
- **`src/proxy/server.ts`** — explicit `claude-mythos-*` ids pin `ANTHROPIC_DEFAULT_FABLE_MODEL` to the requested id, mirroring the existing opus/fable/sonnet/haiku verbatim-passthrough pattern, so the concrete model id reaches the API instead of collapsing to the canonical fable pin.

Users whose Claude auth can't serve `claude-mythos-5` (it's gated to Project Glasswing orgs) get a clear upstream error rather than a silent sonnet response, and can use `fable` / `claude-fable-5` instead. I deliberately did **not** add `claude-mythos-5` to `buildModelList` in `openai.ts` — advertising a gated model in UI pickers seemed misleading; happy to add it if you'd prefer parity.

## Tests

- `models.test.ts`: new `mythos 5` describe block mirroring the fable coverage (primary → `fable[1m]`, subagent → `fable`, Extra Usage cooldown and `MERIDIAN_1M_CONTEXT_SUPPORT=0` downgrades).
- `proxy-env-stripping.test.ts`: explicit `claude-mythos-5` requests pin `ANTHROPIC_DEFAULT_FABLE_MODEL=claude-mythos-5` through the HTTP layer.

Full suite (`npm test`, all 11 bun invocations): 1876 pass, 0 fail.