### PR TITLE
fix(adapters): stop x-session-affinity misrouting Crush to the OpenCode adapter

### DIFF
--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -258,8 +258,47 @@ describe("detectAdapter — OpenCode detection", () => {
     expect(adapter.name).toBe("opencode")
   })
 
-  it("returns openCodeAdapter when x-session-affinity is present", () => {
+  it("returns openCodeAdapter when x-session-affinity is present and nothing else identifies the client", () => {
     const adapter = detectAdapter(makeContext("", { "x-session-affinity": "ses_2a50aeb32ffe" }))
+    expect(adapter).toBe(openCodeAdapter)
+  })
+
+  it("does NOT let x-session-affinity override a Crush User-Agent", () => {
+    // Crush 0.87 sends x-session-affinity + x-session-id alongside its own
+    // User-Agent. While the affinity header was checked ahead of the UA chain,
+    // every Crush request resolved to the OpenCode adapter, silently swapping
+    // in OpenCode's transforms, tool config and session semantics.
+    // Header set captured from a real crush 0.87.0 request.
+    const adapter = detectAdapter(makeContext("Charm-Crush/v0.87.0 (https://charm.land/crush)", {
+      "x-session-affinity": "eee42bf262921f57",
+      "x-session-id": "eee42bf262921f57",
+    }))
+    expect(adapter).toBe(crushAdapter)
+    expect(adapter.name).toBe("crush")
+  })
+
+  it("does NOT let x-session-affinity override a droid User-Agent", () => {
+    const adapter = detectAdapter(makeContext("factory-cli/1.0.0", {
+      "x-session-affinity": "aff-1",
+    }))
+    expect(adapter).toBe(droidAdapter)
+  })
+
+  it("still lets x-opencode-session win over any other client's User-Agent", () => {
+    // OpenCode's plugin header is unambiguous — no other client sends it — so it
+    // must keep outranking the UA chain even though x-session-affinity no longer does.
+    const adapter = detectAdapter(makeContext("Charm-Crush/v0.87.0", {
+      "x-opencode-session": "sess-abc",
+    }))
+    expect(adapter).toBe(openCodeAdapter)
+  })
+
+  it("keeps detecting OpenCode from affinity alone when the UA is unrecognized", () => {
+    // The fallback still has to work: an OpenCode build whose UA we do not know
+    // is exactly what the affinity check exists for.
+    const adapter = detectAdapter(makeContext("some-unknown-client/9", {
+      "x-session-affinity": "ses_abc",
+    }))
     expect(adapter).toBe(openCodeAdapter)
   })
 
@@ -376,10 +415,15 @@ describe("detectAdapter — adapter contracts", () => {
     expect(adapter.extractWorkingDirectory({ messages: [], system: [] })).toBeUndefined()
   })
 
-  it("detected crush adapter returns undefined for session ID", () => {
+  it("detected crush adapter reads Crush's own session headers", () => {
+    // Crush 0.87 sends x-session-id / x-session-affinity; older builds sent
+    // neither, and fingerprint continuity has to keep working for those.
     const adapter = detectAdapter(makeContext("Charm-Crush/v0.51.2"))
-    const ctx = { req: { header: () => "any-value" } }
-    expect(adapter.getSessionId(ctx as any)).toBeUndefined()
+    const ctx = (h: Record<string, string>) => ({ req: { header: (n: string) => h[n] } })
+    expect(adapter.getSessionId(ctx({ "x-session-id": "sid-1" }) as any)).toBe("sid-1")
+    expect(adapter.getSessionId(ctx({}) as any)).toBeUndefined()
+    // Not OpenCode's header.
+    expect(adapter.getSessionId(ctx({ "x-opencode-session": "sess-abc" }) as any)).toBeUndefined()
   })
 
   it("detected crush adapter has crush MCP server name", () => {

--- a/src/__tests__/crush-adapter.test.ts
+++ b/src/__tests__/crush-adapter.test.ts
@@ -11,21 +11,38 @@ describe("crushAdapter — identity", () => {
 })
 
 describe("crushAdapter.getSessionId", () => {
-  it("always returns undefined — Crush sends no session header", () => {
-    const ctx = {
-      req: { header: () => "any-value" },
-    }
-    expect(crushAdapter.getSessionId(ctx as any)).toBeUndefined()
+  const ctxWith = (headers: Record<string, string>) => ({
+    req: { header: (name: string) => headers[name] },
+  }) as any
+
+  it("reads x-session-id, which Crush 0.87 sends", () => {
+    // Older Crush sent no session header and this returned undefined, leaving
+    // continuity to fingerprint lookup. Values captured from a real 0.87 request.
+    expect(crushAdapter.getSessionId(ctxWith({ "x-session-id": "eee42bf262921f57" })))
+      .toBe("eee42bf262921f57")
   })
 
-  it("returns undefined even when x-opencode-session is present", () => {
-    const ctx = {
-      req: {
-        header: (name: string) =>
-          name === "x-opencode-session" ? "sess-abc" : undefined,
-      },
-    }
-    expect(crushAdapter.getSessionId(ctx as any)).toBeUndefined()
+  it("falls back to x-session-affinity", () => {
+    expect(crushAdapter.getSessionId(ctxWith({ "x-session-affinity": "aff-123" })))
+      .toBe("aff-123")
+  })
+
+  it("prefers x-session-id when both are present", () => {
+    // Crush sends both with the same value; x-session-id is the direct one.
+    expect(crushAdapter.getSessionId(ctxWith({
+      "x-session-id": "primary",
+      "x-session-affinity": "secondary",
+    }))).toBe("primary")
+  })
+
+  it("returns undefined for a build that sends neither", () => {
+    // Older Crush: fingerprint-based continuity still has to work.
+    expect(crushAdapter.getSessionId(ctxWith({}))).toBeUndefined()
+  })
+
+  it("ignores x-opencode-session — that header belongs to another client", () => {
+    expect(crushAdapter.getSessionId(ctxWith({ "x-opencode-session": "sess-abc" })))
+      .toBeUndefined()
   })
 })
 

--- a/src/proxy/adapters/crush.ts
+++ b/src/proxy/adapters/crush.ts
@@ -39,11 +39,19 @@ export const crushAdapter: AgentAdapter = {
   name: "crush",
 
   /**
-   * Crush sends no session header.
-   * Session continuity is maintained via fingerprint-based cache lookup.
+   * Crush 0.87 sends `x-session-id` and `x-session-affinity` (same value).
+   * Older builds sent neither, and this returned undefined — session continuity
+   * then rested on fingerprint-based cache lookup.
+   *
+   * Reading the header is not optional now that `x-session-affinity` no longer
+   * resolves Crush to the OpenCode adapter: `openCodeAdapter.getSessionId` falls
+   * back to that header, so while Crush was misdetected it was silently getting
+   * keyed sessions. Returning undefined here would have quietly downgraded Crush
+   * to fingerprint-only continuity as a side effect of fixing the detection —
+   * observed live as `lineage=new` on every turn and a looping session.
    */
-  getSessionId(_c: Context): string | undefined {
-    return undefined
+  getSessionId(c: Context): string | undefined {
+    return c.req.header("x-session-id") ?? c.req.header("x-session-affinity")
   },
 
   /**

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -124,8 +124,9 @@ export function detectAdapter(c: Context): AgentAdapter {
     }
   }
 
-  // OpenCode: plugin injects x-opencode-session; newer versions use x-session-affinity
-  if (c.req.header("x-opencode-session") || c.req.header("x-session-affinity")) {
+  // OpenCode's own plugin injects x-opencode-session. Unambiguous — no other
+  // client sends it — so it outranks every User-Agent heuristic.
+  if (c.req.header("x-opencode-session")) {
     return openCodeAdapter
   }
 
@@ -142,6 +143,17 @@ export function detectAdapter(c: Context): AgentAdapter {
 
   if (userAgent.startsWith("Charm-Crush/")) {
     return crushAdapter
+  }
+
+  // x-session-affinity is a generic session-stickiness header, NOT an OpenCode
+  // marker: Crush 0.87 sends it too (alongside x-session-id), and while it was
+  // checked ahead of the User-Agent chain that made every Crush request resolve
+  // to the OpenCode adapter — swapping in OpenCode's transforms, tool config and
+  // session semantics for a client that has its own. It stays as a fallback for
+  // OpenCode builds whose User-Agent isn't recognizable, but only after the
+  // clients that identify themselves unambiguously have had their say.
+  if (c.req.header("x-session-affinity")) {
+    return openCodeAdapter
   }
 
   // Claude Code CLI — `claude-cli/<version>`. Pi (and downstream Pi-based


### PR DESCRIPTION
Found while validating the Crush 0.56.0 → 0.87.0 upgrade. Not from a report — nobody would have connected the symptom to the cause.

## Bug 1 — Crush is detected as OpenCode

`detectAdapter` checked `x-session-affinity` **before** the User-Agent chain and treated it as an OpenCode marker:

```ts
if (c.req.header("x-opencode-session") || c.req.header("x-session-affinity")) {
  return openCodeAdapter
}
```

Crush 0.87 sends that header. Captured from a real request:

```
user-agent:         Charm-Crush/v0.87.0 (https://charm.land/crush)
x-session-affinity: eee42bf262921f57
x-session-id:       eee42bf262921f57
```

So every Crush request resolved to the OpenCode adapter — swapping in OpenCode's transforms, tool config, MCP server name and CWD extraction for a client that has its own adapter *and* its own transform. Confirmed live before the fix: `adapter=opencode` on a Crush request.

`x-session-affinity` is a generic stickiness header, not an OpenCode marker, so it now decides only after the clients that identify themselves unambiguously. `x-opencode-session` — which no other client sends — still outranks the UA chain.

## Bug 2 — fixing Bug 1 made Crush worse

This is the part I'd have shipped broken if I had trusted the unit tests.

`openCodeAdapter.getSessionId` falls back to `x-session-affinity`. So while Crush was **misdetected**, it was silently getting properly keyed sessions. `crushAdapter.getSessionId` returned `undefined`, its comment still reading "Crush sends no session header" — true when it was written, stale since.

Correcting the detection therefore downgraded Crush from keyed sessions to fingerprint-only continuity. Observed live: `lineage=new` on **every** turn and a session that looped until the 5-minute timeout.

So `crushAdapter` now reads `x-session-id ?? x-session-affinity` (Crush sends both with the same value; the former is the direct one), with the stale comment replaced by the reason it must not go back.

## Verified live, both halves

| | adapter | lineage | result |
|---|---|---|---|
| Before | `opencode` | — | answered (on OpenCode's session semantics) |
| Detection fix only | `crush` | `new` every turn | **looped until timeout** |
| Both fixes | `crush` | `new → new → continuation → continuation` | answered `42` |

The middle row is why this PR has two commits' worth of change and not one.

## Testing

`npm test`: 2397 pass, 0 fail. `npx tsc --noEmit` clean.

Detection: Crush's UA beats `x-session-affinity`; droid's UA does too; `x-opencode-session` still beats a Crush UA; and affinity **still** detects OpenCode when the UA is unrecognized — that fallback is the reason the header is checked at all, so losing it would be a silent regression.

Verified load-bearing: restoring the old precedence fails exactly the two new ordering tests.

Session id: reads `x-session-id`, falls back to `x-session-affinity`, prefers the former when both are present, returns `undefined` for older builds that send neither (fingerprint continuity must keep working), and ignores `x-opencode-session`.

## Two existing tests updated

Both encoded "Crush sends no session header", which the client has since changed. Neither was weakened:

- `crush-adapter.test.ts` — the two `toBeUndefined()` cases stubbed `header: () => "any-value"`, which returns a value for *every* header. Replaced with per-header stubs asserting the real contract, including a case pinning that older builds still return `undefined`.
- `adapter-detection.test.ts` — same stub, same fix; still asserts the detected adapter ignores OpenCode's header.

## Note for whoever adds the next client

Two clients now send `x-session-affinity`, and the OpenCode adapter treats it as its own session key. Any future client sending it inherits both bugs at once: misdetection, and — once detection is fixed — a silent continuity downgrade unless its adapter reads the header too. The pairing is worth remembering as one issue, not two.
