### PR TITLE
fix(session): ignore thinking blocks in the lineage hash

### DIFF
--- a/src/__tests__/lineage-thinking-blocks.test.ts
+++ b/src/__tests__/lineage-thinking-blocks.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Lineage hash stability across thinking-block serialization (#710).
+ *
+ * The hash answers one question: is this the same conversation prefix? A
+ * thinking block's `signature` is an opaque per-generation blob, and
+ * `redacted_thinking` carries only opaque `data` — neither bears on that
+ * question. Before this fix, thinking blocks fell through `normalizeContent`'s
+ * unknown-block branch and were serialized whole, signature included.
+ *
+ * The expensive failure mode is a client that stops echoing thinking blocks
+ * once a tool loop finishes. That message's hash changes for every subsequent
+ * turn, silently downgrading resume to a full replay and rebuilding the prompt
+ * cache from scratch — the cost documented in #689/#701.
+ *
+ * There was no test covering thinking blocks in the lineage hash at all, which
+ * is why the sensitivity went unnoticed.
+ */
+import { describe, it, expect } from "bun:test"
+import { hashMessage, computeLineageHash } from "../proxy/session/lineage"
+import { normalizeContent } from "../proxy/messages"
+
+/** Shape of a real captured signature — opaque, high-entropy, per-generation. */
+const SIG_A = "ErkCCosBCBAYAipArnuwVmIJYId3EvWd4ITxDyTxhyG1oXG7l8E3OBpQo6JfDB"
+const SIG_B = "ZZkCCosBCBAYAipQxxxxVmIJYId3EvWd4ITxDyTxhyG1oXG7l8E3OBpQo6JfXX"
+
+const TEXT = "I'll check the config file."
+
+/** The same logical assistant turn, serialized four ways by different clients. */
+const withThinking = [
+  { type: "thinking", thinking: "The user wants the config.", signature: SIG_A },
+  { type: "text", text: TEXT },
+]
+const thinkingDropped = [
+  { type: "text", text: TEXT },
+]
+const signatureDropped = [
+  { type: "thinking", thinking: "The user wants the config." },
+  { type: "text", text: TEXT },
+]
+const differentSignature = [
+  { type: "thinking", thinking: "The user wants the config.", signature: SIG_B },
+  { type: "text", text: TEXT },
+]
+const differentThinkingText = [
+  { type: "thinking", thinking: "Completely different reasoning this time.", signature: SIG_A },
+  { type: "text", text: TEXT },
+]
+
+describe("lineage hash — thinking block variants (#710)", () => {
+  it("hashes all four captured variants identically", () => {
+    // These four produced four different hashes before the fix.
+    const hashes = [withThinking, thinkingDropped, signatureDropped, differentSignature]
+      .map(c => hashMessage({ role: "assistant", content: c }))
+    expect(new Set(hashes).size).toBe(1)
+  })
+
+  it("is stable when a client stops echoing thinking after a tool loop", () => {
+    // The headline failure mode. Note this is why the fix drops the block
+    // rather than hashing `thinking:<text>` — the latter still churns here.
+    expect(hashMessage({ role: "assistant", content: withThinking }))
+      .toBe(hashMessage({ role: "assistant", content: thinkingDropped }))
+  })
+
+  it("is stable across a re-generated signature", () => {
+    expect(hashMessage({ role: "assistant", content: withThinking }))
+      .toBe(hashMessage({ role: "assistant", content: differentSignature }))
+  })
+
+  it("ignores the thinking text itself, so re-generated reasoning does not churn", () => {
+    // Deliberate: thinking is model-emitted and accompanies the same text and
+    // tool calls, so it never distinguishes two genuinely different prefixes.
+    expect(hashMessage({ role: "assistant", content: withThinking }))
+      .toBe(hashMessage({ role: "assistant", content: differentThinkingText }))
+  })
+
+  it("ignores redacted_thinking, which carries only opaque data", () => {
+    const redacted = [
+      { type: "redacted_thinking", data: "EroCCkYIARgCKkBxx==" },
+      { type: "text", text: TEXT },
+    ]
+    expect(hashMessage({ role: "assistant", content: redacted }))
+      .toBe(hashMessage({ role: "assistant", content: thinkingDropped }))
+  })
+
+  it("still distinguishes turns that differ in real content", () => {
+    // The guard must not become permissive: text, tool_use and tool_result all
+    // still contribute. Without this, dropping every block would "pass".
+    const otherText = [
+      { type: "thinking", thinking: "The user wants the config.", signature: SIG_A },
+      { type: "text", text: "Actually I'll check something else." },
+    ]
+    expect(hashMessage({ role: "assistant", content: withThinking }))
+      .not.toBe(hashMessage({ role: "assistant", content: otherText }))
+  })
+
+  it("still distinguishes a differing tool_use alongside thinking", () => {
+    const callA = [
+      { type: "thinking", thinking: "reasoning", signature: SIG_A },
+      { type: "tool_use", id: "t1", name: "read", input: { path: "a.ts" } },
+    ]
+    const callB = [
+      { type: "thinking", thinking: "reasoning", signature: SIG_A },
+      { type: "tool_use", id: "t1", name: "read", input: { path: "b.ts" } },
+    ]
+    expect(hashMessage({ role: "assistant", content: callA }))
+      .not.toBe(hashMessage({ role: "assistant", content: callB }))
+  })
+
+  it("keeps role separation — same content under a different role differs", () => {
+    expect(hashMessage({ role: "assistant", content: thinkingDropped }))
+      .not.toBe(hashMessage({ role: "user", content: thinkingDropped }))
+  })
+
+  it("leaves no empty segment behind when a thinking block is removed", () => {
+    // Reducing the block to "" instead of filtering it would leave its join
+    // newline in place, churning the hash exactly as the raw block did.
+    expect(normalizeContent(withThinking)).toBe(TEXT)
+    expect(normalizeContent(withThinking)).not.toStartWith("\n")
+  })
+
+  it("normalizes a thinking-only turn to empty rather than a signature blob", () => {
+    expect(normalizeContent([{ type: "thinking", thinking: "hm", signature: SIG_A }])).toBe("")
+  })
+
+  it("keeps a whole-conversation lineage hash stable across the variants", () => {
+    // hashMessage covers one slot; computeLineageHash is what actually gates
+    // resume, so pin the same property end to end.
+    const prefix = [
+      { role: "user", content: "read the config" },
+    ]
+    const a = computeLineageHash([...prefix, { role: "assistant", content: withThinking }])
+    const b = computeLineageHash([...prefix, { role: "assistant", content: thinkingDropped }])
+    const c = computeLineageHash([...prefix, { role: "assistant", content: differentSignature }])
+    expect(a).toBe(b)
+    expect(a).toBe(c)
+  })
+})

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -15,9 +15,34 @@ function stripCacheControlForHashing(obj: any): any {
 }
 
 /**
+ * Content block types that contribute nothing to the lineage hash.
+ *
+ * Thinking blocks are model-emitted reasoning. Their `signature` is an opaque,
+ * high-entropy, per-generation blob, and `redacted_thinking` carries only
+ * opaque `data` — none of it identifies the conversation prefix, which is the
+ * only question the hash exists to answer.
+ *
+ * They are dropped entirely rather than reduced to their text, because the
+ * failure mode is a client that stops echoing thinking blocks once a tool loop
+ * finishes — a common pattern, since only the active loop strictly needs them.
+ * Hashing `thinking:<text>` would still change that message's hash the moment
+ * the block disappears; contributing nothing is what makes the hash stable
+ * across its presence, absence, and any re-signature (#710).
+ *
+ * Deliberate trade-off: two prefixes differing ONLY in thinking now hash alike.
+ * That is correct — thinking always accompanies the same text and tool calls in
+ * its own turn, and those are still hashed, so it never distinguishes two
+ * genuinely different prefixes on its own.
+ */
+const HASH_IGNORED_BLOCK_TYPES = new Set(["thinking", "redacted_thinking"])
+
+/**
  * Normalize message content to a string for hashing and comparison.
  * Handles both string content and array content (Anthropic content blocks).
  * Strips cache_control metadata to ensure hash stability across requests.
+ *
+ * Used only for lineage hashing — see {@link HASH_IGNORED_BLOCK_TYPES}, which
+ * drops content a display-oriented normalizer would need to keep.
  *
  * NOTE: OpenCode sends content as a string on the first request but as
  * an array on subsequent ones. This normalizer handles both formats.
@@ -26,7 +51,9 @@ function stripCacheControlForHashing(obj: any): any {
 export function normalizeContent(content: any): string {
   if (typeof content === "string") return content
   if (Array.isArray(content)) {
-    return content.map((block: any) => {
+    // Filtered, not mapped to "": an empty segment would still leave its
+    // newline behind and churn the hash exactly as the raw block did.
+    return content.filter((block: any) => !HASH_IGNORED_BLOCK_TYPES.has(block?.type)).map((block: any) => {
       if (block.type === "text" && block.text) return block.text
       if (block.type === "tool_use") return `tool_use:${block.id}:${block.name}:${JSON.stringify(block.input)}`
       if (block.type === "tool_result") {


### PR DESCRIPTION
Fixes #710.

## The bug

`hashMessage` hashes `role:normalizeContent(content)`. `normalizeContent` has explicit cases for `text`, `tool_use` and `tool_result`; a `thinking` block fell through to the unknown-block fallback and was serialized whole — **encrypted `signature` included**.

`cache_control` is deliberately stripped before hashing for exactly this reason. Thinking signatures were not, despite being high-entropy per-generation data with no bearing on the conversation's content.

The hash exists to answer one question: *is this the same conversation prefix?* Four serializations of the same logical assistant turn produced four different answers.

## Why it's expensive

A client that stops echoing thinking blocks once a tool loop finishes — a common pattern, since only the active loop strictly needs them — changed that message's hash on **every subsequent turn**. Resume silently downgrades to a full replay, rebuilding the prompt cache from scratch. That's the cost documented in #689/#701.

## The design decision, made explicitly

The issue offered two levels of fix. `thinking:${block.thinking}` only fixes *signature* churn — it does **not** fix the headline failure mode, because a dropped block still removes its segment from the joined string and changes the hash.

So thinking and `redacted_thinking` now contribute **nothing**. That is what makes the hash stable across the block's presence, absence, and re-signature alike.

Two implementation details that matter:

- **Filtered, not mapped to `""`.** An empty segment would leave its `join("\n")` newline behind and churn the hash exactly as the raw block did.
- **`redacted_thinking` too** — it carries only opaque `data`.

**The trade-off, stated plainly:** two prefixes differing *only* in thinking now hash alike. That is correct. Thinking is model-emitted and always accompanies the same text and tool calls within its own turn, and those are still hashed — so it never distinguishes two genuinely different prefixes on its own. The new tests pin both directions: the churn cases collapse, and differing `text`/`tool_use` still separate.

## Verified end to end, with a control

Unit tests prove the hash property; they cannot prove resume actually survives. The same three-request sequence through the real server — establish a session, send a turn containing a thinking block with a signature, then send the follow-up with the thinking block **dropped**:

| | Turn 3 (thinking dropped) |
|---|---|
| **Without this change** | `lineage=new session=new` — diverged, session discarded, full replay |
| **With this change** | `lineage=continuation session=b9b1d161` — resumed |

The control run is what makes this meaningful: I rebuilt without the fix and reproduced the divergence before concluding the fix was responsible.

Also ran a real three-turn OpenCode session with tool calls (6 continuations on one session, 0 divergences, `msgCount` 1→13, and turn 3 correctly recalled turn 1) to confirm nothing regressed for ordinary traffic. Worth noting for the record: **that run emitted no thinking blocks at all**, so it was a no-regression check, not evidence for this fix — which is exactly why the deterministic sequence above exists.

## One-time cost on deploy

Changing what feeds the hash means every **already-cached** session's stored hashes no longer match what its client will send next. Each active conversation diverges once after the upgrade and replays in full, then resumes normally from there. Self-healing, bounded to one turn per conversation, and unavoidable for any hash change — but real, and worth knowing if it shows up as a burst of `lineage=new` right after the release.

## Testing

`npm test`: 2382 pass, 0 fail. `npx tsc --noEmit` clean. All four lineage suites green, including the `lineage-safety` golden matrix.

New `lineage-thinking-blocks.test.ts` — 11 tests: the four captured variants hash identically, stability across drop / re-signature / re-generated thinking text, `redacted_thinking`, no leftover empty segment, a thinking-only turn normalizing to empty, and the whole-conversation `computeLineageHash` property end to end.

Plus three anti-permissiveness guards, so "hash everything to a constant" cannot pass: differing `text` still separates, differing `tool_use` still separates, and role separation holds.

Verified load-bearing: reverting only the filter fails 8 of 11, and the 3 that keep passing are precisely those guards.

## Scope note

`normalizeContent` is exported on the `AgentAdapter` interface, but its only runtime callers are the two lineage hashing sites in `session/lineage.ts` — `adapter.normalizeContent` is referenced nowhere outside tests. Prompt construction uses `flattenUserContent`/`sanitizeTextContent` and is untouched, so no thinking content is dropped from anything the model sees. Its docstring now says it is the lineage-hash normalizer, since it drops content a display-oriented normalizer would need to keep.
