### PR TITLE
feat: add webFetchPreflight toggle, scoped to the adapter it affects

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -89,6 +89,7 @@ kill $(lsof -ti :3456)
 | E34 | [Streaming parallel tool calls (#552)](#e34-streaming-parallel-tool-calls-552) | **Automated**: `bun scripts/e2e-stream-parallel.mjs` — real CLI, SSE mode: parallel tool calls stream intact (no dangling `{}` blocks), denies held past generation, fast follow-up resumes. **Run before any release touching the passthrough tool loop** — mocked suites cannot catch CLI dispatch-ordering bugs (two shipped regressions proved it) | 2026-07-15 |
 | E35 | [SDK boundary assumptions (#694/#708/#710)](#e35-sdk-boundary-assumptions-694708710) | **Automated**: `bun scripts/e2e-sdk-boundary.mjs` — real SDK: rate-limit reset units land in a sane window, every live content-block type is classified for hashing, resume survives a client dropping thinking blocks, and reports whether the gitStatus block still misstates its provenance. **Run after any `@anthropic-ai/claude-agent-sdk` bump** and before releases touching lineage, rate limits, or the system prompt | 2026-07-29 |
 | E36 | [Client detection after an upgrade (#733)](#e36-client-detection-after-an-upgrade-733) | **Automated**: `bun scripts/e2e-client-detection.mjs` — drives each installed client against a local stub, captures its real headers, and asserts the adapter Meridian resolves. **Run after upgrading any client**; costs no tokens | 2026-07-31 |
+| E37 | [WebFetch preflight scope (#748)](#e37-webfetch-preflight-scope-748) | **Automated**: `bun scripts/e2e-webfetch-preflight.mjs` — stubbed `claude` + isolated HOME: the toggle reaches the right adapter's `--settings`, and only `cherry` can actually run the built-in WebFetch, so the documented scope is asserted rather than assumed. **Run before releases touching sdkFeatures, query settings, or tool config**; costs no tokens | 2026-08-03 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3270,3 +3271,58 @@ that test *and* the live script.
 opencode 1.18.9 and crush 0.87 send `x-session-affinity` **and** `x-session-id`
 — which is why one of the tests asserts, as a property, that a shared session
 header can never be what distinguishes two clients.
+
+## E37: WebFetch preflight scope (#748)
+
+**Automated**, and costs **no tokens** — `claude` is replaced by a stub that
+records its argv, and `HOME` is redirected to a temp dir so the run cannot
+touch your real `~/.config/meridian/sdk-features.json`:
+
+```bash
+bun scripts/e2e-webfetch-preflight.mjs
+```
+
+**Why this exists:** the WebFetch Preflight toggle has two independent failure
+modes, and only the first is obvious.
+
+The first is routing: `webFetchPreflight: false` on one adapter must produce
+`skipWebFetchPreflight: true` in *that* adapter's spawn and no other. The value
+is threaded through six separate `buildQueryOptions` call sites in `server.ts`,
+which is exactly the shape where one gets missed and the toggle appears to work
+because you only ever tested the streaming path.
+
+The second is scope, and it is the one that misleads users. The preflight lives
+inside the SDK's built-in `WebFetch`, so the setting only changes behaviour
+where the subprocess can invoke that tool. Every adapter but `cherry` prevents
+it — passthrough modes send `--tools` empty (the SDK's "disable all built-ins")
+and internal modes list `WebFetch` in `--disallowed-tools`. Cherry unblocks the
+built-in web tools so Claude can browse for itself (#481), making it the only
+adapter where the toggle does anything. A toggle that silently does nothing on
+the adapter you flipped it on is worse than no toggle: you believe the hostname
+stopped leaving your network when it never was.
+
+**Pass criteria:**
+- `cherry` + `webFetchPreflight:false` → `skipWebFetchPreflight:true` in argv
+- `cherry` unset → `skipWebFetchPreflight:false` (default matches the
+  subprocess default — an omitted key would silently re-enable the check, the
+  #634 failure mode)
+- `opencode` + `webFetchPreflight:false` → the setting still routes, but the
+  spawn cannot reach the built-in WebFetch, so the case is asserted **INERT**
+- a case where no subprocess spawned **fails** rather than passing quietly —
+  silence is not success
+- the real `sdk-features.json` is byte-identical before and after
+
+**The scope assertion is deliberate.** `builtinWebFetch` is checked per case
+against what `docs/configuration.md` promises. If a future tool-config change
+lets another adapter run the built-in WebFetch, this fails with a pointer to
+the docs — otherwise the scope note rots and users keep turning off a check
+that is still running.
+
+**Verified:** 2026-08-03. Mutation-tested both ways — flipping
+`DEFAULT_FEATURES.webFetchPreflight` to `false` fails the default case, and
+removing `cherry` from `ADAPTER_LABELS` fails the static counterpart in
+`sdk-features-unit.test.ts`.
+
+**Static counterpart:** the `WebFetch preflight scope` block in `query.test.ts`
+pins the same three adapter shapes at the `buildQueryOptions` level, so tool
+config drift fails in CI without starting a proxy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,20 @@ Configure per-adapter at **`/settings`** in the Meridian web UI. Changes take ef
 | **Thinking** | disabled / adaptive / enabled | Extended thinking mode for complex reasoning |
 | **Thinking Passthrough** | on / off | Forward thinking blocks to the client for display |
 | **Shared Memory** | on / off | Share memory directory with Claude Code (`~/.claude`) instead of isolated storage |
+| **WebFetch Preflight** | on / off | Check each WebFetch hostname against the Anthropic blocklist before fetching (default on) |
+
+### WebFetch preflight
+
+Before the WebFetch tool retrieves a URL, the subprocess sends the target
+hostname to `api.anthropic.com/api/web/domain_info` to check it against a
+safety blocklist. Only the hostname goes — not the path or the page — and the
+result is cached per host for five minutes.
+
+The check runs on every provider and is not covered by
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, so turning it off here is the only
+way to keep fetch targets local. With it off, WebFetch retrieves any URL
+without consulting the blocklist; if that matters for your deployment, pair it
+with WebFetch tool permissions on the calling agent.
 
 ### System prompts
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Configure per-adapter at **`/settings`** in the Meridian web UI. Changes take ef
 | **Thinking** | disabled / adaptive / enabled | Extended thinking mode for complex reasoning |
 | **Thinking Passthrough** | on / off | Forward thinking blocks to the client for display |
 | **Shared Memory** | on / off | Share memory directory with Claude Code (`~/.claude`) instead of isolated storage |
-| **WebFetch Preflight** | on / off | Check each WebFetch hostname against the Anthropic blocklist before fetching (default on) |
+| **WebFetch Preflight** | on / off | Check each WebFetch hostname against the Anthropic blocklist before fetching (default on, `cherry` only — see below) |
 
 ### WebFetch preflight
 
@@ -148,11 +148,24 @@ hostname to `api.anthropic.com/api/web/domain_info` to check it against a
 safety blocklist. Only the hostname goes — not the path or the page — and the
 result is cached per host for five minutes.
 
-The check runs on every provider and is not covered by
-`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, so turning it off here is the only
-way to keep fetch targets local. With it off, WebFetch retrieves any URL
-without consulting the blocklist; if that matters for your deployment, pair it
-with WebFetch tool permissions on the calling agent.
+The check is not covered by `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, so
+turning it off here is the only way to keep fetch targets local. With it off,
+WebFetch retrieves any URL without consulting the blocklist; if that matters
+for your deployment, pair it with WebFetch tool permissions on the calling
+agent.
+
+**Scope: this only affects the `cherry` adapter.** The preflight runs inside
+the SDK's built-in `WebFetch`, so it only fires when the Meridian-spawned
+subprocess executes that tool itself. Every other adapter prevents that:
+passthrough-mode adapters (OpenCode, LiteLLM/Passthrough, OpenAI, Codex) send
+`tools: []`, which disables all built-ins, and the internal-mode adapters put
+`WebFetch` in `disallowedTools`. Cherry Studio is the sole adapter that
+unblocks the built-in web tools so Claude can browse for itself (#481), and it
+is therefore the only place this toggle changes behaviour.
+
+If your *client* runs its own WebFetch — the usual case in passthrough mode —
+that fetch and its preflight happen in the client process, under the client's
+own settings. Meridian cannot turn it off from here.
 
 ### System prompts
 

--- a/scripts/e2e-webfetch-preflight.mjs
+++ b/scripts/e2e-webfetch-preflight.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: does the WebFetch Preflight toggle reach the subprocess, and on
+ * which adapters does it actually change anything?
+ *
+ * Two separate claims, and the second is the one that bites:
+ *
+ *   1. `webFetchPreflight: false` on adapter X must emit
+ *      `skipWebFetchPreflight: true` in that spawn's `--settings`, and only
+ *      that adapter's. Unit tests cover buildQueryOptions; this covers the
+ *      whole path — settings file, adapter resolution, six call sites in
+ *      server.ts — which is where a per-adapter setting actually goes wrong.
+ *
+ *   2. The setting only DOES anything where the subprocess can run the SDK's
+ *      built-in WebFetch, because that is where the preflight lives. Every
+ *      adapter but `cherry` prevents that: passthrough modes send `--tools`
+ *      empty (all built-ins off) and internal modes put WebFetch in
+ *      `--disallowed-tools`. Cherry unblocks the web tools so Claude can
+ *      browse for itself (#481), so it is the only adapter where flipping
+ *      this changes behaviour.
+ *
+ * Claim 2 is asserted, not just observed, because it is what docs/configuration.md
+ * promises. If a future tool-config change lets another adapter run the
+ * built-in WebFetch, this fails and the docs need updating — otherwise the
+ * scope note silently rots and users turn off a check that is still running.
+ *
+ * Costs no tokens and needs no Claude Max: `claude` is replaced by a stub that
+ * records its argv and exits. HOME is redirected to a temp dir so the run
+ * cannot read or write your real ~/.config/meridian/sdk-features.json.
+ *
+ *   bun scripts/e2e-webfetch-preflight.mjs
+ *
+ * Run before releases touching sdkFeatures, query.ts settings, or tool config.
+ */
+import { writeFileSync, readFileSync, mkdtempSync, rmSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { spawn } from "node:child_process"
+
+const PORT = Number(process.env.PREFLIGHT_E2E_PORT ?? 3994)
+const BASE = `http://127.0.0.1:${PORT}`
+const ROOT = join(import.meta.dir, "..")
+
+let failures = 0
+const pass = (m) => console.log(`  \x1b[32m✓\x1b[0m ${m}`)
+const fail = (m) => { failures++; console.log(`  \x1b[31m✗\x1b[0m ${m}`) }
+const note = (m) => console.log(`  \x1b[33m•\x1b[0m ${m}`)
+
+/**
+ * What each case configures and what the spawn must then look like.
+ * `builtinWebFetch` is the documented scope claim, asserted per adapter.
+ */
+const CASES = [
+  {
+    adapter: "cherry",
+    features: { webFetchPreflight: false },
+    expectSkip: true,
+    builtinWebFetch: true,
+    why: "cherry runs the built-in WebFetch itself (#481) — the toggle bites here",
+  },
+  {
+    adapter: "cherry",
+    features: null, // leave at default
+    expectSkip: false,
+    builtinWebFetch: true,
+    why: "default is preflight ON, matching the subprocess default",
+  },
+  {
+    adapter: "opencode",
+    features: { webFetchPreflight: false },
+    expectSkip: true,
+    builtinWebFetch: false,
+    why: "setting still routes, but built-ins are off so nothing changes",
+  },
+]
+
+const dir = mkdtempSync(join(tmpdir(), "webfetch-preflight-"))
+const argvLog = join(dir, "argv.log")
+const stub = join(dir, "stub-claude.js")
+
+// The SDK spawns `node <pathToClaudeCodeExecutable>`, so the stub is a JS file.
+// It records argv and exits non-zero; we never need it to speak stream-json.
+writeFileSync(stub, `const fs = require("fs")
+fs.appendFileSync(${JSON.stringify(argvLog)}, JSON.stringify(process.argv.slice(2)) + "\\n")
+process.exit(1)
+`)
+writeFileSync(argvLog, "")
+
+const flagValue = (argv, flag) => {
+  const i = argv.indexOf(flag)
+  return i >= 0 ? argv[i + 1] : null
+}
+
+/** Read the argv of the most recent spawn, or null if nothing spawned. */
+function lastSpawn() {
+  const lines = readFileSync(argvLog, "utf8").trim()
+  if (!lines) return null
+  return JSON.parse(lines.split("\n").at(-1))
+}
+
+async function waitForHealth(deadlineMs = 30_000) {
+  const until = Date.now() + deadlineMs
+  while (Date.now() < until) {
+    try {
+      const r = await fetch(`${BASE}/health`)
+      if (r.ok || r.status === 503) return true
+    } catch { /* not up yet */ }
+    await new Promise(r => setTimeout(r, 300))
+  }
+  return false
+}
+
+const proxy = spawn("bun", ["run", "./bin/cli.ts"], {
+  cwd: ROOT,
+  stdio: "ignore",
+  env: {
+    ...process.env,
+    HOME: dir,                      // isolate sdk-features.json from the real one
+    MERIDIAN_CLAUDE_PATH: stub,
+    CLAUDE_PROXY_PORT: String(PORT),
+  },
+})
+
+const cleanup = () => {
+  try { proxy.kill() } catch { /* already gone */ }
+  rmSync(dir, { recursive: true, force: true })
+}
+process.on("exit", cleanup)
+process.on("SIGINT", () => { cleanup(); process.exit(130) })
+
+console.log("webfetch preflight scope\n")
+
+if (!(await waitForHealth())) {
+  // Silence is not success: no proxy means no evidence either way.
+  fail(`proxy did not come up on ${BASE}`)
+  console.log(`\nFAIL (${failures}) — webfetch preflight`)
+  process.exit(1)
+}
+// `degraded` is expected: the stub cannot answer `claude auth status`.
+note("proxy up (health degraded — the stub has no auth, expected)")
+
+// Guard the isolation itself. If HOME were not honoured this would rewrite the
+// operator's real per-adapter config, which is not an acceptable test cost.
+const realConfig = join(process.env.HOME ?? "/nonexistent", ".config", "meridian", "sdk-features.json")
+const realBefore = existsSync(realConfig) ? readFileSync(realConfig, "utf8") : null
+
+for (const c of CASES) {
+  const label = `${c.adapter} ${c.features ? JSON.stringify(c.features) : "(default)"}`
+  console.log(`\n${label}`)
+
+  await fetch(`${BASE}/settings/api/features/${c.adapter}`, { method: "DELETE" })
+  if (c.features) {
+    const r = await fetch(`${BASE}/settings/api/features/${c.adapter}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(c.features),
+    })
+    if (!r.ok) { fail(`PATCH failed: ${r.status}`); continue }
+  }
+
+  writeFileSync(argvLog, "")
+  await fetch(`${BASE}/v1/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-meridian-agent": c.adapter },
+    body: JSON.stringify({ model: "sonnet", max_tokens: 64, messages: [{ role: "user", content: "hi" }] }),
+  }).catch(() => {}) // the stub exits 1, so an error response is the norm
+
+  const argv = lastSpawn()
+  if (!argv) { fail(`${label}: no subprocess spawned — nothing to check`); continue }
+
+  const settingsRaw = flagValue(argv, "--settings")
+  if (!settingsRaw) { fail(`${label}: no --settings flag in argv`); continue }
+  const settings = JSON.parse(settingsRaw)
+
+  if (settings.skipWebFetchPreflight === c.expectSkip) {
+    pass(`skipWebFetchPreflight=${c.expectSkip} — ${c.why}`)
+  } else {
+    fail(`skipWebFetchPreflight=${settings.skipWebFetchPreflight}, expected ${c.expectSkip}`)
+  }
+
+  // Scope: can this spawn actually invoke the SDK's built-in WebFetch?
+  // `--tools` present-but-empty is the SDK's "disable all built-ins".
+  const tools = flagValue(argv, "--tools")
+  const disallowed = flagValue(argv, "--disallowed-tools") ?? ""
+  const builtinsOff = tools !== null && tools.trim() === ""
+  const blocked = disallowed.includes("WebFetch")
+  const canRun = !builtinsOff && !blocked
+
+  if (canRun === c.builtinWebFetch) {
+    pass(`built-in WebFetch reachable=${canRun} — toggle is ${canRun ? "EFFECTIVE" : "INERT"} here`)
+  } else {
+    fail(
+      `built-in WebFetch reachable=${canRun}, expected ${c.builtinWebFetch}` +
+      ` (--tools=${JSON.stringify(tools)}, WebFetch disallowed=${blocked}).` +
+      ` The scope note in docs/configuration.md is now wrong — fix one or the other.`
+    )
+  }
+}
+
+console.log("\nisolation")
+const realAfter = existsSync(realConfig) ? readFileSync(realConfig, "utf8") : null
+if (realAfter === realBefore) pass("real ~/.config/meridian/sdk-features.json untouched")
+else fail("the run modified the real sdk-features.json — HOME isolation broke")
+
+console.log(`\n${failures === 0 ? "PASS" : `FAIL (${failures})`} — webfetch preflight`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -390,6 +390,30 @@ describe("buildQueryOptions", () => {
     expect(opts.settings.autoDreamEnabled).toBe(false)
   })
 
+  // WebFetch preflight: the subprocess sends each fetch target's hostname to
+  // api.anthropic.com before retrieving it. The setting is emitted on every
+  // request for the same reason the memory keys are — an omitted key falls
+  // back to the subprocess default, which runs the check.
+  it("skips the WebFetch preflight when webFetchPreflight is false", () => {
+    const result = buildQueryOptions(makeContext({ webFetchPreflight: false }))
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(true)
+  })
+
+  it("runs the WebFetch preflight when webFetchPreflight is true", () => {
+    const result = buildQueryOptions(makeContext({ webFetchPreflight: true }))
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(false)
+  })
+
+  it("defaults to running the WebFetch preflight when unset", () => {
+    const result = buildQueryOptions(makeContext())
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(false)
+  })
+
+  it("carries the WebFetch preflight setting into passthrough mode", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, webFetchPreflight: false }))
+    expect((result.options as any).settings.skipWebFetchPreflight).toBe(true)
+  })
+
   it("emits an explicit empty settingSources so the subprocess loads nothing (#634/#490)", () => {
     const result = buildQueryOptions(makeContext({ settingSources: [] }))
     expect((result.options as any).settingSources).toEqual([])

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from "bun:test"
 import { buildQueryOptions, GIT_STATUS_PROVENANCE_NOTE, type QueryContext } from "../proxy/query"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../proxy/tools"
+import { CHERRY_BLOCKED_BUILTIN_TOOLS, CHERRY_INCOMPATIBLE_TOOLS, CHERRY_WEB_TOOLS } from "../proxy/adapters/cherry"
 
 function makeContext(overrides: Partial<QueryContext> = {}): QueryContext {
   return {
@@ -412,6 +413,44 @@ describe("buildQueryOptions", () => {
   it("carries the WebFetch preflight setting into passthrough mode", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, webFetchPreflight: false }))
     expect((result.options as any).settings.skipWebFetchPreflight).toBe(true)
+  })
+
+  // The setting above only *reaches* the subprocess — it changes nothing
+  // unless the subprocess can actually invoke the SDK's built-in WebFetch,
+  // because that is where the preflight lives. These three lock in which
+  // adapter shapes can, so the toggle's real scope can't drift silently.
+  // Documented in docs/configuration.md under "WebFetch preflight".
+  describe("WebFetch preflight scope", () => {
+    const canRunBuiltinWebFetch = (opts: any): boolean => {
+      const builtinsDisabled = Array.isArray(opts.tools) && opts.tools.length === 0
+      return !builtinsDisabled && !(opts.disallowedTools ?? []).includes("WebFetch")
+    }
+
+    it("passthrough adapters disable every built-in, so the toggle is inert", () => {
+      // `tools: []` is documented by the SDK as "disable all built-in tools".
+      const opts = buildQueryOptions(makeContext({
+        passthrough: true, blockedTools: [], incompatibleTools: [],
+      })).options as any
+      expect(opts.tools).toEqual([])
+      expect(canRunBuiltinWebFetch(opts)).toBe(false)
+    })
+
+    it("internal-mode adapters block WebFetch outright, so the toggle is inert", () => {
+      const opts = buildQueryOptions(makeContext({ passthrough: false })).options as any
+      expect(opts.disallowedTools).toContain("WebFetch")
+      expect(canRunBuiltinWebFetch(opts)).toBe(false)
+    })
+
+    it("cherry leaves the built-in WebFetch runnable, so the toggle bites there (#481)", () => {
+      const opts = buildQueryOptions(makeContext({
+        passthrough: false,
+        blockedTools: CHERRY_BLOCKED_BUILTIN_TOOLS,
+        incompatibleTools: CHERRY_INCOMPATIBLE_TOOLS,
+        allowedMcpTools: [...CHERRY_WEB_TOOLS],
+      })).options as any
+      expect(opts.disallowedTools).not.toContain("WebFetch")
+      expect(canRunBuiltinWebFetch(opts)).toBe(true)
+    })
   })
 
   it("emits an explicit empty settingSources so the subprocess loads nothing (#634/#490)", () => {

--- a/src/__tests__/sdk-features-unit.test.ts
+++ b/src/__tests__/sdk-features-unit.test.ts
@@ -158,3 +158,30 @@ describe("sdkFeatures config roundtrip", () => {
     expect(config).toEqual({})
   })
 })
+
+// ── settings UI coverage ────────────────────────────────────────────
+
+// The settings page can only configure adapters it lists in ADAPTER_LABELS.
+// That list was written once (#349) and never updated, so `codex` (#654) and
+// `cherry` (#481) silently had no UI — which is how the webFetchPreflight
+// toggle came to render on seven adapters where it does nothing and none of
+// the one where it does. Keep the two lists in lockstep.
+describe("settings UI adapter coverage", () => {
+  it("renders a label for every adapter getAllFeatureConfigs returns", () => {
+    const { getAllFeatureConfigs } = require("../proxy/sdkFeatures") as typeof import("../proxy/sdkFeatures")
+    const { settingsPageHtml } = require("../telemetry/settingsPage") as typeof import("../telemetry/settingsPage")
+
+    const block = /const ADAPTER_LABELS = \{([\s\S]*?)\n\};/.exec(settingsPageHtml)
+    expect(block).not.toBeNull()
+    const labelled = new Set([...block![1]!.matchAll(/^\s*(\w+):\s*'/gm)].map(m => m[1]!))
+
+    for (const adapter of Object.keys(getAllFeatureConfigs())) {
+      expect(labelled).toContain(adapter)
+    }
+  })
+
+  it("exposes cherry, the only adapter the WebFetch preflight toggle affects", () => {
+    const { getAllFeatureConfigs } = require("../proxy/sdkFeatures") as typeof import("../proxy/sdkFeatures")
+    expect(Object.keys(getAllFeatureConfigs())).toContain("cherry")
+  })
+})

--- a/src/__tests__/sdk-features-unit.test.ts
+++ b/src/__tests__/sdk-features-unit.test.ts
@@ -18,6 +18,11 @@ describe("validateFeatureUpdate", () => {
     expect(result).toEqual({ memory: false, sharedMemory: true })
   })
 
+  it("accepts webFetchPreflight and rejects a non-boolean", () => {
+    expect(validateFeatureUpdate({ webFetchPreflight: false })).toEqual({ webFetchPreflight: false })
+    expect(() => validateFeatureUpdate({ webFetchPreflight: "off" })).toThrow("webFetchPreflight must be a boolean")
+  })
+
   it("accepts codeSystemPrompt and clientSystemPrompt booleans", () => {
     expect(validateFeatureUpdate({ codeSystemPrompt: true })).toEqual({ codeSystemPrompt: true })
     expect(validateFeatureUpdate({ clientSystemPrompt: false })).toEqual({ clientSystemPrompt: false })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -108,6 +108,8 @@ export interface QueryContext {
   dreaming?: boolean
   /** Share memory directory with Claude Code (~/.claude) */
   sharedMemory?: boolean
+  /** Run the WebFetch domain safety check (hostname sent to api.anthropic.com) */
+  webFetchPreflight?: boolean
   /** Per-request cost cap in USD */
   maxBudgetUsd?: number
   /** Fallback model when primary fails */
@@ -330,6 +332,11 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       settings: {
         autoMemoryEnabled: ctx.memory ?? true,
         autoDreamEnabled: ctx.dreaming ?? false,
+        // Always explicit, for the same reason as the memory keys above: an
+        // omitted key falls back to the subprocess default, which is to run
+        // the check. `webFetchPreflight` is the positive form the settings
+        // UI shows; the SDK setting is the negative one.
+        skipWebFetchPreflight: ctx.webFetchPreflight === false,
       },
       // #634/#490: always explicit. Empty array → SDK emits
       // `--setting-sources=` → subprocess loads nothing. Omitting the key

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -26,6 +26,13 @@ export interface AdapterFeatures {
   thinkingPassthrough: boolean
   /** Share memory directory with Claude Code (~/.claude instead of SDK default) */
   sharedMemory: boolean
+  /**
+   * Run the WebFetch domain safety check. Before each fetch the subprocess
+   * sends the target hostname to api.anthropic.com to test it against a
+   * blocklist. Turn off to keep hostnames local; WebFetch then fetches any
+   * URL unchecked, so pair it with tool permissions if that matters.
+   */
+  webFetchPreflight: boolean
   /** Per-request cost cap in USD (0 = disabled) */
   maxBudgetUsd: number
   /** Fallback model when primary fails (empty = disabled) */
@@ -51,6 +58,8 @@ const DEFAULT_FEATURES: AdapterFeatures = {
   thinking: "disabled",
   thinkingPassthrough: false,
   sharedMemory: false,
+  // Matches the subprocess default — opt out, don't opt in.
+  webFetchPreflight: true,
   maxBudgetUsd: 0,
   fallbackModel: "",
   sdkDebug: false,

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -181,7 +181,7 @@ export function getExplicitThinking(adapterName: string): AdapterFeatures["think
  * Get the full config for all adapters (for the settings UI).
  */
 export function getAllFeatureConfigs(): Record<string, AdapterFeatures> {
-  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough", "openai", "codex"]
+  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough", "openai", "codex", "cherry"]
   const result: Record<string, AdapterFeatures> = {}
   for (const name of adapters) {
     result[name] = getFeaturesForAdapter(name)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2588,7 +2588,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
-                    webFetchPreflight: sdkFeatures.webFetchPreflight,
+                        webFetchPreflight: sdkFeatures.webFetchPreflight,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1717,6 +1717,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                     maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                     sdkDebug: sdkFeatures.sdkDebug,
                     additionalDirectories: sdkFeatures.additionalDirectories
@@ -1792,6 +1793,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -1840,6 +1842,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2479,6 +2482,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2539,6 +2543,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories
@@ -2583,6 +2588,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -181,7 +181,7 @@ const FEATURES = [
   { key: 'thinking', label: 'Thinking', desc: 'Extended thinking mode', type: 'select', options: ['disabled', 'adaptive', 'enabled'] },
   { key: 'thinkingPassthrough', label: 'Thinking Passthrough', desc: 'Forward thinking blocks to the client', type: 'toggle' },
   { key: 'sharedMemory', label: 'Shared Memory', desc: 'Share memory with Claude Code (~/.claude) instead of isolated storage', type: 'toggle' },
-  { key: 'webFetchPreflight', label: 'WebFetch Preflight', desc: 'Check each WebFetch hostname against the Anthropic blocklist before fetching — off keeps hostnames local but fetches any URL unchecked', type: 'toggle' },
+  { key: 'webFetchPreflight', label: 'WebFetch Preflight', desc: 'Check each WebFetch hostname against the Anthropic blocklist before fetching — off keeps hostnames local but fetches any URL unchecked. Only affects Cherry Studio; other adapters never run the SDK\\'s built-in WebFetch', type: 'toggle' },
   { key: 'maxBudgetUsd', label: 'Max Budget (USD)', desc: 'Per-request cost cap — query aborts if exceeded (0 = disabled)', type: 'number' },
   { key: 'fallbackModel', label: 'Fallback Model', desc: 'Auto-fallback model if primary fails', type: 'select', options: ['', 'sonnet', 'opus', 'haiku', 'sonnet[1m]', 'opus[1m]'] },
   { key: 'sdkDebug', label: 'SDK Debug Logging', desc: 'Enable verbose SDK debug output to proxy stderr', type: 'toggle' },
@@ -196,6 +196,11 @@ const ADAPTER_LABELS = {
   pi: 'Pi',
   droid: 'Droid',
   passthrough: 'LiteLLM / Passthrough',
+  codex: 'Codex CLI (/v1/responses)',
+  // Cherry is the only adapter that lets the SDK subprocess run the built-in
+  // WebSearch/WebFetch itself (#481), so it is the only one where the WebFetch
+  // Preflight entry in FEATURES has any effect. It has to be reachable here.
+  cherry: 'Cherry Studio',
 };
 
 let currentConfig = {};

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -181,6 +181,7 @@ const FEATURES = [
   { key: 'thinking', label: 'Thinking', desc: 'Extended thinking mode', type: 'select', options: ['disabled', 'adaptive', 'enabled'] },
   { key: 'thinkingPassthrough', label: 'Thinking Passthrough', desc: 'Forward thinking blocks to the client', type: 'toggle' },
   { key: 'sharedMemory', label: 'Shared Memory', desc: 'Share memory with Claude Code (~/.claude) instead of isolated storage', type: 'toggle' },
+  { key: 'webFetchPreflight', label: 'WebFetch Preflight', desc: 'Check each WebFetch hostname against the Anthropic blocklist before fetching — off keeps hostnames local but fetches any URL unchecked', type: 'toggle' },
   { key: 'maxBudgetUsd', label: 'Max Budget (USD)', desc: 'Per-request cost cap — query aborts if exceeded (0 = disabled)', type: 'number' },
   { key: 'fallbackModel', label: 'Fallback Model', desc: 'Auto-fallback model if primary fails', type: 'select', options: ['', 'sonnet', 'opus', 'haiku', 'sonnet[1m]', 'opus[1m]'] },
   { key: 'sdkDebug', label: 'SDK Debug Logging', desc: 'Enable verbose SDK debug output to proxy stderr', type: 'toggle' },
@@ -232,7 +233,7 @@ function showSaved() {
 function hasAnyEnabled(features) {
   return features.codeSystemPrompt || !features.clientSystemPrompt || features.claudeMd !== 'off' || features.memory || features.dreaming ||
          features.thinking !== 'disabled' || features.thinkingPassthrough ||
-         features.sharedMemory || features.maxBudgetUsd > 0 ||
+         features.sharedMemory || features.webFetchPreflight === false || features.maxBudgetUsd > 0 ||
          features.fallbackModel || features.sdkDebug ||
          features.additionalDirectories;
 }


### PR DESCRIPTION
Supersedes #748 by @wayniacal, whose commit is cherry-picked here unchanged (fork PRs can't merge directly — `main` requires signed commits).

Wayne's work is the whole feature: `webFetchPreflight` as a per-adapter toggle mapping to the SDK's `skipWebFetchPreflight`, defaulting to on, emitted explicitly on every request for the same #634 reason the memory keys are. That plumbing is correct and untouched.

The second commit fixes one thing his verification couldn't see, and makes the proof reproducible.

## The toggle was inert on every adapter that could reach it

The preflight lives inside the SDK's **built-in** `WebFetch`, so it only fires when the Meridian-spawned subprocess runs that tool itself. Every adapter in the settings UI prevents that:

- **passthrough modes** (OpenCode, LiteLLM/Passthrough, OpenAI, Codex) send `tools: []` — the SDK's documented "disable all built-in tools"
- **internal modes** put `WebFetch` in `disallowedTools` — "removed from the model's context and cannot be used"

`cherry` is the sole adapter that unblocks the built-in web tools so Claude can browse for itself (#481). It's the only place the toggle does anything — and it had **no settings UI at all**, missing from both `ADAPTER_LABELS` and `getAllFeatureConfigs()`.

So the toggle rendered on seven adapters where it does nothing, and none of the one where it does. That's worse than not shipping it: you flip it, nothing errors, and you believe hostnames stopped leaving your network when they never were.

`ADAPTER_LABELS` was written once in #349 and never updated, which had also left `codex` (#654) unconfigurable since it shipped. Both are added, with a test pinning the two lists together so the next adapter can't land invisible.

## Proof, not description

`scripts/e2e-webfetch-preflight.mjs` (E2E.md **E37**) replaces `claude` with a stub that records its argv and redirects `HOME` to a temp dir. **Costs no tokens, needs no Claude Max**, and asserts per adapter both that the setting reaches the right spawn *and* whether that spawn can reach the built-in WebFetch:

```
cherry {"webFetchPreflight":false}
  ✓ skipWebFetchPreflight=true
  ✓ built-in WebFetch reachable=true  — toggle is EFFECTIVE here
cherry (default)
  ✓ skipWebFetchPreflight=false       — matches the subprocess default (#634 mode)
opencode {"webFetchPreflight":false}
  ✓ skipWebFetchPreflight=true        — setting routes correctly...
  ✓ built-in WebFetch reachable=false — ...but the toggle is INERT here
isolation
  ✓ real ~/.config/meridian/sdk-features.json untouched
```

The scope claim in `docs/configuration.md` is **asserted**, not assumed. If a future tool-config change lets another adapter run the built-in WebFetch, the script fails pointing at the docs — otherwise the scope note rots silently.

Mutation-tested rather than trusted green:
- flipping `DEFAULT_FEATURES.webFetchPreflight` to `false` → E2E fails the default case
- dropping `cherry` from `ADAPTER_LABELS` → the static UI-coverage test fails

## Note on the original verification

The network table in #748 (`preflight on` → api.anthropic.com appears; `off` → it doesn't) almost certainly measured the **client** process rather than Meridian's subprocess. The subprocess contacts `api.anthropic.com` for the model call regardless, so that peer can't appear and disappear with this flag. Argv + tool-flag capture is used here instead, since it's the only signal that distinguishes the two processes.

Worth stating plainly for anyone reading the docs: if your *client* runs its own WebFetch — the usual case in passthrough mode — that fetch and its preflight happen in the client process under the client's own settings. Meridian can't turn it off from here.

## Changes beyond the cherry-pick

- `cherry` + `codex` exposed in `getAllFeatureConfigs()` and `ADAPTER_LABELS`
- scope section in `docs/configuration.md`; settings-UI description says which adapter it affects
- 3 scope tests in `query.test.ts`, 2 UI-coverage guards in `sdk-features-unit.test.ts`
- `scripts/e2e-webfetch-preflight.mjs` + E2E.md E37
- indentation fix on one of the six threaded call sites

## Verification

- `npm test` — 2476 passing, 0 failing
- `npm run typecheck` — clean
- `bun scripts/e2e-webfetch-preflight.mjs` — PASS
