### PR TITLE
fix: hold non-stream denies until turn end — parallel calls survive both modes (#592)

### DIFF
--- a/src/__tests__/proxy-nonstream-deny-hold.test.ts
+++ b/src/__tests__/proxy-nonstream-deny-hold.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Non-stream deny-hold — #592.
+ *
+ * The CLI dispatches PreToolUse hooks per-block MID-GENERATION and cancels
+ * the in-flight turn when a deny lands (#625). The streaming path holds
+ * deny responses until turn generation completes; the non-stream path
+ * returned them immediately, so of N parallel calls in one assistant turn
+ * only the first survived — live A/B showed stream=2 calls, non-stream=1.
+ *
+ * This mock is CLI-faithful in the way the older non-stream mocks are NOT:
+ * the block-1 hook fires while block 2 is still "generating", and if the
+ * deny settles before generation ends, the assistant message is emitted
+ * truncated (cancel-on-deny). Holding the deny lets both blocks complete.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+let hook1SettledBeforeTurnEnd: boolean | undefined
+
+const tu = (id: string, path: string) => ({
+  type: "tool_use", id, name: "read", input: { filePath: path },
+})
+const denyMsg = (ids: string[]) => ({
+  type: "user",
+  message: {
+    role: "user",
+    content: ids.map((id) => ({ type: "tool_result", tool_use_id: id, is_error: true, content: "forwarded" })),
+  },
+})
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    const isStreaming = opts.options?.includePartialMessages === true
+    return (async function* () {
+      const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+      yield { type: "system", subtype: "init", session_id: "sdk-ns-1" }
+      if (isStreaming || !preHook) {
+        // Streaming path not under test here
+        yield {
+          type: "assistant", uuid: "u1",
+          message: { id: "m1", type: "message", role: "assistant", content: [{ type: "text", text: "ok" }], model: "claude-sonnet-5", stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 } },
+          session_id: "sdk-ns-1",
+        }
+        return
+      }
+
+      // Turn 1 generation begins. The CLI dispatches block 1's hook while
+      // block 2 is still generating.
+      let settled = false
+      const deny1 = preHook({ tool_name: "read", tool_use_id: "tu1", tool_input: { filePath: "/tmp/a.txt" } })
+        .then((r: any) => { settled = true; return r })
+
+      // "Generation time" for block 2
+      await new Promise((r) => setTimeout(r, 40))
+      hook1SettledBeforeTurnEnd = settled
+
+      if (settled) {
+        // Cancel-on-deny: block 2 is beheaded; only block 1 exists.
+        yield {
+          type: "assistant", uuid: "u1",
+          message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },
+          session_id: "sdk-ns-1",
+        }
+        await deny1
+        yield denyMsg(["tu1"])
+        return
+      }
+
+      // Deny held → generation completed with BOTH blocks.
+      yield {
+        type: "assistant", uuid: "u1",
+        message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt"), tu("tu2", "/tmp/b.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },
+        session_id: "sdk-ns-1",
+      }
+      const deny2 = preHook({ tool_name: "read", tool_use_id: "tu2", tool_input: { filePath: "/tmp/b.txt" } })
+      await deny1
+      yield denyMsg(["tu1"])
+      await deny2
+      yield denyMsg(["tu2"])
+    })()
+  },
+  createSdkMcpServer: () => ({
+    type: "sdk", name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+describe("non-stream deny-hold (#592)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    hook1SettledBeforeTurnEnd = undefined
+  })
+
+  it("holds denies until the turn's assistant message — both parallel calls survive", async () => {
+    // Passthrough is on via the OpenCode adapter default.
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await app.fetch(
+      new Request("http://localhost/v1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "sonnet", stream: false, max_tokens: 500,
+          tools: [{ name: "read", description: "Read a file", input_schema: { type: "object", properties: { filePath: { type: "string" } }, required: ["filePath"] } }],
+          messages: [{ role: "user", content: "read both files" }],
+        }),
+      })
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+
+    // The deny must NOT have settled while the turn was still generating
+    expect(hook1SettledBeforeTurnEnd).toBe(false)
+    // Both parallel same-tool calls delivered, matching streaming behavior
+    expect(toolUses.length).toBe(2)
+    expect(toolUses.map((t: any) => t.input.filePath).sort()).toEqual(["/tmp/a.txt", "/tmp/b.txt"])
+    expect(body.stop_reason).toBe("tool_use")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1300,14 +1300,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // pending call whose result never arrives and misattributes
                 // the results it does receive ("the read tool is returning
                 // the wrong file").
-                // Hold the deny until turn-1 generation completes (streaming
-                // only — see holdDenyUntilTurnEnd above). Returning it
+                // Hold the deny until turn-1 generation completes — BOTH
+                // modes (see holdDenyUntilTurnEnd above). Returning it
                 // immediately lets the CLI cancel the in-flight generation and
-                // behead any parallel call still streaming after this one.
+                // behead any parallel call still generating after this one
+                // (#625 streaming; #592 proved non-stream identically). The
+                // streaming path flags turnGenerating from message_start; the
+                // non-stream path pre-sets it per attempt and releases when
+                // the turn's assistant message arrives in the iterator.
                 // Skip when the query is already aborted (forced-single fired
                 // requestAbort above — the subprocess is dying; holding would
                 // only delay until the timeout).
-                if (stream && earlyStopEnabled && turnGenerating && !requestAbort.controller.signal.aborted) {
+                if (earlyStopEnabled && turnGenerating && !requestAbort.controller.signal.aborted) {
                   await holdDenyUntilTurnEnd()
                 }
                 if (isExactDuplicate) {
@@ -1418,6 +1422,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // stderr emitted by THIS attempt's subprocess only — retries
                 // must not re-match a previous attempt's refusal text.
                 const attemptStderrStart = stderrLines.length
+                // #592: non-stream has no message_start signal — turn 1 is by
+                // definition generating from query start until its assistant
+                // message arrives (release sites: assistant arrival in the
+                // consumer loop, attempt error, loop exit).
+                turnGenerating = true
                 try {
                   for await (const event of query(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
@@ -1450,6 +1459,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   return
                 } catch (error) {
                   const errMsg = error instanceof Error ? error.message : String(error)
+
+                  // #592: the attempt's subprocess is gone — release any deny
+                  // still held for it so retries don't inherit dead holds.
+                  releaseHeldDenies("non_stream_attempt_error")
 
                   // Never retry after response content was yielded — response is committed
                   if (didYieldContent) throw error
@@ -1637,6 +1650,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
               }
               if (message.type === "assistant") {
+                // #592: the turn's generation is complete — held denies can
+                // return without the CLI cancelling anything in flight.
+                releaseHeldDenies("assistant_message")
                 assistantMessages += 1
                 // Capture SDK assistant UUID for undo rollback
                 if ((message as any).uuid) {
@@ -1733,6 +1749,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }
             }
 
+            // #592: safety net — any deny still held at loop exit belongs to
+            // a turn that is no longer generating.
+            releaseHeldDenies("non_stream_loop_exit")
+
             claudeLog("upstream.completed", {
               mode: "non_stream",
               model,
@@ -1750,6 +1770,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               plog(`[PROXY] ${requestMeta.requestId} discovered=${discoveredTools.size} (${newNames}) session_total=${allNames.length}`)
             }
           } catch (error) {
+            // #592: mirror the loop-exit release on the failure path.
+            releaseHeldDenies("non_stream_error")
             const stderrOutput = stderrLines.join("\n").trim()
             if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
               error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`


### PR DESCRIPTION
## Summary

Fixes #592. Of the issue's three claims, two were already resolved by the #552-saga work (streaming delivery; the repeat-heuristic firing on parallel calls is disabled under early stop). The third was still live and the unit tests hid it: **non-stream dropped all but the first of N parallel same-tool calls**.

### Proof it was real
Identical forced-two-reads request through a real proxy: streaming delivered **2** `tool_use` blocks, non-stream delivered **1**. The existing non-stream test passed because its mock dispatches PreToolUse hooks *after* yielding the full assistant message — reality dispatches them per-block mid-generation and cancels the turn when a deny lands (#625's root cause).

### Fix
Extend the #625 deny-hold to non-stream:
- hold condition loses the `stream &&` gate; non-stream pre-sets `turnGenerating` per attempt (turn 1 is generating from query start until its assistant message arrives — there is no `message_start` to observe)
- release on assistant-message arrival in the consumer loop, on attempt error (busy/stale retries must not inherit dead holds), and at loop exit / outer catch as safety nets

### Verification
- New CLI-faithful test (`proxy-nonstream-deny-hold.test.ts`): models mid-generation hook dispatch + cancel-on-deny; RED on main, GREEN here; completes in ~400ms — the release fires via the assistant signal, not the 8s timeout
- Full suite 2094 pass, tsc clean
- **Live A/B**: same request now yields 2/2 in both modes
- E34 live streaming harness 3/3 clean (mandatory for tool-loop changes)