### PR TITLE
test: catch a client changing the headers Meridian detects it by

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -88,6 +88,7 @@ kill $(lsof -ti :3456)
 | E33 | [OpenAI Compat: system prompt, no preset](#e33-openai-compat-system-prompt-no-preset) | `/v1/chat/completions` honours the client's system prompt without injecting the claude_code preset (openai adapter default) | 2026-06-15 |
 | E34 | [Streaming parallel tool calls (#552)](#e34-streaming-parallel-tool-calls-552) | **Automated**: `bun scripts/e2e-stream-parallel.mjs` — real CLI, SSE mode: parallel tool calls stream intact (no dangling `{}` blocks), denies held past generation, fast follow-up resumes. **Run before any release touching the passthrough tool loop** — mocked suites cannot catch CLI dispatch-ordering bugs (two shipped regressions proved it) | 2026-07-15 |
 | E35 | [SDK boundary assumptions (#694/#708/#710)](#e35-sdk-boundary-assumptions-694708710) | **Automated**: `bun scripts/e2e-sdk-boundary.mjs` — real SDK: rate-limit reset units land in a sane window, every live content-block type is classified for hashing, resume survives a client dropping thinking blocks, and reports whether the gitStatus block still misstates its provenance. **Run after any `@anthropic-ai/claude-agent-sdk` bump** and before releases touching lineage, rate limits, or the system prompt | 2026-07-29 |
+| E36 | [Client detection after an upgrade (#733)](#e36-client-detection-after-an-upgrade-733) | **Automated**: `bun scripts/e2e-client-detection.mjs` — drives each installed client against a local stub, captures its real headers, and asserts the adapter Meridian resolves. **Run after upgrading any client**; costs no tokens | 2026-07-31 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3189,3 +3190,54 @@ real bugs by reverting each fix and re-running:
 `ContentBlockParam` union out of the installed SDK and fails when a new block
 type appears in none of the three buckets — so the next `thinking` is caught by
 CI on the dependency bump rather than by a user.
+
+## E36: Client detection after an upgrade (#733)
+
+**Automated**, and costs **no tokens** — every request is answered by a local
+stub and never forwarded upstream:
+
+```bash
+bun scripts/e2e-client-detection.mjs            # check for drift
+bun scripts/e2e-client-detection.mjs --update   # re-record the fixture
+```
+
+**Why this exists:** Meridian picks an adapter from request headers, so a client
+changing what it sends silently reroutes it — and nothing fails.
+
+Crush 0.87 added `x-session-affinity`, which detection checked ahead of the
+User-Agent chain, so every Crush request resolved to the **OpenCode** adapter:
+OpenCode's transforms, tool config, MCP server name and CWD extraction applied
+to a client with its own. Then fixing the detection made it *worse*, because
+`openCodeAdapter.getSessionId` falls back to that same header — Crush had been
+getting keyed sessions by accident, and correct detection downgraded it to
+fingerprint-only continuity, looping until timeout.
+
+That was found by upgrading a client and running one turn. No user would connect
+"sessions feel wrong" to header precedence, and no unit test can watch a client
+change its headers.
+
+**Pass criteria:**
+- every installed client resolves to the adapter recorded in
+  `src/__tests__/fixtures/client-headers.json`
+- a client that never reaches the capture server **fails** rather than being
+  silently skipped — silence is not success
+- an uninstalled client is skipped with a note, so the script is runnable on a
+  machine that has only some clients
+
+**Also reported, not failed:** headers added or removed since the recorded
+capture, and User-Agent changes. A new header is exactly how #733 started, one
+release before it did damage — so it is surfaced even while detection is still
+correct.
+
+**Adding a client:** one entry in the `CLIENTS` table (how to write its config
+and run one turn), then `--update`.
+
+**Static counterpart:** `client-detection-fixtures.test.ts` pins detection
+against the same captured header sets, so a change to detection ORDERING fails
+in CI without needing any client installed. Verified: reintroducing #733 fails
+that test *and* the live script.
+
+**Note on the fixtures:** they are real captures, not hand-written. Both
+opencode 1.18.9 and crush 0.87 send `x-session-affinity` **and** `x-session-id`
+— which is why one of the tests asserts, as a property, that a shared session
+header can never be what distinguishes two clients.

--- a/scripts/e2e-client-detection.mjs
+++ b/scripts/e2e-client-detection.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: what each installed client actually sends, and which adapter that
+ * resolves to.
+ *
+ * Meridian picks an adapter from request headers. A client changing what it
+ * sends silently reroutes it — and nothing fails:
+ *
+ *   Crush 0.87 added `x-session-affinity`, which detection checked ahead of the
+ *   User-Agent chain, so every Crush request resolved to the OpenCode adapter.
+ *   OpenCode's transforms, tool config and session semantics were applied to a
+ *   client that has its own. Then fixing the detection made it WORSE, because
+ *   `openCodeAdapter.getSessionId` falls back to that same header, so Crush had
+ *   been getting keyed sessions by accident (#733).
+ *
+ * That was found by upgrading a client and running one turn. No user would
+ * connect "sessions feel wrong" to header precedence, and no unit test can see
+ * a client change its headers. This script makes that check repeatable.
+ *
+ * `client-detection-fixtures.test.ts` covers the other half — it pins detection
+ * against the captured sets, so a change to detection ORDERING fails in CI.
+ * This script catches a change on the CLIENT side.
+ *
+ * Requires the clients under test to be installed. Costs no tokens: requests
+ * are answered by a local stub, never forwarded upstream.
+ *
+ *   bun scripts/e2e-client-detection.mjs            # check for drift
+ *   bun scripts/e2e-client-detection.mjs --update   # rewrite the fixture
+ *
+ * Run after upgrading any client, and before releases touching detect.ts.
+ */
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { spawn } from "node:child_process"
+import { createServer } from "node:http"
+import { detectAdapter } from "../src/proxy/adapters/detect.ts"
+
+const FIXTURE = join(import.meta.dir, "..", "src", "__tests__", "fixtures", "client-headers.json")
+const UPDATE = process.argv.includes("--update")
+const PORT = Number(process.env.CLIENT_DETECT_PORT ?? 3995)
+
+/** Headers that are per-request noise, not identity. Dropped before diffing. */
+const VOLATILE = new Set([
+  "host", "content-length", "connection", "accept-encoding", "authorization",
+  "x-api-key", "x-stainless-retry-count", "x-stainless-timeout", "cookie",
+])
+/** Header values that change every run; keep the KEY, normalize the value. */
+const VOLATILE_VALUES = new Set(["x-session-affinity", "x-session-id", "x-opencode-session"])
+
+/**
+ * How to drive each client headlessly. `configFor` writes a project-local
+ * config pointing at the capture server; `argv` runs one non-interactive turn.
+ *
+ * Adding a client is a new entry here plus `--update`.
+ */
+const CLIENTS = [
+  {
+    name: "opencode",
+    bin: "opencode",
+    versionArgs: ["--version"],
+    configFor: (dir, url) => [["opencode.json", JSON.stringify({
+      $schema: "https://opencode.ai/config.json",
+      model: "anthropic/claude-sonnet-5",
+      provider: { anthropic: { options: { apiKey: "dummy", baseURL: url } } },
+    }, null, 2)]],
+    argv: (dir) => ["run", "--dir", dir, "hi"],
+  },
+  {
+    name: "crush",
+    bin: "crush",
+    versionArgs: ["--version"],
+    configFor: (dir, url) => [["crush.json", JSON.stringify({
+      $schema: "https://crush.charm.sh/schema.json",
+      providers: {
+        capture: {
+          id: "capture", name: "Capture", type: "anthropic",
+          base_url: url, api_key: "dummy",
+          models: [{ id: "claude-sonnet-4-6", name: "s", context_length: 200000, max_output: 512 }],
+        },
+      },
+      models: {
+        large: { provider: "capture", model: "claude-sonnet-4-6" },
+        small: { provider: "capture", model: "claude-sonnet-4-6" },
+      },
+    }, null, 2)]],
+    argv: () => ["run", "hi"],
+  },
+]
+
+let failures = 0
+const fail = (m) => { failures++; console.error(`  ✗ ${m}`) }
+const pass = (m) => console.log(`  ✓ ${m}`)
+const note = (m) => console.log(`  · ${m}`)
+
+async function which(bin) {
+  return new Promise((res) => {
+    const p = spawn("which", [bin], { stdio: "ignore" })
+    p.on("close", (code) => res(code === 0))
+    p.on("error", () => res(false))
+  })
+}
+
+async function versionOf(client) {
+  return new Promise((res) => {
+    let out = ""
+    const p = spawn(client.bin, client.versionArgs)
+    p.stdout.on("data", (d) => { out += d })
+    p.on("close", () => res(out.trim().split("\n")[0]?.replace(/^\D*/, "") || "unknown"))
+    p.on("error", () => res("unknown"))
+  })
+}
+
+/** Run one client turn against a capture server; resolve with its headers. */
+async function capture(client, dir) {
+  return new Promise((resolve) => {
+    let captured = null
+    const server = createServer((req, res) => {
+      if (!captured) {
+        captured = {}
+        for (const [k, v] of Object.entries(req.headers)) captured[k.toLowerCase()] = String(v)
+      }
+      const body = JSON.stringify({
+        id: "m", type: "message", role: "assistant", model: "x",
+        content: [{ type: "text", text: "ok" }],
+        stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 },
+      })
+      res.writeHead(200, { "content-type": "application/json" })
+      res.end(body)
+    })
+    server.listen(PORT, "127.0.0.1", () => {
+      const url = `http://127.0.0.1:${PORT}`
+      for (const [file, content] of client.configFor(dir, url)) {
+        writeFileSync(join(dir, file), content)
+      }
+      const proc = spawn(client.bin, client.argv(dir), { cwd: dir, stdio: "ignore" })
+      // Clients differ wildly in startup cost (MCP servers, model probes);
+      // resolve as soon as a request lands rather than waiting for exit.
+      const deadline = setTimeout(() => { proc.kill(); server.close(); resolve(captured) }, 90_000)
+      const poll = setInterval(() => {
+        if (captured) {
+          clearInterval(poll); clearTimeout(deadline)
+          proc.kill(); server.close(); resolve(captured)
+        }
+      }, 500)
+      proc.on("error", () => {
+        clearInterval(poll); clearTimeout(deadline); server.close(); resolve(null)
+      })
+    })
+  })
+}
+
+/** Strip per-request noise so two runs of the same client compare equal. */
+function normalize(headers) {
+  const out = {}
+  for (const [k, v] of Object.entries(headers)) {
+    if (VOLATILE.has(k)) continue
+    out[k] = VOLATILE_VALUES.has(k) ? "<session>" : v
+  }
+  return out
+}
+
+const fixture = JSON.parse(readFileSync(FIXTURE, "utf8"))
+const results = []
+
+for (const client of CLIENTS) {
+  console.log(`\n${client.name}`)
+  if (!(await which(client.bin))) {
+    // Not a failure — a machine without the client installed can still run this.
+    note(`${client.bin} not installed, skipping`)
+    continue
+  }
+  const version = await versionOf(client)
+  const dir = mkdtempSync(join(tmpdir(), `client-detect-${client.name}-`))
+  let headers
+  try {
+    headers = await capture(client, dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+
+  if (!headers) {
+    // Silence is not success: a client that never reached us tells us nothing.
+    fail(`${client.name} ${version}: no request captured (startup failure or timeout)`)
+    continue
+  }
+
+  const adapter = detectAdapter({
+    req: { header: (n) => (n ? headers[n.toLowerCase()] : { ...headers }) },
+  })
+
+  const prior = fixture.captures.filter(c => c.client === client.name)
+  const expected = prior[0]?.expectedAdapter
+  if (!expected) {
+    note(`${client.name} ${version}: no fixture yet — detected "${adapter.name}". Re-run with --update to record it.`)
+  } else if (adapter.name !== expected) {
+    fail(`${client.name} ${version}: detected "${adapter.name}", fixture expects "${expected}" — did this client change its headers?`)
+  } else {
+    pass(`${client.name} ${version} -> ${adapter.name}`)
+  }
+
+  // Report header drift even when detection still happens to be right: a new
+  // header is exactly how #733 started, one release before it did damage.
+  const now = normalize(headers)
+  const before = prior.find(c => !c.headers["x-opencode-session"])
+  if (before) {
+    const beforeNorm = normalize(before.headers)
+    const added = Object.keys(now).filter(k => !(k in beforeNorm))
+    const removed = Object.keys(beforeNorm).filter(k => !(k in now))
+    const uaChanged = now["user-agent"] !== beforeNorm["user-agent"]
+    if (added.length) note(`new headers since ${before.version}: ${added.join(", ")}`)
+    if (removed.length) note(`headers gone since ${before.version}: ${removed.join(", ")}`)
+    if (uaChanged) note(`User-Agent changed: "${beforeNorm["user-agent"]}" -> "${now["user-agent"]}"`)
+  }
+
+  results.push({
+    client: client.name,
+    version,
+    capturedAt: new Date().toISOString().slice(0, 10),
+    expectedAdapter: adapter.name,
+    headers: now,
+  })
+}
+
+if (UPDATE) {
+  // Keep entries this run could not re-capture (uninstalled clients, and the
+  // plugin-variant sets that need a configured plugin to reproduce).
+  const kept = fixture.captures.filter(c =>
+    !results.some(r => r.client === c.client) || c.headers["x-opencode-session"])
+  fixture.captures = [...kept, ...results].sort((a, b) =>
+    a.client.localeCompare(b.client) || a.version.localeCompare(b.version))
+  writeFileSync(FIXTURE, JSON.stringify(fixture, null, 2) + "\n")
+  console.log(`\nfixture updated: ${FIXTURE}`)
+}
+
+console.log(`\n${failures === 0 ? "PASS" : `FAIL (${failures})`} — client detection`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/__tests__/client-detection-fixtures.test.ts
+++ b/src/__tests__/client-detection-fixtures.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Adapter detection against REAL captured client headers.
+ *
+ * `adapter-detection.test.ts` covers detection with hand-written headers, which
+ * proves the logic behaves as its author intended. It cannot catch the failure
+ * that actually shipped: a CLIENT changing what it sends.
+ *
+ * Crush 0.87 added `x-session-affinity`, which detection checked ahead of the
+ * User-Agent chain, so every Crush request silently resolved to the OpenCode
+ * adapter — OpenCode's transforms, tool config and session semantics applied to
+ * a client with its own (#733). Nothing failed. No user could connect
+ * "sessions feel wrong" to header precedence.
+ *
+ * This file pins detection against header sets captured from real clients, so
+ * a change to detection ordering fails here. The client side is covered by
+ * `scripts/e2e-client-detection.mjs`, which re-captures from installed clients
+ * and diffs against the same fixture.
+ */
+import { describe, it, expect } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { detectAdapter } from "../proxy/adapters/detect"
+
+interface Capture {
+  client: string
+  version: string
+  capturedAt: string
+  expectedAdapter: string
+  note?: string
+  headers: Record<string, string>
+}
+
+const FIXTURE = join(import.meta.dir, "fixtures", "client-headers.json")
+const captures: Capture[] = JSON.parse(readFileSync(FIXTURE, "utf8")).captures
+
+function contextFor(headers: Record<string, string>): any {
+  const lower: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v
+  return {
+    req: {
+      header: (name?: string) => (name ? lower[name.toLowerCase()] : { ...lower }),
+    },
+  }
+}
+
+describe("adapter detection against captured client headers", () => {
+  it("has fixtures to check", () => {
+    // Guards the instrument: an empty or unreadable fixture would make every
+    // test below pass vacuously.
+    expect(captures.length).toBeGreaterThan(0)
+    for (const c of captures) {
+      expect(c.headers && Object.keys(c.headers).length).toBeGreaterThan(0)
+      expect(c.expectedAdapter).toBeTruthy()
+    }
+  })
+
+  for (const c of captures) {
+    it(`routes ${c.client} ${c.version} to the ${c.expectedAdapter} adapter`, () => {
+      const adapter = detectAdapter(contextFor(c.headers))
+      expect(adapter.name).toBe(c.expectedAdapter)
+    })
+  }
+
+  it("does not let a shared session header decide between two clients", () => {
+    // The precise shape of #733, stated as a property rather than a single
+    // case: opencode and crush both send x-session-affinity + x-session-id, so
+    // any rule keying on those alone cannot tell them apart. Whatever
+    // distinguishes them must be something else — today, the User-Agent.
+    const shared = captures.filter(c =>
+      c.headers["x-session-affinity"] && !c.headers["x-opencode-session"])
+    const distinctAdapters = new Set(shared.map(c => c.expectedAdapter))
+
+    expect(shared.length).toBeGreaterThanOrEqual(2)
+    expect(distinctAdapters.size).toBeGreaterThanOrEqual(2)
+
+    for (const c of shared) {
+      expect(detectAdapter(contextFor(c.headers)).name).toBe(c.expectedAdapter)
+    }
+  })
+
+  it("still routes correctly with the session headers stripped", () => {
+    // Isolates the User-Agent's contribution: if detection silently came to
+    // depend on a session header, this would break while the cases above pass.
+    for (const c of captures) {
+      if (c.headers["x-opencode-session"]) continue // that header IS the signal
+      const { "x-session-affinity": _a, "x-session-id": _b, ...rest } = c.headers
+      expect(detectAdapter(contextFor(rest)).name).toBe(c.expectedAdapter)
+    }
+  })
+})

--- a/src/__tests__/fixtures/client-headers.json
+++ b/src/__tests__/fixtures/client-headers.json
@@ -1,0 +1,68 @@
+{
+  "_comment": [
+    "Request headers CAPTURED FROM REAL CLIENTS, not hand-written.",
+    "",
+    "Meridian picks an adapter from these headers, and a client changing them",
+    "silently reroutes it: crush 0.87 added x-session-affinity and was thereby",
+    "detected as OpenCode, inheriting OpenCode's transforms, tool config and",
+    "session semantics (#733). No user could connect the symptom to the cause.",
+    "",
+    "client-detection-fixtures.test.ts asserts each set still resolves to the",
+    "adapter recorded here, so a change to detection ordering fails CI.",
+    "scripts/e2e-client-detection.mjs re-captures from installed clients and",
+    "diffs against this file, so a CLIENT-side change shows up as a git diff.",
+    "",
+    "To add a client: run the live script, which writes the captured set here.",
+    "Secrets are redacted at capture time."
+  ],
+  "captures": [
+    {
+      "client": "crush",
+      "version": "0.87.0",
+      "capturedAt": "2026-07-31",
+      "expectedAdapter": "crush",
+      "headers": {
+        "user-agent": "Charm-Crush/v0.87.0 (https://charm.land/crush)",
+        "accept": "application/json",
+        "anthropic-beta": "interleaved-thinking-2025-05-14",
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+        "x-session-affinity": "<session>",
+        "x-session-id": "<session>",
+        "x-stainless-arch": "arm64",
+        "x-stainless-lang": "go",
+        "x-stainless-os": "MacOS",
+        "x-stainless-package-version": "1.26.0",
+        "x-stainless-runtime": "go",
+        "x-stainless-runtime-version": "go1.26.5"
+      }
+    },
+    {
+      "client": "opencode",
+      "version": "1.18.9",
+      "capturedAt": "2026-07-31",
+      "expectedAdapter": "opencode",
+      "headers": {
+        "content-type": "application/json",
+        "user-agent": "opencode/1.18.9 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14",
+        "anthropic-version": "2023-06-01",
+        "x-session-affinity": "<session>",
+        "x-session-id": "<session>",
+        "accept": "*/*"
+      }
+    },
+    {
+      "client": "opencode",
+      "version": "1.18.9+meridian-plugin",
+      "capturedAt": "2026-07-31",
+      "expectedAdapter": "opencode",
+      "note": "With the Meridian plugin active, x-opencode-session is injected and outranks the User-Agent chain.",
+      "headers": {
+        "user-agent": "opencode/1.18.9 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14",
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+        "x-opencode-session": "ses_045efb928ffejLOGaHyZy9rPdQ"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes the gap that let #733 ship: Meridian picks an adapter from request headers, so a client changing what it sends silently reroutes it — and nothing fails.

## The gap

Crush 0.87 added `x-session-affinity`. Detection checked that header **ahead of** the User-Agent chain, so every Crush request resolved to the **OpenCode** adapter: OpenCode's transforms, tool config, MCP server name and CWD extraction applied to a client that has its own adapter *and* its own transform.

Then fixing the detection made it worse, because `openCodeAdapter.getSessionId` falls back to the same header — Crush had been getting keyed sessions *by accident*, and correct detection downgraded it to fingerprint-only continuity, looping until timeout.

It was found by upgrading a client and running one turn. No user connects "sessions feel wrong" to header precedence, and no unit test can watch a client change its headers.

## Two halves, because they catch different things

### Static — `client-detection-fixtures.test.ts`

Pins detection against header sets **captured from real clients**, so a change to detection *ordering* fails in CI with no client installed.

`adapter-detection.test.ts` already covers hand-written headers, which proves the logic does what its author intended. It cannot catch a client sending something new. These fixtures can.

One test states #733's lesson as a **property** rather than a case:

> opencode 1.18.9 and crush 0.87 both send `x-session-affinity` **and** `x-session-id`, so any rule keying on those alone cannot tell them apart — whatever distinguishes them must be something else.

That fact came out of the capture and is the single most useful thing here. A future maintainer reaching for a session header as an identity signal now trips a test that explains why.

### Live — `scripts/e2e-client-detection.mjs` (E36)

Drives each installed client against a local stub, captures its real headers, and asserts the adapter that resolves — the **client-side** half.

**Costs no tokens.** Requests are answered locally and never forwarded upstream.

- Header additions/removals and User-Agent changes are **reported even when detection is still correct** — a new header is exactly how #733 started, one release before it did damage.
- A client that never reaches the capture server **fails**; silence is not success.
- An uninstalled client is skipped with a note, so this runs on a machine with only some clients.
- Adding a client is one entry in the `CLIENTS` table plus `--update`.

## Verified to catch the bug, not merely to run

Reintroducing #733 fails **both** halves:

```
(fail) routes crush 0.87.0 to the crush adapter
(fail) does not let a shared session header decide between two clients

✗ crush 0.87.0: detected "opencode", fixture expects "crush" — did this client change its headers?
```

The live diagnostic names the client and points at the likely cause.

## Fixtures are captures, not inventions

Recorded with `--update` from real runs. My first pass hand-curated a subset, and the drift report immediately flagged the difference between what I had written and what the clients actually send — so I regenerated from real captures. Session-id values are normalized to `<session>` and secrets dropped at capture time, so the file is stable across runs and carries nothing sensitive.

## Testing

`npm test`: 0 failures across all invocations (2292 in the main run plus the isolated files). `npx tsc --noEmit` clean. Live script passes against opencode 1.18.9 and crush 0.87.0.

E2E.md documents E36 with pass criteria, the no-token property, how to add a client, and the run trigger — **after upgrading any client**.

## Coverage today

opencode (with and without the Meridian plugin) and crush. droid, pi and codex are drivable the same way and each need a `CLIENTS` entry; the table is the extension point, and an uninstalled client is skipped rather than failing.
