### PR TITLE
fix(responses): treat input items without a type as messages

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -40,6 +40,34 @@ describe("translateResponsesToAnthropic", () => {
     expect(r.messages[0]!.role).toBe("user")
   })
 
+  // Bare `{role, content}` items are spec-valid and sent by the Vercel AI SDK.
+  it("treats input items without a type as messages", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { role: "system", content: "Be terse." },
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { role: "assistant", content: [{ type: "output_text", text: "hi" }] },
+      ],
+    })!
+    expect(r.system).toContain("Be terse.")
+    expect(r.messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    ])
+  })
+
+  it("still ignores items that carry no role", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "reasoning", id: "rs_123" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    })!
+    expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }])
+  })
+
   it("maps input_image data URLs to Anthropic image blocks", () => {
     const dataUrl = "data:image/png;base64,iVBORw0KGgo="
     const r = translateResponsesToAnthropic({

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -37,7 +37,8 @@ interface ResponsesContentPart {
 }
 
 interface ResponsesMessageItem {
-  type: "message"
+  /** Optional per the spec — `EasyInputMessage` requires only `role`. */
+  type?: "message"
   role: "user" | "assistant" | "developer" | "system"
   content: ResponsesContentPart[] | string
 }
@@ -165,7 +166,11 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   }
 
   for (const item of items) {
-    switch (item.type) {
+    // Codex always sends `type`, but it defaults to "message" when omitted.
+    // Without this, bare `{role, content}` items hit `default:` and are
+    // dropped, leaving zero messages — upstream then 400s on empty messages.
+    const itemType = item.type ?? ("role" in item ? "message" : undefined)
+    switch (itemType) {
       case "message": {
         const msg = item as ResponsesMessageItem
         if (msg.role === "developer" || msg.role === "system") {


### PR DESCRIPTION
## Problem

`translateResponsesToAnthropic` switches on `item.type`, meridian's code marks `type` as required but `type` is optional on Responses input items as per the official openai spec and should default to `"message"`.

As per OpenAI's published spec, [`EasyInputMessage`](https://github.com/openai/openai-openapi/blob/5c044be3bf3a42854e99e34616564eeb2124a317/openapi.yaml#L37492-L37541) lists only `role` as required, and [`InputMessage`](https://github.com/openai/openai-openapi/blob/5c044be3bf3a42854e99e34616564eeb2124a317/openapi.yaml#L41804-L41842) only `role` + `content`:

```yaml
EasyInputMessage:
  properties:
    role: ...
    content: ...
    type:
      enum: [message]     # present, but…
  required:
    - role                # …not required
```

Codex always sends `type` explicitly, so this worked in practice. Clients that omit it i.e. are following the spec — notably the Vercel AI SDK's `.responses()` model, which emits bare `{role, content}` items — fall through to `default:` and have every message silently dropped. A request whose input is *all* bare items translates to zero messages and is rejected upstream:

```
{"type":"error","error":{"type":"invalid_request_error",
 "message":"messages: Cannot be empty — at least one message is required"}}
```

## Fix

Default `type` to `"message"` when absent and a `role` is present. Roleless items (`item_reference`, `reasoning`, …) keep falling through to `default:` as before.

## Verification

Ran both clients against a proxy on this branch vs. unpatched `main`:

| Client | Before | After |
|---|---|---|
| Codex CLI 0.145.0 | ✅ | ✅ |
| Vercel AI SDK `.responses()` | ❌ `messages: Cannot be empty` | ✅ |

- Added test fails on `main`, passes here.
- `npm test`: 2217 passing, 0 failures. `tsc --noEmit` clean.

Note: [`InputItem`](https://github.com/openai/openai-openapi/blob/5c044be3bf3a42854e99e34616564eeb2124a317/openapi.yaml#L41788-L41803) declares `discriminator: {propertyName: type}`, which sits in tension with `type` being optional — likely why the original assumed it was always present. The `required` lists and real upstream behaviour both accept the bare form.

Spec references pinned to [`openai/openai-openapi@5c044be`](https://github.com/openai/openai-openapi/tree/5c044be3bf3a42854e99e34616564eeb2124a317).