### PR TITLE
feat(nix): package plugins as a meridianPlugins set

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -1,0 +1,27 @@
+name: Update plugin inputs
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+
+      - name: Bump plugin inputs and verify each still builds
+        run: |
+          for input in $(nix flake metadata --json | jq -r '.locks.nodes.root.inputs | keys[] | select(startswith("meridian-plugin-"))'); do
+            nix flake update "$input"
+            nix build ".#meridianPlugins.${input#meridian-plugin-}" --no-link --print-out-paths
+          done
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update plugin flake inputs"
+          file_pattern: flake.lock

--- a/flake.lock
+++ b/flake.lock
@@ -84,6 +84,54 @@
         "type": "github"
       }
     },
+    "meridian-plugin-hermes-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706868,
+        "narHash": "sha256-NZ5jpEEShJPHWhpY/lqU81dkui2CgWf3GhOPKyqNKAM=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "rev": "d3a28e5465fee9eb8ffdde340f4f973fa9d450b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-opencode-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706886,
+        "narHash": "sha256-OhIYu4aZP+6RvlnDxraXfbh3Fez0QZ9pkaekmHkfBzY=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "rev": "59a1bfce767d1994a4bb6a700373e4c11aef3633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-pi-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706871,
+        "narHash": "sha256-S3QdJQvSR3claesMgSPZvVFosuuDeYDgpMwBRR+3zM0=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
+        "rev": "65fe302e570044f6f115805d82b619277a8e538f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1776169885,
@@ -105,6 +153,9 @@
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
+        "meridian-plugin-hermes-scrub": "meridian-plugin-hermes-scrub",
+        "meridian-plugin-opencode-scrub": "meridian-plugin-opencode-scrub",
+        "meridian-plugin-pi-scrub": "meridian-plugin-pi-scrub",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,18 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    meridian-plugin-hermes-scrub = {
+      url = "github:rynfar/meridian-plugin-hermes-scrub";
+      flake = false;
+    };
+    meridian-plugin-opencode-scrub = {
+      url = "github:rynfar/meridian-plugin-opencode-scrub";
+      flake = false;
+    };
+    meridian-plugin-pi-scrub = {
+      url = "github:rynfar/meridian-plugin-pi-scrub";
+      flake = false;
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default";
   };
@@ -46,10 +58,16 @@
         perSystem =
           {
             config,
+            lib,
             pkgs,
             system,
             ...
           }:
+          let
+            inherit (lib.attrsets) filterAttrs mapAttrs' nameValuePair;
+            inherit (lib.strings) hasPrefix removePrefix;
+            inherit (lib.trivial) pipe;
+          in
           {
             _module.args.pkgs = import nixpkgs {
               inherit system;
@@ -60,6 +78,16 @@
               default = config.packages.meridian;
               meridian = pkgs.callPackage ./nix/package.nix { };
             };
+
+            legacyPackages.meridianPlugins = pipe inputs [
+              (filterAttrs (pname: _: hasPrefix "meridian-plugin-" pname))
+              (mapAttrs' (
+                pname: src:
+                nameValuePair (removePrefix "meridian-plugin-" pname) (
+                  pkgs.callPackage ./nix/plugin.nix { inherit pname src; }
+                )
+              ))
+            ];
           };
 
         flake = {
@@ -74,7 +102,13 @@
             default = self.overlays.meridian;
             meridian =
               _: prev:
-              withSystem prev.stdenv.hostPlatform.system ({ self', ... }: { inherit (self'.packages) meridian; });
+              withSystem prev.stdenv.hostPlatform.system (
+                { self', ... }:
+                {
+                  inherit (self'.packages) meridian;
+                  inherit (self'.legacyPackages) meridianPlugins;
+                }
+              );
           };
         };
       }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -95,13 +95,13 @@ in
 
             path = mkOption {
               type = path;
-              example = literalExpression ''"''${plugin}/lib/index.js"'';
+              example = literalExpression "pkgs.meridianPlugins.opencode-scrub.path";
               description = ''
-                Path to the plugin's ESM entry file. Reference an entry
-                *inside a packaged derivation* (e.g. `"''${plugin}/lib/index.js"`)
-                so the plugin's dependencies land in the store next to it — a
-                bare `./file.js` path literal copies only that one file, which
-                breaks plugins that import sibling `node_modules`.
+                Path to the plugin's ESM entry file.
+                Reference an entry *inside a packaged derivation*
+                so the plugin's dependencies land in the store next to it.
+                A bare `./file.js` path literal copies only that one file,
+                which breaks plugins that import sibling `node_modules`.
               '';
             };
           };

--- a/nix/plugin.nix
+++ b/nix/plugin.nix
@@ -1,0 +1,49 @@
+{
+  formats,
+  lib,
+  pname,
+  src,
+  stdenvNoCC,
+  typescript,
+}:
+let
+  inherit (lib.trivial) importJSON;
+  packageFile = packageFormat.generate "package.json" { type = "module"; };
+  packageFormat = formats.json { };
+in
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  let
+    package = importJSON "${finalAttrs.src}/package.json";
+  in
+  {
+    inherit pname src;
+    inherit (package) version;
+
+    strictDeps = true;
+    nativeBuildInputs = [ typescript ];
+
+    buildPhase = ''
+      runHook preBuild
+      tsc
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib
+      cp dist/*.js $out/lib/
+      cp ${packageFile} $out/lib/package.json
+      runHook postInstall
+    '';
+
+    passthru.path = "${finalAttrs.finalPackage}/lib/index.js";
+
+    meta = {
+      inherit (package) description;
+      homepage = "https://github.com/rynfar/${finalAttrs.pname}";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+    };
+  }
+)


### PR DESCRIPTION
Packages the scrub plugins centrally in the meridian flake so consumers pull them from the store instead of vendoring each one. Adds `meridian-plugin-hermes-scrub`, `meridian-plugin-opencode-scrub`, and `meridian-plugin-pi-scrub` as `flake = false` inputs (pinned to each repo's default branch) and builds them into a `legacyPackages.meridianPlugins.<name>` set.

## Packaging

A shared `nix/plugin.nix` builder compiles each plugin with `tsc` and exposes `passthru.path`, the absolute path to the loadable `index.js` a `plugins.json` entry points at. The set is derived from the `meridian-plugin-*` inputs by prefix and exposed through the `meridian` overlay alongside `meridian`, so a consumer references `pkgs.meridianPlugins.opencode-scrub.path` and feeds it to a `plugins.json` entry (or the `pluginConfig` option from #623).

## Keeping inputs fresh

`.github/workflows/update-plugins.yml` runs daily and on `workflow_dispatch`: it bumps every `meridian-plugin-*` input, rebuilds each plugin to gate the commit, and auto-commits `flake.lock` only when all builds pass. It installs upstream Nix via `cachix/install-nix-action` and enumerates inputs from the lock, so it needs no edits when a plugin is added.

## Follow-up for @rynfar: event-driven updates

Daily cron is a stopgap, and only you can replace it. The correct trigger is event-driven: each plugin repo fires a `repository_dispatch` at this repo on push to its default branch, so a bump happens immediately instead of up to 24h later. That wiring lives in the plugin repos you own and needs a cross-repo token in each plugin repo's secrets, since the default `GITHUB_TOKEN` can't dispatch across repos. Once it's in place it fully replaces the cron in this PR. Happy to draft the trigger and the dispatch step for you.
