### PR TITLE
fix(routing): skip OAuth usage refinement for non-claude-max profiles

### DIFF
--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -359,6 +359,58 @@ describe("priority cooldown resolution", () => {
     expect(marks.map(m => m.until)).toEqual([WORK_RESET])
   }, 20_000)
 
+  it("does not attempt an OAuth usage fetch for a non-claude-max profile (#699)", async () => {
+    // `api` profiles authenticate with a key and `oauth-token` profiles keep
+    // their token in env with no on-disk credentials, so the fetch can only
+    // fail — and `force: true` means the 30s cache won't suppress the repeat,
+    // so each exhaustion event pays for a credential read (a
+    // `/usr/bin/security` subprocess on macOS) to learn nothing.
+    const attempted: Array<string | null | undefined> = []
+    __setFetchOAuthUsageOverride(async (opts) => {
+      attempted.push(opts?.profileId)
+      return null
+    })
+    // The shared beforeEach pins the order to "work,personal"; this app has no
+    // "work", so without overriding it the keyed profile is never tried.
+    process.env.MERIDIAN_PROFILE_ORDER = "keyed,personal"
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [
+        { id: "keyed", type: "api", apiKey: "sk-test" },
+        { id: "personal", claudeConfigDir: "/tmp/meridian-test-prof-personal" },
+      ],
+      defaultProfile: "keyed",
+    })
+    // The api profile has no CLAUDE_CONFIG_DIR, so the SDK mock sees "default".
+    failingDirs.add("default")
+    await post(app)
+    await Bun.sleep(20)
+
+    expect(attempted).toEqual([])
+    // The profile is still benched — the guard skips refinement, not the mark.
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).toEqual(["keyed"])
+  }, 20_000)
+
+  it("still refines a claude-max profile, proving the guard is type-scoped and not a blanket skip", async () => {
+    // Control for the test above: without this, deleting the OAuth call
+    // entirely would satisfy the guard test and look correct.
+    const attempted: Array<string | null | undefined> = []
+    __setFetchOAuthUsageOverride(async (opts) => {
+      attempted.push(opts?.profileId)
+      if (opts?.profileId !== "work") return null
+      return { windows: [{ type: "five_hour", utilization: 1, resetsAt: WORK_RESET }], extraUsage: null, fetchedAt: Date.now() }
+    })
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+    await Bun.sleep(20)
+
+    expect(attempted).toEqual(["work"])
+    expect((await exhaustedMarks(app)).map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
   it("never shortens an existing mark with an earlier OAuth reset", async () => {
     rateLimitStore.record("work", {
       status: "rejected",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -532,6 +532,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
    *  leave standing. */
   function refinePriorityCooldown(profileId: string): void {
     const target = getEffectiveProfiles(finalConfig.profiles).find(p => p.id === profileId)
+    // Only `claude-max` profiles have credentials this can consult. `api`
+    // profiles authenticate with a key and have no usage endpoint; `oauth-token`
+    // profiles carry their token in `CLAUDE_CODE_OAUTH_TOKEN` with a config dir
+    // that deliberately holds no on-disk credentials, so the store read finds
+    // nothing there either. `force: true` also means the 30s cache can't
+    // suppress the repeat, so every exhaustion event would pay for a credential
+    // read (a `/usr/bin/security` subprocess on macOS) to learn nothing.
+    // Mirrors the `not_oauth` guard in `/v1/usage/quota/all` and
+    // `credentialStoreForProfile`. Tier 3's conservative default already stands
+    // when this returns early (#699).
+    if ((target?.type ?? "claude-max") !== "claude-max") return
     void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir, force: true })
       .then(usage => {
         if (!usage || usage.stale) return


### PR DESCRIPTION
Fixes #699.

## The bug

`refinePriorityCooldown` (tier 2 of the priority cooldown chain, added in #697) called `fetchOAuthUsage` for any profile that hit a rate limit, with no check on the profile's type.

Only `claude-max` profiles have credentials this can consult:

- **`api`** — authenticates with a key; there is no usage endpoint to ask.
- **`oauth-token`** — carries its token in `CLAUDE_CODE_OAUTH_TOKEN` with a config dir that *deliberately* holds no on-disk credentials, so the credential-store read finds nothing there either. (Worth stating explicitly, since "oauth" in the name suggests otherwise.)

## Impact

Low, and never incorrect. The fetch fails gracefully and returns `null`, so the cooldown falls back to the conservative tier-3 default and nothing is mis-marked.

The cost is waste and inconsistency: `force: true` is passed deliberately (the 30s cache is routinely warmed by telemetry polling and would otherwise starve the refinement), so this path gets no cache suppression on repeat failures. Every exhaustion event on such a profile paid for a credential read — a `/usr/bin/security find-generic-password` subprocess on macOS — to learn nothing. And it diverged from the `not_oauth` guard used one screen away in `/v1/usage/quota/all`, plus `credentialStoreForProfile`.

## The fix

An early return mirroring those guards. The profile's `type` is already on the object the function looks up, so the check is free.

## Testing

`npm test`: 2362 pass, 0 fail. `npx tsc --noEmit` clean.

Two tests, deliberately paired:

- **The guard** — an `api` profile at the head of the priority order fails, and no OAuth fetch is attempted. Also asserts the profile is still benched, since the guard must skip the *refinement*, not the mark.
- **A control** — a `claude-max` profile still refines with the authoritative reset. Without this, deleting the OAuth call entirely would satisfy the guard test and look correct.

Verified load-bearing: removing the guard fails the first test while the control keeps passing.

One wrinkle worth recording for whoever adds the next test here: the shared `beforeEach` pins `MERIDIAN_PROFILE_ORDER=work,personal`, so an app configured with different profile ids silently never routes to them. The new test overrides the order and says why.
