### PR TITLE
fix(replay): preserve edit content and agency in fresh-replay history

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -287,8 +287,10 @@ describe("buildToolUseIndex / tool-result attribution (#552)", () => {
 
   it("indexes every assistant tool_use by id with name and target", () => {
     const idx = buildToolUseIndex(history)
-    expect(idx.get("toolu_w")).toEqual({ name: "write", target: "tmp/test2.txt" })
-    expect(idx.get("toolu_r")).toEqual({ name: "read", target: "tmp/test1.txt" })
+    // write is a mutating tool → carries a content summary so the model can
+    // recognize its own work product on replay (#496 follow-up)
+    expect(idx.get("toolu_w")).toEqual({ name: "write", target: "tmp/test2.txt", contentSummary: "apple" })
+    expect(idx.get("toolu_r")).toEqual({ name: "read", target: "tmp/test1.txt", contentSummary: undefined })
   })
 
   it("extracts common target keys and truncates long ones", () => {
@@ -299,18 +301,111 @@ describe("buildToolUseIndex / tool-result attribution (#552)", () => {
         { type: "tool_use", id: "t3", name: "custom", input: { weird: true } },
       ] },
     ])
-    expect(idx.get("t1")).toEqual({ name: "bash", target: "echo hi" })
+    expect(idx.get("t1")).toEqual({ name: "bash", target: "echo hi", contentSummary: undefined })
     expect(idx.get("t2")!.target!.length).toBeLessThanOrEqual(80)
-    expect(idx.get("t3")).toEqual({ name: "custom", target: undefined })
+    expect(idx.get("t3")).toEqual({ name: "custom", target: undefined, contentSummary: undefined })
   })
 
   it("describeToolCall renders a compact attribution label", () => {
-    expect(describeToolCall({ name: "write", target: "tmp/test2.txt" })).toBe("[write tmp/test2.txt]")
-    expect(describeToolCall({ name: "custom", target: undefined })).toBe("[custom]")
+    expect(describeToolCall({ name: "write", target: "tmp/test2.txt", contentSummary: undefined })).toBe("[your write tmp/test2.txt]")
+    expect(describeToolCall({ name: "custom", target: undefined, contentSummary: undefined })).toBe("[your custom]")
   })
 
   it("returns an empty index for non-array and toolless content", () => {
     expect(buildToolUseIndex([{ role: "user", content: "hi" }]).size).toBe(0)
     expect(buildToolUseIndex([]).size).toBe(0)
+  })
+
+  // #496 follow-up: on fresh replay the assistant's tool_use blocks are dropped,
+  // so without a content summary the model knows THAT it edited a file but not
+  // WHAT it wrote — it then re-derives near-duplicate edits and confabulates a
+  // parallel editor ("the first variant of the comments isn't mine").
+  describe("content summaries for mutating tools", () => {
+    it("edit: summarizes newString", () => {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "e1", name: "edit", input: { filePath: "a.yml", oldString: "old", newString: "# Ignore major bumps\n  - dependency-name: foo" } },
+        ] },
+      ])
+      expect(idx.get("e1")!.contentSummary).toBe("# Ignore major bumps - dependency-name: foo")
+    })
+
+    it("edit: accepts snake_case new_string and PascalCase tool names", () => {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "e2", name: "Edit", input: { file_path: "a.ts", new_string: "const x = 1" } },
+        ] },
+      ])
+      expect(idx.get("e2")!.contentSummary).toBe("const x = 1")
+    })
+
+    it("write: summarizes content", () => {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "w1", name: "write", input: { filePath: "b.txt", content: "hello\nworld" } },
+        ] },
+      ])
+      expect(idx.get("w1")!.contentSummary).toBe("hello world")
+    })
+
+    it("multiedit: summarizes the first edit and notes the count", () => {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "m1", name: "multiedit", input: { filePath: "c.ts", edits: [
+            { oldString: "a", newString: "first new text" },
+            { oldString: "b", newString: "second" },
+            { oldString: "c", newString: "third" },
+          ] } },
+        ] },
+      ])
+      expect(idx.get("m1")!.contentSummary).toBe("3 edits; first: first new text")
+    })
+
+    it("collapses whitespace and truncates long content", () => {
+      const long = ("line one\n\n  line two\t" + "x".repeat(300))
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "e3", name: "edit", input: { filePath: "d.ts", newString: long } },
+        ] },
+      ])
+      const s = idx.get("e3")!.contentSummary!
+      expect(s.startsWith("line one line two")).toBe(true)
+      expect(s.length).toBeLessThanOrEqual(123)
+      expect(s.endsWith("...")).toBe(true)
+      expect(s).not.toContain("\n")
+    })
+
+    it("non-mutating tools get no summary (read/bash/grep)", () => {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "r1", name: "read", input: { filePath: "a.ts" } },
+          { type: "tool_use", id: "b1", name: "bash", input: { command: "rm -rf /tmp/x" } },
+          { type: "tool_use", id: "g1", name: "grep", input: { pattern: "foo" } },
+        ] },
+      ])
+      expect(idx.get("r1")!.contentSummary).toBeUndefined()
+      expect(idx.get("b1")!.contentSummary).toBeUndefined()
+      expect(idx.get("g1")!.contentSummary).toBeUndefined()
+    })
+
+    it("describeToolCall includes the summary when present", () => {
+      expect(describeToolCall({ name: "edit", target: "a.yml", contentSummary: "# Ignore major bumps" }))
+        .toBe('[your edit a.yml → "# Ignore major bumps"]')
+      expect(describeToolCall({ name: "write", target: undefined, contentSummary: "hello" }))
+        .toBe('[your write → "hello"]')
+    })
+
+    it("tolerates malformed inputs without crashing", () => {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [
+          { type: "tool_use", id: "x1", name: "edit", input: { filePath: "a", newString: 42 } },
+          { type: "tool_use", id: "x2", name: "multiedit", input: { filePath: "b", edits: "not-an-array" } },
+          { type: "tool_use", id: "x3", name: "write", input: null },
+        ] },
+      ])
+      expect(idx.get("x1")!.contentSummary).toBeUndefined()
+      expect(idx.get("x2")!.contentSummary).toBeUndefined()
+      expect(idx.get("x3")!.contentSummary).toBeUndefined()
+    })
   })
 })

--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -257,13 +257,50 @@ describe("tool-result attribution on full-history replay (#552)", () => {
     await postWithSession(app, "attribution-session-1", toolLoopHistory, "sdk-attr-1")
 
     const prompt = promptToString(getCaptured()?.prompt)
-    // The write result must be attributed — the model must be able to see IT
-    // wrote tmp/test2.txt, not just an unexplained success string.
-    expect(prompt).toContain("[write tmp/test2.txt]")
+    // The write result must be attributed WITH its content — the model must be
+    // able to recognize its own work product, not just an unexplained success
+    // string (#552 gave it the target; the #496 follow-up adds the content, so
+    // it stops re-deriving near-duplicate edits and blaming a phantom co-editor).
+    expect(prompt).toContain('[your write tmp/test2.txt → "apple"]')
     expect(prompt).toContain("Wrote file successfully")
-    // The read result must be attributed to the right file.
-    expect(prompt).toContain("[read tmp/test1.txt]")
+    // The read result must be attributed to the right file (no content summary
+    // for non-mutating tools).
+    expect(prompt).toContain("[your read tmp/test1.txt]")
     // And the banned verbose shapes must stay banned.
+    assertNoFlattenedToolBlocks(getCaptured()?.prompt)
+  })
+
+  it("replays edit calls with a truncated summary of what changed (#496 follow-up)", async () => {
+    const app = createTestApp()
+    const editHistory = [
+      { role: "user", content: "add ignore rules to dependabot config" },
+      {
+        role: "assistant",
+        content: [{
+          type: "tool_use", id: "toolu_e1", name: "edit",
+          input: {
+            filePath: ".github/dependabot.yml",
+            oldString: "    open-pull-requests-limit: 10",
+            newString: "    open-pull-requests-limit: 10\n    ignore:\n      # Major bumps need manual review\n      - dependency-name: \"*\"",
+          },
+        }],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_e1", content: "Edit applied successfully." },
+          { type: "text", text: "now validate the file" },
+        ],
+      },
+    ]
+    await postWithSession(app, "attribution-session-2", editHistory, "sdk-attr-2")
+
+    const prompt = promptToString(getCaptured()?.prompt)
+    // The model must see WHAT it inserted, whitespace-collapsed, so it can
+    // recognize its own wording later instead of concluding "the first
+    // variant of the comments isn't mine" (stefanpartheym's #496 transcript).
+    expect(prompt).toContain('[your edit .github/dependabot.yml → "open-pull-requests-limit: 10 ignore: # Major bumps need manual review')
+    expect(prompt).toContain("Edit applied successfully.")
     assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 })

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -182,10 +182,55 @@ export interface ToolCallInfo {
   name: string
   /** Compact human-readable target (file path, command, pattern...), if any. */
   target: string | undefined
+  /**
+   * For mutating tools (edit/write/multiedit): a truncated summary of the
+   * content the call produced. On fresh replay the assistant's tool_use
+   * blocks are dropped, so without this the model knows THAT it edited a
+   * file but not WHAT it wrote — it then re-derives near-duplicate edits
+   * and confabulates a parallel editor when it doesn't recognize its own
+   * wording (#496 follow-up, stefanpartheym's transcript).
+   */
+  contentSummary: string | undefined
 }
 
 /** Input keys that identify what a tool call operated on, in priority order. */
 const TOOL_TARGET_KEYS = ["filePath", "file_path", "path", "command", "pattern", "query", "url"] as const
+
+/** Max length of a replayed content summary (before the "..." marker). */
+const CONTENT_SUMMARY_MAX = 120
+
+/** Collapse whitespace runs to single spaces and truncate. */
+function summarizeContent(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined
+  const collapsed = value.replace(/\s+/g, " ").trim()
+  if (!collapsed) return undefined
+  return collapsed.length > CONTENT_SUMMARY_MAX ? collapsed.slice(0, CONTENT_SUMMARY_MAX) + "..." : collapsed
+}
+
+/**
+ * Extract a content summary for mutating tools. Non-mutating tools (read,
+ * bash, grep, ...) return undefined — their target alone identifies the call.
+ */
+function extractContentSummary(name: string, input: unknown): string | undefined {
+  if (!input || typeof input !== "object") return undefined
+  const rec = input as Record<string, unknown>
+  switch (name.toLowerCase()) {
+    case "edit":
+      return summarizeContent(rec.newString ?? rec.new_string)
+    case "write":
+      return summarizeContent(rec.content)
+    case "multiedit": {
+      const edits = rec.edits
+      if (!Array.isArray(edits) || edits.length === 0) return undefined
+      const first = edits[0] as Record<string, unknown> | null | undefined
+      const firstSummary = summarizeContent(first?.newString ?? first?.new_string)
+      if (!firstSummary) return undefined
+      return edits.length > 1 ? `${edits.length} edits; first: ${firstSummary}` : firstSummary
+    }
+    default:
+      return undefined
+  }
+}
 
 /**
  * Index every assistant tool_use block in a conversation by id.
@@ -216,7 +261,11 @@ export function buildToolUseIndex(
           }
         }
       }
-      index.set(block.id, { name: block.name, target })
+      index.set(block.id, {
+        name: block.name,
+        target,
+        contentSummary: extractContentSummary(block.name, input),
+      })
     }
   }
   return index
@@ -224,11 +273,18 @@ export function buildToolUseIndex(
 
 /**
  * Render a compact attribution label for a replayed tool result, e.g.
- * `[write tmp/test2.txt]` or `[bash echo hi]`. Deliberately terse and
- * bracket-formatted differently from the banned `[Tool Use: ...]` /
- * `[Tool Result ...]` shapes (#111/#386) so the model reads it as context,
- * not as tool-call syntax to imitate.
+ * `[write tmp/test2.txt]`, `[bash echo hi]`, or — for mutating tools —
+ * `[edit a.yml → "# Ignore major bumps..."]` so the model can recognize its
+ * own prior work product on replay. Deliberately terse and bracket-formatted
+ * differently from the banned `[Tool Use: ...]` / `[Tool Result ...]` shapes
+ * (#111/#386) so the model reads it as context, not as tool-call syntax to
+ * imitate.
  */
 export function describeToolCall(info: ToolCallInfo): string {
-  return info.target ? `[${info.name} ${info.target}]` : `[${info.name}]`
+  // "your" marks agency: the replay drops the assistant turn that made the
+  // call, so the attribution sits inside a USER turn — without an explicit
+  // owner the model reads it as someone else's action and answers
+  // "I haven't made any edits in this conversation" (verified live).
+  const head = info.target ? `your ${info.name} ${info.target}` : `your ${info.name}`
+  return info.contentSummary ? `[${head} → "${info.contentSummary}"]` : `[${head}]`
 }


### PR DESCRIPTION
Follow-up promised in [#496](https://github.com/rynfar/meridian/issues/496#issuecomment-4960337149) — closes the residual gap behind stefanpartheym's duplicate-edit / phantom-co-editor transcript.

## The gap

When a conversation can't resume and falls back to a fresh replay, assistant `tool_use` blocks are dropped (#111/#386). After #590 the model at least sees `[edit .github/dependabot.yml]: Edit applied successfully` — the *fact* of an edit, but **not what it wrote**. Consequence (Stefan's transcript): the model re-derives a near-duplicate edit, then inspects the file, doesn't recognize its own first wording, and concludes *"someone else was editing the file in parallel."*

## The fix — two parts, both live-verified

1. **Content**: mutating tools (edit/write/multiedit) now carry a truncated, whitespace-collapsed summary of what they produced:
   `[your edit .github/dependabot.yml → "open-pull-requests-limit: 10 ignore: # Major bumps need manual review…"]`
2. **Agency**: the label is marked `your …`. This part came out of honest live testing — content alone was NOT enough. The label sits inside a USER turn (the assistant turn is gone), so without an explicit owner the model answered *"I haven't made any edits in this conversation."* With `your`, it correctly owns the edit.

## Proof (real SDK, headerless fresh replay, same question)

> Q: "The file now has a comment '# Major version bumps are reviewed manually each quarter'. Did you write that exact comment, or was the file edited by someone else in parallel?"

| Build | Answer |
|---|---|
| before | "I did not write that comment" / "I haven't made any edits yet in this conversation" |
| after | **"I wrote that exact comment when I added the ignore rule for major version bumps."** |

## Notes

- With v1.48.0's early stop, fresh replays are rare (sessions resume properly) — this hardens the remaining paths (proxy restart, genuine divergence).
- Summaries are bounded (120 chars, whitespace-collapsed); non-mutating tools (read/bash/grep) unchanged.
- Label shape stays distinct from the banned `[Tool Use: …]`/`[Tool Result …]` formats (#111/#386); the no-flatten regression suite still passes.
- Pure `messages.ts` change + tests. Full suite: 1939 pass / 0 fail; `tsc --noEmit` clean.