### PR TITLE
fix: decouple SDK settings from settingSources — memory:false works with claudeMd off (#634)

### DIFF
--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -372,11 +372,32 @@ describe("buildQueryOptions", () => {
     expect(opts.settings.autoDreamEnabled).toBe(true)
   })
 
-  it("omits settingSources and settings when settingSources empty", () => {
-    const result = buildQueryOptions(makeContext({ settingSources: [] }))
+  // #634: settings (the --settings flag domain) is independent of
+  // settingSources (file domains). Empty sources must still send the memory
+  // controls — otherwise memory:false is silently ignored and the SDK's
+  // built-in default injects MEMORY.md into every session.
+  it("sends settings even when settingSources is empty (#634)", () => {
+    const result = buildQueryOptions(makeContext({ settingSources: [], memory: false, dreaming: false }))
     const opts = result.options as any
-    expect(opts.settingSources).toBeUndefined()
-    expect(opts.settings).toBeUndefined()
+    expect(opts.settings.autoMemoryEnabled).toBe(false)
+    expect(opts.settings.autoDreamEnabled).toBe(false)
+  })
+
+  it("emits an explicit empty settingSources so the subprocess loads nothing (#634/#490)", () => {
+    const result = buildQueryOptions(makeContext({ settingSources: [] }))
+    expect((result.options as any).settingSources).toEqual([])
+  })
+
+  it("emits explicit empty settingSources when the caller passes none at all", () => {
+    const result = buildQueryOptions(makeContext({ settingSources: undefined }))
+    expect((result.options as any).settingSources).toEqual([])
+  })
+
+  it("honors memory:false in passthrough mode too (#634)", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, settingSources: [], memory: false }))
+    const opts = result.options as any
+    expect(opts.settings.autoMemoryEnabled).toBe(false)
+    expect(opts.settingSources).toEqual([])
   })
 
   // sharedMemory env handling — see issue #453 (and upstream

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -272,18 +272,6 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
             // catalog from the request body. Closes #489 (diagnosis by
             // @albe-jj).
             tools: [],
-            // Explicitly disable claude-code's default settings loading.
-            // Without this, claude-code falls back to its built-in default
-            // (load user + project + local) and slurps CLAUDE.md from the
-            // proxy host's cwd into the system prompt — ~hundreds-to-
-            // thousands of tokens of unintended context that has no
-            // business in chat-style passthrough requests (LiteLLM, custom
-            // chat apps, etc.). Empty array → SDK emits `--setting-sources=`
-            // → subprocess loads nothing. The lower-down `settingSources &&
-            // settingSources.length > 0` block still wins when the user
-            // sets `claudeMd` to "project" or "full" because object spread
-            // order gives the later assignment the final word.
-            settingSources: [],
             disallowedTools: [...allBlockedTools],
             ...(passthroughMcp ? {
               allowedTools: [...passthroughMcp.toolNames],
@@ -296,13 +284,22 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
             mcpServers: { [mcpServerName]: createOpencodeMcpServer() },
           }),
       plugins: [],
-      ...(settingSources && settingSources.length > 0 ? {
-        settingSources,
-        settings: {
-          autoMemoryEnabled: ctx.memory ?? true,
-          autoDreamEnabled: ctx.dreaming ?? false,
-        },
-      } : {}),
+      // #634: `settings` (the --settings flag domain) is independent of
+      // `settingSources` (file domains) — never couple them. The memory
+      // controls must reach the SDK even when no setting files are loaded;
+      // gating them on settingSources silently re-enabled auto-memory (the
+      // SDK's built-in default) whenever claudeMd was "off".
+      settings: {
+        autoMemoryEnabled: ctx.memory ?? true,
+        autoDreamEnabled: ctx.dreaming ?? false,
+      },
+      // #634/#490: always explicit. Empty array → SDK emits
+      // `--setting-sources=` → subprocess loads nothing. Omitting the key
+      // makes claude-code fall back to its built-in default (user + project
+      // + local) and slurp CLAUDE.md from the PROXY HOST's cwd into the
+      // system prompt regardless of claudeMd:"off" — #490 fixed this for
+      // passthrough; this extends the same guarantee to every adapter.
+      settingSources: settingSources ?? [],
       ...(onStderr ? { stderr: onStderr } : {}),
       env: {
         // sharedMemory: the user wants the SDK to use Claude Code's default


### PR DESCRIPTION
## Summary

Fixes #634 — root cause and proposed fix by @michaelkrupp were exactly right, this lands his proposal with tests and live verification.

`settings` (`autoMemoryEnabled` / `autoDreamEnabled`) was gated behind `settingSources.length > 0`. With `claudeMd: "off"` — the default — the whole object was dropped, the SDK defaulted auto-memory ON, and `MEMORY.md` was injected into every session. `memory: false` (including the shipped default!) only worked as a side effect of enabling CLAUDE.md loading.

### Changes
- **`settings` always sent** — every adapter, passthrough included
- **`settingSources` always explicit** — `[]` emits `--setting-sources=` (load nothing). Omitting the key made the subprocess load user+project+local and slurp the **proxy host's** cwd CLAUDE.md into context; #490 fixed that for passthrough, this extends it to every adapter (the audit #490 deferred)

### Behavior note
Coding-agent sessions that *implicitly* picked up a CLAUDE.md from the proxy's working directory will no longer see it with `claudeMd: "off"` — that was the leak, not a feature. `claudeMd: "project"`/`"full"` is the supported way to load instruction files.

## Verification
- Contract tests updated in `query.test.ts` (the old test pinned the buggy coupling); 4 new cases incl. passthrough. Full suite 2086 pass, tsc clean
- **Live A/B on the real SDK**: pre-fix build answers "Yes" to having a persistent-memory section in context under `memory:false`; fixed build answers "No"
- Fixed internal-mode instance running from a cwd **with** a CLAUDE.md confirms no guideline leak ("No")