### PR TITLE
fix: frame fresh-session replays in a context-only envelope (#619)

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall } from "../proxy/messages"
+import { frameReplayTurns, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall } from "../proxy/messages"
 
 const img = (id: string) => ({ type: "image", source: { type: "base64", media_type: "image/png", data: id } })
 function userMsg(content: unknown) {
@@ -407,5 +407,50 @@ describe("buildToolUseIndex / tool-result attribution (#552)", () => {
       expect(idx.get("x2")!.contentSummary).toBeUndefined()
       expect(idx.get("x3")!.contentSummary).toBeUndefined()
     })
+  })
+})
+
+describe("frameReplayTurns (#619)", () => {
+  const t = (role: string, text: string) => ({ role, text })
+
+  it("wraps replayed history in an envelope and separates the final user message", () => {
+    const out = frameReplayTurns([
+      t("user", "read the config file"),
+      t("assistant", "[Assistant: I read it, it contains X]"),
+      t("user", "now update the port"),
+    ])
+    expect(out).toStartWith("<conversation_history>\n")
+    expect(out).toContain("read the config file")
+    expect(out).toContain("[Assistant: I read it, it contains X]")
+    expect(out).toContain("</conversation_history>")
+    // Anti-imitation instruction between envelope and live message
+    expect(out).toContain("context only")
+    // The live user message is terminal, outside the envelope
+    expect(out).toEndWith("now update the port")
+    expect(out.indexOf("</conversation_history>")).toBeLessThan(out.indexOf("now update the port"))
+  })
+
+  it("leaves single-turn prompts bare — no envelope for fresh conversations", () => {
+    expect(frameReplayTurns([t("user", "hello")])).toBe("hello")
+  })
+
+  it("falls back to a plain join when the final turn is not a user turn", () => {
+    const out = frameReplayTurns([
+      t("user", "do a thing"),
+      t("assistant", "[Assistant: done]"),
+    ])
+    expect(out).toBe("do a thing\n\n[Assistant: done]")
+  })
+
+  it("skips empty turns and never emits Human: markers", () => {
+    const out = frameReplayTurns([
+      t("user", "first"),
+      t("assistant", ""),
+      t("user", "[your bash ls]:\nfile.txt"),
+      t("user", "final question"),
+    ])
+    expect(out).not.toContain("Human:")
+    expect(out).toEndWith("final question")
+    expect(out).toContain("[your bash ls]:")
   })
 })

--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Fresh-session replay envelope — #619.
+ *
+ * When a multi-turn conversation is rebuilt as a fresh session (no resume),
+ * the flattened history must be framed as context-only with the live user
+ * message separated, so the model answers instead of pattern-continuing the
+ * transcript (self-play / confabulated tool output). Resume deltas stay bare.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+let capturedPrompts: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    capturedPrompts.push(opts.prompt)
+    return (async function* () {
+      yield {
+        type: "assistant",
+        uuid: "uuid-1",
+        message: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 5, output_tokens: 2 },
+        },
+        session_id: "sdk-1",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
+
+function post(app: any, messages: any[], headers: Record<string, string> = {}) {
+  return app.fetch(
+    new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ model: "sonnet", stream: false, messages }),
+    })
+  )
+}
+
+describe("fresh-session replay envelope (#619)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedPrompts = []
+  })
+
+  it("frames a fresh multi-turn replay and separates the live user message", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, [
+      { role: "user", content: "read the config" },
+      { role: "assistant", content: "I read it. Port is 3456." },
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "t1", content: "port=3456" },
+      ] },
+      { role: "user", content: "now change the port to 4000" },
+    ])
+    expect(res.status).toBe(200)
+
+    const prompt = capturedPrompts[0] as string
+    expect(typeof prompt).toBe("string")
+    expect(prompt).toContain("<conversation_history>")
+    expect(prompt).toContain("</conversation_history>")
+    expect(prompt).toContain("context only")
+    // Live message is terminal, outside the envelope
+    expect(prompt.trimEnd()).toEndWith("now change the port to 4000")
+    expect(prompt.indexOf("</conversation_history>")).toBeLessThan(prompt.indexOf("now change the port to 4000"))
+    // Anti-imitation markers preserved, classic trigger absent
+    expect(prompt).toContain("[Assistant: I read it. Port is 3456.]")
+    expect(prompt).not.toContain("Human:")
+  })
+
+  it("leaves single-message fresh conversations bare", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, [{ role: "user", content: "hello" }])
+    expect(res.status).toBe(200)
+    expect(capturedPrompts[0]).toBe("hello")
+  })
+
+  it("keeps resume deltas bare — no envelope on continuation", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const prior = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ]
+    storeSession("sess-env-1", prior, "sdk-prior", "/tmp/test", [null, "uuid-1"])
+
+    const res = await post(
+      app,
+      [...prior, { role: "user", content: "follow up" }],
+      { "x-opencode-session": "sess-env-1" }
+    )
+    expect(res.status).toBe(200)
+    const prompt = capturedPrompts[0] as string
+    expect(prompt).not.toContain("<conversation_history>")
+    expect(prompt).toBe("follow up")
+  })
+})

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -82,6 +82,39 @@ export function getLastUserMessage(messages: Array<{ role: string; content: any 
 }
 
 /**
+ * Frame a fresh-session replay so the model cannot pattern-continue it (#619).
+ *
+ * When a conversation falls off the resume path, its full history is
+ * flattened into one text prompt. Even with the anti-imitation turn markers
+ * (plain user turns, bracketed `[Assistant: ...]` — the #496 fix), a long
+ * replayed transcript still invites the model to continue the *format*
+ * rather than answer the user: self-played turns, confabulated tool output.
+ *
+ * This wraps everything before the final user turn in an explicit
+ * `<conversation_history>` envelope with a context-only instruction, and
+ * presents the final user message separately as the live prompt — mirroring
+ * the structure the OpenAI-compat path has always used. Single-turn prompts
+ * and histories that don't end with a user turn are returned as a plain
+ * join (nothing to separate).
+ */
+export function frameReplayTurns(turns: Array<{ role: string; text: string }>): string {
+  const nonEmpty = turns.filter((t) => t.text)
+  const joined = nonEmpty.map((t) => t.text).join("\n\n")
+  if (nonEmpty.length < 2) return joined
+  const last = nonEmpty[nonEmpty.length - 1]!
+  if (last.role !== "user") return joined
+  const history = nonEmpty.slice(0, -1).map((t) => t.text).join("\n\n")
+  return (
+    `<conversation_history>\n${history}\n</conversation_history>\n\n` +
+    `The above is a replay of your prior conversation with this user — the original session could not be resumed. ` +
+    `It is context only: do not continue or imitate its transcript format, do not write "[Assistant: ...]" markers, ` +
+    `and never invent tool output — use your actual tools when action is needed. ` +
+    `Respond only as the assistant to the user's message below.\n\n` +
+    last.text
+  )
+}
+
+/**
  * Remove fields the Claude Agent SDK attaches to streamed events that are not
  * part of the public Anthropic streaming schema.
  *

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -54,7 +54,7 @@ import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
-import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall } from "./messages"
+import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -279,17 +279,18 @@ function buildFreshPrompt(
   // Same anti-imitation convention as the structured branch above and the
   // main prompt builder: user turns plain, assistant turns bracketed.
   // 'Human:'/'Assistant:' transcript lines teach the model to complete the
-  // transcript itself (#496 self-talk).
-  return messages
-    .map((m) => {
+  // transcript itself (#496 self-talk). frameReplayTurns then wraps the
+  // history in the #619 context-only envelope with the live user message
+  // separated as the actual prompt.
+  return frameReplayTurns(
+    messages.map((m) => {
       if (m.role === "assistant") {
         const assistantText = flattenAssistantContent(m.content)
-        return assistantText ? `[Assistant: ${assistantText}]` : ""
+        return { role: "assistant", text: assistantText ? `[Assistant: ${assistantText}]` : "" }
       }
-      return flattenUserContent(m.content, sanitizeOpts, toolIndex)
+      return { role: "user", text: flattenUserContent(m.content, sanitizeOpts, toolIndex) }
     })
-    .filter(Boolean)
-    .join("\n\n") || ""
+  )
 }
 
 // Routine [PROXY] operational logging. Suppressed when config.silent is set so
@@ -986,17 +987,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // turns bracketed as '[Assistant: ...]'. On resume, drop assistant
         // messages entirely — the resumed SDK session already contains
         // those turns; replaying them as user text is the imitation seed.
-        textPrompt = messagesToConvert
-          ?.map((m: { role: string; content: any }) => {
+        const promptTurns = (messagesToConvert ?? [])
+          .map((m: { role: string; content: any }) => {
             if (m.role === "assistant") {
-              if (isResume) return ""
+              if (isResume) return { role: "assistant", text: "" }
               const assistantText = flattenAssistantContent(m.content)
-              return assistantText ? `[Assistant: ${assistantText}]` : ""
+              return { role: "assistant", text: assistantText ? `[Assistant: ${assistantText}]` : "" }
             }
-            return flattenUserContent(m.content, sanitizeOpts, toolIndex)
+            return { role: "user", text: flattenUserContent(m.content, sanitizeOpts, toolIndex) }
           })
-          .filter(Boolean)
-          .join("\n\n") || ""
+        // Fresh (non-resume) replays get the #619 anti-self-play envelope:
+        // history framed as context-only, the live user message terminal.
+        // Resume deltas are tail-only and stay bare.
+        textPrompt = isResume
+          ? promptTurns.map((t: { text: string }) => t.text).filter(Boolean).join("\n\n") || ""
+          : frameReplayTurns(promptTurns)
       }
 
       // Create a fresh prompt value — can be called multiple times for retry


### PR DESCRIPTION
## Summary

Fixes #619 — completes the self-play (#496) work with the envelope @duncanam proposed.

The earlier fixes removed the classic `Human:`/`Assistant:` completion trigger and made resume-path drops much rarer. What remained: a fresh rebuild still flattened the whole history into one bare prompt with no framing — a long replayed transcript invites format-continuation (self-played turns, confabulated tool output).

### Changes
- `frameReplayTurns()` (pure, `messages.ts`): wraps everything before the final user turn in `<conversation_history>` + a context-only instruction, and presents the live user message separately as the terminal prompt — the same structure the OpenAI-compat path has always used
- Applied to the main fresh-prompt builder and `buildFreshPrompt` (stale-UUID retry path)
- Resume deltas and single-message conversations stay bare; multimodal replays already end with the consolidated live user turn

### Verification
- Unit tests for the helper (envelope, terminal separation, single-turn bare, non-user-final fallback, no `Human:` markers)
- Integration tests capturing the actual SDK prompt: fresh multi-turn framed, single-message bare, resume delta bare
- Full suite 2093 pass, tsc clean
- **Live acceptance per the report**: fresh rebuild of a tool-heavy history through a real proxy → one clean assistant answer, no self-play markers