### PR TITLE
feat: quiet the subprocess's non-essential outbound traffic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,34 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost. Fable 1M is also included at no Extra Usage cost, verified live on both Max and Team.
 
+### Subprocess traffic
+
+Meridian runs the Claude Code CLI as a headless subprocess, so it sets these
+on that process by default:
+
+| Variable | Effect |
+|---|---|
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Usage metrics, error reports, feedback uploads, session-quality surveys |
+| `DISABLE_TELEMETRY` | Usage metrics |
+| `DISABLE_ERROR_REPORTING` | Crash reports to the third-party error tracker |
+| `DISABLE_FEEDBACK_COMMAND` | `/feedback`, `/bug`, `/share` uploads |
+| `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Session-quality survey |
+| `DISABLE_AUTOUPDATER` | CLI self-update underneath a running proxy |
+| `CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL` | Plugin marketplace auto-install |
+
+Nobody reads a headless subprocess's usage metrics, its crash reports describe
+a process the operator never launched by hand, and the feedback commands have
+no interactive session to report on. An auto-update mid-run is version skew,
+not a feature.
+
+Any value set in Meridian's own environment wins, including setting one of
+these to `0` to opt back in.
+
+One thing these do not cover: before WebFetch retrieves a URL, the subprocess
+sends the target hostname to `api.anthropic.com` to check it against a safety
+blocklist. That check is deliberately exempt from
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` upstream and is unaffected here.
+
 ## Endpoints
 
 | Endpoint | Description |

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -46,6 +46,41 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).includePartialMessages).toBeUndefined()
   })
 
+  // The subprocess runs headless behind the proxy — its metrics, crash
+  // reports, feedback uploads and surveys describe a session no human is in.
+  it("quiets the subprocess's non-essential outbound traffic by default", () => {
+    const env = buildQueryOptions(makeContext()).options.env ?? {}
+    expect(env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe("1")
+    expect(env.DISABLE_TELEMETRY).toBe("1")
+    expect(env.DISABLE_ERROR_REPORTING).toBe("1")
+    expect(env.DISABLE_FEEDBACK_COMMAND).toBe("1")
+    expect(env.CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY).toBe("1")
+    expect(env.DISABLE_AUTOUPDATER).toBe("1")
+    expect(env.CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL).toBe("1")
+  })
+
+  it("lets the inherited env opt back into telemetry", () => {
+    const result = buildQueryOptions(makeContext({
+      cleanEnv: { DISABLE_TELEMETRY: "0", DISABLE_ERROR_REPORTING: "0" },
+    }))
+    expect(result.options.env?.DISABLE_TELEMETRY).toBe("0")
+    expect(result.options.env?.DISABLE_ERROR_REPORTING).toBe("0")
+    // Untouched keys keep the quiet default.
+    expect(result.options.env?.DISABLE_FEEDBACK_COMMAND).toBe("1")
+  })
+
+  it("lets envOverrides opt back into telemetry", () => {
+    const result = buildQueryOptions(makeContext({
+      envOverrides: { CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "0" },
+    }))
+    expect(result.options.env?.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe("0")
+  })
+
+  it("keeps the quiet defaults in passthrough mode", () => {
+    const env = buildQueryOptions(makeContext({ passthrough: true })).options.env ?? {}
+    expect(env.DISABLE_TELEMETRY).toBe("1")
+  })
+
   it("applies envOverrides after inherited env", () => {
     const result = buildQueryOptions(makeContext({
       cleanEnv: { ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6" },

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -13,6 +13,29 @@ import { envInt } from "../env"
 import type { Effort } from "./effort"
 
 /**
+ * Env defaults that quiet the subprocess's own outbound traffic.
+ *
+ * The subprocess here is infrastructure, not somebody's editor: it runs
+ * headless, nobody reads its usage metrics, its crash reports describe a
+ * process the operator never launched by hand, and `/feedback` and the
+ * session-quality survey have no interactive session to report on. The
+ * auto-updater is worse than useless — a version change underneath a running
+ * proxy is a source of skew, not a feature.
+ *
+ * Spread *before* the inherited env so anything the operator sets — including
+ * setting these to "0" — still wins.
+ */
+const QUIET_SUBPROCESS_ENV: Record<string, string> = {
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+  DISABLE_TELEMETRY: "1",
+  DISABLE_ERROR_REPORTING: "1",
+  DISABLE_FEEDBACK_COMMAND: "1",
+  CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY: "1",
+  DISABLE_AUTOUPDATER: "1",
+  CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL: "1",
+}
+
+/**
  * Return a copy of `env` with `CLAUDE_CONFIG_DIR` removed. Used by the
  * sharedMemory branch — see the comment at the env construction site.
  *
@@ -340,6 +363,8 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       settingSources: settingSources ?? [],
       ...(onStderr ? { stderr: onStderr } : {}),
       env: {
+        // First, so an operator-set value of any kind overrides it.
+        ...QUIET_SUBPROCESS_ENV,
         // sharedMemory: the user wants the SDK to use Claude Code's default
         // config dir so memories sync. Counter-intuitively we DON'T set
         // CLAUDE_CONFIG_DIR=$HOME/.claude here — explicitly setting it (even


### PR DESCRIPTION
The Claude Code CLI Meridian spawns is infrastructure rather than somebody's editor: it runs headless, nobody reads its usage metrics, its crash reports describe a process the operator never launched by hand, and `/feedback` and the session-quality survey have no interactive session to report on. Auto-updating underneath a running proxy is version skew, not a feature.

## Change

Seven documented opt-outs set on the subprocess env:

| Variable | Effect |
|---|---|
| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Metrics, error reports, feedback uploads, surveys |
| `DISABLE_TELEMETRY` | Usage metrics |
| `DISABLE_ERROR_REPORTING` | Crash reports to the third-party tracker |
| `DISABLE_FEEDBACK_COMMAND` | `/feedback`, `/bug`, `/share` |
| `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Session-quality survey |
| `DISABLE_AUTOUPDATER` | CLI self-update mid-run |
| `CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL` | Plugin marketplace auto-install |

Spread **before** the inherited env, so any value the operator sets wins — including setting one to `0` to opt back in. Tests cover the defaults, both opt-back-in paths (`cleanEnv` and `envOverrides`), and passthrough.

Deliberately not included: `CLAUDE_CODE_SKIP_PROMPT_HISTORY`, which would stop the subprocess writing `~/.claude/projects/*.jsonl` — the files session resume and recovery read.

This does not cover the WebFetch domain check, which upstream exempts from `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`. That is #748.

`npm test`: 11 suites, 2471 passing, 0 failing. `tsc --noEmit` clean.