### PR TITLE
feat(telemetry): usage-value batch — cost estimation (#629) + model-scoped quotas (#624)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,6 +69,8 @@ src/
 │   ├── routes.ts              ← Telemetry API endpoints
 │   ├── logStore.ts            ← Diagnostic log ring buffer
 │   ├── dashboard.ts           ← HTML dashboard
+│   ├── pricing.ts             ← Static API list prices + cost estimation (pure)
+│   ├── pricingStore.ts        ← User pricing overrides (persisted JSON)
 │   ├── profileBar.ts          ← Shared profile switcher bar (injected into HTML pages)
 │   ├── profilePage.ts         ← Profile management page HTML
 │   └── types.ts               ← Telemetry types

--- a/MONITORING.md
+++ b/MONITORING.md
@@ -34,6 +34,27 @@ The SDK uses 5-minute TTL prompt caching. On each turn, the system prompt + tool
 
 Meridian sorts tools alphabetically before registration to keep the prefix stable. If you see cache misses on continuations, something is changing the prefix between turns.
 
+## Estimated Cost
+
+The Overview tab shows an **Estimated Cost** section: a headline card with the window's total, per-model cards, and a table breaking down input/output/cache-read/cache-write tokens with the estimated USD per model. The same data is available on the API as `costEstimate` in `GET /telemetry/summary`.
+
+What the number means:
+
+- It is the **equivalent Anthropic API list price** for the window's token usage. Claude Max requests are covered by the subscription and are never billed per token. Use it to gauge how much value the subscription is delivering, not as a bill.
+- Rates are a static table in [`src/telemetry/pricing.ts`](./src/telemetry/pricing.ts) (cache reads at 0.1x input, cache writes at the 5-minute TTL rate of 1.25x input, the TTL the SDK uses). Verify against [claude.com/pricing](https://claude.com/pricing) after model launches or price changes.
+- Models without a pricing entry are **excluded from the total** and flagged "no pricing" in the table rather than silently counted as $0.
+- The landing page also shows an **Est. Cost (24h)** card next to Median TTFB and Error Rate.
+
+### Overriding rates
+
+The **Model Pricing** section on the Settings page (`/settings`) edits the rates without code changes:
+
+- Edit any built-in model's rates to override them (marked "Override" with a Reset button).
+- Add models the built-in table doesn't know about; they are priced immediately and stop showing as "no pricing".
+- Cache read/write rates are optional when adding a model; they default to 0.1x and 1.25x of the input rate.
+
+Overrides persist to `~/.config/meridian/model-pricing.json` (override the path with `MERIDIAN_PRICING_CONFIG`) and take effect on the next dashboard refresh, no restart needed. The API surface is `GET /settings/api/pricing`, `PUT /settings/api/pricing/:model`, and `DELETE /settings/api/pricing/:model`.
+
 ## Quick Health Check
 
 ```bash

--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -85,6 +85,53 @@ describe("oauthUsage", () => {
     expect(sevenDay!.utilization).toBeCloseTo(0.05, 5)
   })
 
+  test("parses model-scoped weekly limits without duplicating aggregate windows", async () => {
+    const resetsAt = "2026-07-20T12:00:00Z"
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify({
+      five_hour: { utilization: 15, resets_at: "2026-07-15T18:00:00Z" },
+      seven_day: { utilization: 56, resets_at: "2026-07-20T12:00:00Z" },
+      limits: [
+        {
+          kind: "session",
+          group: "session",
+          percent: 15,
+          resets_at: "2026-07-15T18:00:00Z",
+          scope: { model: null, surface: null },
+        },
+        {
+          kind: "weekly_all",
+          group: "weekly",
+          percent: 56,
+          resets_at: resetsAt,
+          scope: { model: null, surface: null },
+        },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 57,
+          resets_at: resetsAt,
+          scope: { model: { id: null, display_name: "Fable" }, surface: null },
+        },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 20,
+          resets_at: resetsAt,
+          scope: { model: null, surface: "api" },
+        },
+      ],
+    }), { status: 200 }))
+
+    const result = await fetchOAuthUsage({ force: true, store: makeStore("t"), fetchImpl })
+
+    expect(result!.windows).toHaveLength(3)
+    expect(result!.windows.find(w => w.type === "seven_day_fable")).toEqual({
+      type: "seven_day_fable",
+      utilization: 0.57,
+      resetsAt: Date.parse(resetsAt),
+    })
+  })
+
   test("normalizes utilization from 0..100 to 0..1", async () => {
     const fetchImpl = fixedFetch(() => new Response(JSON.stringify({
       five_hour: { utilization: 87.5, resets_at: "2026-04-26T22:30:00Z" },

--- a/src/__tests__/pricing-routes.test.ts
+++ b/src/__tests__/pricing-routes.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Route-level tests for the model-pricing settings API (#629 follow-up).
+ * The pure logic is covered in pricing-unit/pricing-store-unit; these pin the
+ * HTTP contract: shapes, validation status codes, and the malformed-JSON 400.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { resetPricingOverridesCache } = await import("../telemetry/pricingStore")
+
+describe("pricing settings routes", () => {
+  let dir: string
+  let saved: string | undefined
+  let app: any
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "meridian-pricing-routes-"))
+    saved = process.env.MERIDIAN_PRICING_CONFIG
+    process.env.MERIDIAN_PRICING_CONFIG = join(dir, "model-pricing.json")
+    resetPricingOverridesCache()
+    app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+  })
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.MERIDIAN_PRICING_CONFIG
+    else process.env.MERIDIAN_PRICING_CONFIG = saved
+    resetPricingOverridesCache()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const get = () => app.fetch(new Request("http://localhost/settings/api/pricing"))
+  const put = (model: string, body: string) =>
+    app.fetch(new Request(`http://localhost/settings/api/pricing/${encodeURIComponent(model)}`, {
+      method: "PUT", headers: { "Content-Type": "application/json" }, body,
+    }))
+  const del = (model: string) =>
+    app.fetch(new Request(`http://localhost/settings/api/pricing/${encodeURIComponent(model)}`, { method: "DELETE" }))
+
+  it("GET returns builtin table + overrides", async () => {
+    const res = await get()
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.builtin["claude-opus-4-8"]).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
+    expect(body.overrides).toEqual({})
+  })
+
+  it("PUT persists an override; DELETE removes it", async () => {
+    const putRes = await put("my-model", JSON.stringify({ inputPerMTok: 2, outputPerMTok: 4 }))
+    expect(putRes.status).toBe(200)
+    resetPricingOverridesCache()
+    let body = await (await get()).json() as any
+    expect(body.overrides["my-model"]).toMatchObject({ inputPerMTok: 2, outputPerMTok: 4 })
+
+    expect((await del("my-model")).status).toBe(200)
+    resetPricingOverridesCache()
+    body = await (await get()).json() as any
+    expect(body.overrides).toEqual({})
+  })
+
+  it("PUT rejects invalid rates with 400 + message", async () => {
+    const res = await put("my-model", JSON.stringify({ inputPerMTok: -1, outputPerMTok: 4 }))
+    expect(res.status).toBe(400)
+    expect(((await res.json()) as any).error).toContain("non-negative")
+  })
+
+  it("PUT rejects malformed JSON with 400, not 500", async () => {
+    const res = await put("my-model", "{not json")
+    expect(res.status).toBe(400)
+  })
+
+  it("PUT rejects an empty model key with 400", async () => {
+    const res = await put("   ", JSON.stringify({ inputPerMTok: 1, outputPerMTok: 2 }))
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/__tests__/pricing-store-unit.test.ts
+++ b/src/__tests__/pricing-store-unit.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  validatePricingUpdate,
+  validateModelKey,
+  getPricingOverrides,
+  setPricingOverride,
+  deletePricingOverride,
+  resetPricingOverridesCache,
+} from "../telemetry/pricingStore"
+import { resolveModelPricing } from "../telemetry/pricing"
+
+describe("validatePricingUpdate", () => {
+  it("accepts full rate objects", () => {
+    const result = validatePricingUpdate({
+      inputPerMTok: 5,
+      outputPerMTok: 25,
+      cacheReadPerMTok: 0.5,
+      cacheWritePerMTok: 6.25,
+    })
+    expect(result).toEqual({
+      inputPerMTok: 5,
+      outputPerMTok: 25,
+      cacheReadPerMTok: 0.5,
+      cacheWritePerMTok: 6.25,
+    })
+  })
+
+  it("derives cache rates from the input rate when omitted", () => {
+    const result = validatePricingUpdate({ inputPerMTok: 4, outputPerMTok: 20 })
+    expect(result.cacheReadPerMTok).toBeCloseTo(0.4, 10)
+    expect(result.cacheWritePerMTok).toBeCloseTo(5, 10)
+  })
+
+  it("requires inputPerMTok and outputPerMTok", () => {
+    expect(() => validatePricingUpdate({ outputPerMTok: 20 })).toThrow("inputPerMTok is required")
+    expect(() => validatePricingUpdate({ inputPerMTok: 4 })).toThrow("outputPerMTok is required")
+  })
+
+  it("rejects negative, non-finite, and non-numeric rates", () => {
+    expect(() => validatePricingUpdate({ inputPerMTok: -1, outputPerMTok: 20 })).toThrow("non-negative")
+    expect(() => validatePricingUpdate({ inputPerMTok: Infinity, outputPerMTok: 20 })).toThrow("non-negative")
+    expect(() => validatePricingUpdate({ inputPerMTok: "5", outputPerMTok: 20 })).toThrow("non-negative")
+    expect(() => validatePricingUpdate({ inputPerMTok: 5, outputPerMTok: 20, cacheReadPerMTok: -0.1 })).toThrow("non-negative")
+  })
+
+  it("rejects non-object bodies", () => {
+    expect(() => validatePricingUpdate(null)).toThrow("JSON object")
+    expect(() => validatePricingUpdate([1])).toThrow("JSON object")
+    expect(() => validatePricingUpdate("x")).toThrow("JSON object")
+  })
+
+  it("accepts zero rates (free models)", () => {
+    const result = validatePricingUpdate({ inputPerMTok: 0, outputPerMTok: 0 })
+    expect(result).toEqual({ inputPerMTok: 0, outputPerMTok: 0, cacheReadPerMTok: 0, cacheWritePerMTok: 0 })
+  })
+})
+
+describe("validateModelKey", () => {
+  it("normalizes case, whitespace, and the [1m] suffix", () => {
+    expect(validateModelKey("  Claude-Opus-4-8  ")).toBe("claude-opus-4-8")
+    expect(validateModelKey("opus[1m]")).toBe("opus")
+  })
+
+  it("rejects empty and oversized keys", () => {
+    expect(() => validateModelKey("")).toThrow("non-empty")
+    expect(() => validateModelKey("   ")).toThrow("non-empty")
+    expect(() => validateModelKey("x".repeat(201))).toThrow("at most 200")
+  })
+})
+
+describe("pricing override persistence", () => {
+  let dir: string
+  let configPath: string
+  const savedEnv = { meridian: undefined as string | undefined, legacy: undefined as string | undefined }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "meridian-pricing-test-"))
+    configPath = join(dir, "model-pricing.json")
+    savedEnv.meridian = process.env.MERIDIAN_PRICING_CONFIG
+    savedEnv.legacy = process.env.CLAUDE_PROXY_PRICING_CONFIG
+    process.env.MERIDIAN_PRICING_CONFIG = configPath
+    delete process.env.CLAUDE_PROXY_PRICING_CONFIG
+    resetPricingOverridesCache()
+  })
+
+  afterEach(() => {
+    if (savedEnv.meridian === undefined) delete process.env.MERIDIAN_PRICING_CONFIG
+    else process.env.MERIDIAN_PRICING_CONFIG = savedEnv.meridian
+    if (savedEnv.legacy === undefined) delete process.env.CLAUDE_PROXY_PRICING_CONFIG
+    else process.env.CLAUDE_PROXY_PRICING_CONFIG = savedEnv.legacy
+    resetPricingOverridesCache()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it("returns empty overrides when no file exists", () => {
+    expect(getPricingOverrides()).toEqual({})
+  })
+
+  it("persists, reads back, and deletes an override", () => {
+    const pricing = validatePricingUpdate({ inputPerMTok: 7, outputPerMTok: 35 })
+    setPricingOverride("my-custom-model", pricing)
+
+    expect(existsSync(configPath)).toBe(true)
+    expect(getPricingOverrides()["my-custom-model"]).toEqual(pricing)
+
+    // Survives a cache reset (fresh read from disk)
+    resetPricingOverridesCache()
+    expect(getPricingOverrides()["my-custom-model"]).toEqual(pricing)
+
+    deletePricingOverride("my-custom-model")
+    expect(getPricingOverrides()).toEqual({})
+  })
+
+  it("normalizes the model key on write", () => {
+    setPricingOverride("  My-Model[1m] ", validatePricingUpdate({ inputPerMTok: 1, outputPerMTok: 2 }))
+    expect(Object.keys(getPricingOverrides())).toEqual(["my-model"])
+  })
+
+  it("skips malformed entries in the file instead of discarding it", () => {
+    setPricingOverride("good-model", validatePricingUpdate({ inputPerMTok: 1, outputPerMTok: 2 }))
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"))
+    raw["bad-model"] = { inputPerMTok: "not-a-number" }
+    const { writeFileSync } = require("node:fs") as typeof import("node:fs")
+    writeFileSync(configPath, JSON.stringify(raw))
+    resetPricingOverridesCache()
+
+    const overrides = getPricingOverrides()
+    expect(overrides["good-model"]).toBeDefined()
+    expect(overrides["bad-model"]).toBeUndefined()
+  })
+
+  it("feeds resolveModelPricing: overrides beat the built-in table", () => {
+    setPricingOverride("claude-opus-4-8", validatePricingUpdate({ inputPerMTok: 9, outputPerMTok: 45 }))
+    const overrides = getPricingOverrides()
+
+    expect(resolveModelPricing("claude-opus-4-8", overrides)!.inputPerMTok).toBe(9)
+    // [1m] and case variants resolve to the same override
+    expect(resolveModelPricing("Claude-Opus-4-8[1m]", overrides)!.inputPerMTok).toBe(9)
+    // Without overrides the built-in rate still applies
+    expect(resolveModelPricing("claude-opus-4-8")!.inputPerMTok).toBe(5)
+  })
+
+  it("feeds resolveModelPricing: overrides price otherwise-unknown models", () => {
+    setPricingOverride("my-router-model", validatePricingUpdate({ inputPerMTok: 2, outputPerMTok: 4 }))
+    const overrides = getPricingOverrides()
+
+    expect(resolveModelPricing("my-router-model")).toBeNull()
+    expect(resolveModelPricing("my-router-model", overrides)!.outputPerMTok).toBe(4)
+  })
+})

--- a/src/__tests__/pricing-unit.test.ts
+++ b/src/__tests__/pricing-unit.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "bun:test"
+import {
+  resolveModelPricing,
+  estimateRequestCostUsd,
+  computeCostEstimate,
+} from "../telemetry/pricing"
+import { computeSummary } from "../telemetry/percentiles"
+import type { RequestMetric } from "../telemetry/types"
+
+function makeMetric(overrides: Partial<RequestMetric> = {}): RequestMetric {
+  return {
+    requestId: `req-${Math.random().toString(36).slice(2, 8)}`,
+    timestamp: Date.now(),
+    model: "sonnet",
+    mode: "stream",
+    isResume: false,
+    isPassthrough: false,
+    status: 200,
+    queueWaitMs: 5,
+    proxyOverheadMs: 12,
+    ttfbMs: 120,
+    upstreamDurationMs: 800,
+    totalDurationMs: 850,
+    contentBlocks: 3,
+    textEvents: 10,
+    error: null,
+    ...overrides,
+  }
+}
+
+describe("resolveModelPricing", () => {
+  it("resolves SDK aliases meridian uses", () => {
+    expect(resolveModelPricing("opus")).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
+    expect(resolveModelPricing("sonnet")).toMatchObject({ inputPerMTok: 3, outputPerMTok: 15 })
+    expect(resolveModelPricing("haiku")).toMatchObject({ inputPerMTok: 1, outputPerMTok: 5 })
+    expect(resolveModelPricing("fable")).toMatchObject({ inputPerMTok: 10, outputPerMTok: 50 })
+  })
+
+  it("strips the [1m] extended-context suffix", () => {
+    expect(resolveModelPricing("opus[1m]")).toMatchObject({ inputPerMTok: 5 })
+    expect(resolveModelPricing("sonnet[1m]")).toMatchObject({ inputPerMTok: 3 })
+    expect(resolveModelPricing("fable[1m]")).toMatchObject({ inputPerMTok: 10 })
+  })
+
+  it("resolves concrete API model IDs", () => {
+    expect(resolveModelPricing("claude-opus-4-8")).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
+    expect(resolveModelPricing("claude-sonnet-4-6")).toMatchObject({ inputPerMTok: 3 })
+    expect(resolveModelPricing("claude-fable-5")).toMatchObject({ inputPerMTok: 10 })
+  })
+
+  it("falls back to family pricing for dated snapshot IDs", () => {
+    expect(resolveModelPricing("claude-haiku-4-5-20251001")).toMatchObject({ inputPerMTok: 1, outputPerMTok: 5 })
+    expect(resolveModelPricing("claude-sonnet-4-5-20250929")).toMatchObject({ inputPerMTok: 3 })
+    expect(resolveModelPricing("claude-opus-4-7-20260101")).toMatchObject({ inputPerMTok: 5 })
+  })
+
+  it("prices legacy models at their historical rates", () => {
+    expect(resolveModelPricing("claude-opus-4-1")).toMatchObject({ inputPerMTok: 15, outputPerMTok: 75 })
+    expect(resolveModelPricing("claude-opus-4-20250514")).toMatchObject({ inputPerMTok: 15 })
+    expect(resolveModelPricing("claude-3-opus-20240229")).toMatchObject({ inputPerMTok: 15 })
+    expect(resolveModelPricing("claude-3-5-haiku-20241022")).toMatchObject({ inputPerMTok: 0.8, outputPerMTok: 4 })
+    expect(resolveModelPricing("claude-3-haiku-20240307")).toMatchObject({ inputPerMTok: 0.25 })
+  })
+
+  it("derives cache rates from the input rate", () => {
+    const opus = resolveModelPricing("opus")!
+    expect(opus.cacheReadPerMTok).toBeCloseTo(0.5, 10)
+    expect(opus.cacheWritePerMTok).toBeCloseTo(6.25, 10)
+  })
+
+  it("returns null for unrecognized models", () => {
+    expect(resolveModelPricing("gpt-4o")).toBeNull()
+    expect(resolveModelPricing("unknown")).toBeNull()
+    expect(resolveModelPricing("")).toBeNull()
+  })
+
+  it("prices claude-sonnet-5 at the introductory rate", () => {
+    // $2/$10 through 2026-08-31, then $3/$15 (see pricing.ts comment)
+    expect(resolveModelPricing("claude-sonnet-5")).toMatchObject({ inputPerMTok: 2, outputPerMTok: 10 })
+  })
+
+  it("prefers user overrides over the built-in table and family fallback", () => {
+    const overrides = {
+      "claude-opus-4-8": { inputPerMTok: 9, outputPerMTok: 45, cacheReadPerMTok: 0.9, cacheWritePerMTok: 11.25 },
+      "totally-custom": { inputPerMTok: 1, outputPerMTok: 2, cacheReadPerMTok: 0.1, cacheWritePerMTok: 1.25 },
+    }
+    expect(resolveModelPricing("claude-opus-4-8", overrides)!.inputPerMTok).toBe(9)
+    expect(resolveModelPricing("claude-opus-4-8[1m]", overrides)!.inputPerMTok).toBe(9)
+    expect(resolveModelPricing("totally-custom", overrides)!.outputPerMTok).toBe(2)
+    // Models without an override still resolve normally
+    expect(resolveModelPricing("haiku", overrides)!.inputPerMTok).toBe(1)
+  })
+})
+
+describe("estimateRequestCostUsd", () => {
+  it("computes cost from all four token buckets", () => {
+    const pricing = resolveModelPricing("opus")!
+    const metric = makeMetric({
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      cacheReadInputTokens: 10_000_000,
+      cacheCreationInputTokens: 1_000_000,
+    })
+    // 1M in ($5) + 1M out ($25) + 10M cache read ($5) + 1M cache write ($6.25)
+    expect(estimateRequestCostUsd(metric, pricing)).toBeCloseTo(41.25, 6)
+  })
+
+  it("treats missing token fields as zero", () => {
+    const pricing = resolveModelPricing("opus")!
+    expect(estimateRequestCostUsd(makeMetric(), pricing)).toBe(0)
+  })
+})
+
+describe("computeCostEstimate", () => {
+  it("returns zeros for an empty window", () => {
+    const estimate = computeCostEstimate([])
+    expect(estimate.totalUsd).toBe(0)
+    expect(estimate.byModel).toEqual({})
+    expect(estimate.unpricedRequestCount).toBe(0)
+  })
+
+  it("aggregates tokens and cost per model", () => {
+    const metrics = [
+      makeMetric({
+        requestModel: "claude-haiku-4-5-20251001",
+        inputTokens: 500_000,
+        outputTokens: 200_000,
+        cacheReadInputTokens: 1_000_000,
+        cacheCreationInputTokens: 400_000,
+      }),
+      makeMetric({
+        requestModel: "claude-haiku-4-5-20251001",
+        inputTokens: 500_000,
+        outputTokens: 0,
+      }),
+    ]
+
+    const estimate = computeCostEstimate(metrics)
+    const haiku = estimate.byModel["claude-haiku-4-5-20251001"]!
+
+    expect(haiku.requests).toBe(2)
+    expect(haiku.inputTokens).toBe(1_000_000)
+    expect(haiku.outputTokens).toBe(200_000)
+    expect(haiku.cacheReadTokens).toBe(1_000_000)
+    expect(haiku.cacheCreationTokens).toBe(400_000)
+    // 1M in ($1) + 0.2M out ($1) + 1M cache read ($0.10) + 0.4M cache write ($0.50)
+    expect(haiku.estimatedUsd).toBeCloseTo(2.6, 6)
+    expect(estimate.totalUsd).toBeCloseTo(2.6, 6)
+  })
+
+  it("groups by requestModel, falling back to the SDK model alias", () => {
+    const metrics = [
+      makeMetric({ requestModel: "claude-opus-4-8", model: "opus", inputTokens: 1_000_000 }),
+      makeMetric({ requestModel: undefined, model: "opus", inputTokens: 1_000_000 }),
+    ]
+
+    const estimate = computeCostEstimate(metrics)
+    expect(estimate.byModel["claude-opus-4-8"]!.estimatedUsd).toBeCloseTo(5, 6)
+    expect(estimate.byModel["opus"]!.estimatedUsd).toBeCloseTo(5, 6)
+    expect(estimate.totalUsd).toBeCloseTo(10, 6)
+  })
+
+  it("flags unrecognized models instead of pricing them at $0", () => {
+    const metrics = [
+      makeMetric({ requestModel: "some-custom-model", inputTokens: 1_000_000 }),
+      makeMetric({ requestModel: "some-custom-model", inputTokens: 1_000_000 }),
+      makeMetric({ requestModel: "claude-opus-4-8", inputTokens: 1_000_000 }),
+    ]
+
+    const estimate = computeCostEstimate(metrics)
+    expect(estimate.byModel["some-custom-model"]!.estimatedUsd).toBeNull()
+    expect(estimate.byModel["some-custom-model"]!.inputTokens).toBe(2_000_000)
+    expect(estimate.unpricedRequestCount).toBe(2)
+    // Unpriced requests are excluded from the total, not counted as $0
+    expect(estimate.totalUsd).toBeCloseTo(5, 6)
+  })
+
+  it("counts requests with no token data toward the model's request count", () => {
+    const estimate = computeCostEstimate([makeMetric({ requestModel: "claude-opus-4-8" })])
+    expect(estimate.byModel["claude-opus-4-8"]!.requests).toBe(1)
+    expect(estimate.byModel["claude-opus-4-8"]!.estimatedUsd).toBe(0)
+  })
+})
+
+describe("computeSummary costEstimate integration", () => {
+  it("includes a zeroed costEstimate in the empty summary", () => {
+    const summary = computeSummary([], 3_600_000)
+    expect(summary.costEstimate).toEqual({ totalUsd: 0, byModel: {}, unpricedRequestCount: 0 })
+  })
+
+  it("exposes the window's cost estimate on the summary", () => {
+    const summary = computeSummary(
+      [makeMetric({ requestModel: "claude-opus-4-8", inputTokens: 1_000_000, outputTokens: 200_000 })],
+      3_600_000,
+    )
+    // 1M in ($5) + 0.2M out ($5)
+    expect(summary.costEstimate.totalUsd).toBeCloseTo(10, 6)
+    expect(summary.costEstimate.byModel["claude-opus-4-8"]!.requests).toBe(1)
+  })
+
+  it("applies pricing overrides passed to computeSummary", () => {
+    const overrides = {
+      "claude-opus-4-8": { inputPerMTok: 10, outputPerMTok: 50, cacheReadPerMTok: 1, cacheWritePerMTok: 12.5 },
+    }
+    const summary = computeSummary(
+      [makeMetric({ requestModel: "claude-opus-4-8", inputTokens: 1_000_000 })],
+      3_600_000,
+      overrides,
+    )
+    expect(summary.costEstimate.totalUsd).toBeCloseTo(10, 6)
+  })
+})

--- a/src/__tests__/profile-usage.test.ts
+++ b/src/__tests__/profile-usage.test.ts
@@ -20,6 +20,7 @@ describe("labelForWindow", () => {
     expect(labelForWindow("seven_day")).toBe("7d")
     expect(labelForWindow("seven_day_opus")).toBe("7d Opus")
     expect(labelForWindow("seven_day_sonnet")).toBe("7d Sonnet")
+    expect(labelForWindow("seven_day_fable")).toBe("7d Fable")
     expect(labelForWindow("seven_day_oauth_apps")).toBe("7d Apps")
     expect(labelForWindow("seven_day_cowork")).toBe("7d Cowork")
     expect(labelForWindow("seven_day_omelette")).toBe("7d Omelette")

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -40,6 +40,18 @@ interface RawOAuthExtraUsage {
   currency?: string
 }
 
+interface RawOAuthLimit {
+  kind?: string
+  percent?: number | null
+  resets_at?: string | null
+  scope?: {
+    model?: {
+      id?: string | null
+      display_name?: string | null
+    } | null
+  } | null
+}
+
 interface RawOAuthUsageResponse {
   five_hour?: RawOAuthWindow | null
   seven_day?: RawOAuthWindow | null
@@ -50,6 +62,7 @@ interface RawOAuthUsageResponse {
   seven_day_omelette?: RawOAuthWindow | null
   iguana_necktie?: RawOAuthWindow | null
   omelette_promotional?: RawOAuthWindow | null
+  limits?: RawOAuthLimit[] | null
   extra_usage?: RawOAuthExtraUsage | null
 }
 
@@ -102,6 +115,21 @@ function normalizeUtilization(raw: number | null | undefined): number | null {
   return Math.max(0, raw / 100)
 }
 
+function modelScopedWindowType(limit: RawOAuthLimit): string | null {
+  if (limit.kind !== "weekly_scoped") return null
+
+  const model = limit.scope?.model
+  const name = model?.display_name?.trim() || model?.id?.trim()
+  if (!name) return null
+
+  const slug = name
+    .toLowerCase()
+    .replace(/^claude[\s_-]+/, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+  return slug ? `seven_day_${slug}` : null
+}
+
 function buildSnapshot(raw: RawOAuthUsageResponse): OAuthUsageSnapshot {
   const windows: OAuthUsageWindow[] = []
   for (const key of WINDOW_TYPES) {
@@ -111,6 +139,19 @@ function buildSnapshot(raw: RawOAuthUsageResponse): OAuthUsageSnapshot {
     const resetsAt = parseIsoToMs(w.resets_at)
     if (utilization === null && resetsAt === null) continue
     windows.push({ type: key as string, utilization, resetsAt })
+  }
+
+  const windowTypes = new Set(windows.map(window => window.type))
+  for (const limit of raw.limits ?? []) {
+    const type = modelScopedWindowType(limit)
+    if (!type || windowTypes.has(type)) continue
+
+    const utilization = normalizeUtilization(limit.percent)
+    const resetsAt = parseIsoToMs(limit.resets_at)
+    if (utilization === null && resetsAt === null) continue
+
+    windows.push({ type, utilization, resetsAt })
+    windowTypes.add(type)
   }
 
   const extra = raw.extra_usage

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3235,8 +3235,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   app.put("/settings/api/pricing/:model", async (c) => {
     const { validatePricingUpdate, setPricingOverride } = require("../telemetry/pricingStore") as typeof import("../telemetry/pricingStore")
     const model = c.req.param("model")
-    const body = await c.req.json()
     try {
+      // json() throws on malformed bodies — keep it inside the try so the
+      // client gets a 400, not a 500 (house pattern: /profiles/active).
+      const body = await c.req.json()
       setPricingOverride(model, validatePricingUpdate(body))
     } catch (e) {
       return c.json({ error: (e as Error).message }, 400)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3226,6 +3226,33 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return c.json({ ok: true })
   })
 
+  // Model pricing for the telemetry cost estimate: built-in table + user overrides
+  app.get("/settings/api/pricing", (c) => {
+    const { BUILTIN_MODEL_PRICING } = require("../telemetry/pricing") as typeof import("../telemetry/pricing")
+    const { getPricingOverrides } = require("../telemetry/pricingStore") as typeof import("../telemetry/pricingStore")
+    return c.json({ builtin: BUILTIN_MODEL_PRICING, overrides: getPricingOverrides() })
+  })
+  app.put("/settings/api/pricing/:model", async (c) => {
+    const { validatePricingUpdate, setPricingOverride } = require("../telemetry/pricingStore") as typeof import("../telemetry/pricingStore")
+    const model = c.req.param("model")
+    const body = await c.req.json()
+    try {
+      setPricingOverride(model, validatePricingUpdate(body))
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400)
+    }
+    return c.json({ ok: true })
+  })
+  app.delete("/settings/api/pricing/:model", (c) => {
+    const { deletePricingOverride } = require("../telemetry/pricingStore") as typeof import("../telemetry/pricingStore")
+    try {
+      deletePricingOverride(c.req.param("model"))
+    } catch (e) {
+      return c.json({ error: (e as Error).message }, 400)
+    }
+    return c.json({ ok: true })
+  })
+
   // Prometheus metrics endpoint
   app.get("/metrics", (c) => {
     const body = renderPrometheusMetrics(telemetryStore)

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -146,6 +146,15 @@ function fmtTok(n) {
   return n > 1000000 ? (n/1000000).toFixed(1) + 'M' : n > 1000 ? Math.round(n/1000) + 'k' : String(n);
 }
 
+// Model names come from client-supplied request bodies (requestModel) — escape
+// before concatenating into innerHTML so a quirky/malicious client can't
+// script the dashboard.
+function esc(s) {
+  return String(s).replace(/[&<>"']/g, function (ch) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+  });
+}
+
 function usd(v) {
   if (v == null) return '—';
   if (v > 0 && v < 0.01) return '$' + v.toFixed(4);
@@ -255,7 +264,7 @@ function render(s, reqs, logs, quota) {
     html += '<div class="cards">'
       + card('Est. API Cost', usd(ce.totalUsd), 'window total at API list prices');
     for (const [model, m] of costRows) {
-      html += card(model, usd(m.estimatedUsd), m.requests + ' req' + (m.requests === 1 ? '' : 's'));
+      html += card(esc(model), usd(m.estimatedUsd), m.requests + ' req' + (m.requests === 1 ? '' : 's'));
     }
     html += '</div>';
 
@@ -264,7 +273,7 @@ function render(s, reqs, logs, quota) {
       + '<th>Cache Read</th><th>Cache Write</th><th>Est. Cost</th></tr></thead><tbody>';
     for (const [model, m] of costRows) {
       html += '<tr>'
-        + '<td>' + model + (m.estimatedUsd == null ? ' <span style="font-size:10px;color:var(--yellow)">no pricing</span>' : '') + '</td>'
+        + '<td>' + esc(model) + (m.estimatedUsd == null ? ' <span style="font-size:10px;color:var(--yellow)">no pricing</span>' : '') + '</td>'
         + '<td class="mono">' + m.requests + '</td>'
         + '<td class="mono">' + fmtTok(m.inputTokens) + '</td>'
         + '<td class="mono">' + fmtTok(m.outputTokens) + '</td>'
@@ -289,7 +298,7 @@ function render(s, reqs, logs, quota) {
   if (models.length > 0) {
     html += '<div class="cards">';
     for (const [name, data] of models) {
-      html += card(name, data.count + ' reqs', 'avg ' + ms(data.avgTotalMs));
+      html += card(esc(name), data.count + ' reqs', 'avg ' + ms(data.avgTotalMs));
     }
     html += '</div>';
   }

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -142,6 +142,17 @@ function ago(ts) {
   return Math.floor(s/3600) + 'h ago';
 }
 
+function fmtTok(n) {
+  return n > 1000000 ? (n/1000000).toFixed(1) + 'M' : n > 1000 ? Math.round(n/1000) + 'k' : String(n);
+}
+
+function usd(v) {
+  if (v == null) return '—';
+  if (v > 0 && v < 0.01) return '$' + v.toFixed(4);
+  if (v < 100) return '$' + v.toFixed(2);
+  return '$' + Math.round(v).toLocaleString();
+}
+
 function pctRow(label, color, phase) {
   return '<tr>'
     + '<td><span class="phase-dot" style="background:' + color + '"></span>' + label + '</td>'
@@ -224,7 +235,6 @@ function render(s, reqs, logs, quota) {
   // Token usage cards
   if (s.tokenUsage) {
     const t = s.tokenUsage;
-    const fmtTok = n => n > 1000000 ? (n/1000000).toFixed(1) + 'M' : n > 1000 ? Math.round(n/1000) + 'k' : String(n);
     html += '<div class="section"><div class="section-title">Token Usage</div></div>';
     html += '<div class="cards">'
       + card('Input Tokens', fmtTok(t.totalInputTokens), '')
@@ -233,6 +243,45 @@ function render(s, reqs, logs, quota) {
       + card('Cache Write', fmtTok(t.totalCacheCreationTokens), '')
       + card('Avg Cache Hit', (t.avgCacheHitRate * 100).toFixed(0) + '%', t.cacheMissOnResumeCount > 0 ? t.cacheMissOnResumeCount + ' cache miss on resume' : '')
       + '</div>';
+  }
+
+  // Estimated cost: static API list pricing applied to the window's token usage
+  if (s.costEstimate && Object.keys(s.costEstimate.byModel).length > 0) {
+    const ce = s.costEstimate;
+    const costRows = Object.entries(ce.byModel)
+      .sort((a, b) => (b[1].estimatedUsd || 0) - (a[1].estimatedUsd || 0));
+
+    html += '<div class="section"><div class="section-title">Estimated Cost</div></div>';
+    html += '<div class="cards">'
+      + card('Est. API Cost', usd(ce.totalUsd), 'window total at API list prices');
+    for (const [model, m] of costRows) {
+      html += card(model, usd(m.estimatedUsd), m.requests + ' req' + (m.requests === 1 ? '' : 's'));
+    }
+    html += '</div>';
+
+    html += '<div class="section">'
+      + '<table><thead><tr><th>Model</th><th>Requests</th><th>Input</th><th>Output</th>'
+      + '<th>Cache Read</th><th>Cache Write</th><th>Est. Cost</th></tr></thead><tbody>';
+    for (const [model, m] of costRows) {
+      html += '<tr>'
+        + '<td>' + model + (m.estimatedUsd == null ? ' <span style="font-size:10px;color:var(--yellow)">no pricing</span>' : '') + '</td>'
+        + '<td class="mono">' + m.requests + '</td>'
+        + '<td class="mono">' + fmtTok(m.inputTokens) + '</td>'
+        + '<td class="mono">' + fmtTok(m.outputTokens) + '</td>'
+        + '<td class="mono">' + fmtTok(m.cacheReadTokens) + '</td>'
+        + '<td class="mono">' + fmtTok(m.cacheCreationTokens) + '</td>'
+        + '<td class="mono">' + usd(m.estimatedUsd) + '</td>'
+        + '</tr>';
+    }
+    html += '</tbody></table>'
+      + '<div class="usage-note" style="margin-top:8px">Estimated at static Anthropic API list prices'
+      + ' (cache writes at the 5-minute TTL rate). Claude Max usage is covered by your subscription'
+      + ' (equivalent API cost, not a charge).'
+      + (ce.unpricedRequestCount > 0
+          ? ' ' + ce.unpricedRequestCount + ' request' + (ce.unpricedRequestCount === 1 ? '' : 's') + ' from unrecognized models excluded.'
+          : '')
+      + ' Rates are editable in <a href="/settings" style="color:var(--accent)">Settings</a>.'
+      + '</div></div>';
   }
 
   // Model breakdown

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -92,6 +92,7 @@ export const landingHtml = `<!DOCTYPE html>
 </div>
 <script>
 function ms(v){if(v==null||v===0)return '\u2014';return v<1000?v+'ms':(v/1000).toFixed(1)+'s'}
+function esc(s){return String(s).replace(/[&<>"']/g,function(ch){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]})}
 function usd(v){if(v==null)return '\u2014';if(v>0&&v<0.01)return '$'+v.toFixed(4);if(v<100)return '$'+v.toFixed(2);return '$'+Math.round(v).toLocaleString()}
 function card(l,v,d,c){return '<div class="card"><div class="card-label">'+l+'</div><div class="card-value '+(c||'')+'">'+v+'</div>'+(d?'<div class="card-detail">'+d+'</div>':'')+'</div>'}
 
@@ -112,7 +113,7 @@ function render(h,s){
   if(h.auth?.loggedIn){o+='<div class="info-grid"><span class="info-label">Email</span><span class="info-value">'+(h.auth.email||'\u2014')+'</span><span class="info-label">Subscription</span><span class="info-value">'+(h.auth.subscriptionType||'\u2014')+'</span><span class="info-label">Mode</span><span class="info-value">'+(h.mode||'internal')+'</span><span class="info-label">Endpoint</span><span class="info-value">http://'+location.host+'</span></div>'}
   else{o+='<div class="info-grid"><span class="info-label">Status</span><span class="info-value" style="color:var(--yellow)">'+(h.error||'Not authenticated')+'</span></div>'}
   o+='</div>';
-  if(s.byModel&&Object.keys(s.byModel).length>0){o+='<div class="section"><div class="section-title">Models (24h)</div><div class="grid">';for(const[n,d]of Object.entries(s.byModel))o+=card(n,d.count,'avg '+ms(d.avgTotalMs),'');o+='</div></div>'}
+  if(s.byModel&&Object.keys(s.byModel).length>0){o+='<div class="section"><div class="section-title">Models (24h)</div><div class="grid">';for(const[n,d]of Object.entries(s.byModel))o+=card(esc(n),d.count,'avg '+ms(d.avgTotalMs),'');o+='</div></div>'}
   o+='<div class="section"><div class="section-title">Connect an Agent</div><div class="snippet"><div class="snippet-tabs"><div class="snippet-tab active" onclick="showTab(this,&apos;opencode&apos;)">OpenCode</div><div class="snippet-tab" onclick="showTab(this,&apos;crush&apos;)">Crush</div><div class="snippet-tab" onclick="showTab(this,&apos;generic&apos;)">Any Tool</div></div><div id="tab-opencode"><code>ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://'+location.host+' opencode</code></div><div id="tab-crush" style="display:none"><code>'+JSON.stringify({providers:{meridian:{type:"anthropic",base_url:"http://"+location.host,api_key:"x",models:[{id:"claude-sonnet-4-5-20250514",name:"Sonnet 4.5"}]}}},null,2)+'</code></div><div id="tab-generic" style="display:none"><code>export ANTHROPIC_API_KEY=x\\nexport ANTHROPIC_BASE_URL=http://'+location.host+'</code></div></div></div>';
   o+='<div class="links"><a href="/telemetry" class="link">\ud83d\udcca Telemetry</a><a href="/settings" class="link">\ud83d\udd27 Settings</a><a href="/profiles" class="link">\ud83d\udc64 Profiles</a><a href="/health" class="link">\ud83e\ude7a Health</a><a href="/telemetry/summary" class="link">\ud83d\udcc8 Stats API</a><a href="https://github.com/rynfar/meridian" class="link">\u2699\ufe0f GitHub</a></div>';
   o+='<div class="footer">Meridian \u00b7 Built on the <a href="https://github.com/anthropics/claude-code-sdk-js">Claude Code SDK</a></div>';

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -92,6 +92,7 @@ export const landingHtml = `<!DOCTYPE html>
 </div>
 <script>
 function ms(v){if(v==null||v===0)return '\u2014';return v<1000?v+'ms':(v/1000).toFixed(1)+'s'}
+function usd(v){if(v==null)return '\u2014';if(v>0&&v<0.01)return '$'+v.toFixed(4);if(v<100)return '$'+v.toFixed(2);return '$'+Math.round(v).toLocaleString()}
 function card(l,v,d,c){return '<div class="card"><div class="card-label">'+l+'</div><div class="card-value '+(c||'')+'">'+v+'</div>'+(d?'<div class="card-detail">'+d+'</div>':'')+'</div>'}
 
 async function refresh(){
@@ -106,7 +107,7 @@ function render(h,s){
   let o='';
   o+='<div class="status-banner"><div class="status-dot '+dot+'"></div><span class="status-text">'+(st==='healthy'?'Operational':st==='degraded'?'Degraded':'Offline')+'</span><span class="status-detail">Port '+location.port+' \u00b7 '+(h.mode||'internal')+' mode</span></div>';
   const er=s.totalRequests>0?((s.errorCount/s.totalRequests)*100).toFixed(1):'0';
-  o+='<div class="grid">'+card('Requests (24h)',s.totalRequests,'','violet')+card('Median Response',ms(s.totalDuration?.p50),'p95: '+ms(s.totalDuration?.p95),'')+card('Median TTFB',ms(s.ttfb?.p50),'p95: '+ms(s.ttfb?.p95),'')+card('Error Rate',er+'%',s.errorCount+' errors',parseFloat(er)>5?'':'green')+'</div>';
+  o+='<div class="grid">'+card('Requests (24h)',s.totalRequests,'','violet')+card('Median Response',ms(s.totalDuration?.p50),'p95: '+ms(s.totalDuration?.p95),'')+card('Median TTFB',ms(s.ttfb?.p50),'p95: '+ms(s.ttfb?.p95),'')+card('Error Rate',er+'%',s.errorCount+' errors',parseFloat(er)>5?'':'green')+card('Est. Cost (24h)',usd(s.costEstimate?.totalUsd),'API list prices','violet')+'</div>';
   o+='<div class="section"><div class="section-title">Account</div>';
   if(h.auth?.loggedIn){o+='<div class="info-grid"><span class="info-label">Email</span><span class="info-value">'+(h.auth.email||'\u2014')+'</span><span class="info-label">Subscription</span><span class="info-value">'+(h.auth.subscriptionType||'\u2014')+'</span><span class="info-label">Mode</span><span class="info-value">'+(h.mode||'internal')+'</span><span class="info-label">Endpoint</span><span class="info-value">http://'+location.host+'</span></div>'}
   else{o+='<div class="info-grid"><span class="info-label">Status</span><span class="info-value" style="color:var(--yellow)">'+(h.error||'Not authenticated')+'</span></div>'}

--- a/src/telemetry/percentiles.ts
+++ b/src/telemetry/percentiles.ts
@@ -3,6 +3,7 @@
  */
 
 import type { RequestMetric, PhaseTiming, TelemetrySummary } from "./types"
+import { computeCostEstimate, type ModelPricing } from "./pricing"
 
 export function computePercentiles(values: number[]): PhaseTiming {
   if (values.length === 0) return { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
@@ -24,8 +25,15 @@ export function computePercentiles(values: number[]): PhaseTiming {
  * Compute a TelemetrySummary from an array of RequestMetric.
  * Both MemoryTelemetryStore and SqliteTelemetryStore use this
  * to guarantee identical output.
+ *
+ * pricingOverrides: user-defined model rates (from pricingStore) applied
+ * to the cost estimate; omit for built-in pricing only.
  */
-export function computeSummary(metrics: RequestMetric[], windowMs: number): TelemetrySummary {
+export function computeSummary(
+  metrics: RequestMetric[],
+  windowMs: number,
+  pricingOverrides?: Record<string, ModelPricing>,
+): TelemetrySummary {
   if (metrics.length === 0) {
     const emptyPhase: PhaseTiming = { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 }
     return {
@@ -49,6 +57,7 @@ export function computeSummary(metrics: RequestMetric[], windowMs: number): Tele
         avgCacheHitRate: 0,
         cacheMissOnResumeCount: 0,
       },
+      costEstimate: { totalUsd: 0, byModel: {}, unpricedRequestCount: 0 },
     }
   }
 
@@ -130,5 +139,6 @@ export function computeSummary(metrics: RequestMetric[], windowMs: number): Tele
         : 0,
       cacheMissOnResumeCount,
     },
+    costEstimate: computeCostEstimate(metrics, pricingOverrides),
   }
 }

--- a/src/telemetry/pricing.ts
+++ b/src/telemetry/pricing.ts
@@ -1,0 +1,192 @@
+/**
+ * Static Anthropic API list pricing and cost estimation (PURE, no I/O).
+ *
+ * Meridian proxies Claude Max, so requests are covered by the subscription
+ * and never billed per token. The numbers produced here answer a different
+ * question: "what would this usage have cost at API list prices?", useful
+ * for judging how much value the subscription is delivering.
+ *
+ * Rates are USD per million tokens, verified against the official pricing
+ * docs (platform.claude.com/docs/en/about-claude/pricing, snapshot 2026-07).
+ * Users can override any rate, or add models missing from this table, via
+ * the settings page (persisted by pricingStore.ts; overrides win in
+ * resolveModelPricing). Cache rates are derived from the input rate:
+ *   - cache read  = 0.10× input
+ *   - cache write = 1.25× input (5-minute TTL, the TTL the SDK uses, see
+ *     MONITORING.md; 1-hour TTL writes bill at 2×, so if a client opted into
+ *     the long TTL this estimate is a floor)
+ *
+ * Models without a table entry are excluded from the total and surfaced via
+ * `unpricedRequestCount` instead of silently costing $0.
+ */
+
+import type { RequestMetric, CostEstimate, ModelCostBreakdown } from "./types"
+
+export interface ModelPricing {
+  /** USD per 1M uncached input tokens */
+  inputPerMTok: number
+  /** USD per 1M output tokens */
+  outputPerMTok: number
+  /** USD per 1M cache-read input tokens */
+  cacheReadPerMTok: number
+  /** USD per 1M cache-write (creation) input tokens */
+  cacheWritePerMTok: number
+}
+
+export const CACHE_READ_MULTIPLIER = 0.1
+export const CACHE_WRITE_MULTIPLIER = 1.25
+
+/** Normalize a model string for pricing lookup: trimmed, lowercase, [1m] suffix stripped. */
+export function normalizeModelKey(model: string): string {
+  return model.trim().toLowerCase().replace(/\[1m\]$/, "")
+}
+
+function rates(inputPerMTok: number, outputPerMTok: number): ModelPricing {
+  return {
+    inputPerMTok,
+    outputPerMTok,
+    cacheReadPerMTok: inputPerMTok * CACHE_READ_MULTIPLIER,
+    cacheWritePerMTok: inputPerMTok * CACHE_WRITE_MULTIPLIER,
+  }
+}
+
+const FABLE = rates(10, 50)
+const OPUS = rates(5, 25) // Opus 4.5 and later
+const OPUS_LEGACY = rates(15, 75) // Opus 4.1 and earlier
+const SONNET = rates(3, 15) // every Sonnet generation to date, standard rate
+// Sonnet 5 introductory pricing runs through 2026-08-31; standard 3/15 applies
+// from 2026-09-01. Update this entry (or set a settings override) after that.
+const SONNET_5_INTRO = rates(2, 10)
+const HAIKU = rates(1, 5) // Haiku 4.5
+const HAIKU_35 = rates(0.8, 4)
+const HAIKU_3 = rates(0.25, 1.25)
+
+/**
+ * Exact-match table. Keys are lowercase, checked after stripping the [1m]
+ * suffix. Covers the SDK aliases meridian itself uses (opus, sonnet, ...)
+ * plus concrete API model IDs that clients commonly send. Dated snapshot
+ * IDs (e.g. claude-haiku-4-5-20251001) fall through to the family rules.
+ *
+ * Exported for the settings page, which lists these models with their
+ * default rates so users can override them.
+ */
+export const BUILTIN_MODEL_PRICING: Record<string, ModelPricing> = {
+  fable: FABLE,
+  "claude-fable-5": FABLE,
+  "claude-mythos-5": FABLE,
+  opus: OPUS,
+  "claude-opus-4-8": OPUS,
+  "claude-opus-4-7": OPUS,
+  "claude-opus-4-6": OPUS,
+  "claude-opus-4-5": OPUS,
+  "claude-opus-4-1": OPUS_LEGACY,
+  "claude-opus-4-0": OPUS_LEGACY,
+  "claude-opus-4-20250514": OPUS_LEGACY,
+  "claude-3-opus-20240229": OPUS_LEGACY,
+  sonnet: SONNET,
+  "claude-sonnet-5": SONNET_5_INTRO,
+  "claude-sonnet-4-6": SONNET,
+  "claude-sonnet-4-5": SONNET,
+  haiku: HAIKU,
+  "claude-haiku-4-5": HAIKU,
+  "claude-3-5-haiku-20241022": HAIKU_35,
+  "claude-3-haiku-20240307": HAIKU_3,
+}
+
+/**
+ * Resolve a model string to pricing. User-defined overrides win, then the
+ * exact built-in table, then family fallback so versioned/dated IDs
+ * (claude-opus-4-8, claude-haiku-4-5-20251001) and future releases still
+ * price at their family's current rate.
+ * Returns null for unrecognized models; callers must not treat that as $0.
+ */
+export function resolveModelPricing(
+  model: string,
+  overrides?: Record<string, ModelPricing>,
+): ModelPricing | null {
+  const normalized = normalizeModelKey(model)
+
+  if (overrides) {
+    const override = overrides[normalized]
+    if (override) return override
+  }
+
+  const exact = BUILTIN_MODEL_PRICING[normalized]
+  if (exact) return exact
+
+  if (normalized.includes("fable") || normalized.includes("mythos")) return FABLE
+  if (normalized.includes("haiku")) {
+    if (normalized.includes("3-5") || normalized.includes("3.5")) return HAIKU_35
+    if (/haiku-3\b|3-haiku/.test(normalized)) return HAIKU_3
+    return HAIKU
+  }
+  if (normalized.includes("opus")) {
+    if (/opus-4-1\b|opus-4-1-|opus-4-0|opus-4-2025|3-opus/.test(normalized)) return OPUS_LEGACY
+    return OPUS
+  }
+  if (normalized.includes("sonnet")) return SONNET
+
+  return null
+}
+
+/** Estimated USD for a single request's token usage at the given rates. */
+export function estimateRequestCostUsd(metric: RequestMetric, pricing: ModelPricing): number {
+  return (
+    ((metric.inputTokens ?? 0) / 1e6) * pricing.inputPerMTok +
+    ((metric.outputTokens ?? 0) / 1e6) * pricing.outputPerMTok +
+    ((metric.cacheReadInputTokens ?? 0) / 1e6) * pricing.cacheReadPerMTok +
+    ((metric.cacheCreationInputTokens ?? 0) / 1e6) * pricing.cacheWritePerMTok
+  )
+}
+
+/** Round to micro-dollars to keep JSON output free of float noise. */
+function roundUsd(value: number): number {
+  return Math.round(value * 1e6) / 1e6
+}
+
+/**
+ * Aggregate estimated cost per model across a set of metrics.
+ * Grouping key is requestModel || model, matching computeSummary's byModel.
+ * Pass overrides (from pricingStore) to apply user-defined rates.
+ */
+export function computeCostEstimate(
+  metrics: RequestMetric[],
+  overrides?: Record<string, ModelPricing>,
+): CostEstimate {
+  const byModel: Record<string, ModelCostBreakdown> = {}
+  let totalUsd = 0
+  let unpricedRequestCount = 0
+
+  for (const metric of metrics) {
+    const modelKey = metric.requestModel || metric.model
+    const pricing = resolveModelPricing(modelKey, overrides)
+    const entry = byModel[modelKey] ??= {
+      requests: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      estimatedUsd: pricing === null ? null : 0,
+    }
+
+    entry.requests++
+    entry.inputTokens += metric.inputTokens ?? 0
+    entry.outputTokens += metric.outputTokens ?? 0
+    entry.cacheReadTokens += metric.cacheReadInputTokens ?? 0
+    entry.cacheCreationTokens += metric.cacheCreationInputTokens ?? 0
+
+    if (pricing === null) {
+      unpricedRequestCount++
+      continue
+    }
+    const cost = estimateRequestCostUsd(metric, pricing)
+    entry.estimatedUsd = (entry.estimatedUsd ?? 0) + cost
+    totalUsd += cost
+  }
+
+  for (const entry of Object.values(byModel)) {
+    if (entry.estimatedUsd !== null) entry.estimatedUsd = roundUsd(entry.estimatedUsd)
+  }
+
+  return { totalUsd: roundUsd(totalUsd), byModel, unpricedRequestCount }
+}

--- a/src/telemetry/pricingStore.ts
+++ b/src/telemetry/pricingStore.ts
@@ -1,0 +1,154 @@
+/**
+ * User-defined model pricing overrides.
+ *
+ * Lets users correct a stale built-in rate or define pricing for models the
+ * static table in pricing.ts doesn't know about (custom routers, brand-new
+ * releases). Overrides win over the built-in table in resolveModelPricing.
+ *
+ * Persisted to ~/.config/meridian/model-pricing.json (override the path with
+ * MERIDIAN_PRICING_CONFIG). Read at request time with a short cache, so
+ * settings-page edits show up on the next dashboard refresh without a proxy
+ * restart. Mirrors the sdkFeatures.ts persistence pattern.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { homedir } from "node:os"
+import { env } from "../env"
+import {
+  CACHE_READ_MULTIPLIER,
+  CACHE_WRITE_MULTIPLIER,
+  normalizeModelKey,
+  type ModelPricing,
+} from "./pricing"
+
+export type PricingOverrides = Record<string, ModelPricing>
+
+const MAX_MODEL_KEY_LENGTH = 200
+
+function getConfigPath(): string {
+  const explicit = env("PRICING_CONFIG")
+  if (explicit) return explicit
+  const dir = join(homedir(), ".config", "meridian")
+  return join(dir, "model-pricing.json")
+}
+
+let cachedOverrides: PricingOverrides | null = null
+let cachedPath: string | null = null
+let lastReadTime = 0
+const CACHE_TTL_MS = 5000
+
+function readOverrides(): PricingOverrides {
+  const path = getConfigPath()
+  const now = Date.now()
+  if (cachedOverrides && cachedPath === path && now - lastReadTime < CACHE_TTL_MS) {
+    return cachedOverrides
+  }
+
+  try {
+    if (existsSync(path)) {
+      const raw = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>
+      const result: PricingOverrides = {}
+      for (const [model, value] of Object.entries(raw)) {
+        try {
+          result[normalizeModelKey(model)] = validatePricingUpdate(value)
+        } catch {
+          // Skip malformed entries rather than discarding the whole file
+        }
+      }
+      cachedOverrides = result
+    } else {
+      cachedOverrides = {}
+    }
+  } catch {
+    cachedOverrides = {}
+  }
+  cachedPath = path
+  lastReadTime = now
+  return cachedOverrides
+}
+
+function writeOverrides(overrides: PricingOverrides): void {
+  const path = getConfigPath()
+  const tmp = `${path}.tmp`
+  try {
+    const dir = dirname(path)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    writeFileSync(tmp, JSON.stringify(overrides, null, 2))
+    renameSync(tmp, path)
+    cachedOverrides = overrides
+    cachedPath = path
+    lastReadTime = Date.now()
+  } catch (e) {
+    console.error("[pricing] write failed:", (e as Error).message)
+  }
+}
+
+/** Current user-defined pricing overrides, keyed by normalized model string. */
+export function getPricingOverrides(): PricingOverrides {
+  return readOverrides()
+}
+
+/**
+ * Validate a pricing update body into a complete ModelPricing.
+ * inputPerMTok and outputPerMTok are required; cache rates are optional and
+ * derived from the input rate (read 0.1x, write 1.25x) when omitted.
+ * Throws on invalid input.
+ */
+export function validatePricingUpdate(raw: unknown): ModelPricing {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("body must be a JSON object")
+  }
+  const input = raw as Record<string, unknown>
+
+  const readRate = (key: string, required: boolean): number | undefined => {
+    const value = input[key]
+    if (value === undefined || value === null || value === "") {
+      if (required) throw new Error(`${key} is required`)
+      return undefined
+    }
+    if (typeof value !== "number" || !isFinite(value) || value < 0) {
+      throw new Error(`${key} must be a non-negative finite number`)
+    }
+    return value
+  }
+
+  const inputPerMTok = readRate("inputPerMTok", true)!
+  const outputPerMTok = readRate("outputPerMTok", true)!
+  const cacheReadPerMTok = readRate("cacheReadPerMTok", false) ?? inputPerMTok * CACHE_READ_MULTIPLIER
+  const cacheWritePerMTok = readRate("cacheWritePerMTok", false) ?? inputPerMTok * CACHE_WRITE_MULTIPLIER
+
+  return { inputPerMTok, outputPerMTok, cacheReadPerMTok, cacheWritePerMTok }
+}
+
+/** Validate the model key for an override. Throws on invalid input. */
+export function validateModelKey(model: string): string {
+  const normalized = normalizeModelKey(model)
+  if (normalized.length === 0) throw new Error("model must be a non-empty string")
+  if (normalized.length > MAX_MODEL_KEY_LENGTH) {
+    throw new Error(`model must be at most ${MAX_MODEL_KEY_LENGTH} characters`)
+  }
+  return normalized
+}
+
+/** Create or replace the pricing override for a model. */
+export function setPricingOverride(model: string, pricing: ModelPricing): void {
+  const key = validateModelKey(model)
+  const overrides = { ...readOverrides(), [key]: pricing }
+  writeOverrides(overrides)
+}
+
+/** Remove the pricing override for a model (reverts to the built-in table). */
+export function deletePricingOverride(model: string): void {
+  const key = validateModelKey(model)
+  const overrides = { ...readOverrides() }
+  delete overrides[key]
+  writeOverrides(overrides)
+}
+
+/** Reset the read cache — for testing only (path changes between tests). */
+export function resetPricingOverridesCache(): void {
+  cachedOverrides = null
+  cachedPath = null
+  lastReadTime = 0
+}

--- a/src/telemetry/profileUsage.ts
+++ b/src/telemetry/profileUsage.ts
@@ -18,6 +18,7 @@ export const WINDOW_LABELS: Record<string, string> = {
   seven_day: "7d",
   seven_day_opus: "7d Opus",
   seven_day_sonnet: "7d Sonnet",
+  seven_day_fable: "7d Fable",
   seven_day_oauth_apps: "7d Apps",
   seven_day_cowork: "7d Cowork",
   seven_day_omelette: "7d Omelette",

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -90,6 +90,28 @@ export const settingsPageHtml = `<!DOCTYPE html>
     border-radius: 6px; padding: 4px 12px; font-size: 11px; cursor: pointer;
   }
   .reset-btn:hover { border-color: var(--red); color: var(--red); }
+
+  /* Model pricing */
+  .pricing-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .pricing-table th { text-align: left; padding: 8px 10px; color: var(--muted); font-weight: 500;
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 1px solid var(--border); }
+  .pricing-table td { padding: 6px 10px; border-bottom: 1px solid var(--border); }
+  .pricing-table tr:last-child td { border-bottom: none; }
+  .pricing-model { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; word-break: break-all; }
+  .pricing-input { background: var(--bg); color: var(--text); border: 1px solid var(--border);
+    border-radius: 6px; padding: 4px 8px; font-size: 12px; width: 84px; text-align: right;
+    font-variant-numeric: tabular-nums; }
+  .pricing-input:focus { border-color: var(--accent); outline: none; }
+  .pricing-badge { font-size: 10px; padding: 2px 8px; border-radius: 10px;
+    text-transform: uppercase; letter-spacing: 0.5px; white-space: nowrap; }
+  .badge-override { background: rgba(210, 153, 34, 0.15); color: var(--yellow); }
+  .badge-builtin { background: rgba(139, 148, 158, 0.15); color: var(--muted); }
+  .pricing-add { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 14px;
+    padding-top: 14px; border-top: 1px solid var(--border); }
+  .pricing-add input[type="text"] { width: 240px; text-align: left; }
+  .add-btn { background: var(--accent); border: none; color: #fff; border-radius: 6px;
+    padding: 5px 14px; font-size: 12px; font-weight: 500; cursor: pointer; }
+  .pricing-note { font-size: 11px; color: var(--muted); margin-top: 12px; line-height: 1.6; }
 </style>
 </head>
 <body>
@@ -106,6 +128,32 @@ ${profileBarHtml}
   </p>
 
   <div id="adapters"></div>
+
+  <h1 style="margin-top:40px">Model Pricing</h1>
+  <p class="subtitle" style="max-width:720px;line-height:1.6">
+    Rates used by the telemetry cost estimate, in USD per million tokens. Edit a value to override the
+    built-in rate, or add models the built-in table doesn't know about (they show as "no pricing" on the
+    dashboard until defined here). Changes apply on the next dashboard refresh.
+  </p>
+  <div class="adapter-card">
+    <table class="pricing-table">
+      <thead><tr><th>Model</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Write</th><th>Source</th><th></th></tr></thead>
+      <tbody id="pricingRows"></tbody>
+    </table>
+    <div class="pricing-add">
+      <input type="text" class="pricing-input" id="newModelName" placeholder="model id (e.g. claude-opus-9)">
+      <input type="number" class="pricing-input" id="newModelInput" placeholder="input" min="0" step="0.01">
+      <input type="number" class="pricing-input" id="newModelOutput" placeholder="output" min="0" step="0.01">
+      <input type="number" class="pricing-input" id="newModelCacheRead" placeholder="cache read" min="0" step="0.01">
+      <input type="number" class="pricing-input" id="newModelCacheWrite" placeholder="cache write" min="0" step="0.01">
+      <button class="add-btn" onclick="addPricingModel()">Add Model</button>
+    </div>
+    <div class="pricing-note">
+      Cache read and cache write are optional; when left blank they default to 0.1x and 1.25x of the
+      input rate (the 5-minute cache TTL multipliers). Verify current list prices at
+      <a href="https://claude.com/pricing" target="_blank" rel="noreferrer" style="color:var(--accent)">claude.com/pricing</a>.
+    </div>
+  </div>
 </div>
 
 <div class="save-indicator" id="saveIndicator">Saved</div>
@@ -240,7 +288,127 @@ function render() {
   }
 }
 
+// ---- Model pricing (telemetry cost estimate) ----
+let pricingData = { builtin: {}, overrides: {} };
+
+function fmtRate(v) { return String(Math.round(v * 10000) / 10000); }
+
+async function loadPricing() {
+  const res = await fetch('/settings/api/pricing');
+  pricingData = await res.json();
+  renderPricing();
+}
+
+async function putPricing(model, rates) {
+  const res = await fetch('/settings/api/pricing/' + encodeURIComponent(model), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(rates),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(function () { return {}; });
+    alert('Could not save pricing: ' + (err.error || ('HTTP ' + res.status)));
+    return false;
+  }
+  showSaved();
+  return true;
+}
+
+async function removePricing(model) {
+  await fetch('/settings/api/pricing/' + encodeURIComponent(model), { method: 'DELETE' });
+  showSaved();
+  await loadPricing();
+}
+
+function rateCell(value, onCommit) {
+  const td = document.createElement('td');
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '0';
+  input.step = '0.01';
+  input.className = 'pricing-input';
+  input.value = fmtRate(value);
+  input.addEventListener('change', onCommit);
+  td.appendChild(input);
+  return { td: td, input: input };
+}
+
+function renderPricing() {
+  const tbody = document.getElementById('pricingRows');
+  tbody.innerHTML = '';
+  const models = Array.from(new Set(
+    Object.keys(pricingData.builtin).concat(Object.keys(pricingData.overrides))
+  )).sort();
+
+  for (const model of models) {
+    const override = pricingData.overrides[model];
+    const effective = override || pricingData.builtin[model];
+    const tr = document.createElement('tr');
+
+    const nameTd = document.createElement('td');
+    nameTd.className = 'pricing-model';
+    nameTd.textContent = model;
+    tr.appendChild(nameTd);
+
+    const cells = [];
+    const commit = async function () {
+      const rates = {
+        inputPerMTok: parseFloat(cells[0].input.value),
+        outputPerMTok: parseFloat(cells[1].input.value),
+        cacheReadPerMTok: parseFloat(cells[2].input.value),
+        cacheWritePerMTok: parseFloat(cells[3].input.value),
+      };
+      for (const k in rates) { if (!isFinite(rates[k]) || rates[k] < 0) return; }
+      if (await putPricing(model, rates)) await loadPricing();
+    };
+    ['inputPerMTok', 'outputPerMTok', 'cacheReadPerMTok', 'cacheWritePerMTok'].forEach(function (key) {
+      const cell = rateCell(effective[key], commit);
+      cells.push(cell);
+      tr.appendChild(cell.td);
+    });
+
+    const badgeTd = document.createElement('td');
+    const badge = document.createElement('span');
+    badge.className = 'pricing-badge ' + (override ? 'badge-override' : 'badge-builtin');
+    badge.textContent = override ? 'Override' : 'Built-in';
+    badgeTd.appendChild(badge);
+    tr.appendChild(badgeTd);
+
+    const actionTd = document.createElement('td');
+    if (override) {
+      const btn = document.createElement('button');
+      btn.className = 'reset-btn';
+      btn.textContent = pricingData.builtin[model] ? 'Reset' : 'Remove';
+      btn.addEventListener('click', function () { removePricing(model); });
+      actionTd.appendChild(btn);
+    }
+    tr.appendChild(actionTd);
+
+    tbody.appendChild(tr);
+  }
+}
+
+async function addPricingModel() {
+  const name = document.getElementById('newModelName').value.trim();
+  const inputRate = parseFloat(document.getElementById('newModelInput').value);
+  const outputRate = parseFloat(document.getElementById('newModelOutput').value);
+  if (!name) { alert('Enter a model id'); return; }
+  if (!isFinite(inputRate) || !isFinite(outputRate)) { alert('Enter input and output rates (USD per million tokens)'); return; }
+  const rates = { inputPerMTok: inputRate, outputPerMTok: outputRate };
+  const cacheRead = parseFloat(document.getElementById('newModelCacheRead').value);
+  const cacheWrite = parseFloat(document.getElementById('newModelCacheWrite').value);
+  if (isFinite(cacheRead)) rates.cacheReadPerMTok = cacheRead;
+  if (isFinite(cacheWrite)) rates.cacheWritePerMTok = cacheWrite;
+  if (await putPricing(name, rates)) {
+    ['newModelName', 'newModelInput', 'newModelOutput', 'newModelCacheRead', 'newModelCacheWrite'].forEach(function (id) {
+      document.getElementById(id).value = '';
+    });
+    await loadPricing();
+  }
+}
+
 loadConfig();
+loadPricing();
 ${profileBarJs}
 </script>
 </body>

--- a/src/telemetry/sqlite.ts
+++ b/src/telemetry/sqlite.ts
@@ -1,6 +1,7 @@
 import Database from "libsql"
 import type { RequestMetric, TelemetrySummary, ITelemetryStore, IDiagnosticLogStore, DiagnosticLog } from "./types"
 import { computeSummary } from "./percentiles"
+import { getPricingOverrides } from "./pricingStore"
 
 const METRICS_SCHEMA = `
 CREATE TABLE IF NOT EXISTS metrics (
@@ -208,7 +209,7 @@ class SqliteTelemetryStore implements ITelemetryStore {
   summarize(windowMs: number = 60 * 60 * 1000): TelemetrySummary {
     const since = Date.now() - windowMs
     const metrics = this.getRecent({ limit: 100_000, since })
-    return computeSummary(metrics, windowMs)
+    return computeSummary(metrics, windowMs, getPricingOverrides())
   }
 
   clear(): void {

--- a/src/telemetry/store.ts
+++ b/src/telemetry/store.ts
@@ -7,6 +7,7 @@
 
 import type { RequestMetric, TelemetrySummary, ITelemetryStore } from "./types"
 import { computeSummary } from "./percentiles"
+import { getPricingOverrides } from "./pricingStore"
 
 const DEFAULT_CAPACITY = 1000
 
@@ -84,7 +85,7 @@ export class MemoryTelemetryStore implements ITelemetryStore {
   summarize(windowMs: number = 60 * 60 * 1000): TelemetrySummary {
     const since = Date.now() - windowMs
     const metrics = this.getRecent({ limit: this.capacity, since })
-    return computeSummary(metrics, windowMs)
+    return computeSummary(metrics, windowMs, getPricingOverrides())
   }
 
   /** Clear all stored metrics. */

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -129,6 +129,28 @@ export interface PhaseTiming {
   avg: number
 }
 
+/** Per-model token totals and estimated cost at static API list prices. */
+export interface ModelCostBreakdown {
+  requests: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  /** Estimated USD for this model's requests; null when the model has no pricing entry */
+  estimatedUsd: number | null
+}
+
+/** Aggregate cost estimate across a window. Estimates only: Claude Max
+ *  usage is covered by the subscription; this is the equivalent API cost. */
+export interface CostEstimate {
+  /** Sum across all priced models (unpriced models excluded) */
+  totalUsd: number
+  /** Keyed by requestModel || model, matching TelemetrySummary.byModel */
+  byModel: Record<string, ModelCostBreakdown>
+  /** Requests whose model had no pricing entry, excluded from totalUsd */
+  unpricedRequestCount: number
+}
+
 export interface TelemetrySummary {
   /** Time window these stats cover */
   windowMs: number
@@ -164,6 +186,9 @@ export interface TelemetrySummary {
     /** Requests where cache hit rate was 0 despite being a resume */
     cacheMissOnResumeCount: number
   }
+
+  /** Estimated cost of the window's usage at static API list prices */
+  costEstimate: CostEstimate
 }
 
 /** Storage backend for request metrics. */


### PR DESCRIPTION
Lands two community PRs together with review fix-ups, preserving authorship via cherry-pick:

- **#624** by @thalysguimaraes — parse Anthropic's model-scoped weekly limits (`seven_day_fable` etc.) into the normalized window shape. **Live-verified against a real account: the Fable weekly quota now surfaces (was invisible).**
- **#629** by @kilabyte — cost estimation across the dashboard/landing/settings: equivalent API-list-price value of the window's usage, per-model breakdown, user-editable pricing with persisted overrides. **Pricing table audited rate-by-rate against July 2026 list prices — accurate, including Sonnet 5 intro pricing with documented expiry and correct cache multipliers.**

Fix-ups applied on top (third commit):
1. `PUT /settings/api/pricing/:model` returned 500 on malformed JSON → now 400
2. Model names (client-supplied `requestModel`) HTML-escaped in the new cost UI **and** the pre-existing byModel cards + landing page (same injection class)
3. Route-level tests for the three new endpoints

## Verification
- Full suite 2045 pass / 0 fail (incl. both PRs' own tests), tsc clean
- Live: cost math hand-checked against a real request ($0.0287 for a sonnet turn — exact), settings PUT/GET/DELETE round-trip, malformed JSON → 400, dashboard renders the section with esc() intact, `seven_day_fable=9%` from the live account
- Coexists cleanly with this week's envelope-integrity and Usage-tab work

Closes #624. Closes #629. Credit to both authors — their commits land as authored.