### PR TITLE
feat(health): report how long the login has left

### DIFF
--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -821,3 +821,172 @@ describe("startBackgroundRefresh timer clamping (#515)", () => {
     expect(d).toBeLessThan(MAX_32BIT)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Login (refresh-token) expiry — the "your login expires in N days" signal
+// ---------------------------------------------------------------------------
+
+describe("refreshTokenExpiresAt persistence", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it("persists refresh_token_expires_at when Anthropic returns it", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const rolled = Date.now() + 30 * 86_400_000
+    const { store, getStored } = makeStore()
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_at: rolled }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBe(rolled)
+  })
+
+  it("derives it from refresh_token_expires_in", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, getStored } = makeStore()
+    const before = Date.now()
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_in: 60 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    const got = getStored().claudeAiOauth.refreshTokenExpiresAt
+    expect(got).toBeGreaterThanOrEqual(before + 60_000)
+    expect(got).toBeLessThanOrEqual(Date.now() + 60_000)
+  })
+
+  it("keeps the existing value when the response omits it", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const pinned = Date.now() + 5 * 86_400_000
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = pinned
+    const { store, getStored } = makeStore(seeded)
+    mockFetch(async () => makeSuccessResponse(MOCK_TOKEN_RESPONSE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    // Must not be silently dropped — the countdown is built on it.
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBe(pinned)
+    expect(getStored().claudeAiOauth.accessToken).toBe("new-access-token")
+  })
+})
+
+describe("getAuthRenewalStatus", () => {
+  it("reports days remaining and stays quiet outside the warning window", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 19 * 86_400_000 - 3_600_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBe(19)
+    expect(status.renewalRequiredSoon).toBe(false)
+  })
+
+  it("flags renewal once inside the warning window", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 3 * 86_400_000 - 3_600_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBe(3)
+    expect(status.renewalRequiredSoon).toBe(true)
+  })
+
+  it("flags an already-expired login with a negative day count", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() - 2 * 86_400_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBeLessThan(0)
+    expect(status.renewalRequiredSoon).toBe(true)
+  })
+
+  it("stays quiet when the field is absent — absence is not evidence of expiry", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const { store } = makeStore()
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.refreshTokenExpiresAt).toBeUndefined()
+    expect(status.daysUntilRenewal).toBeUndefined()
+    expect(status.renewalRequiredSoon).toBe(false)
+  })
+
+  it("stays quiet when there are no credentials at all", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const { store } = makeStore(null)
+
+    expect((await getAuthRenewalStatus(store, 7)).renewalRequiredSoon).toBe(false)
+  })
+
+  it("does not throw when the credential store read fails", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const store: CredentialStore = {
+      async read() { throw new Error("keychain locked") },
+      async write() { return true },
+    }
+
+    expect((await getAuthRenewalStatus(store, 7)).renewalRequiredSoon).toBe(false)
+  })
+})
+
+describe("refreshTokenExpiresAt sanity guard", () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(() => { globalThis.fetch = originalFetch })
+
+  it("rejects a seconds-precision expiry instead of writing a 1970 timestamp", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const pinned = Date.now() + 5 * 86_400_000
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    seeded.claudeAiOauth.refreshTokenExpiresAt = pinned
+    const { store, getStored } = makeStore(seeded)
+    // Seconds, not ms — would otherwise land ~56 years in the past.
+    const seconds = Math.floor((Date.now() + 30 * 86_400_000) / 1000)
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_at: seconds }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBe(pinned)
+  })
+
+  it("rejects an already-past expiry", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, getStored } = makeStore()
+    mockFetch(async () => makeSuccessResponse({ ...MOCK_TOKEN_RESPONSE, refresh_token_expires_at: Date.now() - 1000 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(getStored().claudeAiOauth.refreshTokenExpiresAt).toBeUndefined()
+  })
+})
+
+describe("getAuthRenewalStatus day arithmetic matches the CLI", () => {
+  // The CLI computes Math.ceil((refreshTokenExpiresAt - now) / 86400000) and
+  // prints it as "Your login expires in N days". Reporting a different number
+  // for the same instant would make /health and the terminal contradict.
+  it("rounds a partial day up, as the CLI does", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    // 12 hours out: the CLI says "1 day", not "0".
+    seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 43_200_000
+    const { store } = makeStore(seeded)
+
+    const status = await getAuthRenewalStatus(store, 7)
+    expect(status.daysUntilRenewal).toBe(1)
+    expect(status.renewalRequiredSoon).toBe(true)
+  })
+})
+
+describe("DEFAULT_RENEWAL_WARN_DAYS", () => {
+  it("is 3 days and is what getAuthRenewalStatus uses when unspecified", async () => {
+    const { getAuthRenewalStatus, DEFAULT_RENEWAL_WARN_DAYS } = await import("../proxy/tokenRefresh")
+    expect(DEFAULT_RENEWAL_WARN_DAYS).toBe(3)
+
+    const outside = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    outside.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 4 * 86_400_000 - 3_600_000
+    expect((await getAuthRenewalStatus(makeStore(outside).store)).renewalRequiredSoon).toBe(false)
+
+    const inside = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    inside.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 3 * 86_400_000 - 3_600_000
+    expect((await getAuthRenewalStatus(makeStore(inside).store)).renewalRequiredSoon).toBe(true)
+  })
+})

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -1134,3 +1134,55 @@ describe("getAuthRenewalStatus caching", () => {
     expect(reads()).toBe(2)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Warning-window parsing
+//
+// Extracted from the /health handler so it is testable without mocking the
+// whole server, and so server.ts orchestrates rather than computes. `0` is a
+// legitimate setting — warn only once the login has actually lapsed — so a
+// `Number(raw) || DEFAULT` shortcut would silently swallow it.
+// ---------------------------------------------------------------------------
+
+describe("resolveRenewalWarnDays", () => {
+  it("defaults when unset", async () => {
+    const { resolveRenewalWarnDays, DEFAULT_RENEWAL_WARN_DAYS } = await import("../proxy/tokenRefresh")
+    expect(resolveRenewalWarnDays(undefined)).toBe(DEFAULT_RENEWAL_WARN_DAYS)
+    expect(resolveRenewalWarnDays("")).toBe(DEFAULT_RENEWAL_WARN_DAYS)
+  })
+
+  it("accepts 0 rather than swallowing it as falsy", async () => {
+    const { resolveRenewalWarnDays } = await import("../proxy/tokenRefresh")
+    expect(resolveRenewalWarnDays("0")).toBe(0)
+  })
+
+  it("accepts a positive window", async () => {
+    const { resolveRenewalWarnDays } = await import("../proxy/tokenRefresh")
+    expect(resolveRenewalWarnDays("14")).toBe(14)
+    expect(resolveRenewalWarnDays(" 7 ")).toBe(7)
+  })
+
+  it("falls back to the default for a negative or non-numeric value", async () => {
+    const { resolveRenewalWarnDays, DEFAULT_RENEWAL_WARN_DAYS } = await import("../proxy/tokenRefresh")
+    expect(resolveRenewalWarnDays("-1")).toBe(DEFAULT_RENEWAL_WARN_DAYS)
+    expect(resolveRenewalWarnDays("soon")).toBe(DEFAULT_RENEWAL_WARN_DAYS)
+    expect(resolveRenewalWarnDays("NaN")).toBe(DEFAULT_RENEWAL_WARN_DAYS)
+  })
+
+  it("a 0 window means the flag only fires once the login has lapsed", async () => {
+    const { getAuthRenewalStatus, resolveRenewalWarnDays, resetAuthRenewalCache } = await import("../proxy/tokenRefresh")
+    resetAuthRenewalCache()
+    const warnDays = resolveRenewalWarnDays("0")
+
+    const soon = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    soon.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 2 * 86_400_000
+    const stillValid: CredentialStore = { async read() { return soon }, async write() { return true } }
+
+    const lapsed = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+    lapsed.claudeAiOauth.refreshTokenExpiresAt = Date.now() - 86_400_000
+    const expired: CredentialStore = { async read() { return lapsed }, async write() { return true } }
+
+    expect((await getAuthRenewalStatus(stillValid, warnDays)).renewalRequiredSoon).toBe(false)
+    expect((await getAuthRenewalStatus(expired, warnDays)).renewalRequiredSoon).toBe(true)
+  })
+})

--- a/src/__tests__/token-refresh.test.ts
+++ b/src/__tests__/token-refresh.test.ts
@@ -990,3 +990,147 @@ describe("DEFAULT_RENEWAL_WARN_DAYS", () => {
     expect((await getAuthRenewalStatus(makeStore(inside).store)).renewalRequiredSoon).toBe(true)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Renewal-status caching
+//
+// /health is polled every 10s per open dashboard page (profileBar.ts,
+// landing.ts), by plugin health checks, and by external monitors. On macOS a
+// credential-store read spawns `/usr/bin/security find-generic-password`, so
+// an uncached read here means a subprocess per poll — for a value that moves
+// on a ~30-day cadence. Mirrors the TTL caching getClaudeAuthStatusAsync and
+// fetchOAuthUsage already use.
+// ---------------------------------------------------------------------------
+
+function makeCountingStore(refreshKey: string | undefined, expiresAt: number | undefined) {
+  let reads = 0
+  const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+  if (expiresAt === undefined) delete seeded.claudeAiOauth.refreshTokenExpiresAt
+  else seeded.claudeAiOauth.refreshTokenExpiresAt = expiresAt
+  const store: CredentialStore = {
+    ...(refreshKey ? { refreshKey } : {}),
+    async read() { reads++; return seeded },
+    async write() { return true },
+  }
+  return { store, reads: () => reads }
+}
+
+describe("getAuthRenewalStatus caching", () => {
+  beforeEach(async () => {
+    const { resetAuthRenewalCache } = await import("../proxy/tokenRefresh")
+    resetAuthRenewalCache()
+  })
+
+  it("reads the credential store once for repeated calls on the same refreshKey", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const { store, reads } = makeCountingStore("file:/tmp/cache-a/.credentials.json", Date.now() + 19 * 86_400_000)
+
+    await getAuthRenewalStatus(store, 3)
+    await getAuthRenewalStatus(store, 3)
+    await getAuthRenewalStatus(store, 3)
+
+    expect(reads()).toBe(1)
+  })
+
+  it("still recomputes the day count and flag from the cached expiry", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    // Only the store READ is cached; warnDays and elapsed time must stay live,
+    // or a monitor changing its threshold would keep seeing the old verdict.
+    const { store } = makeCountingStore("file:/tmp/cache-b/.credentials.json", Date.now() + 5 * 86_400_000)
+
+    const outside = await getAuthRenewalStatus(store, 3)
+    const inside = await getAuthRenewalStatus(store, 7)
+
+    expect(outside.renewalRequiredSoon).toBe(false)
+    expect(inside.renewalRequiredSoon).toBe(true)
+    expect(inside.daysUntilRenewal).toBe(outside.daysUntilRenewal)
+  })
+
+  it("does not cache when the store has no refreshKey", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    // Identity is unknown, so caching could conflate unrelated stores.
+    const { store, reads } = makeCountingStore(undefined, Date.now() + 19 * 86_400_000)
+
+    await getAuthRenewalStatus(store, 3)
+    await getAuthRenewalStatus(store, 3)
+
+    expect(reads()).toBe(2)
+  })
+
+  it("keeps distinct refreshKeys separate", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    const personal = makeCountingStore("file:/tmp/personal/.credentials.json", Date.now() + 19 * 86_400_000)
+    const work = makeCountingStore("file:/tmp/work/.credentials.json", Date.now() + 2 * 86_400_000)
+
+    const p = await getAuthRenewalStatus(personal.store, 3)
+    const w = await getAuthRenewalStatus(work.store, 3)
+
+    expect(p.renewalRequiredSoon).toBe(false)
+    expect(w.renewalRequiredSoon).toBe(true)
+    expect(personal.reads()).toBe(1)
+    expect(work.reads()).toBe(1)
+  })
+
+  it("does not cache a failed read, so a transient blip retries", async () => {
+    const { getAuthRenewalStatus, resetAuthRenewalCache } = await import("../proxy/tokenRefresh")
+    resetAuthRenewalCache()
+    let reads = 0
+    let fail = true
+    const store: CredentialStore = {
+      refreshKey: "file:/tmp/flaky/.credentials.json",
+      async read() {
+        reads++
+        if (fail) throw new Error("keychain unavailable")
+        const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+        seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 19 * 86_400_000
+        return seeded
+      },
+      async write() { return true },
+    }
+
+    const first = await getAuthRenewalStatus(store, 3)
+    expect(first.renewalRequiredSoon).toBe(false)
+    expect(first.refreshTokenExpiresAt).toBeUndefined()
+
+    fail = false
+    const second = await getAuthRenewalStatus(store, 3)
+    expect(reads).toBe(2)
+    expect(second.daysUntilRenewal).toBe(19)
+  })
+
+  it("shares one in-flight read across concurrent callers", async () => {
+    const { getAuthRenewalStatus } = await import("../proxy/tokenRefresh")
+    let reads = 0
+    const store: CredentialStore = {
+      refreshKey: "file:/tmp/concurrent/.credentials.json",
+      async read() {
+        reads++
+        await new Promise((r) => setTimeout(r, 20))
+        const seeded = JSON.parse(JSON.stringify(MOCK_CREDENTIALS))
+        seeded.claudeAiOauth.refreshTokenExpiresAt = Date.now() + 19 * 86_400_000
+        return seeded
+      },
+      async write() { return true },
+    }
+
+    const results = await Promise.all([
+      getAuthRenewalStatus(store, 3),
+      getAuthRenewalStatus(store, 3),
+      getAuthRenewalStatus(store, 3),
+    ])
+
+    expect(reads).toBe(1)
+    expect(results.map((r) => r.daysUntilRenewal)).toEqual([19, 19, 19])
+  })
+
+  it("resetAuthRenewalCache forces the next call to re-read", async () => {
+    const { getAuthRenewalStatus, resetAuthRenewalCache } = await import("../proxy/tokenRefresh")
+    const { store, reads } = makeCountingStore("file:/tmp/cache-c/.credentials.json", Date.now() + 19 * 86_400_000)
+
+    await getAuthRenewalStatus(store, 3)
+    resetAuthRenewalCache()
+    await getAuthRenewalStatus(store, 3)
+
+    expect(reads()).toBe(2)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -50,7 +50,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, type CredentialStore } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, DEFAULT_RENEWAL_WARN_DAYS, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
   createDesignLogin,
@@ -3662,6 +3662,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // lazy in createProxyServer); startProxyServer eagerly populates it.
       const claudeExecutableInfo = getResolvedClaudeExecutableInfo()
 
+      // How long the login itself has left. Surfaced here because it is the
+      // one auth failure the proxy cannot recover from on its own, and it is
+      // knowable days in advance — external monitors alert on
+      // `renewalRequiredSoon`. Best-effort: a credential-store hiccup must not
+      // turn a healthy proxy into a degraded one.
+      const rawWarnDays = process.env.MERIDIAN_AUTH_RENEWAL_WARN_DAYS
+      const parsedWarnDays = rawWarnDays ? Number(rawWarnDays) : NaN
+      // Explicit finite check rather than `|| DEFAULT`: 0 is a legitimate
+      // setting (warn only once the login has actually lapsed) and would
+      // otherwise be swallowed as falsy.
+      const warnDays = Number.isFinite(parsedWarnDays) && parsedWarnDays >= 0
+        ? parsedWarnDays
+        : DEFAULT_RENEWAL_WARN_DAYS
+      // Read the *profile's* credential store, not the default one — profiles
+      // are separate auth contexts keyed by CLAUDE_CONFIG_DIR, so the default
+      // store would report an unrelated account's expiry.
+      const renewalConfigDir = profileEnvOverrides?.CLAUDE_CONFIG_DIR
+      const renewal = await getAuthRenewalStatus(
+        renewalConfigDir ? createPlatformCredentialStore({ claudeConfigDir: renewalConfigDir }) : undefined,
+        warnDays,
+      ).catch(() => ({ renewalRequiredSoon: false }))
+
       return c.json({
         status: "healthy",
         version: serverVersion,
@@ -3669,6 +3691,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           loggedIn: true,
           email: auth.email,
           subscriptionType: auth.subscriptionType,
+          ...renewal,
         },
         mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
         ...(claudeExecutableInfo ? { claudeExecutable: claudeExecutableInfo } : {}),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -50,7 +50,7 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
-import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, DEFAULT_RENEWAL_WARN_DAYS, type CredentialStore } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
   createDesignLogin,
@@ -3667,14 +3667,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // knowable days in advance — external monitors alert on
       // `renewalRequiredSoon`. Best-effort: a credential-store hiccup must not
       // turn a healthy proxy into a degraded one.
-      const rawWarnDays = process.env.MERIDIAN_AUTH_RENEWAL_WARN_DAYS
-      const parsedWarnDays = rawWarnDays ? Number(rawWarnDays) : NaN
-      // Explicit finite check rather than `|| DEFAULT`: 0 is a legitimate
-      // setting (warn only once the login has actually lapsed) and would
-      // otherwise be swallowed as falsy.
-      const warnDays = Number.isFinite(parsedWarnDays) && parsedWarnDays >= 0
-        ? parsedWarnDays
-        : DEFAULT_RENEWAL_WARN_DAYS
+      const warnDays = resolveRenewalWarnDays(process.env.MERIDIAN_AUTH_RENEWAL_WARN_DAYS)
       // Read the *profile's* credential store, not the default one — profiles
       // are separate auth contexts keyed by CLAUDE_CONFIG_DIR, so the default
       // store would report an unrelated account's expiry.

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -55,6 +55,16 @@ interface OAuthCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
+  /**
+   * When the *refresh* token itself stops working — i.e. when the login dies
+   * and an interactive `claude login` becomes mandatory. Written by the CLI at
+   * login; optional because nothing guarantees its presence.
+   *
+   * Distinct from `expiresAt`, which is the ~8h access-token lifetime that the
+   * background scheduler rolls on its own. No amount of refreshing extends
+   * this one unless Anthropic hands back a new value (see `doRefresh`).
+   */
+  refreshTokenExpiresAt?: number
   scopes?: string[]
   subscriptionType?: string
   rateLimitTier?: string
@@ -298,7 +308,14 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
     return false
   }
 
-  let tokenData: { access_token: string; refresh_token?: string; expires_in?: number; expires_at?: number }
+  let tokenData: {
+    access_token: string
+    refresh_token?: string
+    expires_in?: number
+    expires_at?: number
+    refresh_token_expires_at?: number
+    refresh_token_expires_in?: number
+  }
   try {
     tokenData = await response.json() as typeof tokenData
   } catch (err) {
@@ -311,17 +328,37 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
     tokenData.expires_at ??
     (tokenData.expires_in ? now + tokenData.expires_in * 1000 : now + 8 * 60 * 60 * 1000)
 
+  // The refresh token is rotated on every refresh, so its expiry may roll
+  // forward too. Anthropic does not currently document returning this, and the
+  // old code dropped it unconditionally — leaving the on-disk value frozen at
+  // login time and any renewal countdown built on it pessimistic. Persist it
+  // when offered; keep the previous value when not, which is the conservative
+  // direction (warn early rather than never).
+  const refreshTokenExpiresAtRaw =
+    tokenData.refresh_token_expires_at ??
+    (tokenData.refresh_token_expires_in ? now + tokenData.refresh_token_expires_in * 1000 : undefined)
+  // A refresh that just succeeded proves the refresh token is still valid, so
+  // its expiry must lie in the future. Reject anything else — a seconds-rather
+  // -than-ms value would land in 1970 and read downstream as "login already
+  // expired", turning a healthy proxy into a permanent alert.
+  const refreshTokenExpiresAt =
+    refreshTokenExpiresAtRaw && refreshTokenExpiresAtRaw > now ? refreshTokenExpiresAtRaw : undefined
+
   credentials.claudeAiOauth = {
     ...credentials.claudeAiOauth,
     accessToken: tokenData.access_token,
     refreshToken: tokenData.refresh_token ?? refreshToken,
     expiresAt,
+    ...(refreshTokenExpiresAt ? { refreshTokenExpiresAt } : {}),
   }
 
   const written = await store.write(credentials)
   if (!written) return false
 
-  claudeLog("token_refresh.success", { expiresAt })
+  // Logged so it is observable whether Anthropic ever rolls the refresh-token
+  // window — undefined here means the renewal countdown stays anchored to the
+  // last interactive login.
+  claudeLog("token_refresh.success", { expiresAt, refreshTokenExpiresAt })
   return true
 }
 
@@ -349,6 +386,65 @@ export async function ensureFreshToken(
   if (!expiresAt) return false
   if (expiresAt - Date.now() > bufferMs) return true
   return refreshOAuthToken(s)
+}
+
+/**
+ * Default warning window before the login dies, in days.
+ *
+ * Three, matching the CLI's own `tff` constant — the window outside which it
+ * suppresses the expiry tip entirely. The login only lasts 30 days, so a wider
+ * window would spend a tenth of every cycle in the alerting state and train
+ * the alert to be ignored. Override with MERIDIAN_AUTH_RENEWAL_WARN_DAYS.
+ */
+export const DEFAULT_RENEWAL_WARN_DAYS = 3
+
+export interface AuthRenewalStatus {
+  /** Epoch ms the refresh token stops working, when known. */
+  refreshTokenExpiresAt?: number
+  /** Whole days until then. Negative once it has passed. */
+  daysUntilRenewal?: number
+  /** True once inside the warning window — the field monitors should alert on. */
+  renewalRequiredSoon: boolean
+}
+
+/**
+ * Report how long the *login* has left, as opposed to the access token.
+ *
+ * This is the signal behind Claude Code's "your login expires in N days"
+ * warning: when the refresh token dies, the background scheduler can no longer
+ * keep the proxy alive and someone must run `claude login` interactively.
+ * Nothing in the automated path recovers from it.
+ *
+ * `renewalRequiredSoon` stays false when the expiry is unknown — an absent
+ * field is not evidence of an imminent problem, and alerting on it would fire
+ * on every deployment that predates the CLI writing it.
+ */
+export async function getAuthRenewalStatus(
+  store?: CredentialStore,
+  warnDays = DEFAULT_RENEWAL_WARN_DAYS,
+): Promise<AuthRenewalStatus> {
+  const s = store ?? createPlatformCredentialStore()
+  let credentials: CredentialsFile | null = null
+  try {
+    credentials = await s.read()
+  } catch {
+    return { renewalRequiredSoon: false }
+  }
+
+  const refreshTokenExpiresAt = credentials?.claudeAiOauth?.refreshTokenExpiresAt
+  if (!refreshTokenExpiresAt) return { renewalRequiredSoon: false }
+
+  const msRemaining = refreshTokenExpiresAt - Date.now()
+  // Ceil, matching the CLI's own `Math.ceil(remaining / 86400000)` so this
+  // number reads identically to the "Your login expires in N days" warning
+  // Claude Code prints. Flooring here would report one day fewer than the
+  // terminal does and make the two impossible to reconcile.
+  const daysUntilRenewal = Math.ceil(msRemaining / 86_400_000)
+  return {
+    refreshTokenExpiresAt,
+    daysUntilRenewal,
+    renewalRequiredSoon: daysUntilRenewal <= warnDays,
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -399,6 +399,21 @@ export async function ensureFreshToken(
  */
 export const DEFAULT_RENEWAL_WARN_DAYS = 3
 
+/**
+ * Parse the MERIDIAN_AUTH_RENEWAL_WARN_DAYS window, falling back to the
+ * default for anything unusable.
+ *
+ * An explicit finite check rather than `Number(raw) || DEFAULT`: `0` is a
+ * legitimate setting — warn only once the login has actually lapsed — and the
+ * shortcut would swallow it as falsy. Negative windows are rejected too; they
+ * would mean "warn only after the login has been dead for N days", which no
+ * monitor wants.
+ */
+export function resolveRenewalWarnDays(raw: string | undefined): number {
+  const parsed = raw ? Number(raw) : NaN
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_RENEWAL_WARN_DAYS
+}
+
 export interface AuthRenewalStatus {
   /** Epoch ms the refresh token stops working, when known. */
   refreshTokenExpiresAt?: number

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -329,11 +329,12 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
     (tokenData.expires_in ? now + tokenData.expires_in * 1000 : now + 8 * 60 * 60 * 1000)
 
   // The refresh token is rotated on every refresh, so its expiry may roll
-  // forward too. Anthropic does not currently document returning this, and the
-  // old code dropped it unconditionally — leaving the on-disk value frozen at
-  // login time and any renewal countdown built on it pessimistic. Persist it
-  // when offered; keep the previous value when not, which is the conservative
-  // direction (warn early rather than never).
+  // forward too. Anthropic does not currently document returning this. The
+  // previous code preserved any on-disk value through the spread below but
+  // never parsed a new one from the response, so the stored expiry could only
+  // ever be as old as the last interactive login — leaving any countdown built
+  // on it pessimistic. Persist it when offered; keep the previous value when
+  // not, which is the conservative direction (warn early rather than never).
   const refreshTokenExpiresAtRaw =
     tokenData.refresh_token_expires_at ??
     (tokenData.refresh_token_expires_in ? now + tokenData.refresh_token_expires_in * 1000 : undefined)
@@ -419,19 +420,76 @@ export interface AuthRenewalStatus {
  * field is not evidence of an imminent problem, and alerting on it would fire
  * on every deployment that predates the CLI writing it.
  */
+/**
+ * How long a read of the refresh-token expiry stays fresh.
+ *
+ * `/health` is hot: the dashboard polls it every 10s per open page, plugin
+ * health checks hit it, and external monitors poll it too. On macOS a
+ * credential-store read spawns `/usr/bin/security find-generic-password`, so
+ * reading per request means a subprocess per poll — for a value that moves on
+ * a ~30-day cadence. Five minutes is far shorter than any meaningful change to
+ * the login window and still collapses ~97% of the reads.
+ */
+const RENEWAL_EXPIRY_TTL_MS = 5 * 60_000
+
+const renewalExpiryCache = new Map<string, { value: number | undefined; at: number }>()
+const renewalExpiryInflight = new Map<string, Promise<number | undefined>>()
+
+/** Drop cached refresh-token expiries — for tests, and after a re-login. */
+export function resetAuthRenewalCache(): void {
+  renewalExpiryCache.clear()
+  renewalExpiryInflight.clear()
+}
+
+/**
+ * Read the refresh-token expiry, cached per credential store.
+ *
+ * Keyed on `refreshKey`, which both real stores set (`keychain:` / `file:`).
+ * A store WITHOUT one is not cached at all: its identity is unknown, so
+ * caching could conflate genuinely different accounts — the same reasoning
+ * that makes the key profile-scoped in the first place.
+ *
+ * A failed read is never cached. A keychain blip should retry on the next
+ * poll, not suppress the renewal warning for the whole TTL.
+ */
+async function readRefreshTokenExpiry(s: CredentialStore): Promise<number | undefined> {
+  const key = s.refreshKey
+  if (key) {
+    const cached = renewalExpiryCache.get(key)
+    if (cached && Date.now() - cached.at < RENEWAL_EXPIRY_TTL_MS) return cached.value
+    const inflight = renewalExpiryInflight.get(key)
+    if (inflight) return inflight
+  }
+
+  const read = (async (): Promise<number | undefined> => {
+    let credentials: CredentialsFile | null = null
+    try {
+      credentials = await s.read()
+    } catch {
+      return undefined
+    }
+    const value = credentials?.claudeAiOauth?.refreshTokenExpiresAt
+    if (key) renewalExpiryCache.set(key, { value, at: Date.now() })
+    return value
+  })()
+
+  if (!key) return read
+  renewalExpiryInflight.set(key, read)
+  try {
+    return await read
+  } finally {
+    renewalExpiryInflight.delete(key)
+  }
+}
+
 export async function getAuthRenewalStatus(
   store?: CredentialStore,
   warnDays = DEFAULT_RENEWAL_WARN_DAYS,
 ): Promise<AuthRenewalStatus> {
   const s = store ?? createPlatformCredentialStore()
-  let credentials: CredentialsFile | null = null
-  try {
-    credentials = await s.read()
-  } catch {
-    return { renewalRequiredSoon: false }
-  }
-
-  const refreshTokenExpiresAt = credentials?.claudeAiOauth?.refreshTokenExpiresAt
+  // Only the READ is cached. The day count and the flag are recomputed every
+  // call so elapsed time and a changed warnDays are always reflected.
+  const refreshTokenExpiresAt = await readRefreshTokenExpiry(s)
   if (!refreshTokenExpiresAt) return { renewalRequiredSoon: false }
 
   const msRemaining = refreshTokenExpiresAt - Date.now()


### PR DESCRIPTION
Lands @CrazyCoder's work from #711, cherry-picked with authorship preserved, plus a caching fix and coverage for the parts that lived in `server.ts`.

## The original feature (credit: @CrazyCoder, #711)

The background scheduler keeps the *access* token alive indefinitely, so the proxy looks healthy right up until it isn't. The **refresh token** has its own expiry, and when that lapses nothing automated recovers — every request 401s until someone runs `claude login`. That deadline was invisible: `/health` reported only `loggedIn: true`, and `refreshTokenExpiresAt` — which the CLI already writes — was read nowhere.

`/health` now carries `refreshTokenExpiresAt`, `daysUntilRenewal`, and `renewalRequiredSoon`, so a monitor can alert on one boolean instead of doing date arithmetic in a shell script. `doRefresh` also now parses a returned refresh-token expiry instead of leaving the stored value frozen at the last interactive login.

Several judgement calls in the original are worth keeping visible:

- **A returned expiry that isn't in the future is rejected.** A refresh that just succeeded proves the token is valid, so a seconds-rather-than-milliseconds value would otherwise persist as a 1970 timestamp and read as "already expired" — pinning a deployment to a permanent alert.
- **Absence never raises the flag.** An absent field isn't evidence of imminent expiry.
- **The lookup is profile-scoped.** Profiles are separate auth contexts keyed by `CLAUDE_CONFIG_DIR`; the default store would report an unrelated account.
- **`Math.ceil`, matching the CLI**, so `/health` and the terminal never disagree by a day.

That last pair proved their worth immediately — see the verification below.

## Added on top

**Caching (`b33f2beb`).** `getAuthRenewalStatus` read the credential store on every call, and on macOS that read spawns `/usr/bin/security find-generic-password`. `/health` is hot: the dashboard polls it every 10s per open page (`profileBar.ts`, `landing.ts`), plugin health checks hit it, and external monitors poll it too — so this was a subprocess per poll, for a value that moves on a ~30-day cadence.

Now cached for 5 minutes, keyed on the store's `refreshKey`, with in-flight sharing so concurrent polls collapse to one read. This mirrors the TTL caching `getClaudeAuthStatusAsync` and `fetchOAuthUsage` already use — the same handler was already doing exactly this one line above.

Three properties are deliberate and tested: a store **without** a `refreshKey` is not cached (identity unknown, so caching could conflate accounts — which is also what keeps the original 13 tests valid unchanged); a **failed** read is never cached, so a keychain blip retries next poll rather than suppressing the warning for the whole TTL; and only the *read* is cached — the day count and flag are recomputed each call so elapsed time and a changed `warnDays` stay live.

**Extracted and tested the warn-window parsing (`632e35c5`).** The `MERIDIAN_AUTH_RENEWAL_WARN_DAYS` parse lived inline in the handler, which made it untestable without process-global module mocking and put computation in a file meant to orchestrate. Now `resolveRenewalWarnDays()` in `tokenRefresh.ts`, covered directly — including the `0` case the explicit finite check exists for, which a `Number(raw) || DEFAULT` shortcut would swallow as falsy.

**Corrected a comment.** It said the previous code "dropped it unconditionally"; in fact the spread preserved any on-disk value — it just never parsed a *new* one from the response. The PR description had this right; only the inline comment was wrong.

## Verification

Live, against real credentials on this machine:

```
personal profile: {"refreshTokenExpiresAt":1786080046027,"daysUntilRenewal":9,"renewalRequiredSoon":false}
expires: 2026-08-07 05:20
```

A real 30-day login window, 9 days out, correctly outside the 3-day warning window.

The two edge cases earned their keep on the very first run. The active profile here is `work`, whose keychain entry predates the CLI writing `refreshTokenExpiresAt`:

| store | has the field |
|---|---|
| default (`personal`) | yes |
| `work` profile | **no** |

So `/health` returned `renewalRequiredSoon: false` with the other two fields absent — exactly right. Had "absence" been treated as evidence, this deployment would have alerted permanently; had the lookup not been profile-scoped, it would have reported `personal`'s expiry under `work`'s identity.

`npm test`: 0 failures (72 in `token-refresh.test.ts`, up from 60). `npx tsc --noEmit` clean. `npm run build` succeeds.

## Not addressed

No integration test asserts the `/health` response literally contains the fields — that path needs process-global module mocking, which this repo has been bitten by before. The wiring is a spread of a returned object and the returned object is well covered, so the residual risk is low, but it is uncovered rather than covered.

Closes #711.
