### PR TITLE
ci: publish semver Docker tags on release (#594)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,9 @@ jobs:
       # is exactly what we want for a single-package repo.
       release_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs['.--tag_name'] }}
+      # Bare semver (e.g. "1.45.4") for Docker tags — the '.--version' output
+      # is prefixed by manifest path ('.'), same convention as '.--tag_name'.
+      version: ${{ steps.release.outputs['.--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -76,3 +79,59 @@ jobs:
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Publish the semver-tagged Docker image on release.
+  #
+  # docker.yml can't do this: its `push: tags: meridian-v*` trigger never fires
+  # for release tags, because release-please creates them with the default
+  # GITHUB_TOKEN and GitHub suppresses workflow triggers from GITHUB_TOKEN-
+  # created refs (recursion guard). So docker.yml only ever publishes `latest`
+  # (from its main-branch trigger, which fires on the human release-PR merge),
+  # and semver Docker tags stopped at 1.29.1 when the release flow moved to
+  # release-please (#594). This job runs inside release-please.yml — which DOES
+  # fire, since it's triggered by that same merge — and pushes the semver tags
+  # itself. `latest` stays owned by docker.yml.
+  docker:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.version }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem

Closes #594. The last semver-tagged Docker image is `1.29.1`; only `latest` has published since.

**Root cause:** `docker.yml` publishes semver tags only via its `push: tags: meridian-v*` trigger, but those tags are created by `release-please-action` using the default `GITHUB_TOKEN` — and **GitHub deliberately suppresses workflow triggers for refs created by `GITHUB_TOKEN`** (a recursion guard). So the tag build never fires. `latest` keeps updating because it comes from `docker.yml`'s `branches: main` trigger, and the release-PR *merge* is a human action that does trigger workflows. Semver stopped at 1.29.1 — exactly when the release flow moved to release-please.

## Fix

Add a `docker` job to `release-please.yml` (which *does* run, since the release-PR merge triggers it), gated on `release_created == 'true'`. It checks out the release tag and pushes the multi-arch image with the semver tags (`X.Y.Z` and `X.Y`), using `docker/metadata-action`'s `type=semver,...,value=${version}` — the explicit `value=` uses the release-please version output directly rather than the git ref, so it works regardless of trigger. A new `version` output (`.--version`) feeds it.

`latest` and PR builds stay owned by `docker.yml` — clean separation.

## Validation

- YAML parses; `actionlint` clean (exit 0) on both workflows.
- End-to-end can only be confirmed on the next real release (Actions workflows can't be dry-run through a tag event) — I'll verify `ghcr.io/rynfar/meridian:<version>` appears after the next release cuts.

Note: the `publish_only` emergency dispatch still won't build Docker (release-please job is skipped, so there's no version output); `docker.yml`'s own `workflow_dispatch` remains the manual escape hatch for that.