### PR TITLE
docs: flag the connector default as an upgrade-time behaviour change

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,6 +217,21 @@ Passthrough mode keeps it off regardless of this setting. There the client
 executes tools, and it has no way to run one that exists only inside the
 subprocess.
 
+> **Upgrading to 1.60.0 — this turns something off that used to be on.**
+>
+> Before 1.60.0, connectors loaded for any adapter *not* running in
+> passthrough mode. In practice that meant **`cherry`, `droid`, and anything
+> started with `MERIDIAN_PASSTHROUGH=0`** — those sessions silently lose
+> connector tools on upgrade until you switch this on at `/settings`.
+>
+> Adapters that default to passthrough, `opencode` included, are unaffected:
+> connectors were already disabled for them.
+>
+> Nothing errors when a connector tool disappears — the model simply stops
+> having it, and answers as if the data were unavailable. If a session that
+> used to reach your Drive or Gmail stops doing so after upgrading, this
+> setting is why.
+
 ### System prompts
 
 The system prompt controls are independent — any combination works:


### PR DESCRIPTION
Follow-up to #759, which is unreleased on `main`.

#759 gates claude.ai connectors behind an opt-in defaulting to off. For `cherry`, `droid`, and `MERIDIAN_PASSTHROUGH=0` deployments that is a **removal of working functionality**, and it fails silently: no error, the model simply stops having the tool and answers as if the data were unavailable.

The docs said "off by default" but never said it used to be on, so someone upgrading had no path from "my agent lost Drive access" back to this setting. Adds an explicit upgrade callout naming the affected adapters.

Ships in 1.60.0 alongside the change it describes.