### PR TITLE
feat: OpenAI Responses API (/v1/responses) for Codex CLI (#475)

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,30 @@ ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://127.0.0.1:3456 \
 
 > **Note:** `--no-stream` is incompatible due to a litellm parsing issue — use the default streaming mode.
 
+### Codex CLI
+
+Codex CLI ≥ 0.96 dropped `wire_api = "chat"` and speaks only the OpenAI **Responses API** (`/v1/responses`), which Meridian serves. Add a provider to `~/.codex/config.toml`:
+
+```toml
+model = "claude-sonnet-5"
+model_provider = "meridian"
+
+[model_providers.meridian]
+name = "Meridian"
+base_url = "http://127.0.0.1:3456/v1"
+wire_api = "responses"
+env_key = "MERIDIAN_KEY"    # any value unless MERIDIAN_API_KEY is set
+```
+
+```bash
+MERIDIAN_KEY=x codex "refactor this function"
+MERIDIAN_KEY=x codex exec "run the tests and summarize failures"   # non-interactive
+```
+
+Codex is a tool-driving agent — Meridian runs the `/v1/responses` endpoint in **passthrough** mode automatically (Codex executes its own shell/apply-patch tools), so no `MERIDIAN_PASSTHROUGH` change is needed. A harmless `Model metadata for 'claude-sonnet-5' not found` warning from Codex is expected — it doesn't recognize non-OpenAI model ids but works regardless.
+
+`model_reasoning_effort` is supported and won't stall the CLI, but Claude's private thinking isn't yet carried **across** turns — the Responses API's encrypted-reasoning envelope is OpenAI-specific and incompatible with Claude's signed thinking blocks, so cross-turn reasoning continuity is deferred (each turn still reasons with full context including tool results). Verified on Codex 0.144 with plain, tool-driving, and reasoning-enabled turns.
+
 ### OpenAI-compatible tools (Open WebUI, Continue, etc.)
 
 Meridian speaks the OpenAI protocol natively — no LiteLLM or translation proxy needed.
@@ -664,6 +688,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 | [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see above) — full tool support via passthrough; detected via `x-meridian-agent: pi` header |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Verified | `ANTHROPIC_BASE_URL` — remote clients share a Max subscription over the network; client CWD preserved in system prompt |
 | [Cherry Studio](https://github.com/CherryHQ/cherry-studio) | ✅ Verified | `cherry` adapter (see above) — chat client with Claude's built-in web search via internal mode |
+| [Codex CLI](https://github.com/openai/codex) | ✅ Verified | `/v1/responses` (see above) — Responses-API provider, passthrough tool execution; verified on 0.144 (plain + tool-driving turns) |
 | [Continue](https://github.com/continuedev/continue) | 🔲 Untested | OpenAI-compatible endpoints should work — set `apiBase` to `http://127.0.0.1:3456` |
 
 Tested an agent or built a plugin? [Open an issue](https://github.com/rynfar/meridian/issues) and we'll add it.
@@ -684,12 +709,14 @@ src/proxy/
 │   ├── cherry.ts          ← Cherry Studio adapter (internal mode + web search)
 │   ├── claudecode.ts      ← Claude Code adapter (remote clients sharing a Max host)
 │   ├── openai.ts          ← OpenAI-endpoint adapter (/v1/chat/completions)
+│   ├── codex.ts           ← Codex CLI adapter (/v1/responses, forced passthrough)
 │   └── passthrough.ts     ← LiteLLM passthrough adapter
 ├── query.ts               ← SDK query options builder
 ├── errors.ts              ← Error classification
 ├── models.ts              ← Model mapping (sonnet/opus/haiku, agentMode)
 ├── tokenRefresh.ts        ← Cross-platform OAuth token refresh
 ├── openai.ts              ← OpenAI ↔ Anthropic format translation (pure)
+├── openaiResponses.ts     ← OpenAI Responses API ↔ Anthropic translation (pure)
 ├── setup.ts               ← OpenCode plugin configuration
 ├── session/
 │   ├── lineage.ts         ← Per-message hashing, mutation classification (pure)
@@ -805,6 +832,7 @@ ANTHROPIC_API_KEY=your-secret-key ANTHROPIC_BASE_URL=http://meridian-host:3456 o
 | `POST /v1/messages` | Anthropic Messages API |
 | `POST /messages` | Alias for `/v1/messages` |
 | `POST /v1/chat/completions` | OpenAI-compatible chat completions |
+| `POST /v1/responses` | OpenAI Responses API (Codex CLI ≥ 0.96) |
 | `GET /v1/models` | OpenAI-compatible model list |
 | `GET /health` | Auth status, mode, plugin status |
 | `POST /auth/refresh` | Manually refresh the OAuth token |

--- a/docs/superpowers/specs/2026-07-08-codex-responses-api-design.md
+++ b/docs/superpowers/specs/2026-07-08-codex-responses-api-design.md
@@ -1,0 +1,170 @@
+# Design: OpenAI Responses API endpoint (`/v1/responses`) for Codex
+
+**Issue:** #475 · **Date:** 2026-07-08 · **Status:** approved, pre-implementation
+
+## Goal
+
+Add `POST /v1/responses` so the Codex CLI/app (≥ 0.96, verified against 0.143.0)
+can run on Claude via a Claude Max subscription through Meridian. Codex speaks
+only OpenAI's Responses API; Meridian has `/v1/messages` and
+`/v1/chat/completions` but not `/v1/responses`, so Codex currently gets a 404.
+
+## Non-goals
+
+- Full fidelity with every OpenAI Responses feature. We target the subset Codex
+  actually sends (verified by capturing real 0.143 traffic).
+- Image/audio input, background mode, `previous_response_id` server-side state
+  (Codex runs `store: false` / stateless).
+- Perfect reasoning continuity in phase 1 (see Phasing).
+
+## Verified wire format (captured from Codex 0.143)
+
+Request Codex sends to `/v1/responses`:
+
+```
+model: "gpt-5.5"
+instructions: <~21KB system prompt string>
+input: [ {type:"message", role:"developer"|"user"|"assistant", content:[{type:"input_text"|"output_text", text}]},
+         {type:"function_call", name, arguments, call_id},              # on tool turns
+         {type:"function_call_output", call_id, output},                # on tool turns
+         {type:"reasoning", ...} ]                                      # when reasoning enabled
+tools: [ {type:"function", name, description, strict, parameters:<JSON schema>} ]
+tool_choice: "auto"        parallel_tool_calls: true
+reasoning: { effort: "low"|... }        text: { verbosity }
+stream: true               store: false        include: ["reasoning.encrypted_content"]
+prompt_cache_key, client_metadata          # ignorable passthrough
+Headers: authorization: Bearer <env_key>, accept: text/event-stream, x-codex-* metadata
+```
+
+Response SSE event shapes Codex accepts (confirmed — a stand-in server emitting
+these drove a clean turn in real Codex 0.143):
+
+```
+response.created            → { response: {id, object:"response", model, status:"in_progress", output:[]} }
+response.in_progress
+response.output_item.added  → { output_index, item: {type:"message"|"function_call"|"reasoning", id, ...} }
+response.content_part.added → { item_id, output_index, content_index, part:{type:"output_text", text:""} }
+response.output_text.delta  → { item_id, output_index, content_index, delta }
+response.output_text.done   → { item_id, output_index, content_index, text }
+response.content_part.done
+response.output_item.done   → { output_index, item }
+response.completed          → { response: {..., status:"completed", output:[...], usage:{input_tokens,output_tokens,total_tokens}} }
+# tool calls: output_item.added(function_call) + response.function_call_arguments.delta/.done + output_item.done
+```
+
+Codex is a **tool-driving agentic client**: it sends `tools`, expects tool calls
+back, executes them locally, and returns `function_call_output`. So this endpoint
+must run in **passthrough** mode (tool_use flows back to the client) — the same
+mode the client-driven tool-loop fix (PR #571) hardened.
+
+## Architecture
+
+Mirror the existing `/v1/chat/completions` adapter (`src/proxy/openai.ts` +
+route in `server.ts`), which forwards **in-process** to `/v1/messages` via
+`app.fetch()` and reuses auth, model mapping, session handling, and the
+passthrough tool loop.
+
+- **`src/proxy/openaiResponses.ts`** — pure translation module (no HTTP/Hono),
+  unit-testable in isolation:
+  - `translateResponsesToAnthropic(body): AnthropicRequestBody | null`
+  - `translateAnthropicToResponses(anthropicRes, ctx): ResponsesObject` (non-stream)
+  - `createResponsesSseTranslator(ctx)` — stateful Anthropic-SSE → Responses-SSE
+  - shared types + a `buildResponsesModelList` if needed for any `/models` parity
+- **Route `app.post("/v1/responses")`** in `server.ts` (thin; orchestration only):
+  1. parse body → `translateResponsesToAnthropic` → 400 if invalid.
+  2. build internal `Request("http://internal/v1/messages")` with forwarded auth
+     headers and an agent tag that **forces passthrough** (see below).
+  3. non-stream: translate the Anthropic JSON → single `response` object.
+  4. stream: pipe Anthropic SSE through `createResponsesSseTranslator`, emit
+     Responses SSE, terminate on `response.completed`.
+
+### Forcing passthrough
+
+Codex cannot function unless tool_use is returned to it. Tag the internal hop
+(e.g. `x-meridian-agent: "codex"` or a dedicated header) and add a small adapter
+/ resolution so this endpoint runs passthrough regardless of the global
+`MERIDIAN_PASSTHROUGH`. Reuse the existing adapter pattern (the `openai` adapter
+already exists for `/v1/chat/completions`; add a `codex`/`responses` variant, or
+extend `openai`, that sets `usesPassthrough() => true` and `codeSystemPrompt`
+OFF so Codex's own 21KB instructions aren't overridden by the Claude Code
+preset). Decision at implementation time: new adapter vs. extend `openai` — new
+adapter is cleaner and keeps agent-specific logic isolated per ARCHITECTURE.md.
+
+## Translation detail
+
+### Request (Responses → Anthropic)
+
+| Responses field | Anthropic |
+|---|---|
+| `instructions` | `system` (string) |
+| `input[]` message (role user/assistant) + `input_text`/`output_text` parts | `messages[]` with text content |
+| `input[]` message role `developer` | folded into `system` (Codex harness instructions) |
+| `input[]` `function_call {name, arguments, call_id}` | assistant `tool_use {id:call_id, name, input:JSON.parse(arguments)}` |
+| `input[]` `function_call_output {call_id, output}` | user `tool_result {tool_use_id:call_id, content:output}` |
+| `input[]` `reasoning` | phase 1: dropped · phase 2: decoded → Claude `thinking` block |
+| `tools[]` `function {name, description, parameters}` | `tools[] {name, description, input_schema:parameters}` |
+| `tool_choice` | `tool_choice` (auto/any/tool) |
+| `reasoning.effort` | effort → thinking level (reuse existing effort mapping) |
+| `max_output_tokens` | `max_tokens` |
+| `temperature`, `top_p` | passthrough |
+| `stream` | `stream` |
+| `model` | via existing `mapModelToClaudeModel` (unknown `gpt-5.5` → default Claude; `x-meridian-profile`/model overrides still apply) |
+
+Consecutive same-role messages merged as Anthropic requires alternating roles;
+assistant `tool_use` + following `tool_result` linked by `call_id`.
+
+### Response (Anthropic → Responses)
+
+- Non-stream: assemble one `response` object; `output[]` = message item with
+  `output_text` parts (from Anthropic text blocks) + `function_call` items (from
+  tool_use blocks); `usage` mapped; `status:"completed"`.
+- Stream: the SSE translator maps Anthropic events to the Responses event
+  sequence above. Anthropic `content_block_start(text)` → `output_item.added` +
+  `content_part.added`; `content_block_delta(text_delta)` → `output_text.delta`;
+  tool_use block → `function_call` item + `function_call_arguments.delta/.done`;
+  `message_delta(stop_reason)` + `message_stop` → `output_item.done` +
+  `response.completed` with usage. Thinking blocks: phase 1 stripped (mirrors
+  `openai.ts` behavior for non-native clients).
+
+## Error handling
+
+- Invalid/missing `input` and `model` → 400 `invalid_request_error`, Responses-shaped.
+- Upstream `/v1/messages` non-2xx → surface status + message as a Responses error.
+- Streaming: on mid-stream upstream error, emit a `response.failed` (or terminate
+  cleanly) so Codex doesn't hang; log via existing telemetry.
+- Reuse `requireAuth`; forward `authorization`/`x-api-key` on the internal hop.
+
+## Testing
+
+- **Unit** (`src/__tests__/openai-responses*.test.ts`, mirror the 3 existing
+  `openai*` test files): request translation (message/function_call/
+  function_call_output/tools/instructions), non-stream response assembly, and the
+  SSE translator (text + tool-call sequences) — pure, no mocks needed beyond the
+  translator input.
+- **Integration**: through the HTTP layer with a mocked SDK (mirror existing
+  passthrough integration tests) — assert `/v1/responses` forwards, forces
+  passthrough, and returns correct Responses SSE.
+- **E2E (real Codex 0.143)**: isolated `CODEX_HOME` with a `meridian` provider
+  (`wire_api="responses"`, `base_url` → patched Meridian, `env_key`), run
+  `codex exec "<prompt>"` and confirm: (a) a plain reply renders, (b) a
+  tool-using task (e.g. "list files then summarize") drives exec_command tool
+  calls and completes. The capture harness + isolated config are already built.
+
+## Phasing
+
+- **Phase 1 (this spec):** base `/v1/responses` — text + function tool calling,
+  streaming + non-streaming, forced passthrough, model mapping. Reasoning items
+  **omitted** (verified working). Ships Codex-on-Claude end to end.
+- **Phase 2 (fast-follow):** encrypted-envelope reasoning continuity. Pack
+  Claude's `{thinking, signature}` into `reasoning.encrypted_content` (opaque to
+  Codex), round-trip it, and unpack on the next turn to restore Claude's signed
+  thinking. Requires empirical verification that Codex echoes the blob byte-for-
+  byte and that Claude accepts the reconstructed signature under fresh-replay
+  (no session resume). Fallback: reasoning-as-plain-text summary (display only,
+  no continuity).
+
+## Stable API contract note
+
+`/v1/responses` becomes a new public endpoint. Add it to the endpoints list in
+the `/` root response and document the Codex `config.toml` provider setup in the
+README. No changes to existing endpoints or the plugin-facing contract.

--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -1,0 +1,283 @@
+/**
+ * OpenAI Responses API translation — #475 (Codex CLI ≥ 0.96).
+ *
+ * Wire shapes mirror real Codex 0.143 traffic captured in the design spec
+ * (docs/superpowers/specs/2026-07-08-codex-responses-api-design.md).
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  translateResponsesToAnthropic,
+  translateAnthropicToResponses,
+  createResponsesSseTranslator,
+} from "../proxy/openaiResponses"
+
+describe("translateResponsesToAnthropic", () => {
+  it("returns null without input", () => {
+    expect(translateResponsesToAnthropic({ model: "claude-sonnet-5" })).toBeNull()
+  })
+
+  it("maps string input to a single user message", () => {
+    const r = translateResponsesToAnthropic({ model: "claude-sonnet-5", input: "hi" })!
+    expect(r.model).toBe("claude-sonnet-5")
+    expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hi" }] }])
+    expect(r.stream).toBe(false)
+  })
+
+  it("maps instructions to system and folds developer messages in", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      instructions: "You are Codex.",
+      input: [
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "House rules." }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    })!
+    expect(r.system).toContain("You are Codex.")
+    expect(r.system).toContain("House rules.")
+    expect(r.messages).toHaveLength(1)
+    expect(r.messages[0]!.role).toBe("user")
+  })
+
+  it("maps the codex tool round-trip: function_call + function_call_output", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "list files" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "Listing." }] },
+        { type: "function_call", name: "shell", arguments: '{"command":["ls"]}', call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: "a.txt\nb.txt" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "thanks" }] },
+      ],
+    })!
+    // Consecutive same-role turns merge (Anthropic requires alternating
+    // roles): the trailing tool_result + "thanks" text become one user turn.
+    const roles = r.messages.map((m: any) => m.role)
+    expect(roles).toEqual(["user", "assistant", "user"])
+    const assistant = r.messages[1]! as any
+    expect(assistant.content.some((b: any) => b.type === "text" && b.text === "Listing.")).toBe(true)
+    const toolUse = assistant.content.find((b: any) => b.type === "tool_use")
+    expect(toolUse).toEqual({ type: "tool_use", id: "call_1", name: "shell", input: { command: ["ls"] } })
+    const finalUser = (r.messages[2] as any).content
+    expect(finalUser[0]).toEqual({ type: "tool_result", tool_use_id: "call_1", content: "a.txt\nb.txt" })
+    expect(finalUser.some((b: any) => b.type === "text" && b.text === "thanks")).toBe(true)
+  })
+
+  it("skips reasoning items (phase 1)", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "reasoning", summary: [], encrypted_content: "opaque" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "q" }] },
+      ],
+    })!
+    expect(r.messages).toHaveLength(1)
+  })
+
+  it("maps function tools, tool_choice, and limits", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: "x",
+      tools: [{ type: "function", name: "shell", description: "run", strict: false, parameters: { type: "object", properties: {} } }],
+      tool_choice: "auto",
+      parallel_tool_calls: true,
+      max_output_tokens: 4096,
+      temperature: 0.4,
+      stream: true,
+    })!
+    expect(r.tools).toEqual([{ name: "shell", description: "run", input_schema: { type: "object", properties: {} } }])
+    expect(r.tool_choice).toEqual({ type: "auto" })
+    expect(r.max_tokens).toBe(4096)
+    expect(r.temperature).toBe(0.4)
+    expect(r.stream).toBe(true)
+  })
+
+  it("maps forced tool_choice variants", () => {
+    const req = (tc: unknown) => translateResponsesToAnthropic({ model: "m", input: "x", tool_choice: tc })!
+    expect(req("required").tool_choice).toEqual({ type: "any" })
+    expect(req({ type: "function", name: "shell" }).tool_choice).toEqual({ type: "tool", name: "shell" })
+    expect(req("none").tool_choice).toBeUndefined()
+  })
+})
+
+describe("translateAnthropicToResponses (non-stream)", () => {
+  const ctx = { responseId: "resp_1", model: "claude-sonnet-5", created: 1700000000 }
+
+  it("assembles a completed response with text output", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "text", text: "Hello!" }],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 5 },
+    }, ctx) as any
+    expect(out.id).toBe("resp_1")
+    expect(out.object).toBe("response")
+    expect(out.status).toBe("completed")
+    expect(out.model).toBe("claude-sonnet-5")
+    const msg = out.output.find((o: any) => o.type === "message")
+    expect(msg.role).toBe("assistant")
+    expect(msg.content).toEqual([{ type: "output_text", text: "Hello!", annotations: [] }])
+    expect(out.usage).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 })
+  })
+
+  it("maps tool_use blocks to function_call items", () => {
+    const out = translateAnthropicToResponses({
+      content: [
+        { type: "text", text: "Running." },
+        { type: "tool_use", id: "toolu_1", name: "shell", input: { command: ["ls"] } },
+      ],
+      stop_reason: "tool_use",
+      usage: { input_tokens: 3, output_tokens: 2 },
+    }, ctx) as any
+    const fc = out.output.find((o: any) => o.type === "function_call")
+    expect(fc.call_id).toBe("toolu_1")
+    expect(fc.name).toBe("shell")
+    expect(JSON.parse(fc.arguments)).toEqual({ command: ["ls"] })
+    expect(fc.status).toBe("completed")
+  })
+
+  it("strips thinking blocks (phase 1)", () => {
+    const out = translateAnthropicToResponses({
+      content: [
+        { type: "thinking", thinking: "hmm", signature: "sig" },
+        { type: "text", text: "Answer." },
+      ],
+      stop_reason: "end_turn",
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }, ctx) as any
+    expect(JSON.stringify(out.output)).not.toContain("hmm")
+    expect(out.output.find((o: any) => o.type === "message").content[0].text).toBe("Answer.")
+  })
+})
+
+describe("createResponsesSseTranslator (stream)", () => {
+  const ctx = { responseId: "resp_s", model: "claude-sonnet-5", created: 1700000000 }
+
+  function run(events: Array<Record<string, unknown>>) {
+    const translate = createResponsesSseTranslator(ctx)
+    const out: Array<{ event: string; data: Record<string, unknown> }> = []
+    for (const e of events) out.push(...translate(e as any))
+    return out
+  }
+
+  const textStream = [
+    { type: "message_start", message: { id: "m1", usage: { input_tokens: 12 } } },
+    { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hel" } },
+    { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "lo" } },
+    { type: "content_block_stop", index: 0 },
+    { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 7 } },
+    { type: "message_stop" },
+  ]
+
+  it("emits the Responses event sequence for a text turn", () => {
+    const out = run(textStream)
+    const types = out.map((e) => e.event)
+    expect(types[0]).toBe("response.created")
+    expect(types[1]).toBe("response.in_progress")
+    expect(types).toContain("response.output_item.added")
+    expect(types).toContain("response.content_part.added")
+    expect(types.filter((t) => t === "response.output_text.delta")).toHaveLength(2)
+    expect(types).toContain("response.output_text.done")
+    expect(types).toContain("response.content_part.done")
+    expect(types).toContain("response.output_item.done")
+    expect(types[types.length - 1]).toBe("response.completed")
+  })
+
+  it("accumulates text and reports usage in response.completed", () => {
+    const out = run(textStream)
+    const done = out.find((e) => e.event === "response.output_text.done")!
+    expect((done.data as any).text).toBe("Hello")
+    const completed = out.find((e) => e.event === "response.completed")!
+    const resp = (completed.data as any).response
+    expect(resp.status).toBe("completed")
+    expect(resp.usage).toEqual({ input_tokens: 12, output_tokens: 7, total_tokens: 19 })
+    const msg = resp.output.find((o: any) => o.type === "message")
+    expect(msg.content[0].text).toBe("Hello")
+  })
+
+  it("emits function_call items with argument deltas for tool_use blocks", () => {
+    const out = run([
+      { type: "message_start", message: { id: "m1", usage: { input_tokens: 5 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_9", name: "shell", input: {} } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"command":' } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '["ls"]}' } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 4 } },
+      { type: "message_stop" },
+    ])
+    const types = out.map((e) => e.event)
+    const added = out.find((e) => e.event === "response.output_item.added")!
+    expect((added.data as any).item.type).toBe("function_call")
+    expect((added.data as any).item.call_id).toBe("toolu_9")
+    expect((added.data as any).item.name).toBe("shell")
+    expect(types.filter((t) => t === "response.function_call_arguments.delta")).toHaveLength(2)
+    const argsDone = out.find((e) => e.event === "response.function_call_arguments.done")!
+    expect(JSON.parse((argsDone.data as any).arguments)).toEqual({ command: ["ls"] })
+    const itemDone = out.find((e) => e.event === "response.output_item.done")!
+    expect(JSON.parse((itemDone.data as any).item.arguments)).toEqual({ command: ["ls"] })
+    const completed = out.find((e) => e.event === "response.completed")!
+    const fc = (completed.data as any).response.output.find((o: any) => o.type === "function_call")
+    expect(fc.call_id).toBe("toolu_9")
+  })
+
+  it("skips thinking blocks without emitting items", () => {
+    const out = run([
+      { type: "message_start", message: { id: "m1", usage: { input_tokens: 1 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "pondering" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Hi" } },
+      { type: "content_block_stop", index: 1 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 2 } },
+      { type: "message_stop" },
+    ])
+    expect(JSON.stringify(out)).not.toContain("pondering")
+    const added = out.filter((e) => e.event === "response.output_item.added")
+    expect(added).toHaveLength(1)
+    expect((added[0]!.data as any).item.type).toBe("message")
+  })
+
+  it("assigns increasing sequence numbers", () => {
+    const out = run(textStream)
+    const seqs = out.map((e) => (e.data as any).sequence_number)
+    for (let i = 1; i < seqs.length; i++) expect(seqs[i]).toBeGreaterThan(seqs[i - 1])
+  })
+
+  it("emits a placeholder reasoning item when reasoning was requested (#475 hang fix)", () => {
+    // Codex 0.144 hangs if it asked for reasoning (include reasoning.*) and
+    // no reasoning item appears in the output. Emit one empty placeholder.
+    const translate = createResponsesSseTranslator({ ...ctx, reasoningRequested: true })
+    const out: Array<{ event: string; data: Record<string, unknown> }> = []
+    for (const e of textStream) out.push(...translate(e as any))
+    const reasoningAdded = out.find(
+      (e) => e.event === "response.output_item.added" && (e.data as any).item?.type === "reasoning"
+    )
+    expect(reasoningAdded).toBeDefined()
+    // And it appears in the terminal response output.
+    const completed = out.find((e) => e.event === "response.completed")!
+    const reasoning = (completed.data as any).response.output.find((o: any) => o.type === "reasoning")
+    expect(reasoning).toBeDefined()
+    // Absent by default (no phantom reasoning when not requested).
+    const plain = createResponsesSseTranslator(ctx)
+    const plainOut: Array<{ event: string; data: Record<string, unknown> }> = []
+    for (const e of textStream) plainOut.push(...translate(e as any))
+    void plainOut
+    const noReasoning = run(textStream).find(
+      (e) => e.event === "response.output_item.added" && (e.data as any).item?.type === "reasoning"
+    )
+    expect(noReasoning).toBeUndefined()
+    void plain
+  })
+
+  it("embeds a `type` field in every data payload matching the event name", () => {
+    // The Responses SSE format is self-describing; Codex's deserializer is
+    // #[serde(tag = "type")]. A payload without `type` fails to parse and
+    // Codex reports "stream closed before response.completed" — the exact
+    // symptom that blocked the first live run. Data `type` must equal the
+    // SSE `event:` name for every emission.
+    for (const e of run(textStream)) {
+      expect((e.data as any).type).toBe(e.event)
+    }
+  })
+})

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -1,0 +1,155 @@
+/**
+ * /v1/responses endpoint integration — #475.
+ *
+ * Through the HTTP layer with a mocked SDK: asserts the route forwards to
+ * /v1/messages, forces passthrough (codex adapter), and returns Responses
+ * shapes for both non-stream and stream.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import {
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+let capturedOptions: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    capturedOptions.push(opts.options || {})
+    const isStreaming = opts.options?.includePartialMessages === true
+    return (async function* () {
+      // Fire the PreToolUse deny hook if present (passthrough capture path)
+      const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+      if (isStreaming) {
+        yield messageStart("msg-1")
+        yield textBlockStart(0)
+        yield textDelta(0, "Hello from Codex")
+        yield blockStop(0)
+        yield messageDelta("end_turn")
+        yield messageStop()
+      }
+      void preHook
+      yield {
+        type: "assistant",
+        uuid: "uuid-1",
+        message: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "Hello from Codex" }],
+          model: "claude-sonnet-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 11, output_tokens: 4 },
+        },
+        session_id: "sdk-1",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  // Force internal mode globally — the codex adapter must override it to
+  // passthrough regardless.
+  const prev = process.env.MERIDIAN_PASSTHROUGH
+  process.env.MERIDIAN_PASSTHROUGH = "0"
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  process.env.MERIDIAN_PASSTHROUGH = prev
+  return app
+}
+
+function postResponses(app: any, body: any) {
+  return app.fetch(
+    new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+  )
+}
+
+describe("/v1/responses (#475)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedOptions = []
+  })
+
+  it("400s when input is missing", async () => {
+    const app = createTestApp()
+    const res = await postResponses(app, { model: "claude-sonnet-5" })
+    expect(res.status).toBe(400)
+    const body = await res.json() as any
+    expect(body.error.type).toBe("invalid_request_error")
+  })
+
+  it("non-stream: returns a completed response object", async () => {
+    const app = createTestApp()
+    const res = await postResponses(app, { model: "claude-sonnet-5", input: "hi", stream: false })
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.object).toBe("response")
+    expect(body.status).toBe("completed")
+    expect(body.id).toStartWith("resp_")
+    const msg = body.output.find((o: any) => o.type === "message")
+    expect(msg.content[0].text).toBe("Hello from Codex")
+    expect(body.usage.total_tokens).toBe(15)
+  })
+
+  it("forces passthrough even when the global default is internal", async () => {
+    const app = createTestApp()
+    await postResponses(app, {
+      model: "claude-sonnet-5",
+      input: "list files",
+      tools: [{ type: "function", name: "shell", description: "run", parameters: { type: "object", properties: {} } }],
+      stream: false,
+    })
+    // Passthrough forwards tools as MCP + registers the deny hook — the SDK
+    // options reflect passthrough mode (disallowedTools present, mcpServers set).
+    expect(capturedOptions.length).toBeGreaterThan(0)
+    const opts = capturedOptions[0]!
+    expect(opts.mcpServers).toBeDefined()
+    // codeSystemPrompt OFF: no claude_code preset appended to the system prompt
+    const sp = opts.systemPrompt
+    const spStr = typeof sp === "string" ? sp : JSON.stringify(sp ?? "")
+    expect(spStr).not.toContain("claude_code")
+  })
+
+  it("stream: emits the Responses SSE sequence terminating in response.completed", async () => {
+    const app = createTestApp()
+    const res = await postResponses(app, { model: "claude-sonnet-5", input: "hi", stream: true })
+    expect(res.status).toBe(200)
+    expect(res.headers.get("Content-Type")).toContain("text/event-stream")
+    const text = await res.text()
+    expect(text).toContain("event: response.created")
+    expect(text).toContain("event: response.output_text.delta")
+    expect(text).toContain("event: response.completed")
+    expect(text).not.toContain("Human:")
+    // Accumulated text present in the terminal event
+    const lastCompleted = text.split("event: response.completed")[1] || ""
+    expect(lastCompleted).toContain("Hello from Codex")
+  })
+
+  it("is advertised in the root endpoint list", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/", { headers: { accept: "application/json" } }))
+    const body = await res.json() as any
+    expect(body.endpoints).toContain("/v1/responses")
+  })
+})

--- a/src/proxy/adapters/codex.ts
+++ b/src/proxy/adapters/codex.ts
@@ -1,0 +1,30 @@
+/**
+ * Codex CLI endpoint adapter (#475).
+ *
+ * The `/v1/responses` route serves the Codex CLI (≥ 0.96), which is a
+ * tool-driving agentic client: it sends `tools`, expects tool_use back,
+ * executes them locally, and returns `function_call_output`. So this endpoint
+ * MUST run in passthrough mode — tool_use flows back to the client — unlike
+ * the generic `openai` adapter which follows the global passthrough setting.
+ *
+ * The handler tags the internal /v1/messages hop with `x-meridian-agent:
+ * codex` so this adapter is selected deterministically. Behaviour otherwise
+ * mirrors `opencode` (tools, MCP server, transforms); the differences are:
+ *   - `usesPassthrough() => true` — always forward tool calls (Codex needs them)
+ *   - `codeSystemPrompt` OFF (sdkFeatures.ADAPTER_DEFAULTS) — Codex ships its
+ *     own ~21KB instructions; the Claude Code preset must not override them
+ *
+ * NOTE: agent-specific (Codex). Keep this a thin re-identification of the
+ * OpenCode adapter; do not fork behaviour here.
+ */
+
+import type { AgentAdapter } from "../adapter"
+import { openCodeAdapter } from "./opencode"
+
+export const codexAdapter: AgentAdapter = {
+  ...openCodeAdapter,
+  name: "codex",
+  usesPassthrough() {
+    return true
+  },
+}

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -15,6 +15,7 @@ import { piAdapter } from "./pi"
 import { forgeCodeAdapter } from "./forgecode"
 import { claudeCodeAdapter } from "./claudecode"
 import { openAiAdapter } from "./openai"
+import { codexAdapter } from "./codex"
 import { cherryAdapter } from "./cherry"
 import { loadAdapterInstances, matchesInstance, type AdapterInstanceDef } from "../adapterInstances"
 
@@ -33,6 +34,9 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   // Generic OpenAI-compatible endpoint (/v1/chat/completions). Selected via
   // the x-meridian-agent: openai tag the handler sets on the internal hop.
   openai: openAiAdapter,
+  // Codex CLI endpoint (/v1/responses). Forces passthrough — Codex executes
+  // its own tools. Selected via the x-meridian-agent: codex internal tag.
+  codex: codexAdapter,
 }
 
 const envDefault = process.env.MERIDIAN_DEFAULT_AGENT || ""

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -118,6 +118,8 @@ export interface AnthropicRequestBody {
   temperature?: number
   top_p?: number
   tools?: AnthropicTool[]
+  /** Tool selection constraint (carried from Responses `tool_choice`, #475). */
+  tool_choice?: { type: "auto" | "any" | "tool"; name?: string }
   /** Reasoning effort carried from the OpenAI request so the internal
    *  /v1/messages hop forwards it to the SDK (value gated by normalizeEffort). */
   reasoning_effort?: string

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -1,0 +1,494 @@
+/**
+ * OpenAI Responses API ⇄ Anthropic translation (#475).
+ *
+ * Pure functions — no HTTP/Hono — mirroring `openai.ts` (the chat-completions
+ * adapter). Serves the Codex CLI ≥ 0.96, which dropped `wire_api="chat"` and
+ * now speaks only `POST /v1/responses`. The `/v1/responses` route in
+ * server.ts forwards in-process to `/v1/messages` and pipes the response
+ * through these translators.
+ *
+ * Scope is Phase 1 of the approved design spec
+ * (docs/superpowers/specs/2026-07-08-codex-responses-api-design.md): text +
+ * function tool-calling, streaming and non-streaming, forced passthrough.
+ * Reasoning items are omitted (verified working against real Codex 0.143).
+ *
+ * NOTE: agent-specific (Codex). Kept isolated per ARCHITECTURE.md — this
+ * module owns the Responses wire format; no Responses logic leaks elsewhere.
+ */
+
+import type {
+  AnthropicRequestBody,
+  AnthropicMessage,
+  AnthropicContentBlock,
+  AnthropicTool,
+} from "./openai"
+
+// ---------------------------------------------------------------------------
+// Responses request types (subset Codex actually sends)
+// ---------------------------------------------------------------------------
+
+interface ResponsesContentPart {
+  type: "input_text" | "output_text" | string
+  text?: string
+}
+
+interface ResponsesMessageItem {
+  type: "message"
+  role: "user" | "assistant" | "developer" | "system"
+  content: ResponsesContentPart[] | string
+}
+interface ResponsesFunctionCallItem {
+  type: "function_call"
+  name: string
+  arguments: string
+  call_id: string
+}
+interface ResponsesFunctionCallOutputItem {
+  type: "function_call_output"
+  call_id: string
+  output: string
+}
+interface ResponsesReasoningItem {
+  type: "reasoning"
+  [k: string]: unknown
+}
+type ResponsesInputItem =
+  | ResponsesMessageItem
+  | ResponsesFunctionCallItem
+  | ResponsesFunctionCallOutputItem
+  | ResponsesReasoningItem
+
+interface ResponsesTool {
+  type: "function" | string
+  name: string
+  description?: string
+  strict?: boolean
+  parameters?: unknown
+}
+
+export interface ResponsesRequest {
+  model?: string
+  instructions?: string
+  input?: string | ResponsesInputItem[]
+  tools?: ResponsesTool[]
+  tool_choice?: unknown
+  parallel_tool_calls?: boolean
+  max_output_tokens?: number
+  temperature?: number
+  top_p?: number
+  reasoning?: { effort?: string }
+  stream?: boolean
+  [k: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// Request translation: Responses → Anthropic
+// ---------------------------------------------------------------------------
+
+function partsToText(content: ResponsesContentPart[] | string): string {
+  if (typeof content === "string") return content
+  return content
+    .filter((p) => typeof p.text === "string")
+    .map((p) => p.text)
+    .join("")
+}
+
+/**
+ * Map a Responses `tool_choice` to Anthropic's. Codex sends `"auto"`,
+ * `"required"`, `"none"`, or `{type:"function", name}`. `"none"` maps to
+ * undefined (Anthropic has no explicit none — omitting lets the model decide,
+ * and Codex only sends none when it doesn't want tools anyway).
+ */
+function mapToolChoice(tc: unknown): AnthropicRequestBody["tool_choice"] {
+  if (tc === "auto") return { type: "auto" }
+  if (tc === "required") return { type: "any" }
+  if (tc && typeof tc === "object") {
+    const o = tc as { type?: string; name?: string }
+    if (o.type === "function" && o.name) return { type: "tool", name: o.name }
+    if (o.type === "auto") return { type: "auto" }
+    if (o.type === "any" || o.type === "required") return { type: "any" }
+  }
+  return undefined
+}
+
+/**
+ * Translate a Responses request to an Anthropic /v1/messages body.
+ * Returns null when `input` is missing (invalid request).
+ */
+export function translateResponsesToAnthropic(body: ResponsesRequest): AnthropicRequestBody | null {
+  if (body.input === undefined || body.input === null) return null
+
+  const items: ResponsesInputItem[] =
+    typeof body.input === "string"
+      ? [{ type: "message", role: "user", content: [{ type: "input_text", text: body.input }] }]
+      : body.input
+
+  // System: instructions + any developer/system-role messages folded in
+  // (Codex's harness rules arrive as developer turns).
+  const systemParts: string[] = []
+  if (body.instructions) systemParts.push(body.instructions)
+
+  const messages: AnthropicMessage[] = []
+  const pushBlock = (role: "user" | "assistant", block: AnthropicContentBlock) => {
+    const last = messages[messages.length - 1]
+    if (last && last.role === role && Array.isArray(last.content)) {
+      last.content.push(block)
+    } else {
+      messages.push({ role, content: [block] })
+    }
+  }
+
+  for (const item of items) {
+    switch (item.type) {
+      case "message": {
+        const msg = item as ResponsesMessageItem
+        if (msg.role === "developer" || msg.role === "system") {
+          const t = partsToText(msg.content)
+          if (t) systemParts.push(t)
+          break
+        }
+        const text = partsToText(msg.content)
+        if (text) pushBlock(msg.role === "assistant" ? "assistant" : "user", { type: "text", text })
+        break
+      }
+      case "function_call": {
+        const fc = item as ResponsesFunctionCallItem
+        let input: Record<string, unknown> = {}
+        try { input = fc.arguments ? JSON.parse(fc.arguments) : {} } catch { input = {} }
+        pushBlock("assistant", { type: "tool_use", id: fc.call_id, name: fc.name, input })
+        break
+      }
+      case "function_call_output": {
+        const fo = item as ResponsesFunctionCallOutputItem
+        pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: fo.output })
+        break
+      }
+      case "reasoning":
+        // Phase 1: dropped. Phase 2 decodes the encrypted envelope back into
+        // a Claude thinking block for reasoning continuity.
+        break
+      default:
+        break
+    }
+  }
+
+  const result: AnthropicRequestBody = {
+    model: typeof body.model === "string" ? body.model : "",
+    messages,
+    max_tokens: body.max_output_tokens ?? 8192,
+    stream: body.stream ?? false,
+  }
+  if (systemParts.length > 0) result.system = systemParts.join("\n\n")
+  if (Array.isArray(body.tools) && body.tools.length > 0) {
+    result.tools = body.tools
+      .filter((t) => t.type === "function")
+      .map((t): AnthropicTool => ({
+        name: t.name,
+        description: t.description ?? "",
+        input_schema: t.parameters ?? { type: "object", properties: {} },
+      }))
+  }
+  const tc = mapToolChoice(body.tool_choice)
+  if (tc) result.tool_choice = tc
+  if (body.temperature !== undefined) result.temperature = body.temperature
+  if (body.top_p !== undefined) result.top_p = body.top_p
+  if (body.reasoning?.effort !== undefined) result.reasoning_effort = body.reasoning.effort
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Response translation: Anthropic → Responses (non-streaming)
+// ---------------------------------------------------------------------------
+
+export interface ResponsesCtx {
+  responseId: string
+  model: string
+  created: number
+  /**
+   * The client asked for reasoning (Codex sends `reasoning.effort` +
+   * `include: ["reasoning.encrypted_content"]`). Phase 1 doesn't forward
+   * Claude's signed thinking, but Codex 0.144 HANGS waiting for a reasoning
+   * item it requested — so we emit one empty placeholder reasoning item to
+   * satisfy its state machine. Set from `reasoningRequested(body)`.
+   */
+  reasoningRequested?: boolean
+}
+
+/** Did the Responses request ask for reasoning output? */
+export function reasoningRequested(body: ResponsesRequest): boolean {
+  if (body.reasoning && typeof body.reasoning === "object") return true
+  const include = (body as { include?: unknown }).include
+  return Array.isArray(include) && include.some((v) => typeof v === "string" && v.startsWith("reasoning"))
+}
+
+interface AnthropicResponseLike {
+  content?: Array<Record<string, unknown>>
+  stop_reason?: string
+  usage?: { input_tokens?: number; output_tokens?: number }
+}
+
+function mapUsage(usage: { input_tokens?: number; output_tokens?: number } | undefined) {
+  const input = usage?.input_tokens ?? 0
+  const output = usage?.output_tokens ?? 0
+  return { input_tokens: input, output_tokens: output, total_tokens: input + output }
+}
+
+/**
+ * Assemble a complete Responses `response` object from an Anthropic response.
+ * Text blocks become a single `message` item with `output_text` parts;
+ * tool_use blocks become `function_call` items. Thinking blocks are dropped.
+ */
+export function translateAnthropicToResponses(res: AnthropicResponseLike, ctx: ResponsesCtx): Record<string, unknown> {
+  const output: Array<Record<string, unknown>> = []
+  const textParts: Array<{ type: "output_text"; text: string; annotations: unknown[] }> = []
+
+  for (const block of res.content ?? []) {
+    if (block.type === "text" && typeof block.text === "string") {
+      textParts.push({ type: "output_text", text: block.text, annotations: [] })
+    } else if (block.type === "tool_use") {
+      output.push({
+        type: "function_call",
+        id: `fc_${block.id}`,
+        call_id: block.id,
+        name: block.name,
+        arguments: JSON.stringify(block.input ?? {}),
+        status: "completed",
+      })
+    }
+    // thinking: dropped (phase 1)
+  }
+
+  // Message item first (Codex renders assistant text), then tool calls — but
+  // only emit a message item if there is text (a pure tool turn has none).
+  if (textParts.length > 0) {
+    output.unshift({
+      type: "message",
+      id: `msg_${ctx.responseId}`,
+      status: "completed",
+      role: "assistant",
+      content: textParts,
+    })
+  }
+
+  // Placeholder reasoning item (#475) so a reasoning-requesting client doesn't
+  // hang waiting for one — see the streaming translator for the rationale.
+  if (ctx.reasoningRequested) {
+    output.unshift({
+      type: "reasoning",
+      id: `rs_${ctx.responseId}`,
+      summary: [],
+      encrypted_content: null,
+      status: "completed",
+    })
+  }
+
+  return {
+    id: ctx.responseId,
+    object: "response",
+    created_at: ctx.created,
+    model: ctx.model,
+    status: "completed",
+    output,
+    usage: mapUsage(res.usage),
+    parallel_tool_calls: true,
+    tool_choice: "auto",
+    tools: [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Response translation: Anthropic SSE → Responses SSE (streaming)
+// ---------------------------------------------------------------------------
+
+export interface AnthropicSseEvent {
+  type: string
+  index?: number
+  message?: { id?: string; usage?: { input_tokens?: number } }
+  content_block?: { type?: string; id?: string; name?: string; input?: unknown }
+  delta?: { type?: string; text?: string; partial_json?: string; thinking?: string; stop_reason?: string }
+  usage?: { output_tokens?: number }
+}
+
+export interface ResponsesSseEmission {
+  event: string
+  data: Record<string, unknown>
+}
+
+/**
+ * Stateful Anthropic-SSE → Responses-SSE translator. One instance per stream;
+ * call with each Anthropic event, emit the returned Responses events in order.
+ */
+export function createResponsesSseTranslator(ctx: ResponsesCtx) {
+  let seq = 0
+  let outputIndex = 0
+  let inputTokens = 0
+  let outputTokens = 0
+  let createdEmitted = false
+
+  // Per-open-block state, keyed by Anthropic block index.
+  interface BlockState {
+    kind: "text" | "tool" | "skip"
+    outputIndex: number
+    itemId: string
+    text: string          // accumulated text (text blocks)
+    args: string          // accumulated JSON (tool blocks)
+    callId?: string
+    name?: string
+  }
+  const blocks = new Map<number, BlockState>()
+  // Completed items collected for the terminal response.completed.
+  const finalOutput: Array<Record<string, unknown>> = []
+
+  // The Responses event `data` payload MUST carry its own `type` field — the
+  // OpenAI Responses SSE format is self-describing and Codex's deserializer
+  // is `#[serde(tag = "type")]`, so a payload without `type` fails to parse
+  // and Codex treats the whole stream as broken ("stream closed before
+  // response.completed") even though every event was sent. The SSE `event:`
+  // line alone is not enough.
+  const emit = (event: string, data: Record<string, unknown>): ResponsesSseEmission => ({
+    event,
+    data: { type: event, ...data, sequence_number: seq++ },
+  })
+
+  const responseEnvelope = (status: string, extra: Record<string, unknown> = {}) => ({
+    id: ctx.responseId,
+    object: "response",
+    created_at: ctx.created,
+    model: ctx.model,
+    status,
+    ...extra,
+  })
+
+  return (event: AnthropicSseEvent): ResponsesSseEmission[] => {
+    const out: ResponsesSseEmission[] = []
+
+    switch (event.type) {
+      case "message_start": {
+        inputTokens = event.message?.usage?.input_tokens ?? 0
+        if (!createdEmitted) {
+          createdEmitted = true
+          out.push(emit("response.created", { response: responseEnvelope("in_progress", { output: [] }) }))
+          out.push(emit("response.in_progress", { response: responseEnvelope("in_progress", { output: [] }) }))
+          // Placeholder reasoning item (#475): Codex hangs if it requested
+          // reasoning and no reasoning item appears. Phase 1 forwards no
+          // actual thinking; an empty item satisfies the client's state
+          // machine. Codex echoes it back next turn — where our request
+          // translator drops reasoning items — so it's inert.
+          if (ctx.reasoningRequested) {
+            const oi = outputIndex++
+            const itemId = `rs_${ctx.responseId}`
+            const item = { type: "reasoning", id: itemId, summary: [] as unknown[], encrypted_content: null, status: "completed" }
+            out.push(emit("response.output_item.added", { output_index: oi, item: { ...item, status: "in_progress" } }))
+            finalOutput.push(item)
+            out.push(emit("response.output_item.done", { output_index: oi, item }))
+          }
+        }
+        break
+      }
+
+      case "content_block_start": {
+        const idx = event.index ?? 0
+        const cb = event.content_block ?? {}
+        if (cb.type === "text") {
+          const oi = outputIndex++
+          const itemId = `msg_${ctx.responseId}_${oi}`
+          blocks.set(idx, { kind: "text", outputIndex: oi, itemId, text: "", args: "" })
+          out.push(emit("response.output_item.added", {
+            output_index: oi,
+            item: { type: "message", id: itemId, status: "in_progress", role: "assistant", content: [] },
+          }))
+          out.push(emit("response.content_part.added", {
+            item_id: itemId, output_index: oi, content_index: 0,
+            part: { type: "output_text", text: "", annotations: [] },
+          }))
+        } else if (cb.type === "tool_use") {
+          const oi = outputIndex++
+          const itemId = `fc_${cb.id}`
+          blocks.set(idx, { kind: "tool", outputIndex: oi, itemId, text: "", args: "", callId: cb.id, name: cb.name })
+          out.push(emit("response.output_item.added", {
+            output_index: oi,
+            item: { type: "function_call", id: itemId, call_id: cb.id, name: cb.name, arguments: "", status: "in_progress" },
+          }))
+        } else {
+          // thinking / unknown → skip, but track so deltas/stop are ignored.
+          blocks.set(idx, { kind: "skip", outputIndex: -1, itemId: "", text: "", args: "" })
+        }
+        break
+      }
+
+      case "content_block_delta": {
+        const idx = event.index ?? 0
+        const st = blocks.get(idx)
+        if (!st || st.kind === "skip") break
+        if (st.kind === "text" && event.delta?.type === "text_delta" && typeof event.delta.text === "string") {
+          st.text += event.delta.text
+          out.push(emit("response.output_text.delta", {
+            item_id: st.itemId, output_index: st.outputIndex, content_index: 0, delta: event.delta.text,
+          }))
+        } else if (st.kind === "tool" && event.delta?.type === "input_json_delta" && typeof event.delta.partial_json === "string") {
+          st.args += event.delta.partial_json
+          out.push(emit("response.function_call_arguments.delta", {
+            item_id: st.itemId, output_index: st.outputIndex, delta: event.delta.partial_json,
+          }))
+        }
+        break
+      }
+
+      case "content_block_stop": {
+        const idx = event.index ?? 0
+        const st = blocks.get(idx)
+        if (!st || st.kind === "skip") break
+        if (st.kind === "text") {
+          out.push(emit("response.output_text.done", {
+            item_id: st.itemId, output_index: st.outputIndex, content_index: 0, text: st.text,
+          }))
+          out.push(emit("response.content_part.done", {
+            item_id: st.itemId, output_index: st.outputIndex, content_index: 0,
+            part: { type: "output_text", text: st.text, annotations: [] },
+          }))
+          const item = {
+            type: "message", id: st.itemId, status: "completed", role: "assistant",
+            content: [{ type: "output_text", text: st.text, annotations: [] }],
+          }
+          finalOutput.push(item)
+          out.push(emit("response.output_item.done", { output_index: st.outputIndex, item }))
+        } else if (st.kind === "tool") {
+          out.push(emit("response.function_call_arguments.done", {
+            item_id: st.itemId, output_index: st.outputIndex, arguments: st.args,
+          }))
+          const item = {
+            type: "function_call", id: st.itemId, call_id: st.callId, name: st.name,
+            arguments: st.args, status: "completed",
+          }
+          finalOutput.push(item)
+          out.push(emit("response.output_item.done", { output_index: st.outputIndex, item }))
+        }
+        break
+      }
+
+      case "message_delta": {
+        if (typeof event.usage?.output_tokens === "number") outputTokens = event.usage.output_tokens
+        break
+      }
+
+      case "message_stop": {
+        out.push(emit("response.completed", {
+          response: responseEnvelope("completed", {
+            output: finalOutput,
+            usage: { input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: inputTokens + outputTokens },
+            parallel_tool_calls: true,
+            tool_choice: "auto",
+            tools: [],
+          }),
+        }))
+        break
+      }
+
+      default:
+        break
+    }
+
+    return out
+  }
+}

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -85,6 +85,12 @@ const ADAPTER_DEFAULTS: Record<string, Partial<AdapterFeatures>> = {
   cherry: {
     codeSystemPrompt: false,
   },
+  // Codex CLI endpoint (/v1/responses). Codex ships its own ~21KB harness
+  // instructions; keep the Claude Code preset OFF so they aren't overridden
+  // (same rationale as openai). Passthrough is forced in the adapter itself.
+  codex: {
+    codeSystemPrompt: false,
+  },
 }
 
 function getConfigPath(): string {
@@ -166,7 +172,7 @@ export function getExplicitThinking(adapterName: string): AdapterFeatures["think
  * Get the full config for all adapters (for the settings UI).
  */
 export function getAllFeatureConfigs(): Record<string, AdapterFeatures> {
-  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough", "openai"]
+  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough", "openai", "codex"]
   const result: Record<string, AdapterFeatures> = {}
   for (const name of adapters) {
     result[name] = getFeaturesForAdapter(name)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -54,6 +54,7 @@ import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
+import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
@@ -455,7 +456,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         status: "ok",
         service: "meridian",
         format: "anthropic",
-        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/models", "/telemetry", "/metrics", "/health"]
+        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/responses", "/v1/models", "/telemetry", "/metrics", "/health"]
       })
     }
     return c.html(landingHtml)
@@ -3642,6 +3643,119 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             }
             controller.enqueue(encoder.encode("data: [DONE]\n\n"))
           }
+          controller.close()
+        }
+      },
+    })
+
+    return new Response(readable, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+      },
+    })
+  })
+
+  // --- OpenAI Responses API endpoint (#475) ---
+  // Serves the Codex CLI (>= 0.96), which dropped wire_api="chat" and speaks
+  // only /v1/responses. Translates Responses <-> Anthropic and forwards
+  // in-process to /v1/messages via app.fetch() (no network roundtrip),
+  // reusing auth, model mapping, session handling, and the passthrough tool
+  // loop — mirroring /v1/chat/completions. Tagged x-meridian-agent: codex so
+  // the codex adapter is selected (forces passthrough; preset OFF).
+  // See src/proxy/openaiResponses.ts for the translation logic.
+  app.post("/v1/responses", async (c) => {
+    const rawBody = await c.req.json() as ResponsesRequest
+    const anthropicBody = translateResponsesToAnthropic(rawBody)
+
+    if (!anthropicBody) {
+      return c.json(
+        { error: { type: "invalid_request_error", message: "input: Field required", code: null } },
+        400
+      )
+    }
+    if (!anthropicBody.model) {
+      return c.json(
+        { error: { type: "invalid_request_error", message: "model: Field required", code: null } },
+        400
+      )
+    }
+
+    const internalHeaders: Record<string, string> = {
+      "Content-Type": "application/json",
+      "x-meridian-agent": "codex",
+    }
+    const xApiKey = c.req.header("x-api-key")
+    if (xApiKey) internalHeaders["x-api-key"] = xApiKey
+    const authz = c.req.header("authorization")
+    if (authz) internalHeaders["authorization"] = authz
+    const xProfile = c.req.header("x-meridian-profile")
+    if (xProfile) internalHeaders["x-meridian-profile"] = xProfile
+
+    const internalReq = new Request("http://internal/v1/messages", {
+      method: "POST",
+      headers: internalHeaders,
+      body: JSON.stringify(anthropicBody),
+    })
+    const internalRes = await app.fetch(internalReq)
+
+    if (!internalRes.ok) {
+      const errBody = await internalRes.text()
+      return c.json(
+        { error: { type: "upstream_error", message: errBody, code: null } },
+        internalRes.status as 400 | 401 | 429 | 500
+      )
+    }
+
+    const responseId = `resp_${randomUUID().replace(/-/g, "")}`
+    const created = Math.floor(Date.now() / 1000)
+    const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : CANONICAL_SONNET_MODEL
+    const ctx = { responseId, model, created, reasoningRequested: reasoningRequested(rawBody) }
+
+    if (!anthropicBody.stream) {
+      const anthropicRes = await internalRes.json() as Record<string, unknown>
+      return c.json(translateAnthropicToResponses(anthropicRes, ctx))
+    }
+
+    // Streaming: translate Anthropic SSE → Responses SSE.
+    const encoder = new TextEncoder()
+    const readable = new ReadableStream({
+      async start(controller) {
+        const reader = internalRes.body?.getReader()
+        if (!reader) { controller.close(); return }
+
+        const decoder = new TextDecoder()
+        let buffer = ""
+        const translate = createResponsesSseTranslator(ctx)
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            buffer += decoder.decode(value, { stream: true })
+            const lines = buffer.split("\n")
+            buffer = lines.pop() ?? ""
+            for (const line of lines) {
+              if (!line.startsWith("data: ")) continue
+              const dataStr = line.slice(6).trim()
+              if (!dataStr) continue
+              let event: Record<string, unknown>
+              try { event = JSON.parse(dataStr) as Record<string, unknown> }
+              catch { continue }
+              if (typeof event.type !== "string") continue
+              for (const emission of translate(event as unknown as ResponsesAnthropicSseEvent)) {
+                controller.enqueue(encoder.encode(`event: ${emission.event}\ndata: ${JSON.stringify(emission.data)}\n\n`))
+              }
+            }
+          }
+        } catch (err) {
+          // Emit a Responses-shaped failure so Codex doesn't hang.
+          const message = err instanceof Error ? err.message : String(err)
+          controller.enqueue(encoder.encode(
+            `event: response.failed\ndata: ${JSON.stringify({ response: { id: responseId, status: "failed", error: { message } } })}\n\n`
+          ))
+        } finally {
           controller.close()
         }
       },

--- a/src/proxy/transforms/codex.ts
+++ b/src/proxy/transforms/codex.ts
@@ -1,0 +1,20 @@
+import type { Transform, RequestContext } from "../transform"
+
+/**
+ * Codex CLI transform (#475). Runs after the shared OpenCode transform (which
+ * codex reuses for tool config); its only job is to FORCE passthrough on.
+ *
+ * Codex is a tool-driving agentic client — it executes its own tools and needs
+ * tool_use blocks returned to it — so it must run passthrough regardless of the
+ * global MERIDIAN_PASSTHROUGH setting. Internal mode (SDK executes tools) would
+ * leave Codex waiting for tool calls that never come back.
+ */
+export const codexTransforms: Transform[] = [
+  {
+    name: "codex-force-passthrough",
+    adapters: ["codex"],
+    onRequest(ctx: RequestContext): RequestContext {
+      return { ...ctx, passthrough: true }
+    },
+  },
+]

--- a/src/proxy/transforms/opencode.ts
+++ b/src/proxy/transforms/opencode.ts
@@ -8,10 +8,12 @@ import { resolvePassthrough } from "../../env"
 export const openCodeTransforms: Transform[] = [
   {
     name: "opencode-core",
-    // "openai" (/v1/chat/completions) reuses this pipeline via the transform
-    // registry; it must be listed here or the transform is skipped and OpenAI
-    // clients get built-in tools unblocked + passthrough off (#546).
-    adapters: ["opencode", "openai"],
+    // "openai" (/v1/chat/completions) and "codex" (/v1/responses) reuse this
+    // pipeline via the transform registry; each must be listed here or the
+    // transform is skipped and clients get built-in tools unblocked +
+    // passthrough off (#546). Codex additionally FORCES passthrough on via a
+    // follow-on transform (#475).
+    adapters: ["opencode", "openai", "codex"],
 
     onRequest(ctx: RequestContext): RequestContext {
       const body = ctx.body

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -6,6 +6,7 @@ import { piTransforms } from "./pi"
 import { forgeCodeTransforms } from "./forgecode"
 import { passthroughTransforms } from "./passthrough"
 import { cherryTransforms } from "./cherry"
+import { codexTransforms } from "./codex"
 
 const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   opencode: openCodeTransforms,
@@ -19,6 +20,9 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   // tool/passthrough behaviour is identical; only the preset default differs
   // (see sdkFeatures.ADAPTER_DEFAULTS.openai).
   openai: openCodeTransforms,
+  // Codex (/v1/responses): OpenCode's tool config + a follow-on transform
+  // that forces passthrough (Codex executes its own tools). See #475.
+  codex: [...openCodeTransforms, ...codexTransforms],
 }
 
 export function getAdapterTransforms(adapterName: string): readonly Transform[] {


### PR DESCRIPTION
## Summary

Implements `POST /v1/responses` so the **Codex CLI ≥ 0.96** runs on Claude via a Max subscription. Codex dropped `wire_api="chat"` and speaks only the OpenAI Responses API; Meridian had `/v1/messages` and `/v1/chat/completions` but not this. Phase 1 of the approved design spec (`docs/superpowers/specs/2026-07-08-codex-responses-api-design.md`, restarted fresh from Trevor's stale branch).

### What's included
- **`openaiResponses.ts`** — pure Responses ⇄ Anthropic translation (mirrors `openai.ts`): request (`input`/`instructions`/`function_call` round-trip/`tools`/`tool_choice`), non-stream response assembly, and the stateful SSE translator
- **`codex` adapter + transform** — forces passthrough (Codex executes its own shell/apply-patch tools, so tool_use must flow back) regardless of `MERIDIAN_PASSTHROUGH`; `codeSystemPrompt` OFF so Codex's ~21KB harness prompt isn't overridden
- **`POST /v1/responses` route** — in-process forward to `/v1/messages`, tagged `x-meridian-agent: codex`; advertised in the root endpoint list; README provider setup + Tested Agents row

### Two bugs found by live testing (both invisible to curl)
1. **Missing `type` in SSE data.** The Responses format is self-describing and Codex's deserializer is `#[serde(tag = "type")]`. Without `type` inside each `data` payload, Codex fails to parse every event and reports *"stream closed before response.completed"* — even though the whole stream (including `response.completed`) was sent. curl showed a perfect stream; only real Codex revealed it.
2. **Reasoning hang.** If Codex requested reasoning (`include: ["reasoning.encrypted_content"]`) and no reasoning item appeared, it hung indefinitely. Fixed by emitting one empty placeholder `reasoning` item; Codex echoes it back next turn where the request translator drops it (inert). Cross-turn reasoning *continuity* remains Phase 2 (OpenAI's encrypted envelope is incompatible with Claude's signed thinking blocks).

### Verification
- Unit (`openai-responses.test.ts`) + integration (`proxy-responses-endpoint.test.ts`): translation, forced passthrough, SSE sequence, the `type`-field and placeholder-reasoning regressions. Full suite **2116 pass**, tsc clean
- **Live E2E on real Codex 0.144** (isolated `CODEX_HOME`, `wire_api="responses"`): plain reply (`ACKNOWLEDGED`), tool-driving (`cat marker.txt` via shell exec → correct contents), and reasoning-enabled variants of both

Closes #475