### PR TITLE
refactor(nix): drop deprecated homeManagerModules alias; document PATH change

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Then in `~/.config/opencode/opencode.json`:
 
 The service starts automatically on login. Manage it with `systemctl --user {start,stop,restart,status} meridian`.
 
+The module manages only the systemd user service — it does **not** put the `meridian` CLI on your `$PATH`. If you also want to run `meridian` from a shell, add the package yourself:
+
+```nix
+home.packages = [ config.services.meridian.package ];
+```
+
 The plugin path is also available as `config.services.meridian.opencode.pluginPath` for use in your OpenCode config:
 
 ```nix

--- a/flake.nix
+++ b/flake.nix
@@ -63,8 +63,6 @@
           };
 
         flake = {
-          homeManagerModules = self.homeModules;
-
           homeModules = {
             default = self.homeModules.meridian;
             meridian = moduleWithSystem (


### PR DESCRIPTION
Follow-up to #540.

## Changes

- **Drop the `homeManagerModules` compat alias.** `nix flake check` warned `unknown flake output 'homeManagerModules'`, and the README already documents only the modern `homeModules.default`. Clean break.
- **Document the PATH behavior change.** #540 intentionally stopped the module from forcing the package onto `$PATH` (it now manages only the systemd service). Added a README note so existing users know to add `config.services.meridian.package` to `home.packages` if they want the `meridian` CLI in their shell.

## Validation

Ran the full `nix flake check --all-systems` in a Nix container against this branch: **all checks passed**, and the `homeManagerModules` warning is gone (only an unrelated nixpkgs x86_64-darwin deprecation notice remains). No TypeScript/runtime changes.