### PR TITLE
fix(routing): normalize SDK reset timestamps to epoch milliseconds

### DIFF
--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -273,6 +273,33 @@ describe("priority cooldown resolution", () => {
     expect(marks.map(m => m.until)).toEqual([WORK_RESET])
   }, 20_000)
 
+  it("adopts a SECONDS-valued reset from the SDK, which tier 1 could never match before (#708)", async () => {
+    // The SDK reports resetsAt in epoch seconds. Every fixture above uses
+    // milliseconds, which is why the suite never caught it: unconverted, the
+    // tier-1 gate `(e.resetsAt ?? 0) > now` compares ~1.8e9 against ~1.8e12 and
+    // is ALWAYS false, so a genuinely exhausted profile silently fell through to
+    // the 10-minute default. Recording in the SDK's real unit here is the point
+    // of the test — do not "fix" this to milliseconds.
+    const resetMs = Date.now() + 3 * 60 * 60_000
+    const resetSeconds = Math.floor(resetMs / 1000)
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: resetSeconds,
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).toEqual(["work"])
+    // The profile's own reset, not the 10-minute default.
+    expect(marks[0]!.until).toBe(resetSeconds * 1000)
+    expect(marks[0]!.until).toBeGreaterThan(before + 10 * 60_000)
+  }, 20_000)
+
   it("falls back to the 10-minute default when the profile has no entry of its own", async () => {
     rateLimitStore.record("personal", {
       status: "allowed",

--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -163,6 +163,30 @@ describe("GET /v1/usage/quota", () => {
     expect(bucket.isUsingOverage).toBe(false)
   })
 
+  it("exposes SDK reset times in epoch milliseconds, per the documented contract (#708)", async () => {
+    // The SDK reports these in epoch SECONDS. Consumers of this endpoint (the
+    // telemetry "resets in ..." badge, Pylon's quota display) treat the field as
+    // milliseconds, so an unconverted value renders a 1970 date. This only
+    // surfaced in production where OAuth usage is unavailable for a profile,
+    // because otherwise the OAuth value wins the merge and masks it.
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const resetSeconds = 1_785_234_600
+    rateLimitStore.record("default", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      resetsAt: resetSeconds,
+      overageResetsAt: resetSeconds + 600,
+    } as any)
+
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota"))
+    const body = await res.json() as QuotaResponse
+    const bucket = body.buckets[0]!
+    expect(bucket.resetsAt).toBe(resetSeconds * 1000)
+    expect(bucket.overageResetsAt).toBe((resetSeconds + 600) * 1000)
+    // Sanity: a millisecond timestamp is 13 digits and lands in this century.
+    expect(new Date(bucket.resetsAt!).getUTCFullYear()).toBeGreaterThan(2020)
+  })
+
   it("merges OAuth-sourced buckets onto SDK buckets, OAuth wins for utilization/resetsAt", async () => {
     // Override only for this test — afterEach clears it.
     __setFetchOAuthUsageOverride(async () => ({

--- a/src/__tests__/rate-limit-store-units.test.ts
+++ b/src/__tests__/rate-limit-store-units.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit normalization for SDK reset timestamps (#708).
+ *
+ * The SDK reports `resetsAt` / `overageResetsAt` in epoch SECONDS; every
+ * consumer downstream treats them as epoch milliseconds. Proven live: the same
+ * `five_hour` reset arrived as `1785234600292` from OAuth and `1785234600` from
+ * the SDK. Left unconverted, `resetsAt > Date.now()` is always false, so tier 1
+ * of the priority cooldown chain can never match, and `/v1/usage/quota` hands
+ * consumers a 1970-era date.
+ *
+ * Every pre-existing fixture in the suite used millisecond values, which is why
+ * none of them caught this.
+ */
+import { describe, it, expect, beforeEach } from "bun:test"
+import { rateLimitStore, toEpochMs } from "../proxy/rateLimitStore"
+
+/** A plausible "now" in each unit, from the live observation in #708. */
+const RESET_SECONDS = 1785234600
+const RESET_MS = 1785234600000
+
+describe("toEpochMs", () => {
+  it("scales a seconds-valued timestamp to milliseconds", () => {
+    expect(toEpochMs(RESET_SECONDS)).toBe(RESET_MS)
+  })
+
+  it("leaves an already-millisecond timestamp untouched", () => {
+    // The SDK type documents no unit, so the conversion must be idempotent
+    // against a future SDK that switches to milliseconds.
+    expect(toEpochMs(RESET_MS)).toBe(RESET_MS)
+  })
+
+  it("is idempotent — converting twice does not double-scale", () => {
+    expect(toEpochMs(toEpochMs(RESET_SECONDS))).toBe(RESET_MS)
+  })
+
+  it("returns undefined for absent values", () => {
+    expect(toEpochMs(undefined)).toBeUndefined()
+  })
+
+  it("returns undefined for values that cannot be a timestamp", () => {
+    expect(toEpochMs(0)).toBeUndefined()
+    expect(toEpochMs(-1)).toBeUndefined()
+    expect(toEpochMs(NaN)).toBeUndefined()
+    expect(toEpochMs(Infinity)).toBeUndefined()
+  })
+
+  it("keeps the two unit ranges unambiguous at the boundary", () => {
+    // Below the threshold is read as seconds, at or above as milliseconds.
+    // Both branches must land in a sane calendar range rather than 1970.
+    expect(toEpochMs(1e11)).toBe(1e11)
+    expect(toEpochMs(1e11 - 1)).toBe(Math.round((1e11 - 1) * 1000))
+  })
+})
+
+describe("rateLimitStore.record — unit normalization", () => {
+  beforeEach(() => {
+    rateLimitStore.clear()
+  })
+
+  it("stores a seconds-valued resetsAt as milliseconds", () => {
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      resetsAt: RESET_SECONDS,
+    } as any)
+
+    expect(rateLimitStore.get("work", "five_hour")?.resetsAt).toBe(RESET_MS)
+  })
+
+  it("normalizes overageResetsAt from the same payload", () => {
+    // Same source, same units, and exposed by the same endpoint — missing it
+    // would leave half the contract broken.
+    rateLimitStore.record("work", {
+      status: "allowed",
+      rateLimitType: "overage",
+      overageResetsAt: RESET_SECONDS,
+    } as any)
+
+    expect(rateLimitStore.get("work", "overage")?.overageResetsAt).toBe(RESET_MS)
+  })
+
+  it("makes a live reset comparable against Date.now()", () => {
+    // The actual defect: this comparison gates tier 1 of the cooldown chain.
+    const futureSeconds = Math.floor(Date.now() / 1000) + 3600
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      resetsAt: futureSeconds,
+    } as any)
+
+    const entry = rateLimitStore.get("work", "five_hour")!
+    expect(entry.resetsAt!).toBeGreaterThan(Date.now())
+  })
+
+  it("leaves millisecond input unchanged, so existing fixtures stay valid", () => {
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      resetsAt: RESET_MS,
+    } as any)
+
+    expect(rateLimitStore.get("work", "five_hour")?.resetsAt).toBe(RESET_MS)
+  })
+
+  it("records an absent resetsAt as undefined rather than 0", () => {
+    // A 0 would read as a valid past timestamp to `(e.resetsAt ?? 0) > now`
+    // consumers and to the quota endpoint's `?? null`.
+    rateLimitStore.record("work", {
+      status: "allowed",
+      rateLimitType: "seven_day",
+      utilization: 0.4,
+    } as any)
+
+    const entry = rateLimitStore.get("work", "seven_day")!
+    expect(entry.resetsAt).toBeUndefined()
+    expect(entry.utilization).toBe(0.4)
+  })
+
+  it("preserves the other fields it does not own", () => {
+    rateLimitStore.record("work", {
+      status: "allowed_warning",
+      rateLimitType: "five_hour",
+      resetsAt: RESET_SECONDS,
+      utilization: 0.91,
+      isUsingOverage: true,
+    } as any)
+
+    const entry = rateLimitStore.get("work", "five_hour")! as any
+    expect(entry.status).toBe("allowed_warning")
+    expect(entry.utilization).toBe(0.91)
+    expect(entry.isUsingOverage).toBe(true)
+  })
+
+  it("normalizes per profile without cross-contamination", () => {
+    rateLimitStore.record("work", {
+      status: "rejected", rateLimitType: "five_hour", resetsAt: RESET_SECONDS,
+    } as any)
+    rateLimitStore.record("personal", {
+      status: "allowed", rateLimitType: "five_hour", resetsAt: RESET_SECONDS + 600,
+    } as any)
+
+    expect(rateLimitStore.get("work", "five_hour")?.resetsAt).toBe(RESET_MS)
+    expect(rateLimitStore.get("personal", "five_hour")?.resetsAt).toBe(RESET_MS + 600_000)
+  })
+})

--- a/src/__tests__/rate-limit-store.test.ts
+++ b/src/__tests__/rate-limit-store.test.ts
@@ -112,10 +112,14 @@ describe("rateLimitStore", () => {
 
   it("keeps the same bucket type separate per profile", () => {
     const store = new _RateLimitStoreForTests()
-    store.record(WORK, { ...FIVE_HOUR, resetsAt: 1_000 })
-    store.record(PERSONAL, { ...FIVE_HOUR, resetsAt: 9_999 })
-    expect(store.get(WORK, "five_hour")?.resetsAt).toBe(1_000)
-    expect(store.get(PERSONAL, "five_hour")?.resetsAt).toBe(9_999)
+    // Realistic millisecond timestamps. These were once toy values (1_000 /
+    // 9_999), which `toEpochMs` correctly reads as epoch SECONDS and scales
+    // (#708) — the two distinct values are all this test needs, so use ones
+    // that are actually timestamps.
+    store.record(WORK, { ...FIVE_HOUR, resetsAt: 1_730_000_000_000 })
+    store.record(PERSONAL, { ...FIVE_HOUR, resetsAt: 1_730_500_000_000 })
+    expect(store.get(WORK, "five_hour")?.resetsAt).toBe(1_730_000_000_000)
+    expect(store.get(PERSONAL, "five_hour")?.resetsAt).toBe(1_730_500_000_000)
     expect(store.size(WORK)).toBe(1)
     expect(store.size(PERSONAL)).toBe(1)
     expect(store.size()).toBe(2)

--- a/src/proxy/rateLimitStore.ts
+++ b/src/proxy/rateLimitStore.ts
@@ -9,7 +9,7 @@
  *     type: "rate_limit_event",
  *     rate_limit_info: {
  *       status: "allowed" | "allowed_warning" | "rejected",
- *       resetsAt?: number,                              // epoch ms
+ *       resetsAt?: number,                              // epoch SECONDS — see toEpochMs
  *       rateLimitType?: "five_hour" | "seven_day"
  *                     | "seven_day_opus" | "seven_day_sonnet"
  *                     | "overage",
@@ -41,6 +41,36 @@
 
 import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk"
 
+/**
+ * Boundary above which a timestamp is already milliseconds.
+ *
+ * As epoch milliseconds this is 1973-03-03; as epoch seconds it is the year
+ * 5138. Every real reset time arrives either as ~1.8e9 (seconds, today) or
+ * ~1.8e12 (milliseconds, today), so the two ranges cannot collide for any date
+ * this proxy will ever see.
+ */
+const MIN_EPOCH_MS = 1e11
+
+/**
+ * Normalize an SDK reset timestamp to epoch milliseconds.
+ *
+ * The SDK reports these in epoch SECONDS while everything downstream —
+ * `Date.now()` comparisons in the priority-cooldown chain, the documented
+ * `/v1/usage/quota` contract, and consumers like the telemetry badge and Pylon
+ * — is epoch milliseconds. Proven by observing one profile's `five_hour` reset
+ * from both sources minutes apart: OAuth reported `1785234600292` and the SDK
+ * reported `1785234600` for the same instant (#708).
+ *
+ * Detects the unit rather than multiplying unconditionally, because
+ * `SDKRateLimitInfo.resetsAt` is typed `number` with no documented unit. An
+ * unconditional `* 1000` would silently corrupt every value if the SDK ever
+ * switched to milliseconds; this stays correct under either.
+ */
+export function toEpochMs(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined
+  return value < MIN_EPOCH_MS ? Math.round(value * 1000) : value
+}
+
 export interface RateLimitEntry extends SDKRateLimitInfo {
   /** When this entry was captured (epoch ms). */
   observedAt: number
@@ -70,7 +100,14 @@ class RateLimitStore {
       buckets = new Map<RateLimitBucketKey, RateLimitEntry>()
       this.byProfile.set(profileId, buckets)
     }
-    buckets.set(key, { ...info, observedAt })
+    // Normalize units here, at the single boundary where SDK data enters, so no
+    // consumer has to remember that the SDK speaks seconds (#708).
+    buckets.set(key, {
+      ...info,
+      resetsAt: toEpochMs(info.resetsAt),
+      overageResetsAt: toEpochMs(info.overageResetsAt),
+      observedAt,
+    })
   }
 
   /** Snapshot one profile's entries, newest-first by observedAt. */


### PR DESCRIPTION
Fixes #708.

## The bug

The SDK reports `SDKRateLimitInfo.resetsAt` and `overageResetsAt` in epoch **seconds**. Meridian stored them verbatim and then compared and exposed them as epoch **milliseconds**.

Proven rather than inferred from digit count: the same profile's `five_hour` reset was observed from both sources minutes apart.

| Source | Value |
|---|---|
| OAuth (`fetchOAuthUsage` → `parseIsoToMs`) | `1785234600292` |
| SDK (`rate_limit_event` → `rateLimitStore`) | `1785234600` |

`1785234600292 / 1000 = 1785234600.292` — the same instant, truncated to seconds by the SDK path. `fetchOAuthUsage` converts; the SDK path never did.

## Consequence 1 — tier 1 of the priority cooldown was dead code

```ts
.find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now
  && (e.status === "rejected" || (e.utilization ?? 0) >= 1))
```

`now` is `Date.now()` (~1.8e12); `e.resetsAt` was seconds (~1.8e9). The comparison is **always false**, so the `.find` never matched and a genuinely exhausted profile fell through to the 10-minute default or the OAuth tier. The exhaustion gating added in #697 has never once fired in production.

Pre-existing — the comparison predates #697 — and safe only by accident. The guard rejected the value; without it, `until` would have been a 1970 timestamp and the exhaustion mark would have expired instantly.

## Consequence 2 — the quota endpoint leaked the raw value

`GET /v1/usage/quota` passed `entry.resetsAt` straight through, so any consumer following the documented millisecond contract — the telemetry "resets in …" badge, Pylon's quota display — rendered a nonsense date for SDK-sourced buckets. Only visible where OAuth usage is unavailable for a profile, since otherwise the OAuth value wins the merge and masks it.

## The fix

Normalize in `RateLimitStore.record` — the single boundary where SDK data enters — so no consumer has to remember the unit. Covers `overageResetsAt` too: same payload, same units, same endpoint.

**Detects the unit rather than multiplying unconditionally.** `resetsAt` is typed `number` with no documented unit in `sdk.d.ts`, so an unconditional `* 1000` would silently corrupt every value if the SDK ever switched to milliseconds. The threshold is `1e11` — as milliseconds that is 1973, as seconds the year 5138, so the two ranges cannot collide for any date this proxy will see. The conversion is idempotent, which the tests pin.

Absent values normalize to `undefined`, not `0`: a `0` would read as a valid past timestamp to both `(e.resetsAt ?? 0) > now` and the endpoint's `?? null`.

## What this does NOT establish

Tier 1 is now *mechanically* reachable, but I have not proven it fires end to end. That needs a genuinely rate-limited account emitting `status: "rejected"` with a future reset, and I can't manufacture a real 429 on demand.

Worth correcting my own follow-up comment on #708 while I'm here: it claimed the unit fix alone would not revive tier 1 because `utilization` was null. That observation came from a **healthy** bucket, which *should* fail the gate — under-suppressing is the safe direction, and the gate exists to avoid benching a healthy profile. So that comment overstated the problem. The open question is narrower: whether a truly exhausted bucket carries the fields the gate needs.

## Testing

`npm test`: 2360 pass, 0 fail. `npx tsc --noEmit` clean.

New `rate-limit-store-units.test.ts` covers the helper (seconds scaled, milliseconds untouched, idempotent, non-timestamps rejected, both sides of the threshold) and `record` (both fields normalized, per-profile isolation, other fields preserved, absent → `undefined`).

Plus the two consequences, each at the layer where the bug actually bit:

- **Priority routing** — a `rejected` five_hour entry recorded in the SDK's real unit must produce a cooldown from its own reset, not the default. Verified load-bearing: with the normalization removed it fails with `Expected: 1785378974000, Received: 1785368777221` — and that received value is `now + 10min`, the default it silently fell through to. Exactly the production signature.
- **`/v1/usage/quota`** — asserts the response is milliseconds and lands in this century.

## One existing test changed

`rate-limit-store.test.ts` used toy values `1_000` / `9_999` as `resetsAt`, which `toEpochMs` correctly reads as seconds and scales. That test is about per-profile isolation, not units, and only needs two *distinct* values — so it now uses realistic millisecond timestamps like every other fixture in the file. Its assertions are otherwise unchanged.
