### PR TITLE
fix(responses): treat input items without a type as messages

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -40,6 +40,34 @@ describe("translateResponsesToAnthropic", () => {
     expect(r.messages[0]!.role).toBe("user")
   })
 
+  // Bare `{role, content}` items are spec-valid and sent by the Vercel AI SDK.
+  it("treats input items without a type as messages", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { role: "system", content: "Be terse." },
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { role: "assistant", content: [{ type: "output_text", text: "hi" }] },
+      ],
+    })!
+    expect(r.system).toContain("Be terse.")
+    expect(r.messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+      { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    ])
+  })
+
+  it("still ignores items that carry no role", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "reasoning", id: "rs_123" },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    })!
+    expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }])
+  })
+
   it("maps input_image data URLs to Anthropic image blocks", () => {
     const dataUrl = "data:image/png;base64,iVBORw0KGgo="
     const r = translateResponsesToAnthropic({

--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -68,6 +68,59 @@ describe("translateResponsesToAnthropic", () => {
     expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }])
   })
 
+  // `content` is optional on EasyInputMessage (only `role` is required), so a
+  // bare `{role}` must be skipped, not crash the translator. Defaulting a
+  // typeless item to "message" routed these into the message branch, where
+  // partsToBlocks did `content.some(...)` on undefined and threw — surfacing
+  // as an unstructured HTTP 500 from /v1/responses.
+  it("skips a message item that has no content instead of throwing", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { role: "user" },
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    } as unknown as Parameters<typeof translateResponsesToAnthropic>[0])!
+    expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "hello" }] }])
+  })
+
+  it("skips explicitly typed message items that have no content", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [{ type: "message", role: "assistant" }],
+    } as unknown as Parameters<typeof translateResponsesToAnthropic>[0])!
+    expect(r.messages).toEqual([])
+  })
+
+  // A proxy receives untrusted JSON: a non-object array element must be
+  // ignored, not throw. `"role" in item` requires an object operand.
+  it("ignores non-object input items without throwing", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        "hello",
+        42,
+        null,
+        { role: "user", content: [{ type: "input_text", text: "real" }] },
+      ],
+    } as unknown as Parameters<typeof translateResponsesToAnthropic>[0])!
+    expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "real" }] }])
+  })
+
+  // Only a MISSING type defaults to "message". An unknown type must keep
+  // falling through to `default:` even when a role happens to be present,
+  // so future item kinds aren't silently coerced into messages.
+  it("does not coerce an unknown item type into a message", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "some_future_item", role: "user", content: "ignore me" },
+        { role: "user", content: [{ type: "input_text", text: "kept" }] },
+      ],
+    } as unknown as Parameters<typeof translateResponsesToAnthropic>[0])!
+    expect(r.messages).toEqual([{ role: "user", content: [{ type: "text", text: "kept" }] }])
+  })
+
   it("maps input_image data URLs to Anthropic image blocks", () => {
     const dataUrl = "data:image/png;base64,iVBORw0KGgo="
     const r = translateResponsesToAnthropic({

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -37,7 +37,8 @@ interface ResponsesContentPart {
 }
 
 interface ResponsesMessageItem {
-  type: "message"
+  /** Optional per the spec — `EasyInputMessage` requires only `role`. */
+  type?: "message"
   role: "user" | "assistant" | "developer" | "system"
   content: ResponsesContentPart[] | string
 }
@@ -165,7 +166,11 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   }
 
   for (const item of items) {
-    switch (item.type) {
+    // Codex always sends `type`, but it defaults to "message" when omitted.
+    // Without this, bare `{role, content}` items hit `default:` and are
+    // dropped, leaving zero messages — upstream then 400s on empty messages.
+    const itemType = item.type ?? ("role" in item ? "message" : undefined)
+    switch (itemType) {
       case "message": {
         const msg = item as ResponsesMessageItem
         if (msg.role === "developer" || msg.role === "system") {

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -40,7 +40,8 @@ interface ResponsesMessageItem {
   /** Optional per the spec — `EasyInputMessage` requires only `role`. */
   type?: "message"
   role: "user" | "assistant" | "developer" | "system"
-  content: ResponsesContentPart[] | string
+  /** Also optional per the spec: `EasyInputMessage` requires only `role`. */
+  content?: ResponsesContentPart[] | string
 }
 interface ResponsesFunctionCallItem {
   type: "function_call"
@@ -90,7 +91,33 @@ export interface ResponsesRequest {
 // Request translation: Responses → Anthropic
 // ---------------------------------------------------------------------------
 
-function partsToText(content: ResponsesContentPart[] | string): string {
+/**
+ * The effective discriminator for an input item.
+ *
+ * `type` is optional on Responses input items — `EasyInputMessage` requires
+ * only `role` — so a typeless item that carries a role IS a message. Codex
+ * always sends `type`, which is why this went unnoticed; clients that follow
+ * the spec (e.g. the Vercel AI SDK's `.responses()` model) send bare
+ * `{role, content}` and had every message silently dropped, translating to
+ * zero messages and a 400 from upstream.
+ *
+ * Returns undefined for anything unrecognized, so the caller's `default:`
+ * skips it:
+ *   - non-object elements — `input` is untrusted JSON, and `in` THROWS on a
+ *     primitive operand, which would surface as an unstructured HTTP 500
+ *   - a present-but-unknown `type` — future item kinds must not be coerced
+ *     into messages just because they happen to carry a role
+ */
+function itemDiscriminator(item: unknown): string | undefined {
+  if (typeof item !== "object" || item === null) return undefined
+  const record = item as Record<string, unknown>
+  if (typeof record.type === "string") return record.type
+  if (record.type === undefined && "role" in record) return "message"
+  return undefined
+}
+
+function partsToText(content: ResponsesContentPart[] | string | undefined): string {
+  if (content === undefined) return ""
   if (typeof content === "string") return content
   return content
     .filter((p) => typeof p.text === "string")
@@ -103,8 +130,8 @@ function partsToText(content: ResponsesContentPart[] | string): string {
  * no images so the caller keeps the plain-text path. Remote (non-data-URL)
  * images become an omission note, matching the chat-completions adapter.
  */
-function partsToBlocks(content: ResponsesContentPart[] | string): AnthropicContentBlock[] | null {
-  if (typeof content === "string") return null
+function partsToBlocks(content: ResponsesContentPart[] | string | undefined): AnthropicContentBlock[] | null {
+  if (content === undefined || typeof content === "string") return null
   const hasImage = content.some((p) => p.type === "input_image")
   if (!hasImage) return null
 
@@ -166,11 +193,10 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   }
 
   for (const item of items) {
-    // Codex always sends `type`, but it defaults to "message" when omitted.
-    // Without this, bare `{role, content}` items hit `default:` and are
-    // dropped, leaving zero messages — upstream then 400s on empty messages.
-    const itemType = item.type ?? ("role" in item ? "message" : undefined)
-    switch (itemType) {
+    // NOTE: this switches on a COMPUTED discriminator, not on `item.type`, so
+    // TypeScript no longer narrows `item` per case — the `as` casts below are
+    // load-bearing assertions rather than belt-and-braces. Keep them.
+    switch (itemDiscriminator(item)) {
       case "message": {
         const msg = item as ResponsesMessageItem
         if (msg.role === "developer" || msg.role === "system") {


### PR DESCRIPTION
Lands @diwakar-s-maurya's fix from #691, cherry-picked with authorship preserved, plus hardening for three crash paths it exposed.

## The original fix (credit: @diwakar-s-maurya, #691)

`translateResponsesToAnthropic` switched on `item.type`, but `type` is **optional** on Responses input items — [`EasyInputMessage`](https://github.com/openai/openai-openapi/blob/5c044be3bf3a42854e99e34616564eeb2124a317/openapi.yaml#L37492-L37541) requires only `role`. Codex always sends it, so this worked in practice; clients that follow the spec (notably the Vercel AI SDK's `.responses()` model, which emits bare `{role, content}`) fell through to `default:` and had **every message silently dropped**, producing `messages: Cannot be empty` from upstream.

His fix defaults `type` to `"message"` when absent and a `role` is present, leaving roleless items (`reasoning`, `item_reference`, …) falling through as before. The diagnosis, the spec research, and the fix direction are all his.

## Hardening added on top

Routing typeless items into the message branch sent two shapes down a path that then threw. `/v1/responses` has no try/catch around the translate call, so both surfaced as an unstructured `HTTP 500 Internal Server Error`, bypassing the route's `{error:{type,message,code}}` contract:

- **A bare `{role}` with no `content`.** This is the exact spec case the fix cites — `EasyInputMessage` requires only `role` — but `partsToBlocks` did `content.some(...)` on `undefined`.
- **A non-object array element** (`input: ["hello"]`). `"role" in item` throws on a primitive operand, and `input` is untrusted JSON.

While fixing those, a **pre-existing** crash on `main` also fell out: `{type: "message", role}` with no content threw the same way, with or without #691.

Changes:
- `content` is now optional on `ResponsesMessageItem`, matching the spec the fix cites; `partsToText`/`partsToBlocks` accept `undefined`.
- The discriminator moved into a pure `itemDiscriminator()` that guards the object shape before `in`, and only defaults a **missing** type to `"message"` — a present-but-unknown type still falls through, so future item kinds aren't coerced into messages.
- A `NOTE` at the switch records that it now switches on a computed discriminator, so TypeScript no longer narrows per case and the existing `as` casts became load-bearing rather than belt-and-braces.

## Verification

**Real client, end-to-end** — Vercel AI SDK `.responses()` driving Meridian to Claude Max:

| | main | this branch |
|---|---|---|
| AI SDK `.responses()` | ❌ `messages: Cannot be empty` | ✅ `AISDK-RESPONSES-OK`, 204 tokens |

**Malformed input, HTTP status:**

| Input | main | #691 as-is | this branch |
|---|---|---|---|
| `{role:"user"}` no content | 400 | **500** | 400 |
| `["hello"]` non-object | 400 | **500** | 400 |
| `{type:"message",role}` no content | **500** | **500** | 400 |

All three now return the structured error shape.

**No regression:** Codex-shaped requests with an explicit `type` still work (`CODEX-SHAPE-OK`).

`npm test`: 2160 passing, 0 failures. `npx tsc --noEmit` clean.

Closes #691.
