### PR TITLE
feat: gate claude.ai connectors behind an opt-in flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,22 @@ Configure per-adapter at **`/settings`** in the Meridian web UI. Changes take ef
 | **Thinking** | disabled / adaptive / enabled | Extended thinking mode for complex reasoning |
 | **Thinking Passthrough** | on / off | Forward thinking blocks to the client for display |
 | **Shared Memory** | on / off | Share memory directory with Claude Code (`~/.claude`) instead of isolated storage |
+| **claude.ai Connectors** | on / off | Load the MCP connectors attached to your claude.ai account (default off) |
+
+### claude.ai connectors
+
+If your claude.ai account has connectors attached — Drive, Gmail, Calendar —
+the subprocess can fetch them from `/v1/mcp_servers` and connect each one
+through `mcp-proxy.anthropic.com`. Their tools then appear in the session
+alongside the ones Meridian registered.
+
+That is rarely what you want from a proxy: the calling agent negotiated a tool
+surface, and this adds third-party tools it never asked for, plus an outbound
+fetch describing the account. So it is **off by default**.
+
+Passthrough mode keeps it off regardless of this setting. There the client
+executes tools, and it has no way to run one that exists only inside the
+subprocess.
 
 ### System prompts
 

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -297,10 +297,24 @@ describe("buildQueryOptions", () => {
     expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
   })
 
-  it("does not disable Claude.ai MCP servers in normal mode", () => {
+  it("disables Claude.ai MCP servers in normal mode too, by default", () => {
     const result = buildQueryOptions(makeContext({ passthrough: false }))
     const env = (result.options as any).env
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
+  })
+
+  it("loads Claude.ai MCP servers when explicitly opted in", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: false, claudeAiConnectors: true }))
+    const env = (result.options as any).env
     expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBeUndefined()
+  })
+
+  // Passthrough wins over the opt-in: the client executes tools there and
+  // cannot run one that only exists inside the subprocess.
+  it("keeps Claude.ai MCP servers off in passthrough even when opted in", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, claudeAiConnectors: true }))
+    const env = (result.options as any).env
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
   })
 
   it("includes hooks when provided", () => {

--- a/src/__tests__/sdk-features-unit.test.ts
+++ b/src/__tests__/sdk-features-unit.test.ts
@@ -18,6 +18,11 @@ describe("validateFeatureUpdate", () => {
     expect(result).toEqual({ memory: false, sharedMemory: true })
   })
 
+  it("accepts claudeAiConnectors and rejects a non-boolean", () => {
+    expect(validateFeatureUpdate({ claudeAiConnectors: true })).toEqual({ claudeAiConnectors: true })
+    expect(() => validateFeatureUpdate({ claudeAiConnectors: "yes" })).toThrow("claudeAiConnectors must be a boolean")
+  })
+
   it("accepts codeSystemPrompt and clientSystemPrompt booleans", () => {
     expect(validateFeatureUpdate({ codeSystemPrompt: true })).toEqual({ codeSystemPrompt: true })
     expect(validateFeatureUpdate({ clientSystemPrompt: false })).toEqual({ clientSystemPrompt: false })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -108,6 +108,8 @@ export interface QueryContext {
   dreaming?: boolean
   /** Share memory directory with Claude Code (~/.claude) */
   sharedMemory?: boolean
+  /** Load the account's claude.ai MCP connectors (ignored in passthrough) */
+  claudeAiConnectors?: boolean
   /** Per-request cost cap in USD */
   maxBudgetUsd?: number
   /** Fallback model when primary fails */
@@ -351,7 +353,20 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
         // Keychain auth.
         ...(sharedMemory ? stripConfigDir(cleanEnv) : cleanEnv),
         ENABLE_TOOL_SEARCH: hasDeferredTools ? "true" : "false",
-        ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
+        // claude.ai connectors: MCP servers attached to the account's
+        // claude.ai profile (Drive, Gmail, Calendar, …). The subprocess
+        // otherwise fetches them from /v1/mcp_servers and connects each one
+        // through mcp-proxy.anthropic.com, so a caller that asked for none of
+        // that gets third-party tools in its session. Off unless opted in.
+        //
+        // Passthrough forces it off regardless: there the CLIENT executes
+        // tools, and it cannot run one that only exists inside the subprocess
+        // — the same mismatch that made CLAUDE_CODE_USE_POWERSHELL_TOOL a bug
+        // (#441). This was the pre-existing behaviour for passthrough; the
+        // change is that every other adapter now defaults to it too.
+        ...(passthrough || ctx.claudeAiConnectors !== true
+          ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" }
+          : {}),
         // Passthrough: suppress the CLI's "# Scratchpad Directory" context
         // block (#627). It advertises a PROXY-HOST path, but the CLIENT
         // executes the tools — OpenCode 1.18+ permission-blocks writes to

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -26,6 +26,14 @@ export interface AdapterFeatures {
   thinkingPassthrough: boolean
   /** Share memory directory with Claude Code (~/.claude instead of SDK default) */
   sharedMemory: boolean
+  /**
+   * Load the MCP connectors attached to the account's claude.ai profile
+   * (Drive, Gmail, Calendar, …). Off by default: the calling agent never
+   * negotiated those tools, and they reach third parties through
+   * mcp-proxy.anthropic.com. Ignored in passthrough mode, where the client
+   * executes tools and cannot run one that exists only in the subprocess.
+   */
+  claudeAiConnectors: boolean
   /** Per-request cost cap in USD (0 = disabled) */
   maxBudgetUsd: number
   /** Fallback model when primary fails (empty = disabled) */
@@ -51,6 +59,7 @@ const DEFAULT_FEATURES: AdapterFeatures = {
   thinking: "disabled",
   thinkingPassthrough: false,
   sharedMemory: false,
+  claudeAiConnectors: false,
   maxBudgetUsd: 0,
   fallbackModel: "",
   sdkDebug: false,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1717,6 +1717,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                     maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                     sdkDebug: sdkFeatures.sdkDebug,
                     additionalDirectories: sdkFeatures.additionalDirectories
@@ -1792,6 +1793,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -1840,6 +1842,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2479,6 +2482,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2539,6 +2543,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories
@@ -2583,6 +2588,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -181,6 +181,7 @@ const FEATURES = [
   { key: 'thinking', label: 'Thinking', desc: 'Extended thinking mode', type: 'select', options: ['disabled', 'adaptive', 'enabled'] },
   { key: 'thinkingPassthrough', label: 'Thinking Passthrough', desc: 'Forward thinking blocks to the client', type: 'toggle' },
   { key: 'sharedMemory', label: 'Shared Memory', desc: 'Share memory with Claude Code (~/.claude) instead of isolated storage', type: 'toggle' },
+  { key: 'claudeAiConnectors', label: 'claude.ai Connectors', desc: 'Load the MCP connectors attached to your claude.ai account (Drive, Gmail, Calendar). Off by default; always off in passthrough mode', type: 'toggle' },
   { key: 'maxBudgetUsd', label: 'Max Budget (USD)', desc: 'Per-request cost cap — query aborts if exceeded (0 = disabled)', type: 'number' },
   { key: 'fallbackModel', label: 'Fallback Model', desc: 'Auto-fallback model if primary fails', type: 'select', options: ['', 'sonnet', 'opus', 'haiku', 'sonnet[1m]', 'opus[1m]'] },
   { key: 'sdkDebug', label: 'SDK Debug Logging', desc: 'Enable verbose SDK debug output to proxy stderr', type: 'toggle' },
@@ -232,7 +233,7 @@ function showSaved() {
 function hasAnyEnabled(features) {
   return features.codeSystemPrompt || !features.clientSystemPrompt || features.claudeMd !== 'off' || features.memory || features.dreaming ||
          features.thinking !== 'disabled' || features.thinkingPassthrough ||
-         features.sharedMemory || features.maxBudgetUsd > 0 ||
+         features.sharedMemory || features.claudeAiConnectors || features.maxBudgetUsd > 0 ||
          features.fallbackModel || features.sdkDebug ||
          features.additionalDirectories;
 }


### PR DESCRIPTION
Outside passthrough mode, the subprocess fetches the MCP connectors attached to the account's claude.ai profile from `/v1/mcp_servers` and connects each one through `mcp-proxy.anthropic.com`. Their tools then join the session alongside the ones Meridian registered — so a caller that negotiated a tool surface gets third-party tools it never asked for, plus an outbound fetch describing the account.

`ENABLE_CLAUDEAI_MCP_SERVERS: "false"` was already set, but only in passthrough mode. Whether your Gmail shows up in Droid currently depends on a passthrough default that has nothing to do with connectors.

## Change

`claudeAiConnectors`, defaulting to **off**, applied to every adapter.

Passthrough continues to force it off whatever the flag says: there the client executes tools and has no way to run one that exists only inside the subprocess — the same mismatch behind #441.

## Behaviour change

Adapters that do not use passthrough by default — `cherry` (`usesPassthrough(): false`), `droid` (`resolvePassthrough(false)`), and anything running `MERIDIAN_PASSTHROUGH=0` — previously loaded connectors and now need the flag. Adapters that default to passthrough, including `opencode`, are unaffected: they were already covered by the old line.

The existing `does not disable Claude.ai MCP servers in normal mode` test asserted the old default and is updated, with new cases for the opt-in and for passthrough overriding it.

## Verification

Same proxy, `MERIDIAN_PASSTHROUGH=0` (the configuration that previously loaded connectors), subprocess debug via `CLAUDE_CODE_DEBUG_LOGS_DIR`:

**Default (`claudeAiConnectors: false`)**
```
[claudeai-mcp] Disabled via env var
```

**Opted in (`claudeAiConnectors: true`)**
```
[claudeai-mcp] Fetching from https://api.anthropic.com/v1/mcp_servers?limit=1000
[claudeai-mcp] Fetched 3 servers
MCP server "claude.ai Google Drive":    Using claude.ai proxy at https://mcp-proxy.anthropic.com/v1/mcp/…
MCP server "claude.ai Gmail":           Using claude.ai proxy at https://mcp-proxy.anthropic.com/v1/mcp/…
MCP server "claude.ai Google Calendar": Using claude.ai proxy at https://mcp-proxy.anthropic.com/v1/mcp/…
```

`npm test`: 11 suites, 2470 passing, 0 failing. `tsc --noEmit` clean.