### PR TITLE
feat: add webFetchPreflight toggle for the WebFetch domain check

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,20 @@ Configure per-adapter at **`/settings`** in the Meridian web UI. Changes take ef
 | **Thinking** | disabled / adaptive / enabled | Extended thinking mode for complex reasoning |
 | **Thinking Passthrough** | on / off | Forward thinking blocks to the client for display |
 | **Shared Memory** | on / off | Share memory directory with Claude Code (`~/.claude`) instead of isolated storage |
+| **WebFetch Preflight** | on / off | Check each WebFetch hostname against the Anthropic blocklist before fetching (default on) |
+
+### WebFetch preflight
+
+Before the WebFetch tool retrieves a URL, the subprocess sends the target
+hostname to `api.anthropic.com/api/web/domain_info` to check it against a
+safety blocklist. Only the hostname goes — not the path or the page — and the
+result is cached per host for five minutes.
+
+The check runs on every provider and is not covered by
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, so turning it off here is the only
+way to keep fetch targets local. With it off, WebFetch retrieves any URL
+without consulting the blocklist; if that matters for your deployment, pair it
+with WebFetch tool permissions on the calling agent.
 
 ### System prompts
 

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -390,6 +390,30 @@ describe("buildQueryOptions", () => {
     expect(opts.settings.autoDreamEnabled).toBe(false)
   })
 
+  // WebFetch preflight: the subprocess sends each fetch target's hostname to
+  // api.anthropic.com before retrieving it. The setting is emitted on every
+  // request for the same reason the memory keys are — an omitted key falls
+  // back to the subprocess default, which runs the check.
+  it("skips the WebFetch preflight when webFetchPreflight is false", () => {
+    const result = buildQueryOptions(makeContext({ webFetchPreflight: false }))
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(true)
+  })
+
+  it("runs the WebFetch preflight when webFetchPreflight is true", () => {
+    const result = buildQueryOptions(makeContext({ webFetchPreflight: true }))
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(false)
+  })
+
+  it("defaults to running the WebFetch preflight when unset", () => {
+    const result = buildQueryOptions(makeContext())
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(false)
+  })
+
+  it("carries the WebFetch preflight setting into passthrough mode", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, webFetchPreflight: false }))
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(true)
+  })
+
   it("emits an explicit empty settingSources so the subprocess loads nothing (#634/#490)", () => {
     const result = buildQueryOptions(makeContext({ settingSources: [] }))
     expect((result.options as any).settingSources).toEqual([])

--- a/src/__tests__/sdk-features-unit.test.ts
+++ b/src/__tests__/sdk-features-unit.test.ts
@@ -18,6 +18,11 @@ describe("validateFeatureUpdate", () => {
     expect(result).toEqual({ memory: false, sharedMemory: true })
   })
 
+  it("accepts webFetchPreflight and rejects a non-boolean", () => {
+    expect(validateFeatureUpdate({ webFetchPreflight: false })).toEqual({ webFetchPreflight: false })
+    expect(() => validateFeatureUpdate({ webFetchPreflight: "off" })).toThrow("webFetchPreflight must be a boolean")
+  })
+
   it("accepts codeSystemPrompt and clientSystemPrompt booleans", () => {
     expect(validateFeatureUpdate({ codeSystemPrompt: true })).toEqual({ codeSystemPrompt: true })
     expect(validateFeatureUpdate({ clientSystemPrompt: false })).toEqual({ clientSystemPrompt: false })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -108,6 +108,8 @@ export interface QueryContext {
   dreaming?: boolean
   /** Share memory directory with Claude Code (~/.claude) */
   sharedMemory?: boolean
+  /** Run the WebFetch domain safety check (hostname sent to api.anthropic.com) */
+  webFetchPreflight?: boolean
   /** Per-request cost cap in USD */
   maxBudgetUsd?: number
   /** Fallback model when primary fails */
@@ -330,6 +332,11 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       settings: {
         autoMemoryEnabled: ctx.memory ?? true,
         autoDreamEnabled: ctx.dreaming ?? false,
+        // Always explicit, for the same reason as the memory keys above: an
+        // omitted key falls back to the subprocess default, which is to run
+        // the check. `webFetchPreflight` is the positive form the settings
+        // UI shows; the SDK setting is the negative one.
+        skipWebFetchPreflight: ctx.webFetchPreflight === false,
       },
       // #634/#490: always explicit. Empty array → SDK emits
       // `--setting-sources=` → subprocess loads nothing. Omitting the key

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -26,6 +26,13 @@ export interface AdapterFeatures {
   thinkingPassthrough: boolean
   /** Share memory directory with Claude Code (~/.claude instead of SDK default) */
   sharedMemory: boolean
+  /**
+   * Run the WebFetch domain safety check. Before each fetch the subprocess
+   * sends the target hostname to api.anthropic.com to test it against a
+   * blocklist. Turn off to keep hostnames local; WebFetch then fetches any
+   * URL unchecked, so pair it with tool permissions if that matters.
+   */
+  webFetchPreflight: boolean
   /** Per-request cost cap in USD (0 = disabled) */
   maxBudgetUsd: number
   /** Fallback model when primary fails (empty = disabled) */
@@ -51,6 +58,8 @@ const DEFAULT_FEATURES: AdapterFeatures = {
   thinking: "disabled",
   thinkingPassthrough: false,
   sharedMemory: false,
+  // Matches the subprocess default — opt out, don't opt in.
+  webFetchPreflight: true,
   maxBudgetUsd: 0,
   fallbackModel: "",
   sdkDebug: false,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1717,6 +1717,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                     maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                     sdkDebug: sdkFeatures.sdkDebug,
                     additionalDirectories: sdkFeatures.additionalDirectories
@@ -1792,6 +1793,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -1840,6 +1842,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2479,6 +2482,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2539,6 +2543,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories
@@ -2583,6 +2588,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -181,6 +181,7 @@ const FEATURES = [
   { key: 'thinking', label: 'Thinking', desc: 'Extended thinking mode', type: 'select', options: ['disabled', 'adaptive', 'enabled'] },
   { key: 'thinkingPassthrough', label: 'Thinking Passthrough', desc: 'Forward thinking blocks to the client', type: 'toggle' },
   { key: 'sharedMemory', label: 'Shared Memory', desc: 'Share memory with Claude Code (~/.claude) instead of isolated storage', type: 'toggle' },
+  { key: 'webFetchPreflight', label: 'WebFetch Preflight', desc: 'Check each WebFetch hostname against the Anthropic blocklist before fetching — off keeps hostnames local but fetches any URL unchecked', type: 'toggle' },
   { key: 'maxBudgetUsd', label: 'Max Budget (USD)', desc: 'Per-request cost cap — query aborts if exceeded (0 = disabled)', type: 'number' },
   { key: 'fallbackModel', label: 'Fallback Model', desc: 'Auto-fallback model if primary fails', type: 'select', options: ['', 'sonnet', 'opus', 'haiku', 'sonnet[1m]', 'opus[1m]'] },
   { key: 'sdkDebug', label: 'SDK Debug Logging', desc: 'Enable verbose SDK debug output to proxy stderr', type: 'toggle' },
@@ -232,7 +233,7 @@ function showSaved() {
 function hasAnyEnabled(features) {
   return features.codeSystemPrompt || !features.clientSystemPrompt || features.claudeMd !== 'off' || features.memory || features.dreaming ||
          features.thinking !== 'disabled' || features.thinkingPassthrough ||
-         features.sharedMemory || features.maxBudgetUsd > 0 ||
+         features.sharedMemory || features.webFetchPreflight === false || features.maxBudgetUsd > 0 ||
          features.fallbackModel || features.sdkDebug ||
          features.additionalDirectories;
 }


### PR DESCRIPTION
Before WebFetch retrieves a URL, the subprocess sends the target hostname to `api.anthropic.com/api/web/domain_info` to test it against a blocklist. Upstream exempts that check from `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, and `skipWebFetchPreflight` is a settings-file key — but Meridian passes `settingSources: []`, so no settings file is ever loaded. There was no way to turn it off through Meridian.

The SDK already accepts `skipWebFetchPreflight` in the `--settings` domain, which Meridian populates for the memory controls, so this reuses that path.

## Change

`webFetchPreflight` becomes a per-adapter feature, defaulting to **on** — behaviour is unchanged unless you flip it.

It is emitted on every request rather than only when disabled, for the same reason the memory keys are: an omitted key falls back to the subprocess default, which is what #634 hit.

## Verification

Client CLI pointed at Meridian on loopback, so the only reason that process opens a public connection is the preflight:

| | public peers opened by the client | answer |
|---|---|---|
| preflight on | Cloudflare (example.com) **+ api.anthropic.com** | `Example Domain` |
| preflight off | Cloudflare only | `Example Domain` |

WebFetch still works with the check off.

End to end through the proxy, reading the spawned subprocess's argv:

```
--settings {"autoMemoryEnabled":false,"autoDreamEnabled":false,"skipWebFetchPreflight":true}
```

Per-adapter routing holds — with the flag set only on `passthrough`, an `opencode` request still emitted `skipWebFetchPreflight:false`.

`npm test`: 11 suites, 2472 passing, 0 failing. `tsc --noEmit` clean.