### PR TITLE
feat(adapters): Cherry Studio adapter with working built-in web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,20 @@ Point any OpenAI-compatible tool at `http://127.0.0.1:3456` with any API key val
 
 > **Note:** Multi-turn conversations work by packing prior turns into the system prompt. Each request is a fresh SDK session — OpenAI clients replay full history themselves and don't use Meridian's session resumption.
 
+### Cherry Studio
+
+[Cherry Studio](https://github.com/CherryHQ/cherry-studio) is a desktop chat client. Point it at Meridian by setting the Anthropic API base URL to `http://127.0.0.1:3456` (any API key value works).
+
+Because Cherry Studio is a chat client rather than a coding agent, select the `cherry` adapter so Claude's **built-in web search** is available (coding-agent adapters block it in favour of their own):
+
+```bash
+MERIDIAN_DEFAULT_AGENT=cherry meridian
+```
+
+The `cherry` adapter runs in internal mode: Claude executes `WebSearch`/`WebFetch` itself and Meridian returns the grounded answer — the internal tool calls are hidden from the client. This resolves the "no WebSearch/WebFetch tool exposed" error (#481).
+
+> Cherry Studio doesn't send a Meridian-specific header, so set `MERIDIAN_DEFAULT_AGENT=cherry` on a Meridian dedicated to it, or send `x-meridian-agent: cherry` if your setup allows custom headers.
+
 ### ForgeCode
 
 Add a custom provider to `~/forge/.forge.toml`:

--- a/src/__tests__/cherry-adapter.test.ts
+++ b/src/__tests__/cherry-adapter.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Cherry Studio adapter — unit tests.
+ *
+ * Cherry Studio is a chat client (not a coding agent). Unlike OpenCode, it
+ * relies on Claude's *own* built-in web search rather than executing tools
+ * itself. Meridian blocks WebSearch/WebFetch globally for coding agents (they
+ * have their own equivalents), which is why #481 saw "no WebSearch/WebFetch
+ * tool exposed". This adapter unblocks the SDK's built-in web tools and runs
+ * internally (non-passthrough) so Claude executes the search and returns a
+ * grounded answer.
+ */
+import { describe, it, expect } from "bun:test"
+import { cherryAdapter } from "../proxy/adapters/cherry"
+import { cherryTransforms } from "../proxy/transforms/cherry"
+import { detectAdapter } from "../proxy/adapters/detect"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../proxy/tools"
+import type { RequestContext } from "../proxy/transform"
+
+function ctxFor(headers: Record<string, string>) {
+  const h = new Headers(headers)
+  return { req: { header: (k: string) => h.get(k) ?? undefined, raw: { headers: h } } } as any
+}
+
+describe("cherryAdapter identity", () => {
+  it("is named 'cherry'", () => {
+    expect(cherryAdapter.name).toBe("cherry")
+  })
+
+  it("runs in internal (non-passthrough) mode so the SDK executes WebSearch", () => {
+    expect(cherryAdapter.usesPassthrough?.()).toBe(false)
+  })
+})
+
+describe("cherryAdapter tool policy", () => {
+  it("does NOT block the built-in web tools", () => {
+    const blocked = cherryAdapter.getBlockedBuiltinTools()
+    expect(blocked).not.toContain("WebSearch")
+    expect(blocked).not.toContain("WebFetch")
+  })
+
+  it("still blocks the other built-ins (Read/Write/Bash/etc.)", () => {
+    const blocked = cherryAdapter.getBlockedBuiltinTools()
+    for (const t of BLOCKED_BUILTIN_TOOLS) {
+      if (t === "WebSearch" || t === "WebFetch") continue
+      expect(blocked).toContain(t)
+    }
+  })
+
+  it("does NOT list WebSearch among agent-incompatible tools", () => {
+    expect(cherryAdapter.getAgentIncompatibleTools()).not.toContain("WebSearch")
+  })
+
+  it("allows exactly the built-in web tools (no filesystem MCP tools for a chat client)", () => {
+    const allowed = cherryAdapter.getAllowedMcpTools()
+    expect([...allowed].sort()).toEqual(["WebFetch", "WebSearch"])
+  })
+})
+
+describe("cherryTransforms onRequest", () => {
+  const base: RequestContext = {
+    adapter: "cherry",
+    body: { messages: [{ role: "user", content: "search the web" }] },
+    headers: new Headers(),
+    model: "sonnet",
+    messages: [{ role: "user", content: "search the web" }],
+    systemContext: undefined,
+    tools: undefined,
+    stream: false,
+    workingDirectory: "/tmp",
+    blockedTools: [],
+    incompatibleTools: [],
+    allowedMcpTools: [],
+  } as any
+
+  const out = cherryTransforms[0]!.onRequest!(base)
+
+  it("puts WebSearch/WebFetch in the allowlist", () => {
+    expect([...out.allowedMcpTools].sort()).toEqual(["WebFetch", "WebSearch"])
+  })
+
+  it("keeps the web tools OUT of both disallowed lists", () => {
+    expect(out.blockedTools).not.toContain("WebSearch")
+    expect(out.blockedTools).not.toContain("WebFetch")
+    expect(out.incompatibleTools).not.toContain("WebSearch")
+  })
+
+  it("still disallows the rest of the blocked built-ins", () => {
+    for (const t of CLAUDE_CODE_ONLY_TOOLS) {
+      if (t === "WebSearch") continue
+      expect(out.incompatibleTools).toContain(t)
+    }
+  })
+
+  it("runs non-passthrough (SDK executes the search internally)", () => {
+    expect(out.passthrough).toBe(false)
+  })
+
+  it("hides internal tool_use and unrenderable thinking from the chat client", () => {
+    expect(out.hidesInternalTools).toBe(true)
+    expect(out.supportsThinking).toBe(false)
+  })
+})
+
+describe("detectAdapter → cherry", () => {
+  it("selects cherry via x-meridian-agent: cherry", () => {
+    expect(detectAdapter(ctxFor({ "x-meridian-agent": "cherry" })).name).toBe("cherry")
+  })
+
+  it("also accepts the 'cherrystudio' alias", () => {
+    expect(detectAdapter(ctxFor({ "x-meridian-agent": "cherrystudio" })).name).toBe("cherry")
+  })
+})

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -454,3 +454,73 @@ describe("Integration: native server tools fail fast", () => {
     expect(response.status).not.toBe(400)
   })
 })
+
+// ============================================================
+// CHERRY STUDIO ADAPTER — web search unblocked (#481)
+// ============================================================
+
+async function postAs(app: any, agent: string, body: any) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": "dummy", "x-meridian-agent": agent },
+    body: JSON.stringify(body),
+  }))
+}
+
+describe("Integration: Cherry Studio web search", () => {
+  let app: any
+
+  beforeAll(() => {
+    app = createTestApp()
+  })
+
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "Node.js 24 is the latest LTS." }])]
+    capturedQueryParams = null
+  })
+
+  it("invokes the SDK with WebSearch/WebFetch ALLOWED and NOT disallowed", async () => {
+    const response = await postAs(app, "cherry", {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [{ role: "user", content: "search the web for the latest node LTS" }],
+    })
+
+    expect(response.status).toBe(200)
+    const opts = capturedQueryParams.options
+    // Web tools are in the allowlist...
+    expect(opts.allowedTools).toContain("WebSearch")
+    expect(opts.allowedTools).toContain("WebFetch")
+    // ...and NOT blocked.
+    expect(opts.disallowedTools).not.toContain("WebSearch")
+    expect(opts.disallowedTools).not.toContain("WebFetch")
+    // Other built-ins stay blocked.
+    expect(opts.disallowedTools).toContain("Bash")
+  })
+
+  it("hides the SDK's internal WebSearch tool_use + thinking, returning only the final answer", async () => {
+    // Simulate the SDK's internal loop: turn 1 thinks + calls WebSearch, turn 2
+    // returns the grounded text. The client must see only the text.
+    mockMessages = [
+      assistantMessage([
+        { type: "thinking", thinking: "Let me search.", signature: "sig" },
+        { type: "tool_use", id: "srch1", name: "WebSearch", input: { query: "node lts" } },
+      ]),
+      assistantMessage([{ type: "text", text: "Node.js 24 is the latest LTS." }]),
+    ]
+
+    const response = await postAs(app, "cherry", {
+      model: "claude-sonnet-4-5",
+      max_tokens: 512,
+      stream: false,
+      messages: [{ role: "user", content: "latest node LTS?" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    expect(body.content.map((b: any) => b.type)).toEqual(["text"])
+    expect(body.content[0].text).toContain("Node.js 24")
+    expect(body.stop_reason).toBe("end_turn")
+  })
+})

--- a/src/proxy/adapters/cherry.ts
+++ b/src/proxy/adapters/cherry.ts
@@ -1,0 +1,79 @@
+/**
+ * Cherry Studio adapter.
+ *
+ * Cherry Studio (https://github.com/CherryHQ/cherry-studio) is a desktop chat
+ * client — not a coding agent. Pointed at Meridian it works for plain chat,
+ * but its web search failed (#481): the model reported it had "no WebSearch or
+ * WebFetch tool exposed". That's because Meridian blocks the SDK's built-in
+ * WebSearch/WebFetch globally — those are blocked for coding agents like
+ * OpenCode, which ship their own web-search equivalents (`websearch_web_search_exa`).
+ *
+ * Unlike a coding agent, Cherry Studio does NOT execute tools itself; it relies
+ * on Claude's own built-in web search. So this adapter:
+ *   - unblocks the SDK's built-in WebSearch/WebFetch (verified to work on the
+ *     Max/OAuth path — the SDK runs the search server-side and returns grounded
+ *     results), and
+ *   - runs in internal (non-passthrough) mode so the SDK actually executes the
+ *     search instead of trying to hand it back to a client that can't run it.
+ *
+ * It exposes only the web tools — no filesystem MCP tools — since a chat client
+ * has no business reading or writing files on the proxy host.
+ *
+ * Detection: selected via `x-meridian-agent: cherry` (or `cherrystudio`) or the
+ * `MERIDIAN_DEFAULT_AGENT=cherry` env var. Cherry Studio doesn't send a
+ * Meridian-specific header, so a user running a dedicated Meridian for it should
+ * set the env default. (If a distinctive User-Agent is confirmed, add UA
+ * detection in detect.ts.)
+ *
+ * NOTE: agent-specific. See ARCHITECTURE.md "Agent-Specific Logic".
+ */
+
+import type { AgentAdapter } from "../adapter"
+import { openCodeAdapter } from "./opencode"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../tools"
+
+/** The SDK built-in web tools Cherry Studio wants Claude to run itself. */
+export const CHERRY_WEB_TOOLS = ["WebSearch", "WebFetch"] as const
+
+const isWebTool = (t: string): boolean => (CHERRY_WEB_TOOLS as readonly string[]).includes(t)
+
+/** Built-ins blocked for Cherry — everything OpenCode blocks EXCEPT the web tools. */
+export const CHERRY_BLOCKED_BUILTIN_TOOLS = BLOCKED_BUILTIN_TOOLS.filter(t => !isWebTool(t))
+
+/** Incompatible tools for Cherry — CLAUDE_CODE_ONLY_TOOLS minus the web tools. */
+export const CHERRY_INCOMPATIBLE_TOOLS = CLAUDE_CODE_ONLY_TOOLS.filter(t => !isWebTool(t))
+
+export const cherryAdapter: AgentAdapter = {
+  // Identity (session tracking, cwd, content normalization) is identical to a
+  // generic Anthropic-API client, so reuse OpenCode's.
+  ...openCodeAdapter,
+  name: "cherry",
+
+  usesPassthrough(): boolean {
+    return false
+  },
+
+  // Cherry Studio has no renderer for the SDK's signed thinking blocks; strip
+  // them (see the hidesInternalTools handling in server.ts).
+  supportsThinking(): boolean {
+    return false
+  },
+
+  getBlockedBuiltinTools(): readonly string[] {
+    return CHERRY_BLOCKED_BUILTIN_TOOLS
+  },
+
+  getAgentIncompatibleTools(): readonly string[] {
+    return CHERRY_INCOMPATIBLE_TOOLS
+  },
+
+  getAllowedMcpTools(): readonly string[] {
+    return [...CHERRY_WEB_TOOLS]
+  },
+
+  // A chat client has no filesystem tools; override OpenCode's core list so
+  // auto-defer doesn't try to always-load read/write/edit/etc.
+  getCoreToolNames(): readonly string[] {
+    return []
+  },
+}

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -15,6 +15,7 @@ import { piAdapter } from "./pi"
 import { forgeCodeAdapter } from "./forgecode"
 import { claudeCodeAdapter } from "./claudecode"
 import { openAiAdapter } from "./openai"
+import { cherryAdapter } from "./cherry"
 
 const ADAPTER_MAP: Record<string, AgentAdapter> = {
   opencode: openCodeAdapter,
@@ -25,6 +26,9 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   forgecode: forgeCodeAdapter,
   "claude-code": claudeCodeAdapter,
   claudecode: claudeCodeAdapter,
+  // Cherry Studio chat client — unblocks the SDK's built-in web search (#481).
+  cherry: cherryAdapter,
+  cherrystudio: cherryAdapter,
   // Generic OpenAI-compatible endpoint (/v1/chat/completions). Selected via
   // the x-meridian-agent: openai tag the handler sets on the internal hop.
   openai: openAiAdapter,

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -78,6 +78,13 @@ const ADAPTER_DEFAULTS: Record<string, Partial<AdapterFeatures>> = {
   openai: {
     codeSystemPrompt: false,
   },
+  // Cherry Studio is a chat client that brings its own system prompt. Default
+  // the ~28KB Claude Code preset OFF (same rationale as openai/passthrough) so
+  // its prompt isn't overridden. WebSearch still works without the preset
+  // (verified). Users can flip it on via the settings UI.
+  cherry: {
+    codeSystemPrompt: false,
+  },
 }
 
 function getConfigPath(): string {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1470,6 +1470,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       claudeLog("passthrough.toolsearch_filtered", { mode: "non_stream" })
                       continue
                     }
+                    // Internal chat clients (Cherry Studio): the SDK executed
+                    // WebSearch/WebFetch itself. Hide the internal tool_use (the
+                    // client can't run it and would loop) and strip thinking the
+                    // client can't render — leave only the final grounded answer.
+                    if (pipelineCtx.hidesInternalTools) {
+                      if (b.type === "tool_use") {
+                        claudeLog("internal_tool.hidden", { mode: "non_stream", name: (b as any).name })
+                        continue
+                      }
+                      if ((b.type === "thinking" || b.type === "redacted_thinking") && !sdkFeatures.thinkingPassthrough) {
+                        claudeLog("internal_tool.thinking_stripped", { mode: "non_stream", type: b.type })
+                        continue
+                      }
+                    }
                     // Strip thinking blocks — meaningless to non-native clients
                     if (passthrough && !pipelineCtx.supportsThinking && !sdkFeatures.thinkingPassthrough && (b.type === "thinking" || b.type === "redacted_thinking")) {
                       claudeLog("passthrough.thinking_stripped", { mode: "non_stream", type: b.type })
@@ -2110,6 +2124,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
                     if (eventType === "content_block_start") {
                       const block = (event as any).content_block
+                      // Internal chat clients (Cherry Studio): the SDK executes
+                      // WebSearch/WebFetch itself. Skip the internal tool_use
+                      // block (client can't run it) and the thinking blocks it
+                      // can't render, so the stream carries only the final answer.
+                      if (
+                        pipelineCtx.hidesInternalTools &&
+                        (block?.type === "tool_use" ||
+                          ((block?.type === "thinking" || block?.type === "redacted_thinking") && !sdkFeatures.thinkingPassthrough))
+                      ) {
+                        if (eventIndex !== undefined) skipBlockIndices.add(eventIndex)
+                        claudeLog("internal_tool.hidden", { mode: "stream", type: block?.type, name: block?.name, index: eventIndex })
+                        continue
+                      }
                       // Strip thinking blocks in passthrough mode — non-native clients
                       // have no renderer for type:"thinking" and may choke on the
                       // encrypted signature field.

--- a/src/proxy/transform.ts
+++ b/src/proxy/transform.ts
@@ -68,6 +68,16 @@ export interface RequestContext {
   supportsThinking: boolean
   shouldTrackFileChanges: boolean
   leaksCwdViaSystemReminder: boolean
+  /**
+   * The client is a pure chat client (no tool-execution loop) that runs the
+   * SDK in internal mode purely to reach Claude's own built-in tools (e.g.
+   * Cherry Studio using WebSearch). The SDK executes those tools itself, so the
+   * proxy must NOT surface the internal tool_use blocks — the client can't run
+   * them and would loop or choke — and should strip thinking blocks it can't
+   * render. Default false: normal internal-mode agents (Droid) keep current
+   * behaviour (their internal tools are mcp__-prefixed and already hidden).
+   */
+  hidesInternalTools?: boolean
   prefersStreaming?: boolean
   extractFileChangesFromToolUse?: (toolName: string, toolInput: unknown) => FileChange[]
 

--- a/src/proxy/transforms/cherry.ts
+++ b/src/proxy/transforms/cherry.ts
@@ -1,0 +1,44 @@
+import type { Transform, RequestContext } from "../transform"
+import {
+  CHERRY_WEB_TOOLS,
+  CHERRY_BLOCKED_BUILTIN_TOOLS,
+  CHERRY_INCOMPATIBLE_TOOLS,
+} from "../adapters/cherry"
+
+/**
+ * Cherry Studio transform — supplies the SDK tool config at request time.
+ *
+ * The runtime tool policy lives here (server.ts reads `pipelineCtx.*`, not the
+ * adapter methods). Cherry is a chat client that wants Claude's own built-in
+ * web search, so we:
+ *   - allow only WebSearch/WebFetch (no filesystem MCP tools),
+ *   - keep those web tools OUT of the disallowed lists, and
+ *   - run non-passthrough so the SDK executes the search internally.
+ *
+ * See adapters/cherry.ts for the full rationale and #481.
+ */
+export const cherryTransforms: Transform[] = [
+  {
+    name: "cherry-core",
+    adapters: ["cherry"],
+
+    onRequest(ctx: RequestContext): RequestContext {
+      return {
+        ...ctx,
+        blockedTools: CHERRY_BLOCKED_BUILTIN_TOOLS,
+        incompatibleTools: CHERRY_INCOMPATIBLE_TOOLS,
+        allowedMcpTools: [...CHERRY_WEB_TOOLS],
+        coreToolNames: [],
+        passthrough: false,
+        // Cherry executes no tools itself — the SDK runs WebSearch internally.
+        // Hide the resulting internal tool_use blocks (and unrenderable thinking)
+        // from the client so it sees only the final grounded answer.
+        hidesInternalTools: true,
+        supportsThinking: false,
+        // Cherry Studio renders assistant text; it has no native "files
+        // changed" surface and doesn't execute tools, so nothing to track.
+        shouldTrackFileChanges: false,
+      }
+    },
+  },
+]

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -5,6 +5,7 @@ import { droidTransforms } from "./droid"
 import { piTransforms } from "./pi"
 import { forgeCodeTransforms } from "./forgecode"
 import { passthroughTransforms } from "./passthrough"
+import { cherryTransforms } from "./cherry"
 
 const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   opencode: openCodeTransforms,
@@ -13,6 +14,7 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   pi: piTransforms,
   forgecode: forgeCodeTransforms,
   passthrough: passthroughTransforms,
+  cherry: cherryTransforms,
   // The OpenAI-compatible endpoint reuses OpenCode's transforms verbatim so
   // tool/passthrough behaviour is identical; only the preset default differs
   // (see sdkFeatures.ADAPTER_DEFAULTS.openai).


### PR DESCRIPTION
Closes #481. **Supersedes #487** (my earlier attempt, parked pending real-UI verification — see below).

## What

Adds a `cherry` adapter so Cherry Studio (a desktop chat client) can use Claude's **built-in web search** through Meridian, fixing the "no WebSearch/WebFetch tool exposed" error from #481.

## Why #481 happened

Cherry Studio is a chat client, not a coding agent — it relies on Claude's own `WebSearch`/`WebFetch` rather than executing tools itself. Meridian blocks those built-ins globally for coding agents (OpenCode et al. ship their own equivalents like `websearch_web_search_exa`), so Cherry fell through to the default adapter and got web search blocked.

## The adapter

- **Unblocks WebSearch/WebFetch** and **puts them in the allowlist** (`getAllowedMcpTools() → ["WebSearch","WebFetch"]`). This second part is load-bearing: the SDK's `allowedTools` is an *allowlist*, so unblocking alone isn't enough — the tool must be explicitly allowed.
- **Internal (non-passthrough) mode** so the SDK executes the search itself.
- **Hides the SDK's internal `tool_use` + `thinking` blocks** from the client (both streaming and non-streaming) so Cherry sees only the final grounded answer with `stop_reason: end_turn` — not a phantom `tool_use` it can't execute.
- Exposes only the web tools (no filesystem access for a chat client); preset OFF (bring-your-own prompt, like the `openai` adapter).

Scoped via a new `hidesInternalTools` flag set **only** by Cherry, so Droid and other internal-mode adapters are byte-for-byte unaffected (their internal tools are `mcp__`-prefixed and already hidden).

## Why this supersedes #487

#487 was the right idea but never got its required real-UI verification. Two gaps it would have hit:
1. It returned `getAllowedMcpTools() → []`, so `allowedTools` would be empty — WebSearch likely never actually exposed.
2. It didn't hide the internal `tool_use`/`thinking`, so responses would carry `stop_reason: tool_use` + a WebSearch block the client can't run.

## Verification

- Proved the SDK's built-in WebSearch **works on the Max/OAuth path** (live probe returned a grounded answer + source URLs).
- Ran the full adapter end-to-end through the real proxy (`startProxyServer` + `x-meridian-agent: cherry`): both **stream and non-stream** return only the final answer, `stop_reason: end_turn`, no leaked `tool_use`.
- Unit tests (adapter + transform + detection) and HTTP integration tests (WebSearch allowed/not-disallowed, internal tool_use hidden). Full suite: 1908 pass / 0 fail; `tsc --noEmit` clean.

## Selection

`MERIDIAN_DEFAULT_AGENT=cherry meridian`, or `x-meridian-agent: cherry` (Cherry Studio has no stable User-Agent, so no auto-detection).

> Still worth a sanity check in the actual Cherry Studio UI, but unlike #487 the server side is now verified working end-to-end.