### PR TITLE
feat: image input and incomplete status for Responses API (/v1/responses)

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -11,6 +11,7 @@ import {
   translateAnthropicToResponses,
   createResponsesSseTranslator,
 } from "../proxy/openaiResponses"
+import type { AnthropicContentBlock } from "../proxy/openai"
 
 describe("translateResponsesToAnthropic", () => {
   it("returns null without input", () => {
@@ -37,6 +38,51 @@ describe("translateResponsesToAnthropic", () => {
     expect(r.system).toContain("House rules.")
     expect(r.messages).toHaveLength(1)
     expect(r.messages[0]!.role).toBe("user")
+  })
+
+  it("maps input_image data URLs to Anthropic image blocks", () => {
+    const dataUrl = "data:image/png;base64,iVBORw0KGgo="
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "what is this?" },
+            { type: "input_image", image_url: dataUrl },
+          ],
+        },
+      ],
+    })!
+    expect(r.messages).toHaveLength(1)
+    const content = r.messages[0]!.content as AnthropicContentBlock[]
+    expect(content[0]).toEqual({ type: "text", text: "what is this?" })
+    expect(content[1]).toEqual({
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" },
+    })
+  })
+
+  it("replaces non-data-URL images with an omission note, keeping the text", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "look" },
+            { type: "input_image", image_url: "https://example.com/x.png" },
+          ],
+        },
+      ],
+    })!
+    const content = r.messages[0]!.content as AnthropicContentBlock[]
+    expect(content).toEqual([
+      { type: "text", text: "look" },
+      { type: "text", text: "[Unsupported input_image omitted: only data URLs are currently supported]" },
+    ])
   })
 
   it("maps the codex tool round-trip: function_call + function_call_output", () => {
@@ -146,6 +192,16 @@ describe("translateAnthropicToResponses (non-stream)", () => {
     }, ctx) as any
     expect(JSON.stringify(out.output)).not.toContain("hmm")
     expect(out.output.find((o: any) => o.type === "message").content[0].text).toBe("Answer.")
+  })
+
+  it("reports incomplete status on a max_tokens stop", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "text", text: "truncated..." }],
+      stop_reason: "max_tokens",
+      usage: { input_tokens: 4, output_tokens: 8 },
+    }, ctx) as any
+    expect(out.status).toBe("incomplete")
+    expect(out.incomplete_details).toEqual({ reason: "max_output_tokens" })
   })
 })
 
@@ -268,6 +324,24 @@ describe("createResponsesSseTranslator (stream)", () => {
     )
     expect(noReasoning).toBeUndefined()
     void plain
+  })
+
+  it("emits response.incomplete on a max_tokens stop", () => {
+    const out = run([
+      { type: "message_start", message: { id: "m1", usage: { input_tokens: 3 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "cut" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "max_tokens" }, usage: { output_tokens: 9 } },
+      { type: "message_stop" },
+    ])
+    const types = out.map((e) => e.event)
+    expect(types).toContain("response.incomplete")
+    expect(types).not.toContain("response.completed")
+    const incomplete = out.find((e) => e.event === "response.incomplete")!
+    const resp = (incomplete.data as any).response
+    expect(resp.status).toBe("incomplete")
+    expect(resp.incomplete_details).toEqual({ reason: "max_output_tokens" })
   })
 
   it("embeds a `type` field in every data payload matching the event name", () => {

--- a/src/__tests__/proxy-responses-image.test.ts
+++ b/src/__tests__/proxy-responses-image.test.ts
@@ -1,0 +1,110 @@
+/**
+ * /v1/responses image input — through the HTTP layer with a mocked SDK.
+ * A real base64 PNG posted as an `input_image` part must reach the SDK as an
+ * actual image content block, not the "[Image attached]" placeholder the
+ * text-only flatten path in server.ts would produce.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+
+// A real, valid 1x1 red PNG (69 bytes).
+const RED_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+
+// The prompt the route handed to query(). Multimodal turns arrive as an async
+// iterable of user messages; a dropped image degrades this to a plain string.
+let capturedPrompt: any = null
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    capturedPrompt = opts.prompt
+    return (async function* () {
+      yield {
+        type: "assistant",
+        uuid: "uuid-1",
+        message: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "I see a red pixel." }],
+          model: "claude-sonnet-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 20, output_tokens: 5 },
+        },
+        session_id: "sdk-1",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function postImageRequest(stream: boolean) {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app.fetch(
+    new Request("http://localhost/v1/responses", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-5",
+        input: [{
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "What color is this pixel?" },
+            { type: "input_image", image_url: `data:image/png;base64,${RED_PNG_B64}` },
+          ],
+        }],
+        stream,
+      }),
+    })
+  )
+}
+
+/** Drain the captured prompt and return the user message's content blocks. */
+async function sdkUserContent(): Promise<any[]> {
+  if (typeof capturedPrompt === "string") return [{ type: "text", text: capturedPrompt }]
+  const msgs: any[] = []
+  for await (const m of capturedPrompt) msgs.push(m)
+  const userMsg = msgs.find((m) => (m.role ?? m.message?.role) === "user")
+  return userMsg?.content ?? userMsg?.message?.content ?? []
+}
+
+function expectImageDelivered(content: any[]) {
+  expect(JSON.stringify(content)).not.toContain("[Image attached]")
+  const image = content.find((b) => b?.type === "image")
+  expect(image?.source).toEqual({ type: "base64", media_type: "image/png", data: RED_PNG_B64 })
+}
+
+describe("/v1/responses image input reaches the SDK", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedPrompt = null
+  })
+
+  it("non-stream: delivers the PNG as an image block with the exact payload", async () => {
+    const res = await postImageRequest(false)
+    expect(res.status).toBe(200)
+    const content = await sdkUserContent()
+    expectImageDelivered(content)
+    expect(JSON.stringify(content)).toContain("What color is this pixel?")
+  })
+
+  it("stream: delivers the PNG as an image block with the exact payload", async () => {
+    const res = await postImageRequest(true)
+    expect(res.status).toBe(200)
+    await res.text() // drain SSE so the route fully runs
+    expectImageDelivered(await sdkUserContent())
+  })
+})

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -11,6 +11,8 @@
  * (docs/superpowers/specs/2026-07-08-codex-responses-api-design.md): text +
  * function tool-calling, streaming and non-streaming, forced passthrough.
  * Reasoning items are omitted (verified working against real Codex 0.143).
+ * Also handles base64 data-URL image input and maps a `max_tokens` stop to an
+ * `incomplete` Responses status.
  *
  * NOTE: agent-specific (Codex). Kept isolated per ARCHITECTURE.md — this
  * module owns the Responses wire format; no Responses logic leaks elsewhere.
@@ -20,6 +22,7 @@ import type {
   AnthropicRequestBody,
   AnthropicMessage,
   AnthropicContentBlock,
+  AnthropicImageBlock,
   AnthropicTool,
 } from "./openai"
 
@@ -28,8 +31,9 @@ import type {
 // ---------------------------------------------------------------------------
 
 interface ResponsesContentPart {
-  type: "input_text" | "output_text" | string
+  type: "input_text" | "output_text" | "input_image" | string
   text?: string
+  image_url?: string
 }
 
 interface ResponsesMessageItem {
@@ -93,6 +97,38 @@ function partsToText(content: ResponsesContentPart[] | string): string {
     .join("")
 }
 
+/** Parse a base64 data URL into an Anthropic image block (data URLs only). */
+function parseDataUrlImage(url: string): AnthropicImageBlock | null {
+  const match = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/s.exec(url)
+  if (!match) return null
+  const mediaType = match[1]
+  const data = match[2]
+  if (!mediaType || !data) return null
+  return { type: "image", source: { type: "base64", media_type: mediaType, data } }
+}
+
+/**
+ * Content blocks for a message with image parts. Returns null when there are
+ * no images so the caller keeps the plain-text path. Remote (non-data-URL)
+ * images become an omission note, matching the chat-completions adapter.
+ */
+function partsToBlocks(content: ResponsesContentPart[] | string): AnthropicContentBlock[] | null {
+  if (typeof content === "string") return null
+  const hasImage = content.some((p) => p.type === "input_image")
+  if (!hasImage) return null
+
+  const blocks: AnthropicContentBlock[] = []
+  for (const part of content) {
+    if (typeof part.text === "string") {
+      blocks.push({ type: "text", text: part.text })
+    } else if (part.type === "input_image") {
+      const image = typeof part.image_url === "string" ? parseDataUrlImage(part.image_url) : null
+      blocks.push(image ?? { type: "text", text: "[Unsupported input_image omitted: only data URLs are currently supported]" })
+    }
+  }
+  return blocks
+}
+
 /**
  * Map a Responses `tool_choice` to Anthropic's. Codex sends `"auto"`,
  * `"required"`, `"none"`, or `{type:"function", name}`. `"none"` maps to
@@ -147,8 +183,14 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
           if (t) systemParts.push(t)
           break
         }
+        const role = msg.role === "assistant" ? "assistant" : "user"
+        const imageBlocks = partsToBlocks(msg.content)
+        if (imageBlocks) {
+          for (const block of imageBlocks) pushBlock(role, block)
+          break
+        }
         const text = partsToText(msg.content)
-        if (text) pushBlock(msg.role === "assistant" ? "assistant" : "user", { type: "text", text })
+        if (text) pushBlock(role, { type: "text", text })
         break
       }
       case "function_call": {
@@ -235,6 +277,14 @@ function mapUsage(usage: { input_tokens?: number; output_tokens?: number } | und
 }
 
 /**
+ * A `max_tokens` stop means truncation — report `incomplete` so the client
+ * can tell a cut-off answer from a finished one.
+ */
+function toResponsesStatus(stopReason: string | undefined): "completed" | "incomplete" {
+  return stopReason === "max_tokens" ? "incomplete" : "completed"
+}
+
+/**
  * Assemble a complete Responses `response` object from an Anthropic response.
  * Text blocks become a single `message` item with `output_text` parts;
  * tool_use blocks become `function_call` items. Thinking blocks are dropped.
@@ -283,12 +333,14 @@ export function translateAnthropicToResponses(res: AnthropicResponseLike, ctx: R
     })
   }
 
+  const status = toResponsesStatus(res.stop_reason)
   return {
     id: ctx.responseId,
     object: "response",
     created_at: ctx.created,
     model: ctx.model,
-    status: "completed",
+    status,
+    ...(status === "incomplete" ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
     output,
     usage: mapUsage(res.usage),
     parallel_tool_calls: true,
@@ -325,6 +377,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
   let inputTokens = 0
   let outputTokens = 0
   let createdEmitted = false
+  let stopReason: string | undefined
 
   // Per-open-block state, keyed by Anthropic block index.
   interface BlockState {
@@ -469,17 +522,20 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
 
       case "message_delta": {
         if (typeof event.usage?.output_tokens === "number") outputTokens = event.usage.output_tokens
+        if (typeof event.delta?.stop_reason === "string") stopReason = event.delta.stop_reason
         break
       }
 
       case "message_stop": {
-        out.push(emit("response.completed", {
-          response: responseEnvelope("completed", {
+        const status = toResponsesStatus(stopReason)
+        out.push(emit(status === "incomplete" ? "response.incomplete" : "response.completed", {
+          response: responseEnvelope(status, {
             output: finalOutput,
             usage: { input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: inputTokens + outputTokens },
             parallel_tool_calls: true,
             tool_choice: "auto",
             tools: [],
+            ...(status === "incomplete" ? { incomplete_details: { reason: "max_output_tokens" } } : {}),
           }),
         }))
         break


### PR DESCRIPTION
## Summary

Two small, additive improvements to the Codex Responses API (POST /v1/responses): image input and truncation reporting. Both were gaps in the #654 implementation — image parts were silently dropped and a token-limited response always reported completed.

Without the fix in this pull request, codex-cli fails to view images.
<img width="2845" height="937" alt="Screenshot_20260724_112021" src="https://github.com/user-attachments/assets/6f6e2408-0ce8-41bf-b118-91cf1fbbc36f" />

## What's included

- Image input — `input_image` content parts carrying a base64 data URL now translate to Anthropic image blocks. Text-only turns keep the existing fast text path untouched; remote (non-data-URL) image URLs remain unsupported and are replaced with an omission note, matching the /v1/chat/completions adapter.
- Incomplete status — an Anthropic `max_tokens` stop now maps to a Responses incomplete status with `incomplete_details: { reason: "max_output_tokens" }`, in both the non-streaming response object and the streaming path (emits response.incomplete instead of response.completed). A truncated answer is now distinguishable from a finished one.

## Verification

- Unit (`openai-responses.test.ts`): data-URL → image block, omission note for non-data-URL images, and the incomplete status for both non-stream and stream.
- End-to-end (`proxy-responses-image.test.ts`): a real 1×1 PNG posted through /v1/responses (non-stream and stream) reaches the mocked SDK as an actual image content block with the exact base64 payload — not the [Image attached] placeholder the text-flatten path would produce. Confirms the image survives translation, hasMultimodalContent detection, and prompt construction.
- Tested with codex-cli 0.145.0 and claude-code-cli 2.1.218