### PR TITLE
fix: scope rate-limit store per profile so priority cooldowns use the right account's reset

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -85,7 +85,7 @@ MERIDIAN_ROUTING=priority MERIDIAN_PROFILE_ORDER=work,personal meridian
 
 - **Conversations keep their account** while it's healthy — a session never flips accounts just because the pool preference changed (protects per-account prompt caches). A session on an exhausted account fails over and then stays on its new account.
 - **Drain-back is new-sessions-only**: when the preferred account's window resets, new sessions prefer it again immediately; existing conversations finish where they are.
-- **Exhaustion is tracked in-memory** with the reported reset time (conservative 10-minute default when unknown) — the home page shows `#n in pool` and `exhausted · resets in …` badges per account.
+- **Exhaustion is tracked in-memory** using that account's own reported reset time (conservative 10-minute default when unknown), refined shortly after by an authoritative check against the usage API that can extend — never shorten — the cooldown once that account's five-hour window is confirmed exhausted. The home page shows `#n in pool` and `exhausted · resets in …` badges per account.
 - When **every** account is exhausted, the last-tried account's error is surfaced unchanged.
 - An explicit `x-meridian-profile` header always bypasses the pool (per-session pinning keeps working).
 - Failovers are logged (`profile.failover` in the diagnostic stream; `profile=<id>(priority)` in request lines).

--- a/docs/superpowers/plans/2026-07-27-profile-scoped-rate-limit-store.md
+++ b/docs/superpowers/plans/2026-07-27-profile-scoped-rate-limit-store.md
@@ -1,0 +1,787 @@
+# Profile-Scoped Rate-Limit Store Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make priority routing's exhaustion cooldown derive from the failing profile's own quota reset instead of whichever profile last wrote to a global singleton.
+
+**Architecture:** Add a profile dimension to `RateLimitStore` (`Map<profileId, Map<bucket, entry>>`) so every read is explicitly per-account, then resolve a failing profile's cooldown from three sources in order: its own scoped `five_hour` entry, a non-blocking authoritative `fetchOAuthUsage` call for that account, and the existing 10-minute default.
+
+**Tech Stack:** TypeScript, Hono, Bun test, `@anthropic-ai/claude-agent-sdk`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md`.
+- Branch is `fix/profile-scoped-rate-limit-store`. **Never** `git push origin main`.
+- No `as any`, `@ts-ignore`, `@ts-expect-error`, or empty catch blocks. (Existing `(event as any)` casts at the SDK-event call sites are pre-existing and stay as-is; do not add new ones.)
+- `npx tsc --noEmit` must pass — `bun test` and `tsup` skip type errors in tests, CI runs typecheck separately.
+- Tests run with `bun test`. Bun's `noUncheckedIndexedAccess` strictness applies: do not index into arrays directly in assertions, map and compare sequences instead (see the existing pattern in `rate-limit-store.test.ts:82-87`).
+- `profileId` is **required** on `record`/`getAll`/`get`. Do not make it optional — an optional parameter would let a call site silently read across accounts again, which is the exact failure being fixed.
+- Commits use Conventional Commits (`fix:`, `test:`, `refactor:`, `docs:`) with no AI attribution lines. Use `git -c commit.gpgsign=false`.
+- Module boundaries: `rateLimitStore.ts` gains no new imports. `routing.ts` and `session/lineage.ts` are not touched.
+
+---
+
+### Task 1: Profile-scope `RateLimitStore`
+
+Self-contained module change plus its unit tests. Nothing outside `rateLimitStore.ts` compiles against the new signatures yet — that is Task 2.
+
+**Files:**
+- Modify: `src/proxy/rateLimitStore.ts` (whole class + module doc comment)
+- Test: `src/__tests__/rate-limit-store.test.ts` (rewrite call sites, add isolation cases)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```ts
+  record(profileId: string, info: SDKRateLimitInfo | undefined | null, observedAt?: number): void
+  getAll(profileId: string): RateLimitEntry[]
+  get(profileId: string, key: RateLimitBucketKey): RateLimitEntry | undefined
+  clear(profileId?: string): void
+  size(profileId?: string): number   // NOTE: method, not a getter
+  ```
+  `RateLimitEntry` and `RateLimitBucketKey` are unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the entire `describe("rateLimitStore", ...)` block in `src/__tests__/rate-limit-store.test.ts` with the version below. Keep lines 1-25 (the header comment, imports, and the `FIVE_HOUR` / `SEVEN_DAY` fixtures) exactly as they are.
+
+```ts
+const WORK = "work"
+const PERSONAL = "personal"
+
+describe("rateLimitStore", () => {
+  it("starts empty", () => {
+    const store = new _RateLimitStoreForTests()
+    expect(store.size()).toBe(0)
+    expect(store.getAll(WORK)).toEqual([])
+  })
+
+  it("records distinct buckets keyed by rateLimitType", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(WORK, SEVEN_DAY)
+    expect(store.size(WORK)).toBe(2)
+    const types = store.getAll(WORK).map(e => e.rateLimitType).sort()
+    expect(types).toEqual(["five_hour", "seven_day"])
+  })
+
+  it("overwrites on second record for same bucket (last-write-wins)", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, { ...FIVE_HOUR, utilization: 0.42 })
+    store.record(WORK, { ...FIVE_HOUR, utilization: 0.55 })
+    expect(store.size(WORK)).toBe(1)
+    expect(store.get(WORK, "five_hour")?.utilization).toBe(0.55)
+  })
+
+  it("buckets entries without rateLimitType under 'default'", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, { status: "allowed", utilization: 0.1 })
+    expect(store.size(WORK)).toBe(1)
+    expect(store.get(WORK, "default")?.utilization).toBe(0.1)
+  })
+
+  it("ignores nullish or non-object input without throwing", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, undefined)
+    store.record(WORK, null as unknown as SDKRateLimitInfo)
+    store.record(WORK, "nope" as unknown as SDKRateLimitInfo)
+    expect(store.size()).toBe(0)
+  })
+
+  it("stamps observedAt on each record", () => {
+    const store = new _RateLimitStoreForTests()
+    const before = Date.now()
+    store.record(WORK, FIVE_HOUR)
+    const after = Date.now()
+    const entry = store.get(WORK, "five_hour")
+    expect(entry?.observedAt).toBeGreaterThanOrEqual(before)
+    expect(entry?.observedAt).toBeLessThanOrEqual(after)
+  })
+
+  it("getAll returns entries newest-first by observedAt", async () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    // Force monotonic observedAt — Bun's `Date.now()` resolution is fine here.
+    await Bun.sleep(2)
+    store.record(WORK, SEVEN_DAY)
+    // Compare the mapped sequence rather than indexing into the array directly
+    // so the test stays under TypeScript's `noUncheckedIndexedAccess` strict
+    // mode (which CI's `tsc --noEmit` enforces but Bun's lenient default tsc
+    // does not).
+    const orderedTypes = store.getAll(WORK).map(e => e.rateLimitType)
+    expect(orderedTypes).toEqual(["seven_day", "five_hour"])
+  })
+
+  it("preserves all SDKRateLimitInfo fields verbatim", () => {
+    const store = new _RateLimitStoreForTests()
+    const full: SDKRateLimitInfo = {
+      status: "allowed_warning",
+      rateLimitType: "overage",
+      utilization: 0.78,
+      resetsAt: 1_730_000_000_000,
+      overageStatus: "allowed",
+      overageResetsAt: 1_730_100_000_000,
+      isUsingOverage: true,
+      surpassedThreshold: 0.75,
+      overageDisabledReason: "no_limits_configured",
+    }
+    store.record(WORK, full)
+    const got = store.get(WORK, "overage")
+    expect(got).toMatchObject(full)
+  })
+
+  // --- Profile isolation (the bug this scoping fixes) ---
+
+  it("keeps the same bucket type separate per profile", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, { ...FIVE_HOUR, resetsAt: 1_000 })
+    store.record(PERSONAL, { ...FIVE_HOUR, resetsAt: 9_999 })
+    expect(store.get(WORK, "five_hour")?.resetsAt).toBe(1_000)
+    expect(store.get(PERSONAL, "five_hour")?.resetsAt).toBe(9_999)
+    expect(store.size(WORK)).toBe(1)
+    expect(store.size(PERSONAL)).toBe(1)
+    expect(store.size()).toBe(2)
+  })
+
+  it("getAll returns only the requested profile's entries", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(PERSONAL, SEVEN_DAY)
+    expect(store.getAll(WORK).map(e => e.rateLimitType)).toEqual(["five_hour"])
+    expect(store.getAll(PERSONAL).map(e => e.rateLimitType)).toEqual(["seven_day"])
+  })
+
+  it("getAll for an unseen profile returns an empty array", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    expect(store.getAll("never-seen")).toEqual([])
+    expect(store.get("never-seen", "five_hour")).toBeUndefined()
+  })
+
+  it("clear(profileId) drops one profile and leaves others intact", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(PERSONAL, FIVE_HOUR)
+    store.clear(WORK)
+    expect(store.getAll(WORK)).toEqual([])
+    expect(store.getAll(PERSONAL).map(e => e.rateLimitType)).toEqual(["five_hour"])
+  })
+
+  it("clear() with no argument drops every profile", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(PERSONAL, SEVEN_DAY)
+    store.clear()
+    expect(store.size()).toBe(0)
+    expect(store.getAll(WORK)).toEqual([])
+    expect(store.getAll(PERSONAL)).toEqual([])
+  })
+
+  it("treats 'default' as an ordinary profile key (single-profile setups)", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record("default", FIVE_HOUR)
+    expect(store.getAll("default").map(e => e.rateLimitType)).toEqual(["five_hour"])
+    expect(store.get("default", "five_hour")?.utilization).toBe(0.42)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+bun test src/__tests__/rate-limit-store.test.ts
+```
+
+Expected: FAIL. Errors along the lines of `store.size is not a function` and records landing in the wrong bucket, because `record` still treats its first argument as the `SDKRateLimitInfo`.
+
+- [ ] **Step 3: Implement the scoped store**
+
+In `src/proxy/rateLimitStore.ts`, replace the singleton paragraph of the module doc comment (currently the block beginning `* Singleton — one Meridian process holds one snapshot at a time.`) with:
+
+```
+ * Entries are scoped per profile. Each profile is a separate Claude Max
+ * subscription with separate quotas, so a flat store would let one account's
+ * reset time be read as another's — which is exactly how priority routing
+ * (`routing: "priority"`) mis-derived exhaustion cooldowns before this was
+ * scoped. Every read names its profile explicitly; single-profile setups
+ * simply use the literal `"default"` key.
+ *
+ * State resets on proxy restart — that's fine because the SDK pushes a fresh
+ * event on the next request. `clear(profileId)` drops one account (wired into
+ * `POST /auth/refresh`, which re-authenticates one credential); `clear()`
+ * drops everything and is used by tests.
+```
+
+Then replace the class body:
+
+```ts
+class RateLimitStore {
+  /** profileId -> (bucket key -> entry). One inner map per configured profile. */
+  private byProfile = new Map<string, Map<RateLimitBucketKey, RateLimitEntry>>()
+
+  /**
+   * Record a rate-limit info snapshot for a specific profile.
+   * Last-write-wins per (profileId, rateLimitType). Older entries for the
+   * same pair are overwritten — clients should treat the latest as canonical.
+   *
+   * `observedAt` defaults to the current wall clock but may be supplied
+   * explicitly so callers (and tests) can control the capture timestamp used
+   * for newest-first ordering in {@link getAll}.
+   */
+  record(profileId: string, info: SDKRateLimitInfo | undefined | null, observedAt: number = Date.now()): void {
+    if (!info || typeof info !== "object") return
+    const key: RateLimitBucketKey = info.rateLimitType ?? "default"
+    let buckets = this.byProfile.get(profileId)
+    if (!buckets) {
+      buckets = new Map<RateLimitBucketKey, RateLimitEntry>()
+      this.byProfile.set(profileId, buckets)
+    }
+    buckets.set(key, { ...info, observedAt })
+  }
+
+  /** Snapshot one profile's entries, newest-first by observedAt. */
+  getAll(profileId: string): RateLimitEntry[] {
+    const buckets = this.byProfile.get(profileId)
+    if (!buckets) return []
+    return Array.from(buckets.values()).sort((a, b) => b.observedAt - a.observedAt)
+  }
+
+  /** Snapshot a single bucket for one profile, or undefined if not yet seen. */
+  get(profileId: string, key: RateLimitBucketKey): RateLimitEntry | undefined {
+    return this.byProfile.get(profileId)?.get(key)
+  }
+
+  /** Bucket count for one profile, or across all profiles when omitted. */
+  size(profileId?: string): number {
+    if (profileId !== undefined) return this.byProfile.get(profileId)?.size ?? 0
+    let total = 0
+    for (const buckets of this.byProfile.values()) total += buckets.size
+    return total
+  }
+
+  /**
+   * Drop stored entries for one profile, or every profile when `profileId`
+   * is omitted. Wired into the `POST /auth/refresh` handler so a refreshed
+   * credential's stale quotas can't linger. Also used by tests for isolation.
+   */
+  clear(profileId?: string): void {
+    if (profileId !== undefined) this.byProfile.delete(profileId)
+    else this.byProfile.clear()
+  }
+}
+```
+
+Leave the `RateLimitEntry` interface, the `RateLimitBucketKey` type, the exported `rateLimitStore` singleton, and the `_RateLimitStoreForTests` export unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+bun test src/__tests__/rate-limit-store.test.ts
+```
+
+Expected: PASS, 16 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -c commit.gpgsign=false add src/proxy/rateLimitStore.ts src/__tests__/rate-limit-store.test.ts
+git -c commit.gpgsign=false commit -m "fix: scope rate-limit store entries per profile"
+```
+
+Note: `npx tsc --noEmit` will still fail at this point — `server.ts` has not been updated. That is expected and is fixed in Task 2.
+
+---
+
+### Task 2: Update `server.ts` call sites
+
+Makes the tree compile again and fixes the same wrong-profile bug in `GET /v1/usage/quota`.
+
+**Files:**
+- Modify: `src/proxy/server.ts` (lines ~484, ~1617, ~2331, ~3676, ~3747, ~4043)
+- Test: `src/__tests__/proxy-usage-quota-route.test.ts`
+
+**Interfaces:**
+- Consumes: `record(profileId, info)`, `getAll(profileId)`, `clear(profileId?)` from Task 1.
+- Produces: nothing new. `priorityCooldownUntil` keeps its current `(now: number)` signature in this task; Task 3 changes it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test inside the existing `describe("GET /v1/usage/quota", ...)` block in `src/__tests__/proxy-usage-quota-route.test.ts`. Match the surrounding tests' setup style — read the existing `beforeEach` to see how `__setFetchOAuthUsageOverride` and `rateLimitStore` are reset, and how an app is created, then follow it exactly.
+
+```ts
+  it("reports the requested profile's SDK buckets, not another profile's", async () => {
+    // Both accounts have recorded a five_hour bucket. Asking for `personal`
+    // must never surface `work`'s numbers.
+    rateLimitStore.record("work", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.99,
+      resetsAt: 1_111_111_111_111,
+    })
+    rateLimitStore.record("personal", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.10,
+      resetsAt: 2_222_222_222_222,
+    })
+    __setFetchOAuthUsageOverride(async () => null)
+
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [
+        { id: "work", claudeConfigDir: "/tmp/meridian-quota-work" },
+        { id: "personal", claudeConfigDir: "/tmp/meridian-quota-personal" },
+      ],
+      defaultProfile: "work",
+    })
+
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota?profile=personal"))
+    expect(res.status).toBe(200)
+    const body = await res.json() as QuotaResponse
+    const fiveHour = body.buckets.filter(b => b.type === "five_hour")
+    expect(fiveHour.map(b => b.resetsAt)).toEqual([2_222_222_222_222])
+    expect(fiveHour.map(b => b.utilization)).toEqual([0.10])
+  })
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+bun test src/__tests__/proxy-usage-quota-route.test.ts
+```
+
+Expected: FAIL. Either a TypeScript/runtime error from `rateLimitStore.record` now requiring a profile id, or the assertion failing because `work`'s `resetsAt` (`1111111111111`) is reported under `personal`.
+
+- [ ] **Step 3: Update the six call sites**
+
+**3a.** `src/proxy/server.ts:484`, inside `priorityCooldownUntil`. This is a compile fix only; the real change lands in Task 3. Replace:
+
+```ts
+    const fiveHour = rateLimitStore.getAll().find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+```
+
+with:
+
+```ts
+    const fiveHour = rateLimitStore.getAll(profileId).find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+```
+
+and change the enclosing signature from `function priorityCooldownUntil(now: number): number {` to:
+
+```ts
+  function priorityCooldownUntil(profileId: string, now: number): number {
+```
+
+Then update its two call sites at `server.ts:567-568` (inside `dispatchPriority`), which currently compute the value twice:
+
+```ts
+      const cooldownUntil = priorityCooldownUntil(candidate, Date.now())
+      priorityExhaustion.mark(candidate, cooldownUntil, "rate_limit_error")
+      claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil })
+```
+
+**3b.** `src/proxy/server.ts:1617` and `src/proxy/server.ts:2331` — the two SDK-event capture sites. `profile` is already in scope in both generators. Replace both occurrences of:
+
+```ts
+                      rateLimitStore.record((event as any).rate_limit_info)
+```
+
+with:
+
+```ts
+                      rateLimitStore.record(profile.id, (event as any).rate_limit_info)
+```
+
+Preserve each site's existing indentation — the two differ.
+
+**3c.** `src/proxy/server.ts:3676`, in `POST /profiles/active`. **Delete** the `rateLimitStore.clear()` line and rewrite the comment above it. Replace:
+
+```ts
+    // Evict all cached SDK sessions — they were started under the old profile's
+    // credentials and cannot be reused with different auth. Also drop the
+    // rate-limit snapshot so /v1/usage/quota doesn't return the previous
+    // profile's quotas under the new profile's identity.
+    clearSessionCache()
+    rateLimitStore.clear()
+```
+
+with:
+
+```ts
+    // Evict all cached SDK sessions — they were started under the old profile's
+    // credentials and cannot be reused with different auth. The rate-limit
+    // store is NOT cleared: entries are profile-scoped, so the new profile
+    // can no longer read the old one's quotas, and other profiles' snapshots
+    // stay valid (consumers judge staleness from `observedAt`).
+    clearSessionCache()
+```
+
+**3d.** `src/proxy/server.ts:3747`, in `POST /auth/refresh`. Replace:
+
+```ts
+      // Drop the rate-limit snapshot — old quotas were observed under the
+      // previous credential and may belong to a different account if the
+      // refresh swapped profiles. The next SDK call repopulates.
+      rateLimitStore.clear()
+```
+
+with:
+
+```ts
+      // Drop this profile's rate-limit snapshot — its quotas were observed
+      // under the previous credential. Scoped to the profile actually
+      // refreshed; other accounts' snapshots are untouched. The next SDK
+      // call repopulates.
+      rateLimitStore.clear(profile.id)
+```
+
+**3e.** `src/proxy/server.ts:4043`, in `GET /v1/usage/quota`. The `targetProfileId` resolution currently happens *below* this line — move the `sdkEntries` declaration so it comes after `targetProfileId` is assigned, then replace:
+
+```ts
+    const sdkEntries = rateLimitStore.getAll().filter(entry => entry.rateLimitType !== undefined)
+```
+
+with:
+
+```ts
+    const sdkEntries = rateLimitStore.getAll(targetProfileId ?? "default")
+      .filter(entry => entry.rateLimitType !== undefined)
+```
+
+Update the comment block above it (the paragraph starting `// Filter out the internal "default" bucket`) by appending:
+
+```
+    // Entries are read for the resolved target profile only — a multi-account
+    // setup must never render one account's SDK buckets under another's
+    // identity.
+```
+
+- [ ] **Step 4: Run tests and typecheck to verify they pass**
+
+```bash
+bun test src/__tests__/proxy-usage-quota-route.test.ts && npx tsc --noEmit
+```
+
+Expected: tests PASS, and `tsc --noEmit` produces no output (the tree compiles again).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -c commit.gpgsign=false add src/proxy/server.ts src/__tests__/proxy-usage-quota-route.test.ts
+git -c commit.gpgsign=false commit -m "fix: read rate-limit entries per profile in quota route and cooldown"
+```
+
+---
+
+### Task 3: Three-tier cooldown resolution
+
+The reliability fix. Adds the authoritative OAuth fallback without putting a network call in the failover path.
+
+**Files:**
+- Modify: `src/proxy/server.ts` (the priority block, ~lines 468-582)
+- Test: `src/__tests__/priority-routing-integration.test.ts`
+
+**Interfaces:**
+- Consumes: `priorityCooldownUntil(profileId, now)` from Task 2; `rateLimitStore.getAll(profileId)` from Task 1; existing `fetchOAuthUsage`, `getEffectiveProfiles`, `priorityExhaustion`, `PRIORITY_DEFAULT_COOLDOWN_MS`, `PRIORITY_COOLDOWN_CAP_MS`, `claudeLog`.
+- Produces: `refinePriorityCooldown(profileId: string): void` — fire-and-forget, returns immediately.
+
+Background for the implementer: `ProfileExhaustion.mark` (`src/proxy/routing.ts:145-149`) ignores any `until` that is not strictly later than the existing mark. That is what makes the late refinement safe — it can only extend a cooldown, never end one early. Exhaustion marks are observable in tests through `GET /profiles/list`, which returns `exhausted: [{ id, until, reason }]` when routing mode is `priority` (`src/proxy/server.ts:3635`). That route sits behind `requireAuth` (`server.ts:454`), but so does `/v1/messages`, which the existing tests already call without credentials — `requireAuth` passes through when no API key is configured, so no auth setup is needed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/__tests__/priority-routing-integration.test.ts`.
+
+First, at the top of the file with the other dynamic imports (near `const { createProxyServer, clearSessionCache } = await import("../proxy/server")`), add:
+
+```ts
+const { __setFetchOAuthUsageOverride } = await import("../proxy/oauthUsage")
+const { rateLimitStore } = await import("../proxy/rateLimitStore")
+```
+
+Then add this helper next to the file's existing `createTestApp` / `post` helpers:
+
+```ts
+async function exhaustedMarks(app: { fetch: (r: Request) => Promise<Response> }) {
+  const res = await app.fetch(new Request("http://localhost/profiles/list"))
+  const body = await res.json() as { exhausted?: Array<{ id: string; until: number; reason: string }> }
+  return body.exhausted ?? []
+}
+```
+
+Then add a new `describe` block. Note the `beforeEach` must reset both the OAuth override and the store, or state bleeds between these cases.
+
+```ts
+describe("priority cooldown resolution", () => {
+  const WORK_RESET = Date.now() + 4 * 60 * 60_000      // 4h out
+  const PERSONAL_RESET = Date.now() + 30 * 60_000      // 30m out
+
+  beforeEach(() => {
+    rateLimitStore.clear()
+    __setFetchOAuthUsageOverride(async () => null)
+  })
+
+  afterEach(() => {
+    rateLimitStore.clear()
+    __setFetchOAuthUsageOverride(null)
+  })
+
+  it("uses the failing profile's OWN five_hour reset, not another profile's", async () => {
+    // personal has a much later reset on record. work is the one that fails.
+    // The old global-singleton bug would hand work personal's number.
+    rateLimitStore.record("personal", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.5,
+      resetsAt: Date.now() + 5 * 60 * 60_000,
+    })
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: WORK_RESET,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).toEqual(["work"])
+    expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("falls back to the 10-minute default when the profile has no entry of its own", async () => {
+    rateLimitStore.record("personal", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.5,
+      resetsAt: Date.now() + 5 * 60 * 60_000,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+    const after = Date.now()
+
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u >= before + 10 * 60_000 && u <= after + 10 * 60_000)).toBe(true)
+  }, 20_000)
+
+  it("refines a default-length mark with the authoritative OAuth reset", async () => {
+    __setFetchOAuthUsageOverride(async (opts) => {
+      if (opts?.profileId !== "work") return null
+      return { windows: [{ type: "five_hour", utilization: 1, resetsAt: WORK_RESET }], extraUsage: null, fetchedAt: Date.now() }
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+    // The refinement is deliberately not awaited by the request path.
+    await Bun.sleep(20)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("never shortens an existing mark with an earlier OAuth reset", async () => {
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: WORK_RESET,
+    })
+    __setFetchOAuthUsageOverride(async () => ({
+      windows: [{ type: "five_hour", utilization: 1, resetsAt: PERSONAL_RESET }],
+      extraUsage: null,
+      fetchedAt: Date.now(),
+    }))
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+    await Bun.sleep(20)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("leaves the mark unchanged when the OAuth fetch returns null or rejects", async () => {
+    __setFetchOAuthUsageOverride(async () => { throw new Error("upstream 503") })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    const res = await post(app)
+    await Bun.sleep(20)
+
+    expect(res.status).toBe(200) // failover still succeeded
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u <= before + 10 * 60_000 + 5_000)).toBe(true)
+  }, 20_000)
+
+  it("does not block failover on the OAuth fetch", async () => {
+    // A fetch that never settles must not stall the request. The explicit
+    // type parameter matters: a bare `new Promise(() => {})` infers
+    // `Promise<unknown>`, which does not satisfy the override's signature
+    // and fails `tsc --noEmit`.
+    __setFetchOAuthUsageOverride(() => new Promise<null>(() => {}))
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    expect(capturedEnvs.some(e => e.includes("prof-personal"))).toBe(true)
+  }, 20_000)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+bun test src/__tests__/priority-routing-integration.test.ts
+```
+
+Expected: the two tier-1 tests may already pass from Task 2's scoping; the three refinement tests FAIL because `refinePriorityCooldown` does not exist yet and the mark is never extended (`expected [WORK_RESET], got [<now+10min>]`).
+
+- [ ] **Step 3: Implement the tiering**
+
+In `src/proxy/server.ts`, replace the whole `priorityCooldownUntil` function (as left by Task 2) with the two functions below. Place them in the same spot, immediately after `priorityProfileOrderSetting`.
+
+```ts
+  /** Tier 1 + 3: this profile's own observed five_hour reset, else a
+   *  conservative default so a mis-mark self-heals. Never blocks. */
+  function priorityCooldownUntil(profileId: string, now: number): number {
+    const fiveHour = rateLimitStore.getAll(profileId)
+      .find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+    const until = fiveHour?.resetsAt ?? now + PRIORITY_DEFAULT_COOLDOWN_MS
+    return Math.min(until, now + PRIORITY_COOLDOWN_CAP_MS)
+  }
+
+  /** Tier 2: the authoritative per-account reset from Anthropic's usage
+   *  endpoint. Deliberately fire-and-forget — the failover path has already
+   *  burned one failed request and must not also wait on a network call.
+   *  `ProfileExhaustion.mark` ignores an `until` that isn't later than the
+   *  existing one, so a late refinement can only EXTEND a cooldown, never
+   *  un-suppress a profile early. A null/failed fetch changes nothing. */
+  function refinePriorityCooldown(profileId: string): void {
+    const target = getEffectiveProfiles(finalConfig.profiles).find(p => p.id === profileId)
+    void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir })
+      .then(usage => {
+        if (!usage) return
+        const now = Date.now()
+        const resetsAt = usage.windows.find(w => w.type === "five_hour")?.resetsAt
+        if (!resetsAt || resetsAt <= now) return
+        const until = Math.min(resetsAt, now + PRIORITY_COOLDOWN_CAP_MS)
+        priorityExhaustion.mark(profileId, until, "rate_limit_error")
+        claudeLog("priority.cooldown_refined", { profile: profileId, until, source: "oauth_usage" })
+      })
+      .catch(err => {
+        claudeLog("priority.cooldown_refine_failed", {
+          profile: profileId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+  }
+```
+
+Then in `dispatchPriority`, extend the mark block written in Task 2 (`server.ts:567-569`) to schedule the refinement:
+
+```ts
+      const cooldownUntil = priorityCooldownUntil(candidate, Date.now())
+      priorityExhaustion.mark(candidate, cooldownUntil, "rate_limit_error")
+      claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil })
+      refinePriorityCooldown(candidate)
+```
+
+`fetchOAuthUsage` and `getEffectiveProfiles` are already imported in `server.ts` — verify with `grep -n "fetchOAuthUsage\|getEffectiveProfiles" src/proxy/server.ts | head -4` and add to the existing import statement only if missing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+bun test src/__tests__/priority-routing-integration.test.ts && npx tsc --noEmit
+```
+
+Expected: all tests PASS (the file's pre-existing cases plus the six new ones), `tsc --noEmit` silent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -c commit.gpgsign=false add src/proxy/server.ts src/__tests__/priority-routing-integration.test.ts
+git -c commit.gpgsign=false commit -m "fix: resolve priority cooldown from the failing profile's own quota reset"
+```
+
+---
+
+### Task 4: Documentation and full verification
+
+**Files:**
+- Modify: `docs/profiles.md`
+- Test: whole suite
+
+- [ ] **Step 1: Check whether the docs describe the old behavior**
+
+```bash
+grep -n "rate-limit\|rateLimitStore\|cooldown\|10 min\|exhaust" docs/profiles.md ARCHITECTURE.md
+```
+
+If a passage states that the rate-limit snapshot is cleared on profile switch, or describes the cooldown as coming from a single global snapshot, update it to describe per-profile scoping and the three-tier resolution (own entry → OAuth usage → 10-minute default). If no such passage exists, skip to Step 2 and note that in the commit.
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+npm test
+```
+
+Expected: PASS. Pay particular attention to `proxy-usage-quota-route.test.ts`, `priority-routing-integration.test.ts`, `rate-limit-store.test.ts`, and `oauth-usage.test.ts` (the last must be unaffected — the `_testOverride` seam is bypassed when a test passes `store` or `fetchImpl`).
+
+- [ ] **Step 3: Typecheck and build**
+
+```bash
+npx tsc --noEmit && npm run build
+```
+
+Expected: both silent/successful.
+
+- [ ] **Step 4: Commit and open the PR**
+
+```bash
+git -c commit.gpgsign=false add -A
+git -c commit.gpgsign=false commit -m "docs: describe per-profile rate-limit scoping"
+git push origin fix/profile-scoped-rate-limit-store
+gh pr create --base main --title "fix: scope rate-limit store per profile so priority cooldowns use the right account's reset"
+```
+
+The PR body must call out the user-visible behavior change flagged in the spec's Risks section: a profile with no recorded SDK events now returns OAuth-only buckets from `GET /v1/usage/quota` where it previously showed another profile's SDK data, and the rate-limit snapshot now survives a profile switch.
+
+- [ ] **Step 5: Wait for CI**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+Expected: the `test` job passes. Do not merge until it is green.
+
+---
+
+## Verification Summary
+
+| Spec requirement | Task |
+|---|---|
+| Nested `Map<profileId, Map<bucket, entry>>` storage | 1 |
+| `profileId` required on `record`/`getAll`/`get` | 1 |
+| `clear(profileId?)` scoped or global | 1 |
+| `size` getter → method | 1 |
+| Module doc comment corrected | 1 |
+| `record(profile.id, …)` at both SDK-event sites | 2 |
+| `/v1/usage/quota` reads scoped entries | 2 |
+| `POST /profiles/active` clear removed | 2 |
+| `POST /auth/refresh` clear scoped | 2 |
+| Tier 1 — own scoped `five_hour` entry | 3 |
+| Tier 2 — non-blocking `fetchOAuthUsage` refinement | 3 |
+| Tier 3 — 10-minute default | 3 |
+| Refinement can only extend, never shorten | 3 |
+| 6h cap preserved on both paths | 3 |
+| Cross-profile regression test | 3 |
+| Docs | 4 |
+
+Out of scope per the spec, and deliberately absent from every task: threshold steering (priority spec §5), the `priorityAssignments` FIFO eviction quirk, and persisting rate-limit state across restarts.

--- a/docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md
+++ b/docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md
@@ -1,0 +1,173 @@
+# Profile-Scoped Rate-Limit Store — Design
+
+**Status:** Approved (owner decisions: root-cause scoping over a local patch; three-tier reset resolution including the OAuth usage fallback).
+**Fixes:** `priorityCooldownUntil` deriving one profile's exhaustion cooldown from another profile's reset time.
+
+## Problem
+
+`priorityCooldownUntil` (`src/proxy/server.ts:481-487`) decides how long to suppress a
+profile that just returned `rate_limit_error`. It reads that duration from
+`rateLimitStore.getAll()`:
+
+```ts
+const fiveHour = rateLimitStore.getAll().find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+```
+
+`rateLimitStore` (`src/proxy/rateLimitStore.ts`) is a process-wide singleton holding a
+flat `Map<RateLimitBucketKey, RateLimitEntry>` — **no profile dimension**. Its own
+doc comment describes the contents as "the active profile's latest known state",
+and it is `clear()`ed on profile switch specifically to stop quotas leaking across
+accounts.
+
+In priority mode that premise no longer holds. Every profile in the pool records
+into the same singleton (`server.ts:1617`, `server.ts:2331`) as requests are
+dispatched across accounts, and there is no profile switch to trigger the clear.
+So when profile A is marked exhausted, the `five_hour` `resetsAt` used to compute
+its cooldown may be **profile B's** reset time.
+
+Consequences:
+
+- **Over-suppression** — A is benched until B's later reset, wasting A's available quota.
+- **Under-suppression** — A is un-benched at B's earlier reset, so the next request
+  through A fails again and burns a full round-trip before failing over.
+
+The bug self-heals via the 6h `PRIORITY_COOLDOWN_CAP_MS` and `ProfileExhaustion`'s
+lazy expiry, so it is not severe — but the mark duration is not reliably A's own,
+and priority routing's whole value is spending each account's quota accurately.
+
+### Same bug, second surface
+
+`GET /v1/usage/quota` (`server.ts:4043`) has the identical latent defect. It resolves a
+`targetProfileId` (honoring an explicit `?profile=` param), fetches OAuth usage
+profile-scoped — and then merges in `rateLimitStore.getAll()`, which is whatever
+profile wrote last. Overage details, and any bucket type OAuth does not expose,
+can therefore be reported under the wrong account's identity.
+
+## Design
+
+### 1. Profile-scope `RateLimitStore`
+
+Add a profile dimension so every read is explicitly per-account. Storage becomes
+nested; the public API takes `profileId` first:
+
+```ts
+entries: Map<string, Map<RateLimitBucketKey, RateLimitEntry>>
+
+record(profileId: string, info: SDKRateLimitInfo | undefined | null, observedAt?: number): void
+getAll(profileId: string): RateLimitEntry[]     // newest-first, as today
+get(profileId: string, key: RateLimitBucketKey): RateLimitEntry | undefined
+clear(profileId?: string): void                 // one profile, or all when omitted
+size(profileId?: string): number                // one profile's buckets, or total
+```
+
+The key is `profile.id`, which is already the literal `"default"` in single-profile
+setups — so single-profile behavior is unchanged.
+
+`profileId` is required on `record`/`getAll`/`get` rather than optional. An optional
+parameter would let a call site silently read across accounts again, which is
+exactly the failure being fixed.
+
+`size` changes from a getter to a method so it can take a `profileId`. Its only
+callers are assertions in `rate-limit-store.test.ts`, which this change updates
+anyway; nothing in `src/proxy/` reads it.
+
+Bounded growth: one inner map per configured profile. No eviction needed.
+
+### 2. Three-tier reset resolution
+
+Scoping alone exposes a gap. If the failing candidate never emitted a
+`rate_limit_event` before erroring, its scoped bucket is empty and the cooldown
+falls back to `PRIORITY_DEFAULT_COOLDOWN_MS` (10 min). Today the unscoped store
+accidentally yields *some* long value; scoped, it would yield nothing. That would
+make cooldowns shorter and churn-ier — profile A retried every 10 minutes through
+a 5-hour outage, each retry costing a failed request.
+
+`priorityCooldownUntil(profileId, now)` therefore resolves the reset from three
+sources, most authoritative first:
+
+1. **Scoped store** — that profile's own live `five_hour.resetsAt`, when the SDK
+   emitted one.
+2. **`fetchOAuthUsage({ profileId, claudeConfigDir })`** — authoritative for that
+   specific account, straight from Anthropic. Already profile-scoped, already
+   cached per profile (30s TTL) with in-flight sharing, already returns `null`
+   gracefully on failure. This source was anticipated by the original priority
+   routing spec (`2026-07-23-priority-profile-routing-design.md` §2).
+3. **10-minute default** — unchanged last resort.
+
+The result is clamped by `PRIORITY_COOLDOWN_CAP_MS` (6h) exactly as today.
+
+**Tier 2 must not block failover.** The failover path has already burned one failed
+request; adding a synchronous network call to it would compound the latency the
+user feels. So:
+
+- Mark the profile immediately using tier 1, else tier 3.
+- Kick off the tier-2 fetch without awaiting it. When it resolves, re-`mark()` with
+  the authoritative value.
+
+This refinement is safe by construction: `ProfileExhaustion.mark` already ignores a
+new `until` that is not later than the existing one (`routing.ts:145-149`), so a late
+refinement can only **extend** a mark, never un-suppress a profile early. A failed
+or `null` fetch changes nothing.
+
+### 3. Call-site changes
+
+| Site | Change |
+|---|---|
+| `server.ts:1617`, `server.ts:2331` | `record(profile.id, info)` — `profile` is already in scope in both generators |
+| `priorityCooldownUntil` (`server.ts:481`) | Signature becomes `(profileId, now)`; implements the three tiers |
+| `dispatchPriority` (`server.ts:567`) | Passes the failing `candidate`; schedules the tier-2 refinement |
+| `GET /v1/usage/quota` (`server.ts:4043`) | `getAll(targetProfileId ?? "default")` |
+| `POST /profiles/active` (`server.ts:3676`) | **Delete** the `clear()` call. It existed only to stop cross-profile leakage, which scoping now prevents structurally; other profiles' snapshots are valid and worth keeping. Update the comment. |
+| `POST /auth/refresh` (`server.ts:3747`) | `clear(profile.id)` — scoped to the credential actually refreshed |
+
+`ProfileExhaustion`, `routing.ts`, and `session/lineage.ts` are untouched. No new
+imports into leaf modules; `rateLimitStore.ts` keeps its single responsibility and
+gains no dependencies. `server.ts` gains no computation — the tiering lives in
+`priorityCooldownUntil`, which is already a local helper in the priority block.
+
+## Testing
+
+**`src/__tests__/rate-limit-store.test.ts`** (update + extend):
+- Two profiles recording the same bucket type do not overwrite each other.
+- `getAll(profileId)` returns only that profile's entries, newest-first ordering preserved.
+- `getAll` for an unseen profile returns `[]`.
+- `clear(profileId)` drops one profile and leaves others intact; `clear()` drops all.
+- `"default"` keying behaves identically to the pre-change single-profile flow.
+
+**`src/__tests__/priority-routing-integration.test.ts`** (extend):
+- **Regression for this bug:** profile B records a `five_hour` `resetsAt`; profile A
+  then fails with `rate_limit_error`; A's exhaustion mark must NOT equal B's reset —
+  it must come from A's own entry, or the 10-minute default when A has none.
+- Tier ordering: A's own scoped entry wins over the OAuth fallback.
+- Tier 2 refinement extends a default-10-minute mark when OAuth reports a later reset.
+- Tier 2 returning `null`, or rejecting, leaves the initial mark unchanged.
+- A late tier-2 value **earlier** than the existing mark does not shorten it.
+- Failover latency: `dispatchPriority` resolves without awaiting the OAuth fetch.
+
+**`src/__tests__/proxy-usage-quota-route.test.ts`** (update + extend):
+- `?profile=b` reports B's SDK-sourced buckets while A's snapshot is also in the store.
+- A profile with no SDK entries still renders OAuth-sourced buckets (no regression).
+
+OAuth usage is stubbed via the existing `_testOverride` / `fetchImpl` seams in
+`oauthUsage.ts` — no network in tests.
+
+## Out of scope
+
+- **Threshold steering** (priority routing spec §5 — avoid a profile at ≥97% of its
+  `five_hour` window). Accurate per-profile utilization is a prerequisite and this
+  change delivers it, but the steering logic itself is separate work.
+- **`priorityAssignments` FIFO eviction** (`server.ts:556-559`) — re-`set`ting a key
+  does not reorder a JS `Map`, so a long-lived active conversation can be evicted
+  ahead of a newer idle one. Real, unrelated, low impact at current volumes.
+- **Persisting rate-limit state across restarts.** Still deliberately in-memory;
+  the first request after a restart repopulates.
+
+## Risks
+
+- **Behavior change on `/v1/usage/quota`.** A profile that has recorded no SDK
+  events now returns OAuth-only buckets where it previously showed another
+  profile's SDK data. This is the fix, not a regression, but it is user-visible in
+  the telemetry UI and worth noting in the PR.
+- **Removing the profile-switch `clear()`** means snapshots outlive a switch. They
+  are correctly attributed now, and `observedAt` already lets consumers judge
+  staleness.

--- a/docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md
+++ b/docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md
@@ -93,9 +93,12 @@ sources, most authoritative first:
    a `five_hour` window with a future `resetsAt` — the rolling window boundary
    exists regardless of consumption — so an ungated read would extend a
    healthy profile's mark out to that boundary on any transient or
-   non-five-hour error. Already profile-scoped, already cached per profile
-   (30s TTL) with in-flight sharing, already returns `null` gracefully on
-   failure. This source was anticipated by the original priority routing spec
+   non-five-hour error. A missing or null `utilization` is treated as NOT
+   exhausted — under-suppressing is the safe direction; over-suppressing a
+   healthy profile is the bug this gate exists to prevent. Already
+   profile-scoped, already cached per profile (30s TTL) with in-flight
+   sharing, already returns `null` gracefully on failure. This source was
+   anticipated by the original priority routing spec
    (`2026-07-23-priority-profile-routing-design.md` §2).
 3. **10-minute default** — unchanged last resort.
 

--- a/docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md
+++ b/docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md
@@ -88,10 +88,15 @@ sources, most authoritative first:
 1. **Scoped store** — that profile's own live `five_hour.resetsAt`, when the SDK
    emitted one.
 2. **`fetchOAuthUsage({ profileId, claudeConfigDir })`** — authoritative for that
-   specific account, straight from Anthropic. Already profile-scoped, already
-   cached per profile (30s TTL) with in-flight sharing, already returns `null`
-   gracefully on failure. This source was anticipated by the original priority
-   routing spec (`2026-07-23-priority-profile-routing-design.md` §2).
+   specific account, straight from Anthropic, but used only when the returned
+   `five_hour` window reports `utilization >= 1`. A healthy account always has
+   a `five_hour` window with a future `resetsAt` — the rolling window boundary
+   exists regardless of consumption — so an ungated read would extend a
+   healthy profile's mark out to that boundary on any transient or
+   non-five-hour error. Already profile-scoped, already cached per profile
+   (30s TTL) with in-flight sharing, already returns `null` gracefully on
+   failure. This source was anticipated by the original priority routing spec
+   (`2026-07-23-priority-profile-routing-design.md` §2).
 3. **10-minute default** — unchanged last resort.
 
 The result is clamped by `PRIORITY_COOLDOWN_CAP_MS` (6h) exactly as today.

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -83,6 +83,26 @@ async function exhaustedMarks(app: { fetch: (r: Request) => Response | Promise<R
 
 const savedEnv: Record<string, string | undefined> = {}
 
+// File-level: every test in this file exhausts a profile through
+// dispatchPriority at some point, which fires refinePriorityCooldown ->
+// fetchOAuthUsage as a real (if fire-and-forget) side effect. Without this,
+// the "priority routing" describe block below (which predates the OAuth
+// refinement tier and sets no override of its own) would hit the real
+// fetchOAuthUsage -> createPlatformCredentialStore on every exhaustion,
+// spawning a `security find-generic-password` subprocess per call and, where
+// a matching credential exists, making a live HTTPS call to Anthropic from
+// the test suite. The "priority cooldown resolution" describe block below
+// still sets its own per-test override in its own beforeEach; Bun runs outer
+// (file-level) hooks before inner (describe-level) ones, so those overrides
+// still win for those tests.
+beforeEach(() => {
+  __setFetchOAuthUsageOverride(async () => null)
+})
+
+afterEach(() => {
+  __setFetchOAuthUsageOverride(null)
+})
+
 describe("priority routing", () => {
   beforeEach(() => {
     capturedEnvs = []
@@ -259,6 +279,31 @@ describe("priority cooldown resolution", () => {
       rateLimitType: "five_hour",
       utilization: 0.5,
       resetsAt: Date.now() + 5 * 60 * 60_000,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+    const after = Date.now()
+
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u >= before + 10 * 60_000 && u <= after + 10 * 60_000)).toBe(true)
+  }, 20_000)
+
+  it("falls back to the 10-minute default when the profile's own five_hour entry is healthy (allowed, utilization < 1)", async () => {
+    // A healthy account always has a five_hour entry with a future resetsAt
+    // — that boundary exists regardless of consumption. This entry alone
+    // doesn't prove the five-hour window caused the failure that's being
+    // handled right now (it could be a seven_day cap instead), so the
+    // synchronous tier-1 mark must not adopt this resetsAt.
+    const futureReset = Date.now() + 3 * 60 * 60_000 // several hours out
+    rateLimitStore.record("work", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.4,
+      resetsAt: futureReset,
     })
     failingDirs.add("prof-work")
     const app = createTestApp()

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -308,7 +308,7 @@ describe("priority cooldown resolution", () => {
     expect(marks.map(m => m.until)).toEqual([WORK_RESET])
   }, 20_000)
 
-  it("leaves the mark unchanged when the OAuth fetch returns null or rejects", async () => {
+  it("leaves the mark unchanged when the OAuth fetch rejects", async () => {
     __setFetchOAuthUsageOverride(async () => { throw new Error("upstream 503") })
     failingDirs.add("prof-work")
     const app = createTestApp()
@@ -321,6 +321,86 @@ describe("priority cooldown resolution", () => {
     const until = marks.map(m => m.until)
     expect(until).toHaveLength(1)
     expect(until.every(u => u <= before + 10 * 60_000 + 5_000)).toBe(true)
+  }, 20_000)
+
+  it("leaves the mark unchanged when the OAuth fetch returns null", async () => {
+    // The null path is the one that actually happens in production:
+    // fetchOAuthUsage swallows its own failures and returns null.
+    __setFetchOAuthUsageOverride(async () => null)
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    const res = await post(app)
+    await Bun.sleep(20)
+
+    expect(res.status).toBe(200) // failover still succeeded
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u <= before + 10 * 60_000 + 5_000)).toBe(true)
+  }, 20_000)
+
+  it("does not extend the mark when the OAuth five_hour window is healthy (utilization < 1)", async () => {
+    // A healthy account always has a five_hour window with a future
+    // resetsAt — the rolling window boundary exists regardless of
+    // consumption. Only utilization >= 1 means that window is the actual
+    // cause of exhaustion; otherwise the conservative 10-minute default
+    // (tier 3) must stand.
+    const futureReset = Date.now() + 3 * 60 * 60_000 // comfortably in the future, well under the 6h cap
+    __setFetchOAuthUsageOverride(async (opts) => {
+      if (opts?.profileId !== "work") return null
+      return { windows: [{ type: "five_hour", utilization: 0.2, resetsAt: futureReset }], extraUsage: null, fetchedAt: Date.now() }
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+    await Bun.sleep(20)
+    const after = Date.now()
+
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u >= before + 10 * 60_000 && u <= after + 10 * 60_000)).toBe(true)
+  }, 20_000)
+
+  it("clamps the synchronous mark to the 6-hour cap even when the profile's own reset is far beyond it", async () => {
+    const farReset = Date.now() + 12 * 60 * 60_000 // 12h out — beyond the 6h cap
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: farReset,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+    const after = Date.now()
+
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u >= before + 6 * 60 * 60_000 && u <= after + 6 * 60 * 60_000)).toBe(true)
+  }, 20_000)
+
+  it("clamps the refinement mark to the 6-hour cap even when OAuth reports a reset far beyond it", async () => {
+    const farReset = Date.now() + 12 * 60 * 60_000 // 12h out — beyond the 6h cap
+    __setFetchOAuthUsageOverride(async (opts) => {
+      if (opts?.profileId !== "work") return null
+      return { windows: [{ type: "five_hour", utilization: 1, resetsAt: farReset }], extraUsage: null, fetchedAt: Date.now() }
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+    await Bun.sleep(20)
+    const after = Date.now()
+
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u >= before + 6 * 60 * 60_000 && u <= after + 6 * 60 * 60_000)).toBe(true)
   }, 20_000)
 
   it("does not block failover on the OAuth fetch", async () => {

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -49,6 +49,8 @@ mock.module("../mcpTools", () => ({
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
 const { resetActiveProfile } = await import("../proxy/profiles")
+const { __setFetchOAuthUsageOverride } = await import("../proxy/oauthUsage")
+const { rateLimitStore } = await import("../proxy/rateLimitStore")
 
 const PROFILES = [
   { id: "work", claudeConfigDir: "/tmp/meridian-test-prof-work" },
@@ -71,6 +73,12 @@ async function post(app: any, headers: Record<string, string> = {}, content = "h
       messages: [{ role: "user", content }],
     }),
   }))
+}
+
+async function exhaustedMarks(app: { fetch: (r: Request) => Response | Promise<Response> }) {
+  const res = await app.fetch(new Request("http://localhost/profiles/list"))
+  const body = await res.json() as { exhausted?: Array<{ id: string; until: number; reason: string }> }
+  return body.exhausted ?? []
 }
 
 const savedEnv: Record<string, string | undefined> = {}
@@ -192,5 +200,139 @@ describe("priority routing", () => {
     const res = await post(app, {}, "mode-off unique message")
     expect(res.status).toBe(429)
     expect(capturedEnvs.every((e) => e.includes("prof-work"))).toBe(true)
+  }, 20_000)
+})
+
+describe("priority cooldown resolution", () => {
+  const WORK_RESET = Date.now() + 4 * 60 * 60_000      // 4h out
+  const PERSONAL_RESET = Date.now() + 30 * 60_000      // 30m out
+
+  beforeEach(() => {
+    capturedEnvs = []
+    failingDirs = new Set()
+    clearSessionCache()
+    resetActiveProfile()
+    savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
+    savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    process.env.MERIDIAN_ROUTING = "priority"
+    process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
+    rateLimitStore.clear()
+    __setFetchOAuthUsageOverride(async () => null)
+  })
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+    rateLimitStore.clear()
+    __setFetchOAuthUsageOverride(null)
+  })
+
+  it("uses the failing profile's OWN five_hour reset, not another profile's", async () => {
+    // personal has a much later reset on record. work is the one that fails.
+    // The old global-singleton bug would hand work personal's number.
+    rateLimitStore.record("personal", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.5,
+      resetsAt: Date.now() + 5 * 60 * 60_000,
+    })
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: WORK_RESET,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).toEqual(["work"])
+    expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("falls back to the 10-minute default when the profile has no entry of its own", async () => {
+    rateLimitStore.record("personal", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.5,
+      resetsAt: Date.now() + 5 * 60 * 60_000,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+    const after = Date.now()
+
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u >= before + 10 * 60_000 && u <= after + 10 * 60_000)).toBe(true)
+  }, 20_000)
+
+  it("refines a default-length mark with the authoritative OAuth reset", async () => {
+    __setFetchOAuthUsageOverride(async (opts) => {
+      if (opts?.profileId !== "work") return null
+      return { windows: [{ type: "five_hour", utilization: 1, resetsAt: WORK_RESET }], extraUsage: null, fetchedAt: Date.now() }
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+    // The refinement is deliberately not awaited by the request path.
+    await Bun.sleep(20)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("never shortens an existing mark with an earlier OAuth reset", async () => {
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: WORK_RESET,
+    })
+    __setFetchOAuthUsageOverride(async () => ({
+      windows: [{ type: "five_hour", utilization: 1, resetsAt: PERSONAL_RESET }],
+      extraUsage: null,
+      fetchedAt: Date.now(),
+    }))
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+    await Bun.sleep(20)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("leaves the mark unchanged when the OAuth fetch returns null or rejects", async () => {
+    __setFetchOAuthUsageOverride(async () => { throw new Error("upstream 503") })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    const res = await post(app)
+    await Bun.sleep(20)
+
+    expect(res.status).toBe(200) // failover still succeeded
+    const marks = await exhaustedMarks(app)
+    const until = marks.map(m => m.until)
+    expect(until).toHaveLength(1)
+    expect(until.every(u => u <= before + 10 * 60_000 + 5_000)).toBe(true)
+  }, 20_000)
+
+  it("does not block failover on the OAuth fetch", async () => {
+    // A fetch that never settles must not stall the request. The explicit
+    // type parameter matters: a bare `new Promise(() => {})` infers
+    // `Promise<unknown>`, which does not satisfy the override's signature
+    // and fails `tsc --noEmit`.
+    __setFetchOAuthUsageOverride(() => new Promise<null>(() => {}))
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    expect(capturedEnvs.some(e => e.includes("prof-personal"))).toBe(true)
   }, 20_000)
 })

--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -32,6 +32,7 @@ mock.module("../mcpTools", () => ({
 const { __setFetchOAuthUsageOverride } = await import("../proxy/oauthUsage")
 const { createProxyServer } = await import("../proxy/server")
 const { rateLimitStore } = await import("../proxy/rateLimitStore")
+const { resetActiveProfile } = await import("../proxy/profiles")
 
 interface QuotaResponseBucket {
   type: string
@@ -54,6 +55,11 @@ interface QuotaResponse {
 describe("GET /v1/usage/quota", () => {
   beforeEach(() => {
     rateLimitStore.clear()
+    // The quota route resolves its target profile from global active-profile state,
+    // which is set by other test files (e.g., profile-switch-integration.test.ts).
+    // Resetting here ensures a leftover active profile id does not make these
+    // fixtures unreadable.
+    resetActiveProfile()
     // Default: no OAuth data merged in. Individual tests override.
     __setFetchOAuthUsageOverride(async () => null)
   })

--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -85,13 +85,13 @@ describe("GET /v1/usage/quota", () => {
     // Explicit, distinct observedAt values make newest-first ordering
     // deterministic without racing the real wall clock (a short sleep does
     // not guarantee a fresh millisecond timestamp under CI load).
-    rateLimitStore.record({
+    rateLimitStore.record("default", {
       status: "allowed",
       rateLimitType: "five_hour",
       utilization: 0.42,
       resetsAt: 1_730_000_000_000,
     }, 1_000)
-    rateLimitStore.record({
+    rateLimitStore.record("default", {
       status: "allowed_warning",
       rateLimitType: "seven_day",
       utilization: 0.91,
@@ -123,8 +123,8 @@ describe("GET /v1/usage/quota", () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
 
     // SDK event without rateLimitType — store buckets it under "default"
-    rateLimitStore.record({ status: "allowed", utilization: 0.1 })
-    rateLimitStore.record({
+    rateLimitStore.record("default", { status: "allowed", utilization: 0.1 })
+    rateLimitStore.record("default", {
       status: "allowed",
       rateLimitType: "five_hour",
       utilization: 0.5,
@@ -140,7 +140,7 @@ describe("GET /v1/usage/quota", () => {
 
   it("nulls out unset optional fields (utilization, resetsAt, overage*)", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
-    rateLimitStore.record({ status: "rejected", rateLimitType: "five_hour" })
+    rateLimitStore.record("default", { status: "rejected", rateLimitType: "five_hour" })
     const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
     const body = await res.json() as QuotaResponse
     const bucket = body.buckets[0]!
@@ -171,7 +171,7 @@ describe("GET /v1/usage/quota", () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
 
     // SDK has its own bucket for five_hour with overage info we want preserved.
-    rateLimitStore.record({
+    rateLimitStore.record("default", {
       status: "allowed",
       rateLimitType: "five_hour",
       utilization: 0.10,         // OAuth (0.36) should win
@@ -205,7 +205,7 @@ describe("GET /v1/usage/quota", () => {
 
   it("preserves overage fields when present", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
-    rateLimitStore.record({
+    rateLimitStore.record("default", {
       status: "allowed_warning",
       rateLimitType: "overage",
       utilization: 0.78,
@@ -226,5 +226,40 @@ describe("GET /v1/usage/quota", () => {
     expect(bucket.overageResetsAt).toBe(1_730_100_000_000)
     expect(bucket.overageDisabledReason).toBe("no_limits_configured")
     expect(bucket.surpassedThreshold).toBe(0.75)
+  })
+
+  it("reports the requested profile's SDK buckets, not another profile's", async () => {
+    // Both accounts have recorded a five_hour bucket. Asking for `personal`
+    // must never surface `work`'s numbers.
+    rateLimitStore.record("work", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.99,
+      resetsAt: 1_111_111_111_111,
+    })
+    rateLimitStore.record("personal", {
+      status: "allowed",
+      rateLimitType: "five_hour",
+      utilization: 0.10,
+      resetsAt: 2_222_222_222_222,
+    })
+    __setFetchOAuthUsageOverride(async () => null)
+
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [
+        { id: "work", claudeConfigDir: "/tmp/meridian-quota-work" },
+        { id: "personal", claudeConfigDir: "/tmp/meridian-quota-personal" },
+      ],
+      defaultProfile: "work",
+    })
+
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota?profile=personal"))
+    expect(res.status).toBe(200)
+    const body = await res.json() as QuotaResponse
+    const fiveHour = body.buckets.filter(b => b.type === "five_hour")
+    expect(fiveHour.map(b => b.resetsAt)).toEqual([2_222_222_222_222])
+    expect(fiveHour.map(b => b.utilization)).toEqual([0.10])
   })
 })

--- a/src/__tests__/rate-limit-store.test.ts
+++ b/src/__tests__/rate-limit-store.test.ts
@@ -24,76 +24,70 @@ const SEVEN_DAY: SDKRateLimitInfo = {
   surpassedThreshold: 0.9,
 }
 
+const WORK = "work"
+const PERSONAL = "personal"
+
 describe("rateLimitStore", () => {
   it("starts empty", () => {
     const store = new _RateLimitStoreForTests()
-    expect(store.size).toBe(0)
-    expect(store.getAll()).toEqual([])
+    expect(store.size()).toBe(0)
+    expect(store.getAll(WORK)).toEqual([])
   })
 
   it("records distinct buckets keyed by rateLimitType", () => {
     const store = new _RateLimitStoreForTests()
-    store.record(FIVE_HOUR)
-    store.record(SEVEN_DAY)
-    expect(store.size).toBe(2)
-    const types = store.getAll().map(e => e.rateLimitType).sort()
+    store.record(WORK, FIVE_HOUR)
+    store.record(WORK, SEVEN_DAY)
+    expect(store.size(WORK)).toBe(2)
+    const types = store.getAll(WORK).map(e => e.rateLimitType).sort()
     expect(types).toEqual(["five_hour", "seven_day"])
   })
 
   it("overwrites on second record for same bucket (last-write-wins)", () => {
     const store = new _RateLimitStoreForTests()
-    store.record({ ...FIVE_HOUR, utilization: 0.42 })
-    store.record({ ...FIVE_HOUR, utilization: 0.55 })
-    expect(store.size).toBe(1)
-    expect(store.get("five_hour")?.utilization).toBe(0.55)
+    store.record(WORK, { ...FIVE_HOUR, utilization: 0.42 })
+    store.record(WORK, { ...FIVE_HOUR, utilization: 0.55 })
+    expect(store.size(WORK)).toBe(1)
+    expect(store.get(WORK, "five_hour")?.utilization).toBe(0.55)
   })
 
   it("buckets entries without rateLimitType under 'default'", () => {
     const store = new _RateLimitStoreForTests()
-    store.record({ status: "allowed", utilization: 0.1 })
-    expect(store.size).toBe(1)
-    expect(store.get("default")?.utilization).toBe(0.1)
+    store.record(WORK, { status: "allowed", utilization: 0.1 })
+    expect(store.size(WORK)).toBe(1)
+    expect(store.get(WORK, "default")?.utilization).toBe(0.1)
   })
 
   it("ignores nullish or non-object input without throwing", () => {
     const store = new _RateLimitStoreForTests()
-    store.record(undefined)
-    store.record(null as unknown as SDKRateLimitInfo)
-    store.record("nope" as unknown as SDKRateLimitInfo)
-    expect(store.size).toBe(0)
+    store.record(WORK, undefined)
+    store.record(WORK, null as unknown as SDKRateLimitInfo)
+    store.record(WORK, "nope" as unknown as SDKRateLimitInfo)
+    expect(store.size()).toBe(0)
   })
 
   it("stamps observedAt on each record", () => {
     const store = new _RateLimitStoreForTests()
     const before = Date.now()
-    store.record(FIVE_HOUR)
+    store.record(WORK, FIVE_HOUR)
     const after = Date.now()
-    const entry = store.get("five_hour")
+    const entry = store.get(WORK, "five_hour")
     expect(entry?.observedAt).toBeGreaterThanOrEqual(before)
     expect(entry?.observedAt).toBeLessThanOrEqual(after)
   })
 
   it("getAll returns entries newest-first by observedAt", async () => {
     const store = new _RateLimitStoreForTests()
-    store.record(FIVE_HOUR)
+    store.record(WORK, FIVE_HOUR)
     // Force monotonic observedAt — Bun's `Date.now()` resolution is fine here.
     await Bun.sleep(2)
-    store.record(SEVEN_DAY)
+    store.record(WORK, SEVEN_DAY)
     // Compare the mapped sequence rather than indexing into the array directly
     // so the test stays under TypeScript's `noUncheckedIndexedAccess` strict
     // mode (which CI's `tsc --noEmit` enforces but Bun's lenient default tsc
     // does not).
-    const orderedTypes = store.getAll().map(e => e.rateLimitType)
+    const orderedTypes = store.getAll(WORK).map(e => e.rateLimitType)
     expect(orderedTypes).toEqual(["seven_day", "five_hour"])
-  })
-
-  it("clear() empties the store", () => {
-    const store = new _RateLimitStoreForTests()
-    store.record(FIVE_HOUR)
-    store.record(SEVEN_DAY)
-    store.clear()
-    expect(store.size).toBe(0)
-    expect(store.getAll()).toEqual([])
   })
 
   it("preserves all SDKRateLimitInfo fields verbatim", () => {
@@ -109,8 +103,62 @@ describe("rateLimitStore", () => {
       surpassedThreshold: 0.75,
       overageDisabledReason: "no_limits_configured",
     }
-    store.record(full)
-    const got = store.get("overage")
+    store.record(WORK, full)
+    const got = store.get(WORK, "overage")
     expect(got).toMatchObject(full)
+  })
+
+  // --- Profile isolation (the bug this scoping fixes) ---
+
+  it("keeps the same bucket type separate per profile", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, { ...FIVE_HOUR, resetsAt: 1_000 })
+    store.record(PERSONAL, { ...FIVE_HOUR, resetsAt: 9_999 })
+    expect(store.get(WORK, "five_hour")?.resetsAt).toBe(1_000)
+    expect(store.get(PERSONAL, "five_hour")?.resetsAt).toBe(9_999)
+    expect(store.size(WORK)).toBe(1)
+    expect(store.size(PERSONAL)).toBe(1)
+    expect(store.size()).toBe(2)
+  })
+
+  it("getAll returns only the requested profile's entries", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(PERSONAL, SEVEN_DAY)
+    expect(store.getAll(WORK).map(e => e.rateLimitType)).toEqual(["five_hour"])
+    expect(store.getAll(PERSONAL).map(e => e.rateLimitType)).toEqual(["seven_day"])
+  })
+
+  it("getAll for an unseen profile returns an empty array", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    expect(store.getAll("never-seen")).toEqual([])
+    expect(store.get("never-seen", "five_hour")).toBeUndefined()
+  })
+
+  it("clear(profileId) drops one profile and leaves others intact", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(PERSONAL, FIVE_HOUR)
+    store.clear(WORK)
+    expect(store.getAll(WORK)).toEqual([])
+    expect(store.getAll(PERSONAL).map(e => e.rateLimitType)).toEqual(["five_hour"])
+  })
+
+  it("clear() with no argument drops every profile", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record(WORK, FIVE_HOUR)
+    store.record(PERSONAL, SEVEN_DAY)
+    store.clear()
+    expect(store.size()).toBe(0)
+    expect(store.getAll(WORK)).toEqual([])
+    expect(store.getAll(PERSONAL)).toEqual([])
+  })
+
+  it("treats 'default' as an ordinary profile key (single-profile setups)", () => {
+    const store = new _RateLimitStoreForTests()
+    store.record("default", FIVE_HOUR)
+    expect(store.getAll("default").map(e => e.rateLimitType)).toEqual(["five_hour"])
+    expect(store.get("default", "five_hour")?.utilization).toBe(0.42)
   })
 })

--- a/src/proxy/rateLimitStore.ts
+++ b/src/proxy/rateLimitStore.ts
@@ -27,13 +27,17 @@
  * in memory. State resets on proxy restart — that's fine because the SDK will
  * push a fresh event on the next request.
  *
- * Singleton — one Meridian process holds one snapshot at a time. With
- * multi-profile setups (`x-meridian-profile` / `POST /profiles/active`)
- * each profile is a separate Claude Max subscription with separate quotas,
- * so the store is **cleared on profile switch and on `/auth/refresh`** —
- * the next SDK call repopulates it for the active profile. Consumers of
- * `/v1/usage/quota` should treat the snapshot as "the active profile's
- * latest known state" and re-fetch after switching profiles.
+ * Entries are scoped per profile. Each profile is a separate Claude Max
+ * subscription with separate quotas, so a flat store would let one account's
+ * reset time be read as another's — which is exactly how priority routing
+ * (`routing: "priority"`) mis-derived exhaustion cooldowns before this was
+ * scoped. Every read names its profile explicitly; single-profile setups
+ * simply use the literal `"default"` key.
+ *
+ * State resets on proxy restart — that's fine because the SDK pushes a fresh
+ * event on the next request. `clear(profileId)` drops one account (wired into
+ * `POST /auth/refresh`, which re-authenticates one credential); `clear()`
+ * drops everything and is used by tests.
  */
 
 import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk"
@@ -47,45 +51,57 @@ export interface RateLimitEntry extends SDKRateLimitInfo {
 export type RateLimitBucketKey = NonNullable<SDKRateLimitInfo["rateLimitType"]> | "default"
 
 class RateLimitStore {
-  private entries = new Map<RateLimitBucketKey, RateLimitEntry>()
+  /** profileId -> (bucket key -> entry). One inner map per configured profile. */
+  private byProfile = new Map<string, Map<RateLimitBucketKey, RateLimitEntry>>()
 
   /**
-   * Record a rate-limit info snapshot.
-   * Last-write-wins per bucket key (rateLimitType). Older entries for the
-   * same key are overwritten — clients should treat the latest as canonical.
+   * Record a rate-limit info snapshot for a specific profile.
+   * Last-write-wins per (profileId, rateLimitType). Older entries for the
+   * same pair are overwritten — clients should treat the latest as canonical.
    *
    * `observedAt` defaults to the current wall clock but may be supplied
    * explicitly so callers (and tests) can control the capture timestamp used
    * for newest-first ordering in {@link getAll}.
    */
-  record(info: SDKRateLimitInfo | undefined | null, observedAt: number = Date.now()): void {
+  record(profileId: string, info: SDKRateLimitInfo | undefined | null, observedAt: number = Date.now()): void {
     if (!info || typeof info !== "object") return
     const key: RateLimitBucketKey = info.rateLimitType ?? "default"
-    this.entries.set(key, { ...info, observedAt })
+    let buckets = this.byProfile.get(profileId)
+    if (!buckets) {
+      buckets = new Map<RateLimitBucketKey, RateLimitEntry>()
+      this.byProfile.set(profileId, buckets)
+    }
+    buckets.set(key, { ...info, observedAt })
   }
 
-  /** Snapshot all current entries, newest-first by observedAt. */
-  getAll(): RateLimitEntry[] {
-    return Array.from(this.entries.values()).sort((a, b) => b.observedAt - a.observedAt)
+  /** Snapshot one profile's entries, newest-first by observedAt. */
+  getAll(profileId: string): RateLimitEntry[] {
+    const buckets = this.byProfile.get(profileId)
+    if (!buckets) return []
+    return Array.from(buckets.values()).sort((a, b) => b.observedAt - a.observedAt)
   }
 
-  /** Snapshot a single bucket, or undefined if not yet seen. */
-  get(key: RateLimitBucketKey): RateLimitEntry | undefined {
-    return this.entries.get(key)
+  /** Snapshot a single bucket for one profile, or undefined if not yet seen. */
+  get(profileId: string, key: RateLimitBucketKey): RateLimitEntry | undefined {
+    return this.byProfile.get(profileId)?.get(key)
   }
 
-  /** Number of distinct buckets observed. */
-  get size(): number {
-    return this.entries.size
+  /** Bucket count for one profile, or across all profiles when omitted. */
+  size(profileId?: string): number {
+    if (profileId !== undefined) return this.byProfile.get(profileId)?.size ?? 0
+    let total = 0
+    for (const buckets of this.byProfile.values()) total += buckets.size
+    return total
   }
 
   /**
-   * Drop all stored entries. Wired into the `POST /profiles/active` and
-   * `POST /auth/refresh` handlers so quotas can't leak across profiles or
-   * stale credential boundaries. Also used by tests for isolation.
+   * Drop stored entries for one profile, or every profile when `profileId`
+   * is omitted. Wired into the `POST /auth/refresh` handler so a refreshed
+   * credential's stale quotas can't linger. Also used by tests for isolation.
    */
-  clear(): void {
-    this.entries.clear()
+  clear(profileId?: string): void {
+    if (profileId !== undefined) this.byProfile.delete(profileId)
+    else this.byProfile.clear()
   }
 }
 

--- a/src/proxy/rateLimitStore.ts
+++ b/src/proxy/rateLimitStore.ts
@@ -34,10 +34,9 @@
  * scoped. Every read names its profile explicitly; single-profile setups
  * simply use the literal `"default"` key.
  *
- * State resets on proxy restart — that's fine because the SDK pushes a fresh
- * event on the next request. `clear(profileId)` drops one account (wired into
- * `POST /auth/refresh`, which re-authenticates one credential); `clear()`
- * drops everything and is used by tests.
+ * `clear(profileId)` drops one account (wired into `POST /auth/refresh`,
+ * which re-authenticates one credential); `clear()` drops everything and is
+ * used by tests.
  */
 
 import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk"

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -492,14 +492,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
    *  burned one failed request and must not also wait on a network call.
    *  `ProfileExhaustion.mark` ignores an `until` that isn't later than the
    *  existing one, so a late refinement can only EXTEND a cooldown, never
-   *  un-suppress a profile early. A null/failed fetch changes nothing. */
+   *  un-suppress a profile early. A null/failed fetch changes nothing.
+   *
+   *  Gated on actual exhaustion: a healthy account always has a `five_hour`
+   *  window with a future `resetsAt` — that boundary exists regardless of
+   *  consumption. The OAuth snapshot is only authoritative about *when* the
+   *  five-hour window resets if that window is actually exhausted
+   *  (`utilization >= 1`); otherwise the triggering error was not five-hour
+   *  exhaustion (upstream overload, a seven_day cap, etc.) and the
+   *  conservative tier-3 default must stand rather than being extended out
+   *  to a boundary that has nothing to do with the failure. A missing/null
+   *  `utilization` is treated as NOT exhausted — under-suppressing is the
+   *  safe direction; over-suppressing a healthy profile is the bug this
+   *  gate exists to prevent. */
   function refinePriorityCooldown(profileId: string): void {
     const target = getEffectiveProfiles(finalConfig.profiles).find(p => p.id === profileId)
     void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir })
       .then(usage => {
         if (!usage) return
+        const fiveHour = usage.windows.find(w => w.type === "five_hour")
+        if (!fiveHour || (fiveHour.utilization ?? 0) < 1) return
         const now = Date.now()
-        const resetsAt = usage.windows.find(w => w.type === "five_hour")?.resetsAt
+        const resetsAt = fiveHour.resetsAt
         if (!resetsAt || resetsAt <= now) return
         const until = Math.min(resetsAt, now + PRIORITY_COOLDOWN_CAP_MS)
         priorityExhaustion.mark(profileId, until, "rate_limit_error")

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -478,10 +478,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return Array.isArray(setting) && setting.length > 0 ? setting : undefined
   }
 
-  function priorityCooldownUntil(now: number): number {
+  function priorityCooldownUntil(profileId: string, now: number): number {
     // Best-available reset signal: the SDK rate-limit store's five_hour reset
     // when known; conservative default otherwise so a mis-mark self-heals.
-    const fiveHour = rateLimitStore.getAll().find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+    const fiveHour = rateLimitStore.getAll(profileId).find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
     const until = fiveHour?.resetsAt ?? now + PRIORITY_DEFAULT_COOLDOWN_MS
     return Math.min(until, now + PRIORITY_COOLDOWN_CAP_MS)
   }
@@ -564,8 +564,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }
         return response
       }
-      priorityExhaustion.mark(candidate, priorityCooldownUntil(Date.now()), "rate_limit_error")
-      claudeLog("priority.exhausted", { profile: candidate, until: priorityCooldownUntil(Date.now()) })
+      const cooldownUntil = priorityCooldownUntil(candidate, Date.now())
+      priorityExhaustion.mark(candidate, cooldownUntil, "rate_limit_error")
+      claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil })
       lastError = errorPayload
       previous = candidate
     }
@@ -1614,7 +1615,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // the SDK as rate_limit_event. We snapshot them in a process-wide
                     // store so /v1/usage/quota can return the latest live state.
                     if ((event as any).type === "rate_limit_event") {
-                      rateLimitStore.record((event as any).rate_limit_info)
+                      rateLimitStore.record(profile.id, (event as any).rate_limit_info)
                     }
                     // Only count real assistant content — not SDK error messages
                     // (which arrive as type:"assistant" with an error field set).
@@ -2328,7 +2329,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }, requestAbort.controller))) {
                       // Same SDK rate-limit capture as the non-stream path.
                       if ((event as any).type === "rate_limit_event") {
-                        rateLimitStore.record((event as any).rate_limit_info)
+                        rateLimitStore.record(profile.id, (event as any).rate_limit_info)
                       }
                       if ((event as any).type === "stream_event") {
                         didYieldClientEvent = true
@@ -3669,11 +3670,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const previousProfile = getActiveProfileId() ?? null
     setActiveProfile(body.profile!)
     // Evict all cached SDK sessions — they were started under the old profile's
-    // credentials and cannot be reused with different auth. Also drop the
-    // rate-limit snapshot so /v1/usage/quota doesn't return the previous
-    // profile's quotas under the new profile's identity.
+    // credentials and cannot be reused with different auth. The rate-limit
+    // store is NOT cleared: entries are profile-scoped, so the new profile
+    // can no longer read the old one's quotas, and other profiles' snapshots
+    // stay valid (consumers judge staleness from `observedAt`).
     clearSessionCache()
-    rateLimitStore.clear()
     // Attribute the switch: multiple surfaces can POST here (the meridian UI,
     // the CLI, pylon's provider switcher, the iOS companion) and the active
     // profile is GLOBAL state — an unexplained flip should be answerable from
@@ -3741,10 +3742,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const store = credentialStoreForProfile(profile)
     const success = store ? await refreshOAuthToken(store) : false
     if (success) {
-      // Drop the rate-limit snapshot — old quotas were observed under the
-      // previous credential and may belong to a different account if the
-      // refresh swapped profiles. The next SDK call repopulates.
-      rateLimitStore.clear()
+      // Drop this profile's rate-limit snapshot — its quotas were observed
+      // under the previous credential. Scoped to the profile actually
+      // refreshed; other accounts' snapshots are untouched. The next SDK
+      // call repopulates.
+      rateLimitStore.clear(profile.id)
       return c.json({ success: true, message: "OAuth token refreshed successfully", profile: profile.id })
     }
     return c.json(
@@ -4040,7 +4042,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     // Filter out the internal "default" bucket — it's a Meridian-side
     // fallback for SDK events missing `rateLimitType`, not a real Anthropic
     // bucket that consumers can render.
-    const sdkEntries = rateLimitStore.getAll().filter(entry => entry.rateLimitType !== undefined)
+    // Entries are read for the resolved target profile only — a multi-account
+    // setup must never render one account's SDK buckets under another's
+    // identity.
 
     // Determine which profile we're querying:
     //   1. Explicit ?profile=<id> query param
@@ -4055,6 +4059,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       || profilesList[0]?.id
       || null
     const targetProfile = targetProfileId ? profilesList.find(p => p.id === targetProfileId) : undefined
+
+    const sdkEntries = rateLimitStore.getAll(targetProfileId ?? "default")
+      .filter(entry => entry.rateLimitType !== undefined)
 
     const oauth = await fetchOAuthUsage({
       profileId: targetProfileId ?? undefined,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4038,13 +4038,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     // (`utilization`, `resetsAt`) win when present — they're always
     // populated. SDK fields fill in overage details and any bucket types
     // OAuth doesn't expose.
-    //
-    // Filter out the internal "default" bucket — it's a Meridian-side
-    // fallback for SDK events missing `rateLimitType`, not a real Anthropic
-    // bucket that consumers can render.
-    // Entries are read for the resolved target profile only — a multi-account
-    // setup must never render one account's SDK buckets under another's
-    // identity.
 
     // Determine which profile we're querying:
     //   1. Explicit ?profile=<id> query param
@@ -4060,6 +4053,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       || null
     const targetProfile = targetProfileId ? profilesList.find(p => p.id === targetProfileId) : undefined
 
+    // Filter out the internal "default" bucket — it's a Meridian-side
+    // fallback for SDK events missing `rateLimitType`, not a real Anthropic
+    // bucket that consumers can render.
+    // Entries are read for the resolved target profile only — a multi-account
+    // setup must never render one account's SDK buckets under another's
+    // identity.
     const sdkEntries = rateLimitStore.getAll(targetProfileId ?? "default")
       .filter(entry => entry.rateLimitType !== undefined)
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -478,12 +478,39 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return Array.isArray(setting) && setting.length > 0 ? setting : undefined
   }
 
+  /** Tier 1 + 3: this profile's own observed five_hour reset, else a
+   *  conservative default so a mis-mark self-heals. Never blocks. */
   function priorityCooldownUntil(profileId: string, now: number): number {
-    // Best-available reset signal: the SDK rate-limit store's five_hour reset
-    // when known; conservative default otherwise so a mis-mark self-heals.
-    const fiveHour = rateLimitStore.getAll(profileId).find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+    const fiveHour = rateLimitStore.getAll(profileId)
+      .find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
     const until = fiveHour?.resetsAt ?? now + PRIORITY_DEFAULT_COOLDOWN_MS
     return Math.min(until, now + PRIORITY_COOLDOWN_CAP_MS)
+  }
+
+  /** Tier 2: the authoritative per-account reset from Anthropic's usage
+   *  endpoint. Deliberately fire-and-forget — the failover path has already
+   *  burned one failed request and must not also wait on a network call.
+   *  `ProfileExhaustion.mark` ignores an `until` that isn't later than the
+   *  existing one, so a late refinement can only EXTEND a cooldown, never
+   *  un-suppress a profile early. A null/failed fetch changes nothing. */
+  function refinePriorityCooldown(profileId: string): void {
+    const target = getEffectiveProfiles(finalConfig.profiles).find(p => p.id === profileId)
+    void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir })
+      .then(usage => {
+        if (!usage) return
+        const now = Date.now()
+        const resetsAt = usage.windows.find(w => w.type === "five_hour")?.resetsAt
+        if (!resetsAt || resetsAt <= now) return
+        const until = Math.min(resetsAt, now + PRIORITY_COOLDOWN_CAP_MS)
+        priorityExhaustion.mark(profileId, until, "rate_limit_error")
+        claudeLog("priority.cooldown_refined", { profile: profileId, until, source: "oauth_usage" })
+      })
+      .catch(err => {
+        claudeLog("priority.cooldown_refine_failed", {
+          profile: profileId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
   }
 
   /** Inspect an inner response for a quota failure without destroying it.
@@ -567,6 +594,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const cooldownUntil = priorityCooldownUntil(candidate, Date.now())
       priorityExhaustion.mark(candidate, cooldownUntil, "rate_limit_error")
       claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil })
+      refinePriorityCooldown(candidate)
       lastError = errorPayload
       previous = candidate
     }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1678,7 +1678,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     advisorModel,
                   }, requestAbort.controller))) {
                     // Capture Claude Max subscription quota updates emitted by
-                    // the SDK as rate_limit_event. We snapshot them in a process-wide
+                    // the SDK as rate_limit_event. We snapshot them in this
+                    // profile's slot of the (per-profile-scoped) rate limit
                     // store so /v1/usage/quota can return the latest live state.
                     if ((event as any).type === "rate_limit_event") {
                       rateLimitStore.record(profile.id, (event as any).rate_limit_info)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -479,10 +479,22 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   }
 
   /** Tier 1 + 3: this profile's own observed five_hour reset, else a
-   *  conservative default so a mis-mark self-heals. Never blocks. */
+   *  conservative default so a mis-mark self-heals. Never blocks.
+   *
+   *  Gated the same way as tier 2's `refinePriorityCooldown`: a healthy
+   *  account always has a `five_hour` window with a future `resetsAt` —
+   *  that boundary exists regardless of consumption, so a scoped entry's
+   *  mere presence doesn't prove the five-hour window caused THIS failure
+   *  (it could be a seven_day cap, or a transient upstream error). Only
+   *  trust the entry's `resetsAt` when it says the window was actually
+   *  exhausted (`status === "rejected"`, or `utilization >= 1` for older
+   *  entries that predate the `status` field); otherwise fall through to
+   *  the conservative default so tier 2 isn't left refining a wrong mark
+   *  it has no way to challenge. */
   function priorityCooldownUntil(profileId: string, now: number): number {
     const fiveHour = rateLimitStore.getAll(profileId)
-      .find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now)
+      .find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now
+        && (e.status === "rejected" || (e.utilization ?? 0) >= 1))
     const until = fiveHour?.resetsAt ?? now + PRIORITY_DEFAULT_COOLDOWN_MS
     return Math.min(until, now + PRIORITY_COOLDOWN_CAP_MS)
   }
@@ -504,12 +516,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
    *  to a boundary that has nothing to do with the failure. A missing/null
    *  `utilization` is treated as NOT exhausted — under-suppressing is the
    *  safe direction; over-suppressing a healthy profile is the bug this
-   *  gate exists to prevent. */
+   *  gate exists to prevent.
+   *
+   *  `force: true` bypasses `fetchOAuthUsage`'s 30s cache: exhaustion is
+   *  rare (off the hot path) and `/v1/usage/quota/all` polling routinely
+   *  keeps that cache warm with a snapshot recorded just before the failure,
+   *  which would otherwise show "just under 1" and starve this refinement
+   *  right when it's needed. `force` only skips the cache read — the
+   *  in-flight-request de-dupe still applies after it, so concurrent
+   *  exhaustions of the same profile still share one upstream call rather
+   *  than stampeding it. A `stale: true` snapshot (served when a fresh fetch
+   *  failed transiently) is not authoritative about the current window, so
+   *  it's skipped too — the conservative default is the safer thing to
+   *  leave standing. */
   function refinePriorityCooldown(profileId: string): void {
     const target = getEffectiveProfiles(finalConfig.profiles).find(p => p.id === profileId)
-    void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir })
+    void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir, force: true })
       .then(usage => {
-        if (!usage) return
+        if (!usage || usage.stale) return
         const fiveHour = usage.windows.find(w => w.type === "five_hour")
         if (!fiveHour || (fiveHour.utilization ?? 0) < 1) return
         const now = Date.now()


### PR DESCRIPTION
## The bug

`priorityCooldownUntil` (`src/proxy/server.ts`) decides how long to bench a profile that just returned `rate_limit_error`. It read that duration from `rateLimitStore.getAll()` — but `rateLimitStore` was a process-wide singleton holding a flat `Map<bucketKey, entry>` with **no profile dimension**.

Its own doc comment described the contents as "the active profile's latest known state", and it was `clear()`ed on profile switch specifically to stop quotas leaking across accounts. In `routing: "priority"` that premise no longer holds: every profile in the pool records into the same singleton as requests are dispatched across accounts, and there is no profile switch to trigger the clear.

So when profile A was marked exhausted, the `five_hour` `resetsAt` used to compute its cooldown could be **profile B's** reset time:

- **Over-suppression** — A benched until B's later reset, wasting A's available quota.
- **Under-suppression** — A un-benched at B's earlier reset, so the next request through A fails again and burns a full round-trip before failing over.

It self-healed via the 6h cap and lazy expiry, so it was never severe — but the mark duration was not reliably A's own, and spending each account's quota accurately is the entire point of priority routing.

`GET /v1/usage/quota` had the identical latent defect: it resolved a `targetProfileId` (honoring `?profile=`), fetched OAuth usage profile-scoped, then merged in `rateLimitStore.getAll()` — whatever profile wrote last.

## The fix

**1. Profile-scope the store.** `Map<profileId, Map<bucket, entry>>`. `profileId` is a required first parameter on `record`/`getAll`/`get` — deliberately not optional, since an optional parameter would let a call site silently read across accounts again. `clear(profileId?)` is scoped or global; `size` became a method. Key is `profile.id`, already the literal `"default"` in single-profile setups, so single-profile behavior is unchanged.

**2. Three-tier cooldown resolution**, most authoritative first:

1. The profile's **own** scoped `five_hour` entry.
2. `fetchOAuthUsage({ profileId, claudeConfigDir })` — authoritative for that specific account, straight from Anthropic.
3. A 10-minute default.

Tier 2 is fire-and-forget: the failover path has already burned one failed request and must not also wait on a network call. The mark is set immediately from tier 1 or 3, and the OAuth result refines it when it lands. This is safe by construction — `ProfileExhaustion.mark` ignores an `until` that isn't later than the existing one, so a late refinement can only **extend** a cooldown, never un-suppress a profile early.

**3. Both tiers gated on actual exhaustion.** A *healthy* account always has a `five_hour` window with a future `resetsAt` — that rolling boundary exists regardless of consumption. Without a gate, a transient 429 or a **seven-day** cap (which `classifyError` deliberately maps to `rate_limit_error`) would take the conservative 10-minute default and extend it to a five-hour boundary that had nothing to do with the failure — reintroducing the same over-suppression through a different door. So:

- Tier 1 requires `status === "rejected" || utilization >= 1`.
- Tier 2 requires `utilization >= 1`, treating missing/null as **not** exhausted.

Under-suppressing is the safe direction; over-suppressing a healthy profile is the bug. This restores what `2026-07-23-priority-profile-routing-design.md` §2 already specified.

Tier 2 also passes `force: true` — `fetchOAuthUsage`'s 30s cache is routinely warmed by the telemetry UI polling `/v1/usage/quota/all`, which would hand the refinement a snapshot showing "just under 1" and starve it exactly when needed. `force` skips only the cache read; in-flight de-duplication still applies, so concurrent exhaustions of one profile share a single upstream call. A `stale: true` snapshot is skipped as non-authoritative.

## User-visible behavior changes

- **`GET /v1/usage/quota`** (stable API surface): a profile with no recorded SDK events now returns OAuth-only buckets where it previously showed **another profile's** SDK data. This is the fix, not a regression, but it is visible in the telemetry UI.
- **`POST /profiles/active`** no longer clears the rate-limit store. That `clear()` existed only to prevent cross-account leakage, which scoping now prevents structurally; other profiles' snapshots stay valid and correctly attributed, and `observedAt` already lets consumers judge staleness.
- **`POST /auth/refresh`** now clears only the profile whose credential was actually refreshed.

## Out of scope

Threshold steering (priority spec §5), the `priorityAssignments` FIFO-vs-LRU eviction quirk, and persisting rate-limit state across restarts.

## Testing

2112 pass, `tsc --noEmit` clean, `npm run build` succeeds.

New coverage includes the direct regression (profile B's reset must never become profile A's mark), cross-profile store isolation, the healthy-account case on both tiers, the 6-hour cap on both paths, and that failover does not block on the OAuth fetch.

Two tests fail in a local full-suite run — `sticky profile routing GOLDEN` and `priority routing mode OFF`. Both fail identically on `main` and are unrelated to this change: the suite reads the developer's real `~/.config/meridian/settings.json`, so on a machine with `"routing": "priority"` configured, the tests that clear `MERIDIAN_ROUTING` to assert default behavior get `priority` from disk. They pass in CI. Worth its own issue.

## Design docs

- `docs/superpowers/specs/2026-07-27-profile-scoped-rate-limit-store-design.md`
- `docs/superpowers/plans/2026-07-27-profile-scoped-rate-limit-store.md`
