### PR TITLE
fix(sanitize): strip Meridian's own markers from assistant content on replay

### DIFF
--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -243,6 +243,62 @@ describe("user-authored <thinking> survives (#720)", () => {
   })
 })
 
+describe("assistant content: Meridian's own markers stripped on replay (#724)", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedPrompts = []
+  })
+
+  it("does not replay Meridian's 'Files changed:' summary back to the model", async () => {
+    // server.ts appends this onto the assistant's last text block; the client
+    // echoes that turn back next request, and before #724 it replayed verbatim.
+    // NON_XML_PATTERNS carried a matcher for it that could never fire, because
+    // the sanitizer only ran on user-authored text.
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, [
+      { role: "user", content: "create a file" },
+      { role: "assistant", content: "Done.\n\n---\nFiles changed:\n  - src/a.ts\n" },
+      { role: "user", content: "now what?" },
+    ])
+    expect(res.status).toBe(200)
+
+    const prompt = capturedPrompts[0] as string
+    expect(prompt).not.toContain("Files changed:")
+    expect(prompt).not.toContain("src/a.ts")
+    // The assistant's real answer must survive.
+    expect(prompt).toContain("Done.")
+    expect(prompt).toContain("now what?")
+  })
+
+  it("leaves XML tags in assistant output alone — that is the model's own answer", async () => {
+    // The #720 failure mirrored: stripping the allowlist from model output
+    // would delete a legitimate answer about configuration.
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, [
+      { role: "user", content: "show me an env block" },
+      { role: "assistant", content: "Sure:\n<env>\nFOO=1\n</env>\nThat sets FOO." },
+      { role: "user", content: "thanks" },
+    ])
+    expect(res.status).toBe(200)
+
+    const prompt = capturedPrompts[0] as string
+    expect(prompt).toContain("FOO=1")
+  })
+
+  it("still strips the same markers from user-authored text", async () => {
+    // The user path must not regress while the assistant path is added.
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const res = await post(app, [
+      { role: "user", content: "<env>cwd=/tmp</env>the question" },
+    ])
+    expect(res.status).toBe(200)
+
+    const prompt = capturedPrompts[0] as string
+    expect(prompt).not.toContain("cwd=/tmp")
+    expect(prompt).toContain("the question")
+  })
+})
+
 /**
  * MERIDIAN_STRIP_THINKING — escape hatch for harnesses observed leaking raw
  * <thinking> tags into user-authored prompts that haven't been surveyed. Off

--- a/src/__tests__/sanitize-assistant-content.test.ts
+++ b/src/__tests__/sanitize-assistant-content.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Assistant-side sanitization (#724) — the unimplemented half of #167.
+ *
+ * Assistant content is replayed into the prompt as `[Assistant: …]` and was
+ * never sanitized. The concrete leak is Meridian's own: `server.ts` appends its
+ * "Files changed:" summary onto the assistant's last text block, the client
+ * echoes that turn back next request, and the summary replays into the model's
+ * context. `NON_XML_PATTERNS` has carried a pattern for it all along which
+ * could never fire, because the sanitizer only ran on user text.
+ *
+ * The scope here is deliberately narrow. See the sanitizeAssistantText doc for
+ * why the XML tag allowlist is NOT applied to model output.
+ */
+import { describe, it, expect } from "bun:test"
+import { sanitizeAssistantText, sanitizeTextContent } from "../proxy/sanitize"
+
+describe("sanitizeAssistantText — branded markers only", () => {
+  it("strips Meridian's own file-change summary", () => {
+    // Exactly the shape formatFileChangeSummary produces, appended to the
+    // assistant's text block by server.ts.
+    const text = "I updated the config.\n\n---\nFiles changed:\n  - src/a.ts\n  - src/b.ts\n"
+    expect(sanitizeAssistantText(text)).toBe("I updated the config.")
+  })
+
+  it("strips the background-task marker", () => {
+    expect(sanitizeAssistantText("before ⚙ background_output [task_id=abc]\nafter"))
+      .toContain("before")
+    expect(sanitizeAssistantText("before ⚙ background_output [task_id=abc]\nafter"))
+      .not.toContain("task_id")
+  })
+
+  it("strips oh-my-opencode's internal markers", () => {
+    expect(sanitizeAssistantText("a<!-- OMO_INTERNAL_INITIATOR -->b")).toBe("ab")
+    expect(sanitizeAssistantText("a[SYSTEM DIRECTIVE: OH-MY-OPENCODE do x]b")).toBe("ab")
+  })
+
+  it("leaves ordinary assistant prose untouched", () => {
+    const text = "Here's what I found in the file."
+    expect(sanitizeAssistantText(text)).toBe(text)
+  })
+
+  it("does NOT strip XML orchestration tags from model output", () => {
+    // The #720 lesson applied to the other direction: a model asked about
+    // configuration legitimately writes <env>. Deleting it would eat the
+    // model's own answer — the same class of bug, mirrored.
+    const answer = "Your config block looks like:\n<env>\nFOO=1\n</env>\nThat sets FOO."
+    expect(sanitizeAssistantText(answer)).toBe(answer)
+  })
+
+  it("does not strip <thinking> from assistant text either", () => {
+    // Even though #167 named it: it is indistinguishable from a model
+    // legitimately writing the tag, and nothing has been observed leaking it.
+    const text = "<thinking>step one</thinking> the answer is 4"
+    expect(sanitizeAssistantText(text)).toBe(text)
+  })
+
+  it("collapses the gap a removed marker leaves behind", () => {
+    expect(sanitizeAssistantText("a\n\n\n---\nFiles changed:\n  - x.ts\n\n\n\nb"))
+      .not.toMatch(/\n{3,}/)
+  })
+
+  it("is a no-op on empty input", () => {
+    expect(sanitizeAssistantText("")).toBe("")
+  })
+
+  it("differs from the user-side sanitizer, which DOES strip the tag allowlist", () => {
+    // Pins the asymmetry as intentional rather than an oversight.
+    const withEnv = "text <env>SECRET=1</env> more"
+    expect(sanitizeTextContent(withEnv, {})).not.toContain("SECRET")
+    expect(sanitizeAssistantText(withEnv)).toContain("SECRET")
+  })
+})

--- a/src/proxy/sanitize.ts
+++ b/src/proxy/sanitize.ts
@@ -139,6 +139,37 @@ export interface SanitizeOptions {
  * Designed to be called on individual content blocks (not concatenated
  * prompt strings) to eliminate cross-block regex matching risk.
  */
+/**
+ * Strip only the branded, harness-generated markers from ASSISTANT text.
+ *
+ * Assistant content is replayed into the prompt as `[Assistant: …]` context and
+ * has never been sanitized — the unimplemented half of #167 (see #724). The
+ * concrete leak is Meridian's own doing: `server.ts` appends its "Files
+ * changed:" summary onto the assistant's last text block, the client echoes
+ * that assistant turn back on the next turn, and the summary replays into the
+ * model's context verbatim. `NON_XML_PATTERNS` has carried a pattern for it all
+ * along, which could never fire because the sanitizer only ran on user text.
+ *
+ * Deliberately NOT the XML tag allowlist. Assistant text is model OUTPUT, and a
+ * model asked about configuration will legitimately write `<env>…</env>` — so
+ * stripping the allowlist here would delete the model's own answer, which is
+ * exactly the failure #720 was about. `NON_XML_PATTERNS` is safe because every
+ * entry is uniquely branded (Meridian's summary, oh-my-opencode's markers, the
+ * background-task marker): no model emits them by accident.
+ *
+ * `tool_result` content is deliberately left alone too — it is tool-generated
+ * and can legitimately contain anything, including text that merely looks like
+ * a marker. Corrupting real tool output is worse than replaying a wrapper.
+ */
+export function sanitizeAssistantText(text: string): string {
+  let result = text
+  for (const pattern of NON_XML_PATTERNS) {
+    pattern.lastIndex = 0
+    result = result.replace(pattern, "")
+  }
+  return result.replace(/\n{3,}/g, "\n\n").trim()
+}
+
 export function sanitizeTextContent(text: string, opts: SanitizeOptions = {}): string {
   let result = text
   const patterns = [...ALL_PATTERNS]

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -83,7 +83,7 @@ import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
 import { detectTokenAnomalies, formatAnomalyAlerts, type TokenSnapshot } from "./tokenHealth"
 import { computeCacheHitRate, formatUsageSummary } from "./tokenUsage"
-import { sanitizeTextContent } from "./sanitize"
+import { sanitizeTextContent, sanitizeAssistantText } from "./sanitize"
 import {
   computeLineageHash,
   hashMessage,
@@ -197,10 +197,15 @@ function normalizeStructuredUserContent(content: any): any {
  * inventing fake tool-call patterns back (issue #111, #386).
  */
 function flattenAssistantContent(content: any): string {
-  if (typeof content === "string") return content
+  // Strips only branded harness markers — notably Meridian's own "Files
+  // changed:" summary, which this server appends to the assistant's last text
+  // block and which the client then echoes back for replay (#724). The XML tag
+  // allowlist is deliberately NOT applied: assistant text is model output, and
+  // a model discussing configuration legitimately writes `<env>` (#720).
+  if (typeof content === "string") return sanitizeAssistantText(content)
   if (!Array.isArray(content)) return String(content ?? "")
   return content
-    .map((b: any) => (b?.type === "text" && b.text ? b.text : ""))
+    .map((b: any) => (b?.type === "text" && b.text ? sanitizeAssistantText(b.text) : ""))
     .filter(Boolean)
     .join("\n")
 }


### PR DESCRIPTION
Fixes #724 — the unimplemented half of #167.

## The leak, and it's ours

The sanitizer had exactly two call sites, both inside `flattenUserContent`. Assistant content is replayed into the prompt as `[Assistant: …]` and was never sanitized.

The concrete leak turns out to be Meridian's own:

1. `server.ts` appends the "Files changed:" summary onto the **assistant's** last text block.
2. The client echoes that assistant turn back on the next request.
3. `flattenAssistantContent` passed it straight through into the replayed prompt.

`NON_XML_PATTERNS` has carried a matcher for this all along — commented *"Meridian's own file change summary leaking back into conversation"* — which could **never fire**, because the sanitizer only ran on user-authored text. The pattern was written for a leak it was never wired to catch.

## Scope decided on evidence, not symmetry

The issue flagged that this needs a judgement call rather than copying the user-side treatment. My decision, and why:

**Assistant text → `NON_XML_PATTERNS` only.** Every entry is uniquely branded — Meridian's summary, oh-my-opencode's markers, the background-task marker. No model emits them by accident, so false positives are structurally impossible.

**NOT the XML tag allowlist.** This is the important one. Assistant text is model *output*, and a model asked about configuration legitimately writes `<env>FOO=1</env>`. Stripping the allowlist there would delete the model's own answer — **the #720 failure, mirrored.** #720 was about deleting the *user's* content on a leak nobody could reproduce; doing the same to model output would repeat it in the other direction. There is a test pinning this asymmetry as intentional.

**`tool_result` left alone.** Tool-generated content can legitimately contain anything, including text that merely looks like a marker — a file whose contents include `<env>`, say. Corrupting real tool output is worse than replaying a wrapper.

**Streamed response path left alone.** #167 asked for it, but no leak has been observed there, and mutating model output in flight is a different risk profile. Applying #720's lesson: don't strip on a hypothesis.

## Testing

`npm test`: 2421 pass, 0 fail. `npx tsc --noEmit` clean.

Unit (9): each branded marker stripped; ordinary prose untouched; **XML tags and `<thinking>` explicitly preserved** in model output; gap collapsing; empty input; and one asserting the user-side sanitizer still *does* strip the allowlist, so the asymmetry reads as intentional rather than an oversight.

End-to-end through the HTTP layer (3), because a unit test cannot show what reaches the prompt: the summary no longer replays while the assistant's real answer survives; `<env>` in assistant output is preserved; and the user path still strips it.

Verified load-bearing — reverting the two call sites fails the summary test specifically:

```
(fail) does not replay Meridian's 'Files changed:' summary back to the model
```

## What is left open

#167's response-forwarding half remains unimplemented, deliberately. If a leak is ever observed on that path, the fix belongs there and should be argued from a captured transcript, not from the fact that #167 mentioned it — which is precisely how the user-side `<thinking>` strip ended up guarding a leak that never came through it.
