### PR TITLE
fix: explicit session keys override the fork/subagent independence guard

### DIFF
--- a/src/__tests__/pi-adapter.test.ts
+++ b/src/__tests__/pi-adapter.test.ts
@@ -11,14 +11,24 @@ describe("piAdapter — identity", () => {
 })
 
 describe("piAdapter.getSessionId", () => {
-  it("always returns undefined — Pi sends no session header", () => {
+  it("returns x-session-affinity when present (orchestrator-supplied session key)", () => {
     const ctx = {
-      req: { header: () => "any-value" },
+      req: {
+        header: (name: string) =>
+          name === "x-session-affinity" ? "worker-run-1" : undefined,
+      },
+    }
+    expect(piAdapter.getSessionId(ctx as any)).toBe("worker-run-1")
+  })
+
+  it("returns undefined without the affinity header — bare pi sends no session header", () => {
+    const ctx = {
+      req: { header: () => undefined },
     }
     expect(piAdapter.getSessionId(ctx as any)).toBeUndefined()
   })
 
-  it("returns undefined even when x-opencode-session is present", () => {
+  it("ignores x-opencode-session (opencode's header is not pi's)", () => {
     const ctx = {
       req: {
         header: (name: string) =>

--- a/src/__tests__/proxy-source-keyed-session.test.ts
+++ b/src/__tests__/proxy-source-keyed-session.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Explicit session keys override the fork/subagent independence guard.
+ *
+ * The x-meridian-source independence guard exists to stop HEADERLESS
+ * concurrent flows from colliding on the shared (firstUserMessage, cwd)
+ * fingerprint. Pylon's long-lived subagent workers were swept up by it:
+ * every turn of a worker conversation fresh-replayed (lineage=new, no
+ * store), so prompt-cache efficiency decayed to the static-prefix floor
+ * (97% → 31%) and turn latency grew with conversation length.
+ *
+ * Keyed sessions cannot collide — distinct workers carry distinct keys —
+ * so an explicit session id disables the guard while headerless forks
+ * keep today's behavior. The pi adapter (pylon's runtime) gains
+ * x-session-affinity support so its flows can carry a key at all.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let mockMessages: unknown[] = []
+let capturedOptions: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedOptions.push(params.options || {})
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const TURN_1 = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "subagent worker task prompt" }],
+}
+
+const TURN_2 = {
+  ...TURN_1,
+  messages: [
+    ...TURN_1.messages,
+    { role: "assistant", content: "ok" },
+    { role: "user", content: "keep going" },
+  ],
+}
+
+describe("explicit session keys override the independence guard", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedOptions = []
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    clearSessionCache()
+  })
+
+  it("pi subagent-worker WITH x-session-affinity resumes across turns", async () => {
+    const app = createTestApp()
+    const headers = {
+      "x-meridian-agent": "pi",
+      "x-meridian-source": "subagent-worker",
+      "x-session-affinity": "worker-run-abc123",
+    }
+    expect((await post(app, TURN_1, headers)).status).toBe(200)
+    expect((await post(app, TURN_2, headers)).status).toBe(200)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[0].resume).toBeUndefined()
+    expect(capturedOptions[1].resume).toBe("test-session")
+  })
+
+  it("pi subagent-worker WITHOUT a session key keeps the independence guard (no resume)", async () => {
+    const app = createTestApp()
+    const headers = { "x-meridian-agent": "pi", "x-meridian-source": "subagent-worker" }
+    await post(app, TURN_1, headers)
+    await post(app, TURN_2, headers)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+
+  it("distinct affinity keys stay isolated (no cross-worker resume)", async () => {
+    const app = createTestApp()
+    const base = { "x-meridian-agent": "pi", "x-meridian-source": "subagent-worker" }
+    await post(app, TURN_1, { ...base, "x-session-affinity": "worker-a" })
+    await post(app, TURN_2, { ...base, "x-session-affinity": "worker-b" })
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+
+  it("fork sources with an explicit key resume too (opencode header path)", async () => {
+    const app = createTestApp()
+    const headers = {
+      "x-meridian-source": "fork-memory-extract",
+      "x-opencode-session": "ses_fork_1",
+    }
+    await post(app, TURN_1, headers)
+    await post(app, TURN_2, headers)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBe("test-session")
+  })
+})

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -70,11 +70,15 @@ export const piAdapter: AgentAdapter = {
   name: "pi",
 
   /**
-   * Pi sends no session header.
-   * Session continuity is maintained via fingerprint-based cache lookup.
+   * Pi itself sends no session header — continuity normally comes from the
+   * fingerprint cache. Orchestrators driving the pi runtime (pylon) can opt
+   * into explicit, collision-proof session keys via x-session-affinity;
+   * an explicit key also overrides the fork/subagent independence guard so
+   * long-lived subagent conversations resume instead of fresh-replaying
+   * every turn (which decayed prompt-cache hits to the static-prefix floor).
    */
-  getSessionId(_c: Context): string | undefined {
-    return undefined
+  getSessionId(c: Context): string | undefined {
+    return c.req.header("x-session-affinity")
   },
 
   extractWorkingDirectory(body: any): string | undefined {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -817,8 +817,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // preserve fingerprint resume instead of treating their tool results
         // as unrelated headerless workflow requests.
         const isClientDrivenLoop = adapterBase !== "claude-code" && !agentSessionId && lastIsToolResult
+        // The fork/subagent independence guard protects HEADERLESS flows from
+        // colliding on the shared (firstUserMessage, cwd) fingerprint. An
+        // explicit session key can't collide — distinct flows carry distinct
+        // keys — so keyed requests resume normally even when marked as a
+        // fork/subagent source. Without this, pylon's long-lived subagent
+        // workers fresh-replayed every turn: prompt-cache hits decayed to the
+        // static-prefix floor and turn latency grew with conversation length.
         const isIndependentSession =
-          requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-") || isClientDrivenLoop || false
+          (!agentSessionId && (requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-"))) ||
+          isClientDrivenLoop || false
         // If the previous turn's background drain is still persisting this
         // session (streaming early stop), wait briefly so the lookup below
         // sees the stored session instead of falling to a fresh replay.


### PR DESCRIPTION
## Problem

Field-observed via pylon (pi runtime): a subagent worker's conversation grew 1 → 45 messages and **every turn ran as a fresh session** — `lineage=new`, different SDK session each request, cache hit-rate decaying 97% → 31%, turn totals up to 122s.

Root cause chain:
1. Pylon stamps subagent children with `x-meridian-source: subagent-<name>` (adopted when the header was observability-only).
2. Meridian's independence guard (built for pylon's one-shot forks) forces `fork-*`/`subagent-*` sources to skip session lookup **and** the end-of-turn store — sweeping up long-lived multi-turn subagent conversations.
3. The pi adapter had no session-header support at all (`getSessionId → undefined`), so there was no escape hatch.

Every worker turn fresh-replayed its whole history: only the static system+tools prefix still cached (the 31% floor) and latency grew with conversation length.

## Fix

- The guard now applies only to **headerless** fork/subagent requests — its actual purpose (fingerprint-collision protection) is preserved verbatim, since explicit keys cannot collide.
- The pi adapter reads `x-session-affinity` (the header the OpenCode adapter already accepts), so orchestrators driving pi can opt into collision-proof keyed sessions.

Same shape as the Codex `prompt_cache_key` fix (#665). Backward compatible: clients that send no key get today's behavior byte-for-byte.

## Tests
- New `proxy-source-keyed-session.test.ts`: keyed subagent resumes across turns; headerless subagent still doesn't; distinct keys stay isolated; keyed `fork-*` (opencode header) resumes.
- `pi-adapter.test.ts` updated to the new getSessionId contract.
- Full suite 2174 pass / 0 fail; typecheck clean.

Pylon-side companion change (stamping unique `x-session-affinity` per subagent conversation) lands separately in pylon-orchestrator.