### PR TITLE
fix(sanitize): stop a self-closing tag swallowing text up to the next paired tag

### DIFF
--- a/src/__tests__/sanitize-selfclosing-greedy.test.ts
+++ b/src/__tests__/sanitize-selfclosing-greedy.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Self-closing tag followed by a paired tag of the same name (#722).
+ *
+ * The paired pattern's opening match, `<tag\b[^>]*>`, also matched a
+ * SELF-CLOSING `<tag />` — `[^>]*` consumes the ` /` — so the lazy body ran on
+ * to the next `</tag>` and deleted the text in between:
+ *
+ *   "a<env />KEEP<env>x</env>b"  ->  "ab"
+ *
+ * This affected every tag identically, including the unconditionally-stripped
+ * orchestration tags, so it was reachable by default — not just through the
+ * opt-in sets.
+ */
+import { describe, it, expect } from "bun:test"
+import { sanitizeTextContent } from "../proxy/sanitize"
+
+const strip = (s: string) => sanitizeTextContent(s, {})
+const stripAll = (s: string) =>
+  sanitizeTextContent(s, { stripSystemReminder: true, stripThinking: true })
+
+describe("self-closing followed by paired tag (#722)", () => {
+  it("keeps text between a self-closing tag and a later paired tag", () => {
+    // The reported shape, on an unconditionally-stripped tag.
+    expect(strip("a<env />KEEP<env>x</env>b")).toBe("aKEEPb")
+  })
+
+  it("keeps text for a self-closing tag with attributes", () => {
+    expect(strip("a<env foo=\"bar\" />KEEP<env>x</env>b")).toBe("aKEEPb")
+  })
+
+  it("keeps text with no space before the slash", () => {
+    expect(strip("a<env/>KEEP<env>x</env>b")).toBe("aKEEPb")
+  })
+
+  it("applies to the opt-in tags too", () => {
+    expect(stripAll("a<thinking />KEEP<thinking>x</thinking>b")).toBe("aKEEPb")
+    expect(stripAll("a<system-reminder />KEEP<system-reminder>x</system-reminder>b"))
+      .toBe("aKEEPb")
+  })
+
+  it("still removes a lone self-closing tag", () => {
+    expect(strip("before<env />after")).toBe("beforeafter")
+  })
+
+  it("still removes an ordinary paired block, content included", () => {
+    expect(strip("before<env>secret</env>after")).toBe("beforeafter")
+  })
+
+  it("still removes a paired block whose opening tag has attributes", () => {
+    // Guards the fix from over-correcting: an opening tag with attributes must
+    // keep matching, since `[^>]*` is what allows them.
+    expect(strip('before<env mode="x">secret</env>after')).toBe("beforeafter")
+  })
+
+  it("handles an attribute value ending in a slash", () => {
+    // `(?<!/)` looks at the character before `>`, which here is a quote — so an
+    // attribute containing or ending with a slash is unaffected.
+    expect(strip('before<env path="a/b/">secret</env>after')).toBe("beforeafter")
+  })
+
+  it("removes multiple self-closing tags without eating between them", () => {
+    expect(strip("a<env />b<env />c")).toBe("abc")
+  })
+
+  it("handles self-closing after a paired block", () => {
+    expect(strip("a<env>x</env>KEEP<env />b")).toBe("aKEEPb")
+  })
+
+  it("handles interleaved distinct tags", () => {
+    // Each tag has its own regex, so a self-closing <env> must not interact
+    // with a paired <tool_exec>.
+    expect(strip("a<env />KEEP<tool_exec>x</tool_exec>b")).toBe("aKEEPb")
+  })
+
+  it("removes nested-looking repeats without leaking the tail", () => {
+    expect(strip("a<env>one</env>MID<env>two</env>b")).toBe("aMIDb")
+  })
+})

--- a/src/proxy/sanitize.ts
+++ b/src/proxy/sanitize.ts
@@ -62,7 +62,18 @@ const ORCHESTRATION_TAGS = [
 function tagPatterns(tag: string): [paired: RegExp, selfClosing: RegExp] {
   return [
     // Paired: <tagname ...>...</tagname>
-    new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi"),
+    //
+    // The `(?<!\/)` is load-bearing. Without it, `[^>]*` happily consumes the
+    // ` /` of a self-closing tag, so `<tag />` matches as an OPENING tag and
+    // the lazy body runs on to the next `</tag>` — deleting everything in
+    // between:
+    //
+    //   "a<env />KEEP<env>x</env>b"  ->  "ab"     (KEEP silently lost)
+    //
+    // Requiring that the character before `>` is not `/` makes a self-closing
+    // tag unmatchable as an opening tag, so the self-closing pattern below
+    // handles it and the intervening text survives (#722).
+    new RegExp(`<${tag}\\b[^>]*(?<!\\/)>[\\s\\S]*?<\\/${tag}>`, "gi"),
     // Self-closing: <tagname ... />
     new RegExp(`<${tag}\\b[^>]*\\/>`, "gi"),
   ]


### PR DESCRIPTION
Fixes #722.

## The bug

The paired-tag pattern's opening match was `<tag\b[^>]*>`. That also matches a **self-closing** `<tag />`, because `[^>]*` happily consumes the ` /`. The lazy body then runs on to the next `</tag>`:

```
"a<env />KEEP<env>x</env>b"  ->  "ab"
```

`KEEP` is silently deleted — user-authored text, gone with no warning.

Filed while fixing #720 and deliberately deferred there: it affects **every** tag identically, and fixing it for one would have created exactly the inconsistency the comments claim doesn't exist. Worth stressing that it is reachable **by default** — `env`, `tool_exec`, `skill_content` and the rest are stripped unconditionally, so this never needed an opt-in flag to bite.

## The fix

Require that the character before `>` is not `/`:

```
<tag\b[^>]*(?<!\/)>[\s\S]*?<\/tag>
```

A self-closing tag becomes unmatchable as an *opening* tag, so the self-closing pattern handles it and the intervening text survives. One place to change, since `tagPatterns()` is already the single encoding of "how you match an orchestration tag" — the unconditional set and both opt-in sets all inherit it.

## Testing

`npm test`: 2409 pass, 0 fail. `npx tsc --noEmit` clean.

12 cases covering both directions — that the fix works, and that it does not over-correct:

- the reported shape, plus attribute and no-space (`<env/>`) variants
- the opt-in tags (`thinking`, `system-reminder`) inherit it
- a lone self-closing tag is **still** removed
- an ordinary paired block is **still** removed, content included
- an opening tag **with attributes** still matches — `[^>]*` is what allows them, so this is the over-correction guard
- an attribute value containing or ending in a slash (`path="a/b/"`) is unaffected, since the lookbehind inspects the character before `>`, which is the quote
- self-closing after a paired block, multiple self-closing tags in a row, interleaved distinct tags, and repeated paired blocks

Verified load-bearing: restoring the old pattern fails exactly the 4 tests that describe the bug, while the 8 over-correction guards keep passing.
