### PR TITLE
fix(session): reject compaction that resumes past the last message

### DIFF
--- a/src/__tests__/lineage-safety.test.ts
+++ b/src/__tests__/lineage-safety.test.ts
@@ -167,7 +167,10 @@ describe("lineage safety: invariants", () => {
       const incomingHashes = computeMessageHashes(s.incoming)
       const { resumeFrom } = result
 
-      expect(resumeFrom, `${s.label} resumeFrom past end`).toBeLessThanOrEqual(s.incoming.length)
+      // Strictly inside the array: resumeFrom is a slice start, so resuming at
+      // the end sends nothing and the caller silently falls back to the last
+      // user message, which is not necessarily the turn the client just added.
+      expect(resumeFrom, `${s.label} resumeFrom leaves nothing to send`).toBeLessThan(s.incoming.length)
 
       if (result.type === "continuation") {
         // Continuation resumes from the stored count, so the stored history
@@ -255,10 +258,10 @@ stored=4 churn=@3 gap=5 => D
 stored=4 shrink-to=1 => U
 stored=4 shrink-to=2 => U
 stored=6 churn=none gap=0 => D
-stored=6 churn=@0 gap=0 => C
-stored=6 churn=@1 gap=0 => C
-stored=6 churn=@2 gap=0 => C
-stored=6 churn=@3 gap=0 => C
+stored=6 churn=@0 gap=0 => D
+stored=6 churn=@1 gap=0 => D
+stored=6 churn=@2 gap=0 => D
+stored=6 churn=@3 gap=0 => D
 stored=6 churn=@4 gap=0 => D
 stored=6 churn=@5 gap=0 => U
 stored=6 churn=none gap=1 => R
@@ -291,14 +294,14 @@ stored=6 churn=@4 gap=5 => D
 stored=6 churn=@5 gap=5 => D
 stored=6 shrink-to=1 => U
 stored=6 shrink-to=3 => U
-stored=6 compaction => C
+stored=6 compaction => D
 stored=8 churn=none gap=0 => D
-stored=8 churn=@0 gap=0 => C
-stored=8 churn=@1 gap=0 => C
-stored=8 churn=@2 gap=0 => C
-stored=8 churn=@3 gap=0 => C
-stored=8 churn=@4 gap=0 => C
-stored=8 churn=@5 gap=0 => C
+stored=8 churn=@0 gap=0 => D
+stored=8 churn=@1 gap=0 => D
+stored=8 churn=@2 gap=0 => D
+stored=8 churn=@3 gap=0 => D
+stored=8 churn=@4 gap=0 => D
+stored=8 churn=@5 gap=0 => D
 stored=8 churn=@6 gap=0 => D
 stored=8 churn=@7 gap=0 => U
 stored=8 churn=none gap=1 => R
@@ -339,7 +342,7 @@ stored=8 churn=@6 gap=5 => D
 stored=8 churn=@7 gap=5 => D
 stored=8 shrink-to=1 => U
 stored=8 shrink-to=4 => U
-stored=8 compaction => C
+stored=8 compaction => D
 unrelated history => D`
 
     expect(actual).toBe(expected)

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -573,3 +573,73 @@ describe("normalizeContextUsage", () => {
     expect(result.output_tokens).toBe(50)
   })
 })
+
+describe("verifyLineage compaction that reaches the end of the incoming array", () => {
+  // Stateless chat frontends (SillyTavern and most roleplay clients) re-send the
+  // whole history every turn and append a constant trailing block after the
+  // user's own message — an injected assistant line plus a prefill sent as a
+  // user message. When the user repeats a turn verbatim, that trailing block
+  // matches the stored tail for several slots, so the suffix anchor lands on the
+  // final message and resumeFrom comes out equal to messages.length.
+  //
+  // The slice is then empty and the caller falls back to getLastUserMessage(),
+  // which returns the constant prefill rather than the turn the user just typed,
+  // so the request reaches the model with the user's input missing entirely.
+  const FAKE_ASSISTANT = "[injected] let's look at what the user wrote"
+  const LATEST = "<latest_human_message>\ngo on\n</latest_human_message>"
+  const PREFILL = "done thinking."
+
+  const head = [
+    msg("user", "turn one"),
+    msg("assistant", "reply one"),
+    msg("user", "turn two"),
+    msg("assistant", "reply two"),
+  ]
+  const trailingBlock = [
+    msg("user", "go on"),
+    msg("assistant", FAKE_ASSISTANT),
+    msg("user", LATEST),
+    msg("user", PREFILL),
+  ]
+  const stored = [...head, ...trailingBlock]
+  const incoming = [
+    ...head,
+    msg("user", "go on"),
+    msg("assistant", "reply three"),
+    ...trailingBlock,
+  ]
+
+  const session = makeSession({
+    messageCount: stored.length,
+    lineageHash: computeLineageHash(stored),
+    messageHashes: computeMessageHashes(stored),
+  })
+
+  it("does not resume with nothing left to send", () => {
+    const result = verifyLineage(session, incoming)
+    if (result.type === "continuation" || result.type === "compaction") {
+      expect(result.resumeFrom).toBeLessThan(incoming.length)
+    }
+  })
+
+  it("replays in full so the user's turn is not dropped", () => {
+    const result = verifyLineage(session, incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
+  })
+
+  it("still detects a real compaction that appends a new turn", () => {
+    // The genuine shape: a long head replaced by a short summary, preserved
+    // tail intact, and the new turn appended after it. resumeFrom stays inside
+    // the array, so this must keep resuming — the fix must not cost it.
+    const compacted = [
+      msg("user", "summary of earlier"),
+      ...stored.slice(-3),
+      msg("assistant", "reply three"),
+      msg("user", "a brand new turn"),
+    ]
+    const result = verifyLineage(session, compacted)
+    expect(result.type).toBe("compaction")
+    if (result.type === "compaction") expect(result.resumeFrom).toBeLessThan(compacted.length)
+  })
+})

--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -114,3 +114,67 @@ describe("fresh-session replay envelope (#619)", () => {
     expect(prompt).toBe("follow up")
   })
 })
+
+/**
+ * #712/#713 — the user's own message must reach the model.
+ *
+ * The lineage tests pin the CLASSIFICATION (compaction that resumes past the
+ * last message is now rejected). This pins the OUTCOME, which is where the bug
+ * actually bit: a wrong verdict made server.ts take its `resumeFrom <
+ * allMessages.length` fallback and send getLastUserMessage() — the LAST
+ * user-role message, which for these clients is a constant injected tail, not
+ * the turn the user just typed. HTTP 200, fluent output, nothing in the logs.
+ *
+ * Stateless chat frontends (SillyTavern and most roleplay UIs) re-send the
+ * whole history every turn and append a constant block after the user's own
+ * message: an injected assistant line plus a prefill sent as a user message.
+ * That block matches the stored tail, so the suffix anchor lands on the final
+ * message. Without a classification test AND this one, a future change to the
+ * fallback could restore the data loss while the lineage tests stayed green.
+ */
+describe("stateless client with a trailing injected block (#712)", () => {
+  const INJECTED_ASSISTANT = { role: "assistant", content: "[post-history instructions]" }
+  const PREFILL = { role: "user", content: "思考已结束。" }
+
+  beforeEach(() => {
+    clearSessionCache()
+    capturedPrompts = []
+  })
+
+  it("delivers the user's message, not the injected prefill", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const prior = [
+      { role: "user", content: "turn one" },
+      { role: "assistant", content: "answer one" },
+      { role: "user", content: "turn two" },
+      { role: "assistant", content: "answer two" },
+      { role: "user", content: "turn three" },
+      { role: "assistant", content: "answer three" },
+      INJECTED_ASSISTANT,
+      PREFILL,
+    ]
+    storeSession("sess-712", prior, "sdk-712", "/tmp/test", prior.map(() => null))
+
+    // Next turn: the assistant replied, the user typed something new, and the
+    // client re-appended its constant block.
+    const res = await post(
+      app,
+      [
+        ...prior.slice(0, 6),
+        { role: "assistant", content: "answer three continued" },
+        { role: "user", content: "WHAT THE USER ACTUALLY ASKED" },
+        INJECTED_ASSISTANT,
+        PREFILL,
+      ],
+      { "x-opencode-session": "sess-712" }
+    )
+    expect(res.status).toBe(200)
+
+    const prompt = capturedPrompts[0] as string
+    expect(typeof prompt).toBe("string")
+    // The whole point: the user's turn is in the prompt.
+    expect(prompt).toContain("WHAT THE USER ACTUALLY ASKED")
+    // And it is not merely the injected tail standing in for it.
+    expect(prompt).not.toBe("思考已结束。")
+  })
+})

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -261,15 +261,34 @@ export function verifyLineage(
   const suffixStartInIncoming = incomingHashes.length - suffixOverlap >= 0
     ? findSuffixAnchorStart(cached.messageHashes, incomingHashes, suffixOverlap)
     : -1
+  // resumeFrom is a slice start, so the preserved suffix must also end before
+  // the last message — a run that reaches the end leaves nothing to send. The
+  // fast path already refuses that shape ("replayed-request"); without the same
+  // guard here, a false suffix match resumes with an empty delta and the caller
+  // falls back to getLastUserMessage().
+  //
+  // That fallback is what makes it silent rather than merely wasteful. Stateless
+  // chat frontends re-send the whole history every turn and append a constant
+  // trailing block after the user's own message (an injected assistant line, a
+  // prefill sent as a user message). Repeat a turn verbatim and that block
+  // matches the stored tail for several slots, so the anchor lands on the final
+  // message. getLastUserMessage() then returns the constant trailing message
+  // instead of the turn the user just typed, and the request reaches the model
+  // with the user's input missing — 200, fluent output, nothing in the logs.
+  //
+  // Genuine compaction is unaffected: a client that compacts also appends the
+  // new turn, which keeps the suffix run away from the end.
+  const compactionResumeFrom = suffixStartInIncoming + suffixOverlap
   if (
     suffixOverlap >= MIN_SUFFIX_FOR_COMPACTION &&
     cached.messageHashes.length >= MIN_STORED_FOR_COMPACTION &&
-    suffixStartInIncoming > 0   // at least one changed message before the preserved suffix
+    suffixStartInIncoming > 0 &&            // at least one changed message before the preserved suffix
+    compactionResumeFrom < messages.length  // and at least one new message after it
   ) {
     return {
       type: "compaction",
       session: cached,
-      resumeFrom: suffixStartInIncoming + suffixOverlap,
+      resumeFrom: compactionResumeFrom,
       suffixOverlap,
     }
   }


### PR DESCRIPTION
Lands @1A7432's fix from #713, cherry-picked with authorship preserved, plus an end-to-end regression test.

Fixes #712.

## The bug

`verifyLineage` could return `compaction` with `resumeFrom === messages.length`. The slice is then empty, so `server.ts` takes its `resumeFrom < allMessages.length` fallback and calls `getLastUserMessage()` — which returns the **last user-role message**. For a stateless chat frontend that appends a constant block after the user's own turn, that message is the injected prefill, not what the user typed.

The result is silent: HTTP 200, fluent output, nothing in the logs. The reporter saw the same 6-character user turn recorded in the SDK transcript **16 times in a row**, with the model continuing its own previous output because that was all it had.

Stateless roleplay frontends hit this routinely — they re-send the whole history every turn and append an injected assistant line plus a prefill sent as a user message. That block matches the stored tail for several slots, so `measureSuffixOverlap` anchors on the final message and `suffixStart + suffixOverlap` lands exactly on `messages.length`.

## Reproduced before fixing

Driving the reported shape through the real lineage path:

```
lineage        : compaction  suffixOverlap=2
resumeFrom     : 10   messages.length = 10     ← resumes past the end
slice empty?   : true
MODEL RECEIVES : "思考已结束。"                  ← the injected prefill
USER ACTUALLY SAID: "MY ACTUAL QUESTION"        ← silently dropped
```

Worth noting the issue text attributes this to the `continuation` path; it is actually `compaction`. The PR's own analysis is the correct one — post-#705 a changed prefix on a growing history already returns `diverged`, so `continuation` could not produce this.

## The fix (credit: @1A7432, #713)

One condition on the compaction branch: the preserved suffix must end *before* the last message, so there is at least one new message to send.

```ts
compactionResumeFrom < messages.length  // and at least one new message after it
```

The reasoning is tight — the fast path already refuses this shape (`messages.length <= cached.messageCount` → `replayed-request`); the compaction branch simply lacked the equivalent guard. Nothing new after the suffix means it is a replay, not a compaction, so it falls through to the existing divergence handling and replays in full. Genuine compaction is unaffected: a client that compacts also appends the new turn, which keeps the run away from the end.

## Added on top: an end-to-end regression test

Their three tests pin the **classification**. This pins the **outcome**, which is where the bug actually bit — a wrong verdict only causes data loss via `server.ts`'s fallback, which no lineage test can see.

The new test drives the reported shape through the real HTTP path with a mocked SDK and asserts the captured prompt contains the user's message. Verified load-bearing: with the guard removed it fails with

```
Expected to contain: "WHAT THE USER ACTUALLY ASKED"
Received: "思考已结束。"
```

which is precisely the reporter's symptom. Without it, a future change to that fallback could restore the data loss while every lineage test stayed green.

## Verification

`npm test`: 0 failures. `npx tsc --noEmit` clean. `npm run build` succeeds. The genuine-compaction pruning-survival case in `session-lineage.test.ts` still resumes, and the `lineage-safety.test.ts` golden matrix is unchanged in the dangerous direction.

## Not addressed here

The reporter raised a second, independent problem in #712: `ORCHESTRATION_TAGS` includes `thinking` and is applied to **user-authored** content via `flattenUserContent` → `sanitizeTextContent`, so a paired `<thinking>…</thinking>` in a user prompt is deleted before the model sees it — on full replay too. Verified, but a separate bug with a separate fix; filed on its own so this change stays one fix.
