### PR TITLE
refactor(nix): use nixpkgs claude-code instead of vendoring

### DIFF
--- a/.github/workflows/check-claude-code.yml
+++ b/.github/workflows/check-claude-code.yml
@@ -1,0 +1,29 @@
+name: Check claude-code availability
+
+on:
+  pull_request:
+    paths:
+      - package.json
+      - bun.lock
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+
+      - name: nixpkgs must provide a claude-code satisfying the floor
+        run: |
+          satisfies() { nix eval .#packages.x86_64-linux.meridian.drvPath >/dev/null 2>&1; }
+          if satisfies; then
+            echo "current nixpkgs claude-code satisfies the @anthropic-ai/claude-code floor"
+            exit 0
+          fi
+          nix flake update nixpkgs
+          if satisfies; then
+            echo "::error::the @anthropic-ai/claude-code floor outpaces the pinned nixpkgs; a bump satisfies it, so run 'nix flake update nixpkgs' and include the flake.lock change in this PR"
+            exit 1
+          fi
+          echo "::error::no released nixpkgs claude-code satisfies the @anthropic-ai/claude-code floor yet; hold this bump until nixpkgs packages it"
+          exit 1

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Then in `~/.config/opencode/opencode.json`:
 
 > **Important:** Do not use `meridian setup` on NixOS. It writes an absolute Nix store path (e.g. `/nix/store/...-meridian-1.x.x/lib/...`) into your OpenCode config, which will break on the next `nixos-rebuild switch` or `home-manager switch` when the store path changes. Use one of the approaches above instead.
 
-> **Note:** The bundled Claude Code binary (`claude.exe`) is patched with `autoPatchelfHook` at build time, so it runs on NixOS out of the box. If you previously enabled `programs.nix-ld.enable = true` as a workaround for `Could not start dynamically linked executable` (#501), that is no longer required for Meridian.
+> **Note:** Meridian's package depends on the unfree `claude-code` from nixpkgs instead of bundling its own binary. The flake accepts the unfree license when it builds the package and exports the finished derivation, so consuming it through the overlay or `packages.<system>.meridian` does not re-run nixpkgs' unfree check and needs no `allowUnfree` setting.
 
 **Home Manager service** -- run Meridian as a user systemd service:
 

--- a/flake.lock
+++ b/flake.lock
@@ -134,11 +134,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
           {
             _module.args.pkgs = import nixpkgs {
               inherit system;
+              config.allowUnfreePredicate = pkg: lib.getName pkg == "claude-code";
               overlays = [ bun2nix.overlays.default ];
             };
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,43 +1,38 @@
 {
-  autoPatchelfHook,
   bun,
   bun2nix,
+  claude-code,
   lib,
   makeWrapper,
   nodejs_22,
-  stdenv,
   stdenvNoCC,
 }:
-stdenvNoCC.mkDerivation {
-  inherit (lib.importJSON ../package.json) version;
+let
+  inherit (lib.cli) toCommandLineGNU;
+  inherit (lib.meta) getExe;
+  inherit (lib.sources) cleanSource;
+  inherit (lib.strings) removePrefix versionOlder;
+  inherit (lib.trivial) importJSON;
+  package = importJSON ../package.json;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit (package) version;
   pname = "meridian";
 
-  src = lib.cleanSource ../.;
+  src = cleanSource ../.;
 
   nativeBuildInputs = [
-    bun2nix.hook
     bun
-    nodejs_22
+    bun2nix.hook
     makeWrapper
-  ]
-  # node_modules vendors native ELF binaries — most importantly
-  # @anthropic-ai/claude-code/bin/claude.exe (the Claude Code CLI the SDK
-  # spawns) and its bundled ripgrep. They are dynamically linked against a
-  # generic-Linux loader path (/lib64/ld-linux-*), which does not exist on
-  # NixOS — every query died with exit=127 "Could not start dynamically
-  # linked executable" (#501). autoPatchelfHook rewrites their interpreter
-  # and rpaths to Nix store paths at build time, so users don't need the
-  # nix-ld escape hatch.
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-
-  # Runtime libraries autoPatchelfHook links the vendored ELFs against.
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    stdenv.cc.cc.lib # libstdc++ / libgcc_s for the bun-compiled claude.exe
+    nodejs_22
   ];
 
   bunDeps = bun2nix.fetchBunDeps { bunNix = ../bun.nix; };
-
-  bunInstallFlags = [ "--linker=hoisted" ];
+  bunInstallFlags = toCommandLineGNU { } {
+    ignore-scripts = true;
+    linker = "hoisted";
+  };
 
   buildPhase = ''
     runHook preBuild
@@ -51,28 +46,25 @@ stdenvNoCC.mkDerivation {
     mkdir -p $out/lib/meridian
     cp -r dist node_modules plugin package.json $out/lib/meridian/
 
-    makeWrapper ${lib.getExe nodejs_22} $out/bin/meridian \
-      --add-flags "$out/lib/meridian/dist/cli.js"
+    rm -rf $out/lib/meridian/node_modules/@anthropic-ai/{claude-code,claude-code-*,claude-agent-sdk-*} \
+      $out/lib/meridian/node_modules/.bin/claude
+
+    makeWrapper ${getExe nodejs_22} $out/bin/${finalAttrs.meta.mainProgram} \
+      --add-flags "$out/lib/meridian/dist/cli.js" \
+      --set MERIDIAN_CLAUDE_PATH ${getExe claude-code}
 
     runHook postInstall
   '';
 
-  # claude.exe is a bun single-file executable: the JS payload is embedded in
-  # the binary. Stripping would discard it and corrupt the CLI, so only the
-  # patchelf part of fixup may touch it.
-  dontStrip = true;
-
-  # Vendored prebuilt binaries may reference optional libs we don't provide
-  # (autoPatchelfHook fails the build on ANY missing dep otherwise). The
-  # loader only needs the ones actually used at runtime; claude.exe's hard
-  # deps (glibc, libstdc++) are covered above.
-  autoPatchelfIgnoreMissingDeps = [ "*" ];
-
   meta = {
-    description = "Local Anthropic API powered by your Claude Max subscription";
-    homepage = "https://github.com/rynfar/meridian";
+    inherit (package) description;
+    broken = versionOlder claude-code.version (
+      removePrefix "^" package.dependencies."@anthropic-ai/claude-code"
+    );
+    homepage = "https://github.com/rynfar/${finalAttrs.pname}";
     license = lib.licenses.mit;
-    mainProgram = "meridian";
+    mainProgram = finalAttrs.pname;
     platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
-}
+})


### PR DESCRIPTION
Switches the Nix package from vendoring the bundled Claude Code binary to using nixpkgs `claude-code`, pointed at via `MERIDIAN_CLAUDE_PATH`.

## Why

With the binary vendored, meridian had to patch a proprietary binary itself. `cp -r node_modules` shipped three ~235 MB copies of the Claude CLI, and `autoPatchelfHook` rewrote the interpreter of Anthropic's prebuilt binary so it would run on NixOS at all; every query died with `exit=127` until that patching landed (#501). It duplicated, less completely, work nixpkgs already does: nixpkgs' `claude-code` wraps the same binary with ripgrep on `PATH`, `procps`, and the bubblewrap sandbox, and it is maintained and reviewed as a first-class package. Relying on it removes both the vendored binaries (the closure was over 1 GB) and the fiddly, breakage-prone job of hand-patching an upstream binary.

## What changes

The wrapper sets `MERIDIAN_CLAUDE_PATH` to `${lib.getExe claude-code}` (the resolver's `env` source wins unconditionally), the vendored binaries are pruned in `installPhase`, and `--ignore-scripts` skips the postinstall that materialized the 248 MB `bin/claude.exe`. That drops `autoPatchelfHook`, `buildInputs`, `dontStrip`, and `autoPatchelfIgnoreMissingDeps`; the only runtime-loaded native binary, libsql's `.node`, is a shared object that resolves its libraries through node's own closure. Closure goes from ~1 GB to ~87 MB.

## The package is now correctly licensed

The most important improvement is licensing. With the binary vendored, the package declared `license = lib.licenses.mit` while its build output redistributed Anthropic's proprietary `claude.exe`, mislabeling the license and shipping an unfree binary that was never declared as such. The package is now correct: it carries no proprietary binary, its MIT license accurately describes meridian's own code, and it depends on the declared-unfree `pkgs.claude-code` like any other unfree dependency.

The unfree component now lives where it belongs, in the dependency. One caveat worth stating plainly: `overlays.default` and the home-manager module re-export the derivation the flake already evaluated with `allowUnfree`, so consuming Meridian through them pulls in `claude-code` without the consumer's own `allowUnfree` opt-in. That is a known property of flakes: a consumer's `nixpkgs.config` does not re-run against an already-evaluated flake output (NixOS/nixpkgs#118115). It applies to any flake exporting an unfree-dependent package and is not introduced by this PR.

## Version coupling

nixpkgs `claude-code` tracks its own cadence, not the SDK's `@anthropic-ai/claude-code` pin, so `meta.broken = versionOlder claude-code.version <floor>` (read from `package.json`) fails the build when the pinned nixpkgs is older than the SDK requires, with `allowBroken` as the escape hatch. `.github/workflows/check-claude-code.yml` runs on `package.json`/`bun.lock` PRs: if a raised floor outpaces the pinned nixpkgs it reports whether `nix flake update nixpkgs` fixes it (bump the lock in the same PR) or nixpkgs hasn't packaged it yet (hold the bump).

Verified: builds, closure ~87 MB, libsql loads unpatched, the SDK's JS imports without its pruned platform binary, and `/health` reports `claudeExecutable.source: "env"` resolving to nixpkgs `claude-code`.
