### PR TITLE
fix(ci): derive Docker release semver from tag_name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,9 +30,6 @@ jobs:
       # is exactly what we want for a single-package repo.
       release_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs['.--tag_name'] }}
-      # Bare semver (e.g. "1.45.4") for Docker tags — the '.--version' output
-      # is prefixed by manifest path ('.'), same convention as '.--tag_name'.
-      version: ${{ steps.release.outputs['.--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -116,14 +113,23 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Derive the bare semver from the release tag. release-please's own
+      # `.--version` output came through empty at job scope, but `.--tag_name`
+      # (used above for checkout) is reliable — strip its `meridian-v` prefix.
+      - name: Derive version from tag
+        id: ver
+        run: echo "version=${TAG#meridian-v}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.version }}
+            type=semver,pattern={{version}},value=${{ steps.ver.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ver.outputs.version }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Problem

The release Docker job added in #597 failed on its first real run (v1.46.0):

```
ERROR: failed to build: tag is needed when pushing to registry
```

`docker/metadata-action` produced **no tags** because `needs.release-please.outputs.version` (wired to release-please's `.--version` output) resolved to an empty string at job scope, so both `type=semver,...,value=` entries were blank. The npm publish, tag, and GitHub Release all succeeded — only the Docker image was skipped.

## Fix

`.--tag_name` is reliable (it already drives the job's `actions/checkout` ref), so derive the bare semver by stripping its `meridian-v` prefix in a small step, and feed that to the metadata action. Removed the non-working `version` job output.

## Validation

- `actionlint` clean.
- Strip logic verified: `meridian-v1.46.0` → `1.46.0` → tags `1.46.0` and `1.46`.
- Full end-to-end can only confirm on the next release (workflows can't be dry-run through the release event) — I'll verify `ghcr.io/rynfar/meridian:<version>` appears then.

Note: v1.46.0's Docker image wasn't published due to this bug; it'll be backfillable via `docker.yml`'s `workflow_dispatch` on the `meridian-v1.46.0` tag if desired.