### PR TITLE
fix(query): correct the preset's false gitStatus provenance claim

### DIFF
--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -302,11 +302,10 @@ describe("Multimodal content", () => {
     })).json()
 
     // System context should be in SDK option, not injected as a structured message
-    expect(capturedQueryParams.options.systemPrompt).toEqual({
-      type: "preset",
-      preset: "claude_code",
-      append: "You are a helpful assistant.",
-    })
+    expect(capturedQueryParams.options.systemPrompt.type).toBe("preset")
+    expect(capturedQueryParams.options.systemPrompt.preset).toBe("claude_code")
+    // Leads with the client's prompt; Meridian's gitStatus note (#694) follows.
+    expect(capturedQueryParams.options.systemPrompt.append).toStartWith("You are a helpful assistant.")
 
     const messages: any[] = []
     for await (const msg of capturedQueryParams.prompt) {

--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -198,11 +198,11 @@ describe("Phase 2: Message format preservation", () => {
 
     // System prompt should be passed via systemPrompt option (append to Claude Code default)
     expect(capturedQueryParams).toBeDefined()
-    expect(capturedQueryParams.options.systemPrompt).toEqual({
-      type: "preset",
-      preset: "claude_code",
-      append: "You are a helpful assistant.",
-    })
+    // The client's system prompt leads the append; Meridian's own addenda (the
+    // gitStatus provenance note, #694) follow it.
+    expect(capturedQueryParams.options.systemPrompt.type).toBe("preset")
+    expect(capturedQueryParams.options.systemPrompt.preset).toBe("claude_code")
+    expect(capturedQueryParams.options.systemPrompt.append).toStartWith("You are a helpful assistant.")
     // Prompt text should NOT contain the system context (it's in the SDK option now)
     const prompt = capturedQueryParams.prompt
     expect(typeof prompt).toBe("string")

--- a/src/__tests__/query-git-status-note.test.ts
+++ b/src/__tests__/query-git-status-note.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for GIT_STATUS_PROVENANCE_NOTE — the addendum that corrects the
+ * `claude_code` preset's claim that its `gitStatus` block describes "the start
+ * of the conversation".
+ *
+ * Meridian issues one `query()` per turn, so the SDK recomputes that block
+ * every turn while still labelling it the conversation's starting state. The
+ * model then reads files it created in earlier turns as pre-existing work and
+ * reports having destroyed the user's uncommitted changes (#694).
+ */
+import { describe, it, expect } from "bun:test"
+import { buildQueryOptions, GIT_STATUS_PROVENANCE_NOTE, type QueryContext } from "../proxy/query"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../proxy/tools"
+
+/** Mirrors the shared context helper in query.test.ts. */
+function ctx(overrides: Partial<QueryContext> = {}): QueryContext {
+  return {
+    prompt: "Hello",
+    model: "sonnet[1m]",
+    workingDirectory: "/tmp/test",
+    systemContext: "",
+    claudeExecutable: "/usr/bin/claude",
+    passthrough: false,
+    stream: false,
+    sdkAgents: {},
+    cleanEnv: {},
+    envOverrides: undefined,
+    hasDeferredTools: false,
+    isUndo: false,
+    blockedTools: BLOCKED_BUILTIN_TOOLS,
+    incompatibleTools: CLAUDE_CODE_ONLY_TOOLS,
+    mcpServerName: MCP_SERVER_NAME,
+    allowedMcpTools: ALLOWED_MCP_TOOLS,
+    ...overrides,
+  }
+}
+
+/** The append string for a request that resolves to the preset. */
+function presetAppend(overrides: Partial<QueryContext> = {}): string {
+  const { options } = buildQueryOptions(ctx(overrides))
+  const sp = options.systemPrompt
+  if (typeof sp !== "object" || sp === null) {
+    throw new Error(`expected preset object, got ${JSON.stringify(sp)}`)
+  }
+  return (sp as { append?: string }).append ?? ""
+}
+
+describe("GIT_STATUS_PROVENANCE_NOTE", () => {
+  it("contradicts the preset's 'start of the conversation' claim", () => {
+    // The note is useless unless it names the specific false claim it corrects;
+    // a vague "git status may be stale" would not tell the model which of two
+    // contradictory sources to believe.
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("start of the conversation")
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("recomputed at the start of every turn")
+  })
+
+  it("tells the model the block is not evidence of provenance", () => {
+    // This is the inference that produced #694: the model treated the block as
+    // proof the files predated its own work.
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("not")
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("predates the conversation")
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("earlier turns")
+  })
+
+  it("points at what to trust instead", () => {
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("conversation history")
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("git status")
+  })
+
+  it("is wrapped in the meridian-note tag used by the cwd addendum", () => {
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("<meridian-note>")
+    expect(GIT_STATUS_PROVENANCE_NOTE).toContain("</meridian-note>")
+  })
+})
+
+describe("buildQueryOptions — gitStatus note placement", () => {
+  it("appends the note when the preset is used with no client system prompt", () => {
+    // The bug does not require a client system prompt, so neither can the fix.
+    const append = presetAppend({ codeSystemPrompt: true })
+    expect(append).toContain(GIT_STATUS_PROVENANCE_NOTE.trim())
+  })
+
+  it("appends the note when the client also sent a system prompt", () => {
+    const append = presetAppend({ codeSystemPrompt: true, systemContext: "You are helpful." })
+    expect(append).toContain("You are helpful.")
+    expect(append).toContain(GIT_STATUS_PROVENANCE_NOTE.trim())
+  })
+
+  it("keeps the client's system prompt first so the note reads as an addendum", () => {
+    const append = presetAppend({ codeSystemPrompt: true, systemContext: "You are helpful." })
+    expect(append.indexOf("You are helpful.")).toBeLessThan(append.indexOf("<meridian-note>"))
+  })
+
+  it("keeps the note after the cwd override, which must stay the first env block", () => {
+    // buildCwdNote documents that its <env> block has to come first so the
+    // subprocess does not inject a competing one; the git note must not
+    // displace it.
+    const append = presetAppend({
+      codeSystemPrompt: true,
+      workingDirectory: "/srv/proxy",
+      clientWorkingDirectory: "/Users/alice/app",
+    })
+    expect(append.indexOf("<env>")).toBeLessThan(append.indexOf("gitStatus"))
+  })
+
+  it("omits the note when the preset is not used", () => {
+    // Without the preset there is no gitStatus block, so the note would be
+    // describing context the model cannot see.
+    const { options } = buildQueryOptions(ctx({
+      codeSystemPrompt: false,
+      systemContext: "You are helpful.",
+    }))
+    expect(options.systemPrompt).toBe("You are helpful.")
+  })
+
+  it("still forces an empty system prompt when the preset is off with nothing to append", () => {
+    // Regression guard for the #489 follow-up: `{}` would let the SDK
+    // reintroduce the preset.
+    const { options } = buildQueryOptions(ctx({ codeSystemPrompt: false }))
+    expect(options.systemPrompt).toBe("")
+  })
+
+  it("applies to passthrough requests, where the bug was reported", () => {
+    // #694 came from OpenCode, which defaults to passthrough. Passthrough turns
+    // are exactly the ones that re-query most often (once per tool round-trip),
+    // so they refresh the block most often.
+    const append = presetAppend({ codeSystemPrompt: true, passthrough: true })
+    expect(append).toContain(GIT_STATUS_PROVENANCE_NOTE.trim())
+  })
+
+  it("applies on resume, not just on fresh sessions", () => {
+    // A resumed turn is where the claim is provably false.
+    const append = presetAppend({ codeSystemPrompt: true, resumeSessionId: "abc-123" })
+    expect(append).toContain(GIT_STATUS_PROVENANCE_NOTE.trim())
+  })
+})

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -2,7 +2,7 @@
  * Tests for the SDK query options builder.
  */
 import { describe, it, expect } from "bun:test"
-import { buildQueryOptions, type QueryContext } from "../proxy/query"
+import { buildQueryOptions, GIT_STATUS_PROVENANCE_NOTE, type QueryContext } from "../proxy/query"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../proxy/tools"
 
 function makeContext(overrides: Partial<QueryContext> = {}): QueryContext {
@@ -118,7 +118,9 @@ describe("buildQueryOptions", () => {
     const sp = (result.options as any).systemPrompt
     expect(sp).toBeDefined()
     expect(sp.type).toBe("preset")
-    expect(sp.append).toBe("Be helpful")
+    expect(sp.append).toStartWith("Be helpful")
+    // Every preset request also carries the gitStatus provenance note (#694).
+    expect(sp.append).toContain(GIT_STATUS_PROVENANCE_NOTE)
   })
 
   it("uses raw system prompt in passthrough mode", () => {
@@ -329,7 +331,9 @@ describe("buildQueryOptions", () => {
     const sp = (result.options as any).systemPrompt
     expect(sp.type).toBe("preset")
     expect(sp.preset).toBe("claude_code")
-    expect(sp.append).toBe("Be helpful")
+    expect(sp.append).toStartWith("Be helpful")
+    // Every preset request also carries the gitStatus provenance note (#694).
+    expect(sp.append).toContain(GIT_STATUS_PROVENANCE_NOTE)
   })
 
   it("uses preset with append in passthrough + settingSources", () => {
@@ -341,10 +345,12 @@ describe("buildQueryOptions", () => {
     const sp = (result.options as any).systemPrompt
     expect(sp.type).toBe("preset")
     expect(sp.preset).toBe("claude_code")
-    expect(sp.append).toBe("Be helpful")
+    expect(sp.append).toStartWith("Be helpful")
+    // Every preset request also carries the gitStatus provenance note (#694).
+    expect(sp.append).toContain(GIT_STATUS_PROVENANCE_NOTE)
   })
 
-  it("uses bare preset when settingSources set but no systemContext", () => {
+  it("appends only Meridian's own note when settingSources set but no systemContext", () => {
     const result = buildQueryOptions(makeContext({
       systemContext: "",
       settingSources: ["user", "project"],
@@ -352,7 +358,8 @@ describe("buildQueryOptions", () => {
     const sp = (result.options as any).systemPrompt
     expect(sp.type).toBe("preset")
     expect(sp.preset).toBe("claude_code")
-    expect(sp.append).toBeUndefined()
+    // No client context to append, so the gitStatus note (#694) stands alone.
+    expect(sp.append).toBe(GIT_STATUS_PROVENANCE_NOTE)
   })
 
   it("omits systemPrompt when no systemContext and no settingSources", () => {
@@ -478,7 +485,9 @@ describe("buildQueryOptions", () => {
     const sp = (result.options as any).systemPrompt
     expect(sp.type).toBe("preset")
     expect(sp.preset).toBe("claude_code")
-    expect(sp.append).toBe("Agent instructions")
+    expect(sp.append).toStartWith("Agent instructions")
+    // Every preset request also carries the gitStatus provenance note (#694).
+    expect(sp.append).toContain(GIT_STATUS_PROVENANCE_NOTE)
   })
 
   it("skips preset when codeSystemPrompt is false in normal mode", () => {
@@ -503,7 +512,7 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).systemPrompt).toBe("")
   })
 
-  it("shows preset without append when codeSystemPrompt true but clientSystemPrompt false", () => {
+  it("drops the client prompt from the append when clientSystemPrompt is false", () => {
     const result = buildQueryOptions(makeContext({
       systemContext: "Agent instructions",
       codeSystemPrompt: true,
@@ -512,7 +521,10 @@ describe("buildQueryOptions", () => {
     const sp = (result.options as any).systemPrompt
     expect(sp.type).toBe("preset")
     expect(sp.preset).toBe("claude_code")
-    expect(sp.append).toBeUndefined()
+    // The guard: the client's prompt is suppressed. Meridian's own gitStatus
+    // note is not client content, so it stays.
+    expect(sp.append).not.toContain("Agent instructions")
+    expect(sp.append).toBe(GIT_STATUS_PROVENANCE_NOTE)
   })
 
   it("strips client prompt when clientSystemPrompt is false in passthrough", () => {
@@ -543,7 +555,9 @@ describe("buildQueryOptions", () => {
     }))
     const sp = (result.options as any).systemPrompt
     expect(sp.type).toBe("preset")
-    expect(sp.append).toBe("Agent instructions")
+    expect(sp.append).toStartWith("Agent instructions")
+    // Every preset request also carries the gitStatus provenance note (#694).
+    expect(sp.append).toContain(GIT_STATUS_PROVENANCE_NOTE)
     const opts = result.options as any
     expect(opts.settingSources).toEqual(["user", "project"])
   })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -199,6 +199,43 @@ export function buildCwdNote(sdkCwd: string, clientCwd?: string): string {
   )
 }
 
+/**
+ * Correct the provenance claim on the preset's `gitStatus` block.
+ *
+ * The `claude_code` preset injects a `gitStatus:` section stating verbatim that
+ * it is "the git status at the start of the conversation" and "will not update
+ * during the conversation". In the real Claude Code CLI that holds: one
+ * long-lived process serves the whole conversation, so the snapshot really is
+ * from its start.
+ *
+ * Meridian breaks that invariant. Every turn is a separate HTTP request and a
+ * separate `query()`, so the SDK recomputes the block each time while it keeps
+ * asserting it is the conversation's starting state. Files the model created in
+ * earlier turns therefore reappear as apparently pre-existing work, and the
+ * model concludes it overwrote the user's uncommitted changes — #694, where it
+ * reported destroying two work-in-progress files it had written itself.
+ *
+ * Verified live: a file created by a third party after session start appears in
+ * the block under the "start of the conversation" caveat, on a session whose
+ * lineage is an unbroken continuation chain. This is not a history-loss bug, so
+ * the resume fixes (#705, #719) do not address it.
+ *
+ * Only meaningful alongside the preset — it is the preset that injects the block
+ * being corrected — so it is appended in that branch only.
+ */
+export const GIT_STATUS_PROVENANCE_NOTE =
+  `\n\n<meridian-note>\n` +
+  `You are reached through a proxy that issues a separate request per turn, so ` +
+  `the \`gitStatus\` block in your system prompt is recomputed at the start of ` +
+  `every turn — despite its claim to describe "the start of the conversation". ` +
+  `Read it as the working tree as of this turn and nothing more. It is not ` +
+  `evidence that a file predates the conversation: files you yourself created or ` +
+  `edited in earlier turns appear in it exactly like pre-existing changes. To ` +
+  `judge whether something predates the conversation, rely on the conversation ` +
+  `history and your own prior tool calls, and run \`git status\` when you need ` +
+  `the current tree.\n` +
+  `</meridian-note>`
+
 function resolveSystemPrompt(
   systemContext: string | undefined,
   passthrough: boolean,
@@ -211,13 +248,14 @@ function resolveSystemPrompt(
   const usePreset = codeSystemPrompt ?? (hasSettings || (!passthrough && !!systemContext))
   const includeClient = clientSystemPrompt ?? true
   const clientContext = includeClient ? systemContext : undefined
-  const append = [clientContext, cwdNote].filter(Boolean).join("") || undefined
 
   if (usePreset) {
-    return append
-      ? { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append } }
-      : { systemPrompt: { type: "preset" as const, preset: "claude_code" as const } }
+    // Always non-empty: the gitStatus correction applies to every preset
+    // request, whether or not the client sent a system prompt.
+    const append = [clientContext, cwdNote, GIT_STATUS_PROVENANCE_NOTE].filter(Boolean).join("")
+    return { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append } }
   }
+  const append = [clientContext, cwdNote].filter(Boolean).join("") || undefined
   if (append) return { systemPrompt: append }
   // Defensive: when `codeSystemPrompt: false` is explicit and there's
   // nothing to append, force an empty-string system prompt so the SDK


### PR DESCRIPTION
Fixes #694.

## The bug

The `claude_code` system-prompt preset injects a `gitStatus:` section that states, verbatim:

> This is the git status at the start of the conversation. Note that this status is a snapshot in time, and will not update during the conversation.

That is true in the real Claude Code CLI: one long-lived process serves the whole conversation, so the snapshot really is from its start.

Meridian breaks the invariant. Every turn is a separate HTTP request and a separate `query()`, so the SDK recomputes the block each turn while it keeps asserting it is the conversation's starting state. Files the model created in earlier turns reappear in it, indistinguishable from the user's own uncommitted work.

The model then reasons correctly from false premises and concludes it clobbered work in progress. In #694 it told the user it had "destroyed two untracked work-in-progress files" — files it had written itself, minutes earlier, in the same session.

## Root cause proven, not inferred

The reporter used OpenCode + Opus 5. Reproduced against a scratch repo with a clean tree:

1. Turn 1 — the model created `widget.ts`.
2. `intruder.ts` was then created **by the harness**, mid-session. The model never touched it and it appeared in neither of the model's own `git status` runs.
3. Turn 2 — the model was asked to quote the block, no tool use.

It quoted:

```
gitStatus: This is the git status at the start of the conversation...
Status:
?? intruder.ts
?? widget.ts
```

A file created *after* session start, listed as the starting state. That is conclusive.

Two things this rules out:

- **Not a lineage or history-loss bug.** The session was an unbroken continuation chain — `lineage=continuation`, `msgCount` 1→3→5→7, zero divergences. #705 and #719 do not touch this. My earlier comment on #694 attributing it to #705 was wrong.
- **It also explains the two facts that story could not.** Why only through Meridian — OpenRouter injects no Claude Code system prompt, so there is no such block — and why Opus 4.x did it too.

## The fix

A note appended to the preset, correcting the provenance claim: the block is per-turn, is not evidence that a file predates the conversation, and the conversation history plus the model's own tool calls are what to trust.

This follows the `buildCwdNote` precedent already in `query.ts` — same class of problem (SDK-injected context that is false under a proxy), same `<meridian-note>` idiom.

Preset branch only. Without the preset there is no `gitStatus` block, so the note would be describing context the model cannot see. It is not gated on resume: a fresh SDK session created mid-conversation (a replay after divergence) gets an equally false block, and that is the likelier shape of the original report.

### Why not `excludeDynamicSections: true`

The SDK offers it, and it is the wrong tool. It only *relocates* git status into the first user message — the false "start of the conversation" framing survives, and on resume the block reads as though the user had said it. Worse, not better.

## Verified live

Same repro on the fix, asking the provenance question that produced the false accusation:

> I created it. It was not pre-existing work. [...] the `gitStatus` block in my system prompt is labeled "git status at the start of the conversation" and it *already* listed `?? widget.ts` on my very first turn — before the file existed, as my `ls` on that same turn proved. That block is recomputed each turn by the harness, so it is not evidence about what predated the session, and here it was actively misleading. If you're using it to distinguish pre-existing work from mine, don't; my own tool history is the reliable record.

Correct attribution, and it now warns the user off the block instead of being misled by it. It also independently confirmed the mechanism: the block listed `widget.ts` on turn 1 *before the file existed*, because the second SDK query of that turn recomputed it post-write.

## Testing

`npm test`: 2345 pass, 0 fail. `npx tsc --noEmit` clean. `npm run build` succeeds.

New coverage in `query-git-status-note.test.ts`: the note names the specific false claim it corrects, denies provenance, points at what to trust instead; and the wiring — present with and without a client system prompt, client prompt still leads the append, the cwd `<env>` override still comes first, present on passthrough and on resume, absent when the preset is off.

Verified load-bearing rather than assumed. Removing only the *wiring* while leaving the constant exported fails exactly the 6 placement tests and none of the 4 content tests:

```
(fail) appends the note when the preset is used with no client system prompt
(fail) appends the note when the client also sent a system prompt
(fail) keeps the client's system prompt first so the note reads as an addendum
(fail) keeps the note after the cwd override, which must stay the first env block
(fail) applies to passthrough requests, where the bug was reported
(fail) applies on resume, not just on fresh sessions
```

## Updated tests

Seven existing assertions pinned the preset's exact `append`, which now carries this note. Each was updated to keep its original guard rather than loosened:

- The four that asserted `append === "<client context>"` now assert it *starts with* the client context and contains the note — preserving "client context goes in the append, not the prompt" and additionally pinning ordering.
- The two that asserted `append === undefined` now assert it equals the note alone. For the `clientSystemPrompt: false` case the real guard is explicit: `not.toContain("Agent instructions")`, since suppressing the *client's* prompt is what that test exists for. Meridian's own note is not client content.
