### PR TITLE
fix: give deferred passthrough sessions a turn for ToolSearch discovery (#547)

### DIFF
--- a/src/__tests__/deferred-tool-loading.test.ts
+++ b/src/__tests__/deferred-tool-loading.test.ts
@@ -242,7 +242,7 @@ describe("auto-defer — threshold-based deferral via HTTP", () => {
     expect(capturedQueryParams.options.env.ENABLE_TOOL_SEARCH).toBe("false")
   })
 
-  it("sets maxTurns to 3 when deferred tools are present", async () => {
+  it("sets maxTurns to 4 when deferred tools are present (+1 for the ToolSearch discovery turn, #547)", async () => {
     mockMessages = [assistantMessage([{ type: "text", text: "Hello" }])]
 
     await app().fetch(new Request("http://localhost/v1/messages", {
@@ -255,7 +255,7 @@ describe("auto-defer — threshold-based deferral via HTTP", () => {
       })),
     }))
 
-    expect(capturedQueryParams.options.maxTurns).toBe(3)
+    expect(capturedQueryParams.options.maxTurns).toBe(4)
   })
 
   it("sets maxTurns to 3 when no deferred tools (passthrough base budget)", async () => {

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -69,12 +69,12 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(3)
   })
 
-  it("sets maxTurns to 3 in passthrough mode with deferred tools (ToolSearch fits within base budget)", () => {
+  it("sets maxTurns to 4 in passthrough mode with deferred tools (+1 for the ToolSearch discovery turn, #547)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, hasDeferredTools: true }))
-    expect(result.options.maxTurns).toBe(3)
+    expect(result.options.maxTurns).toBe(4)
   })
 
-  it("sets maxTurns to 4 in passthrough mode when resume AND deferred tools are both active", () => {
+  it("sets maxTurns to 4 in passthrough mode when resume AND deferred tools are both active (resume rehydration is inline; only the discovery turn adds)", () => {
     const result = buildQueryOptions(makeContext({
       passthrough: true,
       resumeSessionId: "sess-123",
@@ -93,9 +93,9 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(6)
   })
 
-  it("sets maxTurns to 6 in passthrough mode with advisor + deferred tools", () => {
+  it("sets maxTurns to 7 in passthrough mode with advisor + deferred tools (base 3 + discovery 1 + advisor 3)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7", hasDeferredTools: true }))
-    expect(result.options.maxTurns).toBe(6)
+    expect(result.options.maxTurns).toBe(7)
   })
 
   it("sets maxTurns to 7 in passthrough mode with advisor + resume + deferred tools (all three active)", () => {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -138,26 +138,29 @@ export interface BuildQueryResult {
  *     thinking + tool_use exhausting the 2-turn budget mid-handoff and returning
  *     500s on fresh (non-resume) requests. See errors.ts sdk_termination
  *     diagnostic + telemetry.
- *   - Resume / deferred (no extra turn over base): both fit within the 3-turn
- *     budget. Resume rehydration and ToolSearch lookups complete inside turn 1.
- *   - Both resume and deferred (+1): a second prelude phase pushes one phase
- *     out, so budget becomes 4.
+ *   - Deferred tools (+1): a ToolSearch discovery is a real model round-trip
+ *     that consumes a turn before the model can emit the real tool_use. The
+ *     old model wrongly assumed a lone deferred set fit in base 3, so the
+ *     discovery ate into the tool-call budget — deferred sessions hit max_turns
+ *     prematurely, forcing cold-cache retries and churn (#547).
+ *   - Resume (+0): rehydration completes inline within turn 1, so it adds no
+ *     turn — a resumed deferred session is 4, same as a fresh deferred one.
  *   - Advisor (+3): server-side advisor executes call + result + final answer.
  */
 function computePassthroughMaxTurns(
-  resumeSessionId: string | undefined,
   hasDeferredTools: boolean,
   advisorModel: string | undefined,
 ): number {
-  const hasResume = !!resumeSessionId
-  const defaultBase = hasResume && hasDeferredTools ? 4 : 3
+  const deferredBump = hasDeferredTools ? 1 : 0
+  const defaultBase = 3 + deferredBump
   // The base is the SDK's internal-loop budget before it must return control.
   // It's normally enough (the capture path drops re-emitted duplicates and
   // stops the loop when the model starts repeating), but wide parallel tool
   // calls — which the SDK surfaces one assistant turn each — can need more
   // headroom, and orchestration clients hit it on deep chains (#494). Allow
   // MERIDIAN_PASSTHROUGH_MAX_TURNS / CLAUDE_PROXY_PASSTHROUGH_MAX_TURNS to
-  // raise (or lower) the base; the resume/advisor bumps below are unchanged.
+  // raise (or lower) the base (incl. the deferred bump); the advisor bump
+  // below is added on top and is unaffected by the override.
   const configured = envInt("PASSTHROUGH_MAX_TURNS", defaultBase)
   const base = configured > 0 ? configured : defaultBase
   const advisorBump = advisorModel ? 3 : 0
@@ -244,7 +247,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       // is not in PATH — causing subprocess spawns to fail.
       executable: "node" as const,
       maxTurns: passthrough
-        ? computePassthroughMaxTurns(resumeSessionId, hasDeferredTools, ctx.advisorModel)
+        ? computePassthroughMaxTurns(hasDeferredTools, ctx.advisorModel)
         : 200,
       cwd: workingDirectory,
       model,


### PR DESCRIPTION
## Background

Spun out of #547. The reporters saw eviction/cache churn on deferred-tool passthrough sessions, mitigated by `MERIDIAN_DEFER_TOOL_THRESHOLD=0`. I investigated the full chain:

- The claimed "deferred tools cause cross-session leaks" mechanism is **mechanically refuted** — tools don't enter the session fingerprint/lineage/resume key, and the eviction/retry path only ever replays the request's own messages. No content bleed is possible via this path.
- I **live-verified** the one suspect (a nested `session_id` from ToolSearch overwriting the resumable id): instrumented a v1.45.4 build, drove a 21-tool passthrough session with real ToolSearch discovery — the `session_id` stayed identical across every message. Refuted.
- What's left is the real, benign cause: **ToolSearch discovery consumes a turn**, and the passthrough budget didn't account for it, so deferred sessions hit `max_turns` prematurely → cold-cache retries → the churn. `DEFER_THRESHOLD=0` "fixed" it by removing ToolSearch, freeing the budget.

## Fix

Bump the passthrough turn budget by 1 whenever tools are deferred — the discovery round-trip gets its own turn instead of eating into the tool-call budget. Resume rehydration is inline (adds nothing), so:

| case | before | after |
|---|---|---|
| deferred | 3 | **4** |
| resume + deferred | 4 | 4 (unchanged) |
| advisor + deferred | 6 | **7** |
| advisor + resume + deferred | 7 | 7 (unchanged) |

Non-deferred budgets are untouched. This only ever *raises* headroom for deferred sessions, so it can't regress anything — and the loop-break/dedup machinery still stops runaway loops regardless of budget. Also drops the now-unused `resumeSessionId` param from the calc.

## Tests

Updated the `buildQueryOptions` maxTurns matrix in `query.test.ts` and the HTTP-level deferred case in `deferred-tool-loading.test.ts`. Full suite: 1870 pass, 0 fail; `tsc --noEmit` clean.