### PR TITLE
fix(passthrough): defer early stop while a tool_use block is still streaming

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -3106,9 +3106,38 @@ curl -s http://127.0.0.1:3456/v1/chat/completions \
 **Automated** — the one E2E that is a single command:
 
 ```bash
-bun scripts/e2e-stream-parallel.mjs        # 3 attempts (default)
+bun scripts/e2e-stream-parallel.mjs                    # 3 attempts (default)
 E2E_ATTEMPTS=5 bun scripts/e2e-stream-parallel.mjs
+E2E_WIDE=1 bun scripts/e2e-stream-parallel.mjs         # #742 window (see below)
 ```
+
+**`E2E_WIDE=1` — the #742 ordering.** The default prompt produces three
+short-argument calls that close in one delta each, so the deny-before-block-close
+window never opens: the run reports **INCONCLUSIVE for #742** rather than a
+pass, because clean assertions over an ordering that never occurred prove
+nothing. `E2E_WIDE=1` adds a fourth call carrying a multi-KB free-text argument
+— the shape from the original report (a ~2.9 KB subagent prompt) — which keeps
+one block streaming while an earlier call's deny settles. That hit the race on
+**6 of 6** attempts.
+
+The run also watches Meridian's own diagnostics, not just the wire:
+
+| signal | meaning |
+|---|---|
+| `dangling_blocks_closed` / `early_stop` | the race FIRING — the bug's signature |
+| `passthrough.early_stop_deferred` | the fix ENGAGING — race occurred, handled |
+
+Requiring at least one deferral is what makes a green run evidence instead of
+absence. Verified by reverting the fix and re-running the same scenario:
+
+```
+✗ tool task has EMPTY input (the '{} Tool execution aborted' render)
+   widest tool input: 29 bytes across 4 calls      # vs 5259-6418 with the fix
+```
+
+Note the envelope marker did **not** fire in that failing run. The framing
+stayed valid throughout — only the payload assertion caught it. That is exactly
+why #675 mis-triaged this same race as "client impact: none".
 
 **Why this exists:** the CLI dispatches PreToolUse hooks per-block while later
 parallel blocks are still generating, and a deny landing mid-generation makes

--- a/scripts/e2e-stream-parallel.mjs
+++ b/scripts/e2e-stream-parallel.mjs
@@ -27,12 +27,43 @@ import { startProxyServer } from "../src/proxy/server.ts"
 
 const PORT = 3499
 const ATTEMPTS = Number(process.env.E2E_ATTEMPTS ?? 3)
+
+// #742: the early stop used to fire on deny-settlement alone, force-closing a
+// tool_use block that was still streaming its input — a well-formed envelope
+// around TRUNCATED JSON. The client rejects the call and the turn wedges.
+//
+// Framing assertions cannot see that; the envelope was always valid. So this
+// run also watches Meridian's own diagnostics:
+//
+//   dangling_blocks_closed / early_stop  the race FIRING (the bug's signature)
+//   passthrough.early_stop_deferred      the fix ENGAGING (the race occurred
+//                                        and was handled correctly)
+//
+// The second one matters as much as the first: without it a clean run is
+// ambiguous — fixed, or the race simply never happened this time.
+process.env.OPENCODE_CLAUDE_PROVIDER_DEBUG = "1"
+const diag = []
+const realDebug = console.debug.bind(console)
+console.debug = (...args) => { diag.push(args.map(String).join(" ")) }
+
 const inst = await startProxyServer({ port: PORT, host: "127.0.0.1", silent: true })
+
+const diagSince = (from) => diag.slice(from)
+const countMatching = (lines, needle) => lines.filter((l) => l.includes(needle)).length
+
+// #742 needs a WIDE parallel set where at least one input is large enough to
+// still be streaming when an earlier call's deny settles. A short `ls /tmp`
+// argument closes in one delta and never opens the window; the original report
+// was a subagent call carrying a ~2.9 KB prompt.
+const WIDE = process.env.E2E_WIDE === "1"
 
 const TOOLS = [
   { name: "bash", description: "Run a shell command", input_schema: { type: "object", properties: { command: { type: "string" } }, required: ["command"] } },
   { name: "glob", description: "Find files by glob pattern", input_schema: { type: "object", properties: { pattern: { type: "string" } }, required: ["pattern"] } },
   { name: "read", description: "Read a file", input_schema: { type: "object", properties: { filePath: { type: "string" } }, required: ["filePath"] } },
+  // Large free-text argument — the shape that keeps a block streaming long
+  // enough for an earlier deny to settle first (#742).
+  { name: "task", description: "Dispatch a read-only exploration subagent", input_schema: { type: "object", properties: { description: { type: "string" }, prompt: { type: "string" } }, required: ["description", "prompt"] } },
 ]
 
 let failures = 0
@@ -67,12 +98,31 @@ async function sse(sid, messages, maxTokens = 700) {
   }
 }
 
+let deferralsObserved = 0
+let racesFired = 0
+
 for (let n = 1; n <= ATTEMPTS; n++) {
+  const diagFrom = diag.length
   const sid = `e2e-par-${n}-${Math.random().toString(36).slice(2, 6)}`
-  const messages = [{ role: "user", content: "Run `ls /tmp` with bash AND find *.md files with glob AND read /etc/hostname — issue ALL THREE tool calls in parallel in this single response." }]
+  const messages = [{
+    role: "user",
+    content: WIDE
+      ? "Issue these FOUR tool calls in parallel in this single response: " +
+        "(1) bash `ls /tmp`, (2) glob for *.md, (3) read /etc/hostname, and " +
+        "(4) a task call whose `prompt` argument is a detailed 600+ word " +
+        "read-only exploration brief describing, in full prose, how you would " +
+        "audit a Go control-plane repository: directory-by-directory, naming " +
+        "conventions to look for, the ordering of the passes, and what to " +
+        "report at each stage. Write the brief out in full inside the argument."
+      : "Run `ls /tmp` with bash AND find *.md files with glob AND read /etc/hostname — issue ALL THREE tool calls in parallel in this single response.",
+  }]
 
   const t1 = await sse(sid, messages)
   if (t1.tools.length < 2) fail(n, `expected ≥2 parallel tool calls, got ${t1.tools.length}`)
+  if (WIDE) {
+    const biggest = Math.max(0, ...t1.tools.map((t) => t.inputJson.length))
+    console.log(`      widest tool input: ${biggest} bytes across ${t1.tools.length} calls`)
+  }
   if (t1.danglingIdx.length > 0) fail(n, `dangling blocks (red reads): idx=[${t1.danglingIdx.join(",")}]`)
   if (t1.messageStops !== 1) fail(n, `expected 1 message_stop, got ${t1.messageStops}`)
   for (const t of t1.tools) {
@@ -95,13 +145,35 @@ for (let n = 1; n <= ATTEMPTS; n++) {
   const reissued = t2.tools.filter((t) => t1.tools.some((p) => p.name === t.name && p.inputJson === t.inputJson))
   if (reissued.length > 0) fail(n, `model re-issued identical calls (lost memory of turn 1): ${reissued.map((t) => t.name).join(",")}`)
 
-  console.log(`  ✓ attempt ${n}: ${t1.tools.length} parallel calls intact (${t1.tools.map((t) => t.name).join(", ")}), follow-up clean`)
+  // #742: Meridian's own view of the same turn.
+  const lines = diagSince(diagFrom)
+  const deferred = countMatching(lines, "passthrough.early_stop_deferred")
+  const fired = countMatching(lines, "dangling_blocks_closed")
+  deferralsObserved += deferred
+  racesFired += fired
+  if (fired > 0) {
+    fail(n, `early stop closed a still-open block (#742 signature) — ${fired} dangling_blocks_closed`)
+  }
+
+  const raced = deferred > 0 ? `, race hit and deferred x${deferred}` : ""
+  console.log(`  ✓ attempt ${n}: ${t1.tools.length} parallel calls intact (${t1.tools.map((t) => t.name).join(", ")}), follow-up clean${raced}`)
 }
 
 await inst.close?.()
+console.debug = realDebug
+
+console.log(`\n#742 window: deferred ${deferralsObserved}x, races closed mid-block ${racesFired}x`)
 if (failures > 0) {
   console.error(`\nE2E FAILED: ${failures} assertion(s) across ${ATTEMPTS} attempts`)
   process.exit(1)
 }
-console.log(`\nE2E PASSED: ${ATTEMPTS}/${ATTEMPTS} attempts clean`)
+if (deferralsObserved === 0) {
+  // Not a pass. The assertions held, but the ordering this run exists to
+  // exercise never occurred, so it proves nothing about #742. Say so rather
+  // than let a green line imply coverage that wasn't there.
+  console.log(`\nE2E INCONCLUSIVE for #742: ${ATTEMPTS}/${ATTEMPTS} attempts clean, but the deny-before-block-close ordering never occurred.`)
+  console.log(`Re-run with more attempts (E2E_ATTEMPTS=20) to exercise it; the race is intermittent (~2 in 17 requests when first reported).`)
+  process.exit(2)
+}
+console.log(`\nE2E PASSED: ${ATTEMPTS}/${ATTEMPTS} attempts clean, #742 ordering exercised ${deferralsObserved}x and handled without truncation`)
 process.exit(0)

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -232,6 +232,69 @@ describe("Integration: passthrough early stop", () => {
     expect(yieldedCount).toBe(3) // everything drained, old behavior
   })
 
+  // #742: the early stop fires on deny-settlement alone. When the SDK surfaces a
+  // wide parallel set as separate assistant turns, every deny the tracker KNOWS
+  // about can settle while a LATER tool_use block is still mid-input_json_delta.
+  // flushOpenClientBlocks then force-emits its content_block_stop, so the client
+  // gets a well-formed envelope wrapped around TRUNCATED JSON — invisible as a
+  // wire error, which is why the envelope audit (framing) never caught it.
+  //
+  // This asserts payload integrity, not framing: the property #675 missed when
+  // it triaged the same race as "client impact: none".
+  it("stream: does not truncate a still-streaming parallel tool_use when the deny settles first (#742)", async () => {
+    const TAIL = "TAIL_OF_THE_PROMPT"
+    mockMessages = [
+      messageStart("msg_es"),
+      // First tool: completes normally and is the only one the tracker sees.
+      toolUseBlockStart(0, "read", "tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
+      // Second parallel tool opens and is still mid-JSON...
+      toolUseBlockStart(1, "read", "tu2"),
+      inputJsonDelta(1, '{"file_path":"y","note":"HEAD_'),
+      // ...when tu1's deny lands. Every tool the tracker knows about is now
+      // denied, so the early stop fires with block 1 still open.
+      userDenyMessage("tu1"),
+      // The rest of tu2's JSON. Before the fix these are never forwarded.
+      inputJsonDelta(1, TAIL + '"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x and y" }],
+    })
+
+    expect(response.status).toBe(200)
+    const text = await response.text()
+
+    // Reassemble each block's input the way a client does: accumulate
+    // input_json_delta per block index, then parse.
+    const perBlock = new Map<number, string>()
+    for (const line of text.split("\n")) {
+      if (!line.startsWith("data: ")) continue
+      let evt: any
+      try { evt = JSON.parse(line.slice(6)) } catch { continue }
+      if (evt?.type !== "content_block_delta") continue
+      if (evt.delta?.type !== "input_json_delta") continue
+      perBlock.set(evt.index, (perBlock.get(evt.index) ?? "") + evt.delta.partial_json)
+    }
+
+    const blockOne = perBlock.get(1) ?? ""
+    // The failure signature: the client sees the head but never the tail.
+    expect(blockOne).toContain("HEAD_")
+    expect(blockOne).toContain(TAIL)
+    // And what it assembles must actually parse — the client-visible symptom
+    // was InputValidationError on unparseable JSON.
+    expect(() => JSON.parse(blockOne)).not.toThrow()
+    expect(JSON.parse(blockOne).note).toBe("HEAD_" + TAIL)
+  })
+
   it("stream: closes cleanly after the deny — digest events never consumed", async () => {
     mockMessages = [
       messageStart("msg_es"),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2367,6 +2367,51 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // extends the guarantee to ALL close paths (early stop, turn-2
             // suppression, drain-close). With the deny-hold in place blocks
             // normally complete before any close — this is the backstop.
+            // #742: the early stop fires on deny-settlement alone. When the SDK
+            // surfaces a wide parallel set as separate assistant turns, every
+            // deny the tracker KNOWS about can settle while a LATER tool_use
+            // block is still mid-input_json_delta. Closing then produced a
+            // well-formed envelope around TRUNCATED input JSON — the client
+            // rejects the call and the turn wedges. The envelope audit only
+            // measures framing, which is why this read as healthy (#675 triaged
+            // the same race as "client impact: none" on exactly that basis).
+            //
+            // So the stop is deferred while any forwarded block is open, and
+            // fired from the content_block_stop handler once the set empties.
+            let pendingEarlyStop = false
+            let pendingEarlyStopAt = 0
+
+            /** Emit the early-stop close. `reason` is recorded so the deferred
+             *  path is distinguishable from the immediate one in telemetry. */
+            const fireEarlyStop = (reason: "immediate" | "blocks_closed" | "deadline"): void => {
+              earlyStopFired = true
+              claudeLog("passthrough.early_stop", {
+                mode: "stream",
+                captured: capturedToolUses.length,
+                drained: awaitingEarlyStopDrain,
+                reason,
+                deferredMs: pendingEarlyStopAt ? Date.now() - pendingEarlyStopAt : 0,
+              })
+              pendingEarlyStop = false
+              // Still called: on the "deadline" path a block may genuinely be
+              // stuck open, and an unterminated block renders as an aborted
+              // ("red") tool call (#552). The backstop stays — it just no
+              // longer fires on the common ordering.
+              flushOpenClientBlocks("early_stop")
+              safeEnqueue(encoder.encode(
+                `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: lastUsage?.output_tokens ?? 0 } })}\n\n`
+              ), "early_stop")
+              safeEnqueue(encoder.encode(
+                `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+              ), "early_stop")
+              requestAbort.abort("passthrough turn complete")
+              awaitingEarlyStopDrain = false
+              if (!streamClosed) {
+                streamClosed = true
+                try { controller.close() } catch {}
+              }
+            }
+
             const flushOpenClientBlocks = (source: string): void => {
               if (openClientBlocks.size === 0) return
               recordEnvelopeViolations([...openClientBlocks].map((idx) => ({
@@ -2657,22 +2702,25 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       // emissions below only fire in the unusual case where the
                       // denies arrive first (safeEnqueue no-ops when closed).
                       if (shouldEarlyStop(earlyStop) && streamedToolUseIds.size > 0) {
-                        earlyStopFired = true
-                        claudeLog("passthrough.early_stop", { mode: "stream", captured: capturedToolUses.length, drained: awaitingEarlyStopDrain })
-                        flushOpenClientBlocks("early_stop")
-                        safeEnqueue(encoder.encode(
-                          `event: message_delta\ndata: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: lastUsage?.output_tokens ?? 0 } })}\n\n`
-                        ), "early_stop")
-                        safeEnqueue(encoder.encode(
-                          `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
-                        ), "early_stop")
-                        requestAbort.abort("passthrough turn complete")
-                        awaitingEarlyStopDrain = false
-                        if (!streamClosed) {
-                          streamClosed = true
-                          try { controller.close() } catch {}
+                        if (openClientBlocks.size > 0) {
+                          // A forwarded block is still streaming its input.
+                          // Defer rather than truncate it (#742); the deny that
+                          // completed the tracker belongs to a block that has
+                          // already closed, so the open one's stop is close
+                          // behind. Deliberately no `break` — the remaining
+                          // deltas must keep flowing to the client.
+                          if (!pendingEarlyStop) {
+                            pendingEarlyStop = true
+                            pendingEarlyStopAt = Date.now()
+                            claudeLog("passthrough.early_stop_deferred", {
+                              openBlocks: openClientBlocks.size,
+                              captured: capturedToolUses.length,
+                            })
+                          }
+                        } else {
+                          fireEarlyStop("immediate")
+                          break
                         }
-                        break
                       }
                     }
                   }
@@ -2916,6 +2964,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     } else if (eventType === "content_block_stop") {
                       const idx = (event as any).index
                       if (typeof idx === "number") openClientBlocks.delete(idx)
+                      // The block that was mid-stream when the denies settled
+                      // has now been forwarded intact — safe to close (#742).
+                      if (pendingEarlyStop && openClientBlocks.size === 0) {
+                        fireEarlyStop("blocks_closed")
+                        break
+                      }
                     }
 
                     // NOTE: agent-specific (passthrough mode) — close the client stream


### PR DESCRIPTION
Fixes #742. Reported by @forgottener with an unusually precise analysis — the diagnosis was correct in every particular, including the source lines.

## The bug

The early stop fired on deny-settlement alone. When the SDK surfaces a wide parallel set as **separate assistant turns**, every deny the tracker *knows about* can settle while a **later** tool_use block is still mid-`input_json_delta`. `flushOpenClientBlocks("early_stop")` then force-emitted that block's `content_block_stop`.

The client therefore received a **well-formed envelope wrapped around truncated JSON**: `content_block_stop` → `message_delta` → `message_stop`, all valid, with the tool input cut off mid-string. The client rejects the call as unparseable and the turn wedges.

## This invalidates #675's triage

#675 is the same race, and states:

> **Client impact: none** — the backstop closes the block, so no red reads / aborted-call artifacts reach the client. This issue is about closing the race at its source so the backstop goes back to being dead code.

That is wrong, and it is worth recording *why* it was wrong: the envelope audit measures **framing**, and the framing was always valid. Nobody was measuring **payload** integrity. The backstop wasn't preventing harm — it was making data loss look like a clean close. #675 was consequently filed as cosmetic cleanup and would have stayed deprioritized indefinitely.

Confirmed in the control run below: with the fix reverted, the envelope marker `dangling_blocks_closed` **never fired**, while the tool input silently collapsed to 29 bytes.

## The fix

Defer the stop while any forwarded block is open; fire it from the `content_block_stop` handler once the set empties. The deny that completed the tracker belongs to a block that has *already* closed, so the open one's stop is close behind.

Two details worth stating:

- **`flushOpenClientBlocks` is still called on the firing path.** A block can genuinely be stuck open, and an unterminated block renders as an aborted "red" tool call (#552). The backstop stays — it just no longer fires on the common ordering, which is what #675 wanted.
- **Deliberately no `break` on the deferral path.** The remaining deltas must keep flowing; breaking there would reintroduce the truncation by another route.

On the reporter's suggested wording — "the stop event is guaranteed to be close behind in the stream" — I treated that as an assumption rather than a guarantee, per #675's caveat about bounding the wait. A stalled stream is already covered by the upstream idle watchdog and the natural-end close path, both of which still run.

## Proven live, not from reasoning

#675 explicitly forbids fixing this path from reasoning alone, and the history earns that rule: **v1.49.0 and v1.49.1 both shipped "verified" fixes for #552 that failed in the field within hours.**

First, a deterministic reproduction at the integration layer, asserting **payload** integrity rather than framing — the property everyone had been missing. Before the fix:

```
Expected to contain: "TAIL_OF_THE_PROMPT"
Received: "{\"file_path\":\"y\",\"note\":\"HEAD_"
```

Then the real thing. The default E34 prompt produces three short-argument calls that close in one delta each, so the window never opens — 8/8 attempts clean and the run correctly reported **INCONCLUSIVE**, not a pass. `E2E_WIDE=1` adds a fourth call carrying a multi-KB free-text argument, the shape from the original report (~2.9 KB subagent prompt):

| | result |
|---|---|
| **with fix** | 6/6 clean, race deferred **6x**, widest input **5259–6418 bytes** |
| **without fix** | **3/4 FAIL** — `tool task has EMPTY input`, widest input **29 bytes** |

Same scenario, same model, real SDK. That is the before/after.

## E34 changes

- **`E2E_WIDE=1`** scenario that reliably opens the window.
- Watches Meridian's own diagnostics, not just the wire: `dangling_blocks_closed` (race firing) and a new `passthrough.early_stop_deferred` (fix engaging).
- **Refuses to report a pass for #742 when the ordering never occurred**, exiting with a distinct INCONCLUSIVE status. Clean assertions over an ordering that never happened prove nothing, and a green line that implies otherwise is how this class of bug survives.

## Testing

`npm test`: 2304 pass, 0 failures across all invocations. `npx tsc --noEmit` clean. Live E34 as above.

## Follow-up

#675 should be closed as a duplicate of this, with a comment recording that its "client impact: none" assessment was incorrect — so the reasoning error stays visible rather than being quietly deleted.
