### PR TITLE
test: close the windows-smoke postinstall coverage gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,23 @@ jobs:
 
       # Install — this also runs claude-code's postinstall, which is the
       # single most common source of Windows install-time bugs.
+      #
+      # NOTE: bun runs lifecycle scripts through its own bundled POSIX-ish
+      # shell, even on Windows. That makes this step blind to POSIX syntax in
+      # our own `postinstall` — see the npm step below.
       - run: bun install
+
+      # Run our `postinstall` the way npm does: through cmd.exe. bun's shell
+      # happily parses POSIX constructs like `2>/dev/null || true` on Windows,
+      # so the `bun install` above cannot catch them — which is exactly how
+      # #688 shipped a postinstall that broke `npm install` for every Windows
+      # user while this job stayed green.
+      #
+      # `npm run` uses script-shell (cmd.exe on Windows) for the script body,
+      # so a non-portable postinstall fails here with a non-zero exit.
+      - name: postinstall must be cmd.exe-portable
+        run: npm run postinstall
+        shell: cmd
 
       # Run only the resolver tests on Windows. Useful even though they use
       # mocked deps, because the test runner itself exercises path joining,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,24 @@ All changes go through this process, no exceptions:
    gh pr merge <PR_NUMBER> --squash --delete-branch
    ```
 
+   Squash is the default because Release Please parses every commit on `main`
+   for the changelog — squashing keeps changelog entries 1:1 with PRs, whereas
+   merge commits leak every intermediate `fix:`/`feat:` commit into the release
+   notes.
+
+   **Exception — external contributions.** When landing someone else's work,
+   preserve their authorship:
+
+   - **Never retype a contributor's change as your own commit.** Cherry-pick it
+     (`git cherry-pick <sha>`), which keeps them as the commit `Author`, and put
+     any of your own changes in a separate commit on top.
+   - Merge with `--merge` so their commit reaches `main` intact, or squash and
+     verify GitHub's auto-generated `Co-authored-by:` trailer survives your edits
+     to the commit message. Both give countable contribution credit; `--merge`
+     keeps them as sole `Author` of their commit.
+   - Accept the extra changelog line that `--merge` may produce — attribution is
+     worth more than a tidy changelog.
+
 6. **Never** run `git push origin main` directly — all code reaches `main` through merged PRs only.
 
 ## Releasing


### PR DESCRIPTION
Follow-up to #693 / #688.

## The gap

`windows-smoke` is documented as covering the "claude-code postinstall on Windows (#445 class)" of bug. It cannot. The job only runs `bun install`, and **bun executes lifecycle scripts through its own bundled POSIX-ish shell, even on Windows** — so `2>/dev/null || true` parses fine there.

That is precisely how #688 happened: a `postinstall` that broke `npm install` for every Windows user, while a dedicated Windows CI job stayed green the entire time. The job was testing bun's shell, not the shell npm actually uses.

## Changes

**1. `test: run postinstall through cmd.exe in windows-smoke`** — adds a step running `npm run postinstall` with `shell: cmd`. npm uses script-shell (cmd.exe on Windows) for lifecycle script bodies, so a non-portable postinstall now fails the build. Also corrects the misleading comment above `bun install`.

**2. `docs: preserve contributor authorship when landing external PRs`** — squash merge attributes a PR to the merger, so landing external work by squashing (or by retyping the patch) erases the contributor as commit `Author`. Documents cherry-pick + `--merge` as the path for external contributions, and records *why* squash is the default otherwise (Release Please parses every commit on `main`) so the tradeoff is explicit.

## Verification

Validated every workflow file parses, and confirmed the new step resolves to `shell=cmd`:

```
windows-smoke steps:
  - bun install                                | shell=(default:pwsh)
  - postinstall must be cmd.exe-portable       | shell=cmd
  - bun test .../claude-executable-resolver    | shell=bash
  ...
```

The real proof is this job running green on `windows-latest` with the now-portable postinstall from #693 — and it would have gone red against the pre-#693 script.