### PR TITLE
refactor: derive the configurable adapter list from the registry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,8 @@ Meridian can expose Claude Code features to any connected agent. Capabilities li
 
 Configure per-adapter at **`/settings`** in the Meridian web UI. Changes take effect on the next request — no restart needed. Config is persisted to `~/.config/meridian/sdk-features.json`.
 
+Every adapter Meridian can route to appears on that page — the list is derived from the adapter registry, so adding an adapter makes it configurable with no second edit. Alias names (`cherrystudio`, `claudecode`) collapse into their canonical adapter rather than appearing twice.
+
 ### Available features
 
 | Setting | Options | Description |

--- a/src/__tests__/sdk-features-unit.test.ts
+++ b/src/__tests__/sdk-features-unit.test.ts
@@ -167,21 +167,39 @@ describe("sdkFeatures config roundtrip", () => {
 // toggle came to render on seven adapters where it does nothing and none of
 // the one where it does. Keep the two lists in lockstep.
 describe("settings UI adapter coverage", () => {
-  it("renders a label for every adapter getAllFeatureConfigs returns", () => {
+  it("exposes every adapter in the registry, with no aliases", () => {
     const { getAllFeatureConfigs } = require("../proxy/sdkFeatures") as typeof import("../proxy/sdkFeatures")
-    const { settingsPageHtml } = require("../telemetry/settingsPage") as typeof import("../telemetry/settingsPage")
+    const { listAdapterNames } = require("../proxy/adapters/detect") as typeof import("../proxy/adapters/detect")
 
-    const block = /const ADAPTER_LABELS = \{([\s\S]*?)\n\};/.exec(settingsPageHtml)
-    expect(block).not.toBeNull()
-    const labelled = new Set([...block![1]!.matchAll(/^\s*(\w+):\s*'/gm)].map(m => m[1]!))
-
-    for (const adapter of Object.keys(getAllFeatureConfigs())) {
-      expect(labelled).toContain(adapter)
-    }
+    // Not a hardcoded expected list — that is the bug this replaces. Adding an
+    // adapter to ADAPTER_MAP must make it configurable with no second edit.
+    expect(Object.keys(getAllFeatureConfigs()).sort()).toEqual(listAdapterNames().sort())
+    // `cherrystudio` and `claudecode` are alias keys; they must collapse into
+    // their canonical adapter rather than showing up as separate cards.
+    expect(Object.keys(getAllFeatureConfigs())).not.toContain("cherrystudio")
+    expect(Object.keys(getAllFeatureConfigs())).not.toContain("claudecode")
   })
 
-  it("exposes cherry, the only adapter the WebFetch preflight toggle affects", () => {
+  it("includes the adapters that were previously unreachable in the UI", () => {
     const { getAllFeatureConfigs } = require("../proxy/sdkFeatures") as typeof import("../proxy/sdkFeatures")
-    expect(Object.keys(getAllFeatureConfigs())).toContain("cherry")
+    const names = Object.keys(getAllFeatureConfigs())
+    // cherry (#481) is the only adapter the WebFetch preflight toggle affects;
+    // codex (#654) and claude-code were absent for the same hardcoded-list reason.
+    expect(names).toContain("cherry")
+    expect(names).toContain("codex")
+    expect(names).toContain("claude-code")
+  })
+
+  it("renders adapters from the API response, not a hardcoded page list", () => {
+    const { settingsPageHtml } = require("../telemetry/settingsPage") as typeof import("../telemetry/settingsPage")
+    // The render loop must iterate the fetched config. Iterating ADAPTER_LABELS
+    // is what made a new adapter invisible instead of merely unlabelled.
+    expect(settingsPageHtml).toContain("for (const adapter of Object.keys(currentConfig))")
+    expect(settingsPageHtml).not.toContain("Object.entries(ADAPTER_LABELS)")
+  })
+
+  it("falls back to the raw adapter name when no label exists", () => {
+    const { settingsPageHtml } = require("../telemetry/settingsPage") as typeof import("../telemetry/settingsPage")
+    expect(settingsPageHtml).toContain("ADAPTER_LABELS[adapter] || adapter")
   })
 })

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -39,6 +39,25 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   codex: codexAdapter,
 }
 
+/**
+ * Every adapter that can be configured, by canonical name.
+ *
+ * Derived from ADAPTER_MAP rather than listed by hand, because a hand-kept
+ * copy has drifted every single time an adapter was added: the settings UI
+ * missed `codex` from #654 until #752, `cherry` from #481 was never
+ * configurable at all, and `claude-code` was missing from the feature config
+ * as well. Nothing failed in any of those cases — the adapter was simply
+ * absent from /settings, which reads as "this has no settings" rather than
+ * as a bug.
+ *
+ * ADAPTER_MAP keys include aliases (`cherrystudio`, `claudecode`), so
+ * canonical names come from `adapter.name` and duplicates collapse. Insertion
+ * order is preserved so the settings page ordering stays stable.
+ */
+export function listAdapterNames(): string[] {
+  return [...new Set(Object.values(ADAPTER_MAP).map(a => a.name))]
+}
+
 const envDefault = process.env.MERIDIAN_DEFAULT_AGENT || ""
 if (envDefault && !ADAPTER_MAP[envDefault]) {
   console.warn(

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -179,11 +179,16 @@ export function getExplicitThinking(adapterName: string): AdapterFeatures["think
 
 /**
  * Get the full config for all adapters (for the settings UI).
+ *
+ * The adapter list comes from the adapter registry, not a copy kept here —
+ * see listAdapterNames() for why. Required lazily: this module is imported by
+ * request-path code that has no reason to pull in every adapter definition,
+ * and the registry only matters when the settings UI asks for it.
  */
 export function getAllFeatureConfigs(): Record<string, AdapterFeatures> {
-  const adapters = ["opencode", "crush", "forgecode", "pi", "droid", "passthrough", "openai", "codex", "cherry"]
+  const { listAdapterNames } = require("./adapters/detect") as typeof import("./adapters/detect")
   const result: Record<string, AdapterFeatures> = {}
-  for (const name of adapters) {
+  for (const name of listAdapterNames()) {
     result[name] = getFeaturesForAdapter(name)
   }
   return result

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -188,6 +188,10 @@ const FEATURES = [
   { key: 'additionalDirectories', label: 'Additional Directories', desc: 'Comma-separated extra paths Claude can access (monorepo libs, etc.)', type: 'text' },
 ];
 
+// Display names only — NOT the list of adapters to render. The page renders
+// whatever /settings/api/features returns, so a new adapter shows up here the
+// moment it exists, using its raw name until someone gives it a pretty one.
+// A hardcoded list is what hid codex and cherry from this page entirely.
 const ADAPTER_LABELS = {
   opencode: 'OpenCode',
   openai: 'OpenAI (/v1/chat/completions)',
@@ -197,10 +201,8 @@ const ADAPTER_LABELS = {
   droid: 'Droid',
   passthrough: 'LiteLLM / Passthrough',
   codex: 'Codex CLI (/v1/responses)',
-  // Cherry is the only adapter that lets the SDK subprocess run the built-in
-  // WebSearch/WebFetch itself (#481), so it is the only one where the WebFetch
-  // Preflight entry in FEATURES has any effect. It has to be reachable here.
   cherry: 'Cherry Studio',
+  'claude-code': 'Claude Code',
 };
 
 let currentConfig = {};
@@ -247,7 +249,8 @@ function render() {
   const container = document.getElementById('adapters');
   container.innerHTML = '';
 
-  for (const [adapter, label] of Object.entries(ADAPTER_LABELS)) {
+  for (const adapter of Object.keys(currentConfig)) {
+    const label = ADAPTER_LABELS[adapter] || adapter;
     const features = currentConfig[adapter] || {};
     const active = hasAnyEnabled(features);
 


### PR DESCRIPTION
Follow-up to #752. Removes the bug class that PR worked around.

## The pattern

The settings surface kept its own hardcoded copy of the adapter list, separate from `ADAPTER_MAP` in `detect.ts`. That copy has drifted on every adapter added since it was written in #349, and the failure is silent every time — the adapter simply doesn't appear at `/settings`, which reads as "this has no settings" rather than as a bug:

| Adapter | Added | Configurable? |
|---|---|---|
| `codex` | #654 | no UI until #752 |
| `cherry` | #481 | never — which is why #752's WebFetch Preflight toggle rendered on seven adapters where it does nothing, and none of the one where it does |
| `claude-code` | — | **missing from the feature config entirely, still on `main`** — found while writing this |

Three instances, one cause.

## The fix

`listAdapterNames()` derives canonical names from `ADAPTER_MAP`. Alias keys (`cherrystudio`, `claudecode`) collapse via `adapter.name`, so they don't become duplicate cards. `getAllFeatureConfigs()` consumes it — lazily `require`d, since request-path code imports `sdkFeatures` and has no reason to pull in every adapter definition.

The settings page renders whatever `/settings/api/features` returns. `ADAPTER_LABELS` drops to a display-name override with a fallback to the raw name, so a new adapter can be *unlabelled* but never *invisible*. Iterating the label map is exactly what hid `codex` and `cherry`.

Net effect: adding an adapter to `ADAPTER_MAP` makes it configurable with no second edit.

## Tests

The coverage test asserts `Object.keys(getAllFeatureConfigs())` equals `listAdapterNames()` — deliberately not a hardcoded expected list, because that is the bug being removed.

Mutation-tested rather than trusted green:

- reverting the render loop to `Object.entries(ADAPTER_LABELS)` → 2 tests fail
- dropping an adapter from the registry dedup → 1 test fails
- restored → 24 pass

## Verification

- `npm test` — 2478 passing across 11 suites, 0 failing
- `npm run typecheck` — clean
- `bun scripts/e2e-webfetch-preflight.mjs` — PASS (E37 still green; `cherry` remains the only adapter where the toggle bites)
