### PR TITLE
feat: Claude Design MCP proxy (/v1/design/*) with dedicated OAuth flow

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,6 +57,7 @@ src/
 │   ├── profileCli.ts          ← CLI commands for profile management (leaf, I/O)
 │   ├── agentDefs.ts           ← Subagent definition extraction from tool descriptions
 │   ├── agentMatch.ts          ← Fuzzy agent name matching
+│   ├── design.ts              ← Claude Design MCP proxy (token store/refresh, auth precedence, login flow)
 │   └── passthroughTools.ts    ← Tool forwarding mode (agent handles execution)
 ├── fileChanges.ts             ← PostToolUse hook: tracks write/edit ops, formats summary
 ├── mcpTools.ts                ← MCP tool definitions (read, write, edit, bash, glob, grep)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ models.ts          → mapModelToClaudeModel, resolveClaudeExecutableAsync
 tools.ts           → BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME
 messages.ts        → normalizeContent, getLastUserMessage (pure)
 fileChanges.ts     → PostToolUse hook: file write/edit tracking + summary formatting (pure)
+design.ts          → Claude Design MCP proxy: token store/refresh, auth precedence, login flow
 session/
   lineage.ts       → Hashing, lineage verification (PURE — no I/O)
   fingerprint.ts   → extractClientCwd, getConversationFingerprint

--- a/README.md
+++ b/README.md
@@ -667,6 +667,27 @@ Run several configurations of the same adapter side by side — e.g. a passthrou
 
 Built-in adapter names are reserved and can't be shadowed. With no instances configured, detection is exactly the built-in chain. Config file changes apply within ~5s, no restart needed.
 
+### Claude Design MCP
+
+Meridian proxies the Claude Design MCP API (`api.anthropic.com/v1/design/*`), so MCP clients can use Claude Design tools through your local endpoint. Point your MCP client at:
+
+```
+http://127.0.0.1:3456/v1/design/mcp
+```
+
+The Design API requires OAuth scopes (`user:design:read`/`user:design:write`) that Meridian's standard login does not carry, so authorize once with the dedicated flow:
+
+```bash
+curl http://127.0.0.1:3456/design-login          # returns an authorize URL — open it in your browser
+curl -X POST http://127.0.0.1:3456/design-login \
+  -H 'content-type: application/json' \
+  -d '{"code": "<code-from-browser>"}'           # paste the code you were shown
+```
+
+The design token is stored at `~/.config/meridian/design-token.json` (mode `0600`, global across profiles) and refreshed automatically when it expires. If a design request returns `auth_error`, re-run the login flow.
+
+> Contributed by [@sittitep](https://github.com/sittitep) (#543).
+
 ### Any Anthropic-compatible tool
 
 ```bash
@@ -834,6 +855,8 @@ ANTHROPIC_API_KEY=your-secret-key ANTHROPIC_BASE_URL=http://meridian-host:3456 o
 | `POST /v1/chat/completions` | OpenAI-compatible chat completions |
 | `POST /v1/responses` | OpenAI Responses API (Codex CLI ≥ 0.96) |
 | `GET /v1/models` | OpenAI-compatible model list |
+| `GET/POST /v1/design/*` | Claude Design MCP proxy (see [Claude Design MCP](#claude-design-mcp)) |
+| `GET/POST /design-login` | OAuth flow for the design scopes |
 | `GET /health` | Auth status, mode, plugin status |
 | `POST /auth/refresh` | Manually refresh the OAuth token |
 | `GET /telemetry` | Performance dashboard |

--- a/src/__tests__/design-endpoint.test.ts
+++ b/src/__tests__/design-endpoint.test.ts
@@ -1,0 +1,201 @@
+/**
+ * /v1/design/* and /design-login integration — #543.
+ *
+ * Through the HTTP layer with the upstream fetch mocked: asserts the POST
+ * proxy forwards auth + identity encoding, maps the Design API's
+ * 404-for-missing-scopes to a 401 auth_error, strips hop-by-hop response
+ * headers, serves the local GET keepalive stream, and that /design-login
+ * exchanges a code and persists the token file. From #543 by @sittitep.
+ */
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test"
+import { mkdtempSync, rmSync, readFileSync, statSync, existsSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => (async function* () {})(),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const tokenDir = mkdtempSync(join(tmpdir(), "design-test-"))
+const tokenPath = join(tokenDir, "design-token.json")
+process.env.MERIDIAN_DESIGN_TOKEN_PATH = tokenPath
+
+const { createProxyServer } = await import("../proxy/server")
+
+// Upstream mock: captures design-API requests, delegates everything else.
+const realFetch = globalThis.fetch
+let upstreamCalls: Array<{ url: string; headers: Record<string, string>; body: string }> = []
+let upstreamResponse: () => Response = () => new Response("{}", { status: 200 })
+let tokenExchangeResponse: () => Response = () =>
+  new Response(JSON.stringify({ access_token: "designtok", refresh_token: "designref", expires_in: 28800, scope: "user:design:read user:design:write" }), { status: 200 })
+
+globalThis.fetch = (async (input: any, init?: any) => {
+  const url = typeof input === "string" ? input : input.url
+  if (url.startsWith("https://api.anthropic.com/v1/design/")) {
+    const headers: Record<string, string> = {}
+    for (const [k, v] of new Headers(init?.headers ?? {}).entries()) headers[k] = v
+    upstreamCalls.push({ url, headers, body: init?.body ? Buffer.from(init.body).toString() : "" })
+    return upstreamResponse()
+  }
+  if (url === "https://platform.claude.com/v1/oauth/token") {
+    return tokenExchangeResponse()
+  }
+  return realFetch(input, init)
+}) as typeof fetch
+
+afterAll(() => {
+  globalThis.fetch = realFetch
+  rmSync(tokenDir, { recursive: true, force: true })
+  delete process.env.MERIDIAN_DESIGN_TOKEN_PATH
+})
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+describe("/design-login (#543)", () => {
+  beforeEach(() => {
+    upstreamCalls = []
+    rmSync(tokenPath, { force: true })
+  })
+
+  it("GET returns an authorize URL carrying the design scopes", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/design-login"))
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.authorizeUrl).toContain("user%3Adesign%3Aread")
+    expect(body.authorizeUrl).toContain("user%3Adesign%3Awrite")
+  })
+
+  it("POST exchanges the code and writes the token file with mode 0600", async () => {
+    const app = createTestApp()
+    const startRes = await app.fetch(new Request("http://localhost/design-login"))
+    const { authorizeUrl } = await startRes.json() as any
+    const state = new URL(authorizeUrl).searchParams.get("state")!
+
+    const res = await app.fetch(
+      new Request("http://localhost/design-login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ code: `the-code#${state}` }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.success).toBe(true)
+
+    const stored = JSON.parse(readFileSync(tokenPath, "utf-8"))
+    expect(stored.accessToken).toBe("designtok")
+    expect(stored.refreshToken).toBe("designref")
+    expect(statSync(tokenPath).mode & 0o777).toBe(0o600)
+  })
+
+  it("POST with garbage body is a 400, not a crash", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(
+      new Request("http://localhost/design-login", { method: "POST", body: "not json" }),
+    )
+    expect(res.status).toBe(400)
+  })
+})
+
+describe("/v1/design proxy (#543)", () => {
+  beforeEach(() => {
+    upstreamCalls = []
+    rmSync(tokenPath, { force: true })
+    upstreamResponse = () => new Response("{}", { status: 200 })
+  })
+
+  it("GET serves a local SSE keepalive stream without touching upstream", async () => {
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/design/mcp"))
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toContain("text/event-stream")
+    const reader = res.body!.getReader()
+    const { value } = await reader.read()
+    expect(Buffer.from(value!).toString()).toContain(": keepalive")
+    await reader.cancel()
+    expect(upstreamCalls).toHaveLength(0)
+  })
+
+  it("POST proxies to upstream with identity encoding and forwards mcp-session-id both ways", async () => {
+    upstreamResponse = () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json", "mcp-session-id": "up-sess", "transfer-encoding": "chunked" },
+      })
+    const app = createTestApp()
+    const res = await app.fetch(
+      new Request("http://localhost/v1/design/mcp?x=1", {
+        method: "POST",
+        headers: { "content-type": "application/json", "mcp-session-id": "client-sess", "anthropic-beta": "mcp-beta" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+      }),
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get("mcp-session-id")).toBe("up-sess")
+    expect(await res.json()).toEqual({ ok: true })
+
+    expect(upstreamCalls).toHaveLength(1)
+    const call = upstreamCalls[0]!
+    expect(call.url).toBe("https://api.anthropic.com/v1/design/mcp?x=1")
+    expect(call.headers["accept-encoding"]).toBe("identity")
+    expect(call.headers["mcp-session-id"]).toBe("client-sess")
+    expect(call.headers["anthropic-beta"]).toBe("mcp-beta")
+    expect(call.body).toContain("tools/list")
+  })
+
+  it("uses a fresh stored design token as Bearer auth", async () => {
+    const app = createTestApp()
+    // Store a token via the login flow so the file is written the same way
+    const startRes = await app.fetch(new Request("http://localhost/design-login"))
+    const state = new URL(((await startRes.json()) as any).authorizeUrl).searchParams.get("state")!
+    await app.fetch(
+      new Request("http://localhost/design-login", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ code: `code#${state}` }),
+      }),
+    )
+
+    await app.fetch(new Request("http://localhost/v1/design/mcp", { method: "POST", body: "{}" }))
+    expect(upstreamCalls[0]!.headers["authorization"]).toBe("Bearer designtok")
+  })
+
+  it("maps upstream 404 (missing design scopes) to a 401 auth_error pointing at /design-login", async () => {
+    upstreamResponse = () => new Response("not found", { status: 404 })
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/design/mcp", { method: "POST", body: "{}" }))
+    expect(res.status).toBe(401)
+    const body = await res.json() as any
+    expect(body.error.type).toBe("auth_error")
+    expect(body.error.message).toContain("/design-login")
+  })
+
+  it("passes non-auth upstream errors through untouched", async () => {
+    upstreamResponse = () => new Response(JSON.stringify({ boom: true }), { status: 500 })
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/design/mcp", { method: "POST", body: "{}" }))
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ boom: true })
+  })
+
+  it("does not write a token file as a side effect of proxying", async () => {
+    const app = createTestApp()
+    await app.fetch(new Request("http://localhost/v1/design/mcp", { method: "POST", body: "{}" }))
+    expect(existsSync(tokenPath)).toBe(false)
+  })
+})

--- a/src/__tests__/design-module.test.ts
+++ b/src/__tests__/design-module.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for src/proxy/design.ts — the Claude Design MCP proxy module.
+ *
+ * Covers the pure/injected logic: token freshness + refresh-on-expiry,
+ * auth-header precedence (design token → API key → OAuth token → Max
+ * credential store), forward/response header construction, the 404-as-auth
+ * quirk, and the /design-login OAuth session lifecycle. From #543 by
+ * @sittitep.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  DESIGN_SCOPES,
+  type DesignTokenData,
+  type DesignTokenStore,
+  isDesignTokenFresh,
+  getDesignAccessToken,
+  resolveDesignAuthHeaders,
+  buildDesignForwardHeaders,
+  filterUpstreamResponseHeaders,
+  isDesignAuthFailure,
+  createDesignLogin,
+} from "../proxy/design"
+
+function memoryStore(initial: DesignTokenData | null = null): DesignTokenStore & { data: DesignTokenData | null } {
+  const box = {
+    data: initial,
+    async read() { return box.data },
+    async write(d: DesignTokenData) { box.data = d },
+  }
+  return box
+}
+
+const NOW = 1_800_000_000_000
+
+describe("isDesignTokenFresh", () => {
+  it("is fresh well before expiry and stale after", () => {
+    expect(isDesignTokenFresh({ accessToken: "t", expiresAt: NOW + 3_600_000 }, NOW)).toBe(true)
+    expect(isDesignTokenFresh({ accessToken: "t", expiresAt: NOW - 1 }, NOW)).toBe(false)
+  })
+
+  it("treats tokens inside the 60s skew window as stale", () => {
+    expect(isDesignTokenFresh({ accessToken: "t", expiresAt: NOW + 30_000 }, NOW)).toBe(false)
+  })
+})
+
+describe("getDesignAccessToken", () => {
+  it("returns the stored token when fresh", async () => {
+    const store = memoryStore({ accessToken: "fresh-token", expiresAt: NOW + 3_600_000 })
+    const token = await getDesignAccessToken({ store, now: NOW, fetchFn: () => { throw new Error("no fetch expected") } })
+    expect(token).toBe("fresh-token")
+  })
+
+  it("returns null with no stored token", async () => {
+    const token = await getDesignAccessToken({ store: memoryStore(), now: NOW })
+    expect(token).toBeNull()
+  })
+
+  it("refreshes an expired token and persists the result", async () => {
+    const store = memoryStore({ accessToken: "old", refreshToken: "refresh-1", expiresAt: NOW - 1000, scopes: DESIGN_SCOPES })
+    const calls: any[] = []
+    const fetchFn = (async (url: any, init: any) => {
+      calls.push({ url: String(url), body: JSON.parse(init.body) })
+      return new Response(JSON.stringify({ access_token: "new-token", refresh_token: "refresh-2", expires_in: 28800 }), { status: 200 })
+    })
+    const token = await getDesignAccessToken({ store, now: NOW, fetchFn })
+    expect(token).toBe("new-token")
+    expect(calls).toHaveLength(1)
+    expect(calls[0].body.grant_type).toBe("refresh_token")
+    expect(calls[0].body.refresh_token).toBe("refresh-1")
+    expect(store.data?.accessToken).toBe("new-token")
+    expect(store.data?.refreshToken).toBe("refresh-2")
+    expect(store.data?.expiresAt).toBe(NOW + 28800 * 1000)
+  })
+
+  it("keeps the old refresh token when the response omits one", async () => {
+    const store = memoryStore({ accessToken: "old", refreshToken: "refresh-1", expiresAt: NOW - 1000 })
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ access_token: "new-token", expires_in: 3600 }), { status: 200 }))
+    await getDesignAccessToken({ store, now: NOW, fetchFn })
+    expect(store.data?.refreshToken).toBe("refresh-1")
+  })
+
+  it("returns null when expired with no refresh token", async () => {
+    const store = memoryStore({ accessToken: "old", expiresAt: NOW - 1000 })
+    const token = await getDesignAccessToken({ store, now: NOW, fetchFn: () => { throw new Error("no fetch expected") } })
+    expect(token).toBeNull()
+  })
+
+  it("returns null when the refresh request fails", async () => {
+    const store = memoryStore({ accessToken: "old", refreshToken: "refresh-1", expiresAt: NOW - 1000 })
+    const fetchFn = (async () => new Response("nope", { status: 400 }))
+    const token = await getDesignAccessToken({ store, now: NOW, fetchFn })
+    expect(token).toBeNull()
+  })
+})
+
+describe("resolveDesignAuthHeaders", () => {
+  it("prefers the design token over everything else", async () => {
+    const headers = await resolveDesignAuthHeaders({
+      designToken: "design-t",
+      profile: { type: "api", env: { ANTHROPIC_API_KEY: "sk-key" } },
+    })
+    expect(headers).toEqual({ Authorization: "Bearer design-t" })
+  })
+
+  it("falls back to the profile API key", async () => {
+    const headers = await resolveDesignAuthHeaders({
+      designToken: null,
+      profile: { type: "api", env: { ANTHROPIC_API_KEY: "sk-key" } },
+    })
+    expect(headers).toEqual({ "x-api-key": "sk-key" })
+  })
+
+  it("falls back to the profile OAuth token", async () => {
+    const headers = await resolveDesignAuthHeaders({
+      designToken: null,
+      profile: { type: "oauth-token", env: { CLAUDE_CODE_OAUTH_TOKEN: "oauth-t" } },
+    })
+    expect(headers).toEqual({ Authorization: "Bearer oauth-t" })
+  })
+
+  it("falls back to the Max credential store access token", async () => {
+    const headers = await resolveDesignAuthHeaders({
+      designToken: null,
+      profile: { type: "claude-max", env: {} },
+      credentialStore: { read: async () => ({ claudeAiOauth: { accessToken: "max-t" } }) } as any,
+    })
+    expect(headers).toEqual({ Authorization: "Bearer max-t" })
+  })
+
+  it("returns empty headers when nothing is available", async () => {
+    const headers = await resolveDesignAuthHeaders({
+      designToken: null,
+      profile: { type: "claude-max", env: {} },
+    })
+    expect(headers).toEqual({})
+  })
+})
+
+describe("buildDesignForwardHeaders", () => {
+  const get = (headers: Record<string, string>) => (name: string) => headers[name.toLowerCase()]
+
+  it("defaults anthropic-version and forces identity encoding", () => {
+    const h = buildDesignForwardHeaders(get({}), { Authorization: "Bearer t" })
+    expect(h["anthropic-version"]).toBe("2023-06-01")
+    expect(h["accept-encoding"]).toBe("identity")
+    expect(h["Authorization"]).toBe("Bearer t")
+  })
+
+  it("forwards content-type, anthropic-beta, anthropic-version, and mcp-session-id when present", () => {
+    const h = buildDesignForwardHeaders(
+      get({
+        "content-type": "application/json",
+        "anthropic-beta": "mcp-2025",
+        "anthropic-version": "2024-01-01",
+        "mcp-session-id": "sess-9",
+      }),
+      {},
+    )
+    expect(h["content-type"]).toBe("application/json")
+    expect(h["anthropic-beta"]).toBe("mcp-2025")
+    expect(h["anthropic-version"]).toBe("2024-01-01")
+    expect(h["mcp-session-id"]).toBe("sess-9")
+  })
+})
+
+describe("filterUpstreamResponseHeaders", () => {
+  it("drops hop-by-hop headers and keeps the rest", () => {
+    const out = filterUpstreamResponseHeaders([
+      ["content-type", "application/json"],
+      ["mcp-session-id", "sess-1"],
+      ["Transfer-Encoding", "chunked"],
+      ["Connection", "keep-alive"],
+      ["keep-alive", "timeout=5"],
+    ])
+    expect(out).toEqual({ "content-type": "application/json", "mcp-session-id": "sess-1" })
+  })
+})
+
+describe("isDesignAuthFailure", () => {
+  it("treats 401 and the Design API's 404-for-missing-scopes as auth failures", () => {
+    expect(isDesignAuthFailure(401)).toBe(true)
+    expect(isDesignAuthFailure(404)).toBe(true)
+    expect(isDesignAuthFailure(200)).toBe(false)
+    expect(isDesignAuthFailure(500)).toBe(false)
+  })
+})
+
+describe("createDesignLogin", () => {
+  const sessionFactory = (() => {
+    let n = 0
+    return (scopes: string[]) => {
+      n++
+      return { authorizeUrl: `https://auth.example/${n}?scope=${encodeURIComponent(scopes.join(" "))}`, codeVerifier: `verifier-${n}`, state: `state-${n}` }
+    }
+  })()
+
+  it("start() returns an authorize URL with the design scopes", () => {
+    const login = createDesignLogin({ store: memoryStore(), createSession: sessionFactory, now: () => NOW })
+    const res = login.start()
+    expect(res.authorizeUrl).toContain("user%3Adesign%3Aread")
+  })
+
+  it("exchange() trades the code for a token and persists it", async () => {
+    const store = memoryStore()
+    const calls: any[] = []
+    const fetchFn = (async (_url: any, init: any) => {
+      calls.push(JSON.parse(init.body))
+      return new Response(JSON.stringify({ access_token: "design-token", refresh_token: "design-refresh", expires_in: 28800, scope: DESIGN_SCOPES.join(" ") }), { status: 200 })
+    })
+    const login = createDesignLogin({ store, createSession: sessionFactory, fetchFn, now: () => NOW })
+    const { state } = login.startRaw()
+    const result = await login.exchange({ code: `some-code#${state}` })
+    expect(result.status).toBe(200)
+    expect((result.body as any).success).toBe(true)
+    expect(calls[0].grant_type).toBe("authorization_code")
+    expect(calls[0].code).toBe("some-code")
+    expect(store.data?.accessToken).toBe("design-token")
+    expect(store.data?.refreshToken).toBe("design-refresh")
+  })
+
+  it("exchange() rejects an unknown or expired state", async () => {
+    const login = createDesignLogin({ store: memoryStore(), createSession: sessionFactory, now: () => NOW })
+    const result = await login.exchange({ code: "some-code#state-does-not-exist" })
+    expect(result.status).toBe(400)
+    expect((result.body as any).error.type).toBe("session_expired")
+  })
+
+  it("exchange() rejects a missing code", async () => {
+    const login = createDesignLogin({ store: memoryStore(), createSession: sessionFactory, now: () => NOW })
+    const result = await login.exchange({})
+    expect(result.status).toBe(400)
+    expect((result.body as any).error.type).toBe("invalid_request")
+  })
+
+  it("sessions are single-use", async () => {
+    const store = memoryStore()
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ access_token: "t", expires_in: 60 }), { status: 200 }))
+    const login = createDesignLogin({ store, createSession: sessionFactory, fetchFn, now: () => NOW })
+    const { state } = login.startRaw()
+    expect((await login.exchange({ code: `c#${state}` })).status).toBe(200)
+    expect((await login.exchange({ code: `c#${state}` })).status).toBe(400)
+  })
+
+  it("sessions expire after 10 minutes", async () => {
+    const store = memoryStore()
+    let now = NOW
+    const login = createDesignLogin({ store, createSession: sessionFactory, now: () => now })
+    const { state } = login.startRaw()
+    now += 11 * 60 * 1000
+    const result = await login.exchange({ code: `c#${state}` })
+    expect(result.status).toBe(400)
+    expect((result.body as any).error.type).toBe("session_expired")
+  })
+
+  it("a failed token exchange surfaces as 502", async () => {
+    const fetchFn = (async () => new Response("denied", { status: 403 }))
+    const login = createDesignLogin({ store: memoryStore(), createSession: sessionFactory, fetchFn, now: () => NOW })
+    const { state } = login.startRaw()
+    const result = await login.exchange({ code: `c#${state}` })
+    expect(result.status).toBe(502)
+    expect((result.body as any).error.type).toBe("token_exchange_failed")
+  })
+})

--- a/src/__tests__/mcp-grep-tool.test.ts
+++ b/src/__tests__/mcp-grep-tool.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for the opencode MCP grep tool (src/mcpTools.ts).
+ *
+ * The grep tool must not pass user-controlled input through a shell:
+ * interpolating `pattern`/`include`/`path` into an `exec()` string lets a
+ * crafted tool call run arbitrary commands. It must also treat grep's
+ * exit code 1 (no matches) as a normal empty result, not an error.
+ * From #543 by @sittitep.
+ */
+import { describe, it, expect, mock } from "bun:test"
+import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const capturedTools = new Map<string, (args: any) => Promise<any>>()
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  tool: (name: string, _desc: string, _schema: any, handler: (args: any) => Promise<any>) => {
+    capturedTools.set(name, handler)
+    return { name, handler }
+  },
+  createSdkMcpServer: (opts: any) => opts,
+}))
+
+import { createOpencodeMcpServer } from "../mcpTools"
+
+createOpencodeMcpServer()
+const grep = capturedTools.get("grep")!
+
+describe("mcpTools grep tool", () => {
+  it("registers a grep tool", () => {
+    expect(typeof grep).toBe("function")
+  })
+
+  it("finds matches in a directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grep-test-"))
+    try {
+      writeFileSync(join(dir, "a.txt"), "hello needle world\n")
+      const result = await grep({ pattern: "needle", path: dir })
+      expect(result.isError).toBeUndefined()
+      expect(result.content[0].text).toContain("needle")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns (no matches) for grep exit code 1, not an error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grep-test-"))
+    try {
+      writeFileSync(join(dir, "a.txt"), "nothing here\n")
+      const result = await grep({ pattern: "zzz_not_present_zzz", path: dir })
+      expect(result.isError).toBeUndefined()
+      expect(result.content[0].text).toBe("(no matches)")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not execute shell metacharacters in the pattern", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grep-test-"))
+    const pwned = join(dir, "pwned")
+    try {
+      writeFileSync(join(dir, "a.txt"), "innocent content\n")
+      await grep({ pattern: `x"; touch "${pwned}"; echo "`, path: dir })
+      expect(existsSync(pwned)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("does not execute shell metacharacters in the include pattern", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grep-test-"))
+    const pwned = join(dir, "pwned2")
+    try {
+      writeFileSync(join(dir, "a.txt"), "innocent content\n")
+      await grep({ pattern: "innocent", path: dir, include: `*" --include="*"; touch "${pwned}"; echo "` })
+      expect(existsSync(pwned)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/mcp-grep-tool.test.ts
+++ b/src/__tests__/mcp-grep-tool.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the opencode MCP grep tool (src/mcpTools.ts).
+ * Tests for the opencode MCP grep tool handler (src/grepTool.ts).
  *
  * The grep tool must not pass user-controlled input through a shell:
  * interpolating `pattern`/`include`/`path` into an `exec()` string lets a
@@ -7,38 +7,20 @@
  * exit code 1 (no matches) as a normal empty result, not an error.
  * From #543 by @sittitep.
  */
-import { describe, it, expect, mock } from "bun:test"
+import { describe, it, expect } from "bun:test"
 import { mkdtempSync, writeFileSync, existsSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-
-const capturedTools = new Map<string, (args: any) => Promise<any>>()
-
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  tool: (name: string, _desc: string, _schema: any, handler: (args: any) => Promise<any>) => {
-    capturedTools.set(name, handler)
-    return { name, handler }
-  },
-  createSdkMcpServer: (opts: any) => opts,
-}))
-
-import { createOpencodeMcpServer } from "../mcpTools"
-
-createOpencodeMcpServer()
-const grep = capturedTools.get("grep")!
+import { runGrepTool } from "../grepTool"
 
 describe("mcpTools grep tool", () => {
-  it("registers a grep tool", () => {
-    expect(typeof grep).toBe("function")
-  })
-
   it("finds matches in a directory", async () => {
     const dir = mkdtempSync(join(tmpdir(), "grep-test-"))
     try {
       writeFileSync(join(dir, "a.txt"), "hello needle world\n")
-      const result = await grep({ pattern: "needle", path: dir })
+      const result = await runGrepTool({ pattern: "needle", path: dir })
       expect(result.isError).toBeUndefined()
-      expect(result.content[0].text).toContain("needle")
+      expect(result.content[0]!.text).toContain("needle")
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -48,9 +30,9 @@ describe("mcpTools grep tool", () => {
     const dir = mkdtempSync(join(tmpdir(), "grep-test-"))
     try {
       writeFileSync(join(dir, "a.txt"), "nothing here\n")
-      const result = await grep({ pattern: "zzz_not_present_zzz", path: dir })
+      const result = await runGrepTool({ pattern: "zzz_not_present_zzz", path: dir })
       expect(result.isError).toBeUndefined()
-      expect(result.content[0].text).toBe("(no matches)")
+      expect(result.content[0]!.text).toBe("(no matches)")
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -61,7 +43,7 @@ describe("mcpTools grep tool", () => {
     const pwned = join(dir, "pwned")
     try {
       writeFileSync(join(dir, "a.txt"), "innocent content\n")
-      await grep({ pattern: `x"; touch "${pwned}"; echo "`, path: dir })
+      await runGrepTool({ pattern: `x"; touch "${pwned}"; echo "`, path: dir })
       expect(existsSync(pwned)).toBe(false)
     } finally {
       rmSync(dir, { recursive: true, force: true })
@@ -73,7 +55,7 @@ describe("mcpTools grep tool", () => {
     const pwned = join(dir, "pwned2")
     try {
       writeFileSync(join(dir, "a.txt"), "innocent content\n")
-      await grep({ pattern: "innocent", path: dir, include: `*" --include="*"; touch "${pwned}"; echo "` })
+      await runGrepTool({ pattern: "innocent", path: dir, include: `*" --include="*"; touch "${pwned}"; echo "` })
       expect(existsSync(pwned)).toBe(false)
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/src/grepTool.ts
+++ b/src/grepTool.ts
@@ -1,0 +1,33 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+const getCwd = () => process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR ?? process.cwd()
+
+/**
+ * The MCP grep tool handler (registered in mcpTools.ts; lives here so it can
+ * be unit-tested directly). Uses execFile (no shell) so pattern/include/path
+ * can never be interpreted as shell syntax. From #543 by @sittitep.
+ */
+export async function runGrepTool(args: { pattern: string; path?: string; include?: string }) {
+  try {
+    const searchPath = args.path || getCwd()
+    const includePattern = args.include || "*"
+    const grepArgs = ["-rn", `--include=${includePattern}`, args.pattern, searchPath]
+    const { stdout } = await execFileAsync("grep", grepArgs, { maxBuffer: 10 * 1024 * 1024 })
+    return {
+      content: [{ type: "text" as const, text: stdout || "(no matches)" }]
+    }
+  } catch (error: unknown) {
+    // grep exits with code 1 when no matches are found — not a real error
+    const grepError = error as { code?: number; stdout?: string }
+    if (grepError.code === 1) {
+      return { content: [{ type: "text" as const, text: grepError.stdout || "(no matches)" }] }
+    }
+    return {
+      content: [{ type: "text" as const, text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true
+    }
+  }
+}

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -2,11 +2,12 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk"
 import { z } from "zod"
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
-import { exec } from "node:child_process"
+import { exec, execFile } from "node:child_process"
 import { promisify } from "node:util"
 import { glob as globLib } from "glob"
 
 const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 
 const getCwd = () => process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR ?? process.cwd()
 
@@ -180,14 +181,17 @@ export function createOpencodeMcpServer() {
         try {
           const searchPath = args.path || getCwd()
           const includePattern = args.include || "*"
-          
-          let cmd = `grep -rn --include="${includePattern}" "${args.pattern}" "${searchPath}" 2>/dev/null || true`
-          const { stdout } = await execAsync(cmd, { maxBuffer: 10 * 1024 * 1024 })
-          
+          const grepArgs = ["-rn", `--include=${includePattern}`, args.pattern, searchPath]
+          const { stdout } = await execFileAsync("grep", grepArgs, { maxBuffer: 10 * 1024 * 1024 })
           return {
             content: [{ type: "text", text: stdout || "(no matches)" }]
           }
-        } catch (error) {
+        } catch (error: unknown) {
+          // grep exits with code 1 when no matches are found — not a real error
+          const grepError = error as { code?: number; stdout?: string }
+          if (grepError.code === 1) {
+            return { content: [{ type: "text", text: grepError.stdout || "(no matches)" }] }
+          }
           return {
             content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
             isError: true

--- a/src/mcpTools.ts
+++ b/src/mcpTools.ts
@@ -2,12 +2,12 @@ import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk"
 import { z } from "zod"
 import * as fs from "node:fs/promises"
 import * as path from "node:path"
-import { exec, execFile } from "node:child_process"
+import { exec } from "node:child_process"
 import { promisify } from "node:util"
 import { glob as globLib } from "glob"
+import { runGrepTool } from "./grepTool"
 
 const execAsync = promisify(exec)
-const execFileAsync = promisify(execFile)
 
 const getCwd = () => process.env.MERIDIAN_WORKDIR ?? process.env.CLAUDE_PROXY_WORKDIR ?? process.cwd()
 
@@ -177,27 +177,7 @@ export function createOpencodeMcpServer() {
         path: z.string().optional().describe("Directory or file to search in"),
         include: z.string().optional().describe("File pattern to include, e.g., *.ts")
       },
-      async (args) => {
-        try {
-          const searchPath = args.path || getCwd()
-          const includePattern = args.include || "*"
-          const grepArgs = ["-rn", `--include=${includePattern}`, args.pattern, searchPath]
-          const { stdout } = await execFileAsync("grep", grepArgs, { maxBuffer: 10 * 1024 * 1024 })
-          return {
-            content: [{ type: "text", text: stdout || "(no matches)" }]
-          }
-        } catch (error: unknown) {
-          // grep exits with code 1 when no matches are found — not a real error
-          const grepError = error as { code?: number; stdout?: string }
-          if (grepError.code === 1) {
-            return { content: [{ type: "text", text: grepError.stdout || "(no matches)" }] }
-          }
-          return {
-            content: [{ type: "text", text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
-            isError: true
-          }
-        }
-      }
+      runGrepTool
     )
   ]
   })

--- a/src/proxy/design.ts
+++ b/src/proxy/design.ts
@@ -1,0 +1,316 @@
+/**
+ * Claude Design MCP proxy — token store, auth resolution, and login flow.
+ *
+ * Meridian proxies https://api.anthropic.com/v1/design/* so Claude Design
+ * MCP tools work through the same local endpoint as everything else. The
+ * Design API needs OAuth scopes (user:design:read/write) that the standard
+ * Meridian OAuth flow does not request, so a dedicated /design-login flow
+ * obtains and stores a separate design token.
+ *
+ * Originally prototyped in #543 by @sittitep, who discovered the load-bearing
+ * upstream quirks encoded here (404-for-missing-scopes, the silent GET SSE
+ * stream, and the accept-encoding double-decompression hazard).
+ *
+ * This module holds all logic; server.ts only mounts routes.
+ */
+import { homedir } from "node:os"
+import { join, dirname } from "node:path"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import type { CredentialStore } from "./tokenRefresh"
+import {
+  createManualOAuthSession,
+  parseAuthorizationCodeInput,
+  OAUTH_TOKEN_URL,
+  OAUTH_CLIENT_ID,
+  OAUTH_REDIRECT_URI,
+} from "./profileCli"
+
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+export const DESIGN_SCOPES = ["user:design:read", "user:design:write"]
+export const DESIGN_UPSTREAM_ORIGIN = "https://api.anthropic.com"
+
+/** Tokens expiring within this window are treated as already stale. */
+const EXPIRY_SKEW_MS = 60_000
+const LOGIN_SESSION_TTL_MS = 10 * 60 * 1000
+
+export interface DesignTokenData {
+  accessToken: string
+  refreshToken?: string
+  expiresAt: number
+  scopes?: string[]
+}
+
+export interface DesignTokenStore {
+  read(): Promise<DesignTokenData | null>
+  write(data: DesignTokenData): Promise<void>
+}
+
+export function defaultDesignTokenPath(): string {
+  return process.env.MERIDIAN_DESIGN_TOKEN_PATH || join(homedir(), ".config", "meridian", "design-token.json")
+}
+
+export function createFileDesignTokenStore(path: string = defaultDesignTokenPath()): DesignTokenStore {
+  return {
+    async read() {
+      try {
+        const raw = await readFile(path, "utf-8")
+        const data = JSON.parse(raw) as Partial<DesignTokenData>
+        if (typeof data.accessToken === "string" && typeof data.expiresAt === "number") {
+          return data as DesignTokenData
+        }
+        return null
+      } catch {
+        return null
+      }
+    },
+    async write(data) {
+      await mkdir(dirname(path), { recursive: true })
+      await writeFile(path, JSON.stringify(data), { mode: 0o600 })
+    },
+  }
+}
+
+export function isDesignTokenFresh(data: DesignTokenData, now: number = Date.now()): boolean {
+  return data.expiresAt > now + EXPIRY_SKEW_MS
+}
+
+/**
+ * Returns a usable design access token: the stored one if fresh, otherwise
+ * the result of a refresh_token grant (persisted back to the store). Null
+ * when there is no token or the refresh fails — callers fall back to
+ * profile credentials and the upstream tells the user to /design-login.
+ */
+export async function getDesignAccessToken(opts: {
+  store: DesignTokenStore
+  fetchFn?: FetchLike
+  now?: number
+}): Promise<string | null> {
+  const now = opts.now ?? Date.now()
+  const fetchFn = opts.fetchFn ?? fetch
+  const data = await opts.store.read()
+  if (!data) return null
+  if (isDesignTokenFresh(data, now)) return data.accessToken
+  if (!data.refreshToken) return null
+
+  let response: Response
+  try {
+    response = await fetchFn(OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        client_id: OAUTH_CLIENT_ID,
+        refresh_token: data.refreshToken,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+  } catch {
+    return null
+  }
+  if (!response.ok) return null
+
+  let tokenData: { access_token?: string; refresh_token?: string; expires_in?: number; expires_at?: number; scope?: string }
+  try {
+    tokenData = await response.json() as typeof tokenData
+  } catch {
+    return null
+  }
+  if (!tokenData.access_token) return null
+
+  const refreshed: DesignTokenData = {
+    accessToken: tokenData.access_token,
+    refreshToken: tokenData.refresh_token ?? data.refreshToken,
+    expiresAt: tokenData.expires_at ?? now + (tokenData.expires_in ?? 8 * 60 * 60) * 1000,
+    scopes: tokenData.scope?.split(" ").filter(Boolean) ?? data.scopes,
+  }
+  await opts.store.write(refreshed)
+  return refreshed.accessToken
+}
+
+/**
+ * Auth precedence for upstream Design API requests:
+ * design token → profile API key → profile OAuth token → Max credential
+ * store. The design token comes first because it is the only credential
+ * guaranteed to carry the design scopes.
+ */
+export async function resolveDesignAuthHeaders(opts: {
+  designToken: string | null
+  profile: { type: string; env: Record<string, string | undefined> }
+  credentialStore?: CredentialStore
+  ensureFresh?: (store: CredentialStore) => Promise<unknown>
+}): Promise<Record<string, string>> {
+  if (opts.designToken) return { Authorization: `Bearer ${opts.designToken}` }
+  const { profile } = opts
+  if (profile.type === "api" && profile.env.ANTHROPIC_API_KEY) {
+    return { "x-api-key": profile.env.ANTHROPIC_API_KEY }
+  }
+  if (profile.type === "oauth-token" && profile.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    return { Authorization: `Bearer ${profile.env.CLAUDE_CODE_OAUTH_TOKEN}` }
+  }
+  if (opts.credentialStore) {
+    if (opts.ensureFresh) await opts.ensureFresh(opts.credentialStore).catch(() => {})
+    const creds = await opts.credentialStore.read()
+    const token = creds?.claudeAiOauth?.accessToken
+    if (token) return { Authorization: `Bearer ${token}` }
+  }
+  return {}
+}
+
+/**
+ * Headers forwarded upstream. accept-encoding is pinned to identity:
+ * Node's fetch auto-decompresses gzip but keeps the content-encoding
+ * header, so MCP SDK clients receiving the re-served body would try to
+ * decompress it a second time and fail to parse.
+ */
+export function buildDesignForwardHeaders(
+  getHeader: (name: string) => string | undefined,
+  authHeaders: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "anthropic-version": getHeader("anthropic-version") || "2023-06-01",
+    "accept-encoding": "identity",
+    ...authHeaders,
+  }
+  for (const name of ["content-type", "anthropic-beta", "mcp-session-id"]) {
+    const value = getHeader(name)
+    if (value) headers[name] = value
+  }
+  return headers
+}
+
+const HOP_BY_HOP = new Set([
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "upgrade",
+])
+
+/** Forward all upstream headers (including mcp-session-id) minus hop-by-hop. */
+export function filterUpstreamResponseHeaders(headers: Iterable<[string, string]>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of headers) {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) out[key] = value
+  }
+  return out
+}
+
+// NOTE: agent-specific — the Design API returns 404 (not 401) for OAuth
+// tokens that lack user:design:read/write scopes. Both statuses mean the
+// user needs to run /design-login.
+export function isDesignAuthFailure(status: number): boolean {
+  return status === 401 || status === 404
+}
+
+export interface DesignLoginResult {
+  status: number
+  body: unknown
+}
+
+export interface DesignLogin {
+  /** Start a login session; returns the JSON body for GET /design-login. */
+  start(): { authorizeUrl: string; instructions: string }
+  /** Like start() but also exposes the state, for tests. */
+  startRaw(): { authorizeUrl: string; state: string }
+  /** Handle POST /design-login: exchange the pasted code for a token. */
+  exchange(body: unknown): Promise<DesignLoginResult>
+}
+
+export function createDesignLogin(deps: {
+  store: DesignTokenStore
+  createSession?: (scopes: string[]) => { authorizeUrl: string; codeVerifier: string; state: string }
+  fetchFn?: FetchLike
+  now?: () => number
+}): DesignLogin {
+  const createSession = deps.createSession ?? createManualOAuthSession
+  const fetchFn = deps.fetchFn ?? fetch
+  const now = deps.now ?? Date.now
+  const sessions = new Map<string, { codeVerifier: string; expiresAt: number }>()
+
+  const startRaw = () => {
+    for (const [state, session] of sessions) {
+      if (session.expiresAt < now()) sessions.delete(state)
+    }
+    const session = createSession(DESIGN_SCOPES)
+    sessions.set(session.state, { codeVerifier: session.codeVerifier, expiresAt: now() + LOGIN_SESSION_TTL_MS })
+    return { authorizeUrl: session.authorizeUrl, state: session.state }
+  }
+
+  return {
+    startRaw,
+
+    start() {
+      const { authorizeUrl } = startRaw()
+      return {
+        authorizeUrl,
+        instructions:
+          'Open the URL in your browser. After authorizing, POST the code to /design-login with body { "code": "<paste-code-here>" }',
+      }
+    },
+
+    async exchange(rawBody) {
+      const body = (rawBody && typeof rawBody === "object" ? rawBody : {}) as { code?: string; state?: string }
+      const parsed = body.code ? parseAuthorizationCodeInput(body.code) : null
+      if (!parsed) {
+        return { status: 400, body: { type: "error", error: { type: "invalid_request", message: "Missing or invalid 'code' field." } } }
+      }
+
+      const stateKey = parsed.state ?? body.state
+      const stored = stateKey ? sessions.get(stateKey) : undefined
+      if (!stateKey || !stored || stored.expiresAt < now()) {
+        return {
+          status: 400,
+          body: { type: "error", error: { type: "session_expired", message: "OAuth session expired or not found. Call GET /design-login to start a new session." } },
+        }
+      }
+      sessions.delete(stateKey)
+
+      let response: Response
+      try {
+        response = await fetchFn(OAUTH_TOKEN_URL, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            grant_type: "authorization_code",
+            client_id: OAUTH_CLIENT_ID,
+            code: parsed.code,
+            redirect_uri: OAUTH_REDIRECT_URI,
+            code_verifier: stored.codeVerifier,
+            state: stateKey,
+          }),
+          signal: AbortSignal.timeout(30_000),
+        })
+      } catch (err) {
+        return { status: 502, body: { type: "error", error: { type: "upstream_error", message: err instanceof Error ? err.message : String(err) } } }
+      }
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        return {
+          status: 502,
+          body: { type: "error", error: { type: "token_exchange_failed", message: `Token exchange failed (${response.status}): ${text.slice(0, 200)}` } },
+        }
+      }
+
+      const tokenData = await response.json() as { access_token?: string; refresh_token?: string; expires_in?: number; expires_at?: number; scope?: string }
+      if (!tokenData.access_token) {
+        return { status: 502, body: { type: "error", error: { type: "token_exchange_failed", message: "Token response missing access_token." } } }
+      }
+
+      const expiresAt = tokenData.expires_at ?? now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+      const scopes = tokenData.scope?.split(" ").filter(Boolean) ?? DESIGN_SCOPES
+
+      try {
+        await deps.store.write({ accessToken: tokenData.access_token, refreshToken: tokenData.refresh_token, expiresAt, scopes })
+      } catch (err) {
+        return { status: 500, body: { type: "error", error: { type: "storage_error", message: `Failed to store design token: ${err instanceof Error ? err.message : String(err)}` } } }
+      }
+
+      return { status: 200, body: { success: true, scopes } }
+    },
+  }
+}

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -22,9 +22,9 @@ import { createPlatformCredentialStore } from "./tokenRefresh"
 const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
-const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
-const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -79,7 +79,8 @@ function base64Url(bytes: Buffer): string {
   return bytes.toString("base64url")
 }
 
-export function createManualOAuthSession(): ManualOAuthSession {
+export function createManualOAuthSession(scopes?: string[]): ManualOAuthSession {
+  const scopeList = scopes ?? OAUTH_SCOPES
   const codeVerifier = base64Url(randomBytes(32))
   const state = base64Url(randomBytes(32))
   const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url")
@@ -88,7 +89,7 @@ export function createManualOAuthSession(): ManualOAuthSession {
   url.searchParams.set("client_id", OAUTH_CLIENT_ID)
   url.searchParams.set("response_type", "code")
   url.searchParams.set("redirect_uri", OAUTH_REDIRECT_URI)
-  url.searchParams.set("scope", OAUTH_SCOPES.join(" "))
+  url.searchParams.set("scope", scopeList.join(" "))
   url.searchParams.set("code_challenge", codeChallenge)
   url.searchParams.set("code_challenge_method", "S256")
   url.searchParams.set("state", state)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono"
 import { cors } from "hono/cors"
+import { stream } from "hono/streaming"
 import { serve } from "@hono/node-server"
 import type { Server } from "node:http"
 import { homedir } from "node:os"
@@ -50,6 +51,16 @@ import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, rend
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, type CredentialStore } from "./tokenRefresh"
+import {
+  createFileDesignTokenStore,
+  createDesignLogin,
+  getDesignAccessToken,
+  resolveDesignAuthHeaders,
+  buildDesignForwardHeaders,
+  filterUpstreamResponseHeaders,
+  isDesignAuthFailure,
+  DESIGN_UPSTREAM_ORIGIN,
+} from "./design"
 import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
@@ -446,6 +457,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   app.use("/plugins", requireAuth)
   app.use("/settings/*", requireAuth)
   app.use("/settings", requireAuth)
+  app.use("/design-login", requireAuth)
   app.use("/auth/*", requireAuth)
 
   app.get("/", (c) => {
@@ -456,7 +468,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         status: "ok",
         service: "meridian",
         format: "anthropic",
-        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/responses", "/v1/models", "/telemetry", "/metrics", "/health"]
+        endpoints: ["/v1/messages", "/messages", "/v1/chat/completions", "/v1/responses", "/v1/models", "/v1/design/*", "/design-login", "/telemetry", "/metrics", "/health"]
       })
     }
     return c.html(landingHtml)
@@ -4018,6 +4030,91 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         recoverPreviousCommand: `claude --resume ${recovery.previousClaudeSessionId}`,
         note: "Previous session was replaced — if your current session has lost context, try the previous session ID.",
       } : {}),
+    })
+  })
+
+  // --- Claude Design MCP Proxy (#543) ---
+  // All logic lives in ./design; these routes only wire HTTP.
+  const designTokenStore = createFileDesignTokenStore()
+  const designLogin = createDesignLogin({ store: designTokenStore })
+
+  app.get("/design-login", (c) => c.json(designLogin.start()))
+
+  app.post("/design-login", async (c) => {
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ type: "error", error: { type: "invalid_request", message: "Request body must be JSON with a 'code' field." } }, 400)
+    }
+    const result = await designLogin.exchange(body)
+    if (result.status === 200) plog(`[PROXY] Design token stored via /design-login`)
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: { "content-type": "application/json" },
+    })
+  })
+
+  // GET requests to the design MCP are SSE streams for server-initiated
+  // events. Anthropic's Design API pushes nothing over them, so proxying the
+  // GET upstream leaves the MCP client hanging with zero bytes. Serve a
+  // lightweight local keep-alive stream instead.
+  app.get("/v1/design/*", (c) => {
+    c.status(200)
+    c.header("content-type", "text/event-stream")
+    c.header("cache-control", "no-cache")
+    return stream(c, async (s) => {
+      while (!s.aborted) {
+        await s.write(": keepalive\n\n")
+        await s.sleep(15_000)
+      }
+    })
+  })
+
+  // POST requests proxy the MCP JSON-RPC to Anthropic's Design API with
+  // auth resolved by the design module (design token first, then profile
+  // credentials).
+  app.post("/v1/design/*", async (c) => {
+    const profile = resolveProfile(
+      finalConfig.profiles,
+      finalConfig.defaultProfile,
+      c.req.header("x-meridian-profile") || undefined
+    )
+    const url = new URL(c.req.url)
+    const upstreamUrl = `${DESIGN_UPSTREAM_ORIGIN}${url.pathname}${url.search}`
+
+    const designToken = await getDesignAccessToken({ store: designTokenStore })
+    const authHeaders = await resolveDesignAuthHeaders({
+      designToken,
+      profile,
+      credentialStore: credentialStoreForProfile(profile),
+      ensureFresh: ensureFreshToken,
+    })
+
+    const body = await c.req.arrayBuffer()
+    const forwardHeaders = buildDesignForwardHeaders((name) => c.req.header(name), authHeaders)
+
+    let upstreamRes: Response
+    try {
+      upstreamRes = await fetch(upstreamUrl, { method: "POST", headers: forwardHeaders, body })
+    } catch (err) {
+      return c.json(
+        { type: "error", error: { type: "upstream_error", message: err instanceof Error ? err.message : String(err) } },
+        502
+      )
+    }
+
+    if (isDesignAuthFailure(upstreamRes.status)) {
+      return c.json(
+        { type: "error", error: { type: "auth_error", message: "Unauthorized. Run /design-login to authorize Claude Design (adds user:design:read/write scopes)." } },
+        401
+      )
+    }
+
+    plog(`[PROXY] DESIGN upstream=${upstreamRes.status}`)
+    return new Response(upstreamRes.body, {
+      status: upstreamRes.status,
+      headers: filterUpstreamResponseHeaders(upstreamRes.headers.entries()),
     })
   })
 


### PR DESCRIPTION
Takes #543 by @sittitep across the finish line. His POC discovered every load-bearing upstream quirk this encodes — the 404-for-missing-scopes, the silent GET SSE stream, and the accept-encoding double-decompression hazard — and this PR preserves that work with him as co-author.

## What changed from the POC
- **Extracted to `src/proxy/design.ts`** per the module-boundary rules — token store, refresh, auth precedence, header construction, and the login session lifecycle are all directly unit-testable; server.ts only mounts routes.
- **Token refresh implemented**: the stored refresh token is now used on expiry (the POC stored it but let the token die after ~8h). Refresh-on-read, persisted back to the store.
- **Tests**: 24 unit + 9 integration (mocked upstream through the HTTP layer) + 4 for the extracted grep-injection fix. Full suite 2165 pass / 0 fail, typecheck clean.
- **Stowaway landed**: the `mcpTools` grep tool no longer shell-interpolates user input (execFile, exit-1-as-no-matches) — extracted to `src/grepTool.ts` as its own credited commit.
- **Docs**: README section (client config + login flow), endpoints table, ARCHITECTURE/CLAUDE.md module maps.
- Dropped the POC's `bin/start.sh`.

## Live verification
Full MCP handshake against the **real** Design API through the proxy: `initialize` → `notifications/initialized` → `tools/list` all return 200 with real Claude Design tool definitions, using only the Max credential store token. Notably the upstream appears to have relaxed since early July — the 404-for-missing-scopes did not trigger on these operations — so `/design-login` is now the fallback for rejected tokens rather than a hard prerequisite. The mapping and login flow remain in place for accounts/operations the upstream still rejects.

Closes #543