### PR TITLE
fix: never rename a subagent_type that is already a registered agent

### DIFF
--- a/src/__tests__/proxy-agent-fuzzy-match.test.ts
+++ b/src/__tests__/proxy-agent-fuzzy-match.test.ts
@@ -114,21 +114,43 @@ describe("Fallback to generic agent", () => {
 })
 
 describe("resolveAgentAlias", () => {
-  it("returns the canonical target for known aliases", () => {
-    expect(resolveAgentAlias("general-purpose")).toBe("general")
-    expect(resolveAgentAlias("General-Purpose")).toBe("general")
-    expect(resolveAgentAlias("code-reviewer")).toBe("oracle")
-    expect(resolveAgentAlias("planner")).toBe("plan")
+  it("never renames a name that is already a registered agent (#671)", () => {
+    // A user's real `code-review` agent must not be renamed to "oracle".
+    expect(resolveAgentAlias("code-review", ["code-review", "build"])).toBe("code-review")
+    expect(resolveAgentAlias("reviewer", ["reviewer"])).toBe("reviewer")
+    expect(resolveAgentAlias("analyzer", ["analyzer", "general"])).toBe("analyzer")
+  })
+
+  it("preserves the canonical config casing on exact match", () => {
+    expect(resolveAgentAlias("Code-Review", ["code-review"])).toBe("code-review")
+    expect(resolveAgentAlias("EXPLORE", ["explore"])).toBe("explore")
+  })
+
+  it("applies an alias only when its target is a registered agent", () => {
+    // OMO setups: oracle exists, so the alias repair still works.
+    expect(resolveAgentAlias("code-reviewer", ["oracle", "build"])).toBe("oracle")
+    expect(resolveAgentAlias("general-purpose", ["general"])).toBe("general")
+    expect(resolveAgentAlias("planner", ["plan", "build"])).toBe("plan")
+  })
+
+  it("returns the lowercased original when the alias target is not registered", () => {
+    // Renaming to a nonexistent agent can only ever fail — keep the original.
+    expect(resolveAgentAlias("code-reviewer", ["build", "plan"])).toBe("code-reviewer")
+    expect(resolveAgentAlias("research", ["build"])).toBe("research")
+  })
+
+  it("never invents names when no agents are registered", () => {
+    expect(resolveAgentAlias("code-review", [])).toBe("code-review")
+    expect(resolveAgentAlias("general-purpose", [])).toBe("general-purpose")
   })
 
   it("returns the lowercased input when no alias applies", () => {
-    expect(resolveAgentAlias("explore")).toBe("explore")
-    expect(resolveAgentAlias("Explore")).toBe("explore")
-    expect(resolveAgentAlias("custom-agent")).toBe("custom-agent")
+    expect(resolveAgentAlias("custom-agent", ["build"])).toBe("custom-agent")
+    expect(resolveAgentAlias("Explore", [])).toBe("explore")
   })
 
   it("is case-insensitive for alias lookup", () => {
-    expect(resolveAgentAlias("GENERAL-PURPOSE")).toBe("general")
-    expect(resolveAgentAlias("Code-Reviewer")).toBe("oracle")
+    expect(resolveAgentAlias("GENERAL-PURPOSE", ["general"])).toBe("general")
+    expect(resolveAgentAlias("Code-Reviewer", ["oracle"])).toBe("oracle")
   })
 })

--- a/src/proxy/agentMatch.ts
+++ b/src/proxy/agentMatch.ts
@@ -63,10 +63,19 @@ const STRIP_SUFFIXES = ["-agent", "-tool", "-worker", "-task", " agent", " tool"
  * the SDK may validate against registered alias variants (e.g., "general-purpose"
  * is registered by `addCaseVariants`), but the client expects the canonical
  * agent name from its config ("general").
+ *
+ * The alias table exists to REPAIR invalid names, never to remap valid ones
+ * (#671): a name that already matches a registered agent is returned in the
+ * config's canonical casing, and an alias is applied only when its target is
+ * itself registered — renaming to a nonexistent agent can only ever fail.
  */
-export function resolveAgentAlias(input: string): string {
+export function resolveAgentAlias(input: string, validAgents: string[]): string {
   const lowered = input.toLowerCase()
-  return KNOWN_ALIASES[lowered] ?? lowered
+  const exact = validAgents.find(a => a.toLowerCase() === lowered)
+  if (exact) return exact
+  const alias = KNOWN_ALIASES[lowered]
+  if (alias && validAgents.includes(alias)) return alias
+  return lowered
 }
 
 export function fuzzyMatchAgentName(input: string, validAgents: string[]): string {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1240,7 +1240,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // canonical lowercase agent name that OpenCode's config declares.
                 let toolInput = normalizeToolInput(input.tool_input, clientTool?.input_schema)
                 if (toolName.toLowerCase() === "task" && toolInput?.subagent_type && typeof toolInput.subagent_type === "string") {
-                  toolInput = { ...toolInput, subagent_type: resolveAgentAlias(toolInput.subagent_type) }
+                  toolInput = { ...toolInput, subagent_type: resolveAgentAlias(toolInput.subagent_type, validAgentNames) }
                 }
                 // Decide whether to forward this captured tool_use, or drop it
                 // as an artifact of the nested SDK's internal loop. In
@@ -2630,7 +2630,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           try {
                             const parsed = JSON.parse(buffered) as Record<string, unknown>
                             if (typeof parsed.subagent_type === "string") {
-                              parsed.subagent_type = resolveAgentAlias(parsed.subagent_type)
+                              parsed.subagent_type = resolveAgentAlias(parsed.subagent_type, validAgentNames)
                             }
                             fixed = JSON.stringify(parsed)
                           } catch {


### PR DESCRIPTION
Fixes #671 — diagnosed with a precise root-cause writeup by @jesusmgg (down to the exact functions and the suggested rule; this PR implements it as suggested).

## Problem
`resolveAgentAlias()` applied the `KNOWN_ALIASES` table unconditionally at both passthrough call sites (PreToolUse capture + streaming Task-tool JSON buffer). Nine generic names (`code-review`, `reviewer`, `analyzer`, `debugger`, `architect`, …) map to `oracle` — an agent that only exists in oh-my-opencode setups — so any user with a real agent by one of those names got a guaranteed-failing rename: `Unknown agent type: oracle`.

## Fix
`resolveAgentAlias(input, validAgents)` now follows the rule `fuzzyMatchAgentName()` always had:
1. Exact case-insensitive match against registered agents wins (returned in the config's canonical casing).
2. An alias is applied **only when its target is itself registered** — so OMO setups keep the repair behavior exactly.
3. Otherwise the lowercased original passes through — renaming to a nonexistent agent can only ever fail.

Both call sites thread `validAgentNames` (already in scope).

## Tests
Rewrote the `resolveAgentAlias` suite around the new contract: registered-name protection, canonical casing, alias-only-when-target-exists (OMO preserved), no-agents-registered, case-insensitivity. Full suite 2178 pass / 0 fail, typecheck clean.