### PR TITLE
fix(settings): isolate tests from the developer's real settings file

### DIFF
--- a/src/__tests__/preload.ts
+++ b/src/__tests__/preload.ts
@@ -3,5 +3,19 @@
  * Clears environment variables that would interfere with test isolation.
  */
 
+import { mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 // Auth middleware reads this at request time; clear it so tests don't need API keys
 delete process.env.MERIDIAN_API_KEY
+
+// Point settings.ts at a throwaway directory so the suite never reads the
+// developer's real ~/.config/meridian/settings.json. A live
+// `routing: "priority"` setting made the sticky- and priority-routing
+// integration tests fail locally while passing in CI, because both fall back
+// to getSetting("routing") when MERIDIAN_ROUTING is unset — so those tests
+// were asserting against whatever the developer happened to have configured.
+// Keyed by pid so concurrent runs don't share state.
+process.env.MERIDIAN_CONFIG_DIR = join(tmpdir(), `meridian-test-settings-${process.pid}`)
+mkdirSync(process.env.MERIDIAN_CONFIG_DIR, { recursive: true })

--- a/src/__tests__/settings-unit.test.ts
+++ b/src/__tests__/settings-unit.test.ts
@@ -1,54 +1,94 @@
 /**
  * Unit tests for settings.ts — persistent server settings.
+ *
+ * These exercise the real module. Previously the settings path was frozen at
+ * import time from homedir(), so the suite could not redirect it and these
+ * tests re-implemented JSON roundtripping instead — they passed regardless of
+ * what settings.ts actually did. MERIDIAN_CONFIG_DIR makes the module testable.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { loadSettings, saveSettings, getSetting, setSetting } from "../proxy/settings"
 
-// We can't easily mock homedir() in the module, so we test the
-// load/save logic by directly importing and verifying the contract.
-// The module reads/writes ~/.config/meridian/settings.json.
-
-describe("settings module contract", () => {
-  // Use a temp file to avoid polluting real settings
-  const tempDir = join(tmpdir(), `meridian-settings-test-${Date.now()}`)
-  const tempFile = join(tempDir, "test-settings.json")
+describe("settings module", () => {
+  const tempDir = join(tmpdir(), `meridian-settings-unit-${process.pid}`)
+  const settingsFile = join(tempDir, "settings.json")
+  let savedConfigDir: string | undefined
 
   beforeEach(() => {
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    rmSync(tempDir, { recursive: true, force: true })
     mkdirSync(tempDir, { recursive: true })
+    process.env.MERIDIAN_CONFIG_DIR = tempDir
   })
 
   afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
     rmSync(tempDir, { recursive: true, force: true })
   })
 
-  test("JSON roundtrip preserves data", () => {
-    const data = { activeProfile: "work" }
-    writeFileSync(tempFile, JSON.stringify(data, null, 2) + "\n")
-    const loaded = JSON.parse(readFileSync(tempFile, "utf-8"))
-    expect(loaded.activeProfile).toBe("work")
+  test("loadSettings returns empty object when no file exists", () => {
+    expect(existsSync(settingsFile)).toBe(false)
+    expect(loadSettings()).toEqual({})
   })
 
-  test("merge semantics: new keys added, existing keys updated", () => {
-    const initial = { activeProfile: "personal" }
-    writeFileSync(tempFile, JSON.stringify(initial))
-    const current = JSON.parse(readFileSync(tempFile, "utf-8"))
-    const merged = { ...current, activeProfile: "work" }
-    writeFileSync(tempFile, JSON.stringify(merged, null, 2) + "\n")
-    const result = JSON.parse(readFileSync(tempFile, "utf-8"))
+  test("saveSettings then loadSettings roundtrips", () => {
+    saveSettings({ activeProfile: "work" })
+    expect(loadSettings().activeProfile).toBe("work")
+  })
+
+  test("saveSettings merges rather than clobbering existing keys", () => {
+    saveSettings({ activeProfile: "personal", routing: "sticky" })
+    saveSettings({ activeProfile: "work" })
+    const result = loadSettings()
     expect(result.activeProfile).toBe("work")
+    expect(result.routing).toBe("sticky")
   })
 
-  test("missing file returns empty on parse", () => {
-    const missing = join(tempDir, "nonexistent.json")
-    expect(existsSync(missing)).toBe(false)
+  test("saveSettings preserves unknown keys written by other versions", () => {
+    writeFileSync(settingsFile, JSON.stringify({ futureKey: "keep-me" }))
+    saveSettings({ activeProfile: "work" })
+    const raw = JSON.parse(readFileSync(settingsFile, "utf-8"))
+    expect(raw.futureKey).toBe("keep-me")
+    expect(raw.activeProfile).toBe("work")
   })
 
-  test("corrupt JSON doesn't throw", () => {
-    writeFileSync(tempFile, "not json{{{")
-    expect(() => {
-      try { JSON.parse(readFileSync(tempFile, "utf-8")) } catch { /* expected */ }
-    }).not.toThrow()
+  test("corrupt JSON returns empty settings instead of throwing", () => {
+    writeFileSync(settingsFile, "not json{{{")
+    expect(() => loadSettings()).not.toThrow()
+    expect(loadSettings()).toEqual({})
+  })
+
+  test("getSetting / setSetting operate on individual keys", () => {
+    expect(getSetting("routing")).toBeUndefined()
+    setSetting("routing", "priority")
+    expect(getSetting("routing")).toBe("priority")
+  })
+
+  test("profileOrder array survives a roundtrip", () => {
+    setSetting("profileOrder", ["work", "personal"])
+    expect(getSetting("profileOrder")).toEqual(["work", "personal"])
+  })
+
+  test("settings file is written with owner-only permissions", () => {
+    saveSettings({ activeProfile: "work" })
+    expect(statSync(settingsFile).mode & 0o777).toBe(0o600)
+  })
+
+  test("MERIDIAN_CONFIG_DIR redirects reads away from the real config", () => {
+    // The isolation property the whole suite depends on: with the override
+    // set, the module must not fall back to ~/.config/meridian/settings.json.
+    const otherDir = join(tempDir, "elsewhere")
+    mkdirSync(otherDir, { recursive: true })
+    writeFileSync(join(otherDir, "settings.json"), JSON.stringify({ routing: "priority" }))
+
+    saveSettings({ routing: "sticky" })
+    expect(loadSettings().routing).toBe("sticky")
+
+    process.env.MERIDIAN_CONFIG_DIR = otherDir
+    expect(loadSettings().routing).toBe("priority")
   })
 })

--- a/src/proxy/settings.ts
+++ b/src/proxy/settings.ts
@@ -12,7 +12,24 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs"
 import { join, dirname } from "node:path"
 import { homedir } from "node:os"
 
-const SETTINGS_FILE = join(homedir(), ".config", "meridian", "settings.json")
+/**
+ * Resolve the settings file path.
+ *
+ * Resolved per call rather than frozen at import time so tests can redirect
+ * it via MERIDIAN_CONFIG_DIR (see `src/__tests__/preload.ts`). Without the
+ * override the path is exactly what it has always been, so existing installs
+ * are unaffected.
+ *
+ * NOTE: deliberately does NOT honour XDG_CONFIG_HOME — anyone who has that
+ * set would silently relocate to a different settings file and appear to
+ * lose their configuration.
+ */
+function settingsFile(): string {
+  const override = process.env.MERIDIAN_CONFIG_DIR
+  return override
+    ? join(override, "settings.json")
+    : join(homedir(), ".config", "meridian", "settings.json")
+}
 
 export interface MeridianSettings {
   /** Last active profile ID — restored on proxy startup */
@@ -27,9 +44,10 @@ export interface MeridianSettings {
 
 /** Read settings from disk. Returns empty object if file doesn't exist or is invalid. */
 export function loadSettings(): MeridianSettings {
+  const file = settingsFile()
   try {
-    if (!existsSync(SETTINGS_FILE)) return {}
-    return JSON.parse(readFileSync(SETTINGS_FILE, "utf-8"))
+    if (!existsSync(file)) return {}
+    return JSON.parse(readFileSync(file, "utf-8"))
   } catch {
     return {}
   }
@@ -37,13 +55,14 @@ export function loadSettings(): MeridianSettings {
 
 /** Write settings to disk. Merges with existing settings (doesn't clobber unknown keys). */
 export function saveSettings(updates: Partial<MeridianSettings>): void {
+  const file = settingsFile()
   const current = loadSettings()
   const merged = { ...current, ...updates }
   try {
-    mkdirSync(dirname(SETTINGS_FILE), { recursive: true })
-    writeFileSync(SETTINGS_FILE, JSON.stringify(merged, null, 2) + "\n", { mode: 0o600 })
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, JSON.stringify(merged, null, 2) + "\n", { mode: 0o600 })
   } catch (err) {
-    console.warn(`[meridian] Failed to write ${SETTINGS_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to write ${file}: ${err instanceof Error ? err.message : err}`)
   }
 }
 


### PR DESCRIPTION
Two tests fail on any machine with a real `~/.config/meridian/settings.json` and pass in CI, where none exists.

## Root cause

`settings.ts` froze its path at import time:

```ts
const SETTINGS_FILE = join(homedir(), ".config", "meridian", "settings.json")
```

Both routing integration tests delete `MERIDIAN_ROUTING` and expect default behaviour, but the code falls back to `getSetting("routing")` ([server.ts:753](../blob/main/src/proxy/server.ts#L753)) — which read my actual config:

```json
{ "activeProfile": "work", "routing": "priority", "profileOrder": ["work", "personal"] }
```

So the tests asserted against whatever the developer happened to have configured:

```
priority routing > mode OFF is byte-identical    Expected: 429  Received: 200
sticky routing > GOLDEN ... first profile        Expected: "personal"  Received: "work"
```

Confirmed by running both files with a clean `HOME`: 0 failures. The suite was red locally and green remotely, which is the failure mode that teaches you to ignore red.

## Fix

Resolve the path per call and honour `MERIDIAN_CONFIG_DIR`; point the test preload at a throwaway directory so **every** test file is isolated, not just the two that happened to fail.

Without the override the path is byte-for-byte what it was, so existing installs are unaffected.

**Deliberately does not honour `XDG_CONFIG_HOME`.** It would be the more standard thing to support, but anyone who has it set would silently relocate to a different settings file and appear to have lost their configuration — a regression for a cosmetic win.

## Test rewrite

`settings-unit.test.ts` opened with:

> We can't easily mock homedir() in the module, so we test the load/save logic by directly importing and verifying the contract.

It then re-implemented JSON roundtripping against its own temp files. Every assertion was on `JSON.parse`/`writeFileSync` — none reached `settings.ts`, and all four would pass if the module were deleted.

Replaced with tests of the real module, now possible via the override: load/save roundtrip, merge semantics, unknown-key preservation, corrupt-JSON handling, `getSetting`/`setSetting`, `0600` permissions, and the redirect property the suite depends on.

## Verification

- Full suite: **2123 pass, 1 skip, 0 fail** — with my real settings file still in place. First fully green local run.
- The two previously-failing files: **23 pass, 0 fail**, no `HOME` hack.
- `npm run typecheck` clean.