### PR TITLE
fix: serve bounded-stale OAuth usage on transient fetch failures

### DIFF
--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -221,6 +221,55 @@ describe("oauthUsage", () => {
     expect(getCalls()).toBe(2)
   })
 
+  test("serves the last-good snapshot (marked stale) when a later fetch fails upstream", async () => {
+    const { fetchImpl } = countingFetch((calls) =>
+      calls === 1
+        ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+        : new Response("boom", { status: 500 }))
+    const store = makeStore("t")
+    const first = await fetchOAuthUsage({ force: true, store, profileId: "flappy", fetchImpl })
+    expect(first?.stale).toBeUndefined()
+    const second = await fetchOAuthUsage({ force: true, store, profileId: "flappy", fetchImpl })
+    expect(second).not.toBeNull()
+    expect(second!.stale).toBe(true)
+    expect(second!.windows).toEqual(first!.windows)
+  })
+
+  test("serves the last-good snapshot when the credential read starts failing", async () => {
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    let token: string | null = "t"
+    const store: CredentialStore = {
+      async read() {
+        if (!token) return null
+        return { claudeAiOauth: { accessToken: token, refreshToken: "rt", expiresAt: Date.now() + 60_000 } } as any
+      },
+      async write() { return true },
+    }
+    const first = await fetchOAuthUsage({ force: true, store, profileId: "keyblip", fetchImpl })
+    expect(first).not.toBeNull()
+    token = null // Keychain read blip
+    const second = await fetchOAuthUsage({ force: true, store, profileId: "keyblip", fetchImpl })
+    expect(second).not.toBeNull()
+    expect(second!.stale).toBe(true)
+  })
+
+  test("stale fallback is bounded by staleMaxMs", async () => {
+    const { fetchImpl } = countingFetch((calls) =>
+      calls === 1
+        ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+        : new Response("boom", { status: 500 }))
+    const store = makeStore("t")
+    await fetchOAuthUsage({ force: true, store, profileId: "aged", fetchImpl })
+    const second = await fetchOAuthUsage({ force: true, store, profileId: "aged", fetchImpl, staleMaxMs: 0 })
+    expect(second).toBeNull()
+  })
+
+  test("failure with no prior snapshot still returns null", async () => {
+    const fetchImpl = fixedFetch(() => new Response("boom", { status: 500 }))
+    const result = await fetchOAuthUsage({ force: true, store: makeStore("t"), profileId: "nofirst", fetchImpl })
+    expect(result).toBeNull()
+  })
+
   test("ISO date with timezone parses correctly to UTC ms", async () => {
     const iso = "2026-04-26T22:30:00.221857+00:00"
     const fetchImpl = fixedFetch(() => new Response(JSON.stringify({

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -84,9 +84,16 @@ export interface OAuthUsageSnapshot {
   windows: OAuthUsageWindow[]
   extraUsage: OAuthExtraUsageInfo | null
   fetchedAt: number
+  /** Set when this is a previous snapshot served because a fresh fetch
+   *  failed transiently (credential-read blip, upstream error). */
+  stale?: boolean
 }
 
 const CACHE_TTL_MS_DEFAULT = 30_000
+// A transiently failing fetch serves the last-good snapshot instead of
+// blanking the consumer ("no usage data yet" flapping) — but only within
+// this bound, so genuinely dead credentials still surface as missing data.
+const STALE_MAX_MS_DEFAULT = 15 * 60_000
 
 /** Per-profile cache. Key = profileId (or DEFAULT_KEY for the unscoped default). */
 const cacheByProfile = new Map<string, OAuthUsageSnapshot>()
@@ -196,6 +203,8 @@ async function callAnthropic(
 
 export interface FetchOAuthUsageOpts {
   ttlMs?: number
+  /** Max age of a last-good snapshot served on fetch failure (default 15 min). */
+  staleMaxMs?: number
   force?: boolean
   store?: CredentialStore
   profileId?: string | null
@@ -265,10 +274,29 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
 
   const store = opts?.store ?? createPlatformCredentialStore({ claudeConfigDir: opts?.claudeConfigDir })
 
+  const staleMaxMs = opts?.staleMaxMs ?? STALE_MAX_MS_DEFAULT
+  // On transient failure, serve the last-good snapshot (bounded) instead of
+  // null — a credential-read blip or upstream 5xx should not blank the
+  // consumer's usage display until the next successful fetch.
+  const staleOr = (reason: string): OAuthUsageSnapshot | null => {
+    const last = cacheByProfile.get(cacheKey)
+    if (last && Date.now() - last.fetchedAt < staleMaxMs) {
+      claudeLog("oauth_usage.serving_stale", { profile: cacheKey, reason, ageMs: Date.now() - last.fetchedAt })
+      return { ...last, stale: true }
+    }
+    return null
+  }
+
   const promise = (async () => {
     try {
       const token = await readAccessToken(store)
-      if (!token) return null
+      if (!token) {
+        // This read failing intermittently (e.g. a Keychain entry racing a
+        // token-refresh rewrite) was previously silent — log it so flapping
+        // usage displays are diagnosable.
+        claudeLog("oauth_usage.no_token", { profile: cacheKey })
+        return staleOr("no_token")
+      }
 
       let result = await callAnthropic(token, fetchImpl)
       if ("__status" in result && result.__status === 401) {
@@ -276,15 +304,15 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
         const refreshed = await refreshOAuthToken(store)
         if (!refreshed) {
           claudeLog("oauth_usage.refresh_failed", { profile: cacheKey })
-          return null
+          return staleOr("refresh_failed")
         }
         const newToken = await readAccessToken(store)
-        if (!newToken) return null
+        if (!newToken) return staleOr("no_token_after_refresh")
         result = await callAnthropic(newToken, fetchImpl)
       }
       if ("__status" in result) {
         claudeLog("oauth_usage.upstream_error", { profile: cacheKey, status: result.__status })
-        return null
+        return staleOr(`upstream_${result.__status}`)
       }
 
       const snapshot = buildSnapshot(result)
@@ -292,7 +320,7 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
       return snapshot
     } catch (err) {
       claudeLog("oauth_usage.fetch_failed", { profile: cacheKey, error: err instanceof Error ? err.message : String(err) })
-      return null
+      return staleOr("exception")
     } finally {
       inflightByProfile.delete(cacheKey)
     }


### PR DESCRIPTION
## Symptom
The home page's per-profile usage card flapped: a profile showed real usage bars, then "no usage data yet", then bars again — observed on the `work` profile repeatedly.

## Root cause (live-diagnosed)
`fetchOAuthUsage` returns `null` on any failure once its 30s cache expires — with **no stale fallback** — and the most common failure mode turned out to be `readAccessToken()` returning nothing (the profile's Keychain credential read intermittently failing, most plausibly racing token-refresh rewrites of the same entry). That path was also **completely silent**: a live repro returned zero buckets with no log line anywhere, which is why the flapping resisted diagnosis.

## Fix
- Every failure path (`no_token`, `refresh_failed`, upstream non-401, exception) now serves the profile's last-good snapshot, marked `stale: true`, bounded to 15 minutes (`staleMaxMs` opt) — so a transient blip bridges instead of blanking, while genuinely dead credentials still surface as missing data.
- The silent no-token path now logs `oauth_usage.no_token`, and stale serves log `oauth_usage.serving_stale` with the reason — the underlying Keychain race is now diagnosable from telemetry.

## Tests
4 new: stale-on-upstream-failure, stale-on-credential-blip (the observed mode), `staleMaxMs` bound, and no-prior-snapshot still null. Full suite 2182 pass / 0 fail, typecheck clean.