### PR TITLE
feat: env-configurable plugin loading + home-manager plugin settings (#623 by @connor-grady)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Then in `~/.config/opencode/opencode.json`:
       # passthrough = true;
       # defaultAgent = "opencode";
       # sonnetModel = "sonnet";
+      # Load plugins from the Nix store (rendered to a plugins.json manifest).
+      # Point at an entry inside a packaged derivation so its deps come along.
+      # pluginConfig = [ { path = "${pkgs.my-meridian-plugin}/lib/index.js"; } ];
+      # pluginDir = "/path/to/extra/plugins";
     };
     # Extra env vars not covered by settings
     # environment = {
@@ -788,6 +792,8 @@ ANTHROPIC_API_KEY=your-secret-key ANTHROPIC_BASE_URL=http://meridian-host:3456 o
 | `MERIDIAN_SESSION_DIR` | `CLAUDE_PROXY_SESSION_DIR` | `~/.cache/meridian` | Directory for the persisted session store |
 | `MERIDIAN_DEBUG` | `CLAUDE_PROXY_DEBUG` | unset | Set to `1` for verbose request/session logging |
 | `MERIDIAN_SILENT` | `CLAUDE_PROXY_SILENT` | unset | Set to `1` to suppress startup output (used by embedding plugins) |
+| `MERIDIAN_PLUGIN_DIR` | — | `~/.config/meridian/plugins` | Plugin auto-discovery directory |
+| `MERIDIAN_PLUGIN_CONFIG` | — | `~/.config/meridian/plugins.json` | Plugin manifest path |
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost.
 
@@ -879,6 +885,8 @@ npm install @rynfar/meridian-plugin-hermes-scrub
 ```
 
 Paths must be absolute — the loader does not expand `~`.
+
+Both plugin locations are configurable for the standalone CLI: `MERIDIAN_PLUGIN_DIR` overrides the auto-discovery directory and `MERIDIAN_PLUGIN_CONFIG` the manifest path (useful for Nix, containers, or running several instances with different plugin sets).
 
 ## CLI Commands
 

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -38,6 +38,8 @@ Environment variables:
   MERIDIAN_HOST                     Host to bind to (default: 127.0.0.1)
   MERIDIAN_PASSTHROUGH              Enable passthrough mode (tools forwarded to client)
   MERIDIAN_IDLE_TIMEOUT_SECONDS     Idle timeout in seconds (default: 120)
+  MERIDIAN_PLUGIN_DIR               Plugin auto-discovery directory (default: ~/.config/meridian/plugins)
+  MERIDIAN_PLUGIN_CONFIG            Plugin manifest path (default: ~/.config/meridian/plugins.json)
 
 See https://github.com/rynfar/meridian for full documentation.`)
   process.exit(0)
@@ -123,6 +125,8 @@ const execFile = promisify(execFileCallback)
 const port = parseInt(process.env.MERIDIAN_PORT ?? process.env.CLAUDE_PROXY_PORT ?? "3456", 10)
 const host = process.env.MERIDIAN_HOST ?? process.env.CLAUDE_PROXY_HOST ?? "127.0.0.1"
 const idleTimeoutSeconds = parseInt(process.env.MERIDIAN_IDLE_TIMEOUT_SECONDS ?? process.env.CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS ?? "120", 10)
+const pluginDir = process.env.MERIDIAN_PLUGIN_DIR
+const pluginConfigPath = process.env.MERIDIAN_PLUGIN_CONFIG
 
 // Load profile configuration:
 //   1. MERIDIAN_PROFILES env var (JSON array) — takes precedence
@@ -200,7 +204,7 @@ export async function runCli(
     enableDiskProfileDiscovery()
   }
 
-  const proxy = await start({ port, host, idleTimeoutSeconds, profiles, defaultProfile, version, installProcessErrorHandlers: true })
+  const proxy = await start({ port, host, idleTimeoutSeconds, pluginDir, pluginConfigPath, profiles, defaultProfile, version, installProcessErrorHandlers: true })
 
   // Handle EADDRINUSE — preserve CLI behavior of exiting on port conflict
   proxy.server.on("error", (error: NodeJS.ErrnoException) => {

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -6,9 +6,9 @@ packages:
   ...
 }:
 let
-  inherit (lib.attrsets) filterAttrsRecursive mapAttrsToList mapAttrsToListRecursive;
+  inherit (lib.attrsets) mapAttrsToList;
   inherit (lib.generators) mkKeyValueDefault;
-  inherit (lib.lists) concatMap elem;
+  inherit (lib.lists) concatLists elem optional;
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf;
   inherit (lib.options)
@@ -18,12 +18,12 @@ let
     mkPackageOption
     ;
   inherit (lib.strings)
-    join
-    upperChars
-    splitStringBy
+    concatStrings
+    concatStringsSep
+    stringToCharacters
     toUpper
+    upperChars
     ;
-  inherit (lib.trivial) flip pipe;
   inherit (lib.types)
     attrsOf
     bool
@@ -96,13 +96,23 @@ in
             path = mkOption {
               type = path;
               example = literalExpression ''"''${plugin}/lib/index.js"'';
-              description = "Path to the plugin's ESM entry file.";
+              description = ''
+                Path to the plugin's ESM entry file. Reference an entry
+                *inside a packaged derivation* (e.g. `"''${plugin}/lib/index.js"`)
+                so the plugin's dependencies land in the store next to it — a
+                bare `./file.js` path literal copies only that one file, which
+                breaks plugins that import sibling `node_modules`.
+              '';
             };
           };
         });
         default = [ ];
-        apply = mkPluginFile;
-        description = "Plugins to load, in list order, rendered to a `plugins.json` manifest passed as `MERIDIAN_PLUGIN_CONFIG`.";
+        # Render to a manifest only when plugins are actually configured.
+        # Rendering the empty default too would export MERIDIAN_PLUGIN_CONFIG
+        # unconditionally, silently overriding the user's own
+        # ~/.config/meridian/plugins.json.
+        apply = plugins: if plugins == [ ] then null else mkPluginFile plugins;
+        description = "Plugins to load, in list order, rendered to a `plugins.json` manifest passed as `MERIDIAN_PLUGIN_CONFIG`. Leave empty to keep using `~/.config/meridian/plugins.json`.";
       };
 
       pluginDir = mkOption {
@@ -155,18 +165,25 @@ in
 
         Environment =
           let
-            env = flip pipe [
-              (concatMap (splitStringBy (_: curr: elem curr upperChars) true))
-              (map toUpper)
-              (join "_")
-              (s: "MERIDIAN_${s}")
-            ];
+            # camelCase settings name -> SNAKE_CASE fragment ("retentionDays" -> "RETENTION_DAYS")
+            toSnake = s: concatStrings (map (c: if elem c upperChars then "_${c}" else c) (stringToCharacters s));
+            envName = attrPath: "MERIDIAN_" + toUpper (concatStringsSep "_" (map toSnake attrPath));
+            # Flatten cfg.settings into env assignments, skipping nulls.
+            # Restricted to lib functions that have existed for years so the
+            # module imposes no minimum nixpkgs version on consumers.
+            flatten =
+              prefix: attrs:
+              concatLists (
+                mapAttrsToList (
+                  name: value:
+                  if builtins.isAttrs value then
+                    flatten (prefix ++ [ name ]) value
+                  else
+                    optional (value != null) (mkKeyValueDefault { } "=" (envName (prefix ++ [ name ])) value)
+                ) attrs
+              );
           in
-          pipe cfg.settings [
-            (filterAttrsRecursive (_: v: v != null))
-            (mapAttrsToListRecursive (path: value: mkKeyValueDefault { } "=" (env path) value))
-          ]
-          ++ mapAttrsToList (mkKeyValueDefault { } "=") cfg.environment;
+          flatten [ ] cfg.settings ++ mapAttrsToList (mkKeyValueDefault { } "=") cfg.environment;
       };
 
       Install.WantedBy = [ "default.target" ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,109 +1,139 @@
 packages:
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
+  inherit (lib.attrsets) filterAttrsRecursive mapAttrsToList mapAttrsToListRecursive;
+  inherit (lib.generators) mkKeyValueDefault;
+  inherit (lib.lists) concatMap elem;
+  inherit (lib.meta) getExe;
+  inherit (lib.modules) mkIf;
+  inherit (lib.options)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    ;
+  inherit (lib.strings)
+    join
+    upperChars
+    splitStringBy
+    toUpper
+    ;
+  inherit (lib.trivial) flip pipe;
+  inherit (lib.types)
+    attrsOf
+    bool
+    int
+    nullOr
+    port
+    str
+    ;
   cfg = config.services.meridian;
 in
 {
   options.services.meridian = {
-    enable = lib.mkEnableOption "the Meridian proxy service";
+    enable = mkEnableOption "the Meridian proxy service";
 
-    package = lib.mkPackageOption packages "meridian" {
+    package = mkPackageOption packages "meridian" {
       pkgsText = "inputs.meridian.packages.\${pkgs.stdenv.hostPlatform.system}";
     };
 
     settings = {
-      port = lib.mkOption {
-        type = lib.types.port;
+      port = mkOption {
+        type = port;
         default = 3456;
         description = "Port to listen on.";
       };
 
-      host = lib.mkOption {
-        type = lib.types.str;
+      host = mkOption {
+        type = str;
         default = "127.0.0.1";
         description = "Host to bind to.";
       };
 
-      idleTimeoutSeconds = lib.mkOption {
-        type = lib.types.int;
+      idleTimeoutSeconds = mkOption {
+        type = int;
         default = 120;
         description = "HTTP keep-alive idle timeout in seconds.";
       };
 
-      passthrough = lib.mkOption {
-        type = lib.types.nullOr lib.types.bool;
+      passthrough = mkOption {
+        type = nullOr bool;
         default = null;
-        description = "Forward tool calls to client instead of executing. Null lets Meridian auto-detect.";
+        description = "Forward tool calls to client instead of executing. `null` lets Meridian auto-detect.";
       };
 
-      defaultAgent = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
+      defaultAgent = mkOption {
+        type = nullOr str;
         default = null;
-        description = "Default adapter for unrecognized agents (opencode, forgecode, pi, crush, droid, passthrough).";
+        description = "Default adapter for unrecognized agents (`opencode`, `forgecode`, `pi`, `crush`, `droid`, `passthrough`).";
       };
 
-      sonnetModel = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
+      sonnetModel = mkOption {
+        type = nullOr str;
         default = null;
-        description = "Sonnet context tier: 'sonnet' (200k) or 'sonnet[1m]' (1M, requires Extra Usage).";
+        description = "Sonnet context tier: `sonnet` (200k) or `sonnet[1m]` (1M, requires Extra Usage).";
       };
 
       telemetry = {
-        persist = lib.mkOption {
-          type = lib.types.bool;
+        persist = mkOption {
+          type = bool;
           default = false;
           description = "Enable SQLite telemetry persistence.";
         };
 
-        retentionDays = lib.mkOption {
-          type = lib.types.nullOr lib.types.int;
+        retentionDays = mkOption {
+          type = nullOr int;
           default = null;
           description = "Days to retain telemetry data before cleanup.";
         };
       };
     };
 
-    environment = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
+    environment = mkOption {
+      type = attrsOf str;
       default = { };
       description = "Extra environment variables passed to the Meridian service.";
     };
 
-    opencode.pluginPath = lib.mkOption {
-      type = lib.types.str;
+    opencode.pluginPath = mkOption {
+      type = str;
       default = "${cfg.package}/lib/meridian/plugin/meridian.ts";
       readOnly = true;
-      description = "Nix store path to the OpenCode plugin file. Use this to reference the plugin in your OpenCode config.";
+      description = ''
+        Nix store path to the OpenCode plugin file.
+        Use this to reference the plugin in your OpenCode config.
+      '';
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     systemd.user.services.meridian = {
       Unit.Description = "Meridian - Local Anthropic API proxy";
 
       Service = {
         Type = "exec";
-        ExecStart = lib.getExe cfg.package;
+        ExecStart = getExe cfg.package;
         Restart = "on-failure";
         RestartSec = 5;
 
         Environment =
-          lib.pipe
-            {
-              MERIDIAN_DEFAULT_AGENT = cfg.settings.defaultAgent;
-              MERIDIAN_HOST = cfg.settings.host;
-              MERIDIAN_IDLE_TIMEOUT_SECONDS = cfg.settings.idleTimeoutSeconds;
-              MERIDIAN_PASSTHROUGH = cfg.settings.passthrough;
-              MERIDIAN_PORT = cfg.settings.port;
-              MERIDIAN_SONNET_MODEL = cfg.settings.sonnetModel;
-              MERIDIAN_TELEMETRY_PERSIST = cfg.settings.telemetry.persist;
-              MERIDIAN_TELEMETRY_RETENTION_DAYS = cfg.settings.telemetry.retentionDays;
-            }
-            [
-              (lib.filterAttrs (_: v: v != null))
-              (lib.flip lib.mergeAttrs cfg.environment)
-              (lib.mapAttrsToList (lib.generators.mkKeyValueDefault { } "="))
+          let
+            env = flip pipe [
+              (concatMap (splitStringBy (_: curr: elem curr upperChars) true))
+              (map toUpper)
+              (join "_")
+              (s: "MERIDIAN_${s}")
             ];
+          in
+          pipe cfg.settings [
+            (filterAttrsRecursive (_: v: v != null))
+            (mapAttrsToListRecursive (path: value: mkKeyValueDefault { } "=" (env path) value))
+          ]
+          ++ mapAttrsToList (mkKeyValueDefault { } "=") cfg.environment;
       };
 
       Install.WantedBy = [ "default.target" ];

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -12,6 +12,7 @@ let
   inherit (lib.meta) getExe;
   inherit (lib.modules) mkIf;
   inherit (lib.options)
+    literalExpression
     mkEnableOption
     mkOption
     mkPackageOption
@@ -27,11 +28,16 @@ let
     attrsOf
     bool
     int
+    listOf
     nullOr
+    path
     port
     str
+    submodule
     ;
   cfg = config.services.meridian;
+  mkPluginFile = plugins: toString (pluginFormat.generate "plugins.json" { inherit plugins; });
+  pluginFormat = pkgs.formats.json { };
 in
 {
   options.services.meridian = {
@@ -76,6 +82,33 @@ in
         type = nullOr str;
         default = null;
         description = "Sonnet context tier: `sonnet` (200k) or `sonnet[1m]` (1M, requires Extra Usage).";
+      };
+
+      pluginConfig = mkOption {
+        type = listOf (submodule {
+          options = {
+            enabled = mkOption {
+              type = bool;
+              default = true;
+              description = "Whether Meridian loads this plugin. Disabled entries stay in the manifest but are marked disabled.";
+            };
+
+            path = mkOption {
+              type = path;
+              example = literalExpression ''"''${plugin}/lib/index.js"'';
+              description = "Path to the plugin's ESM entry file.";
+            };
+          };
+        });
+        default = [ ];
+        apply = mkPluginFile;
+        description = "Plugins to load, in list order, rendered to a `plugins.json` manifest passed as `MERIDIAN_PLUGIN_CONFIG`.";
+      };
+
+      pluginDir = mkOption {
+        type = nullOr path;
+        default = null;
+        description = "Directory Meridian auto-discovers plugins from. `null` uses Meridian's default (`~/.config/meridian/plugins`).";
       };
 
       telemetry = {


### PR DESCRIPTION
## Summary

Lands #623 by @connor-grady with his three commits cherry-picked verbatim (authorship preserved), plus one fix-up commit.

### From #623
- `bin/cli.ts` reads `MERIDIAN_PLUGIN_DIR` / `MERIDIAN_PLUGIN_CONFIG` and forwards them into `startProxyServer`, making both plugin paths configurable for the standalone proxy (previously embedded-API only)
- home-manager module: `settings.pluginConfig` (list of `{path, enabled}` rendered to a Nix-store `plugins.json`) and `settings.pluginDir`; systemd `Environment` derives `MERIDIAN_*` names automatically from settings attribute paths

### Fix-ups
- **Empty-manifest regression**: `pluginConfig`'s `apply` rendered a manifest even for the default `[]`, so `MERIDIAN_PLUGIN_CONFIG` was always exported — silently overriding every existing HM user's `~/.config/meridian/plugins.json` (the documented mechanism for the official scrub plugins). Empty now maps to `null` (var not exported).
- **No nixpkgs floor**: the derivation used `mapAttrsToListRecursive` / `splitStringBy` / `join` — 2025+ lib additions that would break HM consumers on older nixpkgs, and no CI evaluates this module. Rewritten with long-stable lib functions, same behavior.
- `path` option docs warn against bare path literals (single-file store copies break plugins that import sibling `node_modules`)
- README: config-table rows for both env vars, plugins-section note, HM example

## Verification
- `bun test` 2065 pass, `tsc --noEmit` clean
- Module evaluated end-to-end via `lib.evalModules` in a `nixos/nix` container:
  - defaults → `["MERIDIAN_HOST=…","MERIDIAN_IDLE_TIMEOUT_SECONDS=120","MERIDIAN_PORT=3456","MERIDIAN_TELEMETRY_PERSIST=false", user env]` and **no** `MERIDIAN_PLUGIN_CONFIG`
  - full settings → every derived name correct (`MERIDIAN_TELEMETRY_RETENTION_DAYS`, `MERIDIAN_PLUGIN_DIR`, `MERIDIAN_PLUGIN_CONFIG=/nix/store/…-plugins.json`, …)

Closes #623