### PR TITLE
feat(telemetry): envelope-integrity tripwires for wire-contract violations

### DIFF
--- a/src/__tests__/envelope-integrity.test.ts
+++ b/src/__tests__/envelope-integrity.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Envelope integrity checks — pure functions, no mocks.
+ *
+ * Every #552-family bug (red reads, beheaded parallel calls, lost tool
+ * inputs) was visible at response time as a wire-contract violation the
+ * proxy could have detected itself: a block left open at stream close, a
+ * captured call never delivered, a tool_use delivered with empty input
+ * where the tool requires arguments. These checks turn this week's scars
+ * into always-on runtime tripwires — violations are logged and counted on
+ * the dashboard so the NEXT regression shows up in our logs, not in a
+ * user's redacted transcript two months later.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  checkEmptyToolInputs,
+  checkUndeliveredToolUses,
+  type EnvelopeViolation,
+} from "../proxy/envelopeIntegrity"
+
+const schema = (required: string[]) => ({
+  type: "object",
+  properties: Object.fromEntries(required.map(k => [k, { type: "string" }])),
+  required,
+})
+
+describe("checkEmptyToolInputs", () => {
+  const tools = [
+    { name: "read", input_schema: schema(["filePath"]) },
+    { name: "list_sessions", input_schema: { type: "object", properties: {} } },
+  ]
+
+  it("flags a tool_use with empty input when the tool requires arguments", () => {
+    const v = checkEmptyToolInputs(
+      [{ type: "tool_use", id: "t1", name: "read", input: {} }],
+      tools,
+    )
+    expect(v).toHaveLength(1)
+    expect(v[0]!.type).toBe("empty_tool_input")
+    expect(v[0]!.detail).toContain("read")
+  })
+
+  it("does NOT flag empty input for a tool with no required fields (legit no-arg call)", () => {
+    const v = checkEmptyToolInputs(
+      [{ type: "tool_use", id: "t1", name: "list_sessions", input: {} }],
+      tools,
+    )
+    expect(v).toHaveLength(0)
+  })
+
+  it("does NOT flag tool_use with populated input", () => {
+    const v = checkEmptyToolInputs(
+      [{ type: "tool_use", id: "t1", name: "read", input: { filePath: "/a" } }],
+      tools,
+    )
+    expect(v).toHaveLength(0)
+  })
+
+  it("does NOT flag unknown tools (no schema to judge against)", () => {
+    const v = checkEmptyToolInputs(
+      [{ type: "tool_use", id: "t1", name: "mystery", input: {} }],
+      tools,
+    )
+    expect(v).toHaveLength(0)
+  })
+
+  it("ignores non-tool_use blocks and tolerates malformed input", () => {
+    const v = checkEmptyToolInputs(
+      [
+        { type: "text", text: "hi" },
+        { type: "tool_use", id: "t2", name: "read" }, // missing input entirely
+      ],
+      tools,
+    )
+    expect(v).toHaveLength(1) // missing input on a required-args tool IS a violation
+  })
+
+  it("handles undefined/empty tool list", () => {
+    expect(checkEmptyToolInputs([{ type: "tool_use", id: "t", name: "read", input: {} }], undefined)).toHaveLength(0)
+    expect(checkEmptyToolInputs([], tools)).toHaveLength(0)
+  })
+})
+
+describe("checkUndeliveredToolUses", () => {
+  it("flags captured calls that never reached the client", () => {
+    const v = checkUndeliveredToolUses(
+      [{ id: "t1", name: "read" }, { id: "t2", name: "glob" }],
+      new Set(["t1"]),
+    )
+    expect(v).toHaveLength(1)
+    expect(v[0]!.type).toBe("undelivered_tool_use")
+    expect(v[0]!.detail).toContain("glob")
+  })
+
+  it("passes when everything captured was delivered", () => {
+    const v = checkUndeliveredToolUses(
+      [{ id: "t1", name: "read" }],
+      new Set(["t1", "t9"]),
+    )
+    expect(v).toHaveLength(0)
+  })
+
+  it("passes with no captures", () => {
+    expect(checkUndeliveredToolUses([], new Set())).toHaveLength(0)
+  })
+})

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -586,3 +586,81 @@ describe("dropped calls must not leak to the client (truth-divergence guard)", (
     expect(toolUses.map((t: any) => t.id)).toEqual(["toolu_d1"])
   })
 })
+
+describe("envelope integrity tripwire", () => {
+  // The proxy asserts its own wire contract on every response. The kill-switch
+  // dangling fixture below genuinely produces a red read (block 2 cut before
+  // its stop) — the tripwire must count it in /telemetry so the next
+  // #552-family regression fires in OUR logs, not a user transcript.
+  let origEnv: string | undefined
+  let origEarlyStop: string | undefined
+
+  beforeEach(() => {
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    mockTurns = []
+    capturedController = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origEnv
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+  })
+
+  it("counts a dangling-block violation when a stream cuts a block (legacy fixture)", async () => {
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0" // legacy mid-hook abort → real dangling block
+    const streamEvent = (event: any) => ({
+      type: "stream_event", event, parent_tool_use_id: null,
+      uuid: crypto.randomUUID(), session_id: "test-session",
+    })
+    const twoCallTurn = toolTurn("toolu_ev1", "read", { filePath: "a.txt" })
+    ;(twoCallTurn as any).message.content = [
+      { type: "tool_use", id: "toolu_ev1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      { type: "tool_use", id: "toolu_ev2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "b.txt" } },
+    ]
+    mockTurns = [
+      streamMessageStart(),
+      streamEvent({ type: "content_block_start", index: 1, content_block: { type: "tool_use", id: "toolu_ev1", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+      streamEvent({ type: "content_block_delta", index: 1, delta: { type: "input_json_delta", partial_json: '{"filePath":"a.txt"}' } }),
+      streamEvent({ type: "content_block_stop", index: 1 }),
+      streamEvent({ type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "toolu_ev2", name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+      // No stop for index 2 — abort cuts it (the red read).
+      twoCallTurn,
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    // The telemetry store is process-wide — assert the DELTA from this request.
+    const before = (await (await app.fetch(new Request("http://localhost/telemetry/summary"))).json() as any).envelopeViolationCount ?? 0
+    await readSSE(await post(app, true))
+
+    const after = (await (await app.fetch(new Request("http://localhost/telemetry/summary"))).json() as any).envelopeViolationCount ?? 0
+    expect(after - before).toBeGreaterThanOrEqual(1)
+  })
+
+  it("clean early-stop parallel run records ZERO violations", async () => {
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    const turn = toolTurn("toolu_ok1", "read", { filePath: "a.txt" })
+    ;(turn as any).message.content = [
+      { type: "tool_use", id: "toolu_ok1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      { type: "tool_use", id: "toolu_ok2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "b.txt" } },
+    ]
+    mockTurns = [turn, {
+      type: "user",
+      message: { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_ok1", is_error: true, content: "forwarded" },
+        { type: "tool_result", tool_use_id: "toolu_ok2", is_error: true, content: "forwarded" },
+      ]},
+      parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
+    }]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const before = (await (await app.fetch(new Request("http://localhost/telemetry/summary"))).json() as any).envelopeViolationCount ?? 0
+    const body = await (await post(app, false)).json() as any
+    expect(body.content.filter((b: any) => b.type === "tool_use")).toHaveLength(2)
+
+    const after = (await (await app.fetch(new Request("http://localhost/telemetry/summary"))).json() as any).envelopeViolationCount ?? 0
+    expect(after - before).toBe(0)
+  })
+})

--- a/src/proxy/envelopeIntegrity.ts
+++ b/src/proxy/envelopeIntegrity.ts
@@ -1,0 +1,84 @@
+/**
+ * Envelope integrity checks.
+ *
+ * Every #552-family bug (red reads, beheaded parallel calls, lost tool
+ * inputs) manifested as a wire-contract violation that was visible at
+ * response time — but only to the CLIENT, so we learned about each one from
+ * user transcripts weeks later. These checks make the proxy assert its own
+ * output contract on every response:
+ *
+ *   - dangling_block:        a content block left open at stream close
+ *                            (recorded at the flush site in server.ts)
+ *   - undelivered_tool_use:  a hook-captured call that never reached the client
+ *   - empty_tool_input:      a delivered tool_use with no arguments where the
+ *                            tool's schema requires them (the client-visible
+ *                            shape of a beheaded call)
+ *
+ * Violations are logged (envelope.violation) and counted on /telemetry so
+ * the next regression in this family fires a tripwire in OUR logs instead
+ * of waiting for a user report.
+ *
+ * Pure module — no I/O, no imports from server.ts or session/.
+ */
+
+export interface EnvelopeViolation {
+  type: "dangling_block" | "undelivered_tool_use" | "empty_tool_input"
+  detail: string
+}
+
+interface ToolSchema {
+  name: string
+  input_schema?: { required?: unknown; [key: string]: unknown }
+}
+
+/**
+ * Flag delivered tool_use blocks whose input is empty/missing even though
+ * the tool's schema declares required fields. A legit no-arg tool (empty
+ * `required`) never flags; unknown tools are skipped (nothing to judge by).
+ */
+export function checkEmptyToolInputs(
+  contentBlocks: Array<Record<string, unknown>>,
+  tools: ToolSchema[] | undefined,
+): EnvelopeViolation[] {
+  if (!tools || tools.length === 0 || contentBlocks.length === 0) return []
+  const requiredByName = new Map<string, boolean>()
+  for (const t of tools) {
+    const req = t.input_schema?.required
+    requiredByName.set(t.name, Array.isArray(req) && req.length > 0)
+  }
+  const violations: EnvelopeViolation[] = []
+  for (const b of contentBlocks) {
+    if (b.type !== "tool_use" || typeof b.name !== "string") continue
+    if (!requiredByName.get(b.name)) continue
+    const input = b.input
+    const empty = input == null || (typeof input === "object" && Object.keys(input as object).length === 0)
+    if (empty) {
+      violations.push({
+        type: "empty_tool_input",
+        detail: `tool_use ${b.name} (${String(b.id ?? "?")}) delivered with empty input but schema requires arguments`,
+      })
+    }
+  }
+  return violations
+}
+
+/**
+ * Flag hook-captured tool calls that never reached the client — the
+ * proxy promised the model "forwarded to the client" for these, so a
+ * missing delivery diverges the model's view from reality (#552 family).
+ */
+export function checkUndeliveredToolUses(
+  captured: Array<{ id: string; name: string }>,
+  deliveredIds: ReadonlySet<string>,
+): EnvelopeViolation[] {
+  const violations: EnvelopeViolation[] = []
+  for (const c of captured) {
+    if (!deliveredIds.has(c.id)) {
+      violations.push({
+        type: "undelivered_tool_use",
+        detail: `captured tool_use ${c.name} (${c.id}) was never delivered to the client`,
+      })
+    }
+  }
+  return violations
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -42,6 +42,7 @@ import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { createEarlyStopTracker, noteAssistantContent, noteUserContent, shouldEarlyStop } from "./passthroughEarlyStop"
+import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -1068,6 +1069,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // generation completes (message_delta observed), so the cancel can
       // never land mid-generation. Timeout is a deadlock backstop in case a
       // CLI version serializes hook-then-stream.
+      // Envelope integrity: violations of the proxy's own output contract
+      // (dangling blocks, undelivered captured calls, empty required tool
+      // inputs). Logged loudly + counted on /telemetry so #552-family
+      // regressions trip an alarm in OUR logs instead of user transcripts.
+      const envelopeViolations: string[] = []
+      const recordEnvelopeViolations = (violations: EnvelopeViolation[]): void => {
+        for (const v of violations) {
+          envelopeViolations.push(v.type)
+          claudeLog("envelope.violation", { type: v.type, detail: v.detail })
+          diagnosticLog.error(`${requestMeta.requestId} ENVELOPE VIOLATION [${v.type}] ${v.detail}`, requestMeta.requestId)
+        }
+      }
       const DENY_HOLD_TIMEOUT_MS = 8000
       const pendingDenyReleases: Array<() => void> = []
       // True while a model turn is actively generating (message_start seen,
@@ -1888,7 +1901,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             cacheReadInputTokens: lastUsage?.cache_read_input_tokens,
             cacheCreationInputTokens: lastUsage?.cache_creation_input_tokens,
             cacheHitRate: computeCacheHitRate(lastUsage),
+            ...(envelopeViolations.length > 0 ? { envelopeViolations: [...envelopeViolations] } : {}),
           })
+
+          // Envelope integrity (non-stream): the response must not contain
+          // beheaded calls (empty required inputs) or silently drop captured
+          // calls the model was told were forwarded.
+          if (passthrough) {
+            const deliveredIds = new Set<string>(
+              contentBlocks.filter((b) => b.type === "tool_use" && typeof (b as any).id === "string").map((b) => (b as any).id as string)
+            )
+            recordEnvelopeViolations([
+              ...checkEmptyToolInputs(contentBlocks, requestTools),
+              ...checkUndeliveredToolUses(capturedToolUses, deliveredIds),
+            ])
+          }
 
           // Store session for future resume.
           // Fork/subagent requests don't write to the cache — see lookupSession
@@ -2016,6 +2043,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // normally complete before any close — this is the backstop.
             const flushOpenClientBlocks = (source: string): void => {
               if (openClientBlocks.size === 0) return
+              recordEnvelopeViolations([...openClientBlocks].map((idx) => ({
+                type: "dangling_block" as const,
+                detail: `content block ${idx} still open at ${source} close`,
+              })))
               claudeLog("stream.dangling_blocks_closed", { source, count: openClientBlocks.size })
               for (const idx of openClientBlocks) {
                 safeEnqueue(encoder.encode(
@@ -2635,6 +2666,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 textEventsForwarded += 1
               }
 
+              if (passthrough) {
+                recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
+              }
               claudeLog("upstream.completed", {
                 mode: "stream",
                 model,
@@ -2674,6 +2708,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   for (let i = 0; i < unseenToolUses.length; i++) {
                     const tu = unseenToolUses[i]!
                     const blockIndex = eventsForwarded + i
+                    streamedToolUseIds.add(tu.id)
 
                     // content_block_start
                     safeEnqueue(encoder.encode(
@@ -2824,6 +2859,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   cacheReadInputTokens: lastUsage?.cache_read_input_tokens,
                   cacheCreationInputTokens: lastUsage?.cache_creation_input_tokens,
                   cacheHitRate: computeCacheHitRate(lastUsage),
+                  ...(envelopeViolations.length > 0 ? { envelopeViolations: [...envelopeViolations] } : {}),
                 })
 
                 if (textEventsForwarded === 0) {
@@ -2915,12 +2951,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // a tool_use block's input deltas but before its stop) — an
                 // unterminated block renders client-side as an argument-less
                 // aborted call (#552 "red reads").
-                for (const idx of openClientBlocks) {
-                  safeEnqueue(encoder.encode(
-                    `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: idx })}\n\n`
-                  ), "recover_close_dangling_block")
-                }
-                openClientBlocks.clear()
+                flushOpenClientBlocks("recovery")
 
                 // Mirror the success-path emission: send any unseen tool_uses
                 // (dedup against streamedToolUseIds), then a clean
@@ -2929,6 +2960,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 for (let i = 0; i < unseenToolUses.length; i++) {
                   const tu = unseenToolUses[i]!
                   const blockIndex = eventsForwarded + i
+                  streamedToolUseIds.add(tu.id)
                   safeEnqueue(encoder.encode(
                     `event: content_block_start\ndata: ${JSON.stringify({
                       type: "content_block_start",
@@ -2961,6 +2993,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   `event: message_stop\ndata: {"type":"message_stop"}\n\n`
                 ), "recover_message_stop")
 
+                recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
                 // Record as success — the client got a usable response.
                 const recoverTotalMs = Date.now() - requestStartAt
                 const recoverQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
@@ -2989,6 +3022,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   contentBlocks: eventsForwarded + unseenToolUses.length,
                   textEvents: textEventsForwarded,
                   error: null,
+                  ...(envelopeViolations.length > 0 ? { envelopeViolations: [...envelopeViolations] } : {}),
                 })
 
                 if (!streamClosed) {

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -214,6 +214,7 @@ function render(s, reqs, logs, quota) {
   html += '<div class="cards">'
     + card('Requests', s.totalRequests, s.requestsPerMinute.toFixed(1) + ' req/min')
     + card('Errors', s.errorCount, s.totalRequests > 0 ? ((s.errorCount/s.totalRequests)*100).toFixed(1) + '% error rate' : '')
+    + '<div class="card"><div class="card-label">Envelope</div><div class="card-value" style="color:' + ((s.envelopeViolationCount || 0) > 0 ? 'var(--red)' : 'var(--green)') + '">' + (s.envelopeViolationCount || 0) + '</div><div class="card-detail">' + ((s.envelopeViolationCount || 0) > 0 ? 'wire-contract violations — check logs' : 'wire contract clean') + '</div></div>'
     + card('Median Total', ms(s.totalDuration.p50), 'p95: ' + ms(s.totalDuration.p95))
     + card('Median TTFB', ms(s.ttfb.p50), 'p95: ' + ms(s.ttfb.p95))
     + card('Proxy Overhead', ms(s.proxyOverhead.p50), 'p95: ' + ms(s.proxyOverhead.p95))
@@ -291,6 +292,7 @@ function render(s, reqs, logs, quota) {
     const respW = Math.max((r.upstreamDurationMs - (r.ttfbMs || 0)) * scale, 2);
 
     const lineageBadge = r.lineageType ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:' + ({continuation:'var(--green)',compaction:'var(--yellow)',undo:'var(--purple)',diverged:'var(--red)',new:'var(--muted)'}[r.lineageType] || 'var(--muted)') + ';color:var(--bg)">' + r.lineageType + '</span>' : '';
+    const envBadge = (r.envelopeViolations && r.envelopeViolations.length > 0) ? ' <span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--red);color:var(--bg)" title="' + r.envelopeViolations.join(', ') + '">envelope×' + r.envelopeViolations.length + '</span>' : '';
     const sessionShort = r.sdkSessionId ? r.sdkSessionId.slice(0, 8) : '—';
     const msgCount = r.messageCount != null ? r.messageCount : '?';
 
@@ -301,7 +303,7 @@ function render(s, reqs, logs, quota) {
       + '<td>' + (r.adapter || '—') + sourceBadge + '</td>'
       + '<td>' + (r.requestModel || r.model) + '<br><span style="font-size:10px;color:var(--muted)">' + r.model + '</span></td>'
       + '<td>' + r.mode + (r.hasDeferredTools ? (function() { var sessDisc = r.sessionDiscoveredCount || 0; var loaded = ((r.toolCount || 0) - (r.deferredToolCount || 0)) + sessDisc; var deferred = Math.max(0, (r.deferredToolCount || 0) - sessDisc); var newDisc = r.discoveredTools || []; return '<br><span style="font-size:10px;color:var(--purple)">loaded=' + loaded + ' deferred=' + deferred + '</span>' + (newDisc.length > 0 ? '<br><span style="font-size:10px;color:var(--green)">+' + newDisc.join(', +') + '</span>' : ''); })() : '') + '</td>'
-      + '<td class="mono">' + sessionShort + ' ' + lineageBadge + '<br><span style="font-size:10px;color:var(--muted)">' + msgCount + ' msgs</span></td>'
+      + '<td class="mono">' + sessionShort + ' ' + lineageBadge + envBadge + '<br><span style="font-size:10px;color:var(--muted)">' + msgCount + ' msgs</span></td>'
       + '<td class="' + statusClass + '">' + statusText + '</td>'
       + '<td class="mono">' + ms(r.queueWaitMs) + '</td>'
       + '<td class="mono">' + ms(r.proxyOverheadMs) + '</td>'

--- a/src/telemetry/percentiles.ts
+++ b/src/telemetry/percentiles.ts
@@ -32,6 +32,7 @@ export function computeSummary(metrics: RequestMetric[], windowMs: number): Tele
       windowMs,
       totalRequests: 0,
       errorCount: 0,
+      envelopeViolationCount: 0,
       requestsPerMinute: 0,
       queueWait: emptyPhase,
       proxyOverhead: emptyPhase,
@@ -52,6 +53,7 @@ export function computeSummary(metrics: RequestMetric[], windowMs: number): Tele
   }
 
   const errorCount = metrics.filter(m => m.error !== null).length
+  const envelopeViolationCount = metrics.reduce((sum, m) => sum + (m.envelopeViolations?.length ?? 0), 0)
 
   const oldest = metrics[metrics.length - 1]!.timestamp
   const newest = metrics[0]!.timestamp
@@ -105,6 +107,7 @@ export function computeSummary(metrics: RequestMetric[], windowMs: number): Tele
     windowMs,
     totalRequests: metrics.length,
     errorCount,
+    envelopeViolationCount,
     requestsPerMinute: Math.round(requestsPerMinute * 100) / 100,
     queueWait: computePercentiles(queueWaits),
     proxyOverhead: computePercentiles(overheads),

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -34,6 +34,11 @@ export interface RequestMetric {
   /** Streaming or non-streaming */
   mode: "stream" | "non-stream"
 
+  /** Envelope-integrity violations detected on this response (dangling_block,
+   *  undelivered_tool_use, empty_tool_input). Absent when the envelope was
+   *  clean — the overwhelmingly common case. See proxy/envelopeIntegrity.ts. */
+  envelopeViolations?: string[]
+
   /** Whether the request used session resume */
   isResume: boolean
 
@@ -131,6 +136,9 @@ export interface TelemetrySummary {
   totalRequests: number
   /** Requests that returned an error */
   errorCount: number
+  /** Total envelope-integrity violations across the window (dangling blocks,
+   *  undelivered tool calls, empty required inputs). 0 = wire contract clean. */
+  envelopeViolationCount: number
   /** Requests per minute */
   requestsPerMinute: number
 


### PR DESCRIPTION
Follow-through on kabo's offer to help capture future issues (#552 discussion) — the conclusion was that the highest-value diagnostics run on OUR side: every bug in this family was a wire-contract violation the proxy could have detected itself at response time.

## What it does

Asserts the proxy's own output envelope on every passthrough response:

| Violation | Meaning | The scar it comes from |
|---|---|---|
| `dangling_block` | content block still open at stream close | the `read {}` red reads |
| `undelivered_tool_use` | captured call never reached the client | beheaded parallel calls |
| `empty_tool_input` | delivered call with empty input where the schema requires args | the client-visible shape of a cut call (schema-aware — legit no-arg tools never flag) |

On violation: `envelope.violation` structured log + `ENVELOPE VIOLATION` in the diagnostic log + per-request `envelopeViolations` in telemetry + `envelopeViolationCount` in `/telemetry/summary` + dashboard **Envelope card** (green "wire contract clean" / red count) and a red per-request badge with details on hover.

All stream-close paths unified onto the `flushOpenClientBlocks` helper (the recovery path had its own inline copy that bypassed detection).

## Why it matters

The next #552-family regression fires a red counter on the dashboard and a loud log line with the request ID — instead of surfacing weeks later in a user's redacted transcript. Reporters like kabo don't need to do anything; if something breaks, we see it first.

## Verification
- Pure-module unit tests (schema-aware empty-input logic, undelivered detection)
- Integration: the kill-switch dangling fixture (a genuine red read) increments the counter; a clean early-stop parallel run adds zero
- Live E34: 3/3 clean with tripwires active
- Full suite 2006 pass / 0 fail; tsc clean; summary fields additive (contract-safe)