### PR TITLE
test: guard the SDK boundary that three shipped bugs crossed

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -87,6 +87,7 @@ kill $(lsof -ti :3456)
 | E32 | [Tool-use leak (#416) — opencode + opus-4-7](#e32-tool-use-leak-416--opencode--opus-4-7) | Multi-turn opencode rehydration with prior tool_use blocks does not cause opus-4-7 to emit `[Tool Use:` / `H:` / `Human:` text in its response | 2026-04-26 |
 | E33 | [OpenAI Compat: system prompt, no preset](#e33-openai-compat-system-prompt-no-preset) | `/v1/chat/completions` honours the client's system prompt without injecting the claude_code preset (openai adapter default) | 2026-06-15 |
 | E34 | [Streaming parallel tool calls (#552)](#e34-streaming-parallel-tool-calls-552) | **Automated**: `bun scripts/e2e-stream-parallel.mjs` — real CLI, SSE mode: parallel tool calls stream intact (no dangling `{}` blocks), denies held past generation, fast follow-up resumes. **Run before any release touching the passthrough tool loop** — mocked suites cannot catch CLI dispatch-ordering bugs (two shipped regressions proved it) | 2026-07-15 |
+| E35 | [SDK boundary assumptions (#694/#708/#710)](#e35-sdk-boundary-assumptions-694708710) | **Automated**: `bun scripts/e2e-sdk-boundary.mjs` — real SDK: rate-limit reset units land in a sane window, every live content-block type is classified for hashing, resume survives a client dropping thinking blocks, and reports whether the gitStatus block still misstates its provenance. **Run after any `@anthropic-ai/claude-agent-sdk` bump** and before releases touching lineage, rate limits, or the system prompt | 2026-07-29 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3127,3 +3128,64 @@ the actual client contract.
 **What's being tested:** deny-hold (`holdDenyUntilTurnEnd`), early stop +
 drain, `flushOpenClientBlocks`, `pendingSessionStores` (`server.ts`);
 `passthroughEarlyStop.ts`.
+
+## E35: SDK boundary assumptions (#694/#708/#710)
+
+**Automated** — one command:
+
+```bash
+bun scripts/e2e-sdk-boundary.mjs
+SDK_BOUNDARY_MODEL=claude-sonnet-5 bun scripts/e2e-sdk-boundary.mjs
+```
+
+**Why this exists:** three bugs shipped through this seam in one week, and the
+unit suite was green for all three — because a mocked suite can only assert
+what we already thought to look for.
+
+- **#708** — the SDK reports `resetsAt` in epoch *seconds*. Every fixture used
+  milliseconds, so the mismatch was unobservable and tier 1 of the priority
+  cooldown was dead code for its entire life.
+- **#710** — `thinking` blocks fell into the lineage hash's
+  serialize-everything fallback, folding an encrypted per-generation signature
+  into the hash. There was no thinking-block test at all.
+- **#694** — the `claude_code` preset injects a gitStatus block claiming to be
+  "the git status at the start of the conversation" and recomputes it every
+  turn. A user was told the model had destroyed their work-in-progress files.
+
+Each was found by watching real traffic. This script makes that watching
+repeatable instead of a fresh throwaway probe each time.
+
+**Pass criteria:**
+- every `resetsAt` / `overageResetsAt` lands between now and 8 days out —
+  bounded *both* ways, so a missed `*1000` (1970) and a double one (year 58000)
+  both fail, and the check stays valid if the SDK ever switches units
+- every content-block type observed in live traffic is in one of the three
+  hashing buckets in `messages.ts`
+- a session whose client stops echoing thinking blocks still logs
+  `lineage=continuation`, not a fresh replay
+- a check that cannot gather its evidence **fails** rather than passing quietly
+  (no rate-limit bucket, no content blocks, missing lineage verdicts)
+
+**Informational, not asserted:** check 4 asks the model whether the gitStatus
+block still claims to describe the conversation's start. It is reported rather
+than asserted because a model declining to answer must not fail a release. When
+it reports the block is gone or honestly labelled, `GIT_STATUS_PROVENANCE_NOTE`
+in `query.ts` can be removed.
+
+**Calibrated, not assumed.** Both hard checks were verified to fail against the
+real bugs by reverting each fix and re-running:
+
+```
+✗ units: five_hour.resetsAt=1785404400 is in the past (1970-01-21…) — seconds treated as ms?
+✗ lineage: third turn was lineage=new, expected continuation — dropped thinking blocks churned the hash (#710)
+```
+
+**What's being tested:** `toEpochMs` / `RateLimitStore.record`
+(`rateLimitStore.ts`); `normalizeContent` block classification (`messages.ts`);
+`hashMessage` / `verifyLineage` (`session/lineage.ts`);
+`GIT_STATUS_PROVENANCE_NOTE` (`query.ts`).
+
+**Static counterpart:** `sdk-block-type-coverage.test.ts` reads the
+`ContentBlockParam` union out of the installed SDK and fails when a new block
+type appears in none of the three buckets — so the next `thinking` is caught by
+CI on the dependency bump rather than by a user.

--- a/scripts/e2e-sdk-boundary.mjs
+++ b/scripts/e2e-sdk-boundary.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: the SDK boundary — the assumptions mocks cannot check.
+ *
+ * Three bugs shipped through this seam in one week, and every one was found by
+ * watching real traffic rather than by reasoning about code:
+ *
+ *   #708  The SDK reports `resetsAt` in epoch SECONDS. Every fixture in the
+ *         suite used milliseconds, so the mismatch was unobservable and tier 1
+ *         of the priority cooldown was dead code for its entire life.
+ *   #710  `thinking` blocks fell into the hash's serialize-everything
+ *         fallback, folding an encrypted per-generation signature into the
+ *         lineage hash. There was no thinking-block test at all.
+ *   #694  The `claude_code` preset injects a gitStatus block asserting it is
+ *         "the git status at the start of the conversation" and recomputes it
+ *         every turn. The model read its own creations as pre-existing work and
+ *         told a user it had destroyed their files.
+ *
+ * The unit suite now covers what can be pinned statically (see
+ * sdk-block-type-coverage.test.ts, rate-limit-store-units.test.ts,
+ * lineage-thinking-blocks.test.ts). This script covers what cannot: whether the
+ * SDK still behaves the way those tests assume.
+ *
+ * Requires: Claude Max auth (`claude login`). Costs real tokens. Run before
+ * releases touching session lineage, rate-limit handling, or the system prompt,
+ * and after any @anthropic-ai/claude-agent-sdk bump (see E2E.md):
+ *
+ *   bun scripts/e2e-sdk-boundary.mjs
+ *
+ * Checks:
+ *   1. Rate-limit reset timestamps land in a sane future window — catches a
+ *      missed conversion AND a double conversion, so it stays valid if the SDK
+ *      ever switches units.
+ *   2. Every content-block type real traffic produces is classified for
+ *      hashing — the live counterpart to the static registry.
+ *   3. A conversation resumes after the client stops echoing thinking blocks.
+ *   4. Reports whether the gitStatus block still refreshes mid-conversation, so
+ *      we learn when upstream fixes it and the corrective note can go.
+ */
+import { startProxyServer } from "../src/proxy/server.ts"
+import {
+  HASH_HANDLED_BLOCK_TYPES,
+  HASH_IGNORED_BLOCK_TYPES,
+  HASH_SERIALIZED_BLOCK_TYPES,
+} from "../src/proxy/messages.ts"
+
+const PORT = Number(process.env.SDK_BOUNDARY_PORT ?? 3498)
+const MODEL = process.env.SDK_BOUNDARY_MODEL ?? "claude-haiku-4-5-20251001"
+
+// Capture the proxy's own log lines: `lineage=` is the only place the resume
+// decision is observable, and there is no endpoint that exposes it. plog writes
+// to console.error, so the server must NOT run silent.
+const proxyLog = []
+const realError = console.error.bind(console)
+// plog writes via console.error and is gated by `silent`, so the server runs
+// non-silent and its output is diverted here instead of to the terminal.
+console.error = (...args) => { proxyLog.push(args.map(String).join(" ")) }
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1" })
+const BASE = `http://127.0.0.1:${PORT}`
+
+/** Index into proxyLog, so a check only reads lines its own requests produced. */
+const mark = () => proxyLog.length
+
+/** Lineage verdicts logged since `from`, oldest first. */
+function lineageSince(from) {
+  return proxyLog.slice(from)
+    .map(l => l.match(/lineage=([a-z-]+)/)?.[1])
+    .filter(Boolean)
+}
+
+let failures = 0
+// Reports go to the real stderr/stdout — console.error is the proxy's now.
+const fail = (check, msg) => { failures++; realError(`  ✗ ${check}: ${msg}`) }
+const pass = (check, msg) => console.log(`  ✓ ${check}: ${msg}`)
+const note = (msg) => console.log(`  · ${msg}`)
+
+async function post(sid, messages, maxTokens = 64) {
+  const r = await fetch(`${BASE}/v1/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-opencode-session": sid },
+    body: JSON.stringify({ model: MODEL, max_tokens: maxTokens, messages }),
+  })
+  return { status: r.status, body: await r.json() }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Rate-limit reset units (#708)
+// ---------------------------------------------------------------------------
+console.log("\n1. rate-limit reset units")
+{
+  await post("sdk-boundary-quota", [{ role: "user", content: "say ok" }])
+  const r = await fetch(`${BASE}/v1/usage/quota`)
+  const quota = await r.json()
+  const withReset = (quota.buckets ?? []).filter(b => b.resetsAt != null)
+
+  if (withReset.length === 0) {
+    // Not a pass. A silent "no data" is how a units bug hides.
+    fail("units", "no bucket carried a resetsAt — cannot verify units (is the SDK still emitting rate_limit_event?)")
+  } else {
+    const now = Date.now()
+    const EIGHT_DAYS = 8 * 24 * 60 * 60_000
+    for (const b of withReset) {
+      // Bounded both ways on purpose: a missed *1000 lands in 1970, a double
+      // *1000 lands in the year 58000. Either fails.
+      if (b.resetsAt < now - 60_000) {
+        fail("units", `${b.type}.resetsAt=${b.resetsAt} is in the past (${new Date(b.resetsAt).toISOString()}) — seconds treated as ms?`)
+      } else if (b.resetsAt > now + EIGHT_DAYS) {
+        fail("units", `${b.type}.resetsAt=${b.resetsAt} is beyond any window (${new Date(b.resetsAt).toISOString()}) — double conversion?`)
+      } else {
+        pass("units", `${b.type} resets ${new Date(b.resetsAt).toISOString()}`)
+      }
+      if (b.overageResetsAt != null && b.overageResetsAt < now - 60_000) {
+        fail("units", `${b.type}.overageResetsAt=${b.overageResetsAt} is in the past — unconverted?`)
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Content-block types real traffic produces (#710)
+// ---------------------------------------------------------------------------
+console.log("\n2. content-block classification")
+{
+  const seen = new Set()
+  const collect = (content) => {
+    if (Array.isArray(content)) for (const b of content) if (b?.type) seen.add(b.type)
+  }
+
+  // A plain turn, then one likely to reason and call a tool — between them they
+  // exercise the block shapes ordinary Meridian traffic carries.
+  const a = await post("sdk-boundary-blocks", [{ role: "user", content: "say ok" }])
+  collect(a.body?.content)
+  const b = await post("sdk-boundary-blocks-2", [{
+    role: "user",
+    content: "Think briefly, then answer: what is 17 * 23?",
+  }], 400)
+  collect(b.body?.content)
+
+  if (seen.size === 0) {
+    fail("blocks", "no content blocks observed — the probe learned nothing")
+  } else {
+    const unclassified = [...seen].filter(t =>
+      !HASH_HANDLED_BLOCK_TYPES.has(t) &&
+      !HASH_IGNORED_BLOCK_TYPES.has(t) &&
+      !HASH_SERIALIZED_BLOCK_TYPES.has(t))
+    if (unclassified.length > 0) {
+      fail("blocks", `unclassified in live traffic: ${unclassified.join(", ")} — classify in messages.ts`)
+    } else {
+      pass("blocks", `all classified: ${[...seen].sort().join(", ")}`)
+    }
+    // Not a failure — just the fact worth recording. When it flips, the
+    // thinking-block hashing guard starts earning its keep on this path too.
+    note(seen.has("thinking")
+      ? "thinking blocks ARE present in responses"
+      : "no thinking blocks in this run (model/effort dependent) — check 3 covers the hash path regardless")
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Resume survives a client dropping thinking blocks (#710)
+// ---------------------------------------------------------------------------
+console.log("\n3. resume across dropped thinking blocks")
+{
+  const sid = `sdk-boundary-lineage-${Date.now()}`
+  const from = mark()
+  const SIG = "ErkCCosBCBAYAipArnuwVmIJYId3EvWd4ITxDyTxhyG1oXG7l8E3OBpQo6JfDB"
+
+  await post(sid, [{ role: "user", content: "say ok" }])
+  await post(sid, [
+    { role: "user", content: "say ok" },
+    { role: "assistant", content: [
+      { type: "thinking", thinking: "user wants ok", signature: SIG },
+      { type: "text", text: "ok" },
+    ] },
+    { role: "user", content: "say two" },
+  ])
+  // The failure mode: the client stops echoing thinking once its tool loop ends.
+  const third = await post(sid, [
+    { role: "user", content: "say ok" },
+    { role: "assistant", content: [{ type: "text", text: "ok" }] },
+    { role: "user", content: "say two" },
+    { role: "assistant", content: [{ type: "text", text: "two" }] },
+    { role: "user", content: "say three" },
+  ])
+
+  const verdicts = lineageSince(from)
+  const last = verdicts[verdicts.length - 1]
+
+  if (third.status !== 200) {
+    fail("lineage", `third turn returned ${third.status}`)
+  } else if (verdicts.length < 3) {
+    // Do not pass on missing evidence: if the log capture broke, this check
+    // proves nothing and must say so.
+    fail("lineage", `expected 3 lineage verdicts, captured ${verdicts.length} (${verdicts.join(",")}) — log capture broken?`)
+  } else if (last !== "continuation") {
+    // `new` here means diverged: server.ts renders a diverged result with no
+    // cached session as "new". That is the #710 regression.
+    fail("lineage", `third turn was lineage=${last}, expected continuation — dropped thinking blocks churned the hash (#710)`)
+  } else {
+    pass("lineage", `verdicts ${verdicts.join(" -> ")} — resume survived the dropped thinking block`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Does the gitStatus block still refresh mid-conversation? (#694)
+// ---------------------------------------------------------------------------
+console.log("\n4. gitStatus provenance (informational)")
+{
+  // Meridian appends a note telling the model the block is per-turn. This check
+  // reports whether that note is still NEEDED: if the SDK ever stops
+  // recomputing the block, or starts labelling it honestly, the note can go.
+  // Asking the model is the only way to read the rendered system prompt, so
+  // this is reported rather than asserted — a model that declines to answer
+  // must not fail a release.
+  const sid = `sdk-boundary-gitstatus-${Date.now()}`
+  const r = await post(sid, [{
+    role: "user",
+    content: "Do not use tools. Answer in one line: does your system prompt contain a gitStatus block, and does it claim to be from the start of the conversation? yes/no for each.",
+  }], 200)
+  const text = (r.body?.content ?? []).filter(b => b.type === "text").map(b => b.text).join(" ")
+  if (!text) {
+    note("model returned no text — cannot report on gitStatus this run")
+  } else {
+    note(`model reports: ${text.replace(/\s+/g, " ").slice(0, 220)}`)
+    note("if it reports NO gitStatus block, or an honestly-labelled one, revisit GIT_STATUS_PROVENANCE_NOTE in query.ts (#694)")
+  }
+}
+
+await inst.close()
+console.error = realError
+
+console.log(`\n${failures === 0 ? "PASS" : `FAIL (${failures})`} — SDK boundary`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/__tests__/sdk-block-type-coverage.test.ts
+++ b/src/__tests__/sdk-block-type-coverage.test.ts
@@ -1,0 +1,158 @@
+/**
+ * SDK boundary guard: every content-block type must be classified for hashing.
+ *
+ * Three bugs shipped this way, all invisible to the suite because the suite
+ * only ever asserted what we already knew to look for:
+ *
+ *   - #710 `thinking` fell into `normalizeContent`'s serialize-everything
+ *     fallback, folding an encrypted per-generation signature into the lineage
+ *     hash. Nothing failed; there was no thinking-block test at all.
+ *   - #708 every rate-limit fixture used the wrong unit, so a seconds/ms
+ *     mismatch was unobservable.
+ *   - #694 lived entirely in SDK-injected system-prompt context no test reads.
+ *
+ * The pattern is the same each time: Meridian's assumptions about the SDK's
+ * shape drifted from reality, and only live traffic revealed it. This test
+ * closes the content-block half by reading the union out of the INSTALLED SDK
+ * and failing when a type appears that nobody has classified — so the next
+ * `thinking` is caught by CI on the dependency bump, not by a user.
+ *
+ * Deliberately reads node_modules rather than importing a type: types vanish at
+ * runtime, and the point is to detect an SDK upgrade we have not reviewed.
+ */
+import { describe, it, expect } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import {
+  normalizeContent,
+  HASH_HANDLED_BLOCK_TYPES,
+  HASH_IGNORED_BLOCK_TYPES,
+  HASH_SERIALIZED_BLOCK_TYPES,
+} from "../proxy/messages"
+
+const MESSAGES_DTS = join(
+  process.cwd(),
+  "node_modules/@anthropic-ai/sdk/resources/messages/messages.d.ts",
+)
+
+/**
+ * Pull the `type` discriminator of every member of `ContentBlockParam`.
+ *
+ * Throws rather than returning a partial list: a silently empty result would
+ * make this whole file pass vacuously, which is the exact failure mode it
+ * exists to prevent.
+ */
+function sdkContentBlockTypes(): string[] {
+  const src = readFileSync(MESSAGES_DTS, "utf8")
+  const union = src.match(/export type ContentBlockParam = ([^;]+);/)
+  if (!union?.[1]) {
+    throw new Error(
+      `Could not find the ContentBlockParam union in ${MESSAGES_DTS}. ` +
+      `The SDK's declaration format changed — update this extractor rather ` +
+      `than deleting the test, or block-type drift goes unnoticed again.`,
+    )
+  }
+  const names = union[1].split("|").map(n => n.trim()).filter(Boolean)
+  const types: string[] = []
+  for (const name of names) {
+    const iface = src.match(
+      new RegExp(`export interface ${name} \\{(.*?)\\n\\}`, "s"),
+    )
+    const discriminator = iface?.[1]?.match(/type:\s*'([^']+)'/)
+    if (!discriminator?.[1]) {
+      throw new Error(
+        `Could not read the 'type' discriminator for ${name}. Update the ` +
+        `extractor — an unparsed member would silently escape classification.`,
+      )
+    }
+    types.push(discriminator[1])
+  }
+  if (types.length === 0) throw new Error("Extracted zero block types — extractor is broken.")
+  return types
+}
+
+describe("SDK content-block type coverage", () => {
+  const sdkTypes = sdkContentBlockTypes()
+
+  it("extracts a plausible union from the installed SDK", () => {
+    // Guards the instrument itself. If this shrinks dramatically, the
+    // extractor silently stopped seeing most of the union.
+    expect(sdkTypes.length).toBeGreaterThanOrEqual(10)
+    expect(sdkTypes).toContain("text")
+    expect(sdkTypes).toContain("tool_use")
+    expect(sdkTypes).toContain("thinking")
+  })
+
+  it("classifies every SDK block type into exactly one hashing bucket", () => {
+    const unclassified = sdkTypes.filter(t =>
+      !HASH_HANDLED_BLOCK_TYPES.has(t) &&
+      !HASH_IGNORED_BLOCK_TYPES.has(t) &&
+      !HASH_SERIALIZED_BLOCK_TYPES.has(t))
+
+    // If this fails, the SDK added a content block type. Decide which bucket it
+    // belongs in — see the doc comments on the three sets in messages.ts:
+    //   - opaque/per-generation payload (a signature, a blob) -> IGNORED
+    //   - semantic fields worth hashing precisely            -> HANDLED (+ a case)
+    //   - stable payload, safe to serialize whole            -> SERIALIZED
+    expect(unclassified).toEqual([])
+  })
+
+  it("puts each type in only one bucket", () => {
+    const overlaps = sdkTypes.filter(t =>
+      [HASH_HANDLED_BLOCK_TYPES, HASH_IGNORED_BLOCK_TYPES, HASH_SERIALIZED_BLOCK_TYPES]
+        .filter(s => s.has(t)).length > 1)
+    expect(overlaps).toEqual([])
+  })
+
+  it("does not classify types the SDK no longer has", () => {
+    // Stale entries are how a registry rots into decoration.
+    const known = [
+      ...HASH_HANDLED_BLOCK_TYPES,
+      ...HASH_IGNORED_BLOCK_TYPES,
+      ...HASH_SERIALIZED_BLOCK_TYPES,
+    ]
+    expect(known.filter(t => !sdkTypes.includes(t))).toEqual([])
+  })
+})
+
+describe("hashing behavior matches each block type's bucket", () => {
+  const TEXT = "carrier text"
+  const textBlock = { type: "text", text: TEXT }
+
+  it("IGNORED types contribute nothing to the normalized string", () => {
+    // The property that actually matters: whether the block is present or
+    // absent, the hash input is identical.
+    for (const type of HASH_IGNORED_BLOCK_TYPES) {
+      const withBlock = normalizeContent([
+        { type, thinking: "reasoning", signature: "sig-abc", data: "blob" },
+        textBlock,
+      ])
+      expect(withBlock).toBe(TEXT)
+    }
+  })
+
+  it("HANDLED types contribute their semantic fields, not raw JSON", () => {
+    expect(normalizeContent([textBlock])).toBe(TEXT)
+    expect(normalizeContent([{ type: "tool_use", id: "t1", name: "read", input: { p: 1 } }]))
+      .toBe('tool_use:t1:read:{"p":1}')
+    expect(normalizeContent([{ type: "tool_result", tool_use_id: "t1", content: "out" }]))
+      .toBe("tool_result:t1:out")
+  })
+
+  it("SERIALIZED types round-trip as JSON with cache_control stripped", () => {
+    for (const type of HASH_SERIALIZED_BLOCK_TYPES) {
+      const out = normalizeContent([{ type, cache_control: { type: "ephemeral" }, payload: "x" }])
+      expect(out).toContain(`"type":"${type}"`)
+      expect(out).not.toContain("cache_control")
+    }
+  })
+
+  it("an unclassified type would still be serialized — the registry is the guard, not the code path", () => {
+    // Honest about the design: the fallback still catches anything unknown, so
+    // nothing crashes. The registry test above is what makes that visible
+    // instead of silent. Documented so nobody mistakes this for enforcement.
+    const out = normalizeContent([{ type: "some_future_block", secret: "opaque" }])
+    expect(out).toContain("some_future_block")
+    expect(out).toContain("opaque")
+  })
+})

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -34,7 +34,45 @@ function stripCacheControlForHashing(obj: any): any {
  * its own turn, and those are still hashed, so it never distinguishes two
  * genuinely different prefixes on its own.
  */
-const HASH_IGNORED_BLOCK_TYPES = new Set(["thinking", "redacted_thinking"])
+export const HASH_IGNORED_BLOCK_TYPES = new Set(["thinking", "redacted_thinking"])
+
+/**
+ * Block types with an explicit case in {@link normalizeContent}, hashed on
+ * their semantic fields only.
+ */
+export const HASH_HANDLED_BLOCK_TYPES = new Set(["text", "tool_use", "tool_result"])
+
+/**
+ * Block types deliberately serialized whole by the fallback.
+ *
+ * Reviewed against `ContentBlockParam` and confirmed to carry no
+ * per-generation opaque field: their payloads (`source`, `content`, `title`,
+ * `file_id`) are stable for the same logical content, so serializing them is
+ * safe. `cache_control` is stripped separately.
+ *
+ * The `*_tool_use` / `*_tool_result` entries reference `id` / `tool_use_id`,
+ * which ARE per-generation — but that matches how `tool_use` and `tool_result`
+ * are already hashed, and clients echo the same ids back. Same accepted risk,
+ * not a new one.
+ *
+ * Membership here is a decision, not a default. `sdk-block-type-coverage`
+ * fails when the installed SDK adds a type absent from all three sets, so a
+ * new block type cannot silently land in the fallback the way `thinking` did
+ * (#710).
+ */
+export const HASH_SERIALIZED_BLOCK_TYPES = new Set([
+  "image",
+  "document",
+  "search_result",
+  "server_tool_use",
+  "web_search_tool_result",
+  "web_fetch_tool_result",
+  "code_execution_tool_result",
+  "bash_code_execution_tool_result",
+  "text_editor_code_execution_tool_result",
+  "tool_search_tool_result",
+  "container_upload",
+])
 
 /**
  * Normalize message content to a string for hashing and comparison.


### PR DESCRIPTION
Closes the gap that let #694, #708 and #710 all ship with a green suite.

## The pattern worth naming

Three bugs in one week, same seam, same reason: **Meridian's assumptions about the SDK drifted from what the SDK actually does, and a mocked suite can only assert what someone already thought to look for.**

- **#708** — the SDK reports `resetsAt` in epoch *seconds*. Every fixture used milliseconds, so the mismatch was literally unobservable. Tier 1 of the priority cooldown was dead code for its entire life.
- **#710** — `thinking` fell into the lineage hash's serialize-everything fallback, folding an encrypted per-generation signature into the hash. There was no thinking-block test at all.
- **#694** — the `claude_code` preset recomputes its gitStatus block every turn while claiming to describe the conversation's start. A user was told the model destroyed their work-in-progress files.

Every one was found by watching real traffic, with a throwaway probe rebuilt from scratch each time. This makes the watching repeatable.

## Two guards, because one is not enough

I want to be explicit that a fixture corpus alone would **not** have caught #694 — a fixture faithfully records the wrong label. Catching that class needs an invariant checked against live traffic. So:

### 1. Static — `sdk-block-type-coverage.test.ts`

Reads the `ContentBlockParam` union out of the **installed** SDK and fails when a block type appears in none of three buckets now declared in `messages.ts`:

- `HASH_IGNORED_BLOCK_TYPES` — opaque per-generation payload (`thinking`, `redacted_thinking`)
- `HASH_HANDLED_BLOCK_TYPES` — explicit hashing case (`text`, `tool_use`, `tool_result`)
- `HASH_SERIALIZED_BLOCK_TYPES` — reviewed as content-stable, safe to serialize whole (the remaining 11)

All 16 current types are classified, each with the reasoning recorded. Membership is a decision, not a default — which is precisely what `thinking` never got.

**This is the piece that would have caught #710 before a user reported it.** Verified by simulating that exact state — removing `thinking` from its bucket fails the test and names the offender:

```
+   "thinking",
(fail) classifies every SDK block type into exactly one hashing bucket
```

The extractor **throws** rather than returning a partial list. A silently empty parse would make the entire file pass vacuously, which is the failure mode it exists to prevent. A separate test guards the instrument itself against silent shrinkage.

Honest about its limits: the runtime fallback still serializes anything unknown, so nothing crashes. The registry makes that *visible*, not impossible — and there's a test saying so, so nobody mistakes it for enforcement.

### 2. Live — `scripts/e2e-sdk-boundary.mjs` (E35)

Follows the `e2e-stream-parallel.mjs` precedent, whose own docstring already made this argument: "the test that mocked suites CANNOT provide."

1. **Reset units** — every `resetsAt`/`overageResetsAt` lands between now and 8 days out. Bounded *both* ways on purpose: a missed `*1000` lands in 1970, a doubled one in the year 58000. Stays valid if the SDK ever switches units.
2. **Live block types** — every type real traffic produces is classified, tying the live side to the static registry.
3. **Resume across dropped thinking blocks** — asserts `lineage=continuation` on the exact sequence from #710, read from the proxy's own log line since no endpoint exposes the verdict.
4. **gitStatus provenance** — *reported, not asserted.*

**A check that cannot gather its evidence fails** rather than passing quietly — no rate-limit bucket, no content blocks, or missing lineage verdicts are all failures. Silent "no data" is how a units bug hides.

## Calibrated, not assumed

An instrument nobody has calibrated is worse than none, so both hard checks were verified against the real bugs by reverting each fix and re-running:

```
✗ units: five_hour.resetsAt=1785404400 is in the past (1970-01-21T15:56:44.400Z) — seconds treated as ms?
✗ lineage: third turn was lineage=new, expected continuation — dropped thinking blocks churned the hash (#710)
```

Both name the cause, not just the symptom. And the passing run against live traffic:

```
✓ units: five_hour resets 2026-07-30T09:40:00.000Z
✓ blocks: all classified: text, thinking
· thinking blocks ARE present in responses
✓ lineage: verdicts new -> continuation -> continuation — resume survived the dropped thinking block
· model reports: Yes, my system prompt contains a gitStatus block, and yes, it claims to be from the start of the conversation.
PASS — SDK boundary
```

That third line is worth noting on its own: it confirms **thinking blocks are present in ordinary traffic**, so #710's hash path is live, not theoretical.

## Why #694's check is informational

Reading the rendered system prompt requires asking the model — there is no other access. A model declining to answer must not fail a release, so it reports instead of asserting. Its real job is forward-looking: when it reports the block is gone or honestly labelled, `GIT_STATUS_PROVENANCE_NOTE` in `query.ts` can be deleted. Without it, that note would sit there forever with nobody knowing whether it still earns its place.

## Testing

`npm test`: 2390 pass, 0 fail. `npx tsc --noEmit` clean. `bun scripts/e2e-sdk-boundary.mjs` passes against live SDK traffic.

E2E.md documents E35 with its pass criteria, the calibration output, and the run triggers — **after any `@anthropic-ai/claude-agent-sdk` bump**, and before releases touching lineage, rate limits, or the system prompt.

## What this does not claim

It does not catch *everything*. It closes the three specific seams that drew blood and makes new content-block types self-announcing. Classes still uncovered: streamed-event shape drift, and semantic changes in SDK-injected context other than gitStatus. Both are reachable by extending E35 with further invariants, which is now an edit rather than a from-scratch probe.
