### PR TITLE
feat: quiet the subprocess's non-essential outbound traffic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,34 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost. Fable 1M is also included at no Extra Usage cost, verified live on both Max and Team.
 
+### Subprocess traffic
+
+Meridian runs the Claude Code CLI as a headless subprocess, so it sets these
+on that process by default:
+
+| Variable | Effect |
+|---|---|
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Usage metrics, error reports, feedback uploads, session-quality surveys |
+| `DISABLE_TELEMETRY` | Usage metrics |
+| `DISABLE_ERROR_REPORTING` | Crash reports to the third-party error tracker |
+| `DISABLE_FEEDBACK_COMMAND` | `/feedback`, `/bug`, `/share` uploads |
+| `CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY` | Session-quality survey |
+| `DISABLE_AUTOUPDATER` | CLI self-update underneath a running proxy |
+| `CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL` | Plugin marketplace auto-install |
+
+Nobody reads a headless subprocess's usage metrics, its crash reports describe
+a process the operator never launched by hand, and the feedback commands have
+no interactive session to report on. An auto-update mid-run is version skew,
+not a feature.
+
+Any value set in Meridian's own environment wins, including setting one of
+these to `0` to opt back in.
+
+One thing these do not cover: before WebFetch retrieves a URL, the subprocess
+sends the target hostname to `api.anthropic.com` to check it against a safety
+blocklist. That check is deliberately exempt from
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` upstream and is unaffected here.
+
 ## Endpoints
 
 | Endpoint | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,6 +74,9 @@ One thing these do not cover: before WebFetch retrieves a URL, the subprocess
 sends the target hostname to `api.anthropic.com` to check it against a safety
 blocklist. That check is deliberately exempt from
 `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` upstream and is unaffected here.
+It has its own per-adapter switch — see [WebFetch preflight](#webfetch-preflight)
+— though it only reaches the wire on the `cherry` adapter, since no other
+adapter lets the subprocess run the built-in WebFetch at all.
 
 ## Endpoints
 
@@ -178,11 +181,12 @@ hostname to `api.anthropic.com/api/web/domain_info` to check it against a
 safety blocklist. Only the hostname goes — not the path or the page — and the
 result is cached per host for five minutes.
 
-The check is not covered by `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, so
-turning it off here is the only way to keep fetch targets local. With it off,
-WebFetch retrieves any URL without consulting the blocklist; if that matters
-for your deployment, pair it with WebFetch tool permissions on the calling
-agent.
+The check is not covered by `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` — it is
+the one exception to everything under [Subprocess traffic](#subprocess-traffic)
+— so turning it off here is the only way to keep fetch targets local. With it
+off, WebFetch retrieves any URL without consulting the blocklist; if that
+matters for your deployment, pair it with WebFetch tool permissions on the
+calling agent.
 
 **Scope: this only affects the `cherry` adapter.** The preflight runs inside
 the SDK's built-in `WebFetch`, so it only fires when the Meridian-spawned

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -47,6 +47,41 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).includePartialMessages).toBeUndefined()
   })
 
+  // The subprocess runs headless behind the proxy — its metrics, crash
+  // reports, feedback uploads and surveys describe a session no human is in.
+  it("quiets the subprocess's non-essential outbound traffic by default", () => {
+    const env = buildQueryOptions(makeContext()).options.env ?? {}
+    expect(env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe("1")
+    expect(env.DISABLE_TELEMETRY).toBe("1")
+    expect(env.DISABLE_ERROR_REPORTING).toBe("1")
+    expect(env.DISABLE_FEEDBACK_COMMAND).toBe("1")
+    expect(env.CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY).toBe("1")
+    expect(env.DISABLE_AUTOUPDATER).toBe("1")
+    expect(env.CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL).toBe("1")
+  })
+
+  it("lets the inherited env opt back into telemetry", () => {
+    const result = buildQueryOptions(makeContext({
+      cleanEnv: { DISABLE_TELEMETRY: "0", DISABLE_ERROR_REPORTING: "0" },
+    }))
+    expect(result.options.env?.DISABLE_TELEMETRY).toBe("0")
+    expect(result.options.env?.DISABLE_ERROR_REPORTING).toBe("0")
+    // Untouched keys keep the quiet default.
+    expect(result.options.env?.DISABLE_FEEDBACK_COMMAND).toBe("1")
+  })
+
+  it("lets envOverrides opt back into telemetry", () => {
+    const result = buildQueryOptions(makeContext({
+      envOverrides: { CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "0" },
+    }))
+    expect(result.options.env?.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe("0")
+  })
+
+  it("keeps the quiet defaults in passthrough mode", () => {
+    const env = buildQueryOptions(makeContext({ passthrough: true })).options.env ?? {}
+    expect(env.DISABLE_TELEMETRY).toBe("1")
+  })
+
   it("applies envOverrides after inherited env", () => {
     const result = buildQueryOptions(makeContext({
       cleanEnv: { ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-6" },

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -13,6 +13,29 @@ import { envInt } from "../env"
 import type { Effort } from "./effort"
 
 /**
+ * Env defaults that quiet the subprocess's own outbound traffic.
+ *
+ * The subprocess here is infrastructure, not somebody's editor: it runs
+ * headless, nobody reads its usage metrics, its crash reports describe a
+ * process the operator never launched by hand, and `/feedback` and the
+ * session-quality survey have no interactive session to report on. The
+ * auto-updater is worse than useless — a version change underneath a running
+ * proxy is a source of skew, not a feature.
+ *
+ * Spread *before* the inherited env so anything the operator sets — including
+ * setting these to "0" — still wins.
+ */
+const QUIET_SUBPROCESS_ENV: Record<string, string> = {
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+  DISABLE_TELEMETRY: "1",
+  DISABLE_ERROR_REPORTING: "1",
+  DISABLE_FEEDBACK_COMMAND: "1",
+  CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY: "1",
+  DISABLE_AUTOUPDATER: "1",
+  CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL: "1",
+}
+
+/**
  * Return a copy of `env` with `CLAUDE_CONFIG_DIR` removed. Used by the
  * sharedMemory branch — see the comment at the env construction site.
  *
@@ -347,6 +370,8 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       settingSources: settingSources ?? [],
       ...(onStderr ? { stderr: onStderr } : {}),
       env: {
+        // First, so an operator-set value of any kind overrides it.
+        ...QUIET_SUBPROCESS_ENV,
         // sharedMemory: the user wants the SDK to use Claude Code's default
         // config dir so memories sync. Counter-intuitively we DON'T set
         // CLAUDE_CONFIG_DIR=$HOME/.claude here — explicitly setting it (even


### PR DESCRIPTION
Supersedes #749 by @wayniacal, whose commit is cherry-picked here unchanged. His PR was green on all three checks but sat at `mergeStateStatus: BLOCKED` — `main` requires signed commits, which a fork PR cannot satisfy from the contributor's side.

The feature is entirely his. Seven documented opt-outs set on the spawned subprocess, spread *before* the inherited env so any operator value wins — including setting one to `0` to opt back in.

## Why it's right

The subprocess is infrastructure, not somebody's editor. Nobody reads a headless process's usage metrics, its crash reports describe something the operator never launched by hand, `/feedback` and the session-quality survey have no interactive session to report on, and an auto-update underneath a running proxy is version skew rather than a feature.

Deliberately *not* included: `CLAUDE_CODE_SKIP_PROMPT_HISTORY`, which would stop the subprocess writing the `~/.claude/projects/*.jsonl` files that session resume and recovery read. That exclusion required tracing what actually consumes those files.

## What I verified rather than assumed

| Check | Result |
|---|---|
| All seven variable names exist in the CLI | 7/7 found via `strings` on the bundled `claude.exe` |
| Operator override actually works | precedence confirmed in `query.ts`: quiet defaults (L374) → inherited env (L384) → `envOverrides` (L406) |

The precedence is the part that silently matters. Spread in the other order, the documented "set it to `0`" escape hatch would be dead while still reading as supported. It's correct, and the tests cover both opt-back-in paths (`cleanEnv` and `envOverrides`) plus passthrough.

## The one thing added

A docs cross-link, in its own commit.

Wayne already handled the interaction with #752 — his section states the WebFetch preflight is exempt from `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, which is correct. But #749 and #752 were written against different trees, so neither section pointed at the other; a reader landing on one had no way to know the other existed.

Now they link both ways, and the preflight section says what the exemption costs in practice: it only reaches the wire on `cherry`, the sole adapter that lets the subprocess run the built-in WebFetch at all.

## Verification

- `npm test` — 2482 passing across 11 suites, 0 failing
- `npm run typecheck` — clean
- `bun scripts/e2e-webfetch-preflight.mjs` — PASS

Closes #749
