### PR TITLE
fix(ci): read Docker release version from package.json

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,9 +96,9 @@ jobs:
       contents: read
       packages: write
     steps:
+      # No ref: the workflow was triggered by the release-PR merge, so the
+      # checked-out commit IS the release commit (version bump + changelog).
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -113,14 +113,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Derive the bare semver from the release tag. release-please's own
-      # `.--version` output came through empty at job scope, but `.--tag_name`
-      # (used above for checkout) is reliable — strip its `meridian-v` prefix.
-      - name: Derive version from tag
+      # Read the semver straight from the just-bumped package.json. Both of
+      # release-please's `.--tag_name` / `.--version` outputs resolved empty at
+      # job scope (twice — v1.46.0 and v1.47.0), so don't depend on them.
+      - name: Read version
         id: ver
-        run: echo "version=${TAG#meridian-v}" >> "$GITHUB_OUTPUT"
-        env:
-          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
Third time's the charm on the release Docker job.

## Problem

Both attempts to publish semver Docker images on release failed:
- **#597 (v1.46.0):** `.--version` output empty → no tags.
- **#601 (v1.47.0):** derived version from `.--tag_name`, but that output is *also* empty — the checkout logged `refs/heads/main` (tag_name blank → fell back to default branch) and metadata-action still got a blank version.

Both of release-please's path-prefixed outputs (`.--tag_name`, `.--version`) resolve empty at the `docker` job's scope, despite `releases_created` working fine.

## Fix

Stop depending on those outputs. The release-PR merge that triggers this workflow **is** the version-bump commit, so a plain `actions/checkout` (no ref) gets the bumped `package.json` — read the version straight from it with `node -p`. Bulletproof and output-key-independent.

## Validation

`actionlint` clean. Can only fully confirm on the next release, but the mechanism is now trivial (checked-out `package.json` → `node -p`) with no flaky-output dependency.

Note: v1.46.0's and v1.47.0's Docker images were backfilled manually via `docker.yml`'s `workflow_dispatch` on their tags.