### PR TITLE
feat(profiles): sticky session-to-profile routing via rendezvous hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,22 @@ curl -H "x-meridian-profile: work" ...
 
 You can also switch profiles from the web UI at `http://127.0.0.1:3456/profiles` — a dropdown appears in the nav bar on all pages when profiles are configured.
 
+### Sticky session routing
+
+With multiple profiles (e.g. two Claude Max subscriptions), Meridian can distribute sessions across profiles automatically while preserving **session affinity** — Anthropic's prompt caching is per-account, so a session must stay on one account to keep its ~99% cache hit rate:
+
+```bash
+MERIDIAN_ROUTING=sticky meridian     # or set "routing": "sticky" in ~/.config/meridian/settings.json
+```
+
+- Each session is assigned to a profile by rendezvous hashing of its session id — **deterministic and stateless**, so assignments survive proxy restarts with no state to lose
+- Adding/removing a profile only reassigns the sessions belonging to the changed arm — everything else keeps its warm cache
+- A session's subagent/fork requests share its assignment (same session id → same account)
+- The `x-meridian-profile` header still overrides everything, per request
+- Default is `active` (all traffic to the active profile — the pre-existing behavior); sticky is opt-in
+
+Request logs show the assignment (`profile=work(sticky)`), and `GET /profiles/list` reports the current `routing` mode.
+
 ### Profile commands
 
 | Command | Description |

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -366,3 +366,60 @@ describe("profile auth login env", () => {
     expect(parseAuthorizationCodeInput("https://platform.claude.com/oauth/code/callback?code=abc123&state=state456")).toEqual({ code: "abc123", state: "state456" })
   })
 })
+
+describe("resolveProfile — sticky routing (#383)", () => {
+  const profiles: ProfileConfig[] = [
+    { id: "personal", type: "claude-max", claudeConfigDir: "/p" },
+    { id: "work", type: "claude-max", claudeConfigDir: "/w" },
+  ]
+  const opts = (key?: string, mode?: "active" | "sticky") => ({ stickySessionKey: key, routingMode: mode })
+
+  test("GOLDEN: without routing options the chain is unchanged (header > active > default > first)", () => {
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+    expect(resolveProfile(profiles, "work").id).toBe("work")
+    expect(resolveProfile(profiles, "personal", "work").id).toBe("work")
+    setActiveProfile("work")
+    expect(resolveProfile(profiles, "personal").id).toBe("work")
+  })
+
+  test("GOLDEN: routingMode 'active' with a session key is identical to today", () => {
+    setActiveProfile("personal")
+    expect(resolveProfile(profiles, undefined, undefined, opts("sess-a", "active")).id).toBe("personal")
+  })
+
+  test("sticky: same session key always resolves the same profile", () => {
+    const first = resolveProfile(profiles, undefined, undefined, opts("sess-a", "sticky")).id
+    for (let i = 0; i < 5; i++) {
+      expect(resolveProfile(profiles, undefined, undefined, opts("sess-a", "sticky")).id).toBe(first)
+    }
+  })
+
+  test("sticky: distributes different sessions across profiles", () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 50; i++) {
+      seen.add(resolveProfile(profiles, undefined, undefined, opts(`sess-${i}`, "sticky")).id)
+    }
+    expect(seen.size).toBe(2)
+  })
+
+  test("sticky: explicit header STILL wins over the sticky assignment", () => {
+    // sess-a hashes to "work" (pinned) — the header must override it.
+    expect(resolveProfile(profiles, undefined, "personal", opts("sess-a", "sticky")).id).toBe("personal")
+  })
+
+  test("sticky: beats the active profile (that's the point of the mode)", () => {
+    setActiveProfile("personal")
+    expect(resolveProfile(profiles, undefined, undefined, opts("sess-a", "sticky")).id).toBe("work")
+  })
+
+  test("sticky: no session key falls through to the normal chain", () => {
+    setActiveProfile("work")
+    expect(resolveProfile(profiles, undefined, undefined, opts(undefined, "sticky")).id).toBe("work")
+  })
+
+  test("sticky: no profiles configured stays in single-account mode", () => {
+    const r = resolveProfile(undefined, undefined, undefined, opts("sess-a", "sticky"))
+    expect(r.id).toBe("default")
+    expect(r.env).toEqual({})
+  })
+})

--- a/src/__tests__/routing.test.ts
+++ b/src/__tests__/routing.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for sticky session-to-profile routing — pure functions, no mocks.
+ *
+ * Design (#383, proposed by @ShreeMulay): sessions are assigned to profiles
+ * via rendezvous (highest-random-weight) hashing — deterministic and
+ * stateless, so stickiness survives proxy restarts with no persisted map,
+ * and adding/removing a profile only reassigns the sessions that belonged
+ * to the removed arm (minimal cache disruption).
+ */
+import { describe, it, expect } from "bun:test"
+import { pickStickyProfile, getRoutingMode, RENDEZVOUS_STABLE_GUARD } from "../proxy/routing"
+
+const PROFILES = ["personal", "work"]
+
+describe("pickStickyProfile", () => {
+  it("is deterministic: same session always maps to the same profile", () => {
+    for (const key of ["sess-a", "sess-b", "ses-123", "x"]) {
+      const first = pickStickyProfile(key, PROFILES)
+      for (let i = 0; i < 5; i++) {
+        expect(pickStickyProfile(key, PROFILES)).toBe(first!)
+      }
+    }
+  })
+
+  it("distributes sessions across profiles (not all on one arm)", () => {
+    const counts: Record<string, number> = {}
+    for (let i = 0; i < 200; i++) {
+      const p = pickStickyProfile(`session-${i}`, PROFILES)!
+      counts[p] = (counts[p] ?? 0) + 1
+    }
+    // With 200 sessions over 2 arms, each arm should get a healthy share.
+    expect(counts["personal"]!).toBeGreaterThan(50)
+    expect(counts["work"]!).toBeGreaterThan(50)
+  })
+
+  it("adding a profile only moves sessions to the new arm (rendezvous property)", () => {
+    const before = new Map<string, string>()
+    for (let i = 0; i < 100; i++) before.set(`s-${i}`, pickStickyProfile(`s-${i}`, PROFILES)!)
+
+    const after = new Map<string, string>()
+    for (let i = 0; i < 100; i++) after.set(`s-${i}`, pickStickyProfile(`s-${i}`, [...PROFILES, "third"])!)
+
+    for (const [key, oldProfile] of before) {
+      const newProfile = after.get(key)!
+      // A session either stays where it was, or moves to the NEW arm —
+      // never shuffles between existing arms (that would cold-cache it
+      // for no reason).
+      if (newProfile !== oldProfile) expect(newProfile).toBe("third")
+    }
+  })
+
+  it("removing a profile only reassigns that arm's sessions", () => {
+    const three = [...PROFILES, "third"]
+    const before = new Map<string, string>()
+    for (let i = 0; i < 100; i++) before.set(`s-${i}`, pickStickyProfile(`s-${i}`, three)!)
+
+    for (const [key, oldProfile] of before) {
+      const newProfile = pickStickyProfile(key, PROFILES)!
+      if (oldProfile !== "third") {
+        expect(newProfile).toBe(oldProfile) // survivors stay put
+      } else {
+        expect(PROFILES).toContain(newProfile)
+      }
+    }
+  })
+
+  it("profile order does not matter (set semantics)", () => {
+    for (let i = 0; i < 20; i++) {
+      expect(pickStickyProfile(`s-${i}`, ["a", "b", "c"])).toBe(pickStickyProfile(`s-${i}`, ["c", "a", "b"])!)
+    }
+  })
+
+  it("returns undefined for empty inputs", () => {
+    expect(pickStickyProfile("sess", [])).toBeUndefined()
+    expect(pickStickyProfile("", PROFILES)).toBeUndefined()
+  })
+
+  it("single profile always wins", () => {
+    expect(pickStickyProfile("anything", ["only"])).toBe("only")
+  })
+
+  it("hash outputs are pinned (stickiness must survive upgrades)", () => {
+    // If this test breaks, the hash changed — every user's sessions would
+    // silently reshuffle onto different accounts (cold caches) on upgrade.
+    // Do NOT update these expectations without a migration note.
+    expect(RENDEZVOUS_STABLE_GUARD.every(([key, profiles, want]) =>
+      pickStickyProfile(key, profiles) === want
+    )).toBe(true)
+  })
+})
+
+describe("getRoutingMode", () => {
+  it("defaults to 'active' (current behavior) when unset", () => {
+    expect(getRoutingMode(undefined)).toBe("active")
+    expect(getRoutingMode("")).toBe("active")
+  })
+
+  it("accepts 'sticky'", () => {
+    expect(getRoutingMode("sticky")).toBe("sticky")
+  })
+
+  it("falls back to 'active' for unknown values (never crashes routing)", () => {
+    expect(getRoutingMode("round-robin")).toBe("active")
+    expect(getRoutingMode("STICKY")).toBe("sticky") // case-insensitive
+  })
+})

--- a/src/__tests__/sticky-routing-integration.test.ts
+++ b/src/__tests__/sticky-routing-integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration tests for sticky session-to-profile routing (#383) — full HTTP
+ * layer, mocked SDK. The profile that served a request is observable via the
+ * SDK subprocess env (CLAUDE_CONFIG_DIR carries the profile's config dir).
+ */
+import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let mockMessages: any[] = []
+let capturedEnvs: Array<Record<string, string | undefined>> = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedEnvs.push(params.options?.env ?? {})
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { resetActiveProfile } = await import("../proxy/profiles")
+
+const PROFILES = [
+  { id: "personal", type: "claude-max" as const, claudeConfigDir: "/cfg/personal" },
+  { id: "work", type: "claude-max" as const, claudeConfigDir: "/cfg/work" },
+]
+
+function servedProfile(env: Record<string, string | undefined>): string {
+  if (env.CLAUDE_CONFIG_DIR === "/cfg/personal") return "personal"
+  if (env.CLAUDE_CONFIG_DIR === "/cfg/work") return "work"
+  return "default"
+}
+
+async function post(app: any, session: string, extraHeaders: Record<string, string> = {}) {
+  const r = await app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": session,
+      "user-agent": "opencode/1.0.0",
+      ...extraHeaders,
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-5",
+      max_tokens: 64,
+      stream: false,
+      messages: [{ role: "user", content: `hello from ${session}` }],
+    }),
+  }))
+  await r.json()
+  return servedProfile(capturedEnvs[capturedEnvs.length - 1]!)
+}
+
+describe("Integration: sticky profile routing (#383)", () => {
+  let app: any
+  let savedRouting: string | undefined
+  let savedPassthrough: string | undefined
+
+  beforeAll(() => {
+    const { app: a } = createProxyServer({ port: 0, host: "127.0.0.1", profiles: PROFILES })
+    app = a
+  })
+
+  beforeEach(() => {
+    savedRouting = process.env.MERIDIAN_ROUTING
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+    resetActiveProfile()
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedEnvs = []
+  })
+
+  afterEach(() => {
+    if (savedRouting !== undefined) process.env.MERIDIAN_ROUTING = savedRouting
+    else delete process.env.MERIDIAN_ROUTING
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  it("GOLDEN: without MERIDIAN_ROUTING every session lands on the first profile (current behavior)", async () => {
+    delete process.env.MERIDIAN_ROUTING
+    expect(await post(app, "sess-a")).toBe("personal")
+    expect(await post(app, "sess-b")).toBe("personal")
+    expect(await post(app, "sess-c")).toBe("personal")
+  })
+
+  it("sticky: sessions distribute across profiles and stay sticky", async () => {
+    process.env.MERIDIAN_ROUTING = "sticky"
+    const seen = new Map<string, string>()
+    for (const s of ["sess-a", "sess-b", "sess-c", "sess-d", "sess-e", "sess-f"]) {
+      seen.set(s, await post(app, s))
+    }
+    // Both arms used (sess-a → work, sess-b → personal are pinned by the hash guard).
+    expect(new Set(seen.values()).size).toBe(2)
+    // Re-request each session: identical assignment every time.
+    for (const [s, first] of seen) {
+      expect(await post(app, s)).toBe(first)
+    }
+  })
+
+  it("sticky: x-meridian-profile header still wins", async () => {
+    process.env.MERIDIAN_ROUTING = "sticky"
+    // sess-a hashes to "work" (pinned) — the explicit header overrides it.
+    expect(await post(app, "sess-a", { "x-meridian-profile": "personal" })).toBe("personal")
+  })
+
+  it("sticky: subagent requests with the same session header share the arm", async () => {
+    process.env.MERIDIAN_ROUTING = "sticky"
+    const main = await post(app, "sess-a")
+    const subagent = await post(app, "sess-a", { "x-meridian-source": "subagent-scout" })
+    expect(subagent).toBe(main)
+  })
+})

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -18,6 +18,7 @@ import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 import { homedir } from "node:os"
 import { setSetting, getSetting } from "./settings"
+import { pickStickyProfile, type RoutingMode } from "./routing"
 
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 
@@ -155,17 +156,33 @@ export function hasProfiles(configProfiles: ProfileConfig[] | undefined): boolea
   return getEffectiveProfiles(configProfiles).length > 0
 }
 
+/** Options for the sticky-routing resolution step (#383). */
+export interface ResolveProfileOptions {
+  /** Session identity for sticky assignment (adapter.getSessionId). */
+  stickySessionKey?: string
+  /** Routing mode — "active" (default, pre-#383 chain) or "sticky". */
+  routingMode?: RoutingMode
+}
+
 /**
  * Resolve a profile from the configuration.
+ *
+ * Priority: header > sticky assignment (routing="sticky" only) > active >
+ * config default > first profile. The sticky step exists so multi-account
+ * setups can distribute sessions across profiles WITHOUT losing per-account
+ * prompt caching — see routing.ts. With routingMode unset/"active" the
+ * chain is exactly the pre-#383 behavior.
  *
  * @param profiles - Configured profiles (from ProxyConfig)
  * @param defaultProfile - Default profile ID (from ProxyConfig)
  * @param requestedId - Explicit profile ID from request header
+ * @param options - Sticky-routing inputs (session key + mode)
  */
 export function resolveProfile(
   profiles: ProfileConfig[] | undefined,
   defaultProfile: string | undefined,
-  requestedId?: string
+  requestedId?: string,
+  options?: ResolveProfileOptions
 ): ResolvedProfile {
   const effective = getEffectiveProfiles(profiles)
 
@@ -174,8 +191,15 @@ export function resolveProfile(
     return { id: DEFAULT_PROFILE_ID, type: "claude-max", env: {} }
   }
 
-  // Priority: header > active > config default > first profile
-  const resolvedId = requestedId || activeProfileId || defaultProfile || effective[0]!.id
+  // Sticky assignment: only in sticky mode, only with a session identity,
+  // and always subordinate to an explicit header override.
+  const stickyId =
+    options?.routingMode === "sticky" && options.stickySessionKey
+      ? pickStickyProfile(options.stickySessionKey, effective.map(p => p.id))
+      : undefined
+
+  // Priority: header > sticky > active > config default > first profile
+  const resolvedId = requestedId || stickyId || activeProfileId || defaultProfile || effective[0]!.id
   const profile = effective.find(p => p.id === resolvedId)
 
   if (!profile) {

--- a/src/proxy/routing.ts
+++ b/src/proxy/routing.ts
@@ -1,0 +1,80 @@
+/**
+ * Sticky session-to-profile routing (#383, design by @ShreeMulay).
+ *
+ * With multiple profiles configured, `routing = "sticky"` distributes
+ * sessions across profiles while preserving session affinity — Anthropic's
+ * prompt caching is per-account, so a session that flip-flops between
+ * accounts pays a cold cache (full context re-creation) on every flip.
+ *
+ * Assignment uses rendezvous (highest-random-weight) hashing:
+ *   - deterministic and stateless — stickiness survives proxy restarts with
+ *     no persisted session→profile map to lose or corrupt
+ *   - minimal disruption — adding an arm only moves the sessions that hash
+ *     to the new arm; removing an arm only reassigns that arm's sessions
+ *
+ * Resolution priority (see resolveProfile): explicit x-meridian-profile
+ * header > sticky assignment > active profile > config default > first.
+ * Default mode is "active" (the pre-#383 chain) — existing setups are
+ * byte-identical unless routing is explicitly enabled.
+ *
+ * This is a leaf module — pure functions, no I/O.
+ */
+
+import { createHash } from "node:crypto"
+
+export type RoutingMode = "active" | "sticky"
+
+/**
+ * Parse a routing mode string (from settings or MERIDIAN_ROUTING).
+ * Unknown values fall back to "active" — a typo must never change
+ * routing behavior into something surprising.
+ */
+export function getRoutingMode(raw: string | undefined): RoutingMode {
+  return raw?.toLowerCase() === "sticky" ? "sticky" : "active"
+}
+
+/**
+ * Rendezvous score for a (session, profile) pair: first 8 bytes of
+ * sha256("<session>\0<profile>") as an unsigned bigint. sha256 is stable
+ * across platforms and Node versions, so assignments never reshuffle on
+ * upgrade (see the pinned-hash test).
+ */
+function rendezvousScore(sessionKey: string, profileId: string): bigint {
+  const digest = createHash("sha256").update(`${sessionKey}\0${profileId}`).digest()
+  return digest.readBigUInt64BE(0)
+}
+
+/**
+ * Pick the sticky profile for a session: the profile with the highest
+ * rendezvous score. Returns undefined when there is nothing to pick
+ * (no session identity or no profiles) — callers fall through to the
+ * normal resolution chain.
+ */
+export function pickStickyProfile(sessionKey: string, profileIds: readonly string[]): string | undefined {
+  if (!sessionKey || profileIds.length === 0) return undefined
+  let best: string | undefined
+  let bestScore = -1n
+  for (const id of profileIds) {
+    const score = rendezvousScore(sessionKey, id)
+    if (score > bestScore) {
+      bestScore = score
+      best = id
+    }
+  }
+  return best
+}
+
+/**
+ * Pinned (sessionKey, profiles, expected) triples guarding hash stability.
+ * If an implementation change breaks these, every user's sessions would
+ * silently reshuffle onto different accounts (cold caches) on upgrade —
+ * treat that as a breaking change requiring a migration note, not a test
+ * to update casually.
+ */
+export const RENDEZVOUS_STABLE_GUARD: ReadonlyArray<readonly [string, readonly string[], string]> = [
+  // Hard-pinned literals computed once from sha256 — NOT derived from
+  // pickStickyProfile, so the guard actually detects hash drift.
+  ["sess-a", ["personal", "work"], "work"],
+  ["sess-b", ["personal", "work"], "personal"],
+  ["opencode-3f2a", ["a", "b", "c"], "b"],
+]

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -64,6 +64,8 @@ import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { getRoutingMode } from "./routing"
+import { getSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
 import { detectTokenAnomalies, formatAnomalyAlerts, type TokenSnapshot } from "./tokenHealth"
@@ -498,11 +500,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }
         const outputFormat = parsedOutputFormat.value
 
-        // Resolve profile: header > active > default > first configured
+        // Resolve profile: header > sticky (routing="sticky" only) > active >
+        // default > first configured. Sticky routing (#383) assigns each
+        // client session to a profile via rendezvous hashing so multi-account
+        // setups keep per-account prompt caches warm; the same session key
+        // Meridian already uses for session tracking is the assignment key,
+        // so a session and its subagent/fork requests land on one account.
+        const routingMode = getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing"))
         const profile = resolveProfile(
           finalConfig.profiles,
           finalConfig.defaultProfile,
-          c.req.header("x-meridian-profile") || undefined
+          c.req.header("x-meridian-profile") || undefined,
+          routingMode === "sticky"
+            ? { routingMode, stickySessionKey: adapter.getSessionId(c, body) }
+            : undefined
         )
 
         const authStatus = await getClaudeAuthStatusAsync(
@@ -785,7 +796,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
         const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
         const toolCount = body.tools?.length ?? 0
-        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
+        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
         plog(`[PROXY] ${requestLogLine} msgs=${msgSummary}`)
         diagnosticLog.session(`${requestLogLine}`, requestMeta.requestId)
 
@@ -3080,6 +3091,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return c.json({
       profiles: enriched,
       activeProfile: getActiveProfileId() || finalConfig.defaultProfile || profiles[0]?.id || "default",
+      // Additive (#383): current routing mode so UIs can surface it.
+      routing: getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing")),
     })
   })
 

--- a/src/proxy/settings.ts
+++ b/src/proxy/settings.ts
@@ -17,6 +17,9 @@ const SETTINGS_FILE = join(homedir(), ".config", "meridian", "settings.json")
 export interface MeridianSettings {
   /** Last active profile ID — restored on proxy startup */
   activeProfile?: string
+  /** Profile routing mode (#383): "active" (default) or "sticky".
+   *  MERIDIAN_ROUTING env var takes precedence when set. */
+  routing?: string
 }
 
 /** Read settings from disk. Returns empty object if file doesn't exist or is invalid. */


### PR DESCRIPTION
Closes #383. Design and use case by @ShreeMulay — thank you for the excellent write-up; implemented in-house per maintainer decision, with full credit.

## What

Opt-in `MERIDIAN_ROUTING=sticky` (or `"routing": "sticky"` in settings.json): sessions are distributed across configured profiles **with session affinity**, so multi-account setups keep per-account prompt caches warm (~99% hit vs cold full-context re-creation on every account flip).

New resolution priority: `x-meridian-profile` header > **sticky assignment** > active > default > first.

## Design decision: rendezvous hashing instead of a persisted round-robin map

The original proposal used round-robin + an in-memory session→profile map with LRU eviction. This implementation uses **rendezvous (HRW) hashing** of the session id instead:

- **Stateless & restart-proof** — no map to lose or corrupt; a proxy restart cannot silently reshuffle sessions onto cold caches
- **Minimal disruption** — adding an arm only moves sessions that hash to the new arm; removing an arm only reassigns that arm's sessions (property-tested)
- **Subagents/forks inherit** — same session id → same account, so a session's parallel requests share one cache

No automatic quota failover in v1 (per discussion with @cristianmiranda's concern): silent mid-session re-assignment is functionally safe (it just takes the fresh-replay path) but cold-cache expensive — that wants an explicit opt-in flag as a follow-up, not default magic.

## Safety (the no-breakage guarantees)

- **Default is `active`** — golden tests assert the resolution chain is byte-identical to today when routing is unset (and even when set to `active` with a session key present)
- **Header always wins** — `x-meridian-profile` semantics unchanged (stable-contract surface)
- **Unknown mode strings → `active`** — a typo can never invent surprising routing
- **Pinned-hash guard test** — if the hash function ever drifts, tests fail loudly; silent assignment reshuffles on upgrade are treated as breaking changes
- `GET /profiles/list` gains an **additive** `routing` field; request logs show `profile=<id>(sticky)`

## Tests

- 11 unit tests on the pure routing module (determinism, distribution, rendezvous add/remove properties, pinned hashes)
- 8 resolution-chain tests incl. 2 golden current-behavior tests
- 4 HTTP integration tests (distribution + stickiness across repeated requests, header override, subagent affinity, golden default)
- Full suite: 1962 pass / 0 fail; `tsc --noEmit` clean