### PR TITLE
fix: register claude-code transforms so tool calls pass through

### DIFF
--- a/src/__tests__/proxy-tool-blocking.test.ts
+++ b/src/__tests__/proxy-tool-blocking.test.ts
@@ -92,11 +92,11 @@ function createTestApp() {
   return app
 }
 
-async function sendRequest(app: any, stream: boolean) {
+async function sendRequest(app: any, stream: boolean, headers: Record<string, string> = {}) {
   capturedQueryParams = null
   const response = await app.fetch(new Request("http://localhost/v1/messages", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify({
       model: "claude-sonnet-4-5",
       max_tokens: 128,
@@ -149,6 +149,57 @@ describe("Tool blocking: normal mode (non-passthrough)", () => {
     const app = createTestApp()
     const params = await sendRequest(app, true)
     assertAllToolsBlocked(params, "normal/stream")
+  })
+})
+
+// A Claude Code CLI client drives its own tool loop. server.ts resolves tool
+// config and passthrough from `pipelineCtx.*` — never from the adapter methods
+// — so with no registry entry for "claude-code" the request kept the
+// createRequestContext defaults: `blockedTools: []` and `passthrough:
+// undefined`. The SDK subprocess then had its own Read/Write/Bash available
+// while the client executed the same tool_use blocks locally, so a side effect
+// could happen twice (#735).
+//
+// These go through the HTTP layer on purpose: transform-parity tests assert the
+// transform's VALUES, and every one of them passed while this was broken. The
+// defect was the wiring between the registry and the request, which only a
+// server-level assertion can see.
+describe("Tool blocking: claude-code adapter (#735)", () => {
+  let savedAgent: string | undefined
+  beforeEach(() => {
+    // Default install: no passthrough opt-in, and no default-agent override
+    // (which would reroute the ambiguous claude-cli User-Agent elsewhere).
+    delete process.env.CLAUDE_PROXY_PASSTHROUGH
+    delete process.env.MERIDIAN_PASSTHROUGH
+    savedAgent = process.env.MERIDIAN_DEFAULT_AGENT
+    delete process.env.MERIDIAN_DEFAULT_AGENT
+  })
+  afterEach(() => {
+    if (savedAgent !== undefined) process.env.MERIDIAN_DEFAULT_AGENT = savedAgent
+    else delete process.env.MERIDIAN_DEFAULT_AGENT
+  })
+
+  const CLAUDE_CLI_UA = { "user-agent": "claude-cli/1.0.60 (external)" }
+
+  it("blocks the SDK's built-in tools for a claude-cli client (non-stream)", async () => {
+    const app = createTestApp()
+    const params = await sendRequest(app, false, CLAUDE_CLI_UA)
+    assertAllToolsBlocked(params, "claude-code/non-stream")
+  })
+
+  it("blocks the SDK's built-in tools for a claude-cli client (stream)", async () => {
+    const app = createTestApp()
+    const params = await sendRequest(app, true, CLAUDE_CLI_UA)
+    assertAllToolsBlocked(params, "claude-code/stream")
+  })
+
+  it("does not leave disallowedTools empty, which is the actual regression", async () => {
+    // Stated separately from assertAllToolsBlocked: an empty list is the exact
+    // broken state, and a future change that empties it should fail on a test
+    // whose name says so.
+    const app = createTestApp()
+    const params = await sendRequest(app, false, CLAUDE_CLI_UA)
+    expect((params?.options?.disallowedTools || []).length).toBeGreaterThan(0)
   })
 })
 

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -12,6 +12,9 @@ import { droidAdapter } from "../proxy/adapters/droid"
 import { piAdapter } from "../proxy/adapters/pi"
 import { forgeCodeAdapter } from "../proxy/adapters/forgecode"
 import { passthroughAdapter } from "../proxy/adapters/passthrough"
+import { claudeCodeTransforms } from "../proxy/transforms/claudecode"
+import { claudeCodeAdapter } from "../proxy/adapters/claudecode"
+import { getAdapterTransforms } from "../proxy/transforms/registry"
 
 function makeCtx(adapter: string, body: any = {}) {
   return createRequestContext({
@@ -227,5 +230,74 @@ describe("Passthrough (LiteLLM) transform parity", () => {
   it("matches empty blockedTools", () => {
     const ctx = runTransformHook(passthroughTransforms, "onRequest", makeCtx("passthrough"), "passthrough")
     expect([...ctx.blockedTools]).toEqual([...passthroughAdapter.getBlockedBuiltinTools()])
+  })
+})
+
+// The Claude Code CLI drives its own tool loop. If registry.ts has no entry for
+// adapter "claude-code" (or the transform's `adapters` array omits it), the SDK
+// runs the client's task internally on the proxy host with built-ins unblocked
+// — every Bash/Edit executes twice, once per side. Same class as #546.
+describe("Claude Code transform parity", () => {
+  let savedMP: string | undefined
+  let savedCP: string | undefined
+  beforeEach(() => {
+    savedMP = process.env.MERIDIAN_PASSTHROUGH
+    savedCP = process.env.CLAUDE_PROXY_PASSTHROUGH
+    delete process.env.MERIDIAN_PASSTHROUGH
+    delete process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+  afterEach(() => {
+    if (savedMP !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedMP
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    if (savedCP !== undefined) process.env.CLAUDE_PROXY_PASSTHROUGH = savedCP
+    else delete process.env.CLAUDE_PROXY_PASSTHROUGH
+  })
+
+  it("is registered under the adapter's own name", () => {
+    expect(getAdapterTransforms(claudeCodeAdapter.name)).toBe(claudeCodeTransforms)
+  })
+
+  it("matches blockedTools", () => {
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect([...ctx.blockedTools]).toEqual([...claudeCodeAdapter.getBlockedBuiltinTools()])
+    expect(ctx.blockedTools.length).toBeGreaterThan(0)
+  })
+
+  it("matches incompatibleTools and allowedMcpTools", () => {
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect([...ctx.incompatibleTools]).toEqual([...claudeCodeAdapter.getAgentIncompatibleTools()])
+    expect([...ctx.allowedMcpTools]).toEqual([...claudeCodeAdapter.getAllowedMcpTools()])
+  })
+
+  it("matches coreToolNames (PascalCase, not OpenCode's lowercase)", () => {
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect([...ctx.coreToolNames!]).toEqual([...claudeCodeAdapter.getCoreToolNames!()])
+  })
+
+  it("matches passthrough (default on)", () => {
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect(ctx.passthrough).toBe(claudeCodeAdapter.usesPassthrough!())
+    expect(ctx.passthrough).toBe(true)
+  })
+
+  it("matches passthrough (env off → false)", () => {
+    process.env.MERIDIAN_PASSTHROUGH = "0"
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect(ctx.passthrough).toBe(claudeCodeAdapter.usesPassthrough!())
+    expect(ctx.passthrough).toBe(false)
+  })
+
+  it("matches supportsThinking and shouldTrackFileChanges", () => {
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect(ctx.supportsThinking).toBe(claudeCodeAdapter.supportsThinking!())
+    expect(ctx.shouldTrackFileChanges).toBe(claudeCodeAdapter.shouldTrackFileChanges!())
+  })
+
+  it("matches file change extraction for Edit and Bash", () => {
+    const ctx = runTransformHook(claudeCodeTransforms, "onRequest", makeCtx("claude-code"), "claude-code")
+    expect(ctx.extractFileChangesFromToolUse!("Edit", { file_path: "/a.ts" }))
+      .toEqual(claudeCodeAdapter.extractFileChangesFromToolUse!("Edit", { file_path: "/a.ts" }))
+    expect(ctx.extractFileChangesFromToolUse!("Bash", { command: "echo hi > /tmp/a" }))
+      .toEqual(claudeCodeAdapter.extractFileChangesFromToolUse!("Bash", { command: "echo hi > /tmp/a" }))
   })
 })

--- a/src/proxy/transforms/claudecode.ts
+++ b/src/proxy/transforms/claudecode.ts
@@ -1,0 +1,58 @@
+import type { Transform, RequestContext } from "../transform"
+import { extractFileChangesFromBash, type FileChange } from "../fileChanges"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, ALLOWED_MCP_TOOLS } from "../tools"
+import { resolvePassthrough } from "../../env"
+
+/**
+ * Claude Code transform — supplies the SDK tool config at request time.
+ *
+ * server.ts reads `pipelineCtx.*`, never the adapter methods, so without an
+ * entry here a Claude Code client gets the createRequestContext defaults:
+ * `blockedTools: []` and `passthrough: undefined`. That means the SDK
+ * subprocess runs the client's task with its own built-in Read/Write/Bash on
+ * the proxy host while the client executes the same tool calls locally —
+ * every side effect happens twice (#546, same failure mode as OpenCode's).
+ *
+ * Values mirror claudeCodeAdapter (adapters/claudecode.ts); the parity tests
+ * hold the two in sync. Core tool names are PascalCase here — Claude Code's
+ * toolkit is Read/Write/Edit/Bash/Glob/Grep, not OpenCode's lowercase names.
+ */
+export const claudeCodeTransforms: Transform[] = [
+  {
+    name: "claudecode-core",
+    adapters: ["claude-code"],
+
+    onRequest(ctx: RequestContext): RequestContext {
+      const extractFileChangesFromToolUse = (toolName: string, toolInput: unknown): FileChange[] => {
+        const input = toolInput as Record<string, unknown> | null | undefined
+        const filePath = input?.file_path ?? input?.filePath ?? input?.path
+        const lowerName = toolName.toLowerCase()
+        if (lowerName === "write" && filePath) {
+          return [{ operation: "wrote", path: String(filePath) }]
+        }
+        if ((lowerName === "edit" || lowerName === "multiedit") && filePath) {
+          return [{ operation: "edited", path: String(filePath) }]
+        }
+        if (lowerName === "bash" && input?.command) {
+          return extractFileChangesFromBash(String(input.command))
+        }
+        return []
+      }
+
+      return {
+        ...ctx,
+        blockedTools: BLOCKED_BUILTIN_TOOLS,
+        incompatibleTools: CLAUDE_CODE_ONLY_TOOLS,
+        allowedMcpTools: ALLOWED_MCP_TOOLS,
+        coreToolNames: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+        // Claude Code owns tool execution client-side. Mirrors
+        // claudeCodeAdapter.usesPassthrough().
+        passthrough: resolvePassthrough(true),
+        supportsThinking: true,
+        // Claude Code surfaces its own file edits; don't duplicate them.
+        shouldTrackFileChanges: false,
+        extractFileChangesFromToolUse,
+      }
+    },
+  },
+]

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -7,6 +7,7 @@ import { forgeCodeTransforms } from "./forgecode"
 import { passthroughTransforms } from "./passthrough"
 import { cherryTransforms } from "./cherry"
 import { codexTransforms } from "./codex"
+import { claudeCodeTransforms } from "./claudecode"
 
 const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   opencode: openCodeTransforms,
@@ -16,6 +17,10 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   forgecode: forgeCodeTransforms,
   passthrough: passthroughTransforms,
   cherry: cherryTransforms,
+  // Keyed by adapter.name ("claude-code", not "claudecode"). Without this the
+  // Claude Code CLI falls through to the empty default — built-ins unblocked,
+  // passthrough off — and the SDK re-executes every tool call on the proxy host.
+  "claude-code": claudeCodeTransforms,
   // The OpenAI-compatible endpoint reuses OpenCode's transforms verbatim so
   // tool/passthrough behaviour is identical; only the preset default differs
   // (see sdkFeatures.ADAPTER_DEFAULTS.openai).


### PR DESCRIPTION
Lands @wayniacal's fix from #735, cherry-picked with authorship preserved, plus a server-level regression test.

## The bug

`ADAPTER_TRANSFORMS` had no entry for `claude-code`, so `getAdapterTransforms("claude-code")` returned `[]` and the request kept the `createRequestContext` defaults: `blockedTools: []`, `passthrough: undefined`.

`claudeCodeAdapter.usesPassthrough()` already returns `resolvePassthrough(true)` — but `server.ts` resolves from `pipelineCtx.*` and never calls the adapter methods, so it was dead code. Same class as #546, where `openai` had to be added to a transform's `adapters` array for the same reason.

The consequence is that the SDK subprocess gets its own Read/Write/Bash **unblocked** while the client also executes the returned `tool_use` blocks. Side effects can happen twice — writes, commits, HTTP calls. The reporter's transcript shows two identical API posts 13 ms apart, and a second SDK session that independently edited files, committed, and raced a push to the same branch.

## Verified independently

**The mechanism, deterministically.** `claude-code` is absent from the registry; `envBool("PASSTHROUGH")` is the only fallback; and with no transform the SDK receives an empty `disallowedTools`. Confirmed by removing the registry entry and watching the new HTTP-layer tests fail.

**Live, on a default install** (no `MERIDIAN_PASSTHROUGH`, no `MERIDIAN_DEFAULT_AGENT`) with the real Claude Code CLI: `/health` reports `mode: internal` and requests log `adapter=claude-code`, i.e. exactly the precondition.

**One correction to the PR description.** It states that `MERIDIAN_PASSTHROUGH=1` "does not reach this path either". It does — `envBool("PASSTHROUGH")` is the final fallback in the resolution chain, so setting it *does* turn passthrough on for `claude-code`. That narrows the blast radius to default installs rather than everyone, and explains why this went unnoticed here: this machine sets both `MERIDIAN_PASSTHROUGH=1` and `MERIDIAN_DEFAULT_AGENT=pi`, so it was insulated twice over. The fix is still correct — the default should match `claudeCodeAdapter.usesPassthrough()` rather than depending on an env var.

**On reproducing the doubling itself:** I did not see two writes in a single live run — the model used the bridged tool that time. The doubling is *possible* rather than guaranteed, because with built-ins unblocked the SDK may act host-side **in addition to** delegating; which path the model picks varies per run. The unblocked-built-ins state is deterministic, and that is what the tests pin.

## Review of the change

The transform mirrors `claudeCodeAdapter` value-for-value, and the PascalCase `coreToolNames` reasoning is right: reusing `openCodeTransforms` verbatim would hand the deferral logic OpenCode's lowercase names and defer exactly the tools it means to load eagerly.

Registering under `adapter.name` (`"claude-code"`, not `"claudecode"`) is the subtle part, and the contributor called it out in a comment — worth keeping, since the file is `claudecode.ts` and the mismatch is the kind of thing that gets "tidied" into a bug later.

Duplicating `extractFileChangesFromToolUse` rather than importing it from the adapter matches how `transforms/opencode.ts` already works, so this follows the existing convention instead of inventing one. The parity tests hold the copies in sync.

## Added on top

A server-level test (`proxy-tool-blocking.test.ts`). The contributor's parity tests assert the transform's **values**, and all of them would have passed while this was broken — the defect was the **wiring** between the registry and the request, which only an HTTP-layer assertion can see. The new cases drive a `claude-cli` User-Agent under default-install conditions and assert the SDK actually receives blocked built-ins, including one named for the exact broken state (`disallowedTools` empty).

Verified load-bearing: removing the registry entry fails all three, alongside the contributor's registration check.

## Testing

`npm test`: 2303 pass, 0 failures across all invocations. `npx tsc --noEmit` clean.

## Found while verifying, filed separately

For a `claude-code` client, the model is told the **proxy host's** working directory rather than the client's, so it can compose absolute paths that write to the wrong machine's tree. `extractClientWorkingDirectory` is called unconditionally in `server.ts` and does not branch on passthrough, so this is pre-existing and **not** caused by this change — it is simply easier to notice once tool execution moves client-side. Filed on its own.
