### PR TITLE
ci: enforce the squash settings that keep the changelog 1:1 with PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,31 @@ jobs:
           finally {
             try { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue } catch { }
           }
+
+  # Merge settings are load-bearing, not cosmetic. Release Please parses every
+  # commit on main for the changelog, so a squash body carrying branch commit
+  # subjects produces DUPLICATE entries — that is what #693/#700 hit via
+  # --merge, and the same trap reaches --squash for any 2+ commit PR.
+  #
+  # PR_TITLE + BLANK closes it structurally: the changelog line is the PR
+  # title, and the body holds nothing but the Co-authored-by trailer GitHub
+  # appends (verified — contributor credit survives BLANK).
+  #
+  # This exists so the invariant is enforced rather than remembered. If it
+  # fails, someone changed the repo settings; restore them, do not "fix" this.
+  merge-settings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Squash defaults must keep the changelog 1:1 with PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          settings=$(gh api "repos/${GITHUB_REPOSITORY}" \
+            --jq '.squash_merge_commit_title + "+" + .squash_merge_commit_message')
+          echo "squash title+body = ${settings}"
+          if [ "${settings}" != "PR_TITLE+BLANK" ]; then
+            echo "::error::Expected PR_TITLE+BLANK, got ${settings}."
+            echo "::error::Restore with: gh api -X PATCH repos/${GITHUB_REPOSITORY} \\"
+            echo "::error::  -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=BLANK"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,17 +133,37 @@ jobs:
   # fails, someone changed the repo settings; restore them, do not "fix" this.
   merge-settings:
     runs-on: ubuntu-latest
+    # The merge-settings fields are only returned to a token with admin read.
+    # Without this the API silently omits them and the check compares empty
+    # strings — failing identically whether the settings are right or wrong,
+    # which is a check that cannot pass rather than a check that works.
+    permissions:
+      administration: read
     steps:
       - name: Squash defaults must keep the changelog 1:1 with PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          settings=$(gh api "repos/${GITHUB_REPOSITORY}" \
-            --jq '.squash_merge_commit_title + "+" + .squash_merge_commit_message')
-          echo "squash title+body = ${settings}"
-          if [ "${settings}" != "PR_TITLE+BLANK" ]; then
-            echo "::error::Expected PR_TITLE+BLANK, got ${settings}."
-            echo "::error::Restore with: gh api -X PATCH repos/${GITHUB_REPOSITORY} \\"
-            echo "::error::  -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=BLANK"
+          title=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.squash_merge_commit_title // ""')
+          body=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.squash_merge_commit_message // ""')
+          echo "squash title=${title:-<unreadable>} body=${body:-<unreadable>}"
+
+          # Distinguish "could not check" from "drifted". Treating the first as
+          # the second is noise; treating it as success is worse — the drift
+          # this job exists to catch would sail through unnoticed.
+          if [ -z "${title}" ] || [ -z "${body}" ]; then
+            echo "::error::Could not read the repository merge settings."
+            echo "::error::The API omits them unless the token has administration:read."
+            echo "::error::This is a broken check, NOT a settings problem — fix the workflow."
             exit 1
           fi
+
+          if [ "${title}" != "PR_TITLE" ] || [ "${body}" != "BLANK" ]; then
+            echo "::error::Expected PR_TITLE + BLANK, got ${title} + ${body}."
+            echo "::error::Release Please will emit duplicate changelog entries for any"
+            echo "::error::PR with 2+ conventional commits. Restore with:"
+            echo "::error::  gh api -X PATCH repos/${GITHUB_REPOSITORY} \\"
+            echo "::error::    -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=BLANK"
+            exit 1
+          fi
+          echo "merge settings correct: ${title} + ${body}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,39 +131,57 @@ jobs:
   #
   # This exists so the invariant is enforced rather than remembered. If it
   # fails, someone changed the repo settings; restore them, do not "fix" this.
-  merge-settings:
+  # Release Please parses every commit on main, INCLUDING the body. A commit
+  # whose body carries conventional-commit lines therefore emits the same
+  # changelog entry twice — that is what #693/#700 hit via --merge, and the
+  # same trap reaches --squash whenever a branch has 2+ conventional commits.
+  #
+  # Repo settings (PR_TITLE + BLANK) prevent it, but settings live outside the
+  # repo and nothing stops them drifting back. This checks the OUTCOME on main
+  # rather than the configuration, so it also catches a hand-written --body or
+  # a stray --merge — any cause, not just the one we thought of.
+  #
+  # Deliberately not a settings check: GITHUB_TOKEN cannot read repository
+  # merge settings at all (there is no such permission scope), so that version
+  # compared empty strings and failed whether the settings were right or wrong.
+  changelog-duplication:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    # The merge-settings fields are only returned to a token with admin read.
-    # Without this the API silently omits them and the check compares empty
-    # strings — failing identically whether the settings are right or wrong,
-    # which is a check that cannot pass rather than a check that works.
-    permissions:
-      administration: read
     steps:
-      - name: Squash defaults must keep the changelog 1:1 with PRs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Head commit body must not contain conventional-commit lines
         run: |
-          title=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.squash_merge_commit_title // ""')
-          body=$(gh api "repos/${GITHUB_REPOSITORY}" --jq '.squash_merge_commit_message // ""')
-          echo "squash title=${title:-<unreadable>} body=${body:-<unreadable>}"
+          subject=$(git log -1 --format=%s)
+          body=$(git log -1 --format=%b)
+          echo "subject: ${subject}"
 
-          # Distinguish "could not check" from "drifted". Treating the first as
-          # the second is noise; treating it as success is worse — the drift
-          # this job exists to catch would sail through unnoticed.
-          if [ -z "${title}" ] || [ -z "${body}" ]; then
-            echo "::error::Could not read the repository merge settings."
-            echo "::error::The API omits them unless the token has administration:read."
-            echo "::error::This is a broken check, NOT a settings problem — fix the workflow."
-            exit 1
+          # Release Please's own release commits are merged with --merge by
+          # design (squashing breaks its version anchor), so their body legally
+          # carries the release subject. Exempt only those.
+          case "${subject}" in
+            *"release-please"*|*"chore(main): release"*)
+              echo "release commit — exempt"; exit 0 ;;
+          esac
+          if printf '%s\n' "${body}" | grep -q 'release-please--branches'; then
+            echo "release-please merge commit — exempt"; exit 0
           fi
 
-          if [ "${title}" != "PR_TITLE" ] || [ "${body}" != "BLANK" ]; then
-            echo "::error::Expected PR_TITLE + BLANK, got ${title} + ${body}."
-            echo "::error::Release Please will emit duplicate changelog entries for any"
-            echo "::error::PR with 2+ conventional commits. Restore with:"
-            echo "::error::  gh api -X PATCH repos/${GITHUB_REPOSITORY} \\"
-            echo "::error::    -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=BLANK"
+          # The optional bullet matters: GitHub's COMMIT_MESSAGES body renders
+          # each squashed commit as "* feat: subject", while a --merge body
+          # carries the bare "feat: subject". Match both — missing the bulleted
+          # form would leave the exact trap this job exists for undetected.
+          offenders=$(printf '%s\n' "${body}" \
+            | grep -nE '^[[:space:]]*([*-][[:space:]]+)?(feat|fix|perf|refactor|docs|chore|test|build|ci|style|revert)(\([^)]*\))?!?:' || true)
+
+          if [ -n "${offenders}" ]; then
+            echo "::error::This commit's BODY contains conventional-commit lines:"
+            printf '%s\n' "${offenders}" | while IFS= read -r l; do echo "::error::  ${l}"; done
+            echo "::error::Release Please will emit each of these as a duplicate changelog entry."
+            echo "::error::Cause is usually one of:"
+            echo "::error::  - repo squash settings drifted off PR_TITLE + BLANK"
+            echo "::error::  - the PR was merged with a hand-written --body"
+            echo "::error::  - a non-release PR was merged with --merge instead of --squash"
+            echo "::error::Check the release PR before it ships; see CLAUDE.md 'Development workflow'."
             exit 1
           fi
-          echo "merge settings correct: ${title} + ${body}"
+          echo "clean — body carries no conventional-commit lines"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,37 @@ All changes go through this process, no exceptions:
    renders both avatars on the commit. The only thing lost is sole `Author` on
    the commit, which is not worth a changelog that repeats itself every release.
 
+   **The duplicate-entry trap is closed by repo settings, not by remembering.**
+   The same failure reaches squash whenever a branch has 2+ conventional
+   commits: GitHub would paste each commit subject into the squash body and
+   Release Please would parse them all. The repository is configured so that
+   cannot happen:
+
+   | Setting | Value | Why |
+   |---|---|---|
+   | `squash_merge_commit_title` | `PR_TITLE` | the changelog line is the PR title, never a branch commit's subject |
+   | `squash_merge_commit_message` | `BLANK` | the body carries no commit subjects, so there is nothing extra to parse |
+
+   Verified 2026-08-03 on a throwaway PR: the resulting squash body contained
+   *only* `Co-authored-by:`, which GitHub still appends under `BLANK`. So
+   contributor credit and a 1:1 changelog both hold with no flags.
+
+   **Therefore: plain `gh pr merge <N> --squash --delete-branch` is correct for
+   every PR, single- or multi-commit.** Do not hand-craft `--subject`/`--body`
+   to work around the old trap; that was only needed before these settings, and
+   a hand-written body can reintroduce the duplicate. Do not change these two
+   settings back. Check them with:
+
+   ```bash
+   gh api repos/rynfar/meridian --jq '{t: .squash_merge_commit_title, m: .squash_merge_commit_message}'
+   # expect {"t":"PR_TITLE","m":"BLANK"}
+   ```
+
+   `--admin` is **not** routinely required. `main` requires signed commits, and
+   `commit.gpgsign` is enabled locally, so normal work merges `CLEAN`. Reach for
+   `--admin` only when a PR is genuinely `BLOCKED`, and check
+   `gh pr view <N> --json mergeStateStatus` first rather than adding it by habit.
+
    **`main` requires signed commits, so fork PRs can never be merged directly.**
    An external PR sits at `mergeStateStatus: BLOCKED` with every check green and
    no indication why — `gh pr view <N> --json mergeStateStatus` is the only


### PR DESCRIPTION
Makes the merge workflow safe by construction instead of by recall.

## The trap

Release Please parses every commit on `main`. #693/#700 produced **duplicate** changelog entries because `--merge` put the branch commit's subject in the merge commit body.

`--squash` was adopted as the fix, but the trap was still armed: this repo's `squash_merge_commit_message` was `COMMIT_MESSAGES`, so GitHub pastes *every* branch commit subject into the squash body. Any PR with 2+ conventional commits reproduces the exact same duplicate. #752 only avoided it because the body was hand-crafted at merge time — which is not a control, it's a memory test.

## The fix

Repo settings are now:

| Setting | Value |
|---|---|
| `squash_merge_commit_title` | `PR_TITLE` |
| `squash_merge_commit_message` | `BLANK` |

Verified empirically on a throwaway PR (2 commits, 2 authors) rather than assumed — the resulting squash commit was:

```
SUBJECT: chore: squash behaviour probe (#755)
BODY:
Co-authored-by: Probe Contributor <probe-contributor@example.com>
```

So under `BLANK` GitHub **still appends the co-author trailer**. Contributor credit and a 1:1 changelog both hold, with no flags at merge time. That was the open question blocking this change; it's now answered.

Net effect: plain `gh pr merge <N> --squash --delete-branch` is correct for every PR. Hand-crafted `--subject`/`--body` is no longer needed and is now discouraged, since a hand-written body can reintroduce the duplicate.

## Why a CI job

Settings live outside the repo, so nothing stops them drifting back. The `merge-settings` job asserts `PR_TITLE+BLANK` and fails with the restore command if not. The invariant is enforced, not remembered.

Release Please PRs still use `--merge` — unchanged, and `allow_merge_commit` stays on.