### PR TITLE
ci: accept repository_dispatch for plugin-input bumps (#650)

### DIFF
--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
+  # Event-driven bumps (#650): each meridian-plugin-* repo fires this on
+  # push to its default branch, so a plugin change lands here immediately
+  # instead of up to 24h late. The cron stays as a safety net.
+  repository_dispatch:
+    types: [plugin-updated]
 
 jobs:
   update:


### PR DESCRIPTION
Adds `repository_dispatch: {types: [plugin-updated]}` to the update workflow's triggers — the receiver half of #650. Sender workflows go into each plugin repo; the PAT step remains with @rynfar (instructions on the issue). Cron stays as safety net. CI-config only.