### PR TITLE
feat(nix): package plugins as a meridianPlugins set (#635 by @connor-grady)

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -1,0 +1,27 @@
+name: Update plugin inputs
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+
+      - name: Bump plugin inputs and verify each still builds
+        run: |
+          for input in $(nix flake metadata --json | jq -r '.locks.nodes.root.inputs | keys[] | select(startswith("meridian-plugin-"))'); do
+            nix flake update "$input"
+            nix build ".#meridianPlugins.${input#meridian-plugin-}" --no-link --print-out-paths
+          done
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update plugin flake inputs"
+          file_pattern: flake.lock

--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -21,7 +22,21 @@ jobs:
             nix build ".#meridianPlugins.${input#meridian-plugin-}" --no-link --print-out-paths
           done
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      # All changes reach main through PRs (repo policy — never a direct
+      # push, which branch protection would reject anyway). Re-runs update
+      # the same branch/PR in place. Note: PRs opened with the default
+      # GITHUB_TOKEN don't trigger CI workflows, so the required `test`
+      # check won't run automatically — each plugin build above is the real
+      # gate for a lock bump, and the PR is merged with admin rights like
+      # every other PR in this repo.
+      - uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: "chore: update plugin flake inputs"
-          file_pattern: flake.lock
+          commit-message: "chore: update plugin flake inputs"
+          title: "chore: update plugin flake inputs"
+          body: |
+            Automated bump of the `meridian-plugin-*` flake inputs.
+            Every plugin was rebuilt against its new pin before this PR was
+            opened — a failing build blocks the bump entirely.
+          branch: chore/update-plugin-inputs
+          add-paths: flake.lock
+          delete-branch: true

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Then in `~/.config/opencode/opencode.json`:
       # defaultAgent = "opencode";
       # sonnetModel = "sonnet";
       # Load plugins from the Nix store (rendered to a plugins.json manifest).
-      # Point at an entry inside a packaged derivation so its deps come along.
-      # pluginConfig = [ { path = "${pkgs.my-meridian-plugin}/lib/index.js"; } ];
+      # The official scrub plugins ship prebuilt via the meridian overlay:
+      # pluginConfig = [ { path = pkgs.meridianPlugins.opencode-scrub.path; } ];
       # pluginDir = "/path/to/extra/plugins";
     };
     # Extra env vars not covered by settings
@@ -868,7 +868,9 @@ opt-in plugins instead:
 | [`@rynfar/meridian-plugin-pi-scrub`](https://github.com/rynfar/meridian-plugin-pi-scrub) | Strips Pi's coding-agent-harness prompt line that Anthropic meters as Extra Usage. |
 | [`@rynfar/meridian-plugin-opencode-scrub`](https://github.com/rynfar/meridian-plugin-opencode-scrub) | Strips OpenCode harness boilerplate from the system prompt before it reaches Claude. |
 
-Install into Meridian's config dir and register the built file in
+**Nix users:** the flake packages all three prebuilt — `pkgs.meridianPlugins.<name>` via the `meridian` overlay (or `meridian.legacyPackages.${system}.meridianPlugins`), each exposing `.path` for a `plugins.json` entry or the home-manager `pluginConfig` option. Pins are refreshed by a scheduled workflow that rebuilds every plugin before bumping.
+
+Everyone else: install into Meridian's config dir and register the built file in
 `~/.config/meridian/plugins.json`:
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -84,6 +84,54 @@
         "type": "github"
       }
     },
+    "meridian-plugin-hermes-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706868,
+        "narHash": "sha256-NZ5jpEEShJPHWhpY/lqU81dkui2CgWf3GhOPKyqNKAM=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "rev": "d3a28e5465fee9eb8ffdde340f4f973fa9d450b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-hermes-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-opencode-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706886,
+        "narHash": "sha256-OhIYu4aZP+6RvlnDxraXfbh3Fez0QZ9pkaekmHkfBzY=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "rev": "59a1bfce767d1994a4bb6a700373e4c11aef3633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-opencode-scrub",
+        "type": "github"
+      }
+    },
+    "meridian-plugin-pi-scrub": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783706871,
+        "narHash": "sha256-S3QdJQvSR3claesMgSPZvVFosuuDeYDgpMwBRR+3zM0=",
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
+        "rev": "65fe302e570044f6f115805d82b619277a8e538f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rynfar",
+        "repo": "meridian-plugin-pi-scrub",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1776169885,
@@ -105,6 +153,9 @@
         "bun2nix": "bun2nix",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",
+        "meridian-plugin-hermes-scrub": "meridian-plugin-hermes-scrub",
+        "meridian-plugin-opencode-scrub": "meridian-plugin-opencode-scrub",
+        "meridian-plugin-pi-scrub": "meridian-plugin-pi-scrub",
         "nixpkgs": "nixpkgs",
         "systems": "systems"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,18 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    meridian-plugin-hermes-scrub = {
+      url = "github:rynfar/meridian-plugin-hermes-scrub";
+      flake = false;
+    };
+    meridian-plugin-opencode-scrub = {
+      url = "github:rynfar/meridian-plugin-opencode-scrub";
+      flake = false;
+    };
+    meridian-plugin-pi-scrub = {
+      url = "github:rynfar/meridian-plugin-pi-scrub";
+      flake = false;
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default";
   };
@@ -46,10 +58,16 @@
         perSystem =
           {
             config,
+            lib,
             pkgs,
             system,
             ...
           }:
+          let
+            inherit (lib.attrsets) filterAttrs mapAttrs' nameValuePair;
+            inherit (lib.strings) hasPrefix removePrefix;
+            inherit (lib.trivial) pipe;
+          in
           {
             _module.args.pkgs = import nixpkgs {
               inherit system;
@@ -60,6 +78,16 @@
               default = config.packages.meridian;
               meridian = pkgs.callPackage ./nix/package.nix { };
             };
+
+            legacyPackages.meridianPlugins = pipe inputs [
+              (filterAttrs (pname: _: hasPrefix "meridian-plugin-" pname))
+              (mapAttrs' (
+                pname: src:
+                nameValuePair (removePrefix "meridian-plugin-" pname) (
+                  pkgs.callPackage ./nix/plugin.nix { inherit pname src; }
+                )
+              ))
+            ];
           };
 
         flake = {
@@ -74,7 +102,13 @@
             default = self.overlays.meridian;
             meridian =
               _: prev:
-              withSystem prev.stdenv.hostPlatform.system ({ self', ... }: { inherit (self'.packages) meridian; });
+              withSystem prev.stdenv.hostPlatform.system (
+                { self', ... }:
+                {
+                  inherit (self'.packages) meridian;
+                  inherit (self'.legacyPackages) meridianPlugins;
+                }
+              );
           };
         };
       }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -95,13 +95,13 @@ in
 
             path = mkOption {
               type = path;
-              example = literalExpression ''"''${plugin}/lib/index.js"'';
+              example = literalExpression "pkgs.meridianPlugins.opencode-scrub.path";
               description = ''
-                Path to the plugin's ESM entry file. Reference an entry
-                *inside a packaged derivation* (e.g. `"''${plugin}/lib/index.js"`)
-                so the plugin's dependencies land in the store next to it — a
-                bare `./file.js` path literal copies only that one file, which
-                breaks plugins that import sibling `node_modules`.
+                Path to the plugin's ESM entry file.
+                Reference an entry *inside a packaged derivation*
+                so the plugin's dependencies land in the store next to it.
+                A bare `./file.js` path literal copies only that one file,
+                which breaks plugins that import sibling `node_modules`.
               '';
             };
           };

--- a/nix/plugin.nix
+++ b/nix/plugin.nix
@@ -1,0 +1,49 @@
+{
+  formats,
+  lib,
+  pname,
+  src,
+  stdenvNoCC,
+  typescript,
+}:
+let
+  inherit (lib.trivial) importJSON;
+  packageFile = packageFormat.generate "package.json" { type = "module"; };
+  packageFormat = formats.json { };
+in
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  let
+    package = importJSON "${finalAttrs.src}/package.json";
+  in
+  {
+    inherit pname src;
+    inherit (package) version;
+
+    strictDeps = true;
+    nativeBuildInputs = [ typescript ];
+
+    buildPhase = ''
+      runHook preBuild
+      tsc
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib
+      cp dist/*.js $out/lib/
+      cp ${packageFile} $out/lib/package.json
+      runHook postInstall
+    '';
+
+    passthru.path = "${finalAttrs.finalPackage}/lib/index.js";
+
+    meta = {
+      inherit (package) description;
+      homepage = "https://github.com/rynfar/${finalAttrs.pname}";
+      license = lib.licenses.mit;
+      platforms = lib.platforms.unix;
+    };
+  }
+)


### PR DESCRIPTION
## Summary

Lands #635 by @connor-grady — his three commits cherry-picked verbatim (authorship preserved) plus one fix-up.

### From #635
- Scrub plugins as `flake = false` inputs, built by a shared `nix/plugin.nix` (tsc, `strictDeps`, synthetic ESM `package.json`), exposed as `legacyPackages.meridianPlugins.<name>` with `passthru.path` pointing at the loadable `index.js`
- The set derives from inputs by `meridian-plugin-` prefix — adding a plugin repo needs no builder edits
- Overlay exposes `meridianPlugins` beside `meridian`; hm-module `pluginConfig` example references `pkgs.meridianPlugins.opencode-scrub.path`
- Daily + manual workflow bumps each plugin input, **rebuilding every plugin as the gate** before committing the lock

### Fix-up
- The workflow pushed `flake.lock` straight to main (`git-auto-commit-action`) — repo policy is PRs-only and branch protection rejects direct pushes regardless. Now opens an idempotent PR via `peter-evans/create-pull-request` (caveat noted inline: GITHUB_TOKEN-opened PRs don't trigger CI; the plugin rebuilds are the real gate and admin merge is this repo's normal flow)
- README: official-plugins section documents the prebuilt set; hm example updated

## Verification
- All three plugin repos confirmed dependency-free ESM with `outDir: dist` — the tsc-only builder's assumptions hold
- Built `.#meridianPlugins.pi-scrub` from this branch in a `nixos/nix` container: builds clean (0.2.0), `passthru.path` resolves to the store `lib/index.js`
- `bun test` 2094 pass (TS untouched)

Closes #635