### PR TITLE
fix: retry busy-session resume refusals instead of failing deterministically (#630)

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, isStaleSessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination } from "../proxy/errors"
+import { classifyError, isStaleSessionError, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -145,6 +145,28 @@ describe("classifyError", () => {
     it("detects 'overloaded' keyword", () => {
       const result = classifyError("service overloaded")
       expect(result.status).toBe(503)
+    })
+  })
+
+  describe("busy session (bg agent) detection — #630", () => {
+    const busyLine =
+      "Error: Session 3cff857d-114e-4be3-8a12-99842ad2326e is currently running as a background agent (bg). Use `claude agents` to find and attach to it, or add --fork-session to branch off a copy."
+
+    it("detects the refusal in the error message", () => {
+      expect(isBusySessionError(new Error(busyLine))).toBe(true)
+    })
+
+    it("detects the refusal on captured stderr when the error only carries the exit code", () => {
+      expect(isBusySessionError(new Error("Claude Code process exited with code 1"), busyLine)).toBe(true)
+    })
+
+    it("ignores unrelated exit-1 failures", () => {
+      expect(isBusySessionError(new Error("Claude Code process exited with code 1"))).toBe(false)
+      expect(isBusySessionError(new Error("Claude Code process exited with code 1"), "Warning: Custom betas are only available for API key users.")).toBe(false)
+    })
+
+    it("ignores non-Error values without the needle", () => {
+      expect(isBusySessionError("some string", undefined)).toBe(false)
     })
   })
 

--- a/src/__tests__/proxy-busy-session-retry.test.ts
+++ b/src/__tests__/proxy-busy-session-retry.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for busy-session (bg-agent) resume retry behavior — #630.
+ *
+ * CLAUDE_CODE_SESSION_KIND=bg (#628 scratchpad suppression) registers every
+ * SDK session as a running background agent. A fast follow-up can spawn a
+ * --resume while the previous subprocess for that session is still exiting;
+ * the CLI then refuses with exit 1 and "Session X is currently running as a
+ * background agent (bg)" on stderr. The proxy must wait briefly and retry
+ * the SAME resume (the stale process exits within ~a second), and fall back
+ * to forkSession if the session stays busy — never surface a deterministic
+ * failure the client will blindly re-trigger.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+// Shrink retry backoff so tests run fast (read at server.ts import time)
+process.env.MERIDIAN_BUSY_RETRY_DELAY_MS = "5"
+
+const BUSY_LINE =
+  "Error: Session 3cff857d-114e-4be3-8a12-99842ad2326e is currently running as a background agent (bg). Use `claude agents` to find and attach to it, or add --fork-session to branch off a copy."
+
+// Per-test knobs
+let queryCalls: Array<Record<string, any>> = []
+let queryCallCount = 0
+/** Number of leading resume attempts that fail busy (0 = never busy). */
+let busyFailCount = 0
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    queryCallCount++
+    const callIndex = queryCallCount
+    queryCalls.push(opts.options || {})
+    const isStreaming = opts.options?.includePartialMessages === true
+
+    return (async function* () {
+      if (callIndex <= busyFailCount && opts.options?.resume) {
+        // Mirror production: bg-agent refusal arrives on stderr, the SDK
+        // error itself only carries the exit code.
+        opts.options?.stderr?.(BUSY_LINE)
+        throw new Error("Claude Code process exited with code 1")
+      }
+      if (isStreaming) {
+        yield messageStart(`msg-${callIndex}`)
+        yield textBlockStart(0)
+        yield textDelta(0, `response-${callIndex}`)
+        yield blockStop(0)
+        yield messageDelta("end_turn")
+        yield messageStop()
+      }
+      yield {
+        type: "assistant",
+        uuid: `uuid-${callIndex}`,
+        message: {
+          id: `msg-${callIndex}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: `response-${callIndex}` }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: `sdk-after-${callIndex}`,
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    })
+  )
+}
+
+const priorMessages = [
+  { role: "user", content: "hello" },
+  { role: "assistant", content: "hi there" },
+]
+
+function seed(sessionId: string) {
+  storeSession(sessionId, priorMessages, "sdk-original", "/tmp/test", [null, "uuid-1"])
+}
+
+function continuation() {
+  return [...priorMessages, { role: "user", content: "follow up" }]
+}
+
+describe("Busy-session resume retry (#630)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    queryCalls = []
+    queryCallCount = 0
+    busyFailCount = 0
+  })
+
+  it("retries the same resume after a transient busy refusal (non-streaming)", async () => {
+    const app = createTestApp()
+    seed("sess-busy-1")
+    busyFailCount = 1
+
+    const response = await post(
+      app,
+      { model: "sonnet", stream: false, messages: continuation() },
+      { "x-opencode-session": "sess-busy-1" }
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.content.some((b: any) => b.type === "text")).toBe(true)
+
+    // Attempt 1 and the retry must target the SAME session — not fresh
+    expect(queryCalls.length).toBe(2)
+    expect(queryCalls[0]!.resume).toBe("sdk-original")
+    expect(queryCalls[1]!.resume).toBe("sdk-original")
+    expect(queryCalls[1]!.forkSession).toBeUndefined()
+  })
+
+  it("falls back to forkSession when the session stays busy (non-streaming)", async () => {
+    const app = createTestApp()
+    seed("sess-busy-2")
+    // initial + 3 same-resume retries all busy; the 5th attempt forks
+    busyFailCount = 4
+
+    const response = await post(
+      app,
+      { model: "sonnet", stream: false, messages: continuation() },
+      { "x-opencode-session": "sess-busy-2" }
+    )
+
+    expect(response.status).toBe(200)
+    expect(queryCalls.length).toBe(5)
+    for (let i = 0; i < 4; i++) {
+      expect(queryCalls[i]!.resume).toBe("sdk-original")
+      expect(queryCalls[i]!.forkSession).toBeUndefined()
+    }
+    expect(queryCalls[4]!.resume).toBe("sdk-original")
+    expect(queryCalls[4]!.forkSession).toBe(true)
+  })
+
+  it("retries the same resume after a transient busy refusal (streaming)", async () => {
+    const app = createTestApp()
+    seed("sess-busy-3")
+    busyFailCount = 1
+
+    const response = await post(
+      app,
+      { model: "sonnet", stream: true, messages: continuation() },
+      { "x-opencode-session": "sess-busy-3" }
+    )
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain("event: message_start")
+    expect(text).not.toContain("process exited with code 1")
+
+    expect(queryCalls.length).toBe(2)
+    expect(queryCalls[0]!.resume).toBe("sdk-original")
+    expect(queryCalls[1]!.resume).toBe("sdk-original")
+  })
+
+  it("falls back to forkSession when the session stays busy (streaming)", async () => {
+    const app = createTestApp()
+    seed("sess-busy-4")
+    busyFailCount = 4
+
+    const response = await post(
+      app,
+      { model: "sonnet", stream: true, messages: continuation() },
+      { "x-opencode-session": "sess-busy-4" }
+    )
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+    expect(text).toContain("event: message_start")
+
+    expect(queryCalls.length).toBe(5)
+    expect(queryCalls[4]!.resume).toBe("sdk-original")
+    expect(queryCalls[4]!.forkSession).toBe(true)
+  })
+
+  it("does not retry busy-shaped failures on fresh (non-resume) requests", async () => {
+    const app = createTestApp()
+    // No seeded session: first call has no resume, so the mock succeeds —
+    // but force the stderr line anyway via a resume-less busy simulation
+    // by seeding busyFailCount without a resume (mock only throws on resume,
+    // so this asserts the fresh path never even enters the retry loop).
+    busyFailCount = 99
+
+    const response = await post(app, {
+      model: "sonnet",
+      stream: false,
+      messages: [{ role: "user", content: "hello" }],
+    })
+
+    expect(response.status).toBe(200)
+    expect(queryCalls.length).toBe(1)
+    expect(queryCalls[0]!.resume).toBeUndefined()
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -167,6 +167,20 @@ export function isStaleSessionError(error: unknown): boolean {
 }
 
 /**
+ * Detect the CLI's bg-agent resume refusal (#630). With
+ * CLAUDE_CODE_SESSION_KIND=bg (#628 scratchpad suppression) every SDK
+ * session is registered as a running background agent; a --resume spawned
+ * while the previous subprocess for that session is still exiting is
+ * refused with exit 1. The refusal text arrives on stderr — the SDK error
+ * itself only carries the exit code — so callers pass captured stderr too.
+ */
+export function isBusySessionError(error: unknown, stderr?: string): boolean {
+  const needle = "is currently running as a background agent"
+  const msg = error instanceof Error ? error.message : String(error)
+  return msg.includes(needle) || (stderr?.includes(needle) ?? false)
+}
+
+/**
  * Quick check whether an error message indicates a rate limit.
  * Used by server.ts to decide whether to retry with a smaller context window.
  */

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -70,6 +70,10 @@ export interface QueryContext {
   isUndo: boolean
   /** UUID to rollback to for undo operations */
   undoRollbackUuid?: string
+  /** Fork the resumed session instead of attaching to it (#630 busy-session
+   *  fallback — the original stays registered as a bg agent; the fork gets a
+   *  fresh id with the full history). */
+  forkSession?: boolean
   /** SDK hooks (PreToolUse etc.) */
   sdkHooks?: any
   /** Blocked SDK built-in tools (from pipeline) */
@@ -229,7 +233,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
   const {
     prompt, model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv, hasDeferredTools,
-    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools, incompatibleTools,
+    resumeSessionId, isUndo, undoRollbackUuid, forkSession, sdkHooks, blockedTools, incompatibleTools,
     mcpServerName, allowedMcpTools, onStderr,
     effort, thinking, taskBudget, outputFormat, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
     memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
@@ -336,7 +340,8 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       },
       ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
-      ...(isUndo ? { forkSession: true, ...(undoRollbackUuid ? { resumeSessionAt: undoRollbackUuid } : {}) } : {}),
+      ...(isUndo || forkSession ? { forkSession: true } : {}),
+      ...(isUndo && undoRollbackUuid ? { resumeSessionAt: undoRollbackUuid } : {}),
       ...(sdkHooks ? { hooks: sdkHooks } : {}),
       ...(effort ? { effort } : {}),
       ...(thinking ? { thinking } : {}),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -48,7 +48,7 @@ import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
+import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, type CredentialStore } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
@@ -387,6 +387,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // a fresh replay. Follow-ups briefly await their session's pending store.
   const PENDING_STORE_WAIT_MS = 3000
   const PENDING_STORE_AUTO_RESOLVE_MS = 10000
+
+  // #630: a --resume spawned while the session's previous subprocess is
+  // still exiting is refused ("currently running as a background agent",
+  // a consequence of #628's CLAUDE_CODE_SESSION_KIND=bg). The stale
+  // process exits within ~a second — retry the same resume with linear
+  // backoff, then fork the session as a last resort. Delay is overridable
+  // so tests don't sleep for real.
+  const BUSY_SESSION_MAX_RETRIES = 3
+  const BUSY_SESSION_RETRY_DELAY_MS = parseInt(process.env.MERIDIAN_BUSY_RETRY_DELAY_MS ?? "500", 10)
   const pendingSessionStores = new Map<string, { promise: Promise<void>; resolve: () => void }>()
   const registerPendingStore = (key: string): (() => void) => {
     let resolveFn: () => void = () => {}
@@ -1403,16 +1412,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               let tokenRefreshed = false
               let didFreshBaseRetry = false
+              let busySessionRetries = 0
+              let busySessionFork = false
               while (true) {
                 // Track whether response content was yielded.
                 // The SDK emits metadata (session_id etc.) before the API call;
                 // only "assistant" messages represent actual response content.
                 let didYieldContent = false
+                // stderr emitted by THIS attempt's subprocess only — retries
+                // must not re-match a previous attempt's refusal text.
+                const attemptStderrStart = stderrLines.length
                 try {
                   for await (const event of query(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                    resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    resumeSessionId, isUndo, undoRollbackUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -1443,6 +1457,29 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
                   // Never retry after response content was yielded — response is committed
                   if (didYieldContent) throw error
+
+                  // Retry: session still registered as a running bg agent (#630).
+                  // The previous subprocess for this session (early-stop drain or
+                  // slow exit) hasn't finished dying, so the CLI refused --resume
+                  // with exit 1. Surfacing that would be a deterministic failure —
+                  // the client's identical retry hits the same window. Wait for
+                  // the stale process to exit and retry the SAME resume; if the
+                  // session stays busy, fork it (full history, fresh id).
+                  if (resumeSessionId && isBusySessionError(error, stderrLines.slice(attemptStderrStart).join("\n"))) {
+                    if (busySessionRetries < BUSY_SESSION_MAX_RETRIES) {
+                      busySessionRetries++
+                      claudeLog("session.busy_retry", { mode: "non_stream", attempt: busySessionRetries, resumeSessionId })
+                      plog(`[PROXY] ${requestMeta.requestId} session busy (bg agent), retrying resume ${busySessionRetries}/${BUSY_SESSION_MAX_RETRIES}`)
+                      await new Promise((resolve) => setTimeout(resolve, BUSY_SESSION_RETRY_DELAY_MS * busySessionRetries))
+                      continue
+                    }
+                    if (!busySessionFork) {
+                      busySessionFork = true
+                      claudeLog("session.busy_fork", { mode: "non_stream", resumeSessionId })
+                      plog(`[PROXY] ${requestMeta.requestId} session still busy after ${BUSY_SESSION_MAX_RETRIES} retries — forking session`)
+                      continue
+                    }
+                  }
 
                   // Retry: stale undo UUID — evict session and start fresh (one-shot)
                   if (isStaleSessionError(error)) {
@@ -2076,6 +2113,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
                 let tokenRefreshed = false
                 let didFreshBaseRetry = false
+                let busySessionRetries = 0
+                let busySessionFork = false
 
                 while (true) {
                   // Track whether client-visible SSE events were yielded.
@@ -2083,11 +2122,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // before the API call — those are NOT client-visible and must
                   // not prevent retry. Only stream_event types become SSE output.
                   let didYieldClientEvent = false
+                  // stderr emitted by THIS attempt's subprocess only — retries
+                  // must not re-match a previous attempt's refusal text.
+                  const attemptStderrStart = stderrLines.length
                   try {
                     for await (const event of query(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                      resumeSessionId, isUndo, undoRollbackUuid, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId, isUndo, undoRollbackUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2113,6 +2155,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
                     // Never retry after client-visible SSE events — response is committed
                     if (didYieldClientEvent) throw error
+
+                    // Retry: session still registered as a running bg agent (#630)
+                    // — see the non-stream branch above for the full rationale.
+                    if (resumeSessionId && isBusySessionError(error, stderrLines.slice(attemptStderrStart).join("\n"))) {
+                      if (busySessionRetries < BUSY_SESSION_MAX_RETRIES) {
+                        busySessionRetries++
+                        claudeLog("session.busy_retry", { mode: "stream", attempt: busySessionRetries, resumeSessionId })
+                        plog(`[PROXY] ${requestMeta.requestId} session busy (bg agent), retrying resume ${busySessionRetries}/${BUSY_SESSION_MAX_RETRIES}`)
+                        await new Promise((resolve) => setTimeout(resolve, BUSY_SESSION_RETRY_DELAY_MS * busySessionRetries))
+                        continue
+                      }
+                      if (!busySessionFork) {
+                        busySessionFork = true
+                        claudeLog("session.busy_fork", { mode: "stream", resumeSessionId })
+                        plog(`[PROXY] ${requestMeta.requestId} session still busy after ${BUSY_SESSION_MAX_RETRIES} retries — forking session`)
+                        continue
+                      }
+                    }
 
                     // Retry: stale undo UUID — evict and start fresh (one-shot)
                     if (isStaleSessionError(error)) {


### PR DESCRIPTION
## Summary

Fixes #630 — the bg-agent resume refusal loop introduced by #628's `CLAUDE_CODE_SESSION_KIND=bg` scratchpad suppression.

### Root cause
`SESSION_KIND=bg` registers every SDK session as a *running background agent*. A fast follow-up (typical for subagent tool loops) spawns `--resume` while the previous subprocess for that session is still exiting; the CLI refuses with exit 1 and `Session X is currently running as a background agent (bg)` **on stderr**. Meridian surfaced that as a generic failure, and the client's identical retry hit the same window deterministically — looping until the user cancelled.

### Fix
- `isBusySessionError(error, stderr)` in errors.ts — the SDK error only says "exited with code 1"; the refusal text lives on stderr, matched against the current attempt's stderr only
- Both request paths (stream + non-stream): on a busy refusal during a resume, retry the **same** resume with linear backoff (500ms × attempt, 3 attempts) — the registration clears the instant the stale process exits
- Last resort: one retry with `forkSession: true` (full history under a fresh session id) so the request always makes progress
- `forkSession` added as an explicit `buildQueryOptions` param (previously implied by `isUndo` only)
- `MERIDIAN_BUSY_RETRY_DELAY_MS` test knob for the backoff

### Verification
- Reproduced the exact refusal with the real CLI (2.1.198): two concurrent processes on one session → exit 1 with byte-identical stderr to the report
- Confirmed both recovery paths live: resume succeeds immediately after the stale process exits; `--fork-session` succeeds even while busy
- New integration suite (`proxy-busy-session-retry.test.ts`, 5 tests): transient busy → same-resume retry; persistent busy → fork fallback; fresh (non-resume) requests never enter the retry loop — stream + non-stream
- `isBusySessionError` unit tests incl. the unrelated-exit-1 negative case
- Full suite 2074 pass, tsc clean, E34 live streaming harness 3/3 clean