### PR TITLE
fix(passthrough): capture parallel same-tool calls instead of dropping them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,159 @@
+# AGENTS.md
+
+Project guidelines for AI agents working in this codebase.
+
+## What This Is
+
+A proxy that bridges OpenCode (Anthropic API format) to Codex Max (Agent SDK). See `ARCHITECTURE.md` for the full module map and dependency rules.
+
+## Commands
+
+```bash
+npm test          # Run all tests (bun test)
+npm run build     # Build with tsup
+npm start         # Start the proxy server
+```
+
+## Code Rules
+
+### Module Boundaries
+
+- **Do not add code to `server.ts` that belongs in a leaf module.** If it's pure logic (no HTTP, no Hono), extract it.
+- **`session/lineage.ts` must stay pure.** No side effects, no I/O, no imports from cache or server.
+- **Leaf modules (`errors.ts`, `models.ts`, `tools.ts`, `messages.ts`) must not import from `server.ts` or `session/`.** Dependencies flow downward only.
+- **No circular dependencies.**
+
+### Agent-Specific Logic
+
+OpenCode-specific behavior is documented in `ARCHITECTURE.md` under "Agent-Specific Logic". When modifying these areas:
+
+- Add a `NOTE:` comment marking the code as agent-specific
+- Do not spread agent-specific logic into new modules
+- Future work will use an adapter pattern — see `DEFERRED.md`
+
+### Testing
+
+- Every extracted module must have unit tests
+- Pure functions get direct unit tests (no mocks)
+- Integration tests go through the HTTP layer with mocked SDK
+- **All tests must pass before any change is considered complete**
+- New test files go in `src/__tests__/`
+- **E2E tests** are documented in [`E2E.md`](./E2E.md) — run manually before releases or after major refactors (requires Codex Max subscription)
+
+### Style
+
+- No `as any`, `@ts-ignore`, or `@ts-expect-error`
+- No empty catch blocks
+- Match existing patterns — check neighboring code before writing
+- Keep `server.ts` as thin as possible — it should orchestrate, not compute
+
+## Architecture Quick Reference
+
+```
+server.ts          → HTTP routes, SSE streaming, concurrency (orchestration only)
+adapter.ts         → AgentAdapter interface (extensibility point)
+adapters/
+  opencode.ts      → OpenCode-specific: headers, CWD, tool config
+  forgecode.ts     → ForgeCode-specific: XML CWD, patch/shell tools, passthrough
+query.ts           → buildQueryOptions (shared stream/non-stream SDK call builder)
+errors.ts          → classifyError (pure)
+models.ts          → mapModelToClaudeModel, resolveClaudeExecutableAsync
+tools.ts           → BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME
+messages.ts        → normalizeContent, getLastUserMessage (pure)
+fileChanges.ts     → PostToolUse hook: file write/edit tracking + summary formatting (pure)
+session/
+  lineage.ts       → Hashing, lineage verification (PURE — no I/O)
+  fingerprint.ts   → extractClientCwd, getConversationFingerprint
+  cache.ts         → LRU caches, lookupSession, storeSession (stateful)
+```
+
+## Stable API Contract
+
+External plugins depend on these interfaces. **Do not change without project owner approval.**
+
+| Interface | Location | Used by |
+|-----------|----------|---------|
+| `startProxyServer(config)` → `ProxyInstance` | `server.ts` | Plugins that spawn proxy instances |
+| `ProxyInstance.close()` | `types.ts` | Plugins for graceful shutdown |
+| `ProxyConfig` type | `types.ts` | Plugin configuration |
+| `x-opencode-session` header | `adapters/opencode.ts` | Session tracking from agent plugins |
+| `x-meridian-profile` header | `server.ts`, `profiles.ts` | Per-request profile selection |
+| `GET /health` response shape | `server.ts` | Plugin health checks |
+| `POST /v1/messages` request/response format | `server.ts` | All agents (Anthropic API contract) |
+| `GET /profiles/list` response shape | `server.ts` | Profile management UI and CLI |
+| `POST /profiles/active` request/response | `server.ts` | Profile switching from CLI and UI |
+
+If you need to modify any of these, open an issue first — breaking changes affect downstream plugin authors.
+
+## Git & Workflow
+
+### Commit format
+
+- Format: `type: brief description`
+- Types: feat, fix, refactor, perf, test, docs, chore
+- No AI attribution lines
+
+### Development workflow — NEVER push directly to main
+
+All changes go through this process, no exceptions:
+
+1. **Create a feature branch** from `main`:
+   ```bash
+   git checkout -b feat/my-feature main
+   ```
+
+2. **Make changes, commit, push the branch:**
+   ```bash
+   git add -A && git commit -m "feat: my feature"
+   git push origin feat/my-feature
+   ```
+
+3. **Create a PR** targeting `main`:
+   ```bash
+   gh pr create --title "feat: my feature" --base main
+   ```
+
+4. **Wait for CI** — the `test` job must pass before merging:
+   ```bash
+   gh pr checks <PR_NUMBER>
+   ```
+
+5. **Merge the PR** (squash merge preferred):
+   ```bash
+   gh pr merge <PR_NUMBER> --squash --delete-branch
+   ```
+
+6. **Never** run `git push origin main` directly — all code reaches `main` through merged PRs only.
+
+## Releasing
+
+**Do NOT run `npm version`, `git push --tags`, or `npm publish` manually.**
+
+Releases are handled automatically by [Release Please](https://github.com/googleapis/release-please):
+
+1. Merge PRs to `main` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
+2. Release Please auto-creates/updates a release PR that batches all unreleased changes
+3. Review the release PR — the changelog should only show changes since the last release
+4. When ready to ship, merge the release PR:
+   ```bash
+   gh pr merge <RELEASE_PR_NUMBER> --merge
+   ```
+5. Merging the release PR automatically:
+   - Bumps `package.json` and `CHANGELOG.md`
+   - Creates a git tag (`meridian-v*`) and GitHub Release
+   - Runs tests, builds, and publishes to npm with provenance
+
+Multiple PRs get batched into a single release. Never publish manually.
+
+### Troubleshooting releases
+
+- **Changelog shows entire history?** — Release Please can't find the previous release tag. Check that `meridian-v<version>` tags exist for recent releases: `git tag -l 'meridian-v*' | tail -5`
+- **Release PR not updating?** — It only updates on `push` to `main`. If you closed it, push any commit to main to regenerate.
+- **Publish failed with E403?** — The version was already published. This is safe to ignore; the release is already on npm.
+- **`publish_only` workflow dispatch** — Emergency escape hatch to publish the current version without Release Please. Only use when the normal flow is broken.
+
+### Release config files
+
+- **`.release-please-manifest.json`** — tracks the current released version. Release Please updates this automatically when a release PR is merged. **Do not edit manually** unless resetting the version anchor.
+- **`release-please-config.json`** — defines the release type (`node`), component name, and changelog section mapping.
+- **`.github/workflows/release-please.yml`** — the workflow that runs on every push to `main`. It creates/updates the release PR and publishes to npm when merged.

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -154,10 +154,20 @@ async function readSSE(response: Response) {
 
 describe("Passthrough deny aborts the nested SDK session on loop detection", () => {
   let origEnv: string | undefined
+  let origEarlyStop: string | undefined
 
+  // These tests pin the LEGACY single-step semantics (#571): same-tool
+  // repeats are dropped and abort the query mid-hook. With early stop
+  // enabled (the default since the digest-turn elimination), same-tool
+  // calls are captured as genuine parallelism instead — see the
+  // "parallel same-tool calls" describe below. The legacy path remains
+  // reachable via the MERIDIAN_PASSTHROUGH_EARLY_STOP=0 kill switch and
+  // must keep working for operators who disable early stop.
   beforeEach(() => {
     origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
     process.env.MERIDIAN_PASSTHROUGH = "1"
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
     mockTurns = []
     capturedController = undefined
     capturedResume = undefined
@@ -167,6 +177,8 @@ describe("Passthrough deny aborts the nested SDK session on loop detection", () 
   afterEach(() => {
     if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
     else process.env.MERIDIAN_PASSTHROUGH = origEnv
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
   })
 
   it("non-stream: aborts the SDK query when a same-tool repeat is detected and still returns the distinct tool_use", async () => {
@@ -300,6 +312,187 @@ describe("Passthrough deny aborts the nested SDK session on loop detection", () 
       { role: "user", content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "72F" }] },
     ])
     expect(second.status).toBe(200)
+    expect(capturedResume).toBeUndefined()
+  })
+})
+
+describe("parallel same-tool calls are captured and forwarded (#552 kabo regression)", () => {
+  // Root cause of kabo's v1.49.0 'read {} → Tool execution aborted' loop:
+  // 'read multiple files' makes the model emit TWO parallel read calls in ONE
+  // assistant message. The legacy #571 rule assumed genuine parallelism uses
+  // DISTINCT tool names, so call 2 was dropped + the query SIGTERMed mid-hook
+  // — cutting call 2's already-streamed block (red read), skipping the session
+  // store, and forcing a fresh replay whose '[your read ...]: Tool execution
+  // aborted' lines the model then disowns ("calls I did not make").
+  //
+  // With early stop, the fabricated-loop turns #571 guarded against never
+  // generate (the query stops at deny-persistence), so same-tool-new-args
+  // calls are genuine parallelism and must be captured and forwarded.
+  let origEnv: string | undefined
+  let origEarlyStop: string | undefined
+
+  beforeEach(() => {
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP // early stop ON (default)
+    mockTurns = []
+    capturedController = undefined
+    capturedResume = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origEnv
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+  })
+
+  function parallelReadTurn() {
+    const turn = toolTurn("toolu_pa", "read", { filePath: "a.txt" })
+    ;(turn as any).message.content = [
+      { type: "tool_use", id: "toolu_pa", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      { type: "tool_use", id: "toolu_pb", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "b.txt" } },
+    ]
+    return turn
+  }
+
+  function denyUser(ids: string[]) {
+    return {
+      type: "user",
+      message: {
+        role: "user",
+        content: ids.map((id) => ({
+          type: "tool_result",
+          tool_use_id: id,
+          is_error: true,
+          content: "This tool call has been forwarded to the client for execution.",
+        })),
+      },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: "test-session",
+    }
+  }
+
+  it("non-stream: both parallel reads are captured with full inputs; digest turn never consumed", async () => {
+    mockTurns = [
+      parallelReadTurn(),
+      denyUser(["toolu_pa", "toolu_pb"]),
+      // Digest/fabrication turn — early stop must abort before this is consumed.
+      toolTurn("toolu_garbage", "get_time", { tz: "UTC" }),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await post(app, false)
+    const body = await response.json() as any
+
+    expect(response.status).toBe(200)
+    expect(body.stop_reason).toBe("tool_use")
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.map((t: any) => t.id).sort()).toEqual(["toolu_pa", "toolu_pb"])
+    // Full inputs — no argument-less 'red read'.
+    expect(toolUses.find((t: any) => t.id === "toolu_pa").input).toEqual({ filePath: "a.txt" })
+    expect(toolUses.find((t: any) => t.id === "toolu_pb").input).toEqual({ filePath: "b.txt" })
+    // Early stop aborted the query after the denies were persisted.
+    expect(capturedController!.signal.aborted).toBe(true)
+  })
+
+  it("the parallel-capture session is stored — the follow-up RESUMES instead of fresh-replaying", async () => {
+    mockTurns = [parallelReadTurn(), denyUser(["toolu_pa", "toolu_pb"])]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const first = await post(app, false)
+    expect(first.status).toBe(200)
+
+    mockTurns = [
+      {
+        type: "assistant",
+        message: {
+          id: "msg_final", type: "message", role: "assistant",
+          content: [{ type: "text", text: "Both files read successfully." }],
+          model: "claude-sonnet-4-5-20250929", stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 10 },
+        },
+        parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
+      },
+    ]
+    capturedResume = undefined
+    const second = await post(app, false, [
+      { role: "user", content: "Do the thing." },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "toolu_pa", name: "read", input: { filePath: "a.txt" } },
+        { type: "tool_use", id: "toolu_pb", name: "read", input: { filePath: "b.txt" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_pa", content: "contents of a" },
+        { type: "tool_result", tool_use_id: "toolu_pb", content: "contents of b" },
+      ]},
+    ])
+    expect(second.status).toBe(200)
+    // The stored session is resumed — this is what kills the fresh-replay
+    // '[your read ...]: Tool execution aborted' confusion loop.
+    // (?? guard defeats TS narrowing from the `= undefined` reset above —
+    // the mock closure reassigns it during the request.)
+    expect(capturedResume ?? "(not resumed)").toBe("test-session")
+  })
+
+  it("stream: both parallel read blocks reach the client fully terminated, no error", async () => {
+    const streamEvent = (event: any) => ({
+      type: "stream_event", event, parent_tool_use_id: null,
+      uuid: crypto.randomUUID(), session_id: "test-session",
+    })
+    mockTurns = [
+      streamMessageStart(),
+      streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_pa", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+      streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"filePath":"a.txt"}' } }),
+      streamEvent({ type: "content_block_stop", index: 1 }),
+      streamEvent({ type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "toolu_pb", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+      streamEvent({ type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '{"filePath":"b.txt"}' } }),
+      streamEvent({ type: "content_block_stop", index: 2 }),
+      parallelReadTurn(),
+      denyUser(["toolu_pa", "toolu_pb"]),
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await post(app, true)
+    const events = await readSSE(response)
+    const eventTypes = events.map((e: any) => e.event)
+
+    expect(eventTypes).not.toContain("error")
+    expect(eventTypes).toContain("message_stop")
+    const toolStartIds = events
+      .filter((e: any) => e.event === "content_block_start" && e.data?.content_block?.type === "tool_use")
+      .map((e: any) => e.data.content_block.id)
+    expect(toolStartIds.sort()).toEqual(["toolu_pa", "toolu_pb"])
+    // Every started block terminates — no dangling 'red read'.
+    const startIdxs = events.filter((e: any) => e.event === "content_block_start").map((e: any) => e.data.index)
+    const stopIdxs = events.filter((e: any) => e.event === "content_block_stop").map((e: any) => e.data.index)
+    for (const idx of startIdxs) expect(stopIdxs).toContain(idx)
+    expect(capturedController!.signal.aborted).toBe(true)
+  })
+
+  it("kill switch restores the legacy semantics: mid-hook abort + session NOT stored", async () => {
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
+    mockTurns = [parallelReadTurn(), denyUser(["toolu_pa", "toolu_pb"])]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const first = await post(app, false)
+    expect(first.status).toBe(200)
+    expect(capturedController!.signal.aborted).toBe(true)
+
+    // Legacy: sawDuplicateToolUse skips the store — the follow-up must NOT resume.
+    mockTurns = [toolTurn("toolu_next", "get_time", { tz: "UTC" })]
+    capturedResume = undefined
+    await post(app, false, [
+      { role: "user", content: "Do the thing." },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "toolu_pa", name: "read", input: { filePath: "a.txt" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_pa", content: "contents of a" },
+      ]},
+    ])
     expect(capturedResume).toBeUndefined()
   })
 })

--- a/src/__tests__/proxy-passthrough-single-turn.test.ts
+++ b/src/__tests__/proxy-passthrough-single-turn.test.ts
@@ -117,17 +117,29 @@ function toolBlocks(body: any): Array<{ name: string; id: string; input: any }> 
 
 describe("Passthrough non-streaming: client-driven single-step semantics", () => {
   let origEnv: string | undefined
+  let origEarlyStop: string | undefined
 
+  // Pins the LEGACY (#571) single-step semantics: same-tool re-calls across
+  // internal turns are dropped. With early stop ON (default), same-tool calls
+  // are captured as genuine parallelism and the fabrication turns these
+  // fixtures simulate never generate — see proxy-passthrough-deny-abort's
+  // "parallel same-tool calls" describe for the current-default coverage.
+  // The legacy path stays reachable via MERIDIAN_PASSTHROUGH_EARLY_STOP=0
+  // and must keep working.
   beforeEach(() => {
     mockTurns = []
     origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
     process.env.MERIDIAN_PASSTHROUGH = "1"
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
     clearSessionCache()
   })
 
   afterEach(() => {
     if (origEnv !== undefined) process.env.MERIDIAN_PASSTHROUGH = origEnv
     else delete process.env.MERIDIAN_PASSTHROUGH
+    if (origEarlyStop !== undefined) process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+    else delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
     mockTurns = []
   })
 

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -407,9 +407,17 @@ describe("PreToolUse hook: deny reasons must not promise delivery for dropped ca
   // delivered in a future turn". That promise persists in the resumed SDK
   // session's history, so next turn the model remembers a pending call whose
   // result never arrives and misattributes the results it does receive.
+  //
+  // Runs under the early-stop kill switch: with early stop ON (default),
+  // same-tool re-calls are captured as genuine parallelism and get the
+  // normal forwarded reason — the dropped-call reason only applies in
+  // legacy mode (and to forced-single, which is mode-independent).
+  let savedEarlyStop: string | undefined
   beforeEach(() => {
     savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    savedEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
     process.env.MERIDIAN_PASSTHROUGH = "1"
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
     mockMessages = [assistantMessage([{ type: "text", text: "Done" }])]
     capturedQueryParams = null
     clearSessionCache()
@@ -418,6 +426,8 @@ describe("PreToolUse hook: deny reasons must not promise delivery for dropped ca
   afterEach(() => {
     if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
     else delete process.env.MERIDIAN_PASSTHROUGH
+    if (savedEarlyStop !== undefined) process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = savedEarlyStop
+    else delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
   })
 
   async function getHook(body: Record<string, unknown> = {}) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1132,12 +1132,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 //      collecting — a genuine parallel call to a DIFFERENT tool
                 //      may still follow (robust to duplicate-before-distinct
                 //      ordering). This is the #528 duplication.
-                //   2. Same tool re-called with NEW args: the model fabricated a
-                //      result for the blocked call and continued (a sequential-
-                //      dependency loop, e.g. fetch→fetch→fetch). Stop after the
-                //      distinct set — the client will supply the real result and
-                //      drive the next call. (Genuine parallel uses DISTINCT tool
-                //      names — get_weather + get_time — which are kept.)
+                //   2. Same tool re-called with NEW args — LEGACY (kill switch
+                //      only). #571 assumed genuine parallelism uses DISTINCT
+                //      tool names, but "read three files" makes the model emit
+                //      parallel same-tool calls in ONE assistant message; the
+                //      drop + mid-hook SIGTERM cut the already-streamed second
+                //      block (#552 "red reads": `read {}` aborted), skipped the
+                //      session store, and pushed the follow-up onto a fresh
+                //      replay full of "[your read ...]: Tool execution aborted"
+                //      lines the model then disowned. With early stop, the
+                //      fabricated-loop turns this rule guarded against never
+                //      generate (the query stops the moment every deny is
+                //      persisted), so same-tool-new-args calls are genuine
+                //      parallelism and are captured. The drop remains only
+                //      when the operator disables early stop.
                 //   3. Forced single tool (tool_choice:{type:"tool"} / structured
                 //      output): keep only the first call.
                 // Cases 2 and 3 set sawDuplicateToolUse, the signal the non-
@@ -1145,7 +1153,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // instead of draining the whole turn budget.
                 const signature = toolUseSignature(toolName, toolInput)
                 const isExactDuplicate = capturedSignatures.has(signature)
-                const isSameToolRepeat = !isExactDuplicate && capturedToolNames.has(toolName)
+                const isSameToolRepeat = !earlyStopEnabled && !isExactDuplicate && capturedToolNames.has(toolName)
                 const exceedsForcedSingle = forceSingleToolUse && capturedToolUses.length >= 1
                 if (isExactDuplicate) {
                   claudeLog("passthrough.duplicate_tool_use_dropped", { name: toolName })


### PR DESCRIPTION
Fixes the v1.49.0 regression kabo reported on #552 (the `read {}` → "Tool execution aborted" retry loop).

## Root cause

"Test reading multiple files" makes the model emit **two parallel `read` calls in one assistant message** — correct model behavior. The #571 single-step rule assumed genuine parallelism always uses *distinct* tool names, so the second same-tool call was treated as loop fabrication: dropped + query SIGTERMed **mid-hook**. Three consequences chained into kabo's transcript:

1. The SIGTERM raced the stream pipe — call 2's block had already streamed its `content_block_start` but lost its input deltas → rendered client-side as the argument-less aborted `read {}` (the #552 "red read"; #591's dangling-close made it render instead of hang, but it's still a broken call).
2. `sawDuplicateToolUse` → session **not stored** → the follow-up fresh-replayed.
3. The fresh replay contained `[your read ...]: Tool execution aborted` for the cut call → the model disowned it ("results for calls I did not make") → re-ran the test → same trap, ~10-turn loop.

## Why the fix is safe now (and wasn't before)

The early stop (#609) is what makes the #571 drop rule obsolete: the fabricated-loop turns it guarded against **never generate** — the query is aborted the moment every forwarded call's deny is persisted. So any same-tool-new-args call observed during the assistant turn is genuine parallelism and is now **captured and forwarded** like distinct tools. No mid-hook SIGTERM → no red read; no `sawDuplicateToolUse` → session stores → follow-up **resumes**.

Legacy semantics remain fully reachable under `MERIDIAN_PASSTHROUGH_EARLY_STOP=0`; the tests that pinned them now run under that flag explicitly.

## Verification

- New tests (deny-abort suite): non-stream parallel capture with full inputs + digest turn never consumed; **session stored → follow-up resumes**; stream variant with every block terminated; kill-switch legacy semantics (abort + no store).
- Live against the real SDK: parallel two-file read → `nToolUse=2, emptyInput=0` (pre-fix: 1 forwarded, 1 cut); follow-up turn `lineage=continuation`.
- Full suite: 1986 pass / 0 fail; `tsc --noEmit` clean.