### PR TITLE
fix(passthrough): strip hook-dropped tool calls from the client response

### DIFF
--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -496,3 +496,84 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     expect(capturedResume).toBeUndefined()
   })
 })
+
+describe("dropped calls must not leak to the client (truth-divergence guard)", () => {
+  // The hook can still DROP calls with early stop on: exact duplicates
+  // ("do not repeat") and forced-single overflow (tool_choice:{type:"tool"} —
+  // generateObject needs EXACTLY one call). The model is told those calls
+  // were NOT forwarded — so the client must never see them. Before this
+  // guard, the merge block only added/normalized captured blocks and never
+  // removed dropped ones: a forced-single parallel emission returned BOTH
+  // tool_use blocks (unparseable for generateObject), and the model/client
+  // views diverged — the #552 misattribution seed.
+  let origEnv: string | undefined
+  let origEarlyStop: string | undefined
+
+  beforeEach(() => {
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    mockTurns = []
+    capturedController = undefined
+    capturedResume = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origEnv
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+  })
+
+  it("forced single: parallel emission in ONE message returns exactly one tool_use", async () => {
+    const turn = toolTurn("toolu_j1", "json", { answer: "first" })
+    ;(turn as any).message.content = [
+      { type: "tool_use", id: "toolu_j1", name: `${PASSTHROUGH_PREFIX}json`, input: { answer: "first" } },
+      { type: "tool_use", id: "toolu_j2", name: `${PASSTHROUGH_PREFIX}json`, input: { answer: "second" } },
+    ]
+    mockTurns = [turn]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const req = new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-opencode-session": "forced-single-session" },
+      body: JSON.stringify(makeRequest({
+        stream: false,
+        tools: [tool("json")],
+        tool_choice: { type: "tool", name: "json", disable_parallel_tool_use: true },
+        messages: [{ role: "user", content: "Give me the answer." }],
+      })),
+    })
+    const body = await (await app.fetch(req)).json() as any
+
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.length).toBe(1)
+    expect(toolUses[0].id).toBe("toolu_j1")
+    expect(toolUses[0].input).toEqual({ answer: "first" })
+  })
+
+  it("exact duplicate in ONE message is not delivered twice", async () => {
+    const turn = toolTurn("toolu_d1", "read", { filePath: "a.txt" })
+    ;(turn as any).message.content = [
+      { type: "tool_use", id: "toolu_d1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      // Same name + same input, fresh id — the hook drops it ("do not repeat").
+      { type: "tool_use", id: "toolu_d2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+    ]
+    mockTurns = [turn, {
+      type: "user",
+      message: { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_d1", is_error: true, content: "forwarded" },
+        { type: "tool_result", tool_use_id: "toolu_d2", is_error: true, content: "already forwarded" },
+      ]},
+      parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
+    }]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+
+    const response = await post(app, false)
+    const body = await response.json() as any
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.map((t: any) => t.id)).toEqual(["toolu_d1"])
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -999,6 +999,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const capturedToolUses: Array<{ id: string; name: string; input: any }> = []
       const capturedSignatures = new Set<string>()
       const capturedToolNames = new Set<string>()
+      // Calls the hook DROPPED (exact duplicate / forced-single overflow /
+      // legacy same-tool repeat). The model was told these were NOT forwarded,
+      // so the client must never see them — the merge strips them from the
+      // response. Without this, a forced-single parallel emission returned
+      // BOTH tool_use blocks (unparseable for generateObject) and the
+      // model/client views diverged (#552 misattribution family).
+      const droppedToolUseIds = new Set<string>()
       let sawDuplicateToolUse = false
       // Early stop: the moment every forwarded tool call's deny is persisted
       // (observed as a `user` tool_result in the stream), abort the query so
@@ -1156,8 +1163,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 const isSameToolRepeat = !earlyStopEnabled && !isExactDuplicate && capturedToolNames.has(toolName)
                 const exceedsForcedSingle = forceSingleToolUse && capturedToolUses.length >= 1
                 if (isExactDuplicate) {
+                  droppedToolUseIds.add(input.tool_use_id)
                   claudeLog("passthrough.duplicate_tool_use_dropped", { name: toolName })
                 } else if (isSameToolRepeat || exceedsForcedSingle) {
+                  droppedToolUseIds.add(input.tool_use_id)
                   sawDuplicateToolUse = true
                   claudeLog("passthrough.extra_tool_use_dropped", {
                     name: toolName,
@@ -1669,6 +1678,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // its content blocks, replace the input with the normalized version.
           // If the SDK omitted it (blocked tools may not appear), add it.
           if (passthrough && capturedToolUses.length > 0) {
+            // Strip calls the hook dropped — the model was told they were NOT
+            // forwarded ("do not repeat" / forced-single overflow), so
+            // delivering them anyway diverges the client's view from the
+            // session history (#552) and hands generateObject multiple
+            // structured calls where it requires exactly one.
+            if (droppedToolUseIds.size > 0) {
+              for (let i = contentBlocks.length - 1; i >= 0; i--) {
+                const b = contentBlocks[i]!
+                if (b.type === "tool_use" && droppedToolUseIds.has((b as any).id)) {
+                  contentBlocks.splice(i, 1)
+                }
+              }
+            }
             const capturedById = new Map(capturedToolUses.map(tu => [tu.id, tu]))
             for (const block of contentBlocks) {
               if (block.type === "tool_use" && capturedById.has((block as any).id)) {


### PR DESCRIPTION
Found during the pre-release adversarial sweep of the #552 family (what-the-model-is-told vs what-the-client-sees divergence).

## The hole

The PreToolUse hook still drops calls in two cases with early stop on — **exact duplicates** ("do not repeat") and **forced-single overflow** (`tool_choice:{type:"tool"}`, `generateObject`). The model is told those calls were NOT forwarded. But the non-stream merge block only *added/normalized* captured blocks — it never **removed** dropped ones, so the client received and executed them anyway:

- `generateObject` + parallel emission → **two** structured calls in the response where the AI SDK requires exactly one (unparseable concatenation)
- any dropped-but-delivered call = client history diverges from session history → the #552 misattribution seed

## Fix

Track dropped `tool_use_id`s in the hook; strip matching blocks in the merge. In normal early-stop flows nothing is dropped, so this is a no-op on the hot path.

**Streaming caveat (pre-existing, unchanged):** blocks stream to the client before the hook decides, so the stream path stays best-effort — `generateObject` is non-stream, which is where the contract matters.

## Tests

Two new red→green tests (forced-single parallel → exactly one call; exact duplicate → delivered once). Full suite 1988 pass / 0 fail, tsc clean.