### PR TITLE
fix(nix): patch vendored ELF binaries so claude.exe runs on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Then in `~/.config/opencode/opencode.json`:
 
 > **Important:** Do not use `meridian setup` on NixOS. It writes an absolute Nix store path (e.g. `/nix/store/...-meridian-1.x.x/lib/...`) into your OpenCode config, which will break on the next `nixos-rebuild switch` or `home-manager switch` when the store path changes. Use one of the approaches above instead.
 
+> **Note:** The bundled Claude Code binary (`claude.exe`) is patched with `autoPatchelfHook` at build time, so it runs on NixOS out of the box. If you previously enabled `programs.nix-ld.enable = true` as a workaround for `Could not start dynamically linked executable` (#501), that is no longer required for Meridian.
+
 **Home Manager service** -- run Meridian as a user systemd service:
 
 ```nix

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,9 +1,11 @@
 {
+  autoPatchelfHook,
   bun,
   bun2nix,
   lib,
   makeWrapper,
   nodejs_22,
+  stdenv,
   stdenvNoCC,
 }:
 stdenvNoCC.mkDerivation {
@@ -17,6 +19,20 @@ stdenvNoCC.mkDerivation {
     bun
     nodejs_22
     makeWrapper
+  ]
+  # node_modules vendors native ELF binaries — most importantly
+  # @anthropic-ai/claude-code/bin/claude.exe (the Claude Code CLI the SDK
+  # spawns) and its bundled ripgrep. They are dynamically linked against a
+  # generic-Linux loader path (/lib64/ld-linux-*), which does not exist on
+  # NixOS — every query died with exit=127 "Could not start dynamically
+  # linked executable" (#501). autoPatchelfHook rewrites their interpreter
+  # and rpaths to Nix store paths at build time, so users don't need the
+  # nix-ld escape hatch.
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # Runtime libraries autoPatchelfHook links the vendored ELFs against.
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib # libstdc++ / libgcc_s for the bun-compiled claude.exe
   ];
 
   bunDeps = bun2nix.fetchBunDeps { bunNix = ../bun.nix; };
@@ -41,10 +57,16 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  # The dist/ output is pre-bundled JS run by node via a wrapper; there
-  # are no native binaries or shebangs that need patching. Skipping
-  # fixup also avoids unnecessary work on a large node_modules tree.
-  dontFixup = true;
+  # claude.exe is a bun single-file executable: the JS payload is embedded in
+  # the binary. Stripping would discard it and corrupt the CLI, so only the
+  # patchelf part of fixup may touch it.
+  dontStrip = true;
+
+  # Vendored prebuilt binaries may reference optional libs we don't provide
+  # (autoPatchelfHook fails the build on ANY missing dep otherwise). The
+  # loader only needs the ones actually used at runtime; claude.exe's hard
+  # deps (glibc, libstdc++) are covered above.
+  autoPatchelfIgnoreMissingDeps = [ "*" ];
 
   meta = {
     description = "Local Anthropic API powered by your Claude Max subscription";


### PR DESCRIPTION
Fixes #501.

## Root cause

`nix/package.nix` set `dontFixup = true` with a comment claiming "there are no native binaries or shebangs that need patching." That was wrong: `node_modules/@anthropic-ai/claude-code/bin/claude.exe` — the CLI the SDK spawns for **every query** — is a dynamically linked Linux ELF whose interpreter points at `/lib64/ld-linux-*`. That path doesn't exist on NixOS, so every query died with `exit=127 "Could not start dynamically linked executable"`. The only workaround was system-wide `programs.nix-ld.enable = true`.

## Fix

- `autoPatchelfHook` (Linux only) rewrites the interpreter + rpaths of all vendored ELFs to Nix store paths at build time
- `buildInputs = [ stdenv.cc.cc.lib ]` — claude.exe's complete dep set is glibc + libstdc++/libgcc (**verified**: autoPatchelf resolves it with zero missing deps)
- `dontStrip = true` — claude.exe is a bun single-file executable with an embedded JS payload; stripping would corrupt it
- `autoPatchelfIgnoreMissingDeps = [ "*" ]` — shields unrelated vendored ELFs (e.g. foreign-arch ripgrep builds) from failing the build over libs they never load; claude.exe's own deps are explicitly covered
- README: NixOS note that nix-ld is no longer required for Meridian

## Validation (NixOS container, real binary)

Proof-of-concept derivation applying exactly these hook/inputs to the real `@anthropic-ai/claude-code-linux-arm64@2.1.198` binary:

```
interpreter: /nix/store/…-glibc-2.40-218/lib/ld-linux-aarch64.so.1
$ claude --version
2.1.198 (Claude Code)
exit: 0        ← previously 127, the exact #501 failure
```

Also verified: `aarch64-darwin` and `x86_64-linux` package eval + `nix flake check --all-systems` all pass with the change.

**Honest caveat:** the full `nix build .#meridian` could not be completed in the Docker validation rig — bun2nix's cached install fails there with `PermissionDenied` on **unmodified main as well** (control experiment), i.e. a pre-existing container-environment limitation unrelated to this change. Real-NixOS verification requested from the reporter on #501.

JS side untouched; full suite still 1939 pass / 0 fail.