### PR TITLE
fix(replay): stop rendering Human:/Assistant: transcript lines in prompts

### DIFF
--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -304,3 +304,64 @@ describe("tool-result attribution on full-history replay (#552)", () => {
     assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 })
+
+describe("transcript-format imitation (#496 self-talk regression)", () => {
+  // 'Human:'/'Assistant:' transcript lines in the prompt teach the model the
+  // transcript format — it then completes the pattern itself, emitting
+  // 'Human: ...' turns and self-approving actions (duncanam's report). The
+  // structured/multimodal path already uses the safe convention (user turns
+  // plain, assistant turns as '[Assistant: ...]', resume deltas drop
+  // assistant messages the SDK session already has). The text path must match.
+  const transcriptMarker = /(^|\n)(Human|Assistant): /
+
+  it("resume delta: no transcript markers, assistant delta dropped, results attributed", async () => {
+    const app = createTestApp()
+    // Turn 1 — establish the session
+    await postWithSession(app, "sess-selftalk", [
+      { role: "user", content: "edit the config file" },
+    ], "sdk-selftalk")
+
+    // Turn 2 — client returns the executed tool round-trip
+    capturedParams = null
+    await postWithSession(app, "sess-selftalk", [
+      { role: "user", content: "edit the config file" },
+      { role: "assistant", content: [
+        { type: "text", text: "I'll edit that file now." },
+        { type: "tool_use", id: "tu_st1", name: "edit", input: { filePath: "a.yml", oldString: "x", newString: "y" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tu_st1", content: "Edit applied successfully." },
+      ]},
+    ], "sdk-selftalk")
+
+    expect(getCaptured()?.options?.resume).toBe("sdk-selftalk")
+    const prompt = promptToString(getCaptured()?.prompt)
+    expect(prompt).not.toMatch(transcriptMarker)
+    // The assistant's delta text must NOT be replayed — the resumed SDK
+    // session already contains that turn; re-sending it as user text is the
+    // imitation seed.
+    expect(prompt).not.toContain("I'll edit that file now.")
+    // The tool result (the genuinely new information) must be present + attributed.
+    expect(prompt).toContain("Edit applied successfully.")
+    expect(prompt).toContain("[your edit a.yml")
+  })
+
+  it("fresh multi-turn replay: assistant turns bracketed, no transcript markers", async () => {
+    const app = createTestApp()
+    capturedParams = null
+    // New session header + full history → fresh replay of a text conversation
+    await postWithSession(app, "sess-selftalk-fresh", [
+      { role: "user", content: "what is the capital of France?" },
+      { role: "assistant", content: "Paris." },
+      { role: "user", content: "and of Germany?" },
+    ], "sdk-selftalk-fresh")
+
+    const prompt = promptToString(getCaptured()?.prompt)
+    expect(prompt).not.toMatch(transcriptMarker)
+    // Assistant context survives in the bracketed, non-imitatable shape the
+    // structured path has used since #553.
+    expect(prompt).toContain("[Assistant: Paris.]")
+    expect(prompt).toContain("what is the capital of France?")
+    expect(prompt).toContain("and of Germany?")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -275,13 +275,17 @@ function buildFreshPrompt(
     return (async function* () { for (const msg of prompt) yield msg })()
   }
 
+  // Same anti-imitation convention as the structured branch above and the
+  // main prompt builder: user turns plain, assistant turns bracketed.
+  // 'Human:'/'Assistant:' transcript lines teach the model to complete the
+  // transcript itself (#496 self-talk).
   return messages
     .map((m) => {
-      const role = m.role === "assistant" ? "Assistant" : "Human"
-      const content = m.role === "assistant"
-        ? flattenAssistantContent(m.content)
-        : flattenUserContent(m.content, sanitizeOpts, toolIndex)
-      return content ? `${role}: ${content}` : ""
+      if (m.role === "assistant") {
+        const assistantText = flattenAssistantContent(m.content)
+        return assistantText ? `[Assistant: ${assistantText}]` : ""
+      }
+      return flattenUserContent(m.content, sanitizeOpts, toolIndex)
     })
     .filter(Boolean)
     .join("\n\n") || ""
@@ -934,13 +938,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // resolve even when the originating call sits before a resume-delta
         // boundary (#552).
         const toolIndex = buildToolUseIndex(allMessages ?? messagesToConvert ?? [])
+        // NEVER render 'Human:'/'Assistant:' transcript lines — the model
+        // imitates that format, emitting 'Human: ...' turns itself and
+        // self-approving actions (#496 self-talk). Match the structured
+        // path's proven convention instead: user turns plain, assistant
+        // turns bracketed as '[Assistant: ...]'. On resume, drop assistant
+        // messages entirely — the resumed SDK session already contains
+        // those turns; replaying them as user text is the imitation seed.
         textPrompt = messagesToConvert
           ?.map((m: { role: string; content: any }) => {
-            const role = m.role === "assistant" ? "Assistant" : "Human"
-            const content = m.role === "assistant"
-              ? flattenAssistantContent(m.content)
-              : flattenUserContent(m.content, sanitizeOpts, toolIndex)
-            return content ? `${role}: ${content}` : ""
+            if (m.role === "assistant") {
+              if (isResume) return ""
+              const assistantText = flattenAssistantContent(m.content)
+              return assistantText ? `[Assistant: ${assistantText}]` : ""
+            }
+            return flattenUserContent(m.content, sanitizeOpts, toolIndex)
           })
           .filter(Boolean)
           .join("\n\n") || ""


### PR DESCRIPTION
Part of #496 — fixes duncanam's self-talk report ("the LLM is chatting with itself, thinking it's chatting with me").

## Root cause

Both text-prompt paths (main builder + `buildFreshPrompt`) rendered history as `Human: ...` / `Assistant: ...` lines — **including into resume deltas**. Transcript-format text inside a user message teaches the model the format; it completes the pattern itself → emits `Human: ...` turns → self-talk and self-approval.

## Why it surfaced now (honest regression analysis)

The format is old, but v1.48.0's digest-turn elimination changed two things:
1. The digest turn had been an accidental **turn-closer** — resumed sessions used to end on a cleanly completed assistant turn. Now they end mid-flow at a denied tool call, and a model resumed mid-turn that receives `Assistant: … Human: …` text naturally *continues the transcript*.
2. Far more sessions resume now (the duplicate-abort no-store path went quiet), so the resume-delta path — which replayed the client's assistant text — runs constantly.

## Fix

Align both text paths with the structured/multimodal path's proven convention (#553):
- user turns rendered plain (no `Human:` prefix)
- assistant turns bracketed as `[Assistant: ...]` (context-shaped, not completion-inviting)
- **resume deltas drop assistant messages entirely** — the resumed SDK session already contains those turns; replaying them as user text was the imitation seed

## Verification

- 2 new regression tests: resume delta (no markers, assistant delta dropped, results attributed) + fresh multi-turn (bracketed assistant, no markers)
- Live headless run of the exact reported flow (tool round-trip → resume → follow-up): zero transcript markers, correct tool-result comprehension, clean answers
- Full suite: 1983 pass / 0 fail; `tsc --noEmit` clean