### PR TITLE
fix(pi): read the session identity OMP carries in metadata.user_id

### DIFF
--- a/src/__tests__/pi-adapter.test.ts
+++ b/src/__tests__/pi-adapter.test.ts
@@ -318,3 +318,62 @@ describe("piAdapter.extractFileChangesFromToolUse", () => {
     expect(piAdapter.extractFileChangesFromToolUse!("write", null)).toEqual([])
   })
 })
+
+
+/**
+ * #734: Oh My Pi carries a stable per-agent session id in metadata.user_id
+ * rather than a header. Without reading it, every OMP request ending in
+ * `user[tool_result]` hit the headerless `isClientDrivenLoop` bypass — no
+ * session key means an independent request, which skips lineage lookup and
+ * starts a fresh SDK session on every tool round.
+ */
+describe("piAdapter.getSessionId — body identity fallback (#734)", () => {
+  const ctx = (headers: Record<string, string> = {}) => ({
+    req: { header: (n: string) => headers[n] },
+  }) as any
+
+  const ompBody = (sessionId: string) => ({
+    metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+  })
+
+  it("reads the OMP session id from metadata.user_id", () => {
+    expect(piAdapter.getSessionId(ctx(), ompBody("omp-main-1"))).toBe("omp-main-1")
+  })
+
+  it("keeps x-session-affinity authoritative over the body", () => {
+    // Pi's own convention, and an orchestrator-supplied key must keep winning.
+    expect(piAdapter.getSessionId(ctx({ "x-session-affinity": "hdr" }), ompBody("body")))
+      .toBe("hdr")
+  })
+
+  it("returns undefined for a stock Pi client with neither", () => {
+    // The headerless bypass must stay reachable — it is correct for genuinely
+    // concurrent tool loops with no identity at all.
+    expect(piAdapter.getSessionId(ctx(), {})).toBeUndefined()
+    expect(piAdapter.getSessionId(ctx())).toBeUndefined()
+  })
+
+  it("ignores a plain-string user_id, which is not a session declaration", () => {
+    // Anthropic's user_id is a USER identifier; adopting one as a session key
+    // would collide every conversation from that user into one SDK session.
+    expect(piAdapter.getSessionId(ctx(), { metadata: { user_id: "user-123" } })).toBeUndefined()
+  })
+
+  it("ignores a JSON envelope without a session_id", () => {
+    expect(piAdapter.getSessionId(ctx(), { metadata: { user_id: JSON.stringify({ account: "a" }) } }))
+      .toBeUndefined()
+  })
+
+  it("ignores an empty session_id", () => {
+    expect(piAdapter.getSessionId(ctx(), ompBody(""))).toBeUndefined()
+  })
+
+  it("keeps distinct agents on distinct sessions", () => {
+    // OMP gives Main, Advisor and each subagent its own id; that distinctness
+    // is what makes adopting the key safe against the collision the bypass
+    // exists to prevent.
+    const main = piAdapter.getSessionId(ctx(), ompBody("omp-main"))
+    const advisor = piAdapter.getSessionId(ctx(), ompBody("omp-advisor"))
+    expect(main).not.toBe(advisor)
+  })
+})

--- a/src/__tests__/proxy-source-keyed-session.test.ts
+++ b/src/__tests__/proxy-source-keyed-session.test.ts
@@ -126,3 +126,89 @@ describe("explicit session keys override the independence guard", () => {
     expect(capturedOptions[1].resume).toBe("test-session")
   })
 })
+
+
+/**
+ * #734: Oh My Pi carries a stable per-agent session id in `metadata.user_id`
+ * rather than a header. Meridian's Pi adapter read only the header, so every
+ * OMP request ending in `user[tool_result]` fell into the headerless
+ * `isClientDrivenLoop` bypass — an independent request that skips lineage
+ * lookup and starts a fresh SDK session on every tool round.
+ *
+ * The tool_result shape is the point: a plain `user[text]` follow-up already
+ * resumed, which is why the reporter's telemetry showed 14 continuations for
+ * text turns and 0 for 40 tool-result turns.
+ */
+describe("OMP body session identity survives the tool-result bypass (#734)", () => {
+  const OMP = (sessionId: string) => ({
+    metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+  })
+
+  const TOOL_TURN_1 = {
+    ...TURN_1,
+    ...OMP("omp-main-734"),
+  }
+  /** Ends in user[tool_result] — the shape that triggered the bypass. */
+  const TOOL_TURN_2 = {
+    ...TURN_1,
+    ...OMP("omp-main-734"),
+    messages: [
+      ...TURN_1.messages,
+      { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "read", input: { p: "a" } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "file contents" }] },
+    ],
+  }
+
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedOptions = []
+    clearSessionCache()
+  })
+  afterEach(() => {
+    clearSessionCache()
+  })
+
+  it("resumes a tool-result turn when the body carries an OMP session id", async () => {
+    const app = createTestApp()
+    const headers = { "x-meridian-agent": "pi" }
+    expect((await post(app, TOOL_TURN_1, headers)).status).toBe(200)
+    expect((await post(app, TOOL_TURN_2, headers)).status).toBe(200)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[0].resume).toBeUndefined()
+    expect(capturedOptions[1].resume).toBe("test-session")
+  })
+
+  it("still refuses to resume a tool-result turn with no identity at all", async () => {
+    // The bypass must stay intact for genuinely headerless concurrent loops,
+    // where every request would otherwise share one key and collide.
+    const app = createTestApp()
+    const headers = { "x-meridian-agent": "pi" }
+    const { metadata: _1, ...t1 } = TOOL_TURN_1 as any
+    const { metadata: _2, ...t2 } = TOOL_TURN_2 as any
+    await post(app, t1, headers)
+    await post(app, t2, headers)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+
+  it("keeps distinct OMP agents on distinct sessions", async () => {
+    // Main / Advisor / subagents each get their own id; adopting the key is
+    // only safe because those ids differ.
+    const app = createTestApp()
+    const headers = { "x-meridian-agent": "pi" }
+    await post(app, TOOL_TURN_1, headers)
+    await post(app, { ...TOOL_TURN_2, ...OMP("omp-advisor-734") }, headers)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+
+  it("x-session-affinity still wins over the body id", async () => {
+    const app = createTestApp()
+    const headers = { "x-meridian-agent": "pi", "x-session-affinity": "hdr-734" }
+    await post(app, TOOL_TURN_1, headers)
+    await post(app, { ...TOOL_TURN_2, ...OMP("a-different-body-id") }, headers)
+    expect(capturedOptions).toHaveLength(2)
+    // Same header across both turns, so it resumes despite the body id changing.
+    expect(capturedOptions[1].resume).toBe("test-session")
+  })
+})

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -30,6 +30,7 @@ import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
 import { normalizeContent } from "../messages"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../tools"
 import { resolvePassthrough } from "../../env"
+import { extractClaudeCodeSessionId } from "./claudecode"
 
 const PI_MCP_SERVER_NAME = "pi"
 
@@ -77,8 +78,29 @@ export const piAdapter: AgentAdapter = {
    * long-lived subagent conversations resume instead of fresh-replaying
    * every turn (which decayed prompt-cache hits to the static-prefix floor).
    */
-  getSessionId(c: Context): string | undefined {
-    return c.req.header("x-session-affinity")
+  /**
+   * `x-session-affinity` stays authoritative — that is Pi's own convention and
+   * an orchestrator-supplied key must keep winning.
+   *
+   * Falling back to the body identity is for harnesses that carry a stable
+   * per-agent session id in `metadata.user_id` instead of a header. Oh My Pi
+   * does exactly that (`{"session_id": …}`, distinct for Main, Advisor and each
+   * subagent), and without it every OMP request ending in `user[tool_result]`
+   * fell into the headerless `isClientDrivenLoop` bypass: no session key means
+   * an independent request, which skips lineage lookup and starts a fresh SDK
+   * session every tool round (#734).
+   *
+   * The bypass itself is left intact — it is correct for genuinely headerless
+   * concurrent loops, where a shared key would collide. This only supplies the
+   * key when the client has actually declared one.
+   *
+   * `extractClaudeCodeSessionId` is deliberately strict: `metadata.user_id`
+   * must be, or parse to, an object with a non-empty string `session_id`. A
+   * plain-string user id yields undefined, so clients that do not opt into this
+   * envelope are unaffected.
+   */
+  getSessionId(c: Context, body?: unknown): string | undefined {
+    return c.req.header("x-session-affinity") ?? extractClaudeCodeSessionId(body)
   },
 
   extractWorkingDirectory(body: any): string | undefined {


### PR DESCRIPTION
Fixes #734. Reported by @materemias with a controlled A/B on the real endpoint and 56 requests of live traffic correlation — the analysis was correct as written, including the one-line shape of the fix.

## The bug

Oh My Pi gives Main, Advisor and each subagent a **distinct stable session id**, carried in `metadata.user_id` rather than a header. The Pi adapter read only `x-session-affinity`, so OMP requests had no session key — and every request ending in `user[tool_result]` therefore fell into the headerless `isClientDrivenLoop` bypass: an independent request that skips lineage lookup and starts a fresh SDK session on every tool round.

The tool-result shape is the whole story. A plain `user[text]` follow-up already resumed, which is exactly what the reporter's telemetry shows:

| last message | continuation | new |
|---|---:|---:|
| `user[text]` | 14 | 1 |
| `user[tool_result]` | **0** | **40** |

## Why the proposed fix is the right one

Meridian already parses this precise envelope for Claude Code, so the fix reuses `extractClaudeCodeSessionId` rather than adding a second convention. `handleMessages` already passes `body` to `getSessionId`, and the adapter interface already declares the parameter — the Pi adapter simply ignored it.

**The bypass is left intact.** It is correct for genuinely headerless concurrent loops, where a shared key would collide. This only supplies a key when the client has actually declared one.

## The collision question I checked before accepting it

The bypass exists to prevent exactly the failure this change could reintroduce, so it deserved verification rather than trust.

`extractClaudeCodeSessionId` is strict: `metadata.user_id` must be — or parse to — an object with a **non-empty string `session_id`**. A plain-string user id returns `undefined`. That matters more than it looks: Anthropic's `user_id` is a **user** identifier, and a client sending `"user-123"` would, under a looser reading, collapse every conversation from that user into one SDK session. The strictness is what prevents it, and there are tests pinning each rejection path.

So the blast radius is precisely "clients that deliberately declare a session identity in the documented envelope" — which is the intended signal, and the same contract `claude-code` already relies on.

Also confirmed no circular import: `claudecode.ts` does not import from `pi.ts`.

## Testing

`npm test`: 2315 pass, 0 failures. `npx tsc --noEmit` clean.

**Adapter unit** (`pi-adapter.test.ts`) — reads the OMP id; header stays authoritative; `undefined` for a stock client with neither; and three rejection paths that keep the collision closed (plain-string `user_id`, JSON without `session_id`, empty `session_id`).

**Integration** (`proxy-source-keyed-session.test.ts`) — the reporter's A/B through the HTTP layer, on a turn ending in `user[tool_result]`, which is the shape that triggered the bypass:

- resumes when the body carries an OMP session id
- **still refuses** to resume with no identity at all — the bypass must stay reachable
- distinct OMP agents stay on distinct sessions
- `x-session-affinity` still wins over the body id

Verified load-bearing — reverting the one-line change fails 3 tests, with the integration failure reproducing the reported symptom exactly:

```
(fail) resumes a tool-result turn when the body carries an OMP session id
  Expected: "test-session"
  Received: undefined
```

## Note on the token figures

The issue is careful that its cache-token numbers show where volume concentrates rather than proving a specific quota multiplier, and I've kept that framing — the demonstrated defect is lineage/session reuse, and that is what the tests assert.
