### PR TITLE
feat: env-configurable plugin loading and home-manager plugin settings

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -38,6 +38,8 @@ Environment variables:
   MERIDIAN_HOST                     Host to bind to (default: 127.0.0.1)
   MERIDIAN_PASSTHROUGH              Enable passthrough mode (tools forwarded to client)
   MERIDIAN_IDLE_TIMEOUT_SECONDS     Idle timeout in seconds (default: 120)
+  MERIDIAN_PLUGIN_DIR               Plugin auto-discovery directory (default: ~/.config/meridian/plugins)
+  MERIDIAN_PLUGIN_CONFIG            Plugin manifest path (default: ~/.config/meridian/plugins.json)
 
 See https://github.com/rynfar/meridian for full documentation.`)
   process.exit(0)
@@ -123,6 +125,8 @@ const execFile = promisify(execFileCallback)
 const port = parseInt(process.env.MERIDIAN_PORT ?? process.env.CLAUDE_PROXY_PORT ?? "3456", 10)
 const host = process.env.MERIDIAN_HOST ?? process.env.CLAUDE_PROXY_HOST ?? "127.0.0.1"
 const idleTimeoutSeconds = parseInt(process.env.MERIDIAN_IDLE_TIMEOUT_SECONDS ?? process.env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS ?? "120", 10)
+const pluginDir = process.env.MERIDIAN_PLUGIN_DIR
+const pluginConfigPath = process.env.MERIDIAN_PLUGIN_CONFIG
 
 // Load profile configuration:
 //   1. MERIDIAN_PROFILES env var (JSON array) — takes precedence
@@ -200,7 +204,7 @@ export async function runCli(
     enableDiskProfileDiscovery()
   }
 
-  const proxy = await start({ port, host, idleTimeoutSeconds, profiles, defaultProfile, version, installProcessErrorHandlers: true })
+  const proxy = await start({ port, host, idleTimeoutSeconds, pluginDir, pluginConfigPath, profiles, defaultProfile, version, installProcessErrorHandlers: true })
 
   // Handle EADDRINUSE — preserve CLI behavior of exiting on port conflict
   proxy.server.on("error", (error: NodeJS.ErrnoException) => {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,109 +1,139 @@
 packages:
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
+  inherit (lib.attrsets) filterAttrsRecursive mapAttrsToList mapAttrsToListRecursive;
+  inherit (lib.generators) mkKeyValueDefault;
+  inherit (lib.lists) concatMap elem;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    ;
+  inherit (lib.strings)
+    join
+    upperChars
+    splitStringBy
+    toUpper
+    ;
+  inherit (lib.trivial) flip pipe;
+  inherit (lib.types)
+    attrsOf
+    bool
+    int
+    nullOr
+    port
+    str
+    ;
   cfg = config.services.meridian;
 in
 {
   options.services.meridian = {
-    enable = lib.mkEnableOption "the Meridian proxy service";
+    enable = mkEnableOption "the Meridian proxy service";
 
-    package = lib.mkPackageOption packages "meridian" {
+    package = mkPackageOption packages "meridian" {
       pkgsText = "inputs.meridian.packages.\${pkgs.stdenv.hostPlatform.system}";
     };
 
     settings = {
-      port = lib.mkOption {
-        type = lib.types.port;
+      port = mkOption {
+        type = port;
         default = 3456;
         description = "Port to listen on.";
       };
 
-      host = lib.mkOption {
-        type = lib.types.str;
+      host = mkOption {
+        type = str;
         default = "127.0.0.1";
         description = "Host to bind to.";
       };
 
-      idleTimeoutSeconds = lib.mkOption {
-        type = lib.types.int;
+      idleTimeoutSeconds = mkOption {
+        type = int;
         default = 120;
         description = "HTTP keep-alive idle timeout in seconds.";
       };
 
-      passthrough = lib.mkOption {
-        type = lib.types.nullOr lib.types.bool;
+      passthrough = mkOption {
+        type = nullOr bool;
         default = null;
-        description = "Forward tool calls to client instead of executing. Null lets Meridian auto-detect.";
+        description = "Forward tool calls to client instead of executing. `null` lets Meridian auto-detect.";
       };
 
-      defaultAgent = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
+      defaultAgent = mkOption {
+        type = nullOr str;
         default = null;
-        description = "Default adapter for unrecognized agents (opencode, forgecode, pi, crush, droid, passthrough).";
+        description = "Default adapter for unrecognized agents (`opencode`, `forgecode`, `pi`, `crush`, `droid`, `passthrough`).";
       };
 
-      sonnetModel = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
+      sonnetModel = mkOption {
+        type = nullOr str;
         default = null;
-        description = "Sonnet context tier: 'sonnet' (200k) or 'sonnet[1m]' (1M, requires Extra Usage).";
+        description = "Sonnet context tier: `sonnet` (200k) or `sonnet[1m]` (1M, requires Extra Usage).";
       };
 
       telemetry = {
-        persist = lib.mkOption {
-          type = lib.types.bool;
+        persist = mkOption {
+          type = bool;
           default = false;
           description = "Enable SQLite telemetry persistence.";
         };
 
-        retentionDays = lib.mkOption {
-          type = lib.types.nullOr lib.types.int;
+        retentionDays = mkOption {
+          type = nullOr int;
           default = null;
           description = "Days to retain telemetry data before cleanup.";
         };
       };
     };
 
-    environment = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
+    environment = mkOption {
+      type = attrsOf str;
       default = { };
       description = "Extra environment variables passed to the Meridian service.";
     };
 
-    opencode.pluginPath = lib.mkOption {
-      type = lib.types.str;
+    opencode.pluginPath = mkOption {
+      type = str;
       default = "${cfg.package}/lib/meridian/plugin/meridian.ts";
       readOnly = true;
-      description = "Nix store path to the OpenCode plugin file. Use this to reference the plugin in your OpenCode config.";
+      description = ''
+        Nix store path to the OpenCode plugin file.
+        Use this to reference the plugin in your OpenCode config.
+      '';
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     systemd.user.services.meridian = {
       Unit.Description = "Meridian - Local Anthropic API proxy";
 
       Service = {
         Type = "exec";
-        ExecStart = lib.getExe cfg.package;
+        ExecStart = getExe cfg.package;
         Restart = "on-failure";
         RestartSec = 5;
 
         Environment =
-          lib.pipe
-            {
-              MERIDIAN_DEFAULT_AGENT = cfg.settings.defaultAgent;
-              MERIDIAN_HOST = cfg.settings.host;
-              MERIDIAN_IDLE_TIMEOUT_SECONDS = cfg.settings.idleTimeoutSeconds;
-              MERIDIAN_PASSTHROUGH = cfg.settings.passthrough;
-              MERIDIAN_PORT = cfg.settings.port;
-              MERIDIAN_SONNET_MODEL = cfg.settings.sonnetModel;
-              MERIDIAN_TELEMETRY_PERSIST = cfg.settings.telemetry.persist;
-              MERIDIAN_TELEMETRY_RETENTION_DAYS = cfg.settings.telemetry.retentionDays;
-            }
-            [
-              (lib.filterAttrs (_: v: v != null))
-              (lib.flip lib.mergeAttrs cfg.environment)
-              (lib.mapAttrsToList (lib.generators.mkKeyValueDefault { } "="))
+          let
+            env = flip pipe [
+              (concatMap (splitStringBy (_: curr: elem curr upperChars) true))
+              (map toUpper)
+              (join "_")
+              (s: "MERIDIAN_${s}")
             ];
+          in
+          pipe cfg.settings [
+            (filterAttrsRecursive (_: v: v != null))
+            (mapAttrsToListRecursive (path: value: mkKeyValueDefault { } "=" (env path) value))
+          ]
+          ++ mapAttrsToList (mkKeyValueDefault { } "=") cfg.environment;
       };
 
       Install.WantedBy = [ "default.target" ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -12,6 +12,7 @@ let
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf;
   inherit (lib.options)
+    literalExpression
     mkEnableOption
     mkOption
     mkPackageOption
@@ -27,11 +28,16 @@ let
     attrsOf
     bool
     int
+    listOf
     nullOr
+    path
     port
     str
+    submodule
     ;
   cfg = config.services.meridian;
+  mkPluginFile = plugins: toString (pluginFormat.generate "plugins.json" { inherit plugins; });
+  pluginFormat = pkgs.formats.json { };
 in
 {
   options.services.meridian = {
@@ -76,6 +82,33 @@ in
         type = nullOr str;
         default = null;
         description = "Sonnet context tier: `sonnet` (200k) or `sonnet[1m]` (1M, requires Extra Usage).";
+      };
+
+      pluginConfig = mkOption {
+        type = listOf (submodule {
+          options = {
+            enabled = mkOption {
+              type = bool;
+              default = true;
+              description = "Whether Meridian loads this plugin. Disabled entries stay in the manifest but are marked disabled.";
+            };
+
+            path = mkOption {
+              type = path;
+              example = literalExpression ''"''${plugin}/lib/index.js"'';
+              description = "Path to the plugin's ESM entry file.";
+            };
+          };
+        });
+        default = [ ];
+        apply = mkPluginFile;
+        description = "Plugins to load, in list order, rendered to a `plugins.json` manifest passed as `MERIDIAN_PLUGIN_CONFIG`.";
+      };
+
+      pluginDir = mkOption {
+        type = nullOr path;
+        default = null;
+        description = "Directory Meridian auto-discovers plugins from. `null` uses Meridian's default (`~/.config/meridian/plugins`).";
       };
 
       telemetry = {


### PR DESCRIPTION
`ProxyConfig.pluginDir` and `pluginConfigPath` were only settable through the embedded `createProxyServer` API — the CLI never read them, so a standalone `meridian` process always used the fixed `~/.config/meridian/plugins/` and `~/.config/meridian/plugins.json`. `bin/cli.ts` now reads `MERIDIAN_PLUGIN_DIR` and `MERIDIAN_PLUGIN_CONFIG` and forwards them into `startProxyServer` (documented in `--help`), so both paths are configurable for the standalone proxy.

The home-manager module gains two settings. `services.meridian.settings.pluginConfig` takes a list of `{ path, enabled }` submodules and renders them, in order, to a `plugins.json` manifest in the Nix store (via `pkgs.formats.json`), passed as `MERIDIAN_PLUGIN_CONFIG`. `services.meridian.settings.pluginDir` maps to `MERIDIAN_PLUGIN_DIR`. The service `Environment` now derives each `MERIDIAN_*` variable name automatically from its `settings` attribute path, so new settings are exported without a hand-maintained key mapping.
