### PR TITLE
fix(passthrough): hold denies until generation completes (#552 streaming red reads)

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -86,6 +86,7 @@ kill $(lsof -ti :3456)
 | E30 | [Context Usage via Fingerprint + Restart](#e30-context-usage-via-fingerprint--restart) | Context usage lookup works for headerless sessions and survives proxy restart via shared store | 2026-04-03 |
 | E32 | [Tool-use leak (#416) — opencode + opus-4-7](#e32-tool-use-leak-416--opencode--opus-4-7) | Multi-turn opencode rehydration with prior tool_use blocks does not cause opus-4-7 to emit `[Tool Use:` / `H:` / `Human:` text in its response | 2026-04-26 |
 | E33 | [OpenAI Compat: system prompt, no preset](#e33-openai-compat-system-prompt-no-preset) | `/v1/chat/completions` honours the client's system prompt without injecting the claude_code preset (openai adapter default) | 2026-06-15 |
+| E34 | [Streaming parallel tool calls (#552)](#e34-streaming-parallel-tool-calls-552) | **Automated**: `bun scripts/e2e-stream-parallel.mjs` — real CLI, SSE mode: parallel tool calls stream intact (no dangling `{}` blocks), denies held past generation, fast follow-up resumes. **Run before any release touching the passthrough tool loop** — mocked suites cannot catch CLI dispatch-ordering bugs (two shipped regressions proved it) | 2026-07-15 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3096,3 +3097,33 @@ curl -s http://127.0.0.1:3456/v1/chat/completions \
 **To confirm the preset is actually gone** (the deterministic check), set `codeSystemPrompt` for the `openai` adapter and observe the difference, or rely on the unit test `src/__tests__/proxy-openai-compat.test.ts` → "sends the client system prompt verbatim, without the claude_code preset", which asserts the SDK receives a plain-string `systemPrompt` rather than a `{type: "preset", preset: "claude_code"}` object.
 
 **What's being tested:** `openAiAdapter` (`adapters/openai.ts`), the `x-meridian-agent: openai` tag on the internal hop (`server.ts`), and `ADAPTER_DEFAULTS.openai = { codeSystemPrompt: false }` (`sdkFeatures.ts`).
+
+
+## E34: Streaming parallel tool calls (#552)
+
+**Automated** — the one E2E that is a single command:
+
+```bash
+bun scripts/e2e-stream-parallel.mjs        # 3 attempts (default)
+E2E_ATTEMPTS=5 bun scripts/e2e-stream-parallel.mjs
+```
+
+**Why this exists:** the CLI dispatches PreToolUse hooks per-block while later
+parallel blocks are still generating, and a deny landing mid-generation makes
+the CLI cancel the in-flight request — beheading trailing parallel calls. The
+client renders the cut block as an argument-less `tool {}` "Tool execution
+aborted" (the #552 "red read"), the session store is skipped, and the model
+loops. No mocked suite reproduced this dispatch ordering: v1.49.0 and v1.49.1
+both shipped with "verified" fixes that failed in the field within hours.
+This script runs the REAL CLI through the REAL proxy in SSE mode and asserts
+the actual client contract.
+
+**Pass criteria** (all attempts):
+- ≥2 parallel tool_use blocks reach the client, every block terminated
+- every tool input is complete, parseable JSON (no `{}`)
+- exactly one `message_stop`
+- the instant follow-up does not re-issue identical calls (session resumed)
+
+**What's being tested:** deny-hold (`holdDenyUntilTurnEnd`), early stop +
+drain, `flushOpenClientBlocks`, `pendingSessionStores` (`server.ts`);
+`passthroughEarlyStop.ts`.

--- a/scripts/e2e-stream-parallel.mjs
+++ b/scripts/e2e-stream-parallel.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: streaming passthrough with parallel tool calls (#552 red reads).
+ *
+ * This is the test that mocked suites CANNOT provide: it runs the REAL Claude
+ * CLI through the REAL proxy in SSE mode and validates the client-facing
+ * contract that kabo's and Stefan's transcripts showed breaking. The CLI
+ * dispatches PreToolUse hooks per-block while later parallel blocks are still
+ * generating, and a deny landing mid-generation cancels the in-flight request
+ * — behavior no mock reproduced, which is how two releases shipped with
+ * "verified" fixes that failed in the field.
+ *
+ * Requires: Claude Max auth (`claude login`). Run before releases touching
+ * the passthrough tool loop (see E2E.md):
+ *
+ *   bun scripts/e2e-stream-parallel.mjs
+ *
+ * Asserts, per attempt:
+ *   1. At least 2 parallel tool_use blocks reach the client
+ *   2. Every content_block_start has a matching content_block_stop (no
+ *      dangling blocks → no `tool {}` "Tool execution aborted" renders)
+ *   3. Every tool_use block carries complete, parseable input JSON
+ *   4. Exactly one message_stop (clean envelope)
+ *   5. The instant follow-up turn RESUMES the session (no fresh replay)
+ */
+import { startProxyServer } from "../src/proxy/server.ts"
+
+const PORT = 3499
+const ATTEMPTS = Number(process.env.E2E_ATTEMPTS ?? 3)
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1", silent: true })
+
+const TOOLS = [
+  { name: "bash", description: "Run a shell command", input_schema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] } },
+  { name: "glob", description: "Find files by glob pattern", input_schema: { type: "object", properties: { pattern: { type: "string" } }, required: ["pattern"] } },
+  { name: "read", description: "Read a file", input_schema: { type: "object", properties: { filePath: { type: "string" } }, required: ["filePath"] } },
+]
+
+let failures = 0
+const fail = (attempt, msg) => {
+  failures++
+  console.error(`  ✗ attempt ${attempt}: ${msg}`)
+}
+
+async function sse(sid, messages, maxTokens = 700) {
+  const r = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": "x", "x-opencode-session": sid, "user-agent": "opencode/1.0.0" },
+    body: JSON.stringify({ model: "claude-sonnet-4-5", max_tokens: maxTokens, stream: true, tools: TOOLS, messages }),
+  })
+  const text = await r.text()
+  const parse = (ev) => [...text.matchAll(new RegExp(`event: ${ev}\\ndata: (.*)`, "g"))].map((m) => JSON.parse(m[1]))
+  const starts = parse("content_block_start")
+  const stopIdx = parse("content_block_stop").map((s) => s.index)
+  const deltas = parse("content_block_delta")
+  const tools = starts
+    .filter((s) => s.content_block?.type === "tool_use")
+    .map((s) => ({
+      id: s.content_block.id,
+      name: s.content_block.name,
+      inputJson: deltas.filter((d) => d.index === s.index && d.delta?.type === "input_json_delta").map((d) => d.delta.partial_json).join(""),
+      closed: stopIdx.includes(s.index),
+    }))
+  return {
+    tools,
+    danglingIdx: starts.map((s) => s.index).filter((i) => !stopIdx.includes(i)),
+    messageStops: (text.match(/event: message_stop/g) || []).length,
+  }
+}
+
+for (let n = 1; n <= ATTEMPTS; n++) {
+  const sid = `e2e-par-${n}-${Math.random().toString(36).slice(2, 6)}`
+  const messages = [{ role: "user", content: "Run `ls /tmp` with bash AND find *.md files with glob AND read /etc/hostname — issue ALL THREE tool calls in parallel in this single response." }]
+
+  const t1 = await sse(sid, messages)
+  if (t1.tools.length < 2) fail(n, `expected ≥2 parallel tool calls, got ${t1.tools.length}`)
+  if (t1.danglingIdx.length > 0) fail(n, `dangling blocks (red reads): idx=[${t1.danglingIdx.join(",")}]`)
+  if (t1.messageStops !== 1) fail(n, `expected 1 message_stop, got ${t1.messageStops}`)
+  for (const t of t1.tools) {
+    if (!t.closed) fail(n, `tool ${t.name} block never closed`)
+    try {
+      const input = JSON.parse(t.inputJson || "{}")
+      if (Object.keys(input).length === 0) fail(n, `tool ${t.name} has EMPTY input (the '{} Tool execution aborted' render)`)
+    } catch {
+      fail(n, `tool ${t.name} has unparseable input: ${t.inputJson.slice(0, 60)}`)
+    }
+  }
+
+  // Instant follow-up (the fast-client race): must resume, not fresh-replay.
+  // Detect via a second round: send results, expect a final answer without
+  // the model disowning or re-issuing the calls.
+  messages.push({ role: "assistant", content: t1.tools.map((t) => ({ type: "tool_use", id: t.id, name: t.name, input: JSON.parse(t.inputJson || "{}") })) })
+  messages.push({ role: "user", content: t1.tools.map((t) => ({ type: "tool_result", tool_use_id: t.id, content: `ok: fake result for ${t.name}` })) })
+  const t2 = await sse(sid, messages, 400)
+  if (t2.danglingIdx.length > 0) fail(n, `follow-up has dangling blocks: idx=[${t2.danglingIdx.join(",")}]`)
+  const reissued = t2.tools.filter((t) => t1.tools.some((p) => p.name === t.name && p.inputJson === t.inputJson))
+  if (reissued.length > 0) fail(n, `model re-issued identical calls (lost memory of turn 1): ${reissued.map((t) => t.name).join(",")}`)
+
+  console.log(`  ✓ attempt ${n}: ${t1.tools.length} parallel calls intact (${t1.tools.map((t) => t.name).join(", ")}), follow-up clean`)
+}
+
+await inst.close?.()
+if (failures > 0) {
+  console.error(`\nE2E FAILED: ${failures} assertion(s) across ${ATTEMPTS} attempts`)
+  process.exit(1)
+}
+console.log(`\nE2E PASSED: ${ATTEMPTS}/${ATTEMPTS} attempts clean`)
+process.exit(0)

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -450,6 +450,9 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
       streamEvent({ type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "toolu_pb", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
       streamEvent({ type: "content_block_delta", index: 2, delta: { type: "input_json_delta", partial_json: '{"filePath":"b.txt"}' } }),
       streamEvent({ type: "content_block_stop", index: 2 }),
+      // The turn's message_delta always precedes the denies (real CLI order) —
+      // it also releases the deny-hold so the hooks below don't block.
+      streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } }),
       parallelReadTurn(),
       denyUser(["toolu_pa", "toolu_pb"]),
     ]
@@ -469,6 +472,12 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     const startIdxs = events.filter((e: any) => e.event === "content_block_start").map((e: any) => e.data.index)
     const stopIdxs = events.filter((e: any) => e.event === "content_block_stop").map((e: any) => e.data.index)
     for (const idx of startIdxs) expect(stopIdxs).toContain(idx)
+    // The response ends at the turn boundary; the early-stop abort lands in
+    // the background drain a moment later — poll briefly.
+    const deadline = Date.now() + 1500
+    while (!capturedController!.signal.aborted && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 10))
+    }
     expect(capturedController!.signal.aborted).toBe(true)
   })
 

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Streaming deny-hold + pending-store (#552 red reads, root cause v2).
+ *
+ * Observed live (scripts/e2e-stream-parallel.mjs): the CLI dispatches each
+ * tool's PreToolUse hook AS SOON AS that block finishes streaming — while
+ * later parallel blocks are still generating — and a deny landing
+ * mid-generation makes the CLI CANCEL the in-flight API request. The cancel
+ * beheads trailing parallel calls (client renders `glob {}` "Tool execution
+ * aborted") and the model regenerates them next turn — kabo's loop.
+ *
+ * The mock below models that CLI behavior faithfully — including
+ * cancel-on-deny — which is exactly what previous mocks failed to do (they
+ * fired hooks only after complete turns, so two releases shipped fixes that
+ * passed mocked tests and failed in the field).
+ *
+ * Pins:
+ *   1. Deny-hold: hook responses are held until the turn's message_delta, so
+ *      the cancel can never land mid-generation → all parallel blocks stream
+ *      to completion with full inputs.
+ *   2. Kill switch: without the hold the mock takes its cancel path — and the
+ *      flush guard still closes the beheaded block (no unterminated block).
+ *   3. Pending-store: the background drain finishes AFTER the client response;
+ *      an instant follow-up awaits the in-flight store and RESUMES.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { makeRequest, parseSSE } from "./helpers"
+
+const PREFIX = "mcp__oc__"
+
+let capturedController: AbortController | undefined
+let capturedResume: string | undefined
+let timeline: string[] = []
+// Deny persistence delay — simulates the CLI's post-release deny latency that
+// makes the store land after the client response (the fast-client race).
+let denyDelayMs = 0
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const streamEvent = (event: any) => ({
+  type: "stream_event", event, parent_tool_use_id: null,
+  uuid: crypto.randomUUID(), session_id: "test-session",
+})
+const msgStart = () => streamEvent({
+  type: "message_start",
+  message: { id: "m1", type: "message", role: "assistant", content: [], model: "claude-sonnet-4-5-20250929", stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 0 } },
+})
+const blockStart = (idx: number, name: string, id: string) =>
+  streamEvent({ type: "content_block_start", index: idx, content_block: { type: "tool_use", id, name: `${PREFIX}${name}`, input: {} } })
+const blockDelta = (idx: number, json: string) =>
+  streamEvent({ type: "content_block_delta", index: idx, delta: { type: "input_json_delta", partial_json: json } })
+const blockStop = (idx: number) => streamEvent({ type: "content_block_stop", index: idx })
+const msgDelta = () => streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } })
+const assistantMsg = (blocks: any[]) => ({
+  type: "assistant",
+  message: { id: "m1", type: "message", role: "assistant", content: blocks, model: "claude-sonnet-4-5-20250929", stop_reason: "tool_use", usage: { input_tokens: 10, output_tokens: 30 } },
+  parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
+})
+const denyMsg = (ids: string[]) => ({
+  type: "user",
+  message: { role: "user", content: ids.map((id) => ({ type: "tool_result", tool_use_id: id, is_error: true, content: "denied" })) },
+  parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
+})
+
+// CLI-faithful mock: per-block assistant messages, mid-stream hook dispatch,
+// CANCEL-ON-DENY when a deny resolves while generation is in flight.
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    capturedController = opts?.options?.abortController
+    capturedResume = opts?.options?.resume
+    const hook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+    return (async function* () {
+      if (!hook) {
+        // Follow-up turn (no tools emitted): plain final answer.
+        yield assistantMsg([{ type: "text", text: "All done." }])
+        return
+      }
+      yield msgStart()
+      timeline.push("message_start")
+
+      // bash block streams fully, then its hook dispatches MID-STREAM.
+      yield blockStart(2, "bash", "tb1")
+      yield blockDelta(2, '{"command":"ls /tmp"}')
+      yield assistantMsg([{ type: "tool_use", id: "tb1", name: `${PREFIX}bash`, input: { command: "ls /tmp" } }])
+      yield blockStop(2)
+      let bashDenied = false
+      const bashHook = Promise.resolve(
+        hook({ tool_name: `${PREFIX}bash`, tool_use_id: "tb1", tool_input: { command: "ls /tmp" } }, undefined, { signal: new AbortController().signal })
+      ).then(() => { bashDenied = true; timeline.push("bash_deny_resolved") })
+
+      // The generation gap in which the real CLI would receive the deny.
+      await sleep(25)
+
+      if (bashDenied) {
+        // CANCEL-ON-DENY: glob is beheaded mid-block (start, no stop), the
+        // turn's message_delta never arrives, turn 2 begins. This is the
+        // exact field behavior from kabo's v1.49.1 transcript.
+        timeline.push("CANCELED")
+        yield blockStart(3, "glob", "tg1")
+        yield blockDelta(3, '{"patt') // cut mid-JSON
+        yield denyMsg(["tb1"])
+        yield msgStart() // turn 2
+        timeline.push("turn2_message_start")
+        return
+      }
+
+      // Held deny → generation completes normally.
+      yield blockStart(3, "glob", "tg1")
+      yield blockDelta(3, '{"pattern":"*.md"}')
+      yield assistantMsg([{ type: "tool_use", id: "tg1", name: `${PREFIX}glob`, input: { pattern: "*.md" } }])
+      yield blockStop(3)
+      timeline.push("glob_streamed")
+      const globHook = Promise.resolve(
+        hook({ tool_name: `${PREFIX}glob`, tool_use_id: "tg1", tool_input: { pattern: "*.md" } }, undefined, { signal: new AbortController().signal })
+      ).then(() => timeline.push("glob_deny_resolved"))
+
+      yield msgDelta()
+      timeline.push("message_delta")
+
+      await bashHook
+      await globHook
+      if (denyDelayMs > 0) await sleep(denyDelayMs)
+      yield denyMsg(["tb1"])
+      yield denyMsg(["tg1"])
+      // Early stop aborts here; nothing further should be pulled.
+      timeline.push("post_denies")
+      yield assistantMsg([{ type: "text", text: "turn 2 digest garbage" }])
+      timeline.push("turn2_consumed")
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: (event: string) => { timeline.push(`log:${event}`) },
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+const tool = (name: string) => ({ name, description: `${name} tool`, input_schema: { type: "object", properties: {}, additionalProperties: true } })
+
+async function postStream(app: any, sid: string, messages: unknown[]) {
+  const req = new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-opencode-session": sid },
+    body: JSON.stringify(makeRequest({ stream: true, tools: [tool("bash"), tool("glob")], messages })),
+  })
+  const response = await app.fetch(req)
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let raw = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    raw += decoder.decode(value, { stream: true })
+  }
+  return parseSSE(raw)
+}
+
+function envelope(events: any[]) {
+  const starts = events.filter((e: any) => e.event === "content_block_start")
+  const stopIdx = events.filter((e: any) => e.event === "content_block_stop").map((e: any) => e.data.index)
+  return {
+    toolStarts: starts.filter((e: any) => e.data?.content_block?.type === "tool_use").map((e: any) => e.data.content_block),
+    dangling: starts.map((e: any) => e.data.index).filter((i: number) => !stopIdx.includes(i)),
+  }
+}
+
+describe("streaming deny-hold (#552 root cause v2)", () => {
+  let origPassthrough: string | undefined
+  let origEarlyStop: string | undefined
+
+  beforeEach(() => {
+    origPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    timeline = []
+    denyDelayMs = 0
+    capturedController = undefined
+    capturedResume = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origPassthrough === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origPassthrough
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+  })
+
+  it("holds denies until message_delta — parallel blocks stream to completion, no cancel", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const events = await postStream(app, "hold-1", [{ role: "user", content: "test tools" }])
+    const { toolStarts, dangling } = envelope(events)
+
+    // The mock's cancel path never taken: generation completed.
+    expect(timeline).not.toContain("CANCELED")
+    // The deny resolved only after the turn finished generating.
+    expect(timeline.indexOf("glob_streamed")).toBeLessThan(timeline.indexOf("bash_deny_resolved"))
+    expect(timeline.indexOf("message_delta")).toBeLessThan(timeline.indexOf("bash_deny_resolved"))
+    // Client contract: both tool blocks, fully terminated.
+    expect(toolStarts.map((t: any) => t.id).sort()).toEqual(["tb1", "tg1"])
+    expect(dangling).toEqual([])
+    // The client response ends at the turn boundary while the drain (denies →
+    // early stop → abort) finishes in the background — poll briefly for it.
+    const deadline = Date.now() + 1500
+    while (!capturedController!.signal.aborted && Date.now() < deadline) await sleep(10)
+    // Early stop aborted before the digest turn was consumed.
+    expect(capturedController!.signal.aborted).toBe(true)
+    expect(timeline).not.toContain("turn2_consumed")
+  })
+
+  it("kill switch: cancel path still cannot leave an unterminated block (flush guard)", async () => {
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const events = await postStream(app, "hold-2", [{ role: "user", content: "test tools" }])
+    const { dangling } = envelope(events)
+
+    // Without the hold the mock cancels (legacy field behavior)...
+    expect(timeline).toContain("CANCELED")
+    // ...but every started block is still closed before the stream ends —
+    // the render can no longer be `glob {}` "Tool execution aborted".
+    expect(dangling).toEqual([])
+  })
+
+  it("fast follow-up awaits the in-flight background store and RESUMES", async () => {
+    denyDelayMs = 150 // denies (and thus the store) land after the client response
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    await postStream(app, "hold-3", [{ role: "user", content: "test tools" }])
+
+    // Immediately send the follow-up — before the drain could have stored.
+    capturedResume = undefined
+    await postStream(app, "hold-3", [
+      { role: "user", content: "test tools" },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "tb1", name: "bash", input: { command: "ls /tmp" } },
+        { type: "tool_use", id: "tg1", name: "glob", input: { pattern: "*.md" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "tb1", content: "ok" },
+        { type: "tool_result", tool_use_id: "tg1", content: "ok" },
+      ]},
+    ])
+    expect(capturedResume ?? "(fresh)").toBe("test-session")
+  })
+})

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -72,14 +72,20 @@ export function noteAssistantContent(tracker: EarlyStopTracker, content: unknown
 }
 
 /**
- * Record persisted tool_results from a user message's content. Only results
- * matching an expected id count — unrelated results are ignored.
+ * Record persisted tool_results from a user message's content.
+ *
+ * Records EVERY tool_result id, not just already-expected ones: the CLI
+ * dispatches hooks per-block while later blocks are still streaming, and it
+ * emits per-block assistant messages — so a deny's tool_result can reach the
+ * iterator BEFORE the assistant message that arms its id in `expected`
+ * (observed live, MERIDIAN_TRACE_STREAM). Unmatched ids are harmless:
+ * shouldEarlyStop only ever checks ids that are in `expected`.
  */
 export function noteUserContent(tracker: EarlyStopTracker, content: unknown): void {
   if (!Array.isArray(content)) return
   for (const block of content) {
     const b = block as { type?: unknown; tool_use_id?: unknown } | null | undefined
-    if (b?.type === "tool_result" && typeof b.tool_use_id === "string" && tracker.expected.has(b.tool_use_id)) {
+    if (b?.type === "tool_result" && typeof b.tool_use_id === "string") {
       tracker.resolved.add(b.tool_use_id)
     }
   }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -378,6 +378,32 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // so silently-updated tool definitions force a rebuild.
   const sessionMcpCache = new LRUMap<string, { key: string; mcp: ReturnType<typeof createPassthroughMcpServer> }>(getMaxSessionsLimit())
 
+  // In-flight session stores. The streaming drain design ends the client's
+  // response at the turn boundary (fast), while deny persistence + the early
+  // stop + storeSession continue in the background for ~a second. A client
+  // that executes its tools quickly (small file reads) can send the follow-up
+  // BEFORE the store lands — its lookup misses and the conversation falls to
+  // a fresh replay. Follow-ups briefly await their session's pending store.
+  const PENDING_STORE_WAIT_MS = 3000
+  const PENDING_STORE_AUTO_RESOLVE_MS = 10000
+  const pendingSessionStores = new Map<string, { promise: Promise<void>; resolve: () => void }>()
+  const registerPendingStore = (key: string): (() => void) => {
+    let resolveFn: () => void = () => {}
+    const promise = new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, PENDING_STORE_AUTO_RESOLVE_MS)
+      resolveFn = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+    })
+    const entry = { promise, resolve: resolveFn }
+    pendingSessionStores.set(key, entry)
+    return () => {
+      entry.resolve()
+      if (pendingSessionStores.get(key) === entry) pendingSessionStores.delete(key)
+    }
+  }
+
   const pluginDir = finalConfig.pluginDir ?? join(homedir(), ".config", "meridian", "plugins")
   const pluginConfigPath = finalConfig.pluginConfigPath ?? join(homedir(), ".config", "meridian", "plugins.json")
   let loadedPlugins: LoadedPlugin[] = []
@@ -778,6 +804,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const isClientDrivenLoop = adapterBase !== "claude-code" && !agentSessionId && lastIsToolResult
         const isIndependentSession =
           requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || isClientDrivenLoop || false
+        // If the previous turn's background drain is still persisting this
+        // session (streaming early stop), wait briefly so the lookup below
+        // sees the stored session instead of falling to a fresh replay.
+        if (!isIndependentSession && profileSessionId) {
+          const pendingStore = pendingSessionStores.get(profileSessionId)
+          if (pendingStore) {
+            const waitStart = Date.now()
+            await Promise.race([
+              pendingStore.promise,
+              new Promise((resolve) => setTimeout(resolve, PENDING_STORE_WAIT_MS)),
+            ])
+            claudeLog("session.pending_store_awaited", { waitedMs: Date.now() - waitStart })
+          }
+        }
         let lineageResult = isIndependentSession
           ? { type: "diverged" as const }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
@@ -1017,6 +1057,42 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const earlyStopEnabled = passthrough && process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP !== "0"
       const earlyStop = createEarlyStopTracker()
       let earlyStopFired = false
+      // Deny-hold: the CLI dispatches each tool's PreToolUse hook AS SOON AS
+      // that block finishes streaming — while later parallel blocks are still
+      // generating — and a deny landing mid-generation makes the CLI CANCEL
+      // the in-flight API request (observed live via scripts/e2e-stream-parallel.mjs:
+      // bash's deny arrived between glob's input deltas; glob's block never
+      // received its stop and turn 2 regenerated it). That cancel is what
+      // beheads trailing parallel calls (#552 red reads: `glob {}` aborted)
+      // and re-loops the model. Fix: hold every deny response until turn-1
+      // generation completes (message_delta observed), so the cancel can
+      // never land mid-generation. Timeout is a deadlock backstop in case a
+      // CLI version serializes hook-then-stream.
+      const DENY_HOLD_TIMEOUT_MS = 8000
+      const pendingDenyReleases: Array<() => void> = []
+      // True while a model turn is actively generating (message_start seen,
+      // no message_delta/message_stop yet). Hooks dispatched AFTER generation
+      // completes (the CLI runs tool dispatch semi-sequentially, so later
+      // hooks can fire post-turn) must NOT hold — there is no in-flight
+      // request left to protect, and holding would only add dead time.
+      let turnGenerating = false
+      const releaseHeldDenies = (reason: string): void => {
+        turnGenerating = false
+        if (pendingDenyReleases.length === 0) return
+        claudeLog("passthrough.deny_hold_released", { reason, count: pendingDenyReleases.length })
+        for (const release of pendingDenyReleases.splice(0)) release()
+      }
+      const holdDenyUntilTurnEnd = (): Promise<void> =>
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            claudeLog("passthrough.deny_hold_timeout", { afterMs: DENY_HOLD_TIMEOUT_MS })
+            resolve()
+          }, DENY_HOLD_TIMEOUT_MS)
+          pendingDenyReleases.push(() => {
+            clearTimeout(timer)
+            resolve()
+          })
+        })
       // Forced structured output: a `tool_choice` of {type:"tool",...} (or an
       // explicit disable_parallel_tool_use) means the client — e.g. the AI
       // SDK's generateObject — wants EXACTLY ONE call to that tool. Claude
@@ -1206,6 +1282,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // pending call whose result never arrives and misattributes
                 // the results it does receive ("the read tool is returning
                 // the wrong file").
+                // Hold the deny until turn-1 generation completes (streaming
+                // only — see holdDenyUntilTurnEnd above). Returning it
+                // immediately lets the CLI cancel the in-flight generation and
+                // behead any parallel call still streaming after this one.
+                // Skip when the query is already aborted (forced-single fired
+                // requestAbort above — the subprocess is dying; holding would
+                // only delay until the timeout).
+                if (stream && earlyStopEnabled && turnGenerating && !requestAbort.controller.signal.aborted) {
+                  await holdDenyUntilTurnEnd()
+                }
                 if (isExactDuplicate) {
                   return {
                     decision: "block" as const,
@@ -1913,6 +1999,32 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // path closes these explicitly before its final frames.
             const openClientBlocks = new Set<number>()
 
+            // Announce this request's eventual storeSession to follow-ups: the
+            // drain design ends the client response before the store lands, so
+            // a fast follow-up must await it (see pendingSessionStores).
+            const resolvePendingStore = passthrough && earlyStopEnabled && !isIndependentSession && profileSessionId
+              ? registerPendingStore(profileSessionId)
+              : () => {}
+
+            // Envelope integrity: every path that ends the client stream must
+            // first terminate any content block whose start was forwarded but
+            // whose stop hasn't been — an unterminated block renders
+            // client-side as an argument-less aborted ("red") tool call
+            // (#552). The error-recovery path already does this; this helper
+            // extends the guarantee to ALL close paths (early stop, turn-2
+            // suppression, drain-close). With the deny-hold in place blocks
+            // normally complete before any close — this is the backstop.
+            const flushOpenClientBlocks = (source: string): void => {
+              if (openClientBlocks.size === 0) return
+              claudeLog("stream.dangling_blocks_closed", { source, count: openClientBlocks.size })
+              for (const idx of openClientBlocks) {
+                safeEnqueue(encoder.encode(
+                  `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: idx })}\n\n`
+                ), `${source}_close_dangling`)
+              }
+              openClientBlocks.clear()
+            }
+
             try {
               let currentSessionId: string | undefined
               // Same transparent retry wrapper as the non-streaming path.
@@ -2167,6 +2279,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       if (shouldEarlyStop(earlyStop) && streamedToolUseIds.size > 0) {
                         earlyStopFired = true
                         claudeLog("passthrough.early_stop", { mode: "stream", captured: capturedToolUses.length, drained: awaitingEarlyStopDrain })
+                        flushOpenClientBlocks("early_stop")
                         safeEnqueue(encoder.encode(
                           `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: lastUsage?.output_tokens ?? 0 } })}\n\n`
                         ), "early_stop")
@@ -2207,6 +2320,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     const eventType = (event as any).type
                     const eventIndex = (event as any).index as number | undefined
 
+                    // Turn-generation boundary: release held deny responses.
+                    // message_delta/message_stop = the turn finished cleanly;
+                    // a SECOND message_start = the turn ended some other way
+                    // (belt-and-suspenders so holds can't leak across turns).
+                    if (
+                      eventType === "message_delta" ||
+                      eventType === "message_stop" ||
+                      (eventType === "message_start" && messageStartEmitted)
+                    ) {
+                      releaseHeldDenies(eventType)
+                    }
+                    if (eventType === "message_start") {
+                      turnGenerating = true
+                    }
+
                     // Native structured output is validated only on the SDK's
                     // final result message. Buffer its partial wire events and
                     // emit one valid Anthropic SSE message after validation.
@@ -2236,6 +2364,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       // client sees stop_reason:"tool_use" and executes the tool itself.
                       if (messageStartEmitted) {
                         if (passthrough && streamedToolUseIds.size > 0) {
+                          flushOpenClientBlocks("turn2_suppression")
                           safeEnqueue(encoder.encode(
                             `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: lastUsage?.output_tokens ?? 0 } })}\n\n`
                           ), "passthrough_turn2_stop")
@@ -2427,6 +2556,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       (event as any).delta?.stop_reason === "tool_use" &&
                       streamedToolUseIds.size > 0
                     ) {
+                      flushOpenClientBlocks("drain_close")
                       safeEnqueue(
                         encoder.encode(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`),
                         "passthrough_tool_stream_stop"
@@ -2450,6 +2580,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
               } finally {
                 clearInterval(heartbeat)
+                // Never leak a held deny: if the loop exits for any reason
+                // (abort, error, natural end), unblock pending hook responses.
+                releaseHeldDenies("stream_loop_exit")
               }
 
               if (outputFormat) {
@@ -2531,6 +2664,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
                 storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
               }
+              resolvePendingStore()
 
               if (!streamClosed) {
                 // In passthrough mode, emit captured tool_use blocks as stream events
@@ -2714,6 +2848,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 return
               }
 
+              resolvePendingStore()
               const stderrOutput = stderrLines.join("\n").trim()
               if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
                 error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`


### PR DESCRIPTION
Fixes kabo's v1.49.1 reproduction on #552 — and closes the testing gap that let two releases ship with fixes that failed in the field.

## The real mechanism (observed, not assumed)

kabo's v1.49.1 transcript had the decisive clue: `bash` + `glob {}` — **distinct tools**, so the same-tool drop fixed in #620 couldn't be the (only) cause. A live stream trace against the real CLI showed:

```
content_block_start  glob        ← still streaming its input
content_block_delta  glob
user tool_result (bash, deny)   ← bash's deny lands MID-GLOB
message_start                    ← the CLI CANCELS turn 1 and regenerates!
```

**The CLI dispatches each tool's PreToolUse hook as soon as that block finishes streaming — while later parallel blocks are still generating — and a deny landing mid-generation makes the CLI cancel the in-flight API request.** The cancel beheads the trailing call (rendered client-side as `glob {}` "Tool execution aborted"), turn 1 never gets its message_delta, and the model re-emits the beheaded call next turn → kabo's retry loop. Deterministic: reproduced 4/4 before the fix.

## The fix (four parts, each live-verified)

1. **Deny-hold** — hook deny responses are held until the turn's `message_delta`, so the cancel can never land mid-generation. Result: all parallel calls stream to completion with full inputs (was 0/4 clean; now 3/3 E2E + 4/4 repro).
2. **Tracker order-independence** — denies can arrive before the per-block assistant messages that arm their ids.
3. **`flushOpenClientBlocks`** — every client-stream close path (early stop, turn-2 suppression, drain-close) now terminates open blocks first. No path can leave a dangling block, by construction.
4. **`pendingSessionStores`** — the background drain finishes after the client response; a fast follow-up (small file reads execute in ms) briefly awaits the in-flight store instead of falling to a fresh replay. Live-verified: instant follow-up now `lineage=continuation`.

## The testing gap, closed

The mocked suites modeled hook dispatch happening AFTER complete turns — the real CLI dispatches per-block, mid-stream, with cancel-on-deny. That ordering difference is precisely where both shipped regressions lived.

- **New: `scripts/e2e-stream-parallel.mjs` (E2E.md § E34)** — runs the REAL CLI through the REAL proxy in SSE mode; asserts parallel calls arrive intact, no dangling blocks, complete input JSON, exactly one message_stop, and that the instant follow-up resumes. To be run before any release touching the passthrough tool loop.
- **New mocked suite (`proxy-stream-deny-hold.test.ts`)** — models the OBSERVED CLI behavior **including cancel-on-deny**: without the hold, the mock cancels exactly like the field. This is the mock that would have caught the bug.

## Verification

- Live repro: 0/4 clean before → 4/4 clean after (all three parallel calls, zero dangling)
- E2E harness: 3/3 attempts, both turns
- Full suite: 1991 pass / 0 fail; tsc clean