### PR TITLE
fix: recognize shorter Claude limit wording

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -490,6 +490,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's shorter 'You've hit your limit' wording to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your limit \u00b7 resets 6:40pm (UTC)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps 'usage limit reached' to rate_limit_error", () => {
     const r = classifyError("usage limit reached | resets at 5pm")
     expect(r.type).toBe("rate_limit_error")

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -13,6 +13,8 @@ import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, m
 
 let capturedEnvs: string[] = []
 let failingDirs = new Set<string>()
+const DEFAULT_FAILURE = "429 rate limit reached for this account"
+let failureMessage = DEFAULT_FAILURE
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
@@ -21,7 +23,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const streaming = params.options?.includePartialMessages === true
     return (async function* () {
       if ([...failingDirs].some((f) => dir.includes(f))) {
-        throw new Error("429 rate limit reached for this account")
+        throw new Error(failureMessage)
       }
       if (streaming) {
         yield messageStart("msg-1")
@@ -96,6 +98,7 @@ const savedEnv: Record<string, string | undefined> = {}
 // (file-level) hooks before inner (describe-level) ones, so those overrides
 // still win for those tests.
 beforeEach(() => {
+  failureMessage = DEFAULT_FAILURE
   __setFetchOAuthUsageOverride(async () => null)
 })
 
@@ -143,6 +146,16 @@ describe("priority routing", () => {
     // work attempted (with its internal retry ladder), then personal
     expect(capturedEnvs.some((e) => e.includes("prof-work"))).toBe(true)
     expect(capturedEnvs[capturedEnvs.length - 1]).toContain("prof-personal")
+  }, 20_000)
+
+  it("fails over on the CLI's shorter 'You've hit your limit' wording", async () => {
+    failureMessage = "Claude Code returned an error result: You've hit your limit · resets 6:40pm (UTC)"
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0].text).toContain("prof-personal")
   }, 20_000)
 
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -70,13 +70,14 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
-  // Rate limiting. The CLI phrases 5h-window exhaustion as "You've hit your
-  // session limit · resets <time>" (live-observed) and weekly caps as
-  // "usage limit reached" — both ARE quota exhaustion and must classify as
-  // rate_limit_error (429), not generic api_error: clients back off correctly
-  // and priority routing's failover keys off this class.
+  // Rate limiting. The CLI phrases 5h-window exhaustion as either "You've hit
+  // your session limit · resets <time>" or the shorter "You've hit your limit".
+  // Weekly caps use "usage limit reached". These ARE quota exhaustion and must
+  // classify as rate_limit_error (429), not generic api_error: clients back off
+  // correctly and priority routing's failover keys off this class.
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
-    || lower.includes("hit your session limit") || lower.includes("usage limit reached")) {
+    || lower.includes("hit your session limit") || lower.includes("hit your limit")
+    || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""


### PR DESCRIPTION
## Context

I exhausted the five-hour quota on the preferred profile in a two-profile `priority` setup and expected Meridian to switch to the fallback profile. Instead, the request failed with:

```text
Claude Code returned an error result: You've hit your limit · resets 6:40pm (UTC)
```

Meridian returned this as `500 api_error`, so priority routing did not mark the profile exhausted or try the fallback.

This is a shorter wording variant of the quota error handled in #680: the classifier recognizes `You've hit your session limit`, but not `You've hit your limit`.

## Fix

- classify the shorter wording as `429 rate_limit_error`
- add classifier and priority-failover regression tests