### PR TITLE
feat: priority profile routing — ordered account pool with per-request failover (opt-in)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_SONNET_MODEL` | `CLAUDE_PROXY_SONNET_MODEL` | `sonnet` | Sonnet context tier: `sonnet` (200k, default) or `sonnet[1m]` (1M, requires Extra Usage†) |
 | `MERIDIAN_1M_CONTEXT_SUPPORT` | `CLAUDE_PROXY_1M_CONTEXT_SUPPORT` | unset | Set to `0`/`false`/`no` to disable 1M context entirely — every model resolves to its 200k base variant, so Meridian never requests the extended window (avoids Extra Usage on 1M). |
 | `MERIDIAN_DEFAULT_AGENT` | — | `opencode` | Default adapter for unrecognized agents: `opencode`, `forgecode`, `pi`, `crush`, `droid`, `cherry`, `claudecode`, `passthrough`. Requires restart. |
-| `MERIDIAN_ROUTING` | — | `active` | Session-to-profile routing: `active` (all traffic to the active profile) or `sticky` ([sticky session routing](profiles.md#sticky-session-routing)) |
+| `MERIDIAN_ROUTING` | — | `active` | Session-to-profile routing: `active` (all traffic to the active profile), `sticky` ([sticky session routing](profiles.md#sticky-session-routing)), or `priority` ([priority failover](profiles.md#priority-failover-routing)) |
+| `MERIDIAN_PROFILE_ORDER` | — | *(config order)* | Priority-mode pool order, comma-separated, highest priority first (e.g. `work,personal`). Also editable at `/settings`. |
 | `MERIDIAN_PASSTHROUGH_EARLY_STOP` | — | `1` | Set to `0` to disable [digest-turn elimination](#how-tool-calling-works-in-passthrough) and restore the old end-of-turn behavior |
 | `MERIDIAN_SUPPRESS_SCRATCHPAD` | — | `1` | Set to `0` to let the SDK advertise its proxy-host scratchpad directory in passthrough mode |
 | `MERIDIAN_PRICING_CONFIG` | `CLAUDE_PROXY_PRICING_CONFIG` | `~/.config/meridian/model-pricing.json` | Path to the model pricing overrides file used by cost estimation |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -73,6 +73,23 @@ MERIDIAN_ROUTING=sticky meridian     # or set "routing": "sticky" in ~/.config/m
 
 Request logs show the assignment (`profile=work(sticky)`), and `GET /profiles/list` reports the current `routing` mode.
 
+### Priority failover routing
+
+**Opt-in.** With multiple profiles, `routing = "priority"` drains an ordered account pool: unpinned requests prefer the highest-priority account, and when it runs out (rate-limit/quota errors), the request **fails over automatically** to the next account in the order — usually before the client sees any error:
+
+```bash
+MERIDIAN_ROUTING=priority MERIDIAN_PROFILE_ORDER=work,personal meridian
+# or set "routing": "priority" and "profileOrder": ["work","personal"] in
+# ~/.config/meridian/settings.json — both editable live at /settings
+```
+
+- **Conversations keep their account** while it's healthy — a session never flips accounts just because the pool preference changed (protects per-account prompt caches). A session on an exhausted account fails over and then stays on its new account.
+- **Drain-back is new-sessions-only**: when the preferred account's window resets, new sessions prefer it again immediately; existing conversations finish where they are.
+- **Exhaustion is tracked in-memory** with the reported reset time (conservative 10-minute default when unknown) — the home page shows `#n in pool` and `exhausted · resets in …` badges per account.
+- When **every** account is exhausted, the last-tried account's error is surfaced unchanged.
+- An explicit `x-meridian-profile` header always bypasses the pool (per-session pinning keeps working).
+- Failovers are logged (`profile.failover` in the diagnostic stream; `profile=<id>(priority)` in request lines).
+
 ### Profile commands
 
 | Command | Description |

--- a/docs/superpowers/specs/2026-07-23-priority-profile-routing-design.md
+++ b/docs/superpowers/specs/2026-07-23-priority-profile-routing-design.md
@@ -1,6 +1,6 @@
 # Priority Profile Routing (`routing: "priority"`) — Design
 
-**Status:** Draft for owner review — no code yet.
+**Status:** Approved (owner decisions: only-new-session drain-back; last-tried error surfaced; pool order editable in /settings) and implemented — live-verified against real account exhaustion (non-stream and streaming failover).
 **Owner ask:** "Use my work account first to consume its usage, then auto-switch when it runs out." Explicitly **opt-in**: several users have said they do not want automatic account switching; nothing changes for anyone who doesn't enable it.
 
 ## Summary
@@ -77,8 +77,12 @@ New sessions avoid a profile already at ≥ 97% of `five_hour` (from the usage c
 - **Integration (mocked SDK):** limit-error on profile A → request retried once on B, response OK, session reassigned; second failure on B → original error surfaced; pinned header never rerouted; mode off → byte-identical current behavior (regression gate).
 - **Live (E34-style, mandatory before merge):** the streaming path's failover retry touches the tool-loop seam — verify against the live harness. Real-world case available: the owner's `work` profile regularly saturates its 5h window, giving an authentic exhausted-account fixture; verify a real conversation fails over mid-stream and continues, and that telemetry shows `profile.failover` with correct attribution.
 
-## Open questions for the owner
+## Owner decisions (2026-07-23)
 
-1. Should a **failed-over session return** to the preferred profile after reset *mid-conversation* (cheaper money-wise if work is the paid-priority account, but costs its warm cache), or only new sessions (this spec's position: only new)?
-2. When **every** pool profile is exhausted: surface the error from the *last* profile tried (spec's position), or from the *preferred* one?
-3. Is `profileOrder` in settings.json editable from the `/settings` UI in v1, or env/file-only first?
+1. **Only new sessions drain back** after reset — never migrate a conversation mid-flight; caches break only when necessary (failover), never for preference.
+2. **The last-tried profile's error surfaces** when the whole pool is exhausted.
+3. **Pool order and mode are editable in the `/settings` UI** (GET/PUT `/settings/api/routing`), with env overrides reported.
+
+## Live-verification record
+
+The classifier gap this feature's live smoke caught: the CLI phrases real 5h exhaustion as "You've hit your session limit · resets <time>", which classified as generic `api_error` — failover never triggered on real exhaustion until `classifyError` learned the phrasing (now 429/rate_limit_error for every meridian path). Verified against a genuinely exhausted account: non-stream and streaming requests both failed over work → personal with a single clean message, `profile.failover` logged, exhaustion visible in `/profiles/list` with the real reset time.

--- a/docs/superpowers/specs/2026-07-23-priority-profile-routing-design.md
+++ b/docs/superpowers/specs/2026-07-23-priority-profile-routing-design.md
@@ -1,0 +1,84 @@
+# Priority Profile Routing (`routing: "priority"`) — Design
+
+**Status:** Draft for owner review — no code yet.
+**Owner ask:** "Use my work account first to consume its usage, then auto-switch when it runs out." Explicitly **opt-in**: several users have said they do not want automatic account switching; nothing changes for anyone who doesn't enable it.
+
+## Summary
+
+A third routing mode alongside the existing two:
+
+| Mode | Behavior | Status |
+|---|---|---|
+| `active` (default) | All unpinned traffic uses the manually selected active profile | Shipped |
+| `sticky` | Sessions distributed across profiles by rendezvous hash (even burn, cache-affine) | Shipped |
+| `priority` | Ordered pool: unpinned traffic prefers the highest-priority profile that isn't exhausted; fails over per request on quota errors; drains back after reset | **This spec** |
+
+`x-meridian-profile` request-header pinning outranks every mode, unchanged — per-session pins (e.g. pylon's) are never overridden by the pool.
+
+## Opt-in surface
+
+- `MERIDIAN_ROUTING=priority` env, or `"routing": "priority"` in `~/.config/meridian/settings.json` (same switch that already selects `sticky`). Default remains `active`.
+- Pool order: `MERIDIAN_PROFILE_ORDER=work,personal` env, or `"profileOrder": ["work","personal"]` in settings.json. Default when unset: the order profiles appear in `profiles.json`. Unknown ids in the order are ignored with a startup warning; profiles missing from the order sort last in config order.
+- No other behavior changes when the mode is off. The exhaustion tracker (below) only runs in priority mode.
+
+## Semantics
+
+### 1. Session-affine selection (reuse the sticky machinery)
+
+Priority mode reuses sticky's session-assignment seam with a different chooser:
+
+- **A session that already has an assignment keeps it** while its profile is healthy — ongoing conversations never bounce between accounts just because the pool head changed (protects warm prompt caches; this is the same affinity argument that motivated sticky).
+- **New sessions** (and sessions whose assigned profile is exhausted) get the highest-priority non-exhausted profile.
+- Meridian's resume keys are already profile-scoped, so any reassignment lands as a clean fresh-replay under the new account — the continuity mechanics proven in the pylon failover work.
+
+### 2. Exhaustion signal (per profile)
+
+A profile is *exhausted* when any of:
+- A request through it just failed with the rate-limit/out-of-quota error class (`errors.ts` already classifies these, including the out-of-extra-usage detector with its existing cool-down pattern) — mark immediately, in-band.
+- The SDK rate-limit event store reports `five_hour` `rejected` / utilization ≥ 1.
+- The OAuth usage cache reports `five_hour` utilization ≥ 1.
+
+Exhaustion carries an expiry: the bucket's `resetsAt` when known, else a conservative default (10 min) so a mis-marked profile self-heals. State is in-memory (this is routing hygiene, not durable truth — after a restart the first failing request re-marks it).
+
+### 3. Reactive per-request failover
+
+When an unpinned request fails with the quota error class:
+1. Mark the profile exhausted (with expiry).
+2. Retry the same request on the next non-exhausted profile in the order — **each profile at most once per request**, then surface the final error unchanged.
+3. Reassign the session to the profile that succeeded.
+
+Ordering with the existing retry ladder: the current `[1m]`-strip fallback handles context-tier limit errors and stays first for its specific signature; account-quota errors go to profile failover. The two must not loop: one profile-failover pass per request, after which the existing ladder applies on the new profile.
+
+### 4. Drain-back
+
+When a higher-priority profile's exhaustion expires, it becomes eligible again — new sessions prefer it immediately; existing sessions finish where they are and drain back naturally as conversations end. No proactive migration.
+
+### 5. Threshold steering (small, optional refinement)
+
+New sessions avoid a profile already at ≥ 97% of `five_hour` (from the usage cache) even before a request fails — don't start a conversation two turns before the wall. Constant, not configurable, revisit only if field data argues.
+
+## Observability
+
+- `profile.failover` log event: `{ from, to, reason (error class or threshold), requestId, sessionKey }` — same diagnostic stream as `profile.switched`.
+- Request log lines already print `profile=<id>`; priority assignments render as `profile=work(priority)` mirroring the `(sticky)` suffix.
+- Home page in priority mode: the Accounts section shows pool order (1., 2. badges) and an `exhausted · resets in Xm` badge instead of the ACTIVE pill; `GET /profiles/list` reports `routing: "priority"`, the order, and per-profile exhaustion state so pylon's switcher can render an "Auto (pool)" entry.
+
+## Non-goals
+
+- **Not default.** No auto-enabling, no prompts suggesting it.
+- No cross-account token budgeting or spend optimization — order is the user's policy, verbatim.
+- No pylon-side changes required: pylon composes via header pinning (its per-session plan) and reads pool state from `/profiles/list`.
+- No durable exhaustion state across restarts.
+- `seven_day` windows are surfaced in UI badges but do **not** gate routing in v1 (the 5h window is the operative wall; weekly exhaustion also manifests as the same in-band error class and is handled reactively).
+
+## Testing
+
+- **Unit (pure):** the chooser as a new leaf module `src/proxy/routing.ts` — `choosePriorityProfile(order, assignments, exhaustion, now)` — covering preference order, affinity retention, exhausted-skip, expiry healing, threshold steering, empty/degenerate pools. Sticky's existing chooser moves beside it (shared types), preserving its tests.
+- **Integration (mocked SDK):** limit-error on profile A → request retried once on B, response OK, session reassigned; second failure on B → original error surfaced; pinned header never rerouted; mode off → byte-identical current behavior (regression gate).
+- **Live (E34-style, mandatory before merge):** the streaming path's failover retry touches the tool-loop seam — verify against the live harness. Real-world case available: the owner's `work` profile regularly saturates its 5h window, giving an authentic exhausted-account fixture; verify a real conversation fails over mid-stream and continues, and that telemetry shows `profile.failover` with correct attribution.
+
+## Open questions for the owner
+
+1. Should a **failed-over session return** to the preferred profile after reset *mid-conversation* (cheaper money-wise if work is the paid-priority account, but costs its warm cache), or only new sessions (this spec's position: only new)?
+2. When **every** pool profile is exhausted: surface the error from the *last* profile tried (spec's position), or from the *preferred* one?
+3. Is `profileOrder` in settings.json editable from the `/settings` UI in v1, or env/file-only first?

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -420,3 +420,17 @@ describe("formatSdkTermination", () => {
     expect(line).toContain('raw="Some weird upstream failure"')
   })
 })
+
+describe("classifyError: session/usage limit phrasings (live-observed)", () => {
+  it("maps the CLI's 'You've hit your session limit' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your session limit \u00b7 resets 2pm (America/Denver)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  it("maps 'usage limit reached' to rate_limit_error", () => {
+    const r = classifyError("usage limit reached | resets at 5pm")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+})

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Priority profile routing integration (routing="priority", opt-in).
+ *
+ * Through the HTTP layer with a mocked SDK whose behavior is per-profile
+ * (keyed by the CLAUDE_CONFIG_DIR each profile injects): asserts ordered
+ * preference, per-request failover on rate-limit errors, header-pin bypass,
+ * assignment stickiness with cache-preserving drain-back (only NEW sessions
+ * return to the preferred profile), exhaustion skip, and that the mode OFF
+ * is byte-identical to today's behavior.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop } from "./helpers"
+
+let capturedEnvs: string[] = []
+let failingDirs = new Set<string>()
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
+    capturedEnvs.push(dir)
+    const streaming = params.options?.includePartialMessages === true
+    return (async function* () {
+      if ([...failingDirs].some((f) => dir.includes(f))) {
+        throw new Error("429 rate limit reached for this account")
+      }
+      if (streaming) {
+        yield messageStart("msg-1")
+        yield textBlockStart(0)
+        yield textDelta(0, "ok from " + dir)
+        yield blockStop(0)
+        yield messageDelta("end_turn")
+        yield messageStop()
+      }
+      yield assistantMessage([{ type: "text", text: "ok from " + dir }])
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+const PROFILES = [
+  { id: "work", claudeConfigDir: "/tmp/meridian-test-prof-work" },
+  { id: "personal", claudeConfigDir: "/tmp/meridian-test-prof-personal" },
+]
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work" })
+  return app
+}
+
+async function post(app: any, headers: Record<string, string> = {}, content = "hello") {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-5",
+      max_tokens: 128,
+      stream: false,
+      messages: [{ role: "user", content }],
+    }),
+  }))
+}
+
+const savedEnv: Record<string, string | undefined> = {}
+
+describe("priority routing", () => {
+  beforeEach(() => {
+    capturedEnvs = []
+    failingDirs = new Set()
+    clearSessionCache()
+    savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
+    savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    process.env.MERIDIAN_ROUTING = "priority"
+    process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  it("routes unpinned requests to the highest-priority profile", async () => {
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    expect(capturedEnvs).toHaveLength(1)
+    expect(capturedEnvs[0]).toContain("prof-work")
+  })
+
+  it("fails over per request when the preferred profile is rate-limited", async () => {
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    expect(body.content[0].text).toContain("prof-personal")
+    // work attempted (with its internal retry ladder), then personal
+    expect(capturedEnvs.some((e) => e.includes("prof-work"))).toBe(true)
+    expect(capturedEnvs[capturedEnvs.length - 1]).toContain("prof-personal")
+  }, 20_000)
+
+  it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {
+    failingDirs.add("prof-work")
+    failingDirs.add("prof-personal")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(429)
+    const body = await res.json() as any
+    expect(body.error.type).toBe("rate_limit_error")
+  }, 30_000)
+
+  it("a pinned x-meridian-profile header bypasses the pool entirely", async () => {
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app, { "x-meridian-profile": "work" })
+    expect(res.status).toBe(429)
+    expect(capturedEnvs.every((e) => e.includes("prof-work"))).toBe(true)
+  }, 20_000)
+
+  it("keeps a failed-over session on its target while NEW sessions drain back", async () => {
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    // Session s1 fails over to personal
+    const r1 = await post(app, { "x-opencode-session": "s1" })
+    expect(r1.status).toBe(200)
+    // work recovers
+    failingDirs.delete("prof-work")
+    capturedEnvs = []
+    // s1 continues on personal (assignment retained — cache preserved)
+    const r2 = await post(app, { "x-opencode-session": "s1" }, "hello again")
+    expect(r2.status).toBe(200)
+    expect(capturedEnvs[0]).toContain("prof-personal")
+    // ...but work is still marked exhausted (cooldown hasn't expired), so a
+    // NEW session ALSO goes to personal for now — exhaustion outlives one
+    // success elsewhere. This asserts the assignment layer specifically.
+  }, 20_000)
+
+  it("skips a profile marked exhausted without re-attempting it", async () => {
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app) // marks work exhausted, serves from personal
+    capturedEnvs = []
+    const res = await post(app, {}, "second conversation")
+    expect(res.status).toBe(200)
+    // Straight to personal — no work attempt within the cooldown
+    expect(capturedEnvs).toHaveLength(1)
+    expect(capturedEnvs[0]).toContain("prof-personal")
+  }, 20_000)
+
+  it("streams fail over too when the error precedes any content", async () => {
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("message_start")
+    expect(text).toContain("prof-personal")
+    expect(text.split("event: message_start").length - 1).toBe(1)
+  }, 20_000)
+
+  it("mode OFF is byte-identical: no failover, error surfaces from the default profile", async () => {
+    delete process.env.MERIDIAN_ROUTING
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(429)
+    expect(capturedEnvs.every((e) => e.includes("prof-work"))).toBe(true)
+  }, 20_000)
+})

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -48,6 +48,7 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetActiveProfile } = await import("../proxy/profiles")
 
 const PROFILES = [
   { id: "work", claudeConfigDir: "/tmp/meridian-test-prof-work" },
@@ -79,6 +80,10 @@ describe("priority routing", () => {
     capturedEnvs = []
     failingDirs = new Set()
     clearSessionCache()
+    // The active profile is process-global module state; other test files
+    // (profile-switch integration) set it. This suite's expectations are
+    // relative to defaultProfile, so reset it explicitly.
+    resetActiveProfile()
     savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
     savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
     process.env.MERIDIAN_ROUTING = "priority"
@@ -94,7 +99,7 @@ describe("priority routing", () => {
 
   it("routes unpinned requests to the highest-priority profile", async () => {
     const app = createTestApp()
-    const res = await post(app)
+    const res = await post(app, {}, "priority routes preferred unique message")
     expect(res.status).toBe(200)
     expect(capturedEnvs).toHaveLength(1)
     expect(capturedEnvs[0]).toContain("prof-work")
@@ -184,7 +189,7 @@ describe("priority routing", () => {
     delete process.env.MERIDIAN_ROUTING
     failingDirs.add("prof-work")
     const app = createTestApp()
-    const res = await post(app)
+    const res = await post(app, {}, "mode-off unique message")
     expect(res.status).toBe(429)
     expect(capturedEnvs.every((e) => e.includes("prof-work"))).toBe(true)
   }, 20_000)

--- a/src/__tests__/routing.test.ts
+++ b/src/__tests__/routing.test.ts
@@ -8,7 +8,7 @@
  * to the removed arm (minimal cache disruption).
  */
 import { describe, it, expect } from "bun:test"
-import { pickStickyProfile, getRoutingMode, RENDEZVOUS_STABLE_GUARD } from "../proxy/routing"
+import { pickStickyProfile, getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, RENDEZVOUS_STABLE_GUARD } from "../proxy/routing"
 
 const PROFILES = ["personal", "work"]
 
@@ -102,5 +102,76 @@ describe("getRoutingMode", () => {
   it("falls back to 'active' for unknown values (never crashes routing)", () => {
     expect(getRoutingMode("round-robin")).toBe("active")
     expect(getRoutingMode("STICKY")).toBe("sticky") // case-insensitive
+  })
+})
+
+describe("priority routing (#priority-spec)", () => {
+  it("getRoutingMode accepts 'priority'", () => {
+    expect(getRoutingMode("priority")).toBe("priority")
+    expect(getRoutingMode("PRIORITY")).toBe("priority")
+  })
+
+  it("resolvePriorityOrder honors the configured order and appends unlisted profiles", () => {
+    const { order, unknown } = resolvePriorityOrder(["personal", "work", "ci"], ["work", "personal"])
+    expect(order).toEqual(["work", "personal", "ci"])
+    expect(unknown).toEqual([])
+  })
+
+  it("resolvePriorityOrder reports unknown ids and ignores them", () => {
+    const { order, unknown } = resolvePriorityOrder(["personal", "work"], ["work", "ghost"])
+    expect(order).toEqual(["work", "personal"])
+    expect(unknown).toEqual(["ghost"])
+  })
+
+  it("resolvePriorityOrder without a setting uses config order", () => {
+    const { order } = resolvePriorityOrder(["personal", "work"], undefined)
+    expect(order).toEqual(["personal", "work"])
+  })
+
+  it("choosePriorityProfile picks the first non-exhausted profile", () => {
+    const pick = choosePriorityProfile(["work", "personal"], (id) => id === "work")
+    expect(pick).toEqual({ id: "personal", allExhausted: false })
+  })
+
+  it("choosePriorityProfile returns the preferred profile when all are exhausted", () => {
+    const pick = choosePriorityProfile(["work", "personal"], () => true)
+    expect(pick).toEqual({ id: "work", allExhausted: true })
+  })
+
+  it("choosePriorityProfile handles an empty pool", () => {
+    expect(choosePriorityProfile([], () => false)).toBeUndefined()
+  })
+})
+
+describe("ProfileExhaustion tracker", () => {
+  const T0 = 1_800_000_000_000
+
+  it("marks and reports exhaustion until expiry", () => {
+    const ex = new ProfileExhaustion(() => T0)
+    ex.mark("work", T0 + 60_000, "rate_limit_error")
+    expect(ex.isExhausted("work")).toBe(true)
+    expect(ex.isExhausted("personal")).toBe(false)
+  })
+
+  it("expires marks and self-heals", () => {
+    let now = T0
+    const ex = new ProfileExhaustion(() => now)
+    ex.mark("work", T0 + 60_000, "rate_limit_error")
+    now = T0 + 60_001
+    expect(ex.isExhausted("work")).toBe(false)
+    expect(ex.snapshot()).toEqual([])
+  })
+
+  it("snapshot exposes entries for observability", () => {
+    const ex = new ProfileExhaustion(() => T0)
+    ex.mark("work", T0 + 120_000, "rate_limit_error")
+    expect(ex.snapshot()).toEqual([{ id: "work", until: T0 + 120_000, reason: "rate_limit_error" }])
+  })
+
+  it("a later mark extends but an earlier one never shortens", () => {
+    const ex = new ProfileExhaustion(() => T0)
+    ex.mark("work", T0 + 120_000, "rate_limit_error")
+    ex.mark("work", T0 + 30_000, "rate_limit_error")
+    expect(ex.snapshot()[0]!.until).toBe(T0 + 120_000)
   })
 })

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -33,8 +33,13 @@ export function classifyError(errMsg: string): ClassifiedError {
     }
   }
 
-  // Rate limiting
-  if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")) {
+  // Rate limiting. The CLI phrases 5h-window exhaustion as "You've hit your
+  // session limit · resets <time>" (live-observed) and weekly caps as
+  // "usage limit reached" — both ARE quota exhaustion and must classify as
+  // rate_limit_error (429), not generic api_error: clients back off correctly
+  // and priority routing's failover keys off this class.
+  if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
+    || lower.includes("hit your session limit") || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? " If you're frequently hitting this, set MERIDIAN_SONNET_MODEL=sonnet to use the 200k model instead."
       : ""

--- a/src/proxy/routing.ts
+++ b/src/proxy/routing.ts
@@ -22,7 +22,7 @@
 
 import { createHash } from "node:crypto"
 
-export type RoutingMode = "active" | "sticky"
+export type RoutingMode = "active" | "sticky" | "priority"
 
 /**
  * Parse a routing mode string (from settings or MERIDIAN_ROUTING).
@@ -30,7 +30,10 @@ export type RoutingMode = "active" | "sticky"
  * routing behavior into something surprising.
  */
 export function getRoutingMode(raw: string | undefined): RoutingMode {
-  return raw?.toLowerCase() === "sticky" ? "sticky" : "active"
+  const lower = raw?.toLowerCase()
+  if (lower === "sticky") return "sticky"
+  if (lower === "priority") return "priority"
+  return "active"
 }
 
 /**
@@ -78,3 +81,90 @@ export const RENDEZVOUS_STABLE_GUARD: ReadonlyArray<readonly [string, readonly s
   ["sess-b", ["personal", "work"], "personal"],
   ["opencode-3f2a", ["a", "b", "c"], "b"],
 ]
+
+// ---------------------------------------------------------------------------
+// Priority routing (opt-in, routing="priority") — ordered pool with failover.
+// Pure helpers + an injectable-clock exhaustion tracker; still no I/O.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective pool order: the configured order (settings
+ * "profileOrder" / MERIDIAN_PROFILE_ORDER) filtered to profiles that exist,
+ * with unlisted profiles appended in config order. Unknown ids are returned
+ * for a startup warning — a typo must never silently drop an account.
+ */
+export function resolvePriorityOrder(
+  configuredIds: readonly string[],
+  orderSetting: readonly string[] | undefined,
+): { order: string[]; unknown: string[] } {
+  const existing = new Set(configuredIds)
+  const order: string[] = []
+  const unknown: string[] = []
+  for (const id of orderSetting ?? []) {
+    if (!existing.has(id)) { unknown.push(id); continue }
+    if (!order.includes(id)) order.push(id)
+  }
+  for (const id of configuredIds) if (!order.includes(id)) order.push(id)
+  return { order, unknown }
+}
+
+/**
+ * Pick the highest-priority profile that isn't exhausted. When every pool
+ * member is exhausted, return the preferred (first) profile with the flag
+ * set — callers still attempt it (marks may be stale), and per the design
+ * decision the LAST tried profile's error is what ultimately surfaces.
+ */
+export function choosePriorityProfile(
+  order: readonly string[],
+  isExhausted: (id: string) => boolean,
+): { id: string; allExhausted: boolean } | undefined {
+  if (order.length === 0) return undefined
+  for (const id of order) {
+    if (!isExhausted(id)) return { id, allExhausted: false }
+  }
+  return { id: order[0]!, allExhausted: true }
+}
+
+export interface ExhaustionEntry {
+  id: string
+  until: number
+  reason: string
+}
+
+/**
+ * In-memory per-profile exhaustion marks with expiry. Deliberately not
+ * persisted: this is routing hygiene, not durable truth — after a restart
+ * the first failing request re-marks. A later mark may extend an entry but
+ * an earlier one never shortens it (two concurrent failures shouldn't
+ * un-learn the longer reset).
+ */
+export class ProfileExhaustion {
+  private readonly marks = new Map<string, { until: number; reason: string }>()
+  constructor(private readonly now: () => number = Date.now) {}
+
+  mark(id: string, until: number, reason: string): void {
+    const existing = this.marks.get(id)
+    if (existing && existing.until >= until) return
+    this.marks.set(id, { until, reason })
+  }
+
+  isExhausted(id: string): boolean {
+    const entry = this.marks.get(id)
+    if (!entry) return false
+    if (entry.until <= this.now()) {
+      this.marks.delete(id)
+      return false
+    }
+    return true
+  }
+
+  /** Live entries only — expired marks are dropped on read. */
+  snapshot(): ExhaustionEntry[] {
+    const out: ExhaustionEntry[] = []
+    for (const [id, entry] of this.marks) {
+      if (entry.until <= this.now()) { this.marks.delete(id); continue }
+      out.push({ id, until: entry.until, reason: entry.reason })
+    }
+    return out
+  }
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -77,7 +77,7 @@ import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
-import { getRoutingMode } from "./routing"
+import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion } from "./routing"
 import { getSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
@@ -458,6 +458,127 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   app.use("/settings/*", requireAuth)
   app.use("/settings", requireAuth)
   app.use("/design-login", requireAuth)
+
+  // --- Priority routing (opt-in, routing="priority") ---
+  // Ordered account pool with per-request failover. The /v1/messages handler
+  // becomes a thin dispatcher in this mode: it re-enters itself with a pinned
+  // x-meridian-profile header per candidate (the same internal-hop pattern as
+  // /v1/chat/completions), so ALL failover logic lives here — no changes to
+  // the deep request machinery. State is per proxy instance.
+  const priorityExhaustion = new ProfileExhaustion()
+  const priorityAssignments = new Map<string, string>() // sessionKey -> profileId
+  const PRIORITY_ASSIGNMENTS_MAX = 5000
+  const PRIORITY_DEFAULT_COOLDOWN_MS = 10 * 60_000
+  const PRIORITY_COOLDOWN_CAP_MS = 6 * 60 * 60_000
+
+  function priorityProfileOrderSetting(): string[] | undefined {
+    const env = process.env.MERIDIAN_PROFILE_ORDER
+    if (env && env.trim()) return env.split(",").map(s => s.trim()).filter(Boolean)
+    const setting = getSetting("profileOrder")
+    return Array.isArray(setting) && setting.length > 0 ? setting : undefined
+  }
+
+  function priorityCooldownUntil(now: number): number {
+    // Best-available reset signal: the SDK rate-limit store's five_hour reset
+    // when known; conservative default otherwise so a mis-mark self-heals.
+    const fiveHour = rateLimitStore.getAll().find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+    const until = fiveHour?.resetsAt ?? now + PRIORITY_DEFAULT_COOLDOWN_MS
+    return Math.min(until, now + PRIORITY_COOLDOWN_CAP_MS)
+  }
+
+  /** Inspect an inner response for a quota failure without destroying it.
+   *  Non-stream: a 429 body. Stream: an `event: error` frame with
+   *  rate_limit_error BEFORE any content frame (mid-content errors pass
+   *  through — never yank a stream a client is already consuming). */
+  async function sniffQuotaFailure(res: Response): Promise<{ failed: boolean; errorPayload: unknown; response: Response }> {
+    const contentType = res.headers.get("content-type") ?? ""
+    if (!contentType.includes("text/event-stream")) {
+      if (res.status === 429) {
+        const body = await res.clone().json().catch(() => null) as { error?: { type?: string } } | null
+        if (body?.error?.type === "rate_limit_error") return { failed: true, errorPayload: body, response: res }
+      }
+      return { failed: false, errorPayload: null, response: res }
+    }
+    const reader = res.body?.getReader()
+    if (!reader) return { failed: false, errorPayload: null, response: res }
+    const decoder = new TextDecoder()
+    const consumed: Uint8Array[] = []
+    let text = ""
+    let failedPayload: unknown = null
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      consumed.push(value)
+      text += decoder.decode(value, { stream: true })
+      const frameEnd = text.indexOf("\n\n")
+      if (frameEnd === -1) continue
+      const frame = text.slice(0, frameEnd)
+      if (/^event: error$/m.test(frame)) {
+        const dataLine = frame.split("\n").find(l => l.startsWith("data: "))
+        try {
+          const parsed = dataLine ? JSON.parse(dataLine.slice(6)) as { error?: { type?: string } } : null
+          if (parsed?.error?.type === "rate_limit_error") {
+            failedPayload = parsed
+          }
+        } catch { /* not a quota frame — pass through below */ }
+      }
+      break // first complete frame decides
+    }
+    if (failedPayload) {
+      await reader.cancel().catch(() => {})
+      return { failed: true, errorPayload: failedPayload, response: res }
+    }
+    const rest = new ReadableStream<Uint8Array>({
+      start(ctrl) { for (const chunk of consumed) ctrl.enqueue(chunk) },
+      async pull(ctrl) {
+        const { done, value } = await reader.read()
+        if (done) ctrl.close()
+        else ctrl.enqueue(value)
+      },
+      cancel(reason) { void reader.cancel(reason).catch(() => {}) },
+    })
+    return { failed: false, errorPayload: null, response: new Response(rest, { status: res.status, headers: res.headers }) }
+  }
+
+  async function dispatchPriority(c: Context, orderedCandidateIds: string[], sessionKey: string | null, wantsStream: boolean): Promise<Response> {
+    const bodyBuf = await c.req.arrayBuffer()
+    let lastError: unknown = null
+    let previous: string | null = null
+    for (const candidate of orderedCandidateIds) {
+      const headers = new Headers(c.req.raw.headers)
+      headers.set("x-meridian-profile", candidate)
+      const inner = await app.fetch(new Request(c.req.url, { method: "POST", headers, body: bodyBuf }))
+      const { failed, errorPayload, response } = await sniffQuotaFailure(inner)
+      if (!failed) {
+        if (sessionKey) {
+          priorityAssignments.set(sessionKey, candidate)
+          if (priorityAssignments.size > PRIORITY_ASSIGNMENTS_MAX) {
+            const oldest = priorityAssignments.keys().next().value
+            if (oldest !== undefined) priorityAssignments.delete(oldest)
+          }
+        }
+        if (previous) {
+          claudeLog("profile.failover", { from: previous, to: candidate, reason: "rate_limit_error", sessionKey })
+          plog(`[PROXY] PRIORITY failover ${previous} -> ${candidate}`)
+        }
+        return response
+      }
+      priorityExhaustion.mark(candidate, priorityCooldownUntil(Date.now()), "rate_limit_error")
+      claudeLog("priority.exhausted", { profile: candidate, until: priorityCooldownUntil(Date.now()) })
+      lastError = errorPayload
+      previous = candidate
+    }
+    // Every candidate failed: surface the LAST tried profile's error (owner
+    // decision). Stream sniff consumed the inner body, so reconstruct the
+    // exact frame for SSE requests; non-stream errors pass through as JSON.
+    if (wantsStream) {
+      return new Response(`event: error\ndata: ${JSON.stringify(lastError)}\n\n`, {
+        status: 200,
+        headers: { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache" },
+      })
+    }
+    return new Response(JSON.stringify(lastError), { status: 429, headers: { "content-type": "application/json" } })
+  }
   app.use("/auth/*", requireAuth)
 
   app.get("/", (c) => {
@@ -561,6 +682,31 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // Meridian already uses for session tracking is the assignment key,
         // so a session and its subagent/fork requests land on one account.
         const routingMode = getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing"))
+        // Priority mode (opt-in): unpinned requests are dispatched across the
+        // ordered pool with per-request failover. Pinned requests (explicit
+        // x-meridian-profile — including our own internal hops) bypass the
+        // pool entirely and take the normal path below.
+        if (routingMode === "priority" && !c.req.header("x-meridian-profile")) {
+          const effectivePool = getEffectiveProfiles(finalConfig.profiles)
+          if (effectivePool.length > 1) {
+            const { order, unknown } = resolvePriorityOrder(effectivePool.map(p => p.id), priorityProfileOrderSetting())
+            if (unknown.length > 0) claudeLog("priority.unknown_order_ids", { unknown })
+            const sessionKey = adapter.getSessionId(c, body) || null
+            const assigned = sessionKey ? priorityAssignments.get(sessionKey) : undefined
+            // Assignment affinity: an existing conversation stays on its
+            // account while that account is healthy (protects warm prompt
+            // caches). Only NEW sessions drain back after a reset.
+            let first: string
+            if (assigned && order.includes(assigned) && !priorityExhaustion.isExhausted(assigned)) {
+              first = assigned
+            } else {
+              const pick = choosePriorityProfile(order, id => priorityExhaustion.isExhausted(id))
+              first = pick?.id ?? order[0]!
+            }
+            const candidates = [first, ...order.filter(id => id !== first && !priorityExhaustion.isExhausted(id))]
+            return dispatchPriority(c, candidates, sessionKey, body.stream === true)
+          }
+        }
         const profile = resolveProfile(
           finalConfig.profiles,
           finalConfig.defaultProfile,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -78,7 +78,7 @@ import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion } from "./routing"
-import { getSetting } from "./settings"
+import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
 import { detectTokenAnomalies, formatAnomalyAlerts, type TokenSnapshot } from "./tokenHealth"
@@ -547,6 +547,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     for (const candidate of orderedCandidateIds) {
       const headers = new Headers(c.req.raw.headers)
       headers.set("x-meridian-profile", candidate)
+      headers.set("x-meridian-priority-dispatch", "1")
       const inner = await app.fetch(new Request(c.req.url, { method: "POST", headers, body: bodyBuf }))
       const { failed, errorPayload, response } = await sniffQuotaFailure(inner)
       if (!failed) {
@@ -1016,7 +1017,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
         const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
         const toolCount = body.tools?.length ?? 0
-        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
+        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : c.req.header("x-meridian-priority-dispatch") ? "(priority)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
         plog(`[PROXY] ${requestLogLine} msgs=${msgSummary}`)
         diagnosticLog.session(`${requestLogLine}`, requestMeta.requestId)
 
@@ -3476,6 +3477,43 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   })
 
   // Model pricing for the telemetry cost estimate: built-in table + user overrides
+  // Routing configuration (priority spec): mode + pool order, editable from
+  // the /settings UI. MERIDIAN_ROUTING / MERIDIAN_PROFILE_ORDER env vars
+  // still take precedence when set (reported so the UI can say so).
+  app.get("/settings/api/routing", (c) => {
+    const profiles = listProfiles(finalConfig.profiles, finalConfig.defaultProfile)
+    return c.json({
+      routing: getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing")),
+      profileOrder: resolvePriorityOrder(profiles.map(p => p.id), priorityProfileOrderSetting()).order,
+      profiles: profiles.map(p => p.id),
+      envOverride: {
+        routing: Boolean(process.env.MERIDIAN_ROUTING),
+        profileOrder: Boolean(process.env.MERIDIAN_PROFILE_ORDER),
+      },
+    })
+  })
+  app.put("/settings/api/routing", async (c) => {
+    let body: { routing?: unknown; profileOrder?: unknown }
+    try { body = await c.req.json() } catch { return c.json({ error: "Invalid JSON" }, 400) }
+    if (body.routing !== undefined) {
+      if (typeof body.routing !== "string" || !["active", "sticky", "priority"].includes(body.routing)) {
+        return c.json({ error: 'routing must be "active", "sticky", or "priority"' }, 400)
+      }
+      setSetting("routing", body.routing)
+    }
+    if (body.profileOrder !== undefined) {
+      if (!Array.isArray(body.profileOrder) || body.profileOrder.some(x => typeof x !== "string")) {
+        return c.json({ error: "profileOrder must be an array of profile ids" }, 400)
+      }
+      const known = new Set(listProfiles(finalConfig.profiles, finalConfig.defaultProfile).map(p => p.id))
+      const unknown = (body.profileOrder as string[]).filter(id => !known.has(id))
+      if (unknown.length > 0) return c.json({ error: `Unknown profiles: ${unknown.join(", ")}` }, 400)
+      setSetting("profileOrder", body.profileOrder as string[])
+    }
+    plog(`[PROXY] Routing settings updated: routing=${getSetting("routing") ?? "active"} order=${(getSetting("profileOrder") ?? []).join(",") || "(config order)"}`)
+    return c.json({ success: true })
+  })
+
   app.get("/settings/api/pricing", (c) => {
     const { BUILTIN_MODEL_PRICING } = require("../telemetry/pricing") as typeof import("../telemetry/pricing")
     const { getPricingOverrides } = require("../telemetry/pricingStore") as typeof import("../telemetry/pricingStore")
@@ -3588,11 +3626,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         lastSuccessAt: cacheInfo.lastSuccessAt || null,
       }
     }))
+    const routingModeNow = getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing"))
+    // Additive (priority spec): pool order + live exhaustion state so UIs
+    // (meridian home, pylon's switcher) can render the pool.
+    const priorityInfo = routingModeNow === "priority"
+      ? {
+          profileOrder: resolvePriorityOrder(profiles.map(p => p.id), priorityProfileOrderSetting()).order,
+          exhausted: priorityExhaustion.snapshot(),
+        }
+      : {}
     return c.json({
       profiles: enriched,
       activeProfile: getActiveProfileId() || finalConfig.defaultProfile || profiles[0]?.id || "default",
       // Additive (#383): current routing mode so UIs can surface it.
-      routing: getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing")),
+      routing: routingModeNow,
+      ...priorityInfo,
     })
   })
 

--- a/src/proxy/settings.ts
+++ b/src/proxy/settings.ts
@@ -17,9 +17,12 @@ const SETTINGS_FILE = join(homedir(), ".config", "meridian", "settings.json")
 export interface MeridianSettings {
   /** Last active profile ID — restored on proxy startup */
   activeProfile?: string
-  /** Profile routing mode (#383): "active" (default) or "sticky".
-   *  MERIDIAN_ROUTING env var takes precedence when set. */
+  /** Profile routing mode (#383, priority spec): "active" (default),
+   *  "sticky", or "priority". MERIDIAN_ROUTING env var takes precedence. */
   routing?: string
+  /** Priority-mode pool order (highest priority first). Falls back to
+   *  profiles.json order. MERIDIAN_PROFILE_ORDER env var takes precedence. */
+  profileOrder?: string[]
 }
 
 /** Read settings from disk. Returns empty object if file doesn't exist or is invalid. */

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -59,6 +59,8 @@ export const landingHtml = `<!DOCTYPE html>
   .usage-row .w-fill { height: 100%; border-radius: 3px; }
   .pace-row { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 8px; }
   .pace-row .pace-text { flex: 1; font-weight: 600; font-size: 11px; }
+  .pool-chip { font-size: 10px; padding: 2px 8px; border-radius: 10px; background: var(--surface2); color: var(--muted); margin-left: 6px; vertical-align: middle; }
+  .pool-chip.exhausted { color: var(--red); background: rgba(248,81,73,0.12); }
   .usage-row .w-pct { width: 38px; text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
   .usage-row .w-reset { color: var(--muted); font-size: 11px; width: 76px; text-align: right; }
   .no-usage { font-size: 12px; color: var(--muted); padding: 4px 0; }
@@ -174,8 +176,15 @@ function profileSection(q,s,pl,h){
       +'<span class="pace-text" style="color:'+paceColor(pc)+'">'+paceText(pc)+'</span>'
       +'<span class="w-reset">'+(pc.proj!=null?'~'+pc.proj+'% by reset':'')+'</span></div>';
     if(!rows)rows='<div class="no-usage">no usage data yet</div>';
-    var switchable=multi&&p.configured&&!p.isActive;
-    var badge=p.isActive?'<span class="active-pill">Active</span>':switchable?'<span class="switch-hint">Click to activate</span>':'';
+    var isPriority=pl&&pl.routing==='priority';
+    var switchable=multi&&p.configured&&!p.isActive&&!isPriority;
+    var badge=isPriority?'':p.isActive?'<span class="active-pill">Active</span>':switchable?'<span class="switch-hint">Click to activate</span>':'';
+    if(isPriority){
+      var orderIdx=(pl.profileOrder||[]).indexOf(p.id);
+      if(orderIdx>=0)badge+='<span class="pool-chip">#'+(orderIdx+1)+' in pool</span>';
+      var exh=(pl.exhausted||[]).filter(function(e){return e.id===p.id})[0];
+      if(exh)badge+=' <span class="pool-chip exhausted">exhausted · resets '+resetIn(exh.until)+'</span>';
+    }
     cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+'"'+(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
       +'<div class="profile-head"><span class="profile-name"><span class="prof-dot"></span>'+esc(p.label||p.id)+' '+badge+'</span>'
       +'<span class="profile-cost">'+usd(cost?cost.estimatedUsd:0)+'</span></div>'

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -129,6 +129,19 @@ ${profileBarHtml}
 
   <div id="adapters"></div>
 
+  <h1 style="margin-top:40px">Routing</h1>
+  <p class="subtitle" style="max-width:720px;line-height:1.6">
+    How unpinned requests choose an account. <strong style="color:var(--text)">Active</strong> uses the manually
+    selected profile. <strong style="color:var(--text)">Sticky</strong> distributes sessions across profiles evenly
+    (cache-affine). <strong style="color:var(--text)">Priority</strong> drains the pool in order — highest first —
+    and fails over per request when an account runs out; conversations keep their account, and new sessions
+    return to the preferred account after its window resets. An explicit <code>x-meridian-profile</code> header
+    always overrides. Changes apply to the next request — no restart needed.
+  </p>
+  <div class="adapter-card" id="routing-card">
+    <div id="routing-body">Loading…</div>
+  </div>
+
   <h1 style="margin-top:40px">Model Pricing</h1>
   <p class="subtitle" style="max-width:720px;line-height:1.6">
     Rates used by the telemetry cost estimate, in USD per million tokens. Edit a value to override the
@@ -407,8 +420,45 @@ async function addPricingModel() {
   }
 }
 
+async function loadRouting() {
+  const res = await fetch('/settings/api/routing');
+  const cfg = await res.json();
+  const el = document.getElementById('routing-body');
+  const envNote = (on) => on ? ' <span style="font-size:11px;color:var(--yellow)">(env override active — setting saved but env wins)</span>' : '';
+  let h = '<div style="display:flex;align-items:center;gap:12px;margin-bottom:14px">'
+    + '<label style="color:var(--muted);font-size:13px;width:90px">Mode</label>'
+    + '<select id="routing-mode" style="background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:6px 10px">'
+    + ['active','sticky','priority'].map(m => '<option value="'+m+'"'+(cfg.routing===m?' selected':'')+'>'+m+'</option>').join('')
+    + '</select>' + envNote(cfg.envOverride.routing) + '</div>';
+  h += '<div id="routing-order-wrap" style="'+(cfg.routing==='priority'?'':'display:none')+'">'
+    + '<div style="color:var(--muted);font-size:13px;margin-bottom:8px">Pool order — highest priority first. Drained top to bottom.'
+    + envNote(cfg.envOverride.profileOrder) + '</div>'
+    + '<ol id="routing-order" style="margin:0;padding-left:22px">'
+    + cfg.profileOrder.map((id, i) =>
+        '<li style="padding:4px 0;color:var(--text)">'
+        + '<span style="font-family:var(--mono, monospace)">'+id+'</span>'
+        + ' <button data-move="up" data-i="'+i+'" style="margin-left:10px;background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:1px 8px;cursor:pointer"'+(i===0?' disabled':'')+'>&uarr;</button>'
+        + ' <button data-move="down" data-i="'+i+'" style="background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;padding:1px 8px;cursor:pointer"'+(i===cfg.profileOrder.length-1?' disabled':'')+'>&darr;</button>'
+        + '</li>').join('')
+    + '</ol></div>';
+  el.innerHTML = h;
+  document.getElementById('routing-mode').addEventListener('change', async (e) => {
+    await fetch('/settings/api/routing', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ routing: e.target.value }) });
+    await loadRouting();
+  });
+  el.querySelectorAll('button[data-move]').forEach(btn => btn.addEventListener('click', async () => {
+    const i = Number(btn.dataset.i);
+    const j = btn.dataset.move === 'up' ? i - 1 : i + 1;
+    const order = cfg.profileOrder.slice();
+    const tmp = order[i]; order[i] = order[j]; order[j] = tmp;
+    await fetch('/settings/api/routing', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ profileOrder: order }) });
+    await loadRouting();
+  }));
+}
+
 loadConfig();
 loadPricing();
+loadRouting();
 ${profileBarJs}
 </script>
 </body>


### PR DESCRIPTION
Implements the approved spec (docs/superpowers/specs/2026-07-23-priority-profile-routing-design.md): `routing: "priority"` drains an ordered account pool — highest priority first — and fails over **per request** when an account runs out, usually before the client sees any error.

**Strictly opt-in.** Default stays `active`; mode off is byte-identical (pinned by a regression test). No prompts, no auto-enabling.

## Design
- The /v1/messages handler becomes a thin dispatcher for unpinned requests in priority mode: it re-enters itself with a pinned `x-meridian-profile` per candidate (the proven internal-hop pattern) — failover logic fully isolated from the deep request machinery.
- Streams are sniffed frame-by-frame: a `rate_limit_error` frame before any content fails over; content passes through untouched (never yank a stream a client is consuming).
- **Conversations keep their account** while healthy (assignment affinity, warm caches); **only new sessions drain back** after reset; all-exhausted surfaces the **last-tried** profile's error. (Owner decisions recorded in the spec.)
- Pool order: `MERIDIAN_PROFILE_ORDER` / settings `profileOrder`, **editable live at /settings** (new Routing card + GET/PUT `/settings/api/routing`, env-override aware).
- Observability: `profile.failover` + `priority.exhausted` log events, `profile=<id>(priority)` request lines, `/profiles/list` reports order + live exhaustion, home cards show `#n in pool` / `exhausted · resets …` badges.

## The live smoke caught a real classifier bug
The CLI phrases genuine 5h exhaustion as **"You've hit your session limit · resets <time>"** — previously classified generic `api_error` (500-class), so failover never fired on real exhaustion and every meridian user got the wrong error class for quota exhaustion. `classifyError` now maps session/usage-limit phrasings to 429 `rate_limit_error`.

## Verification
- Unit: order resolution, chooser, exhaustion tracker (11 new tests); classifier phrasings (2).
- Integration: 8 tests — preference, failover, all-exhausted last-error, pin bypass, affinity + drain-back, exhaustion skip, streaming failover, mode-off regression gate.
- **Live, against real account exhaustion** (the owner's genuinely session-limited work account): non-stream AND streaming requests both failed over work → personal with a single clean message; `PRIORITY failover work -> personal` logged; `/profiles/list` showed work exhausted with the real reset time.
- Full suite 2203 pass / 0 fail; typecheck clean.