### PR TITLE
fix(plugin): resolve agent mode for string agents (OpenCode >= 1.17)

### DIFF
--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -14,13 +14,17 @@
  *   { "plugin": ["/absolute/path/to/plugin/meridian.ts"] }
  */
 
+type AgentInput = string | { name?: string; mode?: string }
+
 type Plugin = (input: any) => Promise<{
+  config?: (cfg: { agent?: Record<string, { mode?: string } | undefined> }) => Promise<void> | void
   "chat.headers"?: (
     input: {
       sessionID: string
-      // Typed as string in the SDK types but is actually the full agent
-      // object at runtime: { name: string; mode: "primary" | "subagent" | "all" }
-      agent: string | { name?: string; mode?: string }
+      // Older OpenCode versions pass the full agent object
+      // ({ name, mode: "primary" | "subagent" | "all" }); OpenCode >= 1.17
+      // passes just the agent NAME as a string. Handle both.
+      agent: AgentInput
       model: { providerID: string }
       message: { id: string }
     },
@@ -28,8 +32,49 @@ type Plugin = (input: any) => Promise<{
   ) => Promise<void>
 }>
 
+/**
+ * Modes of OpenCode's built-in agents (they are not listed in the merged
+ * config unless the user overrides them, so the `config` hook alone can't
+ * see them). User-defined agents and built-in overrides are layered on top
+ * from the config hook.
+ */
+const BUILTIN_AGENT_MODES: Record<string, string> = {
+  build: "primary",
+  plan: "primary",
+  general: "subagent",
+  explore: "subagent",
+  // Hidden internal agents. These usually route to small_model (a
+  // non-Anthropic provider) but are mapped defensively.
+  title: "subagent",
+  summary: "subagent",
+  compaction: "subagent",
+}
+
 const MeridianPlugin: Plugin = async () => {
+  // name -> mode, per plugin instance
+  const agentModes: Record<string, string> = { ...BUILTIN_AGENT_MODES }
+
+  const resolve = (agent: AgentInput): { name: string; mode: string } => {
+    if (typeof agent === "object" && agent !== null) {
+      // Legacy runtime shape: full agent object with an explicit mode.
+      return { name: agent.name ?? "unknown", mode: agent.mode ?? "primary" }
+    }
+    // OpenCode >= 1.17: agent is the name string. Resolve the mode from the
+    // merged config (captured in the config hook) + built-in defaults.
+    const name = String(agent)
+    return { name, mode: agentModes[name] ?? "primary" }
+  }
+
   return {
+    // Runs once on init with the merged OpenCode config. Captures the mode
+    // of user-defined agents and built-in overrides so chat.headers can
+    // classify string agent names.
+    config: (cfg) => {
+      for (const [name, def] of Object.entries(cfg?.agent ?? {})) {
+        if (typeof def?.mode === "string") agentModes[name] = def.mode
+      }
+    },
+
     "chat.headers": async (incoming, output) => {
       // Only inject headers for Anthropic provider requests
       if (incoming.model.providerID !== "anthropic") return
@@ -38,18 +83,15 @@ const MeridianPlugin: Plugin = async () => {
       output.headers["x-opencode-session"] = incoming.sessionID
       output.headers["x-opencode-request"] = incoming.message.id
 
-      // Agent mode — runtime value is the full agent object even though
-      // the TypeScript type says string. Read .mode directly.
-      const agent = incoming.agent as { name?: string; mode?: string } | string
-      output.headers["x-opencode-agent-mode"] = typeof agent === "object"
-        ? (agent.mode ?? "primary")
-        : "primary"
-      const rawName = typeof agent === "object"
-        ? (agent.name ?? "unknown")
-        : String(agent)
+      const { name, mode } = resolve(incoming.agent)
+
+      // The proxy expects primary|subagent. "all" agents can act as either;
+      // without per-request context, treat them as primary (full tier) to
+      // preserve capability.
+      output.headers["x-opencode-agent-mode"] = mode === "subagent" ? "subagent" : "primary"
       // Strip non-ASCII characters (e.g. zero-width spaces) that cause
       // "Header has invalid value" errors in Node.js / undici.
-      output.headers["x-opencode-agent-name"] = rawName.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
+      output.headers["x-opencode-agent-name"] = name.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
     },
   }
 }

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the OpenCode plugin's agent-mode header (plugin/meridian.ts).
+ *
+ * OpenCode >= 1.17 passes `agent` to the chat.headers hook as the agent
+ * NAME (a string); older versions passed the full `{ name, mode }` object.
+ * The plugin must classify subagents correctly in both shapes — a string
+ * agent silently mapped to "primary" sends subagent traffic out at the
+ * primary 1M tier, burning rate-limit budget and (field-observed) tripping
+ * Anthropic's extra-usage metering on fresh subagent sessions.
+ */
+import { describe, it, expect } from "bun:test"
+import MeridianPlugin from "../../plugin/meridian"
+
+type Hooks = Awaited<ReturnType<typeof MeridianPlugin>>
+
+async function instance(cfgAgents?: Record<string, { mode?: string }>): Promise<Hooks> {
+  const hooks = await MeridianPlugin({})
+  if (cfgAgents) await hooks.config?.({ agent: cfgAgents })
+  return hooks
+}
+
+async function headersFor(
+  hooks: Hooks,
+  agent: unknown,
+  providerID = "anthropic",
+): Promise<Record<string, string>> {
+  const output = { headers: {} as Record<string, string> }
+  await hooks["chat.headers"]!(
+    {
+      sessionID: "ses_test",
+      agent: agent as any,
+      model: { providerID },
+      message: { id: "msg_test" },
+    },
+    output,
+  )
+  return output.headers
+}
+
+describe("plugin/meridian.ts agent-mode header", () => {
+  it("legacy object agent: reads mode directly", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, { name: "explore", mode: "subagent" })
+    expect(h["x-opencode-agent-mode"]).toBe("subagent")
+    expect(h["x-opencode-agent-name"]).toBe("explore")
+  })
+
+  it("string agent: built-in subagents resolve to subagent", async () => {
+    const hooks = await instance()
+    expect((await headersFor(hooks, "explore"))["x-opencode-agent-mode"]).toBe("subagent")
+    expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  it("string agent: built-in primaries resolve to primary", async () => {
+    const hooks = await instance()
+    expect((await headersFor(hooks, "build"))["x-opencode-agent-mode"]).toBe("primary")
+    expect((await headersFor(hooks, "plan"))["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  it("string agent: user-defined subagent from config resolves to subagent", async () => {
+    const hooks = await instance({ "code-reviewer": { mode: "subagent" } })
+    expect((await headersFor(hooks, "code-reviewer"))["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  it("string agent: config override of a built-in wins", async () => {
+    const hooks = await instance({ general: { mode: "primary" } })
+    expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  it("string agent: unknown names fall back to primary", async () => {
+    const hooks = await instance()
+    expect((await headersFor(hooks, "mystery-agent"))["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  it('mode "all" is normalized to primary', async () => {
+    const hooks = await instance({ flexible: { mode: "all" } })
+    expect((await headersFor(hooks, "flexible"))["x-opencode-agent-mode"]).toBe("primary")
+    const legacy = await headersFor(hooks, { name: "flexible", mode: "all" })
+    expect(legacy["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  it("session and request headers are always set for anthropic requests", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "explore")
+    expect(h["x-opencode-session"]).toBe("ses_test")
+    expect(h["x-opencode-request"]).toBe("msg_test")
+  })
+
+  it("non-anthropic providers get no headers", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "title", "openrouter")
+    expect(Object.keys(h)).toHaveLength(0)
+  })
+
+  it("agent names are sanitized to printable ASCII", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "expl\u200bore\u2728")
+    expect(h["x-opencode-agent-name"]).toBe("explore")
+  })
+
+  it("config hook state is per plugin instance", async () => {
+    const a = await instance({ shared: { mode: "subagent" } })
+    const b = await instance()
+    expect((await headersFor(a, "shared"))["x-opencode-agent-mode"]).toBe("subagent")
+    expect((await headersFor(b, "shared"))["x-opencode-agent-mode"]).toBe("primary")
+  })
+})


### PR DESCRIPTION
## Problem

OpenCode ≥ 1.17 passes `agent` to the `chat.headers` plugin hook as the agent **name** (a string), not the `{ name, mode }` object the plugin expects. The plugin's string branch hardcodes `x-opencode-agent-mode: primary`, so **subagent detection silently never fires** on current OpenCode.

Field data (OpenCode 1.17.20, Meridian 1.52.0): **2280/2280** requests in my journal ran as `agent=primary` — every explore/task subagent went out at the primary 1M tier, burning rate-limit budget. Verified empirically by dumping the hook input:

```json
{"keys":["sessionID","agent","model","provider","message"],"agent":"explore","agentType":"string","providerID":"anthropic"}
```

## Fix

Resolve the mode for string agents from the plugin's `config` hook (merged OpenCode config, which carries `agent.<name>.mode` for user-defined agents and built-in overrides), layered over a built-in agent mode map (`build`/`plan` primary, `general`/`explore` subagent). The legacy object shape keeps working unchanged. `mode: "all"` normalizes to primary (can't tell per-request; preserves capability).

Live-verified on my deployment: subagent requests now log `agent=subagent` and route to the 200k tier, primaries keep `[1m]`.

## Tests

- New `src/__tests__/plugin-agent-mode.test.ts` — 11 direct unit tests of the plugin covering both runtime shapes, config-hook resolution, built-in overrides, `all` normalization, provider filtering, name sanitization, and per-instance state isolation.
- Full suite: 2010+ pass / 0 fail; `bun run typecheck` clean.