### PR TITLE
perf(passthrough): eliminate the billed digest turn after tool capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ MERIDIAN_PASSTHROUGH=0 meridian   # force internal
 
 For large tool sets (>15 tools), non-core tools are automatically deferred via the SDK's ToolSearch mechanism. Core tools (read, write, edit, bash, glob, grep) are always loaded eagerly. The deferral threshold is configurable with `MERIDIAN_DEFER_TOOL_THRESHOLD`.
 
+**Digest-turn elimination** — after a tool call is captured, the SDK would normally invoke the model one more time to "digest" the denial before ending the turn. That extra invocation is discarded by the proxy but fully billed — measured at ~400+ wasted output tokens and 2–3× extra latency per tool step (and on always-thinking models like Fable, a full thinking pass each time). Meridian now aborts the SDK query the moment every tool call's denial is persisted, so the digest turn never generates. Sessions remain resumable and tool-result attribution is unaffected. Kill switch: `MERIDIAN_PASSTHROUGH_EARLY_STOP=0` restores the old behavior.
+
 ### Known limitations
 
 - **Single tool round-trip per request** — in passthrough mode, the SDK is configured with `maxTurns=2` (or 3 for deferred tools). Multi-step agentic loops where Claude needs several consecutive tool calls require the client to re-send after each round.

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Integration tests for the passthrough early stop — full HTTP layer, mocked SDK.
+ *
+ * The mock counts how many messages the proxy actually CONSUMES from the SDK
+ * stream. With early stop, consumption must halt at the deny tool_result —
+ * the digest-turn message (turn 2) is never pulled, which in production means
+ * the digest API call never generates (the billed waste this feature removes).
+ */
+import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { assistantMessage, messageStart, toolUseBlockStart, inputJsonDelta, blockStop, messageDelta } from "./helpers"
+
+let mockMessages: any[] = []
+let yieldedCount = 0
+let capturedQueryParams: any = null
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParams = params
+    return (async function* () {
+      for (const msg of mockMessages) {
+        yieldedCount++
+        yield msg
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+
+function userDenyMessage(toolUseId: string) {
+  return {
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: "forwarded to client", is_error: true }],
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: "test-session",
+  }
+}
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file",
+  input_schema: { type: "object", properties: { file_path: { type: "string" } }, required: ["file_path"] },
+}
+
+async function post(app: any, body: any, sessionHeader = "es-session") {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": sessionHeader,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify(body),
+  }))
+}
+
+describe("Integration: passthrough early stop", () => {
+  let app: any
+  let savedPassthrough: string | undefined
+  let savedEarlyStop: string | undefined
+
+  beforeAll(() => {
+    const { app: a } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    app = a
+  })
+
+  beforeEach(() => {
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    savedEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    mockMessages = []
+    yieldedCount = 0
+    capturedQueryParams = null
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    if (savedEarlyStop !== undefined) process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = savedEarlyStop
+    else delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+  })
+
+  it("non-stream: stops consuming at the deny — digest turn never pulled, abort fired", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "text", text: "Reading the file." },
+        { type: "tool_use", id: "tu1", name: "read", input: { file_path: "/etc/hostname" } },
+      ]),
+      userDenyMessage("tu1"),
+      assistantMessage([{ type: "text", text: "TURN2_GARBAGE_DIGEST" }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read /etc/hostname" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    expect(body.stop_reason).toBe("tool_use")
+    const types = body.content.map((b: any) => b.type)
+    expect(types).toContain("tool_use")
+    expect(JSON.stringify(body.content)).not.toContain("TURN2_GARBAGE_DIGEST")
+    // The money assertion: only turn 1 + the deny were consumed.
+    expect(yieldedCount).toBe(2)
+    // The proxy aborted the SDK query (kills the digest turn in production).
+    expect(capturedQueryParams.options.abortController?.signal?.aborted).toBe(true)
+  })
+
+  it("non-stream: the early-stopped session is stored and the next turn resumes it", async () => {
+    mockMessages = [
+      assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
+      userDenyMessage("tu1"),
+    ]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-resume")
+    expect(first.status).toBe(200)
+
+    // Client executed the tool; extended conversation comes back.
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says hi" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "hi" }] },
+      ],
+    }, "es-resume")
+    expect(second.status).toBe(200)
+    // Resume proof: the SDK was invoked with the stored session id.
+    expect(capturedQueryParams.options.resume).toBe("test-session")
+  })
+
+  it("non-stream: waits for ALL parallel denies before stopping", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "tu1", name: "read", input: { file_path: "a" } },
+        { type: "tool_use", id: "tu2", name: "grep", input: { pattern: "b" } },
+      ]),
+      userDenyMessage("tu1"),
+      userDenyMessage("tu2"),
+      assistantMessage([{ type: "text", text: "TURN2_GARBAGE_DIGEST" }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a and grep b" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    // Both tool_use blocks reach the client — the first deny must not cut off tu2.
+    const ids = body.content.filter((b: any) => b.type === "tool_use").map((b: any) => b.id)
+    expect(ids).toContain("tu1")
+    expect(ids).toContain("tu2")
+    expect(yieldedCount).toBe(3) // turn1 + two denies; digest never pulled
+  })
+
+  it("non-stream: text-only answers are unaffected (no tool calls, no abort)", async () => {
+    mockMessages = [
+      assistantMessage([{ type: "text", text: "just an answer" }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "hi" }],
+    })
+
+    const body = await response.json() as any
+    expect(response.status).toBe(200)
+    expect(body.stop_reason).toBe("end_turn")
+    expect(body.content[0].text).toBe("just an answer")
+    expect(yieldedCount).toBe(1) // fully consumed (only 1 message)
+    expect(capturedQueryParams.options.abortController?.signal?.aborted ?? false).toBe(false)
+  })
+
+  it("kill switch: MERIDIAN_PASSTHROUGH_EARLY_STOP=0 restores full drain", async () => {
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
+    mockMessages = [
+      assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
+      userDenyMessage("tu1"),
+      assistantMessage([{ type: "text", text: "digest" }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    })
+
+    expect(response.status).toBe(200)
+    expect(yieldedCount).toBe(3) // everything drained, old behavior
+  })
+
+  it("stream: closes cleanly after the deny — digest events never consumed", async () => {
+    mockMessages = [
+      messageStart("msg_es"),
+      toolUseBlockStart(0, "read", "tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
+      userDenyMessage("tu1"),
+      // digest turn events — must never be consumed:
+      messageStart("msg_turn2"),
+      assistantMessage([{ type: "text", text: "TURN2_GARBAGE_DIGEST" }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    })
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain('"type":"tool_use"')
+    expect(text).toContain("message_stop")
+    expect(text).not.toContain("TURN2_GARBAGE_DIGEST")
+
+    // The client response completes at turn-1's stop_reason:"tool_use"; the
+    // drain + abort continue in the background. Wait for the abort to land
+    // before asserting consumption.
+    const deadline = Date.now() + 2000
+    while (
+      !capturedQueryParams.options.abortController?.signal?.aborted &&
+      Date.now() < deadline
+    ) {
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+    expect(capturedQueryParams.options.abortController?.signal?.aborted).toBe(true)
+    expect(yieldedCount).toBe(7) // up to and including the deny; turn-2 events never pulled
+  })
+})

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the passthrough early-stop tracker — pure functions, no mocks.
+ *
+ * In passthrough, the model's tool calls are denied ("forwarded to client")
+ * and the SDK then invokes the model AGAIN to digest the deny — a throwaway
+ * turn that is fully billed (on always-thinking models it's a whole thinking
+ * pass per tool step). The tracker watches the SDK stream: once every
+ * client-forwarded tool_use has its deny tool_result persisted (observed as a
+ * `user` message), the proxy can abort the query BEFORE the digest turn fires.
+ * Verified SDK behavior: denied tool_results ARE emitted as user messages
+ * between assistant turns.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  createEarlyStopTracker,
+  isClientForwardedToolUse,
+  noteAssistantContent,
+  noteUserContent,
+  shouldEarlyStop,
+} from "../proxy/passthroughEarlyStop"
+
+import { PASSTHROUGH_MCP_PREFIX } from "../proxy/passthroughTools"
+
+const toolUse = (id: string, name: string) => ({ type: "tool_use", id, name })
+const toolResult = (id: string) => ({ type: "tool_result", tool_use_id: id, is_error: true })
+
+describe("prefix cross-check", () => {
+  it("tracker's duplicated prefix matches the passthrough MCP prefix", () => {
+    // The tracker duplicates the prefix to stay leaf-pure; this guards drift.
+    expect(isClientForwardedToolUse(toolUse("t1", `${PASSTHROUGH_MCP_PREFIX}read`))).toBe(true)
+  })
+})
+
+describe("isClientForwardedToolUse", () => {
+  it("matches passthrough-prefixed MCP tools", () => {
+    expect(isClientForwardedToolUse(toolUse("t1", "mcp__oc__read"))).toBe(true)
+  })
+
+  it("matches bare tool names (SDK sometimes strips the prefix in events)", () => {
+    expect(isClientForwardedToolUse(toolUse("t1", "read"))).toBe(true)
+    expect(isClientForwardedToolUse(toolUse("t2", "Bash"))).toBe(true)
+  })
+
+  it("excludes ToolSearch (internal, SDK-executed for deferred loading)", () => {
+    expect(isClientForwardedToolUse(toolUse("t1", "ToolSearch"))).toBe(false)
+  })
+
+  it("excludes internal MCP tools from other servers", () => {
+    expect(isClientForwardedToolUse(toolUse("t1", "mcp__opencode__read"))).toBe(false)
+  })
+
+  it("excludes non-tool_use blocks", () => {
+    expect(isClientForwardedToolUse({ type: "text", text: "hi" })).toBe(false)
+    expect(isClientForwardedToolUse({ type: "server_tool_use", id: "s1", name: "advisor" })).toBe(false)
+  })
+
+  it("excludes tool_use blocks with no id (can't be tracked)", () => {
+    expect(isClientForwardedToolUse({ type: "tool_use", name: "read" })).toBe(false)
+  })
+})
+
+describe("early-stop tracking", () => {
+  it("does not stop before any tool calls are seen", () => {
+    const t = createEarlyStopTracker()
+    expect(shouldEarlyStop(t)).toBe(false)
+  })
+
+  it("does not stop on a text-only assistant turn", () => {
+    const t = createEarlyStopTracker()
+    noteAssistantContent(t, [{ type: "text", text: "final answer" }])
+    expect(shouldEarlyStop(t)).toBe(false)
+  })
+
+  it("stops after the single tool call's deny is observed", () => {
+    const t = createEarlyStopTracker()
+    noteAssistantContent(t, [toolUse("t1", "mcp__oc__read")])
+    expect(shouldEarlyStop(t)).toBe(false) // deny not yet persisted
+    noteUserContent(t, [toolResult("t1")])
+    expect(shouldEarlyStop(t)).toBe(true)
+  })
+
+  it("waits for ALL parallel tool calls' denies before stopping", () => {
+    const t = createEarlyStopTracker()
+    noteAssistantContent(t, [
+      { type: "text", text: "reading both" },
+      toolUse("t1", "mcp__oc__read"),
+      toolUse("t2", "mcp__oc__grep"),
+    ])
+    noteUserContent(t, [toolResult("t1")])
+    expect(shouldEarlyStop(t)).toBe(false) // t2's deny still pending — do NOT drop it
+    noteUserContent(t, [toolResult("t2")])
+    expect(shouldEarlyStop(t)).toBe(true)
+  })
+
+  it("fires only once (idempotent after stop)", () => {
+    const t = createEarlyStopTracker()
+    noteAssistantContent(t, [toolUse("t1", "read")])
+    noteUserContent(t, [toolResult("t1")])
+    expect(shouldEarlyStop(t)).toBe(true)
+    expect(shouldEarlyStop(t)).toBe(false)
+  })
+
+  it("ignores ToolSearch turns — waits for the real tool call (deferred flow)", () => {
+    const t = createEarlyStopTracker()
+    // Turn 1: ToolSearch (internal, executes for real)
+    noteAssistantContent(t, [toolUse("ts1", "ToolSearch")])
+    noteUserContent(t, [toolResult("ts1")]) // real ToolSearch result
+    expect(shouldEarlyStop(t)).toBe(false)
+    // Turn 2: the actual client tool call
+    noteAssistantContent(t, [toolUse("t1", "mcp__oc__read")])
+    noteUserContent(t, [toolResult("t1")])
+    expect(shouldEarlyStop(t)).toBe(true)
+  })
+
+  it("ignores unrelated tool_results (defensive)", () => {
+    const t = createEarlyStopTracker()
+    noteAssistantContent(t, [toolUse("t1", "read")])
+    noteUserContent(t, [toolResult("unknown-id")])
+    expect(shouldEarlyStop(t)).toBe(false)
+  })
+
+  it("tolerates non-array and malformed content", () => {
+    const t = createEarlyStopTracker()
+    noteAssistantContent(t, "just a string" as unknown)
+    noteAssistantContent(t, null as unknown)
+    noteUserContent(t, undefined as unknown)
+    noteUserContent(t, [{ type: "text", text: "hi" }])
+    expect(shouldEarlyStop(t)).toBe(false)
+  })
+})

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -1,0 +1,101 @@
+/**
+ * Passthrough early-stop tracking.
+ *
+ * In passthrough mode the PreToolUse hook denies every client tool call
+ * ("forwarded to client — end your turn"), but the SDK then invokes the model
+ * one more time to digest the deny. That digest turn is discarded by the proxy
+ * yet fully billed — and on always-thinking models (Fable) it costs a whole
+ * thinking pass per tool step, roughly doubling per-step output spend and
+ * adding a full model round-trip of latency.
+ *
+ * The fix: the SDK emits each denied call's tool_result as a `user` message in
+ * the stream (verified against the real SDK) BEFORE it fires the digest turn's
+ * API request. So the proxy can watch the stream, and the moment every
+ * client-forwarded tool_use from the assistant turn has its deny persisted,
+ * abort the query — the digest turn never generates. Because the denies are
+ * already recorded in the SDK session history at that point, the session stays
+ * coherent and can be stored + resumed (unlike the #580 duplicate-abort case,
+ * which fires mid-hook before persistence).
+ *
+ * Pure module — no I/O, no imports from server.ts or session/.
+ */
+
+/** Passthrough MCP prefix — mirrors PASSTHROUGH_MCP_PREFIX in passthroughTools.
+ *  Duplicated here (with a cross-check test) to keep this module leaf-pure. */
+const CLIENT_TOOL_PREFIX = "mcp__oc__"
+
+/** Internal SDK tool that executes for real (deferred tool discovery) — its
+ *  calls are never forwarded to the client and must not arm the tracker. */
+const INTERNAL_TOOLS = new Set(["ToolSearch"])
+
+export interface EarlyStopTracker {
+  /** tool_use ids of client-forwarded calls awaiting a persisted deny result */
+  expected: Set<string>
+  /** subset of `expected` whose tool_result has been observed in the stream */
+  resolved: Set<string>
+  /** true once shouldEarlyStop has returned true — it fires at most once */
+  fired: boolean
+}
+
+export function createEarlyStopTracker(): EarlyStopTracker {
+  return { expected: new Set(), resolved: new Set(), fired: false }
+}
+
+/**
+ * Is this content block a tool call that the proxy forwards to the client
+ * (as opposed to an internal tool the SDK executes itself)?
+ *
+ * Client tools appear either with the passthrough MCP prefix (mcp__oc__read)
+ * or as bare names (read) — the SDK strips the prefix in some event paths.
+ * Internal MCP tools (mcp__opencode__*) and ToolSearch are excluded.
+ */
+export function isClientForwardedToolUse(block: unknown): boolean {
+  const b = block as { type?: unknown; id?: unknown; name?: unknown } | null | undefined
+  if (!b || b.type !== "tool_use") return false
+  if (typeof b.id !== "string" || b.id.length === 0) return false
+  if (typeof b.name !== "string") return false
+  if (INTERNAL_TOOLS.has(b.name)) return false
+  if (b.name.startsWith("mcp__") && !b.name.startsWith(CLIENT_TOOL_PREFIX)) return false
+  return true
+}
+
+/**
+ * Record the client-forwarded tool_use ids from an assistant message's content.
+ */
+export function noteAssistantContent(tracker: EarlyStopTracker, content: unknown): void {
+  if (!Array.isArray(content)) return
+  for (const block of content) {
+    if (isClientForwardedToolUse(block)) {
+      tracker.expected.add((block as { id: string }).id)
+    }
+  }
+}
+
+/**
+ * Record persisted tool_results from a user message's content. Only results
+ * matching an expected id count — unrelated results are ignored.
+ */
+export function noteUserContent(tracker: EarlyStopTracker, content: unknown): void {
+  if (!Array.isArray(content)) return
+  for (const block of content) {
+    const b = block as { type?: unknown; tool_use_id?: unknown } | null | undefined
+    if (b?.type === "tool_result" && typeof b.tool_use_id === "string" && tracker.expected.has(b.tool_use_id)) {
+      tracker.resolved.add(b.tool_use_id)
+    }
+  }
+}
+
+/**
+ * True exactly once: when at least one client tool call was forwarded and
+ * every forwarded call's deny has been observed in the stream. At that point
+ * the digest turn hasn't generated yet — the caller should abort the query.
+ */
+export function shouldEarlyStop(tracker: EarlyStopTracker): boolean {
+  if (tracker.fired) return false
+  if (tracker.expected.size === 0) return false
+  for (const id of tracker.expected) {
+    if (!tracker.resolved.has(id)) return false
+  }
+  tracker.fired = true
+  return true
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -41,6 +41,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
+import { createEarlyStopTracker, noteAssistantContent, noteUserContent, shouldEarlyStop } from "./passthroughEarlyStop"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -965,6 +966,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const capturedSignatures = new Set<string>()
       const capturedToolNames = new Set<string>()
       let sawDuplicateToolUse = false
+      // Early stop: the moment every forwarded tool call's deny is persisted
+      // (observed as a `user` tool_result in the stream), abort the query so
+      // the SDK's digest turn — a fully-billed, discarded model invocation
+      // (a whole thinking pass per tool step on always-thinking models) —
+      // never generates. Unlike the duplicate-abort above, the session history
+      // is coherent at that point (deny recorded), so the session is stored
+      // and resumed normally. Kill switch: MERIDIAN_PASSTHROUGH_EARLY_STOP=0.
+      const earlyStopEnabled = passthrough && process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP !== "0"
+      const earlyStop = createEarlyStopTracker()
+      let earlyStopFired = false
       // Forced structured output: a `tool_choice` of {type:"tool",...} (or an
       // explicit disable_parallel_tool_use) means the client — e.g. the AI
       // SDK's generateObject — wants EXACTLY ONE call to that tool. Claude
@@ -1425,6 +1436,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 claudeLog("passthrough.loop_break", { mode: "non_stream", assistantMessages, captured: capturedToolUses.length })
                 break
               }
+              // Early stop: abort before the digest turn generates (see the
+              // earlyStop declaration above). The deny tool_results arrive as
+              // `user` messages; when every forwarded call's deny is persisted,
+              // the SDK-side history is coherent and turn 2 hasn't fired yet.
+              if (earlyStopEnabled) {
+                if (message.type === "assistant") {
+                  noteAssistantContent(earlyStop, (message as any).message?.content)
+                } else if (message.type === "user") {
+                  noteUserContent(earlyStop, (message as any).message?.content)
+                  if (shouldEarlyStop(earlyStop)) {
+                    earlyStopFired = true
+                    claudeLog("passthrough.early_stop", { mode: "non_stream", captured: capturedToolUses.length })
+                    requestAbort.abort("passthrough turn complete")
+                    break
+                  }
+                }
+              }
               if (message.type === "assistant") {
                 assistantMessages += 1
                 // Capture SDK assistant UUID for undo rollback
@@ -1715,12 +1743,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // Store session for future resume.
           // Fork/subagent requests don't write to the cache — see lookupSession
           // block above for rationale (avoids polluting the parent's key).
-          // Single-step-aborted sessions are never offered for resume: the
-          // SIGTERM lands before the dropped call's deny is persisted, so the
-          // SDK-side history holds a dangling tool_use ("Stream closed") that
-          // diverges from the client's view — resuming it hands the model
-          // memory of a call whose result never arrives (#552). A fresh
-          // session rebuilt from client history is coherent by construction.
+          // Duplicate-aborted sessions (sawDuplicateToolUse) are never offered
+          // for resume: that SIGTERM lands before the dropped call's deny is
+          // persisted, so the SDK-side history holds a dangling tool_use
+          // ("Stream closed") that diverges from the client's view — resuming
+          // it hands the model memory of a call whose result never arrives
+          // (#552). A fresh session rebuilt from client history is coherent by
+          // construction. Early-stop aborts (earlyStopFired) are different:
+          // they fire only AFTER every forwarded call's deny was observed in
+          // the stream (already persisted), so the history is coherent and the
+          // session is safe to store and resume.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
@@ -1761,6 +1793,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             let textEventsForwarded = 0
             let bytesSent = 0
             let streamClosed = false
+            // Early-stop drain: after the client stream closes at turn-1's
+            // stop_reason:"tool_use", keep consuming SDK messages (nothing is
+            // forwarded — safeEnqueue no-ops once streamClosed) until every
+            // forwarded call's deny is persisted, then abort the query so the
+            // digest turn never generates. Without this the subprocess keeps
+            // running in the background and turn 2 is fully billed, invisibly.
+            let awaitingEarlyStopDrain = false
 
             claudeLog("upstream.start", { mode: "stream", model })
 
@@ -2034,7 +2073,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               )
               try {
                 for await (const message of guardedResponse) {
-                  if (streamClosed) {
+                  if (streamClosed && !awaitingEarlyStopDrain) {
                     break
                   }
 
@@ -2044,6 +2083,41 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   }
                   if (message.type === "assistant" && (message as any).uuid) {
                     sdkUuidMap.push((message as any).uuid)
+                  }
+                  // Early stop: abort before the digest turn generates (see the
+                  // earlyStop declaration above). By deny time the client has
+                  // already received all turn-1 blocks and the stop_reason
+                  // message_delta, so mirror the turn-2 suppression path's
+                  // clean close (message_delta + message_stop) and abort.
+                  if (earlyStopEnabled) {
+                    if (message.type === "assistant") {
+                      noteAssistantContent(earlyStop, (message as any).message?.content)
+                    } else if (message.type === "user") {
+                      noteUserContent(earlyStop, (message as any).message?.content)
+                      // streamedToolUseIds ≥ 1 guarantees the client actually
+                      // received a tool_use block before we stop the query.
+                      // Normally the client stream is already closed by the
+                      // stop_reason:"tool_use" close above (drain mode) — the
+                      // emissions below only fire in the unusual case where the
+                      // denies arrive first (safeEnqueue no-ops when closed).
+                      if (shouldEarlyStop(earlyStop) && streamedToolUseIds.size > 0) {
+                        earlyStopFired = true
+                        claudeLog("passthrough.early_stop", { mode: "stream", captured: capturedToolUses.length, drained: awaitingEarlyStopDrain })
+                        safeEnqueue(encoder.encode(
+                          `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: lastUsage?.output_tokens ?? 0 } })}\n\n`
+                        ), "early_stop")
+                        safeEnqueue(encoder.encode(
+                          `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+                        ), "early_stop")
+                        requestAbort.abort("passthrough turn complete")
+                        awaitingEarlyStopDrain = false
+                        if (!streamClosed) {
+                          streamClosed = true
+                          try { controller.close() } catch {}
+                        }
+                        break
+                      }
+                    }
                   }
                   if (message.type === "result") {
                     const resultUsage = (message as { usage?: unknown }).usage as TokenUsage | undefined
@@ -2271,11 +2345,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       if (typeof idx === "number") openClientBlocks.delete(idx)
                     }
 
-                    // NOTE: agent-specific (passthrough mode) — break immediately when
-                    // the model stops for tool_use so the client can execute the tools
-                    // and send results back. Without this the SDK executes the passthrough
-                    // MCP no-op (→ "passthrough"), feeds that back to the model, and the
-                    // model produces an incorrect fallback response which gets forwarded.
+                    // NOTE: agent-specific (passthrough mode) — close the client stream
+                    // immediately when the model stops for tool_use so the client can
+                    // execute the tools and send results back. Without this the SDK
+                    // executes the passthrough MCP no-op (→ "passthrough"), feeds that
+                    // back to the model, and the model produces an incorrect fallback
+                    // response which gets forwarded.
+                    //
+                    // With early stop enabled, don't break — keep DRAINING the SDK
+                    // stream (nothing forwards after close) until every deny is
+                    // persisted, then abort so the digest turn never generates.
+                    // Without early stop (kill switch), break as before: the
+                    // subprocess finishes turn 2 in the background (billed).
                     if (
                       passthrough &&
                       eventType === "message_delta" &&
@@ -2288,6 +2369,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       )
                       streamClosed = true
                       controller.close()
+                      if (earlyStopEnabled) {
+                        awaitingEarlyStopDrain = true
+                        continue
+                      }
                       break
                     }
 
@@ -2374,10 +2459,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               // Store session for future resume.
               // Fork/subagent requests don't write to the cache (see lookupSession
-              // block for rationale). Single-step-aborted sessions are never
+              // block for rationale). Duplicate-aborted sessions are never
               // offered for resume — their history holds a dangling dropped
-              // call that diverges from the client's view (#552); see the
-              // non-stream store above.
+              // call that diverges from the client's view (#552). Early-stop
+              // aborts are safe to store: every deny was persisted before the
+              // abort. See the non-stream store above.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
@@ -2600,12 +2686,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // tools and drives the next turn (the same outcome as a normal
               // tool-use cycle). Without this, the client sees a 500 even
               // though we already streamed everything it needs.
-              // "aborted" is accepted only for the proxy's own single-step
-              // abort (sawDuplicateToolUse) — a client-disconnect abort must
+              // "aborted" is accepted only for the proxy's own aborts — the
+              // single-step duplicate abort (sawDuplicateToolUse) or the
+              // early stop (earlyStopFired) — a client-disconnect abort must
               // not be recorded as a recovered success.
               const canRecoverAsToolUse =
                 (sdkTerm.reason === "max_turns" ||
-                  (sdkTerm.reason === "aborted" && sawDuplicateToolUse)) &&
+                  (sdkTerm.reason === "aborted" && (sawDuplicateToolUse || earlyStopFired))) &&
                 passthrough &&
                 capturedToolUses.length > 0 &&
                 messageStartEmitted


### PR DESCRIPTION
## The waste

In passthrough, every tool step pays for a **discarded model invocation**. After the PreToolUse hook denies a captured tool call ("forwarded to client"), the SDK invokes the model AGAIN to digest that deny. The proxy throws the result away — but it's fully billed:

- **~415 wasted output tokens per tool step** (the model fabricates a response to the deny)
- **3–4× extra latency per tool step** (a whole model round-trip)
- On always-thinking models (**Fable**), an additional **full thinking pass per tool step**

In streaming mode the waste was *invisible*: the client stream closes at `stop_reason: tool_use`, but the subprocess kept generating turn 2 in the background, billed.

This is the root cause of "token usage through Meridian is much higher than native Claude Code" (#496 follow-up reports) — the overhead multiplies with fable's per-invocation thinking.

## The fix

The SDK emits each denied call's tool_result as a `user` message in the stream **before** it fires the digest turn's API request (verified against the real SDK). So:

1. Track forwarded `tool_use` ids from assistant messages (`passthroughEarlyStop.ts`, pure)
2. Track their deny tool_results from user messages
3. The moment **every** forwarded call's deny is persisted → abort the query. Digest turn never generates.

Because the denies are already recorded in session history at abort time, the session is **coherent** — stored and resumed normally (unlike the duplicate-abort path, #552/#580, which aborts mid-hook before persistence; that path is unchanged).

Streaming: keeps its immediate client close at `stop_reason: tool_use`, then **drains** the SDK stream in the background (nothing forwards after close) until the denies land, then aborts.

## Proof (headless, real SDK, real Max)

Same 3-turn tool conversation, baseline (kill switch) vs early stop:

| | Baseline | Early stop |
|---|---|---|
| T1 tool turn tokens (in+out) | 449 | **11** |
| T1 latency | 15.8s | **4.0s** |
| T3 tool turn tokens | 210 | **18** |
| T3 latency | 9.7s | **2.9s** |
| #552 correctness (tool result attributed exactly) | ✅ | ✅ stream + non-stream |
| Session resume (T2/T3 cache_read ≈ 8.3k, create ≈ 196) | ✅ | ✅ |

## Tests

- 15 unit tests on the pure tracker (parallel calls, ToolSearch/deferred flow, malformed content)
- 6 HTTP integration tests with a consumption-counting SDK mock: digest turn **never pulled**, abort fired, session stored + resumed, parallel denies awaited, text-only turns untouched, kill switch restores full drain
- Full suite: 1929 pass / 0 fail; `tsc --noEmit` clean

## Rollback

`MERIDIAN_PASSTHROUGH_EARLY_STOP=0` restores the old behavior (kill switch, read per request — no restart needed beyond env).