### PR TITLE
feat: gate claude.ai connectors behind an opt-in flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,7 @@ Every adapter Meridian can route to appears on that page — the list is derived
 | **Thinking Passthrough** | on / off | Forward thinking blocks to the client for display |
 | **Shared Memory** | on / off | Share memory directory with Claude Code (`~/.claude`) instead of isolated storage |
 | **WebFetch Preflight** | on / off | Check each WebFetch hostname against the Anthropic blocklist before fetching (default on, `cherry` only — see below) |
+| **claude.ai Connectors** | on / off | Load the MCP connectors attached to your claude.ai account (default off) |
 
 ### WebFetch preflight
 
@@ -200,6 +201,21 @@ is therefore the only place this toggle changes behaviour.
 If your *client* runs its own WebFetch — the usual case in passthrough mode —
 that fetch and its preflight happen in the client process, under the client's
 own settings. Meridian cannot turn it off from here.
+
+### claude.ai connectors
+
+If your claude.ai account has connectors attached — Drive, Gmail, Calendar —
+the subprocess can fetch them from `/v1/mcp_servers` and connect each one
+through `mcp-proxy.anthropic.com`. Their tools then appear in the session
+alongside the ones Meridian registered.
+
+That is rarely what you want from a proxy: the calling agent negotiated a tool
+surface, and this adds third-party tools it never asked for, plus an outbound
+fetch describing the account. So it is **off by default**.
+
+Passthrough mode keeps it off regardless of this setting. There the client
+executes tools, and it has no way to run one that exists only inside the
+subprocess.
 
 ### System prompts
 

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -339,10 +339,25 @@ describe("buildQueryOptions", () => {
     expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
   })
 
+  // Explicit "true", not an omitted key (#634). Expressing the opt-in by
+  // leaving the variable out would make it mean "whatever the subprocess
+  // defaults to" — an upstream flip would then silently re-enable connectors
+  // for opted-in users and disable them for everyone else.
   it("loads Claude.ai MCP servers when explicitly opted in", () => {
     const result = buildQueryOptions(makeContext({ passthrough: false, claudeAiConnectors: true }))
     const env = (result.options as any).env
-    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBeUndefined()
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("true")
+  })
+
+  it("always emits the connector variable, never relying on omission (#634)", () => {
+    for (const ctx of [
+      { passthrough: false },
+      { passthrough: false, claudeAiConnectors: true },
+      { passthrough: true, claudeAiConnectors: true },
+    ]) {
+      const env = (buildQueryOptions(makeContext(ctx)).options as any).env
+      expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBeDefined()
+    }
   })
 
   // Passthrough wins over the opt-in: the client executes tools there and

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -333,10 +333,24 @@ describe("buildQueryOptions", () => {
     expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
   })
 
-  it("does not disable Claude.ai MCP servers in normal mode", () => {
+  it("disables Claude.ai MCP servers in normal mode too, by default", () => {
     const result = buildQueryOptions(makeContext({ passthrough: false }))
     const env = (result.options as any).env
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
+  })
+
+  it("loads Claude.ai MCP servers when explicitly opted in", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: false, claudeAiConnectors: true }))
+    const env = (result.options as any).env
     expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBeUndefined()
+  })
+
+  // Passthrough wins over the opt-in: the client executes tools there and
+  // cannot run one that only exists inside the subprocess.
+  it("keeps Claude.ai MCP servers off in passthrough even when opted in", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, claudeAiConnectors: true }))
+    const env = (result.options as any).env
+    expect(env.ENABLE_CLAUDEAI_MCP_SERVERS).toBe("false")
   })
 
   it("includes hooks when provided", () => {

--- a/src/__tests__/sdk-features-unit.test.ts
+++ b/src/__tests__/sdk-features-unit.test.ts
@@ -23,6 +23,11 @@ describe("validateFeatureUpdate", () => {
     expect(() => validateFeatureUpdate({ webFetchPreflight: "off" })).toThrow("webFetchPreflight must be a boolean")
   })
 
+  it("accepts claudeAiConnectors and rejects a non-boolean", () => {
+    expect(validateFeatureUpdate({ claudeAiConnectors: true })).toEqual({ claudeAiConnectors: true })
+    expect(() => validateFeatureUpdate({ claudeAiConnectors: "yes" })).toThrow("claudeAiConnectors must be a boolean")
+  })
+
   it("accepts codeSystemPrompt and clientSystemPrompt booleans", () => {
     expect(validateFeatureUpdate({ codeSystemPrompt: true })).toEqual({ codeSystemPrompt: true })
     expect(validateFeatureUpdate({ clientSystemPrompt: false })).toEqual({ clientSystemPrompt: false })

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -396,9 +396,14 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
         // — the same mismatch that made CLAUDE_CODE_USE_POWERSHELL_TOOL a bug
         // (#441). This was the pre-existing behaviour for passthrough; the
         // change is that every other adapter now defaults to it too.
-        ...(passthrough || ctx.claudeAiConnectors !== true
-          ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" }
-          : {}),
+        //
+        // Always explicit, never omitted — same reason as the `settings` keys
+        // above (#634). Expressing "on" by leaving the variable out would make
+        // the opt-in mean "whatever the subprocess defaults to", so an upstream
+        // default flip would silently re-enable connectors for everyone who
+        // opted in, and silently disable them for everyone who did not.
+        ENABLE_CLAUDEAI_MCP_SERVERS:
+          !passthrough && ctx.claudeAiConnectors === true ? "true" : "false",
         // Passthrough: suppress the CLI's "# Scratchpad Directory" context
         // block (#627). It advertises a PROXY-HOST path, but the CLIENT
         // executes the tools — OpenCode 1.18+ permission-blocks writes to

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -133,6 +133,8 @@ export interface QueryContext {
   sharedMemory?: boolean
   /** Run the WebFetch domain safety check (hostname sent to api.anthropic.com) */
   webFetchPreflight?: boolean
+  /** Load the account's claude.ai MCP connectors (ignored in passthrough) */
+  claudeAiConnectors?: boolean
   /** Per-request cost cap in USD */
   maxBudgetUsd?: number
   /** Fallback model when primary fails */
@@ -383,7 +385,20 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
         // Keychain auth.
         ...(sharedMemory ? stripConfigDir(cleanEnv) : cleanEnv),
         ENABLE_TOOL_SEARCH: hasDeferredTools ? "true" : "false",
-        ...(passthrough ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" } : {}),
+        // claude.ai connectors: MCP servers attached to the account's
+        // claude.ai profile (Drive, Gmail, Calendar, …). The subprocess
+        // otherwise fetches them from /v1/mcp_servers and connects each one
+        // through mcp-proxy.anthropic.com, so a caller that asked for none of
+        // that gets third-party tools in its session. Off unless opted in.
+        //
+        // Passthrough forces it off regardless: there the CLIENT executes
+        // tools, and it cannot run one that only exists inside the subprocess
+        // — the same mismatch that made CLAUDE_CODE_USE_POWERSHELL_TOOL a bug
+        // (#441). This was the pre-existing behaviour for passthrough; the
+        // change is that every other adapter now defaults to it too.
+        ...(passthrough || ctx.claudeAiConnectors !== true
+          ? { ENABLE_CLAUDEAI_MCP_SERVERS: "false" }
+          : {}),
         // Passthrough: suppress the CLI's "# Scratchpad Directory" context
         // block (#627). It advertises a PROXY-HOST path, but the CLIENT
         // executes the tools — OpenCode 1.18+ permission-blocks writes to

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -33,6 +33,14 @@ export interface AdapterFeatures {
    * URL unchecked, so pair it with tool permissions if that matters.
    */
   webFetchPreflight: boolean
+  /**
+   * Load the MCP connectors attached to the account's claude.ai profile
+   * (Drive, Gmail, Calendar, …). Off by default: the calling agent never
+   * negotiated those tools, and they reach third parties through
+   * mcp-proxy.anthropic.com. Ignored in passthrough mode, where the client
+   * executes tools and cannot run one that exists only in the subprocess.
+   */
+  claudeAiConnectors: boolean
   /** Per-request cost cap in USD (0 = disabled) */
   maxBudgetUsd: number
   /** Fallback model when primary fails (empty = disabled) */
@@ -60,6 +68,7 @@ const DEFAULT_FEATURES: AdapterFeatures = {
   sharedMemory: false,
   // Matches the subprocess default — opt out, don't opt in.
   webFetchPreflight: true,
+  claudeAiConnectors: false,
   maxBudgetUsd: 0,
   fallbackModel: "",
   sdkDebug: false,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1718,6 +1718,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                     maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                     sdkDebug: sdkFeatures.sdkDebug,
                     additionalDirectories: sdkFeatures.additionalDirectories
@@ -1794,6 +1795,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -1843,6 +1845,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2483,6 +2486,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                       maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
@@ -2544,6 +2548,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories
@@ -2589,6 +2594,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                         webFetchPreflight: sdkFeatures.webFetchPreflight,
+                        claudeAiConnectors: sdkFeatures.claudeAiConnectors,
                         maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories

--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -182,6 +182,7 @@ const FEATURES = [
   { key: 'thinkingPassthrough', label: 'Thinking Passthrough', desc: 'Forward thinking blocks to the client', type: 'toggle' },
   { key: 'sharedMemory', label: 'Shared Memory', desc: 'Share memory with Claude Code (~/.claude) instead of isolated storage', type: 'toggle' },
   { key: 'webFetchPreflight', label: 'WebFetch Preflight', desc: 'Check each WebFetch hostname against the Anthropic blocklist before fetching — off keeps hostnames local but fetches any URL unchecked. Only affects Cherry Studio; other adapters never run the SDK\\'s built-in WebFetch', type: 'toggle' },
+  { key: 'claudeAiConnectors', label: 'claude.ai Connectors', desc: 'Load the MCP connectors attached to your claude.ai account (Drive, Gmail, Calendar). Off by default; always off in passthrough mode', type: 'toggle' },
   { key: 'maxBudgetUsd', label: 'Max Budget (USD)', desc: 'Per-request cost cap — query aborts if exceeded (0 = disabled)', type: 'number' },
   { key: 'fallbackModel', label: 'Fallback Model', desc: 'Auto-fallback model if primary fails', type: 'select', options: ['', 'sonnet', 'opus', 'haiku', 'sonnet[1m]', 'opus[1m]'] },
   { key: 'sdkDebug', label: 'SDK Debug Logging', desc: 'Enable verbose SDK debug output to proxy stderr', type: 'toggle' },
@@ -240,7 +241,8 @@ function showSaved() {
 function hasAnyEnabled(features) {
   return features.codeSystemPrompt || !features.clientSystemPrompt || features.claudeMd !== 'off' || features.memory || features.dreaming ||
          features.thinking !== 'disabled' || features.thinkingPassthrough ||
-         features.sharedMemory || features.webFetchPreflight === false || features.maxBudgetUsd > 0 ||
+         features.sharedMemory || features.webFetchPreflight === false ||
+         features.claudeAiConnectors || features.maxBudgetUsd > 0 ||
          features.fallbackModel || features.sdkDebug ||
          features.additionalDirectories;
 }


### PR DESCRIPTION
Supersedes #750 by @wayniacal, cherry-picked and conflict-resolved. His PR was green but sat at `mergeStateStatus: BLOCKED` (fork + signed-commit requirement), and had since gone `DIRTY` against #752/#754.

## The actual defect

Outside passthrough, the subprocess fetches the MCP connectors attached to the account's claude.ai profile from `/v1/mcp_servers` and connects each through `mcp-proxy.anthropic.com`. Their tools join the session next to the ones Meridian registered — so a caller that negotiated a tool surface receives third-party tools it never asked for, plus an outbound fetch describing the account.

`ENABLE_CLAUDEAI_MCP_SERVERS: "false"` was already set, but **only in passthrough mode**. Wayne's framing is the important part: whether your Gmail reaches a Droid session currently depends on a passthrough default that has nothing to do with connectors. The coupling is the bug; the default is the smaller question.

`claudeAiConnectors` defaults **off** for every adapter. Passthrough still forces it off regardless, since there the client executes tools and cannot run one that exists only inside the subprocess (the #441 mismatch).

## Behaviour change — belongs in the release notes

`cherry`, `droid`, and anything running `MERIDIAN_PASSTHROUGH=0` previously loaded connectors and now need the flag. Adapters that default to passthrough, including `opencode`, are unaffected — they were already covered by the old line.

Uniform default rather than a `cherry` carve-out on purpose: a per-adapter exception would make "which adapter am I on?" load-bearing for whether your email is exposed, which is the same invisible-behaviour trap #752 just fixed. `ADAPTER_DEFAULTS` is there if that call ever changes — relaxing later is reversible, tightening later breaks people twice.

## The one change on top of his commit

His opt-in expressed "on" by **omitting** the env var, letting it mean "whatever the subprocess defaults to". That is #634 exactly, and `query.ts` carries the lesson four lines above where this lands:

> *"Always explicit… an omitted key falls back to the subprocess default"*

Now always emitted, `"true"` or `"false"`, with a test pinning that the variable is defined on every path.

**That fix had its own failure mode, so I verified it live instead of assuming.** An `ENABLE_*` flag read by *presence* rather than value would mean explicit `"true"` disables connectors — turning the opt-in into a silent no-op, the exact defect class #752 was about. Same proxy, subprocess debug logs, only the flag changed:

```
claudeAiConnectors=true   → [claudeai-mcp] Fetching from https://api.anthropic.com/v1/mcp_servers?limit=…
                            [claudeai-mcp] Fetched 0 servers
claudeAiConnectors=false  → [claudeai-mcp] Disabled via env var
```

The CLI reads the value. `"true"` enables. (`Fetched 0 servers` because the profile under test has none attached — the discriminator is the fetch attempt, which is exactly what the flag controls.)

## Conflicts

Six, all mechanical adjacent-addition against #752/#754: `query.ts`, `sdkFeatures.ts`, `server.ts`, `settingsPage.ts`, `sdk-features-unit.test.ts`, `docs/configuration.md`. Both sides kept in each.

## Verification

- `npm test` — 2486 passing across 11 suites, 0 failing
- `npm run typecheck` — clean
- live subprocess check above

Closes #750
