### PR TITLE
fix(tools): fail fast on native Anthropic server tools (web_search/web_fetch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ For large tool sets (>15 tools), non-core tools are automatically deferred via t
 - **Single tool round-trip per request** — in passthrough mode, the SDK is configured with `maxTurns=2` (or 3 for deferred tools). Multi-step agentic loops where Claude needs several consecutive tool calls require the client to re-send after each round.
 - **Blocked tools** — 13 built-in SDK tools (Read, Write, Bash, etc.) are blocked to prevent conflicts with the client's own tools. 15 additional Claude Code-only tools (CronCreate, EnterWorktree, Agent, etc.) are blocked because they require capabilities that external clients don't support.
 - **Subagent extraction** — Meridian parses the client's Task tool description to extract subagent names and build SDK AgentDefinitions. If the client's agent framework uses a non-standard format, subagent routing may not work automatically.
+- **Anthropic server tools not supported** — native server-side tools (`web_search_*`, `web_fetch_*`) are a raw Anthropic API feature (billed to an API key) that emits `server_tool_use` / `web_search_tool_result` blocks the Claude Max / Agent SDK path cannot produce. A request carrying one is rejected with a `400` explaining the fix. If a plugin needs server-side web search (e.g. [`opencode-websearch`](https://github.com/emilsvennesson/opencode-websearch)), give it its **own** provider pointed at `https://api.anthropic.com` with your `ANTHROPIC_API_KEY` — don't route that call through Meridian.
 
 ## Multi-Profile Support
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -398,3 +398,59 @@ describe("Integration: Non-stream usage propagation", () => {
     expect(body.usage.output_tokens).toBe(0)
   })
 })
+
+// ============================================================
+// NATIVE SERVER-TOOL FAIL-FAST (#488 / #481)
+// ============================================================
+
+describe("Integration: native server tools fail fast", () => {
+  let app: any
+  let savedPassthrough: string | undefined
+
+  beforeAll(() => {
+    app = createTestApp()
+  })
+
+  beforeEach(() => {
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+    mockMessages = []
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  it("rejects a request carrying the native web_search server tool with an actionable 400", async () => {
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "search the web" }],
+      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(400)
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.message).toContain("web_search_20250305")
+    expect(body.error.message).toContain("api.anthropic.com")
+    expect(body.error.message).toContain("ANTHROPIC_API_KEY")
+  })
+
+  it("does not reject ordinary custom/passthrough tools", async () => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "read a file" }],
+      tools: [{ name: "web-search", description: "opencode custom tool", input_schema: { type: "object", properties: { query: { type: "string" } } } }],
+    })
+
+    // The custom tool must not trip the server-tool fail-fast (it's a client tool, not a server tool).
+    expect(response.status).not.toBe(400)
+  })
+})

--- a/src/__tests__/server-tools.test.ts
+++ b/src/__tests__/server-tools.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for native Anthropic server-tool detection — pure functions, no mocks.
+ *
+ * Meridian bridges to Claude Max via the Agent SDK, which cannot execute
+ * Anthropic's native *server* tools (`web_search_*`, `web_fetch_*`). Those are
+ * a raw Messages-API feature (API-key billed) that produce `server_tool_use` /
+ * `web_search_tool_result` blocks the SDK never emits. When a client (e.g. the
+ * opencode-websearch plugin, #488; Cherry Studio, #481) points such a request
+ * at Meridian, we detect it up front and fail fast with an actionable error
+ * instead of silently bouncing an unrunnable tool back to the agent.
+ */
+import { describe, it, expect } from "bun:test"
+import { detectServerTools, serverToolErrorMessage } from "../proxy/tools"
+
+describe("detectServerTools", () => {
+  it("returns [] when tools is missing or not an array", () => {
+    expect(detectServerTools(undefined)).toEqual([])
+    expect(detectServerTools(null)).toEqual([])
+    expect(detectServerTools("web_search" as unknown)).toEqual([])
+  })
+
+  it("returns [] for ordinary custom/passthrough tools (name + input_schema, no server type)", () => {
+    const tools = [
+      { name: "read", description: "read a file", input_schema: { type: "object" } },
+      { name: "web-search", description: "opencode custom tool", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+      { name: "bash", input_schema: {} },
+    ]
+    expect(detectServerTools(tools)).toEqual([])
+  })
+
+  it("detects the native web_search server tool", () => {
+    const tools = [{ type: "web_search_20250305", name: "web_search", max_uses: 8 }]
+    expect(detectServerTools(tools)).toEqual(["web_search_20250305"])
+  })
+
+  it("detects the native web_fetch server tool", () => {
+    const tools = [{ type: "web_fetch_20250910", name: "web_fetch" }]
+    expect(detectServerTools(tools)).toEqual(["web_fetch_20250910"])
+  })
+
+  it("detects newer date-suffixed variants (matches the family, not one exact date)", () => {
+    const tools = [{ type: "web_search_20260209", name: "web_search" }]
+    expect(detectServerTools(tools)).toEqual(["web_search_20260209"])
+  })
+
+  it("collects every offending type when several are present, deduped and in order", () => {
+    const tools = [
+      { name: "read", input_schema: {} },
+      { type: "web_search_20250305", name: "web_search" },
+      { type: "web_fetch_20250910", name: "web_fetch" },
+      { type: "web_search_20250305", name: "web_search" },
+    ]
+    expect(detectServerTools(tools)).toEqual(["web_search_20250305", "web_fetch_20250910"])
+  })
+
+  it("ignores a non-server 'type' such as the explicit custom-tool marker", () => {
+    const tools = [{ type: "custom", name: "web-search", input_schema: { type: "object" } }]
+    expect(detectServerTools(tools)).toEqual([])
+  })
+})
+
+describe("serverToolErrorMessage", () => {
+  it("names the offending tool types", () => {
+    const msg = serverToolErrorMessage(["web_search_20250305"])
+    expect(msg).toContain("web_search_20250305")
+  })
+
+  it("explains that server tools need the real Anthropic API, not the Max/SDK path", () => {
+    const msg = serverToolErrorMessage(["web_search_20250305"])
+    expect(msg.toLowerCase()).toContain("api.anthropic.com")
+    expect(msg).toContain("ANTHROPIC_API_KEY")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -40,6 +40,7 @@ import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -471,6 +472,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (body.messages.length === 0) {
           return c.json(
             { type: "error", error: { type: "invalid_request_error", message: "messages: Cannot be empty — at least one message is required" } },
+            400
+          )
+        }
+
+        // Native Anthropic server tools (web_search_*, web_fetch_*) can't run
+        // through the Max/SDK path — fail fast with an actionable message
+        // instead of silently bouncing an unrunnable tool back to the agent.
+        // See #488 (opencode-websearch) / #481 (Cherry Studio).
+        const serverTools = detectServerTools(body.tools)
+        if (serverTools.length > 0) {
+          return c.json(
+            { type: "error", error: { type: "invalid_request_error", message: serverToolErrorMessage(serverTools) } },
             400
           )
         }

--- a/src/proxy/tools.ts
+++ b/src/proxy/tools.ts
@@ -49,6 +49,54 @@ export const CLAUDE_CODE_ONLY_TOOLS = [
   "WebSearch",         // OpenCode: websearch_web_search_exa
 ]
 
+/**
+ * Native Anthropic *server* tools carry a dated `type` marker (e.g.
+ * `web_search_20250305`, `web_fetch_20260209`). Unlike custom/passthrough
+ * tools — which have a `name` + `input_schema` and are executed by the client
+ * — these run on Anthropic's servers and emit `server_tool_use` /
+ * `web_search_tool_result` blocks. Meridian bridges to Claude Max via the
+ * Agent SDK, which has no such server tools and cannot produce those blocks,
+ * so a request carrying one can never succeed through the proxy. Match the
+ * web_search/web_fetch families (any date suffix) so we catch future variants.
+ * See #488 (opencode-websearch plugin) and #481 (Cherry Studio).
+ */
+const SERVER_TOOL_TYPE = /^web_(search|fetch)_\d+$/
+
+/**
+ * Return the distinct native-server-tool `type`s present in a request's `tools`
+ * array, in first-seen order. Empty when there are none (the common case) or
+ * when `tools` isn't an array. Pure — no I/O.
+ */
+export function detectServerTools(tools: unknown): string[] {
+  if (!Array.isArray(tools)) return []
+  const found: string[] = []
+  for (const tool of tools) {
+    const type = (tool as { type?: unknown })?.type
+    if (typeof type === "string" && SERVER_TOOL_TYPE.test(type) && !found.includes(type)) {
+      found.push(type)
+    }
+  }
+  return found
+}
+
+/**
+ * Build the actionable error returned when a request carries native server
+ * tools. It tells the user to route that specific call at the real Anthropic
+ * API (with their own key) rather than through Meridian — the plugin already
+ * supports a separate per-provider baseURL, so this is a config fix on their
+ * side, not something Meridian can execute on the Max subscription.
+ */
+export function serverToolErrorMessage(types: string[]): string {
+  const list = types.join(", ")
+  return (
+    `Anthropic server tools (${list}) can't run through Meridian. ` +
+    `Server-side web search/fetch is a raw Anthropic API feature (billed to an API key) ` +
+    `that produces server_tool_use / web_search_tool_result blocks the Claude Max / Agent SDK path cannot emit. ` +
+    `Point the plugin making this call at the real API instead — configure it with a separate provider using ` +
+    `baseURL "https://api.anthropic.com" and your own ANTHROPIC_API_KEY, rather than routing it through Meridian.`
+  )
+}
+
 /** MCP server name used by the calling agent */
 export const MCP_SERVER_NAME = "opencode"
 


### PR DESCRIPTION
## What

Detect native Anthropic **server tools** (`web_search_*`, `web_fetch_*`) in an incoming request and reject it up front with an actionable `400`, instead of silently routing it through passthrough where it dead-ends.

## Why

Meridian bridges to Claude Max via the Agent SDK. Native server tools are a raw Anthropic API feature (billed to an API key) that produces `server_tool_use` / `web_search_tool_result` blocks the SDK **cannot** emit. When a plugin like [`opencode-websearch`](https://github.com/emilsvennesson/opencode-websearch) makes its nested `web_search_20250305` request through Meridian, the passthrough layer registers it as an unrunnable `mcp__oc__web_search` client tool, captures/denies it, and waits for the client to execute a tool it never had — a silent dead end.

The plugin is designed to talk to the **real API with its own key** and already supports a separate per-provider `baseURL`. So the correct fix is a config change on the user's side; Meridian's job is just to say so clearly rather than fail cryptically.

## Change

- `detectServerTools()` + `serverToolErrorMessage()` — pure helpers in `tools.ts`
- Early `400` fail-fast in the `/v1/messages` handler (before output-format parsing)
- Unit tests (`server-tools.test.ts`) + HTTP integration tests
- README "Known limitations" note

The `400` message tells the user to point the plugin at `https://api.anthropic.com` with their own `ANTHROPIC_API_KEY`.

Fixes #488. Also clears the confusing half of #481.