### PR TITLE
feat(ui): per-account weekly pace on home; remove the telemetry Usage tab

### DIFF
--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -76,27 +76,8 @@ export const dashboardHtml = `<!DOCTYPE html>
                 transition: all 0.15s; }
   .log-filter:hover { border-color: var(--accent); color: var(--text); }
   .log-filter.active { background: rgba(88,166,255,0.1); border-color: var(--accent); color: var(--accent); }
-
-  /* Usage tab */
-  .usage-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 12px; margin-bottom: 16px; }
-  .ucard { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 18px; }
-  .ucard-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
-  .ucard-title { font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.5px; }
-  .ucard-reset { font-size: 11px; color: var(--muted); white-space: nowrap; }
-  .ucard-pct { font-size: 32px; font-weight: 600; font-variant-numeric: tabular-nums; line-height: 1.1; margin-top: 8px; color: var(--green); }
-  .ucard.warn .ucard-pct { color: var(--yellow); }
-  .ucard.high .ucard-pct { color: var(--red); }
-  .ucard-sub { font-size: 12px; color: var(--muted); margin-top: 8px; min-height: 16px; }
-  .ubar { position: relative; height: 8px; border-radius: 4px; background: var(--border); overflow: visible; margin-top: 12px; }
-  .ubar-fill { height: 100%; border-radius: 4px; background: var(--green); transition: width 0.4s ease; max-width: 100%; }
-  .ucard.warn .ubar-fill { background: var(--yellow); }
-  .ucard.high .ubar-fill { background: var(--red); }
-  .ubar-marker { position: absolute; top: -3px; bottom: -3px; width: 2px; background: var(--text); opacity: 0.55; border-radius: 1px; }
-  .pace-pill { display: inline-block; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; }
-  .pace-pill.on, .pace-pill.under { background: rgba(63,185,80,0.15); color: var(--green); }
-  .pace-pill.ahead { background: rgba(210,153,34,0.18); color: var(--yellow); }
-  .pace-pill.over { background: rgba(248,81,73,0.15); color: var(--red); }
   .usage-note { font-size: 11px; color: var(--muted); }
+
 ` + profileBarCss + `
 </style>
 </head>
@@ -191,22 +172,20 @@ function setLogFilter(filter) {
 async function refresh() {
   const w = $('#window').value;
   try {
-    const [summary, reqs, logs, quota] = await Promise.all([
+    const [summary, reqs, logs] = await Promise.all([
       fetch('/telemetry/summary?window=' + w).then(r => r.json()),
       fetch('/telemetry/requests?limit=50&since=' + (Date.now() - Number(w))).then(r => r.json()),
       fetch('/telemetry/logs?limit=200&since=' + (Date.now() - Number(w))).then(r => r.json()),
-      fetch('/v1/usage/quota').then(r => r.json()).catch(() => null),
     ]);
-    render(summary, reqs, logs, quota);
+    render(summary, reqs, logs);
     $('#lastUpdate').textContent = 'Updated ' + new Date().toLocaleTimeString();
   } catch (e) {
     $('#content').innerHTML = '<div class="empty">Failed to load telemetry</div>';
   }
 }
 
-function render(s, reqs, logs, quota) {
-  const hasUsage = quota && quota.buckets && quota.buckets.some(b => b.utilization != null);
-  if (s.totalRequests === 0 && (!logs || logs.length === 0) && !hasUsage) {
+function render(s, reqs, logs) {
+  if (s.totalRequests === 0 && (!logs || logs.length === 0)) {
     $('#content').innerHTML = '<div class="empty">No requests recorded yet. Send a request through the proxy to see telemetry.</div>';
     return;
   }
@@ -224,7 +203,6 @@ function render(s, reqs, logs, quota) {
     +   'Requests<span class="tab-badge">' + reqs.length + '</span></div>'
     + '<div class="tab' + (activeTab === 'logs' ? ' active' : '') + '" data-tab="logs" onclick="switchTab(&apos;logs&apos;)">'
     +   'Logs<span class="tab-badge">' + logs.length + '</span></div>'
-    + '<div class="tab' + (activeTab === 'usage' ? ' active' : '') + '" data-tab="usage" onclick="switchTab(&apos;usage&apos;)">Usage</div>'
     + '</div>';
 
   // ==================== Overview tab ====================
@@ -414,10 +392,6 @@ function render(s, reqs, logs, quota) {
   }
   html += '</div>'; // end logs panel
 
-  // ==================== Usage tab ====================
-  html += '<div id="panel-usage" class="tab-panel' + (activeTab === 'usage' ? ' active' : '') + '">';
-  html += renderUsage(quota);
-  html += '</div>'; // end usage panel
 
   $('#content').innerHTML = html;
 }
@@ -427,101 +401,6 @@ function card(label, value, detail) {
     + '<div class="card-value">' + value + '</div>'
     + (detail ? '<div class="card-detail">' + detail + '</div>' : '')
     + '</div>';
-}
-
-// ---- Usage tab helpers (mirror src/telemetry/profileUsage.ts; unit-tested there) ----
-function classifyUtil(u) {
-  if (u == null || !isFinite(u)) return '';
-  if (u >= 0.85) return 'high';
-  if (u >= 0.6) return 'warn';
-  return '';
-}
-function resetIn(resetsAt) {
-  if (resetsAt == null || !isFinite(resetsAt)) return '';
-  var ms = resetsAt - Date.now();
-  if (ms <= 0) return 'resetting…';
-  var m = Math.floor(ms / 60000);
-  if (m < 60) return 'resets in ' + Math.max(1, m) + 'm';
-  var h = Math.floor(m / 60), rm = m % 60;
-  if (h < 24) return 'resets in ' + h + 'h' + (rm ? ' ' + rm + 'm' : '');
-  var d = Math.floor(h / 24), rh = h % 24;
-  return 'resets in ' + d + 'd' + (rh ? ' ' + rh + 'h' : '');
-}
-function pct(u) { return Math.round(Math.max(0, u) * 100); }
-
-function usageCard(title, bucket) {
-  if (!bucket || bucket.utilization == null) {
-    return '<div class="ucard"><div class="ucard-head"><span class="ucard-title">' + title + '</span></div>'
-      + '<div class="ucard-pct" style="color:var(--muted)">—</div>'
-      + '<div class="ucard-sub">No data yet</div></div>';
-  }
-  var u = bucket.utilization;
-  var cls = classifyUtil(u);
-  var fill = Math.min(100, pct(u));
-  return '<div class="ucard ' + cls + '">'
-    + '<div class="ucard-head"><span class="ucard-title">' + title + '</span>'
-    +   '<span class="ucard-reset">' + resetIn(bucket.resetsAt) + '</span></div>'
-    + '<div class="ucard-pct">' + pct(u) + '<span style="font-size:16px;font-weight:500;color:var(--muted)">%</span></div>'
-    + '<div class="ubar"><div class="ubar-fill" style="width:' + fill + '%"></div></div>'
-    + '<div class="ucard-sub">of your ' + title.split('·')[1].trim() + ' allowance used</div>'
-    + '</div>';
-}
-
-// Weekly pace: actual vs. expected (even) consumption at this point in the 7-day window.
-function paceCard(weekly) {
-  if (!weekly || weekly.utilization == null || weekly.resetsAt == null) {
-    return '<div class="ucard"><div class="ucard-head"><span class="ucard-title">Weekly Pace</span></div>'
-      + '<div class="ucard-pct" style="color:var(--muted)">—</div>'
-      + '<div class="ucard-sub">Needs weekly usage data</div></div>';
-  }
-  var WEEK = 7 * 86400000;
-  var start = weekly.resetsAt - WEEK;
-  var elapsed = Math.max(0, Math.min(1, (Date.now() - start) / WEEK));
-  var actual = pct(weekly.utilization);
-  var expected = Math.round(elapsed * 100);
-  var delta = actual - expected;
-  var projected = elapsed >= 0.1 ? Math.round((Math.max(0, weekly.utilization) / elapsed) * 100) : null;
-
-  var pill, label;
-  if (delta > 7) { pill = 'ahead'; label = '+' + delta + '% ahead of pace'; }
-  else if (delta < -7) { pill = 'under'; label = Math.abs(delta) + '% under pace'; }
-  else { pill = 'on'; label = 'On pace'; }
-  if (projected != null && projected >= 100) { pill = 'over'; label = 'On track to run out'; }
-
-  var fill = Math.min(100, actual);
-  var mark = Math.min(100, expected);
-  var proj = projected == null ? '—' : projected + '%';
-  return '<div class="ucard">'
-    + '<div class="ucard-head"><span class="ucard-title">Weekly Pace</span>'
-    +   '<span class="ucard-reset">' + Math.round(elapsed * 100) + '% through week</span></div>'
-    + '<div style="margin-top:8px"><span class="pace-pill ' + pill + '">' + label + '</span></div>'
-    + '<div class="ubar"><div class="ubar-fill" style="width:' + fill + '%;background:' + (pill === 'over' ? 'var(--red)' : pill === 'ahead' ? 'var(--yellow)' : 'var(--green)') + '"></div>'
-    +   '<div class="ubar-marker" style="left:' + mark + '%" title="Expected at even pace"></div></div>'
-    + '<div class="ucard-sub">' + actual + '% used vs ' + expected + '% expected · at this rate ~' + proj + ' by reset</div>'
-    + '</div>';
-}
-
-function renderUsage(quota) {
-  if (!quota || !quota.buckets) {
-    return '<div class="empty">Usage data unavailable.</div>';
-  }
-  var by = {};
-  quota.buckets.forEach(function (b) { by[b.type] = b; });
-  var session = by['five_hour'], weekly = by['seven_day'];
-  if ((!session || session.utilization == null) && (!weekly || weekly.utilization == null)) {
-    return '<div class="empty">No usage data yet — Anthropic reports it after your first request through Meridian.</div>';
-  }
-  var h = '<div class="usage-cards">'
-    + usageCard('Session · 5h', session)
-    + usageCard('Weekly · 7d', weekly)
-    + paceCard(weekly)
-    + '</div>';
-  var asOf = quota.asOf ? new Date(quota.asOf).toLocaleTimeString() : '';
-  h += '<div class="usage-note">'
-    + (quota.profile ? 'Profile: ' + quota.profile + ' · ' : '')
-    + 'Reported by Anthropic' + (asOf ? ' · as of ' + asOf : '')
-    + '</div>';
-  return h;
 }
 
 $('#autoRefresh').addEventListener('change', function() {

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -57,6 +57,8 @@ export const landingHtml = `<!DOCTYPE html>
   .usage-row .w-label { color: var(--muted); width: 64px; flex-shrink: 0; }
   .usage-row .w-bar { flex: 1; height: 6px; background: var(--surface2); border-radius: 3px; overflow: hidden; }
   .usage-row .w-fill { height: 100%; border-radius: 3px; }
+  .pace-row { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 8px; }
+  .pace-row .pace-text { flex: 1; font-weight: 600; font-size: 11px; }
   .usage-row .w-pct { width: 38px; text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
   .usage-row .w-reset { color: var(--muted); font-size: 11px; width: 76px; text-align: right; }
   .no-usage { font-size: 12px; color: var(--muted); padding: 4px 0; }
@@ -96,6 +98,29 @@ function usd(v){if(v==null)return '—';if(v>0&&v<0.01)return '$'+v.toFixed(4);i
 var WIN_LABELS={five_hour:'5h',seven_day:'7d',seven_day_opus:'7d Opus',seven_day_sonnet:'7d Sonnet',seven_day_fable:'7d Fable',seven_day_oauth_apps:'7d Apps',seven_day_cowork:'7d Cowork',seven_day_omelette:'7d Omelette'};
 function winLabel(t){if(WIN_LABELS[t])return WIN_LABELS[t];return t.replace(/^seven_day_/,'7d ').replace(/_/g,' ').replace(/\b\w/g,function(c){return c.toUpperCase()})}
 function utilColor(u){return u>=0.85?'var(--red)':u>=0.6?'var(--yellow)':'var(--green)'}
+// Mirrors computeWeeklyPace in src/telemetry/profileUsage.ts (unit-tested
+// there): actual vs expected (even) consumption at this point in the 7-day
+// window, with the dashboard's over-promotion when the projection hits 100%.
+function weeklyPace(u,resetsAt){
+  var WEEK=7*86400000;
+  if(u==null||resetsAt==null)return null;
+  var el=Math.max(0,Math.min(1,(Date.now()-(resetsAt-WEEK))/WEEK));
+  var actual=Math.round(Math.max(0,u)*100);
+  var expected=Math.round(el*100);
+  var delta=actual-expected;
+  var proj=el>=0.1?Math.round((Math.max(0,u)/el)*100):null;
+  var st=delta>7?'ahead':delta<-7?'under':'on';
+  if(proj!=null&&proj>=100)st='over';
+  return {actual:actual,expected:expected,delta:delta,proj:proj,status:st};
+}
+function paceText(pc){
+  if(pc.status==='over')return 'on track to run out';
+  if(pc.status==='ahead')return '+'+pc.delta+'% ahead of pace';
+  if(pc.status==='under')return Math.abs(pc.delta)+'% under pace';
+  return 'on pace';
+}
+function paceColor(pc){return pc.status==='over'?'var(--red)':pc.status==='ahead'?'var(--yellow)':'var(--green)'}
+
 function resetIn(ts){if(ts==null)return '';var d=ts-Date.now();if(d<=0)return 'resetting…';var m=Math.ceil(d/60000);if(m<60)return 'in '+m+'m';var h=Math.floor(m/60);if(h<24)return 'in '+h+'h'+(m%60?' '+(m%60)+'m':'');var days=Math.floor(h/24);return 'in '+days+'d'+(h%24?' '+(h%24)+'h':'')}
 
 function introSection(h){
@@ -142,6 +167,12 @@ function profileSection(q,s,pl,h){
         +'<span class="w-pct" style="color:'+utilColor(w.utilization)+'">'+pct+'%</span>'
         +'<span class="w-reset">'+resetIn(w.resetsAt)+'</span></div>';
     }
+    var weekly=null;
+    for(var j=0;j<wins.length;j++){if(wins[j].type==='seven_day')weekly=wins[j]}
+    var pc=weekly?weeklyPace(weekly.utilization,weekly.resetsAt):null;
+    if(pc)rows+='<div class="usage-row pace-row"><span class="w-label">pace</span>'
+      +'<span class="pace-text" style="color:'+paceColor(pc)+'">'+paceText(pc)+'</span>'
+      +'<span class="w-reset">'+(pc.proj!=null?'~'+pc.proj+'% by reset':'')+'</span></div>';
     if(!rows)rows='<div class="no-usage">no usage data yet</div>';
     var switchable=multi&&p.configured&&!p.isActive;
     var badge=p.isActive?'<span class="active-pill">Active</span>':switchable?'<span class="switch-hint">Click to activate</span>':'';


### PR DESCRIPTION
Usage data appeared on three surfaces: the home account cards, the telemetry **Usage** tab, and the **Weekly Pace** card inside that tab. Consolidation per owner direction:

- **Telemetry Usage tab removed** entirely (nav, panel, its quota fetch, and the tab-only helpers/CSS — the `.usage-note` style the Overview cost note shares was kept).
- **Weekly pace moves to the home account cards** — pace is inherently per-account, so each card now renders a `pace` row under its usage windows: status-colored text (`on pace` / `n% under` / `+n% ahead` / `on track to run out`) plus the projected %-by-reset. The page JS mirrors the unit-tested `computeWeeklyPace` in `profileUsage.ts`, including the over-promotion when the projection reaches 100%.

Live-verified on the local instance: the personal card correctly shows `on track to run out · ~109% by reset` (63% used, 58% through the week), and /telemetry renders Overview/Requests/Logs only. Full suite + typecheck + design-conformance tests pass.