### PR TITLE
fix(errors): target the extended-context hint at the tier that failed

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, isStaleSessionError, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination } from "../proxy/errors"
+import { classifyError, extendedContextHint, isStaleSessionError, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -56,6 +56,68 @@ describe("classifyError", () => {
       const result = classifyError("Claude Code process exited with code 1\nSubprocess stderr: OAuth token expired")
       expect(result.status).toBe(401)
       expect(result.type).toBe("authentication_error")
+    })
+  })
+
+  describe("extended-context remediation hint (#716)", () => {
+    // A 1M-context rate limit used to advise MERIDIAN_SONNET_MODEL=sonnet
+    // unconditionally. That is a no-op for Sonnet (already 200k by default) and
+    // names the wrong variable for the two tiers that actually default to 1M.
+    const RATE_LIMITED_1M = "429 rate limit reached for 1m context"
+
+    it("names the Fable variable for a fable[1m] request", () => {
+      const r = classifyError(RATE_LIMITED_1M, "fable[1m]")
+      expect(r.message).toContain("MERIDIAN_FABLE_MODEL=fable")
+      expect(r.message).not.toContain("SONNET")
+    })
+
+    it("names the Opus variable for an opus[1m] request", () => {
+      const r = classifyError(RATE_LIMITED_1M, "opus[1m]")
+      expect(r.message).toContain("MERIDIAN_OPUS_MODEL=opus")
+      expect(r.message).not.toContain("SONNET")
+    })
+
+    it("names the Sonnet variable only when the user opted in to sonnet[1m]", () => {
+      const r = classifyError(RATE_LIMITED_1M, "sonnet[1m]")
+      expect(r.message).toContain("MERIDIAN_SONNET_MODEL=sonnet")
+    })
+
+    it("stays silent for a 200k request, where the old advice was a no-op", () => {
+      // This is the reported bug: Sonnet is 200k by default, so telling the
+      // user to set MERIDIAN_SONNET_MODEL=sonnet changes nothing. They set it,
+      // see no difference, and conclude the proxy is broken.
+      const r = classifyError(RATE_LIMITED_1M, "sonnet")
+      expect(r.type).toBe("rate_limit_error")
+      expect(r.message).not.toContain("MERIDIAN")
+    })
+
+    it("treats mythos as the fable tier", () => {
+      expect(extendedContextHint("mythos[1m]")).toContain("MERIDIAN_FABLE_MODEL=fable")
+    })
+
+    it("falls back to the global switch when no model resolved", () => {
+      // The outer error handler can fire before `model` is assigned. The global
+      // switch is correct for every tier, so it is the safe thing to advise.
+      const r = classifyError(RATE_LIMITED_1M)
+      expect(r.message).toContain("MERIDIAN_1M_CONTEXT_SUPPORT=0")
+    })
+
+    it("falls back to the global switch for an unrecognized 1M tier", () => {
+      expect(extendedContextHint("someothermodel[1m]")).toContain("MERIDIAN_1M_CONTEXT_SUPPORT=0")
+    })
+
+    it("adds no hint when the error is unrelated to context", () => {
+      const r = classifyError("429 too many requests", "opus[1m]")
+      expect(r.type).toBe("rate_limit_error")
+      expect(r.message).not.toContain("MERIDIAN")
+    })
+
+    it("still classifies as a rate limit regardless of the hint", () => {
+      for (const m of [undefined, "sonnet", "opus[1m]", "fable[1m]"]) {
+        const r = classifyError(RATE_LIMITED_1M, m)
+        expect(r.status).toBe(429)
+        expect(r.type).toBe("rate_limit_error")
+      }
     })
   })
 

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -10,9 +10,46 @@ export interface ClassifiedError {
 }
 
 /**
- * Detect specific SDK errors and return helpful messages to the client.
+ * Remediation advice for a rate limit hit on an extended-context request.
+ *
+ * `model` is the resolved variant (`opus[1m]`, `fable`, `sonnet`, …). The advice
+ * has to name the tier that actually failed: the three per-tier variables have
+ * opposite polarity, because Sonnet 1M costs Extra Usage on every plan while
+ * Fable and Opus 1M are included on Max/Team (#717). So Sonnet opts *in* to 1M
+ * and the other two opt *out* of it.
+ *
+ * Returns "" rather than guessing when there is nothing useful to say:
+ *
+ *  - The request did not use extended context. Suggesting a 1M variable is
+ *    irrelevant, and for Sonnet — which is 200k by default — the old advice
+ *    was a literal no-op: the user set the variable to the value it already
+ *    had, saw no change, and reasonably concluded Meridian was broken (#716).
+ *  - The tier is unrecognized, where the global switch is the only safe advice.
  */
-export function classifyError(errMsg: string): ClassifiedError {
+export function extendedContextHint(model?: string): string {
+  const advise = (v: string) =>
+    ` If you're frequently hitting this, set ${v} to use the 200k model instead.`
+
+  // No model resolved — the outer catch can fire before `model` is assigned.
+  // The global switch is correct for every tier, so it's the safe fallback.
+  if (!model) return advise("MERIDIAN_1M_CONTEXT_SUPPORT=0")
+
+  const lower = model.toLowerCase()
+  if (!lower.includes("[1m]")) return ""
+  if (lower.includes("fable") || lower.includes("mythos")) return advise("MERIDIAN_FABLE_MODEL=fable")
+  if (lower.includes("opus")) return advise("MERIDIAN_OPUS_MODEL=opus")
+  if (lower.includes("sonnet")) return advise("MERIDIAN_SONNET_MODEL=sonnet")
+  return advise("MERIDIAN_1M_CONTEXT_SUPPORT=0")
+}
+
+/**
+ * Detect specific SDK errors and return helpful messages to the client.
+ *
+ * `model` is the resolved variant for this request, used only to target the
+ * extended-context remediation hint. Optional because the outer error handler
+ * may not have assigned it yet when a request fails early.
+ */
+export function classifyError(errMsg: string, model?: string): ClassifiedError {
   const lower = errMsg.toLowerCase()
 
   // Expired OAuth token (more specific than the generic auth check below)
@@ -41,7 +78,7 @@ export function classifyError(errMsg: string): ClassifiedError {
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
     || lower.includes("hit your session limit") || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
-      ? " If you're frequently hitting this, set MERIDIAN_SONNET_MODEL=sonnet to use the 200k model instead."
+      ? extendedContextHint(model)
       : ""
     return {
       status: 429,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3239,7 +3239,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     type: "upstream_timeout",
                     message: `Upstream stalled: no data for ${error.sinceLastMs}ms`,
                   }
-                : classifyError(errMsg)
+                : classifyError(errMsg, model)
               claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })
 
               // Surface the SDK termination reason (max_turns / process_exit / aborted)


### PR DESCRIPTION
Fixes #716.

## The bug

Rate-limit errors mentioning `1m` or `context` appended a fixed remediation hint:

```ts
" If you're frequently hitting this, set MERIDIAN_SONNET_MODEL=sonnet to use the 200k model instead."
```

That advice is wrong twice over:

- **A no-op for Sonnet.** Sonnet already defaults to `sonnet` (200k) — `sonnet[1m]` requires an explicit opt-in via that same variable. A user following the hint set the variable to the value it already effectively had, saw no change, and reasonably concluded Meridian was broken.
- **The wrong variable for the two tiers that actually default to 1M.** Fable and Opus are the ones that request the extended window. A user hitting an extended-context rate limit on either was told to configure Sonnet, which has nothing to do with their request.

The hint predates `MERIDIAN_FABLE_MODEL` and `MERIDIAN_OPUS_MODEL`, which #714 added for exactly this purpose.

## The fix

`classifyError` now takes the resolved model and names the variable that matches the tier that failed. The polarity differs per tier — Sonnet opts *in* to 1M, Fable and Opus opt *out* — because Sonnet 1M is billed as Extra Usage on every plan while Fable and Opus 1M are included on Max/Team. That asymmetry is #717; here it just means the hint has to know which tier it's talking about.

Two cases deliberately produce **no** hint rather than a guess:

- **The request didn't use extended context** (`sonnet` rather than `sonnet[1m]`). This is the reported no-op, and it's now silent instead of misleading.
- **The error is unrelated to context** — unchanged behavior.

And one falls back to the global switch, which is correct for every tier:

- **No model resolved.** The outer error handler documents that `model` may be unassigned if a request fails early, so that call site deliberately passes nothing and gets `MERIDIAN_1M_CONTEXT_SUPPORT=0`. Same for an unrecognized tier.

## Testing

`npm test`: 2369 pass, 0 fail. `npx tsc --noEmit` clean.

Ten cases: a variable per tier, Mythos routed to the Fable tier, silence for a 200k request and for a non-context error, both global-switch fallbacks, and that the classification stays `rate_limit_error` / 429 across every model value.

Verified load-bearing — restoring the old hardcoded string fails exactly four of them, including the two that describe the reported bug:

```
(fail) names the Fable variable for a fable[1m] request
(fail) names the Opus variable for an opus[1m] request
(fail) stays silent for a 200k request, where the old advice was a no-op
(fail) falls back to the global switch when no model resolved
```

No test asserted the hint's *content* before — only the error type — which is why the staleness went unnoticed.

## Docs

None needed. `docs/configuration.md` and the README already document all three variables and their directions accurately; only the runtime hint was stale.
