### PR TITLE
fix(session): bound modified-continuation resume so stale lineage replays fresh

### DIFF
--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -12,6 +12,7 @@ import {
   verifyLineage,
   normalizeContextUsage,
   MIN_SUFFIX_FOR_COMPACTION,
+  MAX_CONTINUATION_GAP,
   type SessionState,
 } from "../proxy/session/lineage"
 
@@ -377,6 +378,97 @@ describe("verifyLineage", () => {
     const result = verifyLineage(session, incoming, "key", mockCache)
     // Must NOT be compaction — the suffix is at the wrong position
     expect(result.type).not.toBe("compaction")
+    expect(result.type).toBe("diverged")
+  })
+})
+
+describe("verifyLineage modified-continuation gap bound (#689)", () => {
+  // Client-driven tool loops run on throwaway sessions that never persist
+  // back to the lineage store, so the stored session can be many messages
+  // behind the incoming conversation. Resuming such a session sends only
+  // the last user message and drops the intervening tool_use/tool_result
+  // pairs from the SDK context. The bound only allows resume when at most
+  // the last stored slot churned and at most one exchange was appended;
+  // anything further behind must replay fresh (diverged).
+
+  /** Alternating user/assistant conversation: m0, m1, ... m(n-1). */
+  function conversation(n: number) {
+    return Array.from({ length: n }, (_, i) =>
+      msg(i % 2 === 0 ? "user" : "assistant", `m${i}`))
+  }
+
+  function sessionFor(msgs: Array<{ role: string; content: string }>): SessionState {
+    return makeSession({
+      lineageHash: computeLineageHash(msgs),
+      messageCount: msgs.length,
+      messageHashes: computeMessageHashes(msgs),
+    })
+  }
+
+  /** Copy of msgs with the message at `index` replaced by churned content. */
+  function churn(msgs: Array<{ role: string; content: string }>, index: number) {
+    return msgs.map((m, i) => (i === index ? msg(m.role, `${m.content}-churned`) : m))
+  }
+
+  it("resumes when only the last stored slot churned and one exchange was appended", () => {
+    // Mirrors the healthy capture in #689: overlap 5/6, incoming 8, gap 2.
+    const stored = conversation(6)
+    const session = sessionFor(stored)
+    const incoming = [
+      ...churn(stored, 5),
+      msg("assistant", "round 1 summary"),
+      msg("user", "thanks"),
+    ]
+    const result = verifyLineage(session, incoming, "key", mockCache)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      // The store must adopt the incoming history so the next turn resumes cleanly.
+      expect(result.session.messageCount).toBe(incoming.length)
+      expect(result.session.lineageHash).toBe(computeLineageHash(incoming))
+    }
+  })
+
+  it("treats a stored lineage behind by a tool round as diverged (issue repro)", () => {
+    // Mirrors the failing capture in #689: overlap 7/8, incoming 13, gap 5.
+    // The 5 unseen messages are a client-driven tool round the stored
+    // session never saw; resuming would drop them from the SDK context.
+    const stored = conversation(8)
+    const session = sessionFor(stored)
+    const incoming = [
+      ...churn(stored, 7),
+      msg("assistant", "tool_use GREEN-33 + GOLD-44"),
+      msg("user", "tool_result GREEN-33"),
+      msg("user", "tool_result GOLD-44"),
+      msg("assistant", "both commands succeeded"),
+      msg("user", "nice"),
+    ]
+    expect(incoming.length - stored.length).toBeGreaterThan(MAX_CONTINUATION_GAP)
+    const deleted: string[] = []
+    const spyCache = { delete: (key: string) => { deleted.push(key); return true } }
+    const result = verifyLineage(session, incoming, "stale-key", spyCache)
+    expect(result.type).toBe("diverged")
+    // The stale entry must be evicted so the fresh replay re-adopts the
+    // full history and the store self-heals.
+    expect(deleted).toEqual(["stale-key"])
+  })
+
+  it("treats a gap just over the bound as diverged", () => {
+    const stored = conversation(6)
+    const session = sessionFor(stored)
+    const appended = Array.from({ length: MAX_CONTINUATION_GAP + 1 }, (_, i) =>
+      msg(i % 2 === 0 ? "assistant" : "user", `new${i}`))
+    const incoming = [...churn(stored, 5), ...appended]
+    const result = verifyLineage(session, incoming, "key", mockCache)
+    expect(result.type).toBe("diverged")
+  })
+
+  it("treats churn deeper than the last stored slot as diverged even with a small gap", () => {
+    // The stored SDK session holds the old content of the churned message;
+    // resuming would keep stale context the client no longer has.
+    const stored = conversation(4)
+    const session = sessionFor(stored)
+    const incoming = [...churn(stored, 1), msg("user", "one more")]
+    const result = verifyLineage(session, incoming, "key", mockCache)
     expect(result.type).toBe("diverged")
   })
 })

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -37,6 +37,15 @@ export function normalizeContextUsage(usage: TokenUsage): TokenUsageIteration {
  *  required to classify a mutation as compaction rather than a branch. */
 export const MIN_SUFFIX_FOR_COMPACTION = 2
 
+/** Maximum number of new messages (incoming minus stored) a modified
+ *  continuation may append and still resume the stored session. A clean
+ *  conversational turn appends at most one exchange: the previous assistant
+ *  reply plus the new user message. A larger gap means the stored lineage
+ *  missed intervening rounds (client-driven tool loops never persist back
+ *  to the store, #689), and resuming would slice those messages out of the
+ *  SDK context. */
+export const MAX_CONTINUATION_GAP = 2
+
 export interface SessionState {
   claudeSessionId: string
   lastAccess: number
@@ -208,8 +217,9 @@ export interface SessionCacheLike {
  * Decision matrix:
  *   Full prefix match (fast-path)          → continuation (resume normally)
  *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume normally)
- *   Prefix overlap > 0, no suffix          → undo         (fork at rollback point)
- *   No overlap                             → diverged     (start fresh)
+ *   Prefix overlap > 0, no suffix, shrank  → undo         (fork at rollback point)
+ *   Prefix overlap > 0, grew within bound  → continuation (modified continuation)
+ *   Anything else                          → diverged     (start fresh)
  */
 export function verifyLineage(
   cached: SessionState,
@@ -293,17 +303,32 @@ export function verifyLineage(
     return { type: "undo", session: cached, prefixOverlap, rollbackUuid }
   }
 
-  // Modified continuation: most prefix matches but a message was modified
-  // (e.g., cache_control added) and new messages were appended. Treat as
-  // continuation — update stored hashes and resume normally.
+  // Modified continuation: the prefix matches except for benign churn on
+  // the last stored slot (e.g., cache_control added) and new messages were
+  // appended. Resume only when the stored lineage is actually current:
+  //   prefixOverlap >= stored - 1   (only the last stored slot may differ)
+  //   gap <= MAX_CONTINUATION_GAP   (at most one new exchange appended)
+  // A stored session further behind is missing intervening messages (#689:
+  // client-driven tool rounds never persist back to the store), and the
+  // resume slice would drop them from the SDK context. Treat that as
+  // diverged instead: a fresh full-history replay is always correct, and
+  // the store re-adopts the full history at end of turn.
   if (prefixOverlap > 0 && messages.length > cached.messageCount) {
-    const modifiedMsg = `Modified continuation (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, incoming ${messages.length} msgs. Allowing resume.`
-    console.error(`[PROXY] ${modifiedMsg}`)
-    diagnosticLog.lineage(modifiedMsg)
-    cached.lineageHash = computeLineageHash(messages.slice(0, messages.length))
-    cached.messageHashes = incomingHashes
-    cached.messageCount = messages.length
-    return { type: "continuation", session: cached }
+    const gap = messages.length - cached.messageCount
+    if (prefixOverlap >= cached.messageCount - 1 && gap <= MAX_CONTINUATION_GAP) {
+      const modifiedMsg = `Modified continuation (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, incoming ${messages.length} msgs. Allowing resume.`
+      console.error(`[PROXY] ${modifiedMsg}`)
+      diagnosticLog.lineage(modifiedMsg)
+      cached.lineageHash = computeLineageHash(messages.slice(0, messages.length))
+      cached.messageHashes = incomingHashes
+      cached.messageCount = messages.length
+      return { type: "continuation", session: cached }
+    }
+    const staleMsg = `Stale modified continuation (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, incoming ${messages.length} msgs, gap ${gap}. Treating as diverged.`
+    console.error(`[PROXY] ${staleMsg}`)
+    diagnosticLog.lineage(staleMsg)
+    cache.delete(cacheKey)
+    return { type: "diverged" }
   }
 
   // No meaningful overlap — completely different conversation.


### PR DESCRIPTION
Supersedes #690 — cherry-picked from @kilabyte with authorship preserved. Fixes #689.

Landed as a cherry-pick because `main` requires signed commits and the fork commit was unsigned, so #690 was permanently `BLOCKED` despite green checks. Re-signing on cherry-pick is the only path in; the commit is otherwise byte-identical to kilabyte's.

## What it fixes

`verifyLineage`'s modified-continuation branch advances `cached.messageCount` to the incoming length *before* the caller computes the resume slice:

```ts
const knownCount = cachedSession.messageCount || 0        // server.ts:1069
if (knownCount > 0 && knownCount < allMessages.length) {
  messagesToConvert = allMessages.slice(knownCount)
} else {
  messagesToConvert = getLastUserMessage(allMessages)      // ← always taken
}
```

Client-driven tool loops run on throwaway sessions that never persist back to the store, so the stored lineage sits several messages behind. The branch resumed that stale session on any `prefixOverlap > 0`, and the slice collapsed to the last user message — dropping every intervening `tool_use`/`tool_result` from the model's context. The model then truthfully reported the tools returned nothing.

The fix bounds the resume to cases where the stored lineage is genuinely current (`prefixOverlap >= stored - 1` and `gap <= 2`); anything further behind is `diverged`, which replays the full history on a fresh session.

## Validation

**Differential sweep.** Ran `main`'s `verifyLineage` against this one over 264 scenarios (stored length × churn position × gap):

```
scenarios: 264 | unchanged: 204 | changed: 60
transitions: { "continuation -> diverged": 60 }
```

Every behavioural change moves toward the safe verdict; **zero** move the other way. The new code cannot resume anything the old code refused. `compaction` (126 cases) and `undo` are untouched.

**Full suite**, same 2 pre-existing failures at every point — both are profile-routing tests unrelated to lineage, both green in CI, both failing locally on account of environment:

| | tests | pass | fail |
|---|---|---|---|
| base `bf078827` | 2098 | 2095 | 2 |
| #690 alone | 2102 | 2099 | 2 |
| this branch on current `main` | 2119 | 2116 | 2 |

`npm run typecheck` clean. The 4 new unit tests pass; the pre-existing modified-continuation test sits inside the bound and still passes unchanged.

**Scope check.** #697 (merged since #690 opened) touches `server.ts`/`rateLimitStore.ts` only — `session/lineage.ts` and `messages.ts` are untouched, so the differential result holds against current `main`.

## Known cost

Conversations that hit this path now replay the full history instead of resuming, so the SDK rebuilds that session's prompt cache — the decay documented at `server.ts:971`. This lands only on clients exhibiting last-slot churn; clients without it take the fast path, which never mutates `messageCount` and was already correct. Those are precisely the clients that were getting wrong answers before, so it trades silent context loss for cost, not speed for nothing.

Root fix tracked separately: persist tool-loop sessions back to the store so the stored lineage is never behind, which removes both the wrong answers and the replay cost.