### PR TITLE
fix(session): reject compaction that resumes past the last message

### DIFF
--- a/src/__tests__/lineage-safety.test.ts
+++ b/src/__tests__/lineage-safety.test.ts
@@ -167,7 +167,10 @@ describe("lineage safety: invariants", () => {
       const incomingHashes = computeMessageHashes(s.incoming)
       const { resumeFrom } = result
 
-      expect(resumeFrom, `${s.label} resumeFrom past end`).toBeLessThanOrEqual(s.incoming.length)
+      // Strictly inside the array: resumeFrom is a slice start, so resuming at
+      // the end sends nothing and the caller silently falls back to the last
+      // user message, which is not necessarily the turn the client just added.
+      expect(resumeFrom, `${s.label} resumeFrom leaves nothing to send`).toBeLessThan(s.incoming.length)
 
       if (result.type === "continuation") {
         // Continuation resumes from the stored count, so the stored history
@@ -255,10 +258,10 @@ stored=4 churn=@3 gap=5 => D
 stored=4 shrink-to=1 => U
 stored=4 shrink-to=2 => U
 stored=6 churn=none gap=0 => D
-stored=6 churn=@0 gap=0 => C
-stored=6 churn=@1 gap=0 => C
-stored=6 churn=@2 gap=0 => C
-stored=6 churn=@3 gap=0 => C
+stored=6 churn=@0 gap=0 => D
+stored=6 churn=@1 gap=0 => D
+stored=6 churn=@2 gap=0 => D
+stored=6 churn=@3 gap=0 => D
 stored=6 churn=@4 gap=0 => D
 stored=6 churn=@5 gap=0 => U
 stored=6 churn=none gap=1 => R
@@ -291,14 +294,14 @@ stored=6 churn=@4 gap=5 => D
 stored=6 churn=@5 gap=5 => D
 stored=6 shrink-to=1 => U
 stored=6 shrink-to=3 => U
-stored=6 compaction => C
+stored=6 compaction => D
 stored=8 churn=none gap=0 => D
-stored=8 churn=@0 gap=0 => C
-stored=8 churn=@1 gap=0 => C
-stored=8 churn=@2 gap=0 => C
-stored=8 churn=@3 gap=0 => C
-stored=8 churn=@4 gap=0 => C
-stored=8 churn=@5 gap=0 => C
+stored=8 churn=@0 gap=0 => D
+stored=8 churn=@1 gap=0 => D
+stored=8 churn=@2 gap=0 => D
+stored=8 churn=@3 gap=0 => D
+stored=8 churn=@4 gap=0 => D
+stored=8 churn=@5 gap=0 => D
 stored=8 churn=@6 gap=0 => D
 stored=8 churn=@7 gap=0 => U
 stored=8 churn=none gap=1 => R
@@ -339,7 +342,7 @@ stored=8 churn=@6 gap=5 => D
 stored=8 churn=@7 gap=5 => D
 stored=8 shrink-to=1 => U
 stored=8 shrink-to=4 => U
-stored=8 compaction => C
+stored=8 compaction => D
 unrelated history => D`
 
     expect(actual).toBe(expected)

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -573,3 +573,73 @@ describe("normalizeContextUsage", () => {
     expect(result.output_tokens).toBe(50)
   })
 })
+
+describe("verifyLineage compaction that reaches the end of the incoming array", () => {
+  // Stateless chat frontends (SillyTavern and most roleplay clients) re-send the
+  // whole history every turn and append a constant trailing block after the
+  // user's own message — an injected assistant line plus a prefill sent as a
+  // user message. When the user repeats a turn verbatim, that trailing block
+  // matches the stored tail for several slots, so the suffix anchor lands on the
+  // final message and resumeFrom comes out equal to messages.length.
+  //
+  // The slice is then empty and the caller falls back to getLastUserMessage(),
+  // which returns the constant prefill rather than the turn the user just typed,
+  // so the request reaches the model with the user's input missing entirely.
+  const FAKE_ASSISTANT = "[injected] let's look at what the user wrote"
+  const LATEST = "<latest_human_message>\ngo on\n</latest_human_message>"
+  const PREFILL = "done thinking."
+
+  const head = [
+    msg("user", "turn one"),
+    msg("assistant", "reply one"),
+    msg("user", "turn two"),
+    msg("assistant", "reply two"),
+  ]
+  const trailingBlock = [
+    msg("user", "go on"),
+    msg("assistant", FAKE_ASSISTANT),
+    msg("user", LATEST),
+    msg("user", PREFILL),
+  ]
+  const stored = [...head, ...trailingBlock]
+  const incoming = [
+    ...head,
+    msg("user", "go on"),
+    msg("assistant", "reply three"),
+    ...trailingBlock,
+  ]
+
+  const session = makeSession({
+    messageCount: stored.length,
+    lineageHash: computeLineageHash(stored),
+    messageHashes: computeMessageHashes(stored),
+  })
+
+  it("does not resume with nothing left to send", () => {
+    const result = verifyLineage(session, incoming)
+    if (result.type === "continuation" || result.type === "compaction") {
+      expect(result.resumeFrom).toBeLessThan(incoming.length)
+    }
+  })
+
+  it("replays in full so the user's turn is not dropped", () => {
+    const result = verifyLineage(session, incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
+  })
+
+  it("still detects a real compaction that appends a new turn", () => {
+    // The genuine shape: a long head replaced by a short summary, preserved
+    // tail intact, and the new turn appended after it. resumeFrom stays inside
+    // the array, so this must keep resuming — the fix must not cost it.
+    const compacted = [
+      msg("user", "summary of earlier"),
+      ...stored.slice(-3),
+      msg("assistant", "reply three"),
+      msg("user", "a brand new turn"),
+    ]
+    const result = verifyLineage(session, compacted)
+    expect(result.type).toBe("compaction")
+    if (result.type === "compaction") expect(result.resumeFrom).toBeLessThan(compacted.length)
+  })
+})

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -261,15 +261,34 @@ export function verifyLineage(
   const suffixStartInIncoming = incomingHashes.length - suffixOverlap >= 0
     ? findSuffixAnchorStart(cached.messageHashes, incomingHashes, suffixOverlap)
     : -1
+  // resumeFrom is a slice start, so the preserved suffix must also end before
+  // the last message — a run that reaches the end leaves nothing to send. The
+  // fast path already refuses that shape ("replayed-request"); without the same
+  // guard here, a false suffix match resumes with an empty delta and the caller
+  // falls back to getLastUserMessage().
+  //
+  // That fallback is what makes it silent rather than merely wasteful. Stateless
+  // chat frontends re-send the whole history every turn and append a constant
+  // trailing block after the user's own message (an injected assistant line, a
+  // prefill sent as a user message). Repeat a turn verbatim and that block
+  // matches the stored tail for several slots, so the anchor lands on the final
+  // message. getLastUserMessage() then returns the constant trailing message
+  // instead of the turn the user just typed, and the request reaches the model
+  // with the user's input missing — 200, fluent output, nothing in the logs.
+  //
+  // Genuine compaction is unaffected: a client that compacts also appends the
+  // new turn, which keeps the suffix run away from the end.
+  const compactionResumeFrom = suffixStartInIncoming + suffixOverlap
   if (
     suffixOverlap >= MIN_SUFFIX_FOR_COMPACTION &&
     cached.messageHashes.length >= MIN_STORED_FOR_COMPACTION &&
-    suffixStartInIncoming > 0   // at least one changed message before the preserved suffix
+    suffixStartInIncoming > 0 &&            // at least one changed message before the preserved suffix
+    compactionResumeFrom < messages.length  // and at least one new message after it
   ) {
     return {
       type: "compaction",
       session: cached,
-      resumeFrom: suffixStartInIncoming + suffixOverlap,
+      resumeFrom: compactionResumeFrom,
       suffixOverlap,
     }
   }


### PR DESCRIPTION
Fixes #712.

## The bug

`verifyLineage` can return `compaction` with `resumeFrom === messages.length`. The slice is then empty, so `server.ts` takes its `resumeFrom < allMessages.length` fallback and calls `getLastUserMessage()`. For a client whose last message is not the user's turn, that sends the wrong message — and the user's actual input never reaches the model. 200, fluent output, nothing in the logs.

Stateless chat frontends hit this routinely. They re-send the whole history every turn and append a constant trailing block after the user's own message — an injected assistant line, plus a prefill sent as a user message. Repeat a turn verbatim and that block matches the stored tail for several slots, so `measureSuffixOverlap` anchors on the **final** message and `suffixStart + suffixOverlap` lands exactly on `messages.length`.

Captured from a real SillyTavern session (47 messages, stored count 39):

```
suffixOverlap=4  resumeFrom=41  messages.length=41   → slice empty
  → getLastUserMessage() → "思考已结束。"   (the client's prefill, 6 chars)
```

The upstream SDK transcript for that conversation shows the same 6-character user turn 16 times in a row. The model was continuing its own previous output every turn, because that is all it had.

## The fix

One condition in the compaction branch: the preserved suffix must end *before* the last message, so there is at least one new message to send.

The fast path already refuses this shape — `messages.length <= cached.messageCount` → `replayed-request`. The compaction branch simply lacked the equivalent guard. Nothing new after the suffix means it is a replay, not a compaction, so it now falls through to the existing divergence handling and replays in full.

Genuine compaction is unaffected: a client that compacts also appends the new turn, which keeps the run away from the end. The pruning-survival scenario in `session-lineage.test.ts` (middle tool outputs pruned, two turns appended) computes `resumeFrom=9` against `length=11` and still resumes.

## Verification

Replaying the captured 28-turn conversation through the lineage + prompt-building path:

| | user's turn preserved | lost |
|---|---|---|
| before | 25 | 3 |
| after | 28 | 0 |

End-to-end against a local build, same two requests, instruction placed where only a full replay delivers it:

```
stock 1.57.1  → lineage=compaction → "…if 思考已结束。 is meant as a new instruction, could you clarify"
patched       → BANANA
```

## Tests

- `lineage-unit.test.ts` — new block reproducing the shape: asserts no resume with an empty delta, asserts the full replay, and asserts a genuine compaction that appends a new turn still resumes. The first two fail without the fix.
- `lineage-safety.test.ts` — the resume-soundness invariant tightened from `resumeFrom <= incoming.length` to `< incoming.length`. Resuming at the end is never useful: it sends nothing and silently defers to `getLastUserMessage()`.

## Golden matrix

12 verdicts change, all `C -> D` — the conservative direction the header calls for.

- `stored=6|8 churn=@k gap=0` (10 rows) — same-length re-send with one slot edited. Every one had `resumeFrom == length`, so the old verdict resumed with an empty delta and re-sent the last user message while ignoring the edit. Replay is both safer and cheaper to reason about.
- `stored=6|8 compaction` (2 rows) — the synthetic scenario is `[summary, ...stored.slice(-3)]` with nothing appended, so there is genuinely nothing to send. Real clients append the new turn; the new unit test covers that shape and it still resolves to `compaction`.

`npm test` (2164 tests) and `npm run typecheck` pass.
