### PR TITLE
feat: add Claude Opus 5 to the model list, make it the canonical opus

### DIFF
--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test"
 
 // ---------- unit: explicitModelPin + canonical bump ----------
 
-const { explicitModelPin, CANONICAL_SONNET_MODEL } = await import("../proxy/models")
+const { explicitModelPin, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
 
 describe("explicitModelPin (#631)", () => {
   it("pins fully-versioned sonnet ids", () => {
@@ -22,6 +22,7 @@ describe("explicitModelPin (#631)", () => {
   })
 
   it("pins fully-versioned opus and date-suffixed haiku ids", () => {
+    expect(explicitModelPin("claude-opus-5")).toEqual({ ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-5" })
     expect(explicitModelPin("claude-opus-4-7")).toEqual({ ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-7" })
     expect(explicitModelPin("claude-haiku-4-5-20251001")).toEqual({ ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001" })
   })
@@ -48,6 +49,12 @@ describe("explicitModelPin (#631)", () => {
 describe("canonical sonnet pin (#631)", () => {
   it("bare sonnet means the current Sonnet", () => {
     expect(CANONICAL_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+})
+
+describe("canonical opus pin", () => {
+  it("bare opus means the current Opus", () => {
+    expect(CANONICAL_OPUS_MODEL).toBe("claude-opus-5")
   })
 })
 
@@ -113,7 +120,7 @@ describe("explicit model pins reach the subprocess env (#631)", () => {
     expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
   })
 
-  it("claude-opus-4-7 pins the opus tier instead of canonical 4.8", async () => {
+  it("claude-opus-4-7 pins the opus tier instead of canonical 5", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
     const res = await post(app, "claude-opus-4-7")
     expect(res.status).toBe(200)
@@ -125,5 +132,12 @@ describe("explicit model pins reach the subprocess env (#631)", () => {
     const res = await post(app, "sonnet")
     expect(res.status).toBe(200)
     expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+
+  it("bare opus resolves via the canonical pin (now Opus 5)", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, "opus")
+    expect(res.status).toBe(200)
+    expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5")
   })
 })

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1184,15 +1184,16 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 7 models", () => {
-    expect(buildModelList(true).length).toBe(7)
-    expect(buildModelList(false).length).toBe(7)
+  it("returns 8 models", () => {
+    expect(buildModelList(true).length).toBe(8)
+    expect(buildModelList(false).length).toBe(8)
   })
 
-  it("includes sonnet-5, fable-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes sonnet-5, fable-5, opus-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
     expect(ids).toContain("claude-sonnet-5")
     expect(ids).toContain("claude-fable-5")
+    expect(ids).toContain("claude-opus-5")
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")
     expect(ids).toContain("claude-opus-4-8")

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -219,7 +219,7 @@ describe("SDK model pin injection (fixes #419)", () => {
     // Bare alias: no envOverride kicks in, so the canonical pin is exercised.
     await post(app, { ...BASIC_REQUEST, model: "sonnet" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
   })

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -41,7 +41,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
 export const CANONICAL_FABLE_MODEL = "claude-fable-5"
-export const CANONICAL_OPUS_MODEL = "claude-opus-4-8"
+export const CANONICAL_OPUS_MODEL = "claude-opus-5"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-5"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -929,6 +929,15 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       capabilities: FULL_CAPABILITIES,
     },
     {
+      id: "claude-opus-5",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Opus 5",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      capabilities: FULL_CAPABILITIES,
+    },
+    {
       id: "claude-opus-4-6",
       object: "model",
       created: now,


### PR DESCRIPTION
## Summary

Two changes, mirroring the Sonnet 5 rollout (#644):

1. **`/v1/models` never listed `claude-opus-5`** — explicit requests already routed correctly via `explicitModelPin` (the `claude-(...)-\d` regex matches it), but tools that build their picker from the endpoint couldn't offer it. Added as the first Opus entry.
2. **The bare `opus` alias resolved to `claude-opus-4-8`.** Canonical pin bumped to `claude-opus-5` — an alias means "the current model of that tier". `MERIDIAN_DEFAULT_OPUS_MODEL=claude-opus-4-8` restores the old default; explicit ids are honored exactly.

## Verification
- Updated `explicit-model-pins`, `openai`, and `proxy-env-stripping` assertions; added a canonical-opus unit test and a bare-opus integration test.
- Full suite **2204 pass, 1 skip, 0 fail**; `tsc --noEmit` clean.
- Live through a real proxy on Max: `POST /v1/messages` with `claude-opus-5` answered from `claude-opus-5`.
