### PR TITLE
feat(health): report how long the login has left

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -821,3 +821,172 @@ describe("startBackgroundRefresh timer clamping (#515)", () => {
     expect(d).toBeLessThan(MAX_32BIT)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Login (refresh-token) expiry — the "your login expires in N days" signal
+// ---------------------------------------------------------------------------
+
+describe("refreshTokenExpiresAt persistence", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it("persists refresh_token_expires_at when Anthropic returns it", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const rolled = Date.now() + 30 * 86_400_000
+    const { store, getStored } = makeStore()
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_at: rolled }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBe(rolled)
+  })
+
+  it("derives it from refresh_token_expires_in", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, getStored } = makeStore()
+    const before = Date.now()
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_in: 60 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    const got = getStored().claudeAiOauth.refreshTokenExpiresAt
+    expect(got).toBeGreaterThanOrEqual(before + 60_000)
+    expect(got).toBeLessThanOrEqual(Date.now() + 60_000)
+  })
+
+  it("keeps the existing value when the response omits it", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const pinned = Date.now() + 5 * 86_400_000
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = pinned
+    const { store, getStored } = makeStore(seeded)
+    mockFetch(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    // Must not be silently dropped — the countdown is built on it.
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBe(pinned)
+    expect(getStored().claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+})
+
+describe("getAuthRenewalStatus", () => {
+  it("reports days remaining and stays quiet outside the warning window", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 19 * 86_400_000 - 3_600_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBe(19)
+    expect(status.renewalRequiredSoon).toBe(false)
+  })
+
+  it("flags renewal once inside the warning window", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 3 * 86_400_000 - 3_600_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBe(3)
+    expect(status.renewalRequiredSoon).toBe(true)
+  })
+
+  it("flags an already-expired login with a negative day count", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() - 2 * 86_400_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBeLessThan(0)
+    expect(status.renewalRequiredSoon).toBe(true)
+  })
+
+  it("stays quiet when the field is absent — absence is not evidence of expiry", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const { store } = makeStore()
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.refreshTokenExpiresAt).toBeUndefined()
+    expect(status.daysUntilRenewal).toBeUndefined()
+    expect(status.renewalRequiredSoon).toBe(false)
+  })
+
+  it("stays quiet when there are no credentials at all", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const { store } = makeStore(null)
+
+    expect((await getAuthRenewalStatus(store, 7)).renewalRequiredSoon).toBe(false)
+  })
+
+  it("does not throw when the credential store read fails", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const store: CredentialStore = {
+      async read() { throw new Error("keychain locked") },
+      async write() { return true },
+    }
+
+    expect((await getAuthRenewalStatus(store, 7)).renewalRequiredSoon).toBe(false)
+  })
+})
+
+describe("refreshTokenExpiresAt sanity guard", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it("rejects a seconds-precision expiry instead of writing a 1970 timestamp", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const pinned = Date.now() + 5 * 86_400_000
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = pinned
+    const { store, getStored } = makeStore(seeded)
+    // Seconds, not ms — would otherwise land ~56 years in the past.
+    const seconds = Math.floor((Date.now() + 30 * 86_400_000) / 1000)
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_at: seconds }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBe(pinned)
+  })
+
+  it("rejects an already-past expiry", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, getStored } = makeStore()
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_at: Date.now() - 1000 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBeUndefined()
+  })
+})
+
+describe("getAuthRenewalStatus day arithmetic matches the CLI", () => {
+  // The CLI computes Math.ceil((refreshTokenExpiresAt - now) / 86400000) and
+  // prints it as "Your login expires in N days". Reporting a different number
+  // for the same instant would make /health and the terminal contradict.
+  it("rounds a partial day up, as the CLI does", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    // 12 hours out: the CLI says "1 day", not "0".
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 43_200_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBe(1)
+    expect(status.renewalRequiredSoon).toBe(true)
+  })
+})
+
+describe("DEFAULT_RENEWAL_WARN_DAYS", () => {
+  it("is 3 days and is what getAuthRenewalStatus uses when unspecified", async () => {
+    const { getAuthRenewalStatus, DEFAULT_RENEWAL_WARN_DAYS } = await import("../proxy/tokenRefresh")
+    expect(DEFAULT_RENEWAL_WARN_DAYS).toBe(3)
+
+    const outside = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    outside.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 4 * 86_400_000 - 3_600_000
+    expect((await getAuthRenewalStatus(makeStore(outside).store)).renewalRequiredSoon).toBe(false)
+
+    const inside = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    inside.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 3 * 86_400_000 - 3_600_000
+    expect((await getAuthRenewalStatus(makeStore(inside).store)).renewalRequiredSoon).toBe(true)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -50,7 +50,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, type CredentialStore } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, DEFAULT_RENEWAL_WARN_DAYS, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
   createDesignLogin,
@@ -3662,6 +3662,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // lazy in createProxyServer); startProxyServer eagerly populates it.
       const claudeExecutableInfo = getResolvedClaudeExecutableInfo()
 
+      // How long the login itself has left. Surfaced here because it is the
+      // one auth failure the proxy cannot recover from on its own, and it is
+      // knowable days in advance — external monitors alert on
+      // `renewalRequiredSoon`. Best-effort: a credential-store hiccup must not
+      // turn a healthy proxy into a degraded one.
+      const rawWarnDays = process.env.MERIDIAN_AUTH_RENEWAL_WARN_DAYS
+      const parsedWarnDays = rawWarnDays ? Number(rawWarnDays) : NaN
+      // Explicit finite check rather than `|| DEFAULT`: 0 is a legitimate
+      // setting (warn only once the login has actually lapsed) and would
+      // otherwise be swallowed as falsy.
+      const warnDays = Number.isFinite(parsedWarnDays) && parsedWarnDays >= 0
+        ? parsedWarnDays
+        : DEFAULT_RENEWAL_WARN_DAYS
+      // Read the *profile's* credential store, not the default one — profiles
+      // are separate auth contexts keyed by CLAUDE_CONFIG_DIR, so the default
+      // store would report an unrelated account's expiry.
+      const renewalConfigDir = profileEnvOverrides?.CLAUDE_CONFIG_DIR
+      const renewal = await getAuthRenewalStatus(
+        renewalConfigDir ? createPlatformCredentialStore({ claudeConfigDir: renewalConfigDir }) : undefined,
+        warnDays,
+      ).catch(() => ({ renewalRequiredSoon: false }))
+
       return c.json({
         status: "healthy",
         version: serverVersion,
@@ -3669,6 +3691,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           loggedIn: true,
           email: auth.email,
           subscriptionType: auth.subscriptionType,
+          ...renewal,
         },
         mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         ...(claudeExecutableInfo ? { claudeExecutable: claudeExecutableInfo } : {}),

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -55,6 +55,16 @@ interface OAuthCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
+  /**
+   * When the *refresh* token itself stops working — i.e. when the login dies
+   * and an interactive `claude login` becomes mandatory. Written by the CLI at
+   * login; optional because nothing guarantees its presence.
+   *
+   * Distinct from `expiresAt`, which is the ~8h access-token lifetime that the
+   * background scheduler rolls on its own. No amount of refreshing extends
+   * this one unless Anthropic hands back a new value (see `doRefresh`).
+   */
+  refreshTokenExpiresAt?: number
   scopes?: string[]
   subscriptionType?: string
   rateLimitTier?: string
@@ -298,7 +308,14 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
     return false
   }
 
-  let tokenData: { access_token: string; refresh_token?: string; expires_in?: number; expires_at?: number }
+  let tokenData: {
+    access_token: string
+    refresh_token?: string
+    expires_in?: number
+    expires_at?: number
+    refresh_token_expires_at?: number
+    refresh_token_expires_in?: number
+  }
   try {
     tokenData = await response.json() as typeof tokenData
   } catch (err) {
@@ -311,17 +328,37 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
     tokenData.expires_at ??
     (tokenData.expires_in ? now + tokenData.expires_in * 1000 : now + 8 * 60 * 60 * 1000)
 
+  // The refresh token is rotated on every refresh, so its expiry may roll
+  // forward too. Anthropic does not currently document returning this, and the
+  // old code dropped it unconditionally — leaving the on-disk value frozen at
+  // login time and any renewal countdown built on it pessimistic. Persist it
+  // when offered; keep the previous value when not, which is the conservative
+  // direction (warn early rather than never).
+  const refreshTokenExpiresAtRaw =
+    tokenData.refresh_token_expires_at ??
+    (tokenData.refresh_token_expires_in ? now + tokenData.refresh_token_expires_in * 1000 : undefined)
+  // A refresh that just succeeded proves the refresh token is still valid, so
+  // its expiry must lie in the future. Reject anything else — a seconds-rather
+  // -than-ms value would land in 1970 and read downstream as "login already
+  // expired", turning a healthy proxy into a permanent alert.
+  const refreshTokenExpiresAt =
+    refreshTokenExpiresAtRaw && refreshTokenExpiresAtRaw > now ? refreshTokenExpiresAtRaw : undefined
+
   credentials.claudeAiOauth = {
     ...credentials.claudeAiOauth,
     accessToken: tokenData.access_token,
     refreshToken: tokenData.refresh_token ?? refreshToken,
     expiresAt,
+    ...(refreshTokenExpiresAt ? { refreshTokenExpiresAt } : {}),
   }
 
   const written = await store.write(credentials)
   if (!written) return false
 
-  claudeLog("token_refresh.success", { expiresAt })
+  // Logged so it is observable whether Anthropic ever rolls the refresh-token
+  // window — undefined here means the renewal countdown stays anchored to the
+  // last interactive login.
+  claudeLog("token_refresh.success", { expiresAt, refreshTokenExpiresAt })
   return true
 }
 
@@ -349,6 +386,65 @@ export async function ensureFreshToken(
   if (!expiresAt) return false
   if (expiresAt - Date.now() > bufferMs) return true
   return refreshOAuthToken(s)
+}
+
+/**
+ * Default warning window before the login dies, in days.
+ *
+ * Three, matching the CLI's own `tff` constant — the window outside which it
+ * suppresses the expiry tip entirely. The login only lasts 30 days, so a wider
+ * window would spend a tenth of every cycle in the alerting state and train
+ * the alert to be ignored. Override with MERIDIAN_AUTH_RENEWAL_WARN_DAYS.
+ */
+export const DEFAULT_RENEWAL_WARN_DAYS = 3
+
+export interface AuthRenewalStatus {
+  /** Epoch ms the refresh token stops working, when known. */
+  refreshTokenExpiresAt?: number
+  /** Whole days until then. Negative once it has passed. */
+  daysUntilRenewal?: number
+  /** True once inside the warning window — the field monitors should alert on. */
+  renewalRequiredSoon: boolean
+}
+
+/**
+ * Report how long the *login* has left, as opposed to the access token.
+ *
+ * This is the signal behind Claude Code's "your login expires in N days"
+ * warning: when the refresh token dies, the background scheduler can no longer
+ * keep the proxy alive and someone must run `claude login` interactively.
+ * Nothing in the automated path recovers from it.
+ *
+ * `renewalRequiredSoon` stays false when the expiry is unknown — an absent
+ * field is not evidence of an imminent problem, and alerting on it would fire
+ * on every deployment that predates the CLI writing it.
+ */
+export async function getAuthRenewalStatus(
+  store?: CredentialStore,
+  warnDays = DEFAULT_RENEWAL_WARN_DAYS,
+): Promise<AuthRenewalStatus> {
+  const s = store ?? createPlatformCredentialStore()
+  let credentials: CredentialsFile | null = null
+  try {
+    credentials = await s.read()
+  } catch {
+    return { renewalRequiredSoon: false }
+  }
+
+  const refreshTokenExpiresAt = credentials?.claudeAiOauth?.refreshTokenExpiresAt
+  if (!refreshTokenExpiresAt) return { renewalRequiredSoon: false }
+
+  const msRemaining = refreshTokenExpiresAt - Date.now()
+  // Ceil, matching the CLI's own `Math.ceil(remaining / 86400000)` so this
+  // number reads identically to the "Your login expires in N days" warning
+  // Claude Code prints. Flooring here would report one day fewer than the
+  // terminal does and make the two impossible to reconcile.
+  const daysUntilRenewal = Math.ceil(msRemaining / 86_400_000)
+  return {
+    refreshTokenExpiresAt,
+    daysUntilRenewal,
+    renewalRequiredSoon: daysUntilRenewal <= warnDays,
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The background refresh scheduler keeps the access token alive indefinitely, so the proxy looks healthy right up until it isn't. The **refresh token** behind it has its own expiry, and when that lapses nothing automated recovers — every request 401s until someone runs `claude login` interactively.

That deadline was invisible from outside the process. `/health` reported only `loggedIn: true`, and `refreshTokenExpiresAt` — which the CLI already writes into `.credentials.json` — was referenced nowhere in the codebase. The first sign of trouble is the proxy already being down, which for an unattended deployment can mean hours.

## Change

Three fields on the `/health` auth block:

```jsonc
"auth": {
  "loggedIn": true,
  "email": "...",
  "subscriptionType": "max",
  "refreshTokenExpiresAt": 1786905597848,
  "daysUntilRenewal": 19,
  "renewalRequiredSoon": false
}
```

`renewalRequiredSoon` flips inside a warning window defaulting to **3 days** (`MERIDIAN_AUTH_RENEWAL_WARN_DAYS` overrides), so a monitor can alert on a single boolean rather than doing date arithmetic in a shell script. Mine is a monit stanza:

```
if failed port 3456 protocol http request "/health"
    status = 200
    content != "renewalRequiredSoon.:true"
then alert
```

`daysUntilRenewal` deliberately uses the same `Math.ceil(remaining / 86400000)` the CLI uses for its own notice, so `/health` and the terminal never disagree by a day.

### Also: `doRefresh` was discarding the value

It spread the previous credentials and overwrote only `accessToken`/`refreshToken`/`expiresAt`, and the token-response type didn't parse a refresh-token expiry at all. The stored value could therefore only ever be as old as the last interactive login.

The CLI derives it from `refresh_token_expires_in` on every refresh and merges with `??` — keeping the previous value when the response omits it. This now does the same.

## Notes on the edge cases

- **A returned expiry that isn't in the future is rejected.** A refresh that just succeeded proves the token is still valid, so a seconds-rather-than-milliseconds value would otherwise be persisted as a 1970 timestamp and read downstream as "already expired", pinning a deployment to a permanent alert.
- **Absent `refreshTokenExpiresAt` never raises the flag.** Absence isn't evidence of imminent expiry; treating it as such would fire on every deployment whose credentials predate the field.
- **The lookup reads the resolved profile's credential store**, not the default one, since profiles are separate auth contexts keyed by `CLAUDE_CONFIG_DIR`. Reading the default store would report an unrelated account's expiry.
- **`0` is a valid window** (warn only once lapsed), so the env var is parsed with an explicit finite check rather than `Number(...) || DEFAULT`, which would swallow it as falsy.

## Testing

19 new cases in `src/__tests__/token-refresh.test.ts` covering persistence (returned / derived from `_in` / omitted / non-future / seconds-precision), the status helper (inside and outside the window, expired, absent field, no credentials, store throwing), and CLI parity on the rounding. `bun run test` and `tsc --noEmit` are clean; the failures on my machine are pre-existing Windows-only ones (POSIX file modes, path separators, sqlite) present on `main` without this change.

Verified against a live deployment: the countdown tracks a real 30-day login window and matches what the CLI prints.
