### PR TITLE
fix: don't treat transport metadata as a system instruction

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { frameReplayTurns, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall } from "../proxy/messages"
+import { frameReplayTurns, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall, extractSystemText } from "../proxy/messages"
 
 const img = (id: string) => ({ type: "image", source: { type: "base64", media_type: "image/png", data: id } })
 function userMsg(content: unknown) {
@@ -452,5 +452,54 @@ describe("frameReplayTurns (#619)", () => {
     expect(out).not.toContain("Human:")
     expect(out).toEndWith("final question")
     expect(out).toContain("[your bash ls]:")
+  })
+})
+
+describe("extractSystemText", () => {
+  const CLIENT_PROMPT = "You are a release-notes assistant. Answer in bullet points."
+  const BILLING = "x-anthropic-billing-header: cc_version=2.1.220.8b8; cc_entrypoint=sdk-cli;"
+  const SDK_PREAMBLE = "You are a Claude agent, built on Anthropic's Claude Agent SDK."
+
+  it("passes a string system field through unchanged", () => {
+    expect(extractSystemText(CLIENT_PROMPT)).toBe(CLIENT_PROMPT)
+  })
+
+  it("joins text blocks with newlines", () => {
+    expect(extractSystemText([{ type: "text", text: "a" }, { type: "text", text: "b" }]))
+      .toBe("a\nb")
+  })
+
+  // Claude Code's system array leads with a pseudo-HTTP header. Joined
+  // verbatim it sits at the top of the subprocess's system prompt, where it
+  // is noise at best — and it describes a request Meridian never makes, since
+  // the subprocess sends its own billing header.
+  it("drops the billing header block Claude Code smuggles through system", () => {
+    const out = extractSystemText([
+      { type: "text", text: BILLING },
+      { type: "text", text: SDK_PREAMBLE },
+      { type: "text", text: CLIENT_PROMPT },
+    ])
+    expect(out).not.toContain("x-anthropic-billing-header")
+    expect(out).not.toContain("cc_entrypoint")
+    expect(out).toBe(`${SDK_PREAMBLE}\n${CLIENT_PROMPT}`)
+  })
+
+  it("keeps a client prompt that merely mentions a header in prose", () => {
+    const prose = "Always send the x-anthropic-billing-header when relaying."
+    expect(extractSystemText([{ type: "text", text: prose }])).toBe(prose)
+  })
+
+  it("ignores non-text blocks and empty text", () => {
+    expect(extractSystemText([
+      { type: "image", source: {} },
+      { type: "text", text: "" },
+      { type: "text", text: CLIENT_PROMPT },
+    ])).toBe(CLIENT_PROMPT)
+  })
+
+  it("returns empty string for absent or malformed input", () => {
+    expect(extractSystemText(undefined)).toBe("")
+    expect(extractSystemText(null)).toBe("")
+    expect(extractSystemText(42)).toBe("")
   })
 })

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -386,3 +386,40 @@ export function describeToolCall(info: ToolCallInfo): string {
   const head = info.target ? `your ${info.name} ${info.target}` : `your ${info.name}`
   return info.contentSummary ? `[${head} → "${info.contentSummary}"]` : `[${head}]`
 }
+
+/**
+ * Flatten an Anthropic `system` field into the text Meridian forwards as the
+ * SDK subprocess's system prompt.
+ *
+ * Not every block in that array is an instruction. Claude Code passes
+ * transport metadata through the same field — its `system` arrives as:
+ *
+ *   [0] "x-anthropic-billing-header: cc_version=2.1.220.8b8; cc_entrypoint=sdk-cli;"
+ *   [1] "You are a Claude agent, built on Anthropic's Claude Agent SDK."
+ *   [2] <the actual system prompt>
+ *
+ * Block [0] is a header the client smuggles through the body, not something
+ * anyone wrote for a model to read. Joining every block verbatim puts it at
+ * the top of the subprocess's system prompt, where it is at best noise the
+ * model has to skip past.
+ *
+ * It is also meaningless downstream: Meridian's subprocess authenticates as
+ * its own subscription and sends its own billing header, so the client's copy
+ * describes a request that is never made.
+ *
+ * The filter anchors at the start of a block, so a prompt that merely
+ * discusses such a header in prose is left alone.
+ *
+ * Pure: never mutates the input.
+ */
+const TRANSPORT_HEADER_BLOCK = /^\s*x-anthropic-[a-z0-9-]*header\s*:/i
+
+export function extractSystemText(system: unknown): string {
+  if (typeof system === "string") return system
+  if (!Array.isArray(system)) return ""
+  return system
+    .filter((b: any) => b?.type === "text" && typeof b.text === "string" && b.text)
+    .map((b: any) => b.text as string)
+    .filter((text) => !TRANSPORT_HEADER_BLOCK.test(text))
+    .join("\n")
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -66,7 +66,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDef
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
-import { extractAdvisorModel, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
+import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -900,17 +900,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const profileEnv = { ...sdkModelDefaults, ...cleanEnv, ...profile.env }
         const profileCredentialStore = credentialStoreForProfile(profile)
 
-        let systemContext = ""
-        if (body.system) {
-          if (typeof body.system === "string") {
-            systemContext = body.system
-          } else if (Array.isArray(body.system)) {
-            systemContext = body.system
-              .filter((b: any) => b.type === "text" && b.text)
-              .map((b: any) => b.text)
-              .join("\n")
-          }
-        }
+        // Drops transport metadata some clients pass through `system`.
+        let systemContext = extractSystemText(body.system)
 
         // Run the transform pipeline — adapter transforms populate SDK configuration.
         // INVARIANT (#476): behavior keyed by adapter name — transforms, plugin


### PR DESCRIPTION
Claude Code passes a header through the request body. Its `system` arrives as an array of three blocks:

```
[0] "x-anthropic-billing-header: cc_version=2.1.220.8b8; cc_entrypoint=sdk-cli;"
[1] "You are a Claude agent, built on Anthropic's Claude Agent SDK."
[2] <the actual system prompt>
```

`server.ts` joined every text block verbatim, so block [0] landed at the top of the SDK subprocess's system prompt. It is a header the client smuggles through the body, not something written for a model to read — and it is meaningless downstream anyway, since the subprocess authenticates as its own subscription and sends its own billing header. The client's copy describes a request that is never made.

## Change

Extracts the flattening from `server.ts` into a pure `extractSystemText()` in the `messages.ts` leaf module, and drops header-shaped blocks.

## Scope

Deliberately narrow. The pattern is `/^\s*x-anthropic-[a-z0-9-]*header\s*:/i`, anchored at block start:

| input | result |
|---|---|
| `x-anthropic-billing-header: …` | filtered |
| `X-Anthropic-Billing-Header : …` | filtered |
| `x-anthropic-version: 2023-06-01` | **kept** — name doesn't end in "header" |
| `Always send the x-anthropic-billing-header when relaying.` | **kept** — prose |
| header not at the start of the block | **kept** |

## Safety

`query.ts` decides `usePreset` via `codeSystemPrompt ?? (hasSettings || (!passthrough && !!systemContext))`, so a shorter `systemContext` could in principle change preset selection. It cannot in practice: all six call sites pass `codeSystemPrompt: sdkFeatures.codeSystemPrompt`, which is typed `boolean` and always merged over `DEFAULT_FEATURES`, so the `??` never falls through.

This is hygiene, not a behaviour fix — I have no measurement showing the header changes model output.

`npm test`: 11 suites, 2473 passing, 0 failing. `tsc --noEmit` clean.