### PR TITLE
feat: add Claude Opus 5 to the model list, make it the canonical opus

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -56,6 +56,7 @@ Add a provider to `~/.config/crush/crush.json`:
       "api_key": "dummy",
       "models": [
         { "id": "claude-fable-5",    "name": "Claude Fable 5 (1M)",     "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
+        { "id": "claude-opus-5",     "name": "Claude Opus 5 (1M)",      "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
         { "id": "claude-opus-4-8",   "name": "Claude Opus 4.8 (1M)",    "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
         { "id": "claude-opus-4-7",   "name": "Claude Opus 4.7 (1M)",    "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
         { "id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6 (1M)",  "context_window": 1000000, "default_max_tokens": 64000, "can_reason": true, "supports_attachments": true },
@@ -82,6 +83,7 @@ Add Meridian as a custom model provider in `~/.factory/settings.json`:
 {
   "customModels": [
     { "model": "claude-fable-5",          "name": "Fable 5 (Meridian)",    "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
+    { "model": "claude-opus-5",           "name": "Opus 5 (Meridian)",     "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-opus-4-8",         "name": "Opus 4.8 (Meridian)",   "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-opus-4-7",         "name": "Opus 4.7 (Meridian)",   "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-sonnet-4-6",       "name": "Sonnet 4.6 (Meridian)", "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },

--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test"
 
 // ---------- unit: explicitModelPin + canonical bump ----------
 
-const { explicitModelPin, CANONICAL_SONNET_MODEL } = await import("../proxy/models")
+const { explicitModelPin, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
 
 describe("explicitModelPin (#631)", () => {
   it("pins fully-versioned sonnet ids", () => {
@@ -22,6 +22,7 @@ describe("explicitModelPin (#631)", () => {
   })
 
   it("pins fully-versioned opus and date-suffixed haiku ids", () => {
+    expect(explicitModelPin("claude-opus-5")).toEqual({ ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-5" })
     expect(explicitModelPin("claude-opus-4-7")).toEqual({ ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-7" })
     expect(explicitModelPin("claude-haiku-4-5-20251001")).toEqual({ ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5-20251001" })
   })
@@ -48,6 +49,12 @@ describe("explicitModelPin (#631)", () => {
 describe("canonical sonnet pin (#631)", () => {
   it("bare sonnet means the current Sonnet", () => {
     expect(CANONICAL_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+})
+
+describe("canonical opus pin", () => {
+  it("bare opus means the current Opus", () => {
+    expect(CANONICAL_OPUS_MODEL).toBe("claude-opus-5")
   })
 })
 
@@ -113,7 +120,7 @@ describe("explicit model pins reach the subprocess env (#631)", () => {
     expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
   })
 
-  it("claude-opus-4-7 pins the opus tier instead of canonical 4.8", async () => {
+  it("claude-opus-4-7 pins the opus tier instead of canonical 5", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
     const res = await post(app, "claude-opus-4-7")
     expect(res.status).toBe(200)
@@ -125,5 +132,12 @@ describe("explicit model pins reach the subprocess env (#631)", () => {
     const res = await post(app, "sonnet")
     expect(res.status).toBe(200)
     expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
+  })
+
+  it("bare opus resolves via the canonical pin (now Opus 5)", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, "opus")
+    expect(res.status).toBe(200)
+    expect(queryEnvs[0]!.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5")
   })
 })

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1184,15 +1184,16 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 7 models", () => {
-    expect(buildModelList(true).length).toBe(7)
-    expect(buildModelList(false).length).toBe(7)
+  it("returns 8 models", () => {
+    expect(buildModelList(true).length).toBe(8)
+    expect(buildModelList(false).length).toBe(8)
   })
 
-  it("includes sonnet-5, fable-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes sonnet-5, fable-5, opus-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
     expect(ids).toContain("claude-sonnet-5")
     expect(ids).toContain("claude-fable-5")
+    expect(ids).toContain("claude-opus-5")
     expect(ids).toContain("claude-opus-4-6")
     expect(ids).toContain("claude-opus-4-7")
     expect(ids).toContain("claude-opus-4-8")

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1209,10 +1209,12 @@ describe("buildModelList", () => {
   it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {
     const models = buildModelList(true)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
+    const opus5 = models.find(m => m.id === "claude-opus-5")!
     const opus46 = models.find(m => m.id === "claude-opus-4-6")!
     const opus47 = models.find(m => m.id === "claude-opus-4-7")!
     const opus48 = models.find(m => m.id === "claude-opus-4-8")!
     expect(sonnet.context_window).toBe(200_000)
+    expect(opus5.context_window).toBe(1_000_000)
     expect(opus46.context_window).toBe(1_000_000)
     expect(opus47.context_window).toBe(1_000_000)
     expect(opus48.context_window).toBe(1_000_000)
@@ -1221,10 +1223,12 @@ describe("buildModelList", () => {
   it("non-Max gets 200k context for sonnet and all opus variants", () => {
     const models = buildModelList(false)
     const sonnet = models.find(m => m.id === "claude-sonnet-4-6")!
+    const opus5 = models.find(m => m.id === "claude-opus-5")!
     const opus46 = models.find(m => m.id === "claude-opus-4-6")!
     const opus47 = models.find(m => m.id === "claude-opus-4-7")!
     const opus48 = models.find(m => m.id === "claude-opus-4-8")!
     expect(sonnet.context_window).toBe(200_000)
+    expect(opus5.context_window).toBe(200_000)
     expect(opus46.context_window).toBe(200_000)
     expect(opus47.context_window).toBe(200_000)
     expect(opus48.context_window).toBe(200_000)

--- a/src/__tests__/pricing-routes.test.ts
+++ b/src/__tests__/pricing-routes.test.ts
@@ -48,6 +48,7 @@ describe("pricing settings routes", () => {
     const res = await get()
     expect(res.status).toBe(200)
     const body = await res.json() as any
+    expect(body.builtin["claude-opus-5"]).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
     expect(body.builtin["claude-opus-4-8"]).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
     expect(body.overrides).toEqual({})
   })

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -219,7 +219,7 @@ describe("SDK model pin injection (fixes #419)", () => {
     // Bare alias: no envOverride kicks in, so the canonical pin is exercised.
     await post(app, { ...BASIC_REQUEST, model: "sonnet" })
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-8")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
   })

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -41,7 +41,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
 export const CANONICAL_FABLE_MODEL = "claude-fable-5"
-export const CANONICAL_OPUS_MODEL = "claude-opus-4-8"
+export const CANONICAL_OPUS_MODEL = "claude-opus-5"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-5"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"
 

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -929,6 +929,15 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       capabilities: FULL_CAPABILITIES,
     },
     {
+      id: "claude-opus-5",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Opus 5",
+      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      capabilities: FULL_CAPABILITIES,
+    },
+    {
       id: "claude-opus-4-6",
       object: "model",
       created: now,

--- a/src/telemetry/pricing.ts
+++ b/src/telemetry/pricing.ts
@@ -75,6 +75,7 @@ export const BUILTIN_MODEL_PRICING: Record<string, ModelPricing> = {
   "claude-fable-5": FABLE,
   "claude-mythos-5": FABLE,
   opus: OPUS,
+  "claude-opus-5": OPUS,
   "claude-opus-4-8": OPUS,
   "claude-opus-4-7": OPUS,
   "claude-opus-4-6": OPUS,


### PR DESCRIPTION
Cherry-picks @robertn702's work from #684 (authorship preserved) and adds test coverage, pricing registration, and docs.

## Robert's changes (87cfcdad)

1. **`/v1/models` never listed `claude-opus-5`** — explicit requests already routed correctly via `explicitModelPin` (the `claude-(...)-\d` regex matches it), but tools that build their picker from the endpoint couldn't offer it. Added as the first Opus entry.
2. **The bare `opus` alias resolved to `claude-opus-4-8`.** Canonical pin bumped to `claude-opus-5` — an alias means "the current model of that tier". `MERIDIAN_DEFAULT_OPUS_MODEL=claude-opus-4-8` restores the old default; explicit ids are honored exactly.

## Follow-up (ee8c7141)

- **Test coverage.** The two `buildModelList` context-window tests are named "all opus variants" but asserted only 4-6/4-7/4-8, leaving the new entry's `isMaxSubscription` ternary as the only uncovered branch. Both now cover `claude-opus-5`.
- **Pricing.** Registered `claude-opus-5` in `BUILTIN_MODEL_PRICING`. Resolution was already correct via the `includes("opus")` family fallback ($5/$25), but that table is what `GET /pricing` serves as the settings page's list of overridable models — without an entry opus-5 was routable but not overridable, unlike `claude-sonnet-5`. Asserted in `pricing-routes.test.ts`.
- **Docs.** Added Opus 5 to the crush and factory example model lists in `docs/agents.md`.

## CLI floor — checked, no bump needed

`package.json` pins `@anthropic-ai/claude-code` at `^2.1.198`, a floor set by #560 immediately before the Fable 5 routing work in #561. That binary ships no `claude-opus-5` string, so the canonical bump raised the question of whether a user on the floor would regress.

Verified live against the pinned 2.1.198 binary — the SDK passes `ANTHROPIC_DEFAULT_OPUS_MODEL` through to the API verbatim rather than validating it against a built-in registry:

| requested | pin | `modelUsage` |
|---|---|---|
| `opus` | `claude-opus-5` | `claude-opus-5` |
| `opus[1m]` | `claude-opus-5` | `claude-opus-5[1m]` |
| `opus` | `claude-opus-4-8` | `claude-opus-4-8` (control) |

The Fable 5 precedent doesn't apply; no floor bump.

## Verification

- Full suite: **2204 pass, 1 skip, 0 fail**
- `tsc --noEmit` clean
- Live: bare `opus` and `opus[1m]` both answered from `claude-opus-5` on Max

Closes #684