### PR TITLE
fix: expose model-scoped usage limits

### DIFF
--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -85,6 +85,53 @@ describe("oauthUsage", () => {
     expect(sevenDay!.utilization).toBeCloseTo(0.05, 5)
   })
 
+  test("parses model-scoped weekly limits without duplicating aggregate windows", async () => {
+    const resetsAt = "2026-07-20T12:00:00Z"
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify({
+      five_hour: { utilization: 15, resets_at: "2026-07-15T18:00:00Z" },
+      seven_day: { utilization: 56, resets_at: "2026-07-20T12:00:00Z" },
+      limits: [
+        {
+          kind: "session",
+          group: "session",
+          percent: 15,
+          resets_at: "2026-07-15T18:00:00Z",
+          scope: { model: null, surface: null },
+        },
+        {
+          kind: "weekly_all",
+          group: "weekly",
+          percent: 56,
+          resets_at: resetsAt,
+          scope: { model: null, surface: null },
+        },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 57,
+          resets_at: resetsAt,
+          scope: { model: { id: null, display_name: "Fable" }, surface: null },
+        },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 20,
+          resets_at: resetsAt,
+          scope: { model: null, surface: "api" },
+        },
+      ],
+    }), { status: 200 }))
+
+    const result = await fetchOAuthUsage({ force: true, store: makeStore("t"), fetchImpl })
+
+    expect(result!.windows).toHaveLength(3)
+    expect(result!.windows.find(w => w.type === "seven_day_fable")).toEqual({
+      type: "seven_day_fable",
+      utilization: 0.57,
+      resetsAt: Date.parse(resetsAt),
+    })
+  })
+
   test("normalizes utilization from 0..100 to 0..1", async () => {
     const fetchImpl = fixedFetch(() => new Response(JSON.stringify({
       five_hour: { utilization: 87.5, resets_at: "2026-04-26T22:30:00Z" },

--- a/src/__tests__/profile-usage.test.ts
+++ b/src/__tests__/profile-usage.test.ts
@@ -20,6 +20,7 @@ describe("labelForWindow", () => {
     expect(labelForWindow("seven_day")).toBe("7d")
     expect(labelForWindow("seven_day_opus")).toBe("7d Opus")
     expect(labelForWindow("seven_day_sonnet")).toBe("7d Sonnet")
+    expect(labelForWindow("seven_day_fable")).toBe("7d Fable")
     expect(labelForWindow("seven_day_oauth_apps")).toBe("7d Apps")
     expect(labelForWindow("seven_day_cowork")).toBe("7d Cowork")
     expect(labelForWindow("seven_day_omelette")).toBe("7d Omelette")

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -40,6 +40,18 @@ interface RawOAuthExtraUsage {
   currency?: string
 }
 
+interface RawOAuthLimit {
+  kind?: string
+  percent?: number | null
+  resets_at?: string | null
+  scope?: {
+    model?: {
+      id?: string | null
+      display_name?: string | null
+    } | null
+  } | null
+}
+
 interface RawOAuthUsageResponse {
   five_hour?: RawOAuthWindow | null
   seven_day?: RawOAuthWindow | null
@@ -50,6 +62,7 @@ interface RawOAuthUsageResponse {
   seven_day_omelette?: RawOAuthWindow | null
   iguana_necktie?: RawOAuthWindow | null
   omelette_promotional?: RawOAuthWindow | null
+  limits?: RawOAuthLimit[] | null
   extra_usage?: RawOAuthExtraUsage | null
 }
 
@@ -102,6 +115,21 @@ function normalizeUtilization(raw: number | null | undefined): number | null {
   return Math.max(0, raw / 100)
 }
 
+function modelScopedWindowType(limit: RawOAuthLimit): string | null {
+  if (limit.kind !== "weekly_scoped") return null
+
+  const model = limit.scope?.model
+  const name = model?.display_name?.trim() || model?.id?.trim()
+  if (!name) return null
+
+  const slug = name
+    .toLowerCase()
+    .replace(/^claude[\s_-]+/, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+  return slug ? `seven_day_${slug}` : null
+}
+
 function buildSnapshot(raw: RawOAuthUsageResponse): OAuthUsageSnapshot {
   const windows: OAuthUsageWindow[] = []
   for (const key of WINDOW_TYPES) {
@@ -111,6 +139,19 @@ function buildSnapshot(raw: RawOAuthUsageResponse): OAuthUsageSnapshot {
     const resetsAt = parseIsoToMs(w.resets_at)
     if (utilization === null && resetsAt === null) continue
     windows.push({ type: key as string, utilization, resetsAt })
+  }
+
+  const windowTypes = new Set(windows.map(window => window.type))
+  for (const limit of raw.limits ?? []) {
+    const type = modelScopedWindowType(limit)
+    if (!type || windowTypes.has(type)) continue
+
+    const utilization = normalizeUtilization(limit.percent)
+    const resetsAt = parseIsoToMs(limit.resets_at)
+    if (utilization === null && resetsAt === null) continue
+
+    windows.push({ type, utilization, resetsAt })
+    windowTypes.add(type)
   }
 
   const extra = raw.extra_usage

--- a/src/telemetry/profileUsage.ts
+++ b/src/telemetry/profileUsage.ts
@@ -18,6 +18,7 @@ export const WINDOW_LABELS: Record<string, string> = {
   seven_day: "7d",
   seven_day_opus: "7d Opus",
   seven_day_sonnet: "7d Sonnet",
+  seven_day_fable: "7d Fable",
   seven_day_oauth_apps: "7d Apps",
   seven_day_cowork: "7d Cowork",
   seven_day_omelette: "7d Omelette",


### PR DESCRIPTION
## Summary

- parse Anthropic's generic `limits` entries for model-scoped weekly quotas
- expose those entries as the existing normalized window shape (for example, `seven_day_fable`)
- show Fable's quota with the short `7d Fable` label on the profile page

## Why

Anthropic now returns Fable-only usage in a `weekly_scoped` entry under `limits[]`. Meridian currently reads only the older top-level window fields, so `/v1/usage/quota` and `/v1/usage/quota/all` omit that quota even though the upstream response contains it.

The parser ignores session, aggregate weekly, and non-model scoped entries because Meridian already handles the aggregate windows through the existing top-level fields. It also de-duplicates normalized window types to preserve current behavior if Anthropic overlaps response shapes.

## Checks

- `npm test`
- `npm run typecheck`
- `npm run build`
