### PR TITLE
fix: replay stale session histories safely

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,10 +172,16 @@ Every request verifies that incoming messages are a valid continuation of the ca
 
 | Classification | Condition | Action |
 |---------------|-----------|--------|
-| **Continuation** | Prefix hash matches stored | Resume normally |
-| **Compaction** | Suffix preserved, beginning changed | Resume (agent summarized old messages) |
+| **Continuation** | Full stored prefix hash matches | Resume from the stored message boundary |
+| **Compaction** | Suffix preserved, beginning changed | Resume after the matched suffix |
 | **Undo** | Prefix preserved, suffix changed | Fork at rollback point |
-| **Diverged** | No meaningful overlap | Start fresh session |
+| **Diverged** | No overlap, unverifiable state, or a changed cached prefix followed by new messages | Start fresh and replay the complete client history |
+
+Lineage verification is side-effect free. A classification may select an SDK
+session and a replay boundary, but updated message counts and hashes are only
+stored after the upstream request succeeds. When Meridian cannot prove that an
+SDK session contains a section of client history, it starts fresh rather than
+silently skipping that section.
 
 ## Testing Strategy
 

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -11,7 +11,6 @@ import {
   measureSuffixOverlap,
   verifyLineage,
   normalizeContextUsage,
-  MIN_SUFFIX_FOR_COMPACTION,
   type SessionState,
 } from "../proxy/session/lineage"
 
@@ -28,8 +27,6 @@ function makeSession(overrides: Partial<SessionState> = {}): SessionState {
     ...overrides,
   }
 }
-
-const mockCache = { delete: () => true }
 
 describe("computeLineageHash", () => {
   it("returns empty string for empty array", () => {
@@ -169,10 +166,10 @@ describe("measureSuffixOverlap", () => {
 })
 
 describe("verifyLineage", () => {
-  it("returns continuation for empty lineage hash (legacy)", () => {
+  it("returns diverged for an unverifiable legacy session", () => {
     const session = makeSession({ lineageHash: "", messageCount: 0 })
-    const result = verifyLineage(session, [msg("user", "hi")], "key", mockCache)
-    expect(result.type).toBe("continuation")
+    const result = verifyLineage(session, [msg("user", "hi")])
+    expect(result).toEqual({ type: "diverged", reason: "unverifiable" })
   })
 
   it("returns continuation when prefix matches exactly", () => {
@@ -184,8 +181,11 @@ describe("verifyLineage", () => {
     })
     // Same messages + one new one = valid continuation
     const extended = [...msgs, msg("user", "how are you?")]
-    const result = verifyLineage(session, extended, "key", mockCache)
+    const result = verifyLineage(session, extended)
     expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(msgs.length)
+    }
   })
 
   it("returns diverged when no per-message hashes and lineage mismatches", () => {
@@ -194,7 +194,7 @@ describe("verifyLineage", () => {
       messageCount: 2,
       messageHashes: undefined,
     })
-    const result = verifyLineage(session, [msg("user", "different")], "key", mockCache)
+    const result = verifyLineage(session, [msg("user", "different")])
     expect(result.type).toBe("diverged")
   })
 
@@ -209,7 +209,7 @@ describe("verifyLineage", () => {
     })
     // Undo: keep first 2 messages, replace last 2
     const undone = [msg("user", "a"), msg("assistant", "b"), msg("user", "new")]
-    const result = verifyLineage(session, undone, "key", mockCache)
+    const result = verifyLineage(session, undone)
     expect(result.type).toBe("undo")
     if (result.type === "undo") {
       expect(result.prefixOverlap).toBe(2)
@@ -217,9 +217,7 @@ describe("verifyLineage", () => {
     }
   })
 
-  it("returns continuation (not undo) when messages grow with a modified message", () => {
-    // Reproduces the false undo bug: conversation grows from 7 to 9 messages
-    // but message[6] was modified (e.g., cache_control added by OpenCode).
+  it("returns diverged when messages grow after a cached message changed", () => {
     const msgs = [
       msg("user", "a"), msg("assistant", "b"),
       msg("user", "c"), msg("assistant", "d"),
@@ -242,8 +240,66 @@ describe("verifyLineage", () => {
       msg("assistant", "h"),      // New
       msg("user", "i"),           // New
     ]
-    const result = verifyLineage(session, extended, "key", mockCache)
-    // Should be continuation, NOT undo — the conversation grew
+    const result = verifyLineage(session, extended)
+    expect(result).toEqual({
+      type: "diverged",
+      reason: "modified-history",
+      prefixOverlap: 6,
+    })
+  })
+
+  it("does not mutate cached state when a stale 515-message session receives 727 messages", () => {
+    const cachedMessages = Array.from({ length: 515 }, (_, i) =>
+      msg(i % 2 === 0 ? "user" : "assistant", `cached-${i}`)
+    )
+    const session = makeSession({
+      lineageHash: computeLineageHash(cachedMessages),
+      messageCount: cachedMessages.length,
+      messageHashes: computeMessageHashes(cachedMessages),
+    })
+    const originalHashes = [...session.messageHashes!]
+    const incoming = [
+      ...cachedMessages.slice(0, 514),
+      msg("user", "changed-boundary"),
+      ...Array.from({ length: 212 }, (_, i) =>
+        msg((i + 515) % 2 === 0 ? "user" : "assistant", `new-${i}`)
+      ),
+    ]
+
+    const result = verifyLineage(session, incoming)
+
+    expect(incoming).toHaveLength(727)
+    expect(result).toEqual({
+      type: "diverged",
+      reason: "modified-history",
+      prefixOverlap: 514,
+    })
+    expect(session.messageCount).toBe(515)
+    expect(session.lineageHash).toBe(computeLineageHash(cachedMessages))
+    expect(session.messageHashes).toEqual(originalHashes)
+  })
+
+  it("ignores cache_control changes when verifying a strict continuation", () => {
+    const cachedMessages = [{
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    }]
+    const session = makeSession({
+      lineageHash: computeLineageHash(cachedMessages),
+      messageCount: cachedMessages.length,
+      messageHashes: computeMessageHashes(cachedMessages),
+    })
+    const incoming = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello", cache_control: { type: "ephemeral" } }],
+      },
+      msg("assistant", "hi"),
+      msg("user", "continue"),
+    ]
+
+    const result = verifyLineage(session, incoming)
+
     expect(result.type).toBe("continuation")
   })
 
@@ -265,7 +321,7 @@ describe("verifyLineage", () => {
       msg("user", "a"), msg("assistant", "b"),
       msg("user", "c"), msg("assistant", "d-modified"),
     ]
-    const result = verifyLineage(session, modified, "key", mockCache)
+    const result = verifyLineage(session, modified)
     expect(result.type).toBe("undo")
   })
 
@@ -284,7 +340,7 @@ describe("verifyLineage", () => {
     })
     // Fewer messages — clear undo
     const undone = [msg("user", "a"), msg("assistant", "b"), msg("user", "new")]
-    const result = verifyLineage(session, undone, "key", mockCache)
+    const result = verifyLineage(session, undone)
     expect(result.type).toBe("undo")
   })
 
@@ -297,7 +353,7 @@ describe("verifyLineage", () => {
       messageCount: msgs.length,
       messageHashes: computeMessageHashes(msgs),
     })
-    const result = verifyLineage(session, msgs, "key", mockCache)
+    const result = verifyLineage(session, msgs)
     expect(result.type).toBe("diverged")
   })
 
@@ -311,7 +367,7 @@ describe("verifyLineage", () => {
       messageCount: msgs.length,
       messageHashes: computeMessageHashes(msgs),
     })
-    const result = verifyLineage(session, msgs, "key", mockCache)
+    const result = verifyLineage(session, msgs)
     expect(result.type).toBe("diverged")
   })
 
@@ -324,7 +380,7 @@ describe("verifyLineage", () => {
       messageHashes: computeMessageHashes(msgs),
     })
     const extended = [...msgs, msg("assistant", "hi"), msg("user", "how are you?")]
-    const result = verifyLineage(session, extended, "key", mockCache)
+    const result = verifyLineage(session, extended)
     expect(result.type).toBe("continuation")
   })
 
@@ -341,13 +397,23 @@ describe("verifyLineage", () => {
       messageCount: msgs.length,
       messageHashes: hashes,
     })
-    // Compaction: change beginning, keep last MIN_SUFFIX_FOR_COMPACTION messages
+    const originalLineageHash = session.lineageHash
+    const originalMessageHashes = [...session.messageHashes!]
+    // Compaction: change beginning, keep the stored suffix, append a new turn.
     const compacted = [
       msg("user", "summary"), // replaced
       msg("user", "e"), msg("assistant", "f"), // preserved suffix
+      msg("assistant", "new response"), msg("user", "continue"),
     ]
-    const result = verifyLineage(session, compacted, "key", mockCache)
+    const result = verifyLineage(session, compacted)
     expect(result.type).toBe("compaction")
+    if (result.type === "compaction") {
+      expect(result.resumeFrom).toBe(3)
+      expect(result.suffixOverlap).toBe(2)
+    }
+    expect(session.messageCount).toBe(msgs.length)
+    expect(session.lineageHash).toBe(originalLineageHash)
+    expect(session.messageHashes).toEqual(originalMessageHashes)
   })
 
   it("does not false-detect compaction when suffix hashes appear at wrong positions (regression #283)", () => {
@@ -374,7 +440,7 @@ describe("verifyLineage", () => {
       msg("user", "completely-new"),
       msg("assistant", "also-new"),
     ]
-    const result = verifyLineage(session, incoming, "key", mockCache)
+    const result = verifyLineage(session, incoming)
     // Must NOT be compaction — the suffix is at the wrong position
     expect(result.type).not.toBe("compaction")
     expect(result.type).toBe("diverged")

--- a/src/__tests__/proxy-session-resume.test.ts
+++ b/src/__tests__/proxy-session-resume.test.ts
@@ -58,9 +58,10 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
 
 function createTestApp() {
-  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
   return app
 }
 
@@ -86,6 +87,30 @@ async function readStreamFull(response: Response): Promise<string> {
     result += decoder.decode(value, { stream: true })
   }
   return result
+}
+
+function buildStaleSessionFixture() {
+  const cached = Array.from({ length: 515 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: `cached message ${i}`,
+  }))
+  const incoming = [
+    ...cached.slice(0, 514),
+    { role: "user", content: "cached boundary rewritten by the client" },
+    ...Array.from({ length: 212 }, (_, i) => {
+      const messageIndex = i + 515
+      let content = `new message ${messageIndex}`
+      if (messageIndex === 600) content = "WINDOWS MAXWELL CSV SENTINEL"
+      if (messageIndex === 601) content = "ASSISTANT ANALYSIS SENTINEL"
+      if (messageIndex === 726) content = "What did we find in the exported results?"
+      return {
+        role: messageIndex % 2 === 0 ? "user" : "assistant",
+        content,
+      }
+    }),
+  ]
+
+  return { cached, incoming }
 }
 
 // ============================================================
@@ -446,5 +471,81 @@ describe("Session resume: only send last user message on resume", () => {
     expect(capturedQueryParams.prompt).toContain("First message")
     expect(capturedQueryParams.prompt).toContain("Second message")
     expect(capturedQueryParams.options.resume).toBeUndefined()
+  })
+})
+
+describe("Session resume: stale cross-node history", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "Recovered" }])]
+    clearSessionCache()
+    capturedQueryParams = null
+    queryCallCount = 0
+  })
+
+  it("fresh-replays all 727 messages when only 514/515 cached messages match", async () => {
+    const app = createTestApp()
+    const { cached, incoming } = buildStaleSessionFixture()
+    storeSession("oc-stale-nonstream", cached, "sdk-stale-nonstream")
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: incoming,
+    }, { "x-opencode-session": "oc-stale-nonstream" })
+    await response.json()
+
+    expect(cached).toHaveLength(515)
+    expect(incoming).toHaveLength(727)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.prompt).toContain("<conversation_history>")
+    expect(capturedQueryParams.prompt).toContain("WINDOWS MAXWELL CSV SENTINEL")
+    expect(capturedQueryParams.prompt).toContain("ASSISTANT ANALYSIS SENTINEL")
+    expect(capturedQueryParams.prompt.trimEnd()).toEndWith("What did we find in the exported results?")
+
+    capturedQueryParams = null
+    const followUp = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        ...incoming,
+        { role: "assistant", content: "Recovered" },
+        { role: "user", content: "Continue after recovery" },
+      ],
+    }, { "x-opencode-session": "oc-stale-nonstream" })
+    await followUp.json()
+
+    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.prompt).toContain("Continue after recovery")
+    expect(capturedQueryParams.prompt).not.toContain("WINDOWS MAXWELL CSV SENTINEL")
+  })
+
+  it("uses the same full replay fallback for streaming requests", async () => {
+    const app = createTestApp()
+    const { cached, incoming } = buildStaleSessionFixture()
+    storeSession("oc-stale-stream", cached, "sdk-stale-stream")
+    mockMessages = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "Recovered"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: true,
+      messages: incoming,
+    }, { "x-opencode-session": "oc-stale-stream" })
+    await readStreamFull(response)
+
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.prompt).toContain("<conversation_history>")
+    expect(capturedQueryParams.prompt).toContain("WINDOWS MAXWELL CSV SENTINEL")
+    expect(capturedQueryParams.prompt).toContain("ASSISTANT ANALYSIS SENTINEL")
+    expect(capturedQueryParams.prompt.trimEnd()).toEndWith("What did we find in the exported results?")
   })
 })

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -20,7 +20,10 @@ type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
 
 let mockMessages: MockSdkMessage[] = []
-interface CapturedQueryParams { options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string } }
+interface CapturedQueryParams {
+  prompt?: unknown
+  options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string }
+}
 let capturedQueryParams: CapturedQueryParams | null = null
 /** Access capturedQueryParams without TS narrowing to `never` after null assignments */
 function getCaptured(): CapturedQueryParams | null { return capturedQueryParams }
@@ -28,7 +31,7 @@ let queuedSessionIds: string[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
-    capturedQueryParams = params as { options?: { resume?: string } }
+    capturedQueryParams = params as CapturedQueryParams
     const sessionId = queuedSessionIds.shift() || "sdk-session-default"
     return (async function* () {
       for (const msg of mockMessages) {
@@ -68,7 +71,7 @@ afterAll(() => {
 })
 
 function createTestApp() {
-  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
   return app as TestApp
 }
 
@@ -398,17 +401,22 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "topic D" },
     ], "sdk-c")
 
-    // Compaction: beginning summarised, last 4 messages + 2 new
+    // Compaction: beginning summarised, preserved suffix followed by multiple
+    // turns accumulated since this SDK session was last used.
     capturedQueryParams = null
     await post(app, "sess-c", [
       { role: "user", content: "[Summary: A, B and C discussed]" },
       { role: "assistant", content: "C explained" },
       { role: "user", content: "topic D" },
       { role: "assistant", content: "D explained" },
+      { role: "user", content: "INTERMEDIATE COMPACTION SENTINEL" },
+      { role: "assistant", content: "sentinel acknowledged" },
       { role: "user", content: "topic E" },
     ], "sdk-c")
 
     expect(getCaptured()?.options?.resume).toBe("sdk-c")
+    expect(getCaptured()?.prompt).toContain("INTERMEDIATE COMPACTION SENTINEL")
+    expect(getCaptured()?.prompt).toContain("topic E")
   })
 
   it("resumes after compaction reduces message count", async () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -988,8 +988,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             claudeLog("session.pending_store_awaited", { waitedMs: Date.now() - waitStart })
           }
         }
-        let lineageResult = isIndependentSession
-          ? { type: "diverged" as const }
+        let lineageResult: LineageResult = isIndependentSession
+          ? { type: "diverged", reason: "independent-request" }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
         // NOTE: agent-specific (opencode) — when OpenCode's chat.headers plugin
         // hook doesn't fire (category-dispatched or title-generation requests),
@@ -998,12 +998,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // session and be classified as "undo." Downgrade to "diverged" to
         // prevent leaking the old session's conversation history.
         if (lineageResult.type === "undo" && adapterBase === "opencode" && !agentSessionId) {
-          lineageResult = { type: "diverged" }
+          lineageResult = { type: "diverged", reason: "missing-session-header" }
         }
         const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         const resumeSessionId = cachedSession?.claudeSessionId
+        const resumeFrom = lineageResult.type === "continuation" || lineageResult.type === "compaction"
+          ? lineageResult.resumeFrom
+          : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
 
@@ -1066,9 +1069,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // so we only need to send the new user message.
           messagesToConvert = getLastUserMessage(allMessages)
         } else if (isResume) {
-          const knownCount = cachedSession.messageCount || 0
-          if (knownCount > 0 && knownCount < allMessages.length) {
-            messagesToConvert = allMessages.slice(knownCount)
+          if (resumeFrom !== undefined && resumeFrom < allMessages.length) {
+            messagesToConvert = allMessages.slice(resumeFrom)
           } else {
             messagesToConvert = getLastUserMessage(allMessages)
           }

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -6,6 +6,7 @@
  */
 
 import { LRUMap } from "../../utils/lruMap"
+import { diagnosticLog } from "../../telemetry"
 import {
   lookupSharedSession,
   lookupSharedSessionByClaudeId,
@@ -127,6 +128,30 @@ function touchSession(state: SessionState): SessionState {
   return state
 }
 
+function classifyLineage(
+  state: SessionState,
+  messages: Array<{ role: string; content: any }>,
+  cacheKey: string
+): LineageResult {
+  const result = verifyLineage(state, messages)
+
+  if (result.type === "compaction") {
+    const msg = `Compaction detected (key=${cacheKey.slice(0, 8)}…): suffix overlap ${result.suffixOverlap}/${state.messageCount}, resume from incoming message ${result.resumeFrom}.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  } else if (result.type === "undo") {
+    const msg = `Undo detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap}/${state.messageCount}, rollback UUID: ${result.rollbackUuid || "none (legacy session)"}.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  } else if (result.type === "diverged" && result.reason === "modified-history") {
+    const msg = `Stale session detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap || 0}/${state.messageCount}, incoming ${messages.length} msgs. Starting fresh replay.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  }
+
+  return result
+}
+
 /** Look up a cached session by header or fingerprint.
  *  Returns a LineageResult that classifies the mutation and includes the
  *  session state needed for the correct SDK action. */
@@ -138,7 +163,7 @@ export function lookupSession(
   if (sessionId) {
     const cached = sessionCache.get(sessionId)
     if (cached) {
-      const result = verifyLineage(cached, messages, sessionId, sessionCache)
+      const result = classifyLineage(cached, messages, sessionId)
       if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
       return result
     }
@@ -153,20 +178,20 @@ export function lookupSession(
         sdkMessageUuids: shared.sdkMessageUuids,
         contextUsage: shared.contextUsage,
       }
-      const result = verifyLineage(state, messages, sessionId, sessionCache)
+      const result = classifyLineage(state, messages, sessionId)
       if (result.type === "continuation" || result.type === "compaction") {
         sessionCache.set(sessionId, state)
       }
       return result
     }
-    return { type: "diverged" }
+    return { type: "diverged", reason: "not-found" }
   }
 
   const fp = getConversationFingerprint(messages, workingDirectory)
   if (fp) {
     const cached = fingerprintCache.get(fp)
     if (cached) {
-      const result = verifyLineage(cached, messages, fp, fingerprintCache)
+      const result = classifyLineage(cached, messages, fp)
       if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
       return result
     }
@@ -181,14 +206,14 @@ export function lookupSession(
         sdkMessageUuids: shared.sdkMessageUuids,
         contextUsage: shared.contextUsage,
       }
-      const result = verifyLineage(state, messages, fp, fingerprintCache)
+      const result = classifyLineage(state, messages, fp)
       if (result.type === "continuation" || result.type === "compaction") {
         fingerprintCache.set(fp, state)
       }
       return result
     }
   }
-  return { type: "diverged" }
+  return { type: "diverged", reason: "not-found" }
 }
 
 /** Look up a session by the Claude SDK session ID returned in responses.

--- a/src/proxy/session/index.ts
+++ b/src/proxy/session/index.ts
@@ -2,6 +2,6 @@
  * Session management — barrel export.
  */
 export { computeLineageHash, hashMessage, computeMessageHashes, verifyLineage, measurePrefixOverlap, measureSuffixOverlap, MIN_SUFFIX_FOR_COMPACTION } from "./lineage"
-export type { SessionState, LineageResult, SessionCacheLike } from "./lineage"
+export type { SessionState, LineageResult, LineageDivergenceReason } from "./lineage"
 export { extractClientCwd, getConversationFingerprint } from "./fingerprint"
 export { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession } from "./cache"

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -7,7 +7,6 @@
 
 import { createHash } from "crypto"
 import { normalizeContent } from "../messages"
-import { diagnosticLog } from "../../telemetry"
 
 // --- Types ---
 
@@ -62,10 +61,19 @@ export interface SessionState {
  * the information needed to take the correct SDK action.
  */
 export type LineageResult =
-  | { type: "continuation"; session: SessionState }
-  | { type: "compaction";   session: SessionState }
+  | { type: "continuation"; session: SessionState; resumeFrom: number }
+  | { type: "compaction";   session: SessionState; resumeFrom: number; suffixOverlap: number }
   | { type: "undo";         session: SessionState; prefixOverlap: number; rollbackUuid: string | undefined }
-  | { type: "diverged" }
+  | { type: "diverged";     reason: LineageDivergenceReason; prefixOverlap?: number }
+
+export type LineageDivergenceReason =
+  | "unverifiable"
+  | "replayed-request"
+  | "modified-history"
+  | "unrelated-history"
+  | "not-found"
+  | "independent-request"
+  | "missing-session-header"
 
 // --- Hashing ---
 
@@ -196,30 +204,27 @@ function findSuffixAnchorStart(
 
 // --- Lineage verification ---
 
-/** Cache-like interface for verifyLineage — only needs get/set/delete */
-export interface SessionCacheLike {
-  delete(key: string): boolean
-}
-
 /**
  * Verify that incoming messages are a valid continuation of a cached session.
  * Uses per-message hash comparison to deterministically classify mutations.
+ * This function is deliberately side-effect free: it never mutates the cached
+ * state. The caller commits new hashes/counts only after the upstream request
+ * succeeds.
  *
  * Decision matrix:
- *   Full prefix match (fast-path)          → continuation (resume normally)
- *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume normally)
- *   Prefix overlap > 0, no suffix          → undo         (fork at rollback point)
- *   No overlap                             → diverged     (start fresh)
+ *   Full prefix match (fast-path)          → continuation (resume from stored count)
+ *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume after matched suffix)
+ *   Prefix overlap > 0, no suffix, shrank  → undo         (fork at rollback point)
+ *   Cached prefix changed while growing    → diverged     (fresh full-history replay)
+ *   No overlap                             → diverged     (fresh full-history replay)
  */
 export function verifyLineage(
   cached: SessionState,
-  messages: Array<{ role: string; content: any }>,
-  cacheKey: string,
-  cache: SessionCacheLike
+  messages: Array<{ role: string; content: any }>
 ): LineageResult {
-  // No stored lineage (legacy entry or first request) — allow resume
+  // A legacy entry cannot prove which client history its SDK session contains.
   if (!cached.lineageHash || cached.messageCount === 0) {
-    return { type: "continuation", session: cached }
+    return { type: "diverged", reason: "unverifiable" }
   }
 
   // --- Fast path: aggregate lineage hash ---
@@ -230,17 +235,15 @@ export function verifyLineage(
     // Without this guard, identical requests resume the old SDK session and
     // re-send the last user message, causing ghost context accumulation.
     if (messages.length <= cached.messageCount) {
-      cache.delete(cacheKey)
-      return { type: "diverged" }
+      return { type: "diverged", reason: "replayed-request" }
     }
-    return { type: "continuation", session: cached }
+    return { type: "continuation", session: cached, resumeFrom: cached.messageCount }
   }
 
   // --- Slow path: per-message diff ---
   if (!cached.messageHashes || cached.messageHashes.length === 0) {
     // No per-message hashes stored (legacy session). Can't diff — reject.
-    cache.delete(cacheKey)
-    return { type: "diverged" }
+    return { type: "diverged", reason: "unverifiable" }
   }
 
   const incomingHashes = computeMessageHashes(messages)
@@ -263,19 +266,18 @@ export function verifyLineage(
     cached.messageHashes.length >= MIN_STORED_FOR_COMPACTION &&
     suffixStartInIncoming > 0   // at least one changed message before the preserved suffix
   ) {
-    const compactionMsg = `Compaction detected (key=${cacheKey.slice(0, 8)}…): suffix overlap ${suffixOverlap}/${cached.messageHashes.length}. Allowing resume.`
-    console.error(`[PROXY] ${compactionMsg}`)
-    diagnosticLog.lineage(compactionMsg)
-    cached.lineageHash = computeLineageHash(messages)
-    cached.messageHashes = incomingHashes
-    cached.messageCount = messages.length
-    return { type: "compaction", session: cached }
+    return {
+      type: "compaction",
+      session: cached,
+      resumeFrom: suffixStartInIncoming + suffixOverlap,
+      suffixOverlap,
+    }
   }
 
   // Undo: prefix preserved (beginning intact) but suffix changed,
   // AND the conversation shrank (fewer messages). If the conversation grew
-  // (messages.length > cached.messageCount), the client added new messages
-  // after modifying a previous one — that's a continuation, not an undo.
+  // after a cached message changed, the old SDK session cannot prove it has
+  // the intervening history; that case is handled as divergence below.
   if (prefixOverlap > 0 && suffixOverlap === 0 && messages.length <= cached.messageCount) {
     // Find the SDK UUID at the last matching position.
     let rollbackUuid: string | undefined
@@ -287,26 +289,17 @@ export function verifyLineage(
         }
       }
     }
-    const undoMsg = `Undo detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, rollback UUID: ${rollbackUuid || "none (legacy session)"}.`
-    console.error(`[PROXY] ${undoMsg}`)
-    diagnosticLog.lineage(undoMsg)
     return { type: "undo", session: cached, prefixOverlap, rollbackUuid }
   }
 
-  // Modified continuation: most prefix matches but a message was modified
-  // (e.g., cache_control added) and new messages were appended. Treat as
-  // continuation — update stored hashes and resume normally.
+  // A growing history with a changed cached prefix is not proof that the old
+  // SDK session contains the intervening turns. This happens when a request is
+  // routed back to a stale proxy node. Resume would silently skip the missing
+  // history, so force a fresh replay instead.
   if (prefixOverlap > 0 && messages.length > cached.messageCount) {
-    const modifiedMsg = `Modified continuation (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, incoming ${messages.length} msgs. Allowing resume.`
-    console.error(`[PROXY] ${modifiedMsg}`)
-    diagnosticLog.lineage(modifiedMsg)
-    cached.lineageHash = computeLineageHash(messages.slice(0, messages.length))
-    cached.messageHashes = incomingHashes
-    cached.messageCount = messages.length
-    return { type: "continuation", session: cached }
+    return { type: "diverged", reason: "modified-history", prefixOverlap }
   }
 
   // No meaningful overlap — completely different conversation.
-  cache.delete(cacheKey)
-  return { type: "diverged" }
+  return { type: "diverged", reason: "unrelated-history", prefixOverlap }
 }


### PR DESCRIPTION
## Summary

- make lineage verification side-effect free and return an explicit resume boundary
- fresh-replay the complete client history when a growing request changes the cached prefix
- resume compaction after the preserved suffix so every newly accumulated turn is forwarded
- document the safety rule and add streaming/non-streaming regression coverage

## Root cause

In a distributed Meridian deployment, a request can return to a proxy node with a stale local/shared session snapshot. In the observed shape, the node had 515 cached messages while the incoming request had 727, with only the first 514 cached messages matching.

The previous `modified continuation` path updated the cached count/hash to the incoming 727-message state before the server selected the request delta. The server then resumed the older SDK session and sent only the final user message, silently omitting the intervening client history.

This change treats a growing history with a changed cached prefix as unverifiable. It starts a fresh SDK session, replays the complete client history, and only stores the new lineage after the upstream request succeeds. A following request resumes the repaired session normally.

Strict prefix continuations still resume, compaction resumes from the matched suffix boundary, undo still forks at its rollback UUID, and busy/stale-UUID retry paths remain unchanged.

## Tests

- `bun test src/__tests__/lineage-unit.test.ts src/__tests__/proxy-session-resume.test.ts src/__tests__/session-lineage.test.ts` (`82 pass`)
- `bun run test` (`2218 pass`, `1 skip`, `0 fail`)
- `bun run typecheck`
- `bun run build`

The HTTP regression tests cover both streaming and non-streaming 515-to-727 stale-session requests, verify that middle-history sentinels reach the fresh prompt, and verify that the next turn resumes the repaired session instead of replaying again.
