### PR TITLE
fix(plugin): rebuild agent-mode map on config reload

### DIFF
--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -51,8 +51,9 @@ const BUILTIN_AGENT_MODES: Record<string, string> = {
 }
 
 const MeridianPlugin: Plugin = async () => {
-  // name -> mode, per plugin instance
-  const agentModes: Record<string, string> = { ...BUILTIN_AGENT_MODES }
+  // Modes from the merged config, per plugin instance. Replaced wholesale on
+  // every config-hook fire so a reload can't leave stale entries behind.
+  let configModes: Record<string, string> = {}
 
   const resolve = (agent: AgentInput): { name: string; mode: string } => {
     if (typeof agent === "object" && agent !== null) {
@@ -62,17 +63,19 @@ const MeridianPlugin: Plugin = async () => {
     // OpenCode >= 1.17: agent is the name string. Resolve the mode from the
     // merged config (captured in the config hook) + built-in defaults.
     const name = String(agent)
-    return { name, mode: agentModes[name] ?? "primary" }
+    return { name, mode: configModes[name] ?? BUILTIN_AGENT_MODES[name] ?? "primary" }
   }
 
   return {
-    // Runs once on init with the merged OpenCode config. Captures the mode
-    // of user-defined agents and built-in overrides so chat.headers can
-    // classify string agent names.
+    // Runs with the merged OpenCode config (on init, and again on config
+    // reload). Captures the mode of user-defined agents and built-in
+    // overrides so chat.headers can classify string agent names.
     config: (cfg) => {
+      const next: Record<string, string> = {}
       for (const [name, def] of Object.entries(cfg?.agent ?? {})) {
-        if (typeof def?.mode === "string") agentModes[name] = def.mode
+        if (typeof def?.mode === "string") next[name] = def.mode
       }
+      configModes = next
     },
 
     "chat.headers": async (incoming, output) => {

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -104,4 +104,18 @@ describe("plugin/meridian.ts agent-mode header", () => {
     expect((await headersFor(a, "shared"))["x-opencode-agent-mode"]).toBe("subagent")
     expect((await headersFor(b, "shared"))["x-opencode-agent-mode"]).toBe("primary")
   })
+
+  it("config hook re-fire drops agents removed from config", async () => {
+    const hooks = await instance({ temp: { mode: "subagent" } })
+    expect((await headersFor(hooks, "temp"))["x-opencode-agent-mode"]).toBe("subagent")
+    await hooks.config?.({ agent: {} })
+    expect((await headersFor(hooks, "temp"))["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  it("config hook re-fire restores built-in mode when an override is removed", async () => {
+    const hooks = await instance({ general: { mode: "primary" } })
+    expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("primary")
+    await hooks.config?.({ agent: {} })
+    expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("subagent")
+  })
 })


### PR DESCRIPTION
Follow-up to #657 (review note). The plugin's `config` hook layered agent modes additively onto per-instance state, so if OpenCode re-fires the hook on a config reload, an agent removed from config (or a dropped built-in override) kept its stale mode until restart.

Now the config-derived layer is replaced wholesale on every fire, and resolution happens at lookup time: config mode → built-in mode → `primary`. Behavior is otherwise unchanged.

## Tests

Two new cases in `plugin-agent-mode.test.ts` (written first, watched fail on the old code):
- re-fire with an agent removed → falls back to `primary`
- re-fire with a built-in override removed → built-in mode restored

Full suite 2129 pass / 0 fail; typecheck clean.