### PR TITLE
feat(dashboard): add Usage tab (session, weekly, weekly pace) (#503)

### DIFF
--- a/src/__tests__/profile-usage.test.ts
+++ b/src/__tests__/profile-usage.test.ts
@@ -8,7 +8,11 @@ import {
   classifyUtilization,
   formatResetCountdown,
   formatExtraUsage,
+  computeWeeklyPace,
 } from "../telemetry/profileUsage"
+
+const DAY = 86_400_000
+const WEEK = 7 * DAY
 
 describe("labelForWindow", () => {
   it("maps every documented Anthropic window type", () => {
@@ -181,5 +185,61 @@ describe("formatExtraUsage", () => {
     })
     expect(overshoot!.utilizationPct).toBe(100)
     expect(overshoot!.status).toBe("high")
+  })
+})
+
+describe("computeWeeklyPace", () => {
+  // Window resets at `reset`; it started 7 days earlier. `now` sits somewhere
+  // inside that window, giving an expected (even-pace) utilization.
+  const reset = 10 * WEEK // arbitrary fixed epoch
+
+  it("returns null when utilization or resetsAt is missing", () => {
+    expect(computeWeeklyPace(null, reset, reset - 3 * DAY)).toBeNull()
+    expect(computeWeeklyPace(0.5, null, reset - 3 * DAY)).toBeNull()
+    expect(computeWeeklyPace(undefined, reset, reset - 3 * DAY)).toBeNull()
+  })
+
+  it("computes expected % from the position in the 7-day window", () => {
+    // Halfway through the window → expected 50%.
+    const p = computeWeeklyPace(0.5, reset, reset - 3.5 * DAY)!
+    expect(p.expectedPct).toBe(50)
+    expect(p.actualPct).toBe(50)
+    expect(p.deltaPct).toBe(0)
+    expect(p.status).toBe("on")
+  })
+
+  it("flags burning ahead of pace when actual exceeds expected", () => {
+    // 25% through the window (expected 25%) but 60% used.
+    const p = computeWeeklyPace(0.6, reset, reset - 5.25 * DAY)!
+    expect(p.expectedPct).toBe(25)
+    expect(p.actualPct).toBe(60)
+    expect(p.deltaPct).toBe(35)
+    expect(p.status).toBe("ahead")
+  })
+
+  it("flags comfortably under pace when actual trails expected", () => {
+    // 75% through the window (expected 75%) but only 30% used.
+    const p = computeWeeklyPace(0.3, reset, reset - 1.75 * DAY)!
+    expect(p.expectedPct).toBe(75)
+    expect(p.actualPct).toBe(30)
+    expect(p.status).toBe("under")
+  })
+
+  it("projects end-of-window usage at the current rate", () => {
+    // Halfway, 30% used → at this rate ~60% by reset.
+    const p = computeWeeklyPace(0.3, reset, reset - 3.5 * DAY)!
+    expect(p.projectedPct).toBe(60)
+  })
+
+  it("does not project too early in the window (avoids wild extrapolation)", () => {
+    // 2% into the window — extrapolating from a sliver is meaningless.
+    const p = computeWeeklyPace(0.02, reset, reset - WEEK + 0.02 * WEEK)!
+    expect(p.projectedPct).toBeNull()
+  })
+
+  it("clamps elapsed position to the window bounds", () => {
+    // now past reset → treated as full window elapsed (expected 100%).
+    const p = computeWeeklyPace(0.9, reset, reset + DAY)!
+    expect(p.expectedPct).toBe(100)
   })
 })

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -76,6 +76,27 @@ export const dashboardHtml = `<!DOCTYPE html>
                 transition: all 0.15s; }
   .log-filter:hover { border-color: var(--accent); color: var(--text); }
   .log-filter.active { background: rgba(88,166,255,0.1); border-color: var(--accent); color: var(--accent); }
+
+  /* Usage tab */
+  .usage-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; margin-bottom: 16px; }
+  .ucard { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; }
+  .ucard-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+  .ucard-title { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
+  .ucard-reset { font-size: 11px; color: var(--muted); white-space: nowrap; }
+  .ucard-pct { font-size: 32px; font-weight: 600; font-variant-numeric: tabular-nums; line-height: 1.1; margin-top: 8px; color: var(--green); }
+  .ucard.warn .ucard-pct { color: var(--yellow); }
+  .ucard.high .ucard-pct { color: var(--red); }
+  .ucard-sub { font-size: 12px; color: var(--muted); margin-top: 8px; min-height: 16px; }
+  .ubar { position: relative; height: 8px; border-radius: 4px; background: var(--border); overflow: visible; margin-top: 12px; }
+  .ubar-fill { height: 100%; border-radius: 4px; background: var(--green); transition: width 0.4s ease; max-width: 100%; }
+  .ucard.warn .ubar-fill { background: var(--yellow); }
+  .ucard.high .ubar-fill { background: var(--red); }
+  .ubar-marker { position: absolute; top: -3px; bottom: -3px; width: 2px; background: var(--text); opacity: 0.55; border-radius: 1px; }
+  .pace-pill { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; }
+  .pace-pill.on, .pace-pill.under { background: rgba(63,185,80,0.15); color: var(--green); }
+  .pace-pill.ahead { background: rgba(210,153,34,0.18); color: var(--yellow); }
+  .pace-pill.over { background: rgba(248,81,73,0.15); color: var(--red); }
+  .usage-note { font-size: 11px; color: var(--muted); }
 ` + profileBarCss + `
 </style>
 </head>
@@ -150,20 +171,22 @@ function setLogFilter(filter) {
 async function refresh() {
   const w = $('#window').value;
   try {
-    const [summary, reqs, logs] = await Promise.all([
+    const [summary, reqs, logs, quota] = await Promise.all([
       fetch('/telemetry/summary?window=' + w).then(r => r.json()),
       fetch('/telemetry/requests?limit=50&since=' + (Date.now() - Number(w))).then(r => r.json()),
       fetch('/telemetry/logs?limit=200&since=' + (Date.now() - Number(w))).then(r => r.json()),
+      fetch('/v1/usage/quota').then(r => r.json()).catch(() => null),
     ]);
-    render(summary, reqs, logs);
+    render(summary, reqs, logs, quota);
     $('#lastUpdate').textContent = 'Updated ' + new Date().toLocaleTimeString();
   } catch (e) {
     $('#content').innerHTML = '<div class="empty">Failed to load telemetry</div>';
   }
 }
 
-function render(s, reqs, logs) {
-  if (s.totalRequests === 0 && (!logs || logs.length === 0)) {
+function render(s, reqs, logs, quota) {
+  const hasUsage = quota && quota.buckets && quota.buckets.some(b => b.utilization != null);
+  if (s.totalRequests === 0 && (!logs || logs.length === 0) && !hasUsage) {
     $('#content').innerHTML = '<div class="empty">No requests recorded yet. Send a request through the proxy to see telemetry.</div>';
     return;
   }
@@ -181,6 +204,7 @@ function render(s, reqs, logs) {
     +   'Requests<span class="tab-badge">' + reqs.length + '</span></div>'
     + '<div class="tab' + (activeTab === 'logs' ? ' active' : '') + '" data-tab="logs" onclick="switchTab(&apos;logs&apos;)">'
     +   'Logs<span class="tab-badge">' + logs.length + '</span></div>'
+    + '<div class="tab' + (activeTab === 'usage' ? ' active' : '') + '" data-tab="usage" onclick="switchTab(&apos;usage&apos;)">Usage</div>'
     + '</div>';
 
   // ==================== Overview tab ====================
@@ -330,6 +354,11 @@ function render(s, reqs, logs) {
   }
   html += '</div>'; // end logs panel
 
+  // ==================== Usage tab ====================
+  html += '<div id="panel-usage" class="tab-panel' + (activeTab === 'usage' ? ' active' : '') + '">';
+  html += renderUsage(quota);
+  html += '</div>'; // end usage panel
+
   $('#content').innerHTML = html;
 }
 
@@ -338,6 +367,101 @@ function card(label, value, detail) {
     + '<div class="card-value">' + value + '</div>'
     + (detail ? '<div class="card-detail">' + detail + '</div>' : '')
     + '</div>';
+}
+
+// ---- Usage tab helpers (mirror src/telemetry/profileUsage.ts; unit-tested there) ----
+function classifyUtil(u) {
+  if (u == null || !isFinite(u)) return '';
+  if (u >= 0.85) return 'high';
+  if (u >= 0.6) return 'warn';
+  return '';
+}
+function resetIn(resetsAt) {
+  if (resetsAt == null || !isFinite(resetsAt)) return '';
+  var ms = resetsAt - Date.now();
+  if (ms <= 0) return 'resetting…';
+  var m = Math.floor(ms / 60000);
+  if (m < 60) return 'resets in ' + Math.max(1, m) + 'm';
+  var h = Math.floor(m / 60), rm = m % 60;
+  if (h < 24) return 'resets in ' + h + 'h' + (rm ? ' ' + rm + 'm' : '');
+  var d = Math.floor(h / 24), rh = h % 24;
+  return 'resets in ' + d + 'd' + (rh ? ' ' + rh + 'h' : '');
+}
+function pct(u) { return Math.round(Math.max(0, u) * 100); }
+
+function usageCard(title, bucket) {
+  if (!bucket || bucket.utilization == null) {
+    return '<div class="ucard"><div class="ucard-head"><span class="ucard-title">' + title + '</span></div>'
+      + '<div class="ucard-pct" style="color:var(--muted)">—</div>'
+      + '<div class="ucard-sub">No data yet</div></div>';
+  }
+  var u = bucket.utilization;
+  var cls = classifyUtil(u);
+  var fill = Math.min(100, pct(u));
+  return '<div class="ucard ' + cls + '">'
+    + '<div class="ucard-head"><span class="ucard-title">' + title + '</span>'
+    +   '<span class="ucard-reset">' + resetIn(bucket.resetsAt) + '</span></div>'
+    + '<div class="ucard-pct">' + pct(u) + '<span style="font-size:16px;font-weight:500;color:var(--muted)">%</span></div>'
+    + '<div class="ubar"><div class="ubar-fill" style="width:' + fill + '%"></div></div>'
+    + '<div class="ucard-sub">of your ' + title.split('·')[1].trim() + ' allowance used</div>'
+    + '</div>';
+}
+
+// Weekly pace: actual vs. expected (even) consumption at this point in the 7-day window.
+function paceCard(weekly) {
+  if (!weekly || weekly.utilization == null || weekly.resetsAt == null) {
+    return '<div class="ucard"><div class="ucard-head"><span class="ucard-title">Weekly Pace</span></div>'
+      + '<div class="ucard-pct" style="color:var(--muted)">—</div>'
+      + '<div class="ucard-sub">Needs weekly usage data</div></div>';
+  }
+  var WEEK = 7 * 86400000;
+  var start = weekly.resetsAt - WEEK;
+  var elapsed = Math.max(0, Math.min(1, (Date.now() - start) / WEEK));
+  var actual = pct(weekly.utilization);
+  var expected = Math.round(elapsed * 100);
+  var delta = actual - expected;
+  var projected = elapsed >= 0.1 ? Math.round((Math.max(0, weekly.utilization) / elapsed) * 100) : null;
+
+  var pill, label;
+  if (delta > 7) { pill = 'ahead'; label = '+' + delta + '% ahead of pace'; }
+  else if (delta < -7) { pill = 'under'; label = Math.abs(delta) + '% under pace'; }
+  else { pill = 'on'; label = 'On pace'; }
+  if (projected != null && projected >= 100) { pill = 'over'; label = 'On track to run out'; }
+
+  var fill = Math.min(100, actual);
+  var mark = Math.min(100, expected);
+  var proj = projected == null ? '—' : projected + '%';
+  return '<div class="ucard">'
+    + '<div class="ucard-head"><span class="ucard-title">Weekly Pace</span>'
+    +   '<span class="ucard-reset">' + Math.round(elapsed * 100) + '% through week</span></div>'
+    + '<div style="margin-top:8px"><span class="pace-pill ' + pill + '">' + label + '</span></div>'
+    + '<div class="ubar"><div class="ubar-fill" style="width:' + fill + '%;background:' + (pill === 'over' ? 'var(--red)' : pill === 'ahead' ? 'var(--yellow)' : 'var(--green)') + '"></div>'
+    +   '<div class="ubar-marker" style="left:' + mark + '%" title="Expected at even pace"></div></div>'
+    + '<div class="ucard-sub">' + actual + '% used vs ' + expected + '% expected · at this rate ~' + proj + ' by reset</div>'
+    + '</div>';
+}
+
+function renderUsage(quota) {
+  if (!quota || !quota.buckets) {
+    return '<div class="empty">Usage data unavailable.</div>';
+  }
+  var by = {};
+  quota.buckets.forEach(function (b) { by[b.type] = b; });
+  var session = by['five_hour'], weekly = by['seven_day'];
+  if ((!session || session.utilization == null) && (!weekly || weekly.utilization == null)) {
+    return '<div class="empty">No usage data yet — Anthropic reports it after your first request through Meridian.</div>';
+  }
+  var h = '<div class="usage-cards">'
+    + usageCard('Session · 5h', session)
+    + usageCard('Weekly · 7d', weekly)
+    + paceCard(weekly)
+    + '</div>';
+  var asOf = quota.asOf ? new Date(quota.asOf).toLocaleTimeString() : '';
+  h += '<div class="usage-note">'
+    + (quota.profile ? 'Profile: ' + quota.profile + ' · ' : '')
+    + 'Reported by Anthropic' + (asOf ? ' · as of ' + asOf : '')
+    + '</div>';
+  return h;
 }
 
 $('#autoRefresh').addEventListener('change', function() {

--- a/src/telemetry/profileUsage.ts
+++ b/src/telemetry/profileUsage.ts
@@ -108,3 +108,64 @@ export function formatExtraUsage(eu: {
     status: classifyUtilization(utilization),
   }
 }
+
+/**
+ * Weekly-pace comparison for the 7-day usage window.
+ *
+ * Compares how much of the weekly allowance has been consumed against how much
+ * *time* has elapsed in the window — the "am I burning it too fast?" question.
+ * The window resets at `resetsAt` and started 7 days earlier, so the elapsed
+ * fraction gives the expected (even-pace) utilization.
+ *
+ * Returns null when there isn't enough data to compute a meaningful pace
+ * (missing utilization or reset time) — callers should hide the widget then.
+ *
+ * `now` is injectable for tests; production callers omit it.
+ */
+export interface WeeklyPace {
+  /** Actual utilization, rounded to a percent (may exceed 100). */
+  actualPct: number
+  /** Expected utilization at this point in the window, 0..100. */
+  expectedPct: number
+  /** actualPct − expectedPct; positive means ahead of (faster than) pace. */
+  deltaPct: number
+  /** Extrapolated end-of-window utilization at the current rate; null if it's
+   *  too early in the window to project without wild swings. */
+  projectedPct: number | null
+  /** Consumption relative to even pace. */
+  status: "under" | "on" | "ahead"
+  /** Position in the window, 0..1 (fraction of the 7 days elapsed). */
+  elapsedFraction: number
+}
+
+const SEVEN_DAYS_MS = 7 * 86_400_000
+/** Delta (percentage points) within which pace is considered "on track". */
+const PACE_ON_BAND = 7
+/** Don't extrapolate a projection until this fraction of the window elapsed. */
+const PROJECT_MIN_ELAPSED = 0.1
+
+export function computeWeeklyPace(
+  utilization: number | null | undefined,
+  resetsAt: number | null | undefined,
+  now: number = Date.now(),
+): WeeklyPace | null {
+  if (utilization == null || !Number.isFinite(utilization)) return null
+  if (resetsAt == null || !Number.isFinite(resetsAt)) return null
+
+  const windowStart = resetsAt - SEVEN_DAYS_MS
+  const elapsedFraction = Math.max(0, Math.min(1, (now - windowStart) / SEVEN_DAYS_MS))
+
+  const actualPct = Math.round(Math.max(0, utilization) * 100)
+  const expectedPct = Math.round(elapsedFraction * 100)
+  const deltaPct = actualPct - expectedPct
+
+  const status: WeeklyPace["status"] =
+    deltaPct > PACE_ON_BAND ? "ahead" : deltaPct < -PACE_ON_BAND ? "under" : "on"
+
+  const projectedPct =
+    elapsedFraction >= PROJECT_MIN_ELAPSED
+      ? Math.round((Math.max(0, utilization) / elapsedFraction) * 100)
+      : null
+
+  return { actualPct, expectedPct, deltaPct, projectedPct, status, elapsedFraction }
+}


### PR DESCRIPTION
Closes #503.

Adds a **Usage** tab to the telemetry dashboard surfacing the subscription quota that `/v1/usage/quota` already exposes — no backend change needed.

## What it shows
- **Session · 5h** and **Weekly · 7d** — utilization % with a status-colored bar (green/amber/red at the same 60%/85% thresholds the profile page uses) and a reset countdown.
- **Weekly Pace** — the widget the issue specifically asked for: compares *actual* weekly consumption against the *expected* (even-pace) utilization for the current position in the 7-day window. The bar shows a marker at the expected position with the actual fill relative to it, a status pill (`under pace` / `on pace` / `ahead` / `on track to run out`), and an at-this-rate end-of-week projection.

## Implementation
- `computeWeeklyPace` is a pure, unit-tested helper added to `profileUsage.ts` (7 new cases). The dashboard mirrors it inline, matching the existing profile-page pattern.
- The Usage tab renders even before any telemetry requests exist (the empty-state guard now also considers usage data).
- Fetches `/v1/usage/quota` alongside the existing telemetry fetches, resilient to failure (falls back to null → friendly empty state).

## Verification
- Rendered the real dashboard page with mocked quota data and screenshotted both a burning-hot scenario (72% used / 60% expected → red "on track to run out") and a comfortable one (22% / 70% → green "48% under pace"); both match the dashboard's design language.
- Full suite: 1882 pass, 0 fail; `tsc --noEmit` clean.