### PR TITLE
feat: add Sonnet 5 to the model list, make it the canonical sonnet (#631)

### DIFF
--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Explicit model-id pinning — #631.
+ *
+ * All sonnet/opus/haiku/fable-family requests collapse to SDK tier aliases
+ * resolved by ANTHROPIC_DEFAULT_{TIER}_MODEL pins. Before this fix the pins
+ * were canonical-only, so an explicit `claude-sonnet-5` silently resolved to
+ * the canonical sonnet (4.6) — and `claude-opus-4-7` to 4.8. A proxy must
+ * never substitute models: fully-versioned ids now pin their tier for that
+ * request, and the bare aliases mean "the current model of that tier".
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+// ---------- unit: explicitModelPin + canonical bump ----------
+
+const { explicitModelPin, CANONICAL_SONNET_MODEL } = await import("../proxy/models")
+
+describe("explicitModelPin (#631)", () => {
+  it("pins fully-versioned sonnet ids", () => {
+    expect(explicitModelPin("claude-sonnet-5")).toEqual({ ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-5" })
+    expect(explicitModelPin("claude-sonnet-4-6")).toEqual({ ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6" })
+  })
+
+  it("pins fully-versioned opus and date-suffixed haiku ids", () => {
+    expect(explicitModelPin("claude-opus-4-7")).toEqual({ ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-7" })
+    expect(explicitModelPin("claude-haiku-4-5-20251001")).toEqual({ ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001" })
+  })
+
+  it("routes mythos ids through the fable tier pin", () => {
+    expect(explicitModelPin("claude-mythos-5")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-mythos-5" })
+    expect(explicitModelPin("claude-fable-5")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-fable-5" })
+  })
+
+  it("strips the [1m] context suffix before pinning", () => {
+    expect(explicitModelPin("claude-sonnet-5[1m]")).toEqual({ ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-5" })
+  })
+
+  it("leaves bare aliases and family names on the canonical pins", () => {
+    expect(explicitModelPin("sonnet")).toBeUndefined()
+    expect(explicitModelPin("sonnet[1m]")).toBeUndefined()
+    expect(explicitModelPin("opus")).toBeUndefined()
+    expect(explicitModelPin("claude-sonnet")).toBeUndefined()
+    expect(explicitModelPin("gpt-4o")).toBeUndefined()
+    expect(explicitModelPin("")).toBeUndefined()
+  })
+})
+
+describe("canonical sonnet pin (#631)", () => {
+  it("bare sonnet means the current Sonnet", () => {
+    expect(CANONICAL_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+})
+
+// ---------- integration: pins reach the SDK subprocess env ----------
+
+let queryEnvs: Array<Record<string, string | undefined>> = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    queryEnvs.push(opts.options?.env || {})
+    return (async function* () {
+      yield {
+        type: "assistant",
+        uuid: "uuid-1",
+        message: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 5, output_tokens: 2 },
+        },
+        session_id: "sdk-1",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function post(app: any, model: string) {
+  return app.fetch(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, stream: false, messages: [{ role: "user", content: "hi" }] }),
+    })
+  )
+}
+
+describe("explicit model pins reach the subprocess env (#631)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    queryEnvs = []
+  })
+
+  it("claude-sonnet-5 pins the sonnet tier for the request", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, "claude-sonnet-5")
+    expect(res.status).toBe(200)
+    expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+
+  it("claude-opus-4-7 pins the opus tier instead of canonical 4.8", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, "claude-opus-4-7")
+    expect(res.status).toBe(200)
+    expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-7")
+  })
+
+  it("bare sonnet resolves via the canonical pin (now Sonnet 5)", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, "sonnet")
+    expect(res.status).toBe(200)
+    expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+})

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -114,11 +114,11 @@ describe("translateOpenAiToAnthropic", () => {
     expect(result!.system).toContain("<conversation_history>")
   })
 
-  it("defaults model to claude-sonnet-4-6", () => {
+  it("defaults model to the canonical Sonnet", () => {
     const result = translateOpenAiToAnthropic({
       messages: [{ role: "user", content: "Hi" }],
     })
-    expect(result!.model).toBe("claude-sonnet-4-6")
+    expect(result!.model).toBe("claude-sonnet-5")
   })
 
   it("passes through specified model", () => {
@@ -1184,13 +1184,14 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 6 models", () => {
-    expect(buildModelList(true).length).toBe(6)
-    expect(buildModelList(false).length).toBe(6)
+  it("returns 7 models", () => {
+    expect(buildModelList(true).length).toBe(7)
+    expect(buildModelList(false).length).toBe(7)
   })
 
-  it("includes fable-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes sonnet-5, fable-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
+    expect(ids).toContain("claude-sonnet-5")
     expect(ids).toContain("claude-fable-5")
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -220,7 +220,7 @@ describe("SDK model pin injection (fixes #419)", () => {
     await post(app, { ...BASIC_REQUEST, model: "sonnet" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
   })
 
@@ -295,7 +295,7 @@ describe("SDK model pin injection (fixes #419)", () => {
   it("bare 'sonnet' alias requests do not set an envOverride, falling back to the canonical pin", async () => {
     const app = createTestApp()
     await post(app, { ...BASIC_REQUEST, model: "sonnet" })
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-4-6")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
   })
 
   it("shell ANTHROPIC_DEFAULT_* values win over Meridian's pins", async () => {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -42,7 +42,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  */
 export const CANONICAL_FABLE_MODEL = "claude-fable-5"
 export const CANONICAL_OPUS_MODEL = "claude-opus-4-8"
-export const CANONICAL_SONNET_MODEL = "claude-sonnet-4-6"
+export const CANONICAL_SONNET_MODEL = "claude-sonnet-5"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
 
 /**
@@ -63,6 +63,28 @@ export function resolveSdkModelDefaults(
     ANTHROPIC_DEFAULT_SONNET_MODEL: env.MERIDIAN_DEFAULT_SONNET_MODEL ?? CANONICAL_SONNET_MODEL,
     ANTHROPIC_DEFAULT_HAIKU_MODEL: env.MERIDIAN_DEFAULT_HAIKU_MODEL ?? CANONICAL_HAIKU_MODEL,
   }
+}
+
+/**
+ * Per-request tier pin for explicitly versioned model ids (#631).
+ *
+ * mapModelToClaudeModel collapses every family request to a tier alias
+ * ("sonnet"/"opus"/...) that the SDK resolves via ANTHROPIC_DEFAULT_*_MODEL.
+ * With canonical pins alone, an explicit `claude-sonnet-5` silently resolved
+ * to the canonical sonnet — a proxy must never substitute models, so a
+ * fully-versioned id overrides its tier's pin for that request only.
+ *
+ * Bare aliases ("sonnet", "opus[1m]") and unversioned family names return
+ * undefined and keep the canonical pins. Mythos rides the fable tier
+ * (claude-mythos-5 shares it — see mapModelToClaudeModel). A trailing [1m]
+ * suffix is stripped; extended context stays alias-level.
+ */
+export function explicitModelPin(requestedModel: string): Record<string, string> | undefined {
+  const base = requestedModel.trim().toLowerCase().replace(/\[1m\]$/, "")
+  const match = /^claude-(sonnet|opus|haiku|fable|mythos)-\d[\w.-]*$/.exec(base)
+  if (!match) return undefined
+  const tier = match[1] === "mythos" ? "FABLE" : match[1]!.toUpperCase()
+  return { [`ANTHROPIC_DEFAULT_${tier}_MODEL`]: base }
 }
 export interface ClaudeAuthStatus {
   loggedIn?: boolean

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -20,6 +20,8 @@
 // Types
 // ---------------------------------------------------------------------------
 
+import { CANONICAL_SONNET_MODEL } from "./models"
+
 export type OpenAiRole = "system" | "user" | "assistant" | "tool"
 
 export interface OpenAiTextPart {
@@ -521,7 +523,7 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
   }
 
   const result: AnthropicRequestBody = {
-    model: body.model ?? "claude-sonnet-4-6",
+    model: body.model ?? CANONICAL_SONNET_MODEL,
     messages: messagesToSend,
     max_tokens: body.max_tokens ?? body.max_completion_tokens ?? 8192,
     tools: tools,
@@ -906,6 +908,15 @@ const FULL_CAPABILITIES: ModelCapabilities = Object.freeze({
  */
 export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date.now() / 1000)): OpenAiModel[] {
   return [
+    {
+      id: "claude-sonnet-5",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Sonnet 5",
+      context_window: 200_000,
+      capabilities: FULL_CAPABILITIES,
+    },
     {
       id: "claude-sonnet-4-6",
       object: "model",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -51,7 +51,7 @@ import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, type CredentialStore } from "./tokenRefresh"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall } from "./messages"
@@ -568,20 +568,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
         const requestedModel = typeof body.model === "string" ? body.model : "sonnet"
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode)
-        const envOverrides = requestedModel.startsWith("claude-opus-")
-          ? { ANTHROPIC_DEFAULT_OPUS_MODEL: requestedModel }
-          : requestedModel.startsWith("claude-fable-")
-            ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
-            // Mythos shares the fable SDK alias (no separate mythos alias
-            // exists), so an explicit claude-mythos-* id resolves through
-            // ANTHROPIC_DEFAULT_FABLE_MODEL and reaches the API verbatim.
-            : requestedModel.startsWith("claude-mythos-")
-              ? { ANTHROPIC_DEFAULT_FABLE_MODEL: requestedModel }
-              : requestedModel.startsWith("claude-sonnet-")
-                ? { ANTHROPIC_DEFAULT_SONNET_MODEL: requestedModel }
-                : requestedModel.startsWith("claude-haiku-")
-                  ? { ANTHROPIC_DEFAULT_HAIKU_MODEL: requestedModel }
-                  : undefined
+        // Explicitly versioned ids override their tier's canonical pin for
+        // this request (spread last in query.ts env, so they also beat
+        // operator env) — a proxy must never substitute models. Bare aliases
+        // keep the canonical pins. See explicitModelPin for the rules.
+        const envOverrides = explicitModelPin(requestedModel)
         // workingDirectory = SDK subprocess cwd (must exist on the proxy host).
         // clientWorkingDirectory = the client's local path (may not exist here);
         // used for per-project fingerprint bucketing and a system-prompt hint
@@ -3559,7 +3550,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
     const completionId = `chatcmpl-${randomUUID()}`
     const created = Math.floor(Date.now() / 1000)
-    const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : "claude-sonnet-4-6"
+    const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : CANONICAL_SONNET_MODEL
 
     // Resolve SDK features for this request (thinking passthrough setting).
     // The OpenAI endpoint is unambiguously the `openai` adapter — matching the


### PR DESCRIPTION
## Summary

Fixes #631. Two distinct gaps:

1. **`/v1/models` never listed `claude-sonnet-5`** — explicit requests for it already routed correctly (since `0b6215a2`), but tools that build their model picker from the endpoint (Open WebUI, Continue, Droid, etc.) couldn't offer it. Added, listed first.
2. **The bare `sonnet` alias resolved to 4.6.** Canonical pin bumped to `claude-sonnet-5` — an alias means "the current model of that tier". `MERIDIAN_DEFAULT_SONNET_MODEL=claude-sonnet-4-6` restores the old default; explicit ids were and remain honored exactly.

Plus a small altitude cleanup: the inline explicit-pin ternary in server.ts is extracted to a pure, unit-tested `explicitModelPin()` in models.ts — same behavior, and it now strips a trailing `[1m]` before pinning and requires a version digit (malformed family ids fall back to canonical instead of producing an invalid API model id). Hardcoded sonnet-4-6 fallbacks now reference `CANONICAL_SONNET_MODEL`.

## Verification
- New unit + integration suite (`explicit-model-pins.test.ts`, 9 tests); stale canonical assertions updated
- Full suite 2083 pass, tsc clean
- Live through a real proxy on Max: `/v1/models` lists sonnet-5; `POST /v1/messages` with `claude-sonnet-5` answered from `claude-sonnet-5`