### PR TITLE
feat(codex): resume SDK sessions across turns via prompt_cache_key

### DIFF
--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -153,3 +153,50 @@ describe("/v1/responses (#475)", () => {
     expect(body.endpoints).toContain("/v1/responses")
   })
 })
+
+describe("/v1/responses session continuity via prompt_cache_key (#655)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedOptions = []
+  })
+
+  const userItem = {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "Read data.txt and count the lines." }],
+  }
+  // A mid-loop turn: same user item plus the echoed tool call and its output.
+  // The last translated message is a tool_result — exactly the shape the
+  // headerless client-driven-loop guard excludes from fingerprint resume.
+  const loopTurnInput = [
+    userItem,
+    { type: "function_call", name: "exec_command", arguments: '{"cmd":"wc -l data.txt"}', call_id: "toolu_test_1" },
+    { type: "function_call_output", call_id: "toolu_test_1", output: "3 data.txt" },
+  ]
+
+  it("resumes the prior SDK session when prompt_cache_key is stable", async () => {
+    const app = createTestApp()
+    const key = "019f7945-b6ff-77a2-85a7-8875ef953a68"
+    const r1 = await postResponses(app, { model: "claude-sonnet-5", input: [userItem], stream: false, prompt_cache_key: key })
+    expect(r1.status).toBe(200)
+    const r2 = await postResponses(app, { model: "claude-sonnet-5", input: loopTurnInput, stream: false, prompt_cache_key: key })
+    expect(r2.status).toBe(200)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[0].resume).toBeUndefined()
+    expect(capturedOptions[1].resume).toBe("sdk-1")
+  })
+
+  it("does not resume across different prompt_cache_keys", async () => {
+    const app = createTestApp()
+    await postResponses(app, { model: "claude-sonnet-5", input: [userItem], stream: false, prompt_cache_key: "conv-a" })
+    await postResponses(app, { model: "claude-sonnet-5", input: loopTurnInput, stream: false, prompt_cache_key: "conv-b" })
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+
+  it("without prompt_cache_key, tool-loop turns stay independent (pre-#655 behavior)", async () => {
+    const app = createTestApp()
+    await postResponses(app, { model: "claude-sonnet-5", input: [userItem], stream: false })
+    await postResponses(app, { model: "claude-sonnet-5", input: loopTurnInput, stream: false })
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+})

--- a/src/proxy/adapters/codex.ts
+++ b/src/proxy/adapters/codex.ts
@@ -27,4 +27,14 @@ export const codexAdapter: AgentAdapter = {
   usesPassthrough() {
     return true
   },
+  // Codex sends a per-conversation `prompt_cache_key` (mirrored in its
+  // client_metadata as session_id); the /v1/responses route forwards it as
+  // this header so consecutive turns resume the same SDK session (#655) —
+  // which both preserves Claude's signed thinking across turns and keeps
+  // the prompt cache warm. Keyed sessions also bypass the headerless
+  // client-driven-loop guard (see server.ts) safely: distinct conversations
+  // carry distinct keys, so concurrent runs can't collide.
+  getSessionId(c) {
+    return c.req.header("x-codex-session")
+  },
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3698,6 +3698,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       "Content-Type": "application/json",
       "x-meridian-agent": "codex",
     }
+    // NOTE: agent-specific (Codex) — prompt_cache_key is Codex's stable
+    // per-conversation id (mirrored as session_id in its client_metadata).
+    // Forward it as the codex adapter's session header so consecutive turns
+    // resume the same SDK session: Claude's signed thinking then persists
+    // across turns natively and the prompt cache stays warm (#655).
+    const promptCacheKey = (rawBody as { prompt_cache_key?: unknown }).prompt_cache_key
+    if (typeof promptCacheKey === "string" && promptCacheKey.length > 0) {
+      internalHeaders["x-codex-session"] = promptCacheKey
+    }
     const xApiKey = c.req.header("x-api-key")
     if (xApiKey) internalHeaders["x-api-key"] = xApiKey
     const authz = c.req.header("authorization")


### PR DESCRIPTION
Finishes #655 — but not the way the issue sketched. Investigation first, then the fix:

## What we found (live probes against 1.54.0)

- The issue's premise was right: every Codex turn ran `lineage: new` — a fresh SDK session per turn. Root cause is the headerless **client-driven-loop guard** (the #552-era protection): Codex sends no session header and every mid-loop turn ends in a `tool_result`, so its turns were deliberately excluded from fingerprint resume.
- A byte-stable synthetic two-turn sequence **does** resume — the lineage machinery works on this path; Codex just had no key.
- Captured Codex's real payloads: it sends a stable per-conversation **`prompt_cache_key`** (identical across all turns; mirrored as `session_id` in its `client_metadata`). That's a purpose-built session key.

## The fix

Forward `prompt_cache_key` as `x-codex-session` on the internal hop; the codex adapter reads it as its session id. Keyed sessions take the header path, which is immune to the #552 concurrency hazard (distinct conversations carry distinct keys).

## Why this supersedes the encrypted_content plan

Resumed sessions inherit Claude's **signed thinking blocks natively** — the CLI replays its own transcript. The `encrypted_content` bridge could never work anyway: there is no SDK input channel to inject foreign signed thinking into a fresh session. Bonus: the prompt cache stays warm across turns instead of resetting.

## Verification

- 3 new integration tests (turn 2 with a tool_result tail resumes on same key; different keys don't; keyless keeps pre-existing behavior). Full suite 2169 pass / 0 fail, typecheck clean.
- **Live on Codex 0.144**: 7-request tool loop ran `new → 6× continuation (resume: true)`, cache reads grew monotonically (11,440 → 13,551), and the final resumed transcript carried **5 signed thinking blocks** inherited from prior turns.

Remaining edge (acceptable, same as every adapter): thinking is lost if the SDK session itself is lost (proxy restart/eviction) — the turn falls back to a fresh replay of Codex's full history.

Closes #655