### PR TITLE
fix: replay stale session histories safely + lineage safety harness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,10 +172,16 @@ Every request verifies that incoming messages are a valid continuation of the ca
 
 | Classification | Condition | Action |
 |---------------|-----------|--------|
-| **Continuation** | Prefix hash matches stored | Resume normally |
-| **Compaction** | Suffix preserved, beginning changed | Resume (agent summarized old messages) |
+| **Continuation** | Full stored prefix hash matches | Resume from the stored message boundary |
+| **Compaction** | Suffix preserved, beginning changed | Resume after the matched suffix |
 | **Undo** | Prefix preserved, suffix changed | Fork at rollback point |
-| **Diverged** | No meaningful overlap | Start fresh session |
+| **Diverged** | No overlap, unverifiable state, or a changed cached prefix followed by new messages | Start fresh and replay the complete client history |
+
+Lineage verification is side-effect free. A classification may select an SDK
+session and a replay boundary, but updated message counts and hashes are only
+stored after the upstream request succeeds. When Meridian cannot prove that an
+SDK session contains a section of client history, it starts fresh rather than
+silently skipping that section.
 
 ## Testing Strategy
 

--- a/src/__tests__/lineage-safety.test.ts
+++ b/src/__tests__/lineage-safety.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Lineage safety harness.
+ *
+ * `verifyLineage` decides whether an existing SDK session may be resumed, and
+ * from which message. A wrong "resume" silently drops conversation history
+ * from the model's context; a wrong "diverged" only costs a full replay, which
+ * is always correct. The whole safety story is that asymmetry.
+ *
+ * Three separate bugs came from the same root cause — verification mutating
+ * state the caller then read as the resume boundary:
+ *
+ *   - #689  client tool-loop history dropped on the continuation path
+ *   - #692  stale distributed node, 515 cached vs 727 incoming
+ *   - the compaction path: an early churned message plus an appended tool
+ *     round sent 1 message instead of 5, dropping the tool_result
+ *
+ * None were caught by example-based tests, because each needed a specific
+ * shape nobody thought to write down. So this file checks properties over a
+ * generated scenario space instead:
+ *
+ *  1. INVARIANTS — must hold for every input. The important one is
+ *     resume soundness: anything the caller skips must genuinely already be
+ *     in the SDK session. All three bugs above violate it.
+ *  2. GOLDEN MATRIX — the exact verdict per scenario, so any change to
+ *     lineage.ts surfaces as a reviewable diff rather than a silent shift.
+ *
+ * When a change legitimately alters a verdict, update the table in the same
+ * commit and say why. Do not regenerate it blindly: `D -> R` (diverged
+ * becoming resume) is the dangerous direction and needs justifying; `R -> D`
+ * is conservative.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  computeLineageHash,
+  computeMessageHashes,
+  verifyLineage,
+  type SessionState,
+} from "../proxy/session/lineage"
+
+function msg(role: string, content: string) {
+  return { role, content }
+}
+
+function sessionFor(msgs: Array<{ role: string; content: string }>): SessionState {
+  return {
+    claudeSessionId: "sdk-1",
+    lastAccess: 0,
+    lineageHash: computeLineageHash(msgs),
+    messageCount: msgs.length,
+    messageHashes: computeMessageHashes(msgs),
+  }
+}
+
+/** Alternating user/assistant conversation: m0, m1, ... m(n-1). */
+function conversation(n: number) {
+  return Array.from({ length: n }, (_, i) =>
+    msg(i % 2 === 0 ? "user" : "assistant", `m${i}`))
+}
+
+/** Copy of msgs with the message at `index` replaced by different content. */
+function churn(msgs: Array<{ role: string; content: string }>, index: number) {
+  return msgs.map((m, i) => (i === index ? msg(m.role, `${m.content}-changed`) : m))
+}
+
+interface Scenario {
+  label: string
+  stored: Array<{ role: string; content: string }>
+  incoming: Array<{ role: string; content: string }>
+}
+
+/**
+ * Mechanically generated: stored length × churn position × growth, plus the
+ * shrink (undo) and compaction shapes. Mechanical is the point — it covers
+ * combinations nobody would think to write by hand, which is exactly where
+ * all three bugs lived.
+ */
+function scenarios(): Scenario[] {
+  const out: Scenario[] = []
+
+  for (const storedLen of [2, 4, 6, 8]) {
+    const stored = conversation(storedLen)
+
+    for (const gap of [0, 1, 2, 3, 5]) {
+      const appended = Array.from({ length: gap }, (_, i) =>
+        msg(i % 2 === 0 ? "assistant" : "user", `new${i}`))
+
+      out.push({
+        label: `stored=${storedLen} churn=none gap=${gap}`,
+        stored,
+        incoming: [...stored, ...appended],
+      })
+
+      for (let c = 0; c < storedLen; c++) {
+        out.push({
+          label: `stored=${storedLen} churn=@${c} gap=${gap}`,
+          stored,
+          incoming: [...churn(stored, c), ...appended],
+        })
+      }
+    }
+
+    for (const keep of [1, Math.floor(storedLen / 2)]) {
+      if (keep > 0 && keep < storedLen) {
+        out.push({
+          label: `stored=${storedLen} shrink-to=${keep}`,
+          stored,
+          incoming: stored.slice(0, keep),
+        })
+      }
+    }
+
+    if (storedLen >= 6) {
+      out.push({
+        label: `stored=${storedLen} compaction`,
+        stored,
+        incoming: [msg("user", "summary of earlier"), ...stored.slice(-3)],
+      })
+    }
+  }
+
+  out.push({
+    label: "unrelated history",
+    stored: conversation(6),
+    incoming: conversation(4).map((m, i) => msg(m.role, `other${i}`)),
+  })
+
+  return out
+}
+
+const CODE: Record<string, string> = {
+  continuation: "R",
+  compaction: "C",
+  undo: "U",
+  diverged: "D",
+}
+
+describe("lineage safety: invariants", () => {
+  it("never mutates the cached session", () => {
+    // The root cause of #689, #692 and the compaction drop: verification
+    // rewrote messageCount, and the caller then read it as the resume
+    // boundary, so the slice swallowed the entire unseen history.
+    for (const s of scenarios()) {
+      const session = sessionFor(s.stored)
+      const snapshot = JSON.stringify(session)
+      verifyLineage(session, s.incoming)
+      expect(JSON.stringify(session), `${s.label} mutated the cached session`).toBe(snapshot)
+    }
+  })
+
+  it("is deterministic", () => {
+    for (const s of scenarios()) {
+      const a = verifyLineage(sessionFor(s.stored), s.incoming)
+      const b = verifyLineage(sessionFor(s.stored), s.incoming)
+      expect(a.type).toBe(b.type)
+    }
+  })
+
+  it("resume soundness: everything before resumeFrom is already in the session", () => {
+    // THE invariant. The caller sends incoming.slice(resumeFrom), so every
+    // message before that index must genuinely be in the SDK session already.
+    for (const s of scenarios()) {
+      const session = sessionFor(s.stored)
+      const result = verifyLineage(session, s.incoming)
+      if (result.type !== "continuation" && result.type !== "compaction") continue
+
+      const storedHashes = computeMessageHashes(s.stored)
+      const incomingHashes = computeMessageHashes(s.incoming)
+      const { resumeFrom } = result
+
+      expect(resumeFrom, `${s.label} resumeFrom past end`).toBeLessThanOrEqual(s.incoming.length)
+
+      if (result.type === "continuation") {
+        // Continuation resumes from the stored count, so the stored history
+        // must appear unchanged at the same positions.
+        expect(resumeFrom, `${s.label} continuation resumeFrom mismatch`).toBe(s.stored.length)
+        for (let i = 0; i < resumeFrom; i++) {
+          expect(incomingHashes[i], `${s.label} slot ${i} differs but was skipped`).toBe(storedHashes[i]!)
+        }
+      } else {
+        // Compaction: the head is a summary the SDK does not need (it holds
+        // the real history), but the preserved suffix must sit immediately
+        // before resumeFrom, matching the stored tail.
+        const { suffixOverlap } = result
+        expect(suffixOverlap, `${s.label} compaction without a suffix`).toBeGreaterThan(0)
+        for (let k = 1; k <= suffixOverlap; k++) {
+          expect(
+            incomingHashes[resumeFrom - k],
+            `${s.label} preserved suffix does not match stored tail at -${k}`,
+          ).toBe(storedHashes[s.stored.length - k]!)
+        }
+      }
+    }
+  })
+
+  it("never resumes a conversation that did not grow", () => {
+    // Re-sending the last user message to a session that already has it
+    // accumulates ghost context.
+    for (const s of scenarios()) {
+      if (s.incoming.length > s.stored.length) continue
+      const result = verifyLineage(sessionFor(s.stored), s.incoming)
+      expect(result.type, `${s.label} resumed without growing`).not.toBe("continuation")
+    }
+  })
+})
+
+describe("lineage safety: golden verdict matrix", () => {
+  it("matches the pinned verdict for every scenario", () => {
+    const actual = scenarios()
+      .map(s => `${s.label} => ${CODE[verifyLineage(sessionFor(s.stored), s.incoming).type]}`)
+      .join("\n")
+
+    // R=continuation (resume)  C=compaction (resume)  U=undo (fork)  D=diverged (replay)
+    const expected = `stored=2 churn=none gap=0 => D
+stored=2 churn=@0 gap=0 => D
+stored=2 churn=@1 gap=0 => U
+stored=2 churn=none gap=1 => R
+stored=2 churn=@0 gap=1 => D
+stored=2 churn=@1 gap=1 => D
+stored=2 churn=none gap=2 => R
+stored=2 churn=@0 gap=2 => D
+stored=2 churn=@1 gap=2 => D
+stored=2 churn=none gap=3 => R
+stored=2 churn=@0 gap=3 => D
+stored=2 churn=@1 gap=3 => D
+stored=2 churn=none gap=5 => R
+stored=2 churn=@0 gap=5 => D
+stored=2 churn=@1 gap=5 => D
+stored=2 shrink-to=1 => U
+stored=2 shrink-to=1 => U
+stored=4 churn=none gap=0 => D
+stored=4 churn=@0 gap=0 => D
+stored=4 churn=@1 gap=0 => D
+stored=4 churn=@2 gap=0 => D
+stored=4 churn=@3 gap=0 => U
+stored=4 churn=none gap=1 => R
+stored=4 churn=@0 gap=1 => D
+stored=4 churn=@1 gap=1 => D
+stored=4 churn=@2 gap=1 => D
+stored=4 churn=@3 gap=1 => D
+stored=4 churn=none gap=2 => R
+stored=4 churn=@0 gap=2 => D
+stored=4 churn=@1 gap=2 => D
+stored=4 churn=@2 gap=2 => D
+stored=4 churn=@3 gap=2 => D
+stored=4 churn=none gap=3 => R
+stored=4 churn=@0 gap=3 => D
+stored=4 churn=@1 gap=3 => D
+stored=4 churn=@2 gap=3 => D
+stored=4 churn=@3 gap=3 => D
+stored=4 churn=none gap=5 => R
+stored=4 churn=@0 gap=5 => D
+stored=4 churn=@1 gap=5 => D
+stored=4 churn=@2 gap=5 => D
+stored=4 churn=@3 gap=5 => D
+stored=4 shrink-to=1 => U
+stored=4 shrink-to=2 => U
+stored=6 churn=none gap=0 => D
+stored=6 churn=@0 gap=0 => C
+stored=6 churn=@1 gap=0 => C
+stored=6 churn=@2 gap=0 => C
+stored=6 churn=@3 gap=0 => C
+stored=6 churn=@4 gap=0 => D
+stored=6 churn=@5 gap=0 => U
+stored=6 churn=none gap=1 => R
+stored=6 churn=@0 gap=1 => C
+stored=6 churn=@1 gap=1 => C
+stored=6 churn=@2 gap=1 => C
+stored=6 churn=@3 gap=1 => C
+stored=6 churn=@4 gap=1 => D
+stored=6 churn=@5 gap=1 => D
+stored=6 churn=none gap=2 => R
+stored=6 churn=@0 gap=2 => C
+stored=6 churn=@1 gap=2 => C
+stored=6 churn=@2 gap=2 => C
+stored=6 churn=@3 gap=2 => C
+stored=6 churn=@4 gap=2 => D
+stored=6 churn=@5 gap=2 => D
+stored=6 churn=none gap=3 => R
+stored=6 churn=@0 gap=3 => C
+stored=6 churn=@1 gap=3 => C
+stored=6 churn=@2 gap=3 => C
+stored=6 churn=@3 gap=3 => C
+stored=6 churn=@4 gap=3 => D
+stored=6 churn=@5 gap=3 => D
+stored=6 churn=none gap=5 => R
+stored=6 churn=@0 gap=5 => C
+stored=6 churn=@1 gap=5 => C
+stored=6 churn=@2 gap=5 => C
+stored=6 churn=@3 gap=5 => C
+stored=6 churn=@4 gap=5 => D
+stored=6 churn=@5 gap=5 => D
+stored=6 shrink-to=1 => U
+stored=6 shrink-to=3 => U
+stored=6 compaction => C
+stored=8 churn=none gap=0 => D
+stored=8 churn=@0 gap=0 => C
+stored=8 churn=@1 gap=0 => C
+stored=8 churn=@2 gap=0 => C
+stored=8 churn=@3 gap=0 => C
+stored=8 churn=@4 gap=0 => C
+stored=8 churn=@5 gap=0 => C
+stored=8 churn=@6 gap=0 => D
+stored=8 churn=@7 gap=0 => U
+stored=8 churn=none gap=1 => R
+stored=8 churn=@0 gap=1 => C
+stored=8 churn=@1 gap=1 => C
+stored=8 churn=@2 gap=1 => C
+stored=8 churn=@3 gap=1 => C
+stored=8 churn=@4 gap=1 => C
+stored=8 churn=@5 gap=1 => C
+stored=8 churn=@6 gap=1 => D
+stored=8 churn=@7 gap=1 => D
+stored=8 churn=none gap=2 => R
+stored=8 churn=@0 gap=2 => C
+stored=8 churn=@1 gap=2 => C
+stored=8 churn=@2 gap=2 => C
+stored=8 churn=@3 gap=2 => C
+stored=8 churn=@4 gap=2 => C
+stored=8 churn=@5 gap=2 => C
+stored=8 churn=@6 gap=2 => D
+stored=8 churn=@7 gap=2 => D
+stored=8 churn=none gap=3 => R
+stored=8 churn=@0 gap=3 => C
+stored=8 churn=@1 gap=3 => C
+stored=8 churn=@2 gap=3 => C
+stored=8 churn=@3 gap=3 => C
+stored=8 churn=@4 gap=3 => C
+stored=8 churn=@5 gap=3 => C
+stored=8 churn=@6 gap=3 => D
+stored=8 churn=@7 gap=3 => D
+stored=8 churn=none gap=5 => R
+stored=8 churn=@0 gap=5 => C
+stored=8 churn=@1 gap=5 => C
+stored=8 churn=@2 gap=5 => C
+stored=8 churn=@3 gap=5 => C
+stored=8 churn=@4 gap=5 => C
+stored=8 churn=@5 gap=5 => C
+stored=8 churn=@6 gap=5 => D
+stored=8 churn=@7 gap=5 => D
+stored=8 shrink-to=1 => U
+stored=8 shrink-to=4 => U
+stored=8 compaction => C
+unrelated history => D`
+
+    expect(actual).toBe(expected)
+  })
+})

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -12,7 +12,6 @@ import {
   verifyLineage,
   normalizeContextUsage,
   MIN_SUFFIX_FOR_COMPACTION,
-  MAX_CONTINUATION_GAP,
   type SessionState,
 } from "../proxy/session/lineage"
 
@@ -29,8 +28,6 @@ function makeSession(overrides: Partial<SessionState> = {}): SessionState {
     ...overrides,
   }
 }
-
-const mockCache = { delete: () => true }
 
 describe("computeLineageHash", () => {
   it("returns empty string for empty array", () => {
@@ -170,10 +167,10 @@ describe("measureSuffixOverlap", () => {
 })
 
 describe("verifyLineage", () => {
-  it("returns continuation for empty lineage hash (legacy)", () => {
+  it("returns diverged for an unverifiable legacy session", () => {
     const session = makeSession({ lineageHash: "", messageCount: 0 })
-    const result = verifyLineage(session, [msg("user", "hi")], "key", mockCache)
-    expect(result.type).toBe("continuation")
+    const result = verifyLineage(session, [msg("user", "hi")])
+    expect(result).toEqual({ type: "diverged", reason: "unverifiable" })
   })
 
   it("returns continuation when prefix matches exactly", () => {
@@ -185,8 +182,11 @@ describe("verifyLineage", () => {
     })
     // Same messages + one new one = valid continuation
     const extended = [...msgs, msg("user", "how are you?")]
-    const result = verifyLineage(session, extended, "key", mockCache)
+    const result = verifyLineage(session, extended)
     expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(msgs.length)
+    }
   })
 
   it("returns diverged when no per-message hashes and lineage mismatches", () => {
@@ -195,7 +195,7 @@ describe("verifyLineage", () => {
       messageCount: 2,
       messageHashes: undefined,
     })
-    const result = verifyLineage(session, [msg("user", "different")], "key", mockCache)
+    const result = verifyLineage(session, [msg("user", "different")])
     expect(result.type).toBe("diverged")
   })
 
@@ -210,7 +210,7 @@ describe("verifyLineage", () => {
     })
     // Undo: keep first 2 messages, replace last 2
     const undone = [msg("user", "a"), msg("assistant", "b"), msg("user", "new")]
-    const result = verifyLineage(session, undone, "key", mockCache)
+    const result = verifyLineage(session, undone)
     expect(result.type).toBe("undo")
     if (result.type === "undo") {
       expect(result.prefixOverlap).toBe(2)
@@ -218,9 +218,7 @@ describe("verifyLineage", () => {
     }
   })
 
-  it("returns continuation (not undo) when messages grow with a modified message", () => {
-    // Reproduces the false undo bug: conversation grows from 7 to 9 messages
-    // but message[6] was modified (e.g., cache_control added by OpenCode).
+  it("returns diverged when messages grow after a cached message changed", () => {
     const msgs = [
       msg("user", "a"), msg("assistant", "b"),
       msg("user", "c"), msg("assistant", "d"),
@@ -243,8 +241,66 @@ describe("verifyLineage", () => {
       msg("assistant", "h"),      // New
       msg("user", "i"),           // New
     ]
-    const result = verifyLineage(session, extended, "key", mockCache)
-    // Should be continuation, NOT undo — the conversation grew
+    const result = verifyLineage(session, extended)
+    expect(result).toEqual({
+      type: "diverged",
+      reason: "modified-history",
+      prefixOverlap: 6,
+    })
+  })
+
+  it("does not mutate cached state when a stale 515-message session receives 727 messages", () => {
+    const cachedMessages = Array.from({ length: 515 }, (_, i) =>
+      msg(i % 2 === 0 ? "user" : "assistant", `cached-${i}`)
+    )
+    const session = makeSession({
+      lineageHash: computeLineageHash(cachedMessages),
+      messageCount: cachedMessages.length,
+      messageHashes: computeMessageHashes(cachedMessages),
+    })
+    const originalHashes = [...session.messageHashes!]
+    const incoming = [
+      ...cachedMessages.slice(0, 514),
+      msg("user", "changed-boundary"),
+      ...Array.from({ length: 212 }, (_, i) =>
+        msg((i + 515) % 2 === 0 ? "user" : "assistant", `new-${i}`)
+      ),
+    ]
+
+    const result = verifyLineage(session, incoming)
+
+    expect(incoming).toHaveLength(727)
+    expect(result).toEqual({
+      type: "diverged",
+      reason: "modified-history",
+      prefixOverlap: 514,
+    })
+    expect(session.messageCount).toBe(515)
+    expect(session.lineageHash).toBe(computeLineageHash(cachedMessages))
+    expect(session.messageHashes).toEqual(originalHashes)
+  })
+
+  it("ignores cache_control changes when verifying a strict continuation", () => {
+    const cachedMessages = [{
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    }]
+    const session = makeSession({
+      lineageHash: computeLineageHash(cachedMessages),
+      messageCount: cachedMessages.length,
+      messageHashes: computeMessageHashes(cachedMessages),
+    })
+    const incoming = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello", cache_control: { type: "ephemeral" } }],
+      },
+      msg("assistant", "hi"),
+      msg("user", "continue"),
+    ]
+
+    const result = verifyLineage(session, incoming)
+
     expect(result.type).toBe("continuation")
   })
 
@@ -266,7 +322,7 @@ describe("verifyLineage", () => {
       msg("user", "a"), msg("assistant", "b"),
       msg("user", "c"), msg("assistant", "d-modified"),
     ]
-    const result = verifyLineage(session, modified, "key", mockCache)
+    const result = verifyLineage(session, modified)
     expect(result.type).toBe("undo")
   })
 
@@ -285,7 +341,7 @@ describe("verifyLineage", () => {
     })
     // Fewer messages — clear undo
     const undone = [msg("user", "a"), msg("assistant", "b"), msg("user", "new")]
-    const result = verifyLineage(session, undone, "key", mockCache)
+    const result = verifyLineage(session, undone)
     expect(result.type).toBe("undo")
   })
 
@@ -298,7 +354,7 @@ describe("verifyLineage", () => {
       messageCount: msgs.length,
       messageHashes: computeMessageHashes(msgs),
     })
-    const result = verifyLineage(session, msgs, "key", mockCache)
+    const result = verifyLineage(session, msgs)
     expect(result.type).toBe("diverged")
   })
 
@@ -312,7 +368,7 @@ describe("verifyLineage", () => {
       messageCount: msgs.length,
       messageHashes: computeMessageHashes(msgs),
     })
-    const result = verifyLineage(session, msgs, "key", mockCache)
+    const result = verifyLineage(session, msgs)
     expect(result.type).toBe("diverged")
   })
 
@@ -325,7 +381,7 @@ describe("verifyLineage", () => {
       messageHashes: computeMessageHashes(msgs),
     })
     const extended = [...msgs, msg("assistant", "hi"), msg("user", "how are you?")]
-    const result = verifyLineage(session, extended, "key", mockCache)
+    const result = verifyLineage(session, extended)
     expect(result.type).toBe("continuation")
   })
 
@@ -342,13 +398,23 @@ describe("verifyLineage", () => {
       messageCount: msgs.length,
       messageHashes: hashes,
     })
-    // Compaction: change beginning, keep last MIN_SUFFIX_FOR_COMPACTION messages
+    const originalLineageHash = session.lineageHash
+    const originalMessageHashes = [...session.messageHashes!]
+    // Compaction: change beginning, keep the stored suffix, append a new turn.
     const compacted = [
       msg("user", "summary"), // replaced
       msg("user", "e"), msg("assistant", "f"), // preserved suffix
+      msg("assistant", "new response"), msg("user", "continue"),
     ]
-    const result = verifyLineage(session, compacted, "key", mockCache)
+    const result = verifyLineage(session, compacted)
     expect(result.type).toBe("compaction")
+    if (result.type === "compaction") {
+      expect(result.resumeFrom).toBe(3)
+      expect(result.suffixOverlap).toBe(2)
+    }
+    expect(session.messageCount).toBe(msgs.length)
+    expect(session.lineageHash).toBe(originalLineageHash)
+    expect(session.messageHashes).toEqual(originalMessageHashes)
   })
 
   it("does not false-detect compaction when suffix hashes appear at wrong positions (regression #283)", () => {
@@ -375,21 +441,24 @@ describe("verifyLineage", () => {
       msg("user", "completely-new"),
       msg("assistant", "also-new"),
     ]
-    const result = verifyLineage(session, incoming, "key", mockCache)
+    const result = verifyLineage(session, incoming)
     // Must NOT be compaction — the suffix is at the wrong position
     expect(result.type).not.toBe("compaction")
     expect(result.type).toBe("diverged")
   })
 })
 
-describe("verifyLineage modified-continuation gap bound (#689)", () => {
+describe("verifyLineage stale modified continuation (#689)", () => {
   // Client-driven tool loops run on throwaway sessions that never persist
   // back to the lineage store, so the stored session can be many messages
   // behind the incoming conversation. Resuming such a session sends only
   // the last user message and drops the intervening tool_use/tool_result
-  // pairs from the SDK context. The bound only allows resume when at most
-  // the last stored slot churned and at most one exchange was appended;
-  // anything further behind must replay fresh (diverged).
+  // pairs from the SDK context.
+  //
+  // #700 bounded this: resume was allowed when only the last stored slot had
+  // churned and at most one exchange was appended. #692 removed the bound —
+  // a changed slot means the SDK session still holds content the client no
+  // longer claims, so every shape here diverges and replays in full.
 
   /** Alternating user/assistant conversation: m0, m1, ... m(n-1). */
   function conversation(n: number) {
@@ -410,8 +479,10 @@ describe("verifyLineage modified-continuation gap bound (#689)", () => {
     return msgs.map((m, i) => (i === index ? msg(m.role, `${m.content}-churned`) : m))
   }
 
-  it("resumes when only the last stored slot churned and one exchange was appended", () => {
-    // Mirrors the healthy capture in #689: overlap 5/6, incoming 8, gap 2.
+  it("diverges when the last stored slot churned and one exchange was appended", () => {
+    // The healthy-looking capture in #689: overlap 5/6, incoming 8, gap 2.
+    // #700 allowed this to resume as benign churn; #692 does not, because the
+    // stored SDK session holds the pre-churn content of slot 5.
     const stored = conversation(6)
     const session = sessionFor(stored)
     const incoming = [
@@ -419,13 +490,9 @@ describe("verifyLineage modified-continuation gap bound (#689)", () => {
       msg("assistant", "round 1 summary"),
       msg("user", "thanks"),
     ]
-    const result = verifyLineage(session, incoming, "key", mockCache)
-    expect(result.type).toBe("continuation")
-    if (result.type === "continuation") {
-      // The store must adopt the incoming history so the next turn resumes cleanly.
-      expect(result.session.messageCount).toBe(incoming.length)
-      expect(result.session.lineageHash).toBe(computeLineageHash(incoming))
-    }
+    const result = verifyLineage(session, incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
   })
 
   it("treats a stored lineage behind by a tool round as diverged (issue repro)", () => {
@@ -442,24 +509,22 @@ describe("verifyLineage modified-continuation gap bound (#689)", () => {
       msg("assistant", "both commands succeeded"),
       msg("user", "nice"),
     ]
-    expect(incoming.length - stored.length).toBeGreaterThan(MAX_CONTINUATION_GAP)
-    const deleted: string[] = []
-    const spyCache = { delete: (key: string) => { deleted.push(key); return true } }
-    const result = verifyLineage(session, incoming, "stale-key", spyCache)
+    const result = verifyLineage(session, incoming)
     expect(result.type).toBe("diverged")
-    // The stale entry must be evicted so the fresh replay re-adopts the
-    // full history and the store self-heals.
-    expect(deleted).toEqual(["stale-key"])
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
   })
 
-  it("treats a gap just over the bound as diverged", () => {
+  it("leaves the cached session untouched when it diverges", () => {
+    // #692 makes verification side-effect free: the caller evicts and commits
+    // new lineage only after the upstream request succeeds, so a stale entry
+    // is never rewritten by a failed turn.
     const stored = conversation(6)
     const session = sessionFor(stored)
-    const appended = Array.from({ length: MAX_CONTINUATION_GAP + 1 }, (_, i) =>
-      msg(i % 2 === 0 ? "assistant" : "user", `new${i}`))
-    const incoming = [...churn(stored, 5), ...appended]
-    const result = verifyLineage(session, incoming, "key", mockCache)
-    expect(result.type).toBe("diverged")
+    const before = { count: session.messageCount, hash: session.lineageHash }
+    const incoming = [...churn(stored, 5), msg("assistant", "a"), msg("user", "b")]
+    verifyLineage(session, incoming)
+    expect(session.messageCount).toBe(before.count)
+    expect(session.lineageHash).toBe(before.hash)
   })
 
   it("treats churn deeper than the last stored slot as diverged even with a small gap", () => {
@@ -468,7 +533,7 @@ describe("verifyLineage modified-continuation gap bound (#689)", () => {
     const stored = conversation(4)
     const session = sessionFor(stored)
     const incoming = [...churn(stored, 1), msg("user", "one more")]
-    const result = verifyLineage(session, incoming, "key", mockCache)
+    const result = verifyLineage(session, incoming)
     expect(result.type).toBe("diverged")
   })
 })

--- a/src/__tests__/proxy-session-resume.test.ts
+++ b/src/__tests__/proxy-session-resume.test.ts
@@ -58,9 +58,10 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
 
 function createTestApp() {
-  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
   return app
 }
 
@@ -86,6 +87,30 @@ async function readStreamFull(response: Response): Promise<string> {
     result += decoder.decode(value, { stream: true })
   }
   return result
+}
+
+function buildStaleSessionFixture() {
+  const cached = Array.from({ length: 515 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: `cached message ${i}`,
+  }))
+  const incoming = [
+    ...cached.slice(0, 514),
+    { role: "user", content: "cached boundary rewritten by the client" },
+    ...Array.from({ length: 212 }, (_, i) => {
+      const messageIndex = i + 515
+      let content = `new message ${messageIndex}`
+      if (messageIndex === 600) content = "WINDOWS MAXWELL CSV SENTINEL"
+      if (messageIndex === 601) content = "ASSISTANT ANALYSIS SENTINEL"
+      if (messageIndex === 726) content = "What did we find in the exported results?"
+      return {
+        role: messageIndex % 2 === 0 ? "user" : "assistant",
+        content,
+      }
+    }),
+  ]
+
+  return { cached, incoming }
 }
 
 // ============================================================
@@ -446,5 +471,81 @@ describe("Session resume: only send last user message on resume", () => {
     expect(capturedQueryParams.prompt).toContain("First message")
     expect(capturedQueryParams.prompt).toContain("Second message")
     expect(capturedQueryParams.options.resume).toBeUndefined()
+  })
+})
+
+describe("Session resume: stale cross-node history", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "Recovered" }])]
+    clearSessionCache()
+    capturedQueryParams = null
+    queryCallCount = 0
+  })
+
+  it("fresh-replays all 727 messages when only 514/515 cached messages match", async () => {
+    const app = createTestApp()
+    const { cached, incoming } = buildStaleSessionFixture()
+    storeSession("oc-stale-nonstream", cached, "sdk-stale-nonstream")
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: incoming,
+    }, { "x-opencode-session": "oc-stale-nonstream" })
+    await response.json()
+
+    expect(cached).toHaveLength(515)
+    expect(incoming).toHaveLength(727)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.prompt).toContain("<conversation_history>")
+    expect(capturedQueryParams.prompt).toContain("WINDOWS MAXWELL CSV SENTINEL")
+    expect(capturedQueryParams.prompt).toContain("ASSISTANT ANALYSIS SENTINEL")
+    expect(capturedQueryParams.prompt.trimEnd()).toEndWith("What did we find in the exported results?")
+
+    capturedQueryParams = null
+    const followUp = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: false,
+      messages: [
+        ...incoming,
+        { role: "assistant", content: "Recovered" },
+        { role: "user", content: "Continue after recovery" },
+      ],
+    }, { "x-opencode-session": "oc-stale-nonstream" })
+    await followUp.json()
+
+    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.prompt).toContain("Continue after recovery")
+    expect(capturedQueryParams.prompt).not.toContain("WINDOWS MAXWELL CSV SENTINEL")
+  })
+
+  it("uses the same full replay fallback for streaming requests", async () => {
+    const app = createTestApp()
+    const { cached, incoming } = buildStaleSessionFixture()
+    storeSession("oc-stale-stream", cached, "sdk-stale-stream")
+    mockMessages = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "Recovered"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 1024,
+      stream: true,
+      messages: incoming,
+    }, { "x-opencode-session": "oc-stale-stream" })
+    await readStreamFull(response)
+
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.prompt).toContain("<conversation_history>")
+    expect(capturedQueryParams.prompt).toContain("WINDOWS MAXWELL CSV SENTINEL")
+    expect(capturedQueryParams.prompt).toContain("ASSISTANT ANALYSIS SENTINEL")
+    expect(capturedQueryParams.prompt.trimEnd()).toEndWith("What did we find in the exported results?")
   })
 })

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -20,7 +20,10 @@ type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
 
 let mockMessages: MockSdkMessage[] = []
-interface CapturedQueryParams { options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string } }
+interface CapturedQueryParams {
+  prompt?: unknown
+  options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string }
+}
 let capturedQueryParams: CapturedQueryParams | null = null
 /** Access capturedQueryParams without TS narrowing to `never` after null assignments */
 function getCaptured(): CapturedQueryParams | null { return capturedQueryParams }
@@ -28,7 +31,7 @@ let queuedSessionIds: string[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
-    capturedQueryParams = params as { options?: { resume?: string } }
+    capturedQueryParams = params as CapturedQueryParams
     const sessionId = queuedSessionIds.shift() || "sdk-session-default"
     return (async function* () {
       for (const msg of mockMessages) {
@@ -68,7 +71,7 @@ afterAll(() => {
 })
 
 function createTestApp() {
-  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
   return app as TestApp
 }
 
@@ -398,17 +401,22 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "topic D" },
     ], "sdk-c")
 
-    // Compaction: beginning summarised, last 4 messages + 2 new
+    // Compaction: beginning summarised, preserved suffix followed by multiple
+    // turns accumulated since this SDK session was last used.
     capturedQueryParams = null
     await post(app, "sess-c", [
       { role: "user", content: "[Summary: A, B and C discussed]" },
       { role: "assistant", content: "C explained" },
       { role: "user", content: "topic D" },
       { role: "assistant", content: "D explained" },
+      { role: "user", content: "INTERMEDIATE COMPACTION SENTINEL" },
+      { role: "assistant", content: "sentinel acknowledged" },
       { role: "user", content: "topic E" },
     ], "sdk-c")
 
     expect(getCaptured()?.options?.resume).toBe("sdk-c")
+    expect(getCaptured()?.prompt).toContain("INTERMEDIATE COMPACTION SENTINEL")
+    expect(getCaptured()?.prompt).toContain("topic E")
   })
 
   it("resumes after compaction reduces message count", async () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1055,8 +1055,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             claudeLog("session.pending_store_awaited", { waitedMs: Date.now() - waitStart })
           }
         }
-        let lineageResult = isIndependentSession
-          ? { type: "diverged" as const }
+        let lineageResult: LineageResult = isIndependentSession
+          ? { type: "diverged", reason: "independent-request" }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
         // NOTE: agent-specific (opencode) — when OpenCode's chat.headers plugin
         // hook doesn't fire (category-dispatched or title-generation requests),
@@ -1065,12 +1065,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // session and be classified as "undo." Downgrade to "diverged" to
         // prevent leaking the old session's conversation history.
         if (lineageResult.type === "undo" && adapterBase === "opencode" && !agentSessionId) {
-          lineageResult = { type: "diverged" }
+          lineageResult = { type: "diverged", reason: "missing-session-header" }
         }
         const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         const resumeSessionId = cachedSession?.claudeSessionId
+        const resumeFrom = lineageResult.type === "continuation" || lineageResult.type === "compaction"
+          ? lineageResult.resumeFrom
+          : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
 
@@ -1133,9 +1136,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // so we only need to send the new user message.
           messagesToConvert = getLastUserMessage(allMessages)
         } else if (isResume) {
-          const knownCount = cachedSession.messageCount || 0
-          if (knownCount > 0 && knownCount < allMessages.length) {
-            messagesToConvert = allMessages.slice(knownCount)
+          if (resumeFrom !== undefined && resumeFrom < allMessages.length) {
+            messagesToConvert = allMessages.slice(resumeFrom)
           } else {
             messagesToConvert = getLastUserMessage(allMessages)
           }

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -6,6 +6,7 @@
  */
 
 import { LRUMap } from "../../utils/lruMap"
+import { diagnosticLog } from "../../telemetry"
 import {
   lookupSharedSession,
   lookupSharedSessionByClaudeId,
@@ -127,6 +128,30 @@ function touchSession(state: SessionState): SessionState {
   return state
 }
 
+function classifyLineage(
+  state: SessionState,
+  messages: Array<{ role: string; content: any }>,
+  cacheKey: string
+): LineageResult {
+  const result = verifyLineage(state, messages)
+
+  if (result.type === "compaction") {
+    const msg = `Compaction detected (key=${cacheKey.slice(0, 8)}…): suffix overlap ${result.suffixOverlap}/${state.messageCount}, resume from incoming message ${result.resumeFrom}.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  } else if (result.type === "undo") {
+    const msg = `Undo detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap}/${state.messageCount}, rollback UUID: ${result.rollbackUuid || "none (legacy session)"}.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  } else if (result.type === "diverged" && result.reason === "modified-history") {
+    const msg = `Stale session detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap || 0}/${state.messageCount}, incoming ${messages.length} msgs. Starting fresh replay.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  }
+
+  return result
+}
+
 /** Look up a cached session by header or fingerprint.
  *  Returns a LineageResult that classifies the mutation and includes the
  *  session state needed for the correct SDK action. */
@@ -138,7 +163,7 @@ export function lookupSession(
   if (sessionId) {
     const cached = sessionCache.get(sessionId)
     if (cached) {
-      const result = verifyLineage(cached, messages, sessionId, sessionCache)
+      const result = classifyLineage(cached, messages, sessionId)
       if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
       return result
     }
@@ -153,20 +178,20 @@ export function lookupSession(
         sdkMessageUuids: shared.sdkMessageUuids,
         contextUsage: shared.contextUsage,
       }
-      const result = verifyLineage(state, messages, sessionId, sessionCache)
+      const result = classifyLineage(state, messages, sessionId)
       if (result.type === "continuation" || result.type === "compaction") {
         sessionCache.set(sessionId, state)
       }
       return result
     }
-    return { type: "diverged" }
+    return { type: "diverged", reason: "not-found" }
   }
 
   const fp = getConversationFingerprint(messages, workingDirectory)
   if (fp) {
     const cached = fingerprintCache.get(fp)
     if (cached) {
-      const result = verifyLineage(cached, messages, fp, fingerprintCache)
+      const result = classifyLineage(cached, messages, fp)
       if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
       return result
     }
@@ -181,14 +206,14 @@ export function lookupSession(
         sdkMessageUuids: shared.sdkMessageUuids,
         contextUsage: shared.contextUsage,
       }
-      const result = verifyLineage(state, messages, fp, fingerprintCache)
+      const result = classifyLineage(state, messages, fp)
       if (result.type === "continuation" || result.type === "compaction") {
         fingerprintCache.set(fp, state)
       }
       return result
     }
   }
-  return { type: "diverged" }
+  return { type: "diverged", reason: "not-found" }
 }
 
 /** Look up a session by the Claude SDK session ID returned in responses.

--- a/src/proxy/session/index.ts
+++ b/src/proxy/session/index.ts
@@ -2,6 +2,6 @@
  * Session management — barrel export.
  */
 export { computeLineageHash, hashMessage, computeMessageHashes, verifyLineage, measurePrefixOverlap, measureSuffixOverlap, MIN_SUFFIX_FOR_COMPACTION } from "./lineage"
-export type { SessionState, LineageResult, SessionCacheLike } from "./lineage"
+export type { SessionState, LineageResult, LineageDivergenceReason } from "./lineage"
 export { extractClientCwd, getConversationFingerprint } from "./fingerprint"
 export { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession } from "./cache"

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -7,7 +7,6 @@
 
 import { createHash } from "crypto"
 import { normalizeContent } from "../messages"
-import { diagnosticLog } from "../../telemetry"
 
 // --- Types ---
 
@@ -37,15 +36,6 @@ export function normalizeContextUsage(usage: TokenUsage): TokenUsageIteration {
  *  required to classify a mutation as compaction rather than a branch. */
 export const MIN_SUFFIX_FOR_COMPACTION = 2
 
-/** Maximum number of new messages (incoming minus stored) a modified
- *  continuation may append and still resume the stored session. A clean
- *  conversational turn appends at most one exchange: the previous assistant
- *  reply plus the new user message. A larger gap means the stored lineage
- *  missed intervening rounds (client-driven tool loops never persist back
- *  to the store, #689), and resuming would slice those messages out of the
- *  SDK context. */
-export const MAX_CONTINUATION_GAP = 2
-
 export interface SessionState {
   claudeSessionId: string
   lastAccess: number
@@ -71,10 +61,19 @@ export interface SessionState {
  * the information needed to take the correct SDK action.
  */
 export type LineageResult =
-  | { type: "continuation"; session: SessionState }
-  | { type: "compaction";   session: SessionState }
+  | { type: "continuation"; session: SessionState; resumeFrom: number }
+  | { type: "compaction";   session: SessionState; resumeFrom: number; suffixOverlap: number }
   | { type: "undo";         session: SessionState; prefixOverlap: number; rollbackUuid: string | undefined }
-  | { type: "diverged" }
+  | { type: "diverged";     reason: LineageDivergenceReason; prefixOverlap?: number }
+
+export type LineageDivergenceReason =
+  | "unverifiable"
+  | "replayed-request"
+  | "modified-history"
+  | "unrelated-history"
+  | "not-found"
+  | "independent-request"
+  | "missing-session-header"
 
 // --- Hashing ---
 
@@ -205,31 +204,27 @@ function findSuffixAnchorStart(
 
 // --- Lineage verification ---
 
-/** Cache-like interface for verifyLineage — only needs get/set/delete */
-export interface SessionCacheLike {
-  delete(key: string): boolean
-}
-
 /**
  * Verify that incoming messages are a valid continuation of a cached session.
  * Uses per-message hash comparison to deterministically classify mutations.
+ * This function is deliberately side-effect free: it never mutates the cached
+ * state. The caller commits new hashes/counts only after the upstream request
+ * succeeds.
  *
  * Decision matrix:
- *   Full prefix match (fast-path)          → continuation (resume normally)
- *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume normally)
+ *   Full prefix match (fast-path)          → continuation (resume from stored count)
+ *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume after matched suffix)
  *   Prefix overlap > 0, no suffix, shrank  → undo         (fork at rollback point)
- *   Prefix overlap > 0, grew within bound  → continuation (modified continuation)
- *   Anything else                          → diverged     (start fresh)
+ *   Cached prefix changed while growing    → diverged     (fresh full-history replay)
+ *   No overlap                             → diverged     (fresh full-history replay)
  */
 export function verifyLineage(
   cached: SessionState,
-  messages: Array<{ role: string; content: any }>,
-  cacheKey: string,
-  cache: SessionCacheLike
+  messages: Array<{ role: string; content: any }>
 ): LineageResult {
-  // No stored lineage (legacy entry or first request) — allow resume
+  // A legacy entry cannot prove which client history its SDK session contains.
   if (!cached.lineageHash || cached.messageCount === 0) {
-    return { type: "continuation", session: cached }
+    return { type: "diverged", reason: "unverifiable" }
   }
 
   // --- Fast path: aggregate lineage hash ---
@@ -240,17 +235,15 @@ export function verifyLineage(
     // Without this guard, identical requests resume the old SDK session and
     // re-send the last user message, causing ghost context accumulation.
     if (messages.length <= cached.messageCount) {
-      cache.delete(cacheKey)
-      return { type: "diverged" }
+      return { type: "diverged", reason: "replayed-request" }
     }
-    return { type: "continuation", session: cached }
+    return { type: "continuation", session: cached, resumeFrom: cached.messageCount }
   }
 
   // --- Slow path: per-message diff ---
   if (!cached.messageHashes || cached.messageHashes.length === 0) {
     // No per-message hashes stored (legacy session). Can't diff — reject.
-    cache.delete(cacheKey)
-    return { type: "diverged" }
+    return { type: "diverged", reason: "unverifiable" }
   }
 
   const incomingHashes = computeMessageHashes(messages)
@@ -273,19 +266,18 @@ export function verifyLineage(
     cached.messageHashes.length >= MIN_STORED_FOR_COMPACTION &&
     suffixStartInIncoming > 0   // at least one changed message before the preserved suffix
   ) {
-    const compactionMsg = `Compaction detected (key=${cacheKey.slice(0, 8)}…): suffix overlap ${suffixOverlap}/${cached.messageHashes.length}. Allowing resume.`
-    console.error(`[PROXY] ${compactionMsg}`)
-    diagnosticLog.lineage(compactionMsg)
-    cached.lineageHash = computeLineageHash(messages)
-    cached.messageHashes = incomingHashes
-    cached.messageCount = messages.length
-    return { type: "compaction", session: cached }
+    return {
+      type: "compaction",
+      session: cached,
+      resumeFrom: suffixStartInIncoming + suffixOverlap,
+      suffixOverlap,
+    }
   }
 
   // Undo: prefix preserved (beginning intact) but suffix changed,
   // AND the conversation shrank (fewer messages). If the conversation grew
-  // (messages.length > cached.messageCount), the client added new messages
-  // after modifying a previous one — that's a continuation, not an undo.
+  // after a cached message changed, the old SDK session cannot prove it has
+  // the intervening history; that case is handled as divergence below.
   if (prefixOverlap > 0 && suffixOverlap === 0 && messages.length <= cached.messageCount) {
     // Find the SDK UUID at the last matching position.
     let rollbackUuid: string | undefined
@@ -297,41 +289,25 @@ export function verifyLineage(
         }
       }
     }
-    const undoMsg = `Undo detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, rollback UUID: ${rollbackUuid || "none (legacy session)"}.`
-    console.error(`[PROXY] ${undoMsg}`)
-    diagnosticLog.lineage(undoMsg)
     return { type: "undo", session: cached, prefixOverlap, rollbackUuid }
   }
 
-  // Modified continuation: the prefix matches except for benign churn on
-  // the last stored slot (e.g., cache_control added) and new messages were
-  // appended. Resume only when the stored lineage is actually current:
-  //   prefixOverlap >= stored - 1   (only the last stored slot may differ)
-  //   gap <= MAX_CONTINUATION_GAP   (at most one new exchange appended)
-  // A stored session further behind is missing intervening messages (#689:
-  // client-driven tool rounds never persist back to the store), and the
-  // resume slice would drop them from the SDK context. Treat that as
-  // diverged instead: a fresh full-history replay is always correct, and
-  // the store re-adopts the full history at end of turn.
+  // A growing history with a changed cached prefix is not proof that the old
+  // SDK session contains the intervening turns. This happens when a request is
+  // routed back to a stale proxy node (#692), and when a client-driven tool
+  // round runs on a throwaway session that never persists back to the store
+  // (#689). Resume would silently skip the missing history, so force a fresh
+  // replay instead.
+  //
+  // This subsumes the MAX_CONTINUATION_GAP bound added in #700: that allowed a
+  // resume when only the last stored slot had churned and at most one exchange
+  // was appended. A changed slot is a changed slot — the SDK session still
+  // holds content the client no longer claims — so the bound is gone and the
+  // whole shape diverges.
   if (prefixOverlap > 0 && messages.length > cached.messageCount) {
-    const gap = messages.length - cached.messageCount
-    if (prefixOverlap >= cached.messageCount - 1 && gap <= MAX_CONTINUATION_GAP) {
-      const modifiedMsg = `Modified continuation (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, incoming ${messages.length} msgs. Allowing resume.`
-      console.error(`[PROXY] ${modifiedMsg}`)
-      diagnosticLog.lineage(modifiedMsg)
-      cached.lineageHash = computeLineageHash(messages.slice(0, messages.length))
-      cached.messageHashes = incomingHashes
-      cached.messageCount = messages.length
-      return { type: "continuation", session: cached }
-    }
-    const staleMsg = `Stale modified continuation (key=${cacheKey.slice(0, 8)}…): prefix overlap ${prefixOverlap}/${cached.messageHashes.length}, incoming ${messages.length} msgs, gap ${gap}. Treating as diverged.`
-    console.error(`[PROXY] ${staleMsg}`)
-    diagnosticLog.lineage(staleMsg)
-    cache.delete(cacheKey)
-    return { type: "diverged" }
+    return { type: "diverged", reason: "modified-history", prefixOverlap }
   }
 
   // No meaningful overlap — completely different conversation.
-  cache.delete(cacheKey)
-  return { type: "diverged" }
+  return { type: "diverged", reason: "unrelated-history", prefixOverlap }
 }


### PR DESCRIPTION
Supersedes #692 — cherry-picked from @Ca134 (William Shi) with authorship preserved, rebased onto main after #700, plus a safety harness.

Landed as a cherry-pick because `main` requires signed commits and fork commits are unsigned — #692 was permanently `BLOCKED` despite green checks, same as #688/#690.

## Three bugs, one root cause

`verifyLineage` mutated the cached session's `messageCount`, and the caller then read that same field as the resume boundary. The slice collapsed to `getLastUserMessage`, silently dropping everything in between:

| | reported in | path |
|---|---|---|
| client tool-loop history dropped | #689 | continuation |
| stale distributed node, 515 cached vs 727 incoming | #692 | continuation |
| **early churn + appended tool round** | **unreported — found reviewing this** | **compaction** |

The third was still live on `main` after #700. A stored=8 / incoming=13 case sent **1** message and dropped 4, including a `tool_result`:

```
main today:  messages reaching the model: 1   dropped: tool_use RED-77, tool_result RED-77, summary, BLUE-99
with this:   messages reaching the model: 5   dropped: none          (resumeFrom=8)
```

## The fix

Verification is now side-effect free and returns an explicit `resumeFrom` (plus `suffixOverlap` for compaction). The caller commits new hashes/counts only after the upstream request succeeds, so a failed turn can't poison the store. This also satisfies the CLAUDE.md rule that `session/lineage.ts` stay pure — which the previous code violated by mutating its argument and calling `cache.delete`.

Strict prefix continuations still resume, compaction resumes from the matched suffix boundary, undo still forks at its rollback UUID, busy/stale-UUID retry paths unchanged.

### Rebase resolution

- **Removes `MAX_CONTINUATION_GAP`** (#700). Dead here: a changed prefix slot means the SDK session holds content the client no longer claims, so the shape diverges regardless of gap size.
- **Reworks #700's regression block rather than dropping it.** Three of its four scenarios already asserted `diverged` and are unchanged. The fourth asserted that last-slot churn *resumes* — the behaviour this deliberately reverses — so it now asserts divergence. Added a test pinning the no-mutation guarantee.

## Safety harness

None of the three bugs were caught by example-based tests, because each needed a shape nobody thought to write down. `src/__tests__/lineage-safety.test.ts` checks properties over a mechanically generated matrix (stored length × churn position × growth, plus shrink and compaction shapes) — 131 scenarios, 725 assertions:

- never mutates the cached session
- deterministic
- **resume soundness** — everything before `resumeFrom` must genuinely already be in the SDK session. All three bugs violate this one.
- never resumes a conversation that did not grow

Plus a golden verdict table, so future changes to `lineage.ts` surface as a reviewable diff instead of a silent shift.

**The harness was verified to fail.** Reintroducing the compaction mutation turns 2 of 5 tests red with exact diagnostics (`mutated the cached session`, `preserved suffix does not match stored tail at -1`). A test never seen failing is not evidence — that is the lesson from `settings-unit.test.ts` in #703, which asserted on `JSON.parse` and would have passed with its module deleted.

## Verification

- Full suite **2132 pass, 1 skip, 0 fail**
- `npm run typecheck` clean
- Compaction repro re-run against this branch: 5 of 5 appended messages reach the model, cached state unmutated