### PR TITLE
fix(passthrough): never leave a passthrough continuation unanswered

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -90,6 +90,7 @@ kill $(lsof -ti :3456)
 | E35 | [SDK boundary assumptions (#694/#708/#710)](#e35-sdk-boundary-assumptions-694708710) | **Automated**: `bun scripts/e2e-sdk-boundary.mjs` — real SDK: rate-limit reset units land in a sane window, every live content-block type is classified for hashing, resume survives a client dropping thinking blocks, and reports whether the gitStatus block still misstates its provenance. **Run after any `@anthropic-ai/claude-agent-sdk` bump** and before releases touching lineage, rate limits, or the system prompt | 2026-07-29 |
 | E36 | [Client detection after an upgrade (#733)](#e36-client-detection-after-an-upgrade-733) | **Automated**: `bun scripts/e2e-client-detection.mjs` — drives each installed client against a local stub, captures its real headers, and asserts the adapter Meridian resolves. **Run after upgrading any client**; costs no tokens | 2026-07-31 |
 | E37 | [WebFetch preflight scope (#748)](#e37-webfetch-preflight-scope-748) | **Automated**: `bun scripts/e2e-webfetch-preflight.mjs` — stubbed `claude` + isolated HOME: the toggle reaches the right adapter's `--settings`, and only `cherry` can actually run the built-in WebFetch, so the documented scope is asserted rather than assumed. **Run before releases touching sdkFeatures, query settings, or tool config**; costs no tokens | 2026-08-03 |
+| E38 | [Silent turns (#768)](#e38-silent-turns-768) | **Automated**: `bun scripts/e2e-silent-turn.mjs` — real CLI, SSE mode, second turn of a fresh session: asserts the outcome (did the client get text or a tool call?) rather than any one cause, so a cause not yet found fails it too. Pair a `MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` run against `MERIDIAN_SILENT_TURN_RECOVERY=0` for the before/after. **Run before any release touching the passthrough tool loop, prompt assembly, or session resume** | 2026-08-11 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3326,3 +3327,64 @@ removing `cherry` from `ADAPTER_LABELS` fails the static counterpart in
 **Static counterpart:** the `WebFetch preflight scope` block in `query.test.ts`
 pins the same three adapter shapes at the `buildQueryOptions` level, so tool
 config drift fails in CI without starting a proxy.
+
+## E38: Silent turns (#768)
+
+**Automated**, costs real tokens (two turns per attempt, plus one per silence
+the recovery repairs):
+
+```bash
+bun scripts/e2e-silent-turn.mjs
+E2E_ATTEMPTS=10 bun scripts/e2e-silent-turn.mjs
+
+# The pair that actually proves the guard, on demand:
+MERIDIAN_DEBUG_FORCE_SILENT_TURN=1 MERIDIAN_SILENT_TURN_RECOVERY=0 bun scripts/e2e-silent-turn.mjs  # FAILS
+MERIDIAN_DEBUG_FORCE_SILENT_TURN=1 bun scripts/e2e-silent-turn.mjs                                  # passes
+```
+
+**Why this exists:** three separate defects have now ended in the same shape —
+`stop_reason: "end_turn"`, HTTP 200, `error: null`, and nothing the client can
+act on. An interrupted tail, an unsettled client abort, a spent deny at the
+boundary seam. Each was found by reading a transcript after the fact; each
+mocked suite stayed green while the field kept breaking.
+
+They have nothing in common except their outcome, so the outcome is what this
+measures. Every turn is asked one question — did the client receive text or a
+tool call? — which a cause nobody has found yet fails exactly like the three
+known ones.
+
+It drives the shape all three took: a tool call, then the turn that must answer
+its result, in a fresh session each attempt. Every observed silence landed on a
+session's **second** turn, where the deny is the largest thing in a still-short
+context.
+
+**Fault injection, and why it is not optional.** The live rate is about three in
+five hundred requests. A ten-attempt run expects 0.06 occurrences, so a green
+run without injection is ambiguous — the guard works, or the defect simply did
+not happen. That ambiguity is what let two earlier "verified" fixes ship broken.
+`MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` drops the upstream turn's text deltas while
+leaving its block start and stop, which is the production signature exactly;
+detection, recovery, envelope and telemetry then run for real against a real
+model. Only the trigger is synthetic.
+
+**Pass criteria:**
+
+- every turn under test carries text or ≥1 tool call
+- exactly one `message_stop` per turn
+- any `error` event precedes `message_stop` — behind it, clients have already
+  stopped reading and the failure is invisible
+- a failed turn with no text does not claim `stop_reason: "end_turn"`
+- an attempt where the model never called a tool is reported as **skipped**,
+  not counted as a pass: it never reached the shape under test
+
+**Reading the output:** `silent: 0` says the client always got an answer, not
+that nothing broke upstream — `upstream: N silent turns detected, M recovered`
+is where the mechanism shows itself. Compare an injected run with recovery ON
+against the same run with `MERIDIAN_SILENT_TURN_RECOVERY=0`; comparing a single
+recovery-ON run against nothing tells you almost nothing.
+
+**Verified:** 2026-08-11. Injected, recovery OFF: 2/2 attempts FAIL with
+`text=0 tools=0`. Injected, recovery ON: 2/2 pass, the answer arriving as real
+text deltas. Uninjected, both settings: 3/3 pass, no silences — the live rate is
+far below what a run this size can see, which is the whole reason injection
+exists.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,7 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_ROUTING` | — | `active` | Session-to-profile routing: `active` (all traffic to the active profile), `sticky` ([sticky session routing](profiles.md#sticky-session-routing)), or `priority` ([priority failover](profiles.md#priority-failover-routing)) |
 | `MERIDIAN_PROFILE_ORDER` | — | *(config order)* | Priority-mode pool order, comma-separated, highest priority first (e.g. `work,personal`). Also editable at `/settings`. |
 | `MERIDIAN_PASSTHROUGH_EARLY_STOP` | — | `1` | Set to `0` to disable [digest-turn elimination](#how-tool-calling-works-in-passthrough) and restore the old end-of-turn behavior |
+| `MERIDIAN_SILENT_TURN_RECOVERY` | — | `1` | Set to `0` to stop spending a recovery turn on a [silent turn](#silent-turns). Detection and telemetry stay on either way |
 | `MERIDIAN_SUPPRESS_SCRATCHPAD` | — | `1` | Set to `0` to let the SDK advertise its proxy-host scratchpad directory in passthrough mode |
 | `MERIDIAN_PRICING_CONFIG` | `CLAUDE_PROXY_PRICING_CONFIG` | `~/.config/meridian/model-pricing.json` | Path to the model pricing overrides file used by cost estimation |
 | `MERIDIAN_PROFILES` | — | unset | JSON array of profile configs (overrides disk discovery). See [Multi-Profile Support](profiles.md). |
@@ -267,6 +268,18 @@ MERIDIAN_PASSTHROUGH=0 meridian   # force internal
 For large tool sets (>15 tools), non-core tools are automatically deferred via the SDK's ToolSearch mechanism. Core tools (read, write, edit, bash, glob, grep) are always loaded eagerly. The deferral threshold is configurable with `MERIDIAN_DEFER_TOOL_THRESHOLD`.
 
 **Digest-turn elimination** — after a tool call is captured, the SDK would normally invoke the model one more time to "digest" the denial before ending the turn. That extra invocation is discarded by the proxy but fully billed — measured at ~400+ wasted output tokens and 2–3× extra latency per tool step (and on always-thinking models like Fable, a full thinking pass each time). Meridian now aborts the SDK query the moment every tool call's denial is persisted, so the digest turn never generates. Sessions remain resumable and tool-result attribution is unaffected. Kill switch: `MERIDIAN_PASSTHROUGH_EARLY_STOP=0` restores the old behavior.
+
+### Silent turns
+
+A **silent turn** is a completed turn whose terminal envelope carries nothing the client can act on: no text, no tool call. On the wire it is indistinguishable from success — `stop_reason: "end_turn"`, HTTP 200, `error: null` — so a client does not retry, and an autonomous run treats a lost turn as a finished one.
+
+Three separate defects have produced this shape (all fixed in rynfar/meridian#768): a session resumed from an interrupted tail, a client abort that never settled its session, and a spent `end your turn now` deny landing immediately before a boundary continuation. They have nothing in common but their outcome, so Meridian now guards the outcome directly:
+
+- **Detection.** Every completed turn is classified: text or a tool call means productive, anything else is silent. `thinking` deliberately does not count — thinking plus an empty text block *is* the defect's signature. Silent turns are recorded as `response.silent_turn` in `/telemetry/logs` and named at session level, because an autonomous run has nobody to notice a quiet telemetry row.
+- **Recovery.** One extra turn, in the same session, forked from the deny boundary rather than appended to the silent tail — appending is what compounds one empty turn into an empty session. The nudge names the contradiction and discharges it, rather than just asking again like the CLI's own no-visible-output prompt, which failed on all three observed cases because the offending instruction was still standing. At most one attempt; never when the client has already disconnected. A recovery that itself fails leaves the original envelope intact and never turns a delivered turn into a failed request. Kill switch: `MERIDIAN_SILENT_TURN_RECOVERY=0` keeps detection and telemetry, skips the spend.
+- **Honest failure envelopes.** When a turn dies mid-stream, the `error` event now precedes `message_stop` — clients stop reading at `message_stop`, so an error queued behind it was written into a stream nobody was consuming. A failed turn that produced no text also reports `stop_reason: "max_tokens"` (truncated) instead of `"end_turn"` (finished), which is what lets a client tell a crash from a completed answer.
+
+Coverage: `E38` in [E2E.md](../E2E.md), with `MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` reproducing the shape on demand — the live rate is roughly three in five hundred requests, far too rare for a test run to wait for.
 
 ### Known limitations
 

--- a/scripts/e2e-silent-turn.mjs
+++ b/scripts/e2e-silent-turn.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: the silent-turn invariant — a terminal envelope must carry text or
+ * a tool call.
+ *
+ * WHY THIS EXISTS
+ *
+ * Three defects have ended in the same shape: `stop_reason: "end_turn"`, HTTP
+ * 200, `error: null`, nothing the client can act on. Each was found by reading
+ * a transcript after the fact, and each mocked suite went green while the field
+ * kept breaking — the trigger is a model choosing between two instructions,
+ * which no mock reproduces.
+ *
+ * So this measures the OUTCOME rather than any one cause. It runs the real CLI
+ * through the real proxy and asks a single question of every turn: did the
+ * client receive something actionable? A cause we have not found yet fails this
+ * the same way the three known ones did.
+ *
+ * WHAT IT DOES
+ *
+ * Drives the exact shape all three incidents took — a tool call, then the
+ * follow-up turn that must answer its result — because every observed silence
+ * landed on a session's SECOND turn, where the deny is the largest thing in a
+ * still-short context. Each attempt is a fresh session, so each gets its own
+ * second turn.
+ *
+ *   bun scripts/e2e-silent-turn.mjs
+ *   E2E_ATTEMPTS=10 bun scripts/e2e-silent-turn.mjs
+ *   MERIDIAN_SILENT_TURN_RECOVERY=0 bun scripts/e2e-silent-turn.mjs   # baseline
+ *
+ * Requires Claude Max auth (`claude login`). Costs real tokens: two turns per
+ * attempt, plus one more for every silence the recovery catches.
+ *
+ * READING THE RESULT
+ *
+ * - `silent: 0` with recovery ON says the client always got an answer. It does
+ *   NOT say no turn came back empty upstream — check `recovered` for that.
+ * - `recovered: n` is the interesting number: n silences happened and n were
+ *   repaired. That is the guard doing its job, and the only direct evidence
+ *   the mechanism engages on a live model.
+ * - Run with the kill switch to measure the underlying rate. Comparing a
+ *   recovery-ON run against nothing tells you little; comparing ON against OFF
+ *   tells you both the rate and the repair.
+ */
+import { startProxyServer } from "../src/proxy/server.ts"
+
+const PORT = Number(process.env.E2E_PORT ?? 3497)
+const ATTEMPTS = Number(process.env.E2E_ATTEMPTS ?? 3)
+const MODEL = process.env.E2E_MODEL ?? "claude-sonnet-4-5"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+process.env.OPENCODE_CLAUDE_PROVIDER_DEBUG = "1"
+
+const diag = []
+console.debug = (...args) => { diag.push(args.map(String).join(" ")) }
+
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1", silent: true })
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file from disk",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string", description: "Absolute path" } },
+    required: ["file_path"],
+  },
+}
+
+/** Parse an SSE body into events, keeping order. */
+function parseSSE(body) {
+  const out = []
+  for (const chunk of body.split("\n\n")) {
+    const ev = /^event: (.+)$/m.exec(chunk)
+    const data = /^data: (.+)$/m.exec(chunk)
+    if (!ev) continue
+    let parsed
+    try { parsed = data ? JSON.parse(data[1]) : undefined } catch { parsed = undefined }
+    out.push({ event: ev[1], data: parsed })
+  }
+  return out
+}
+
+async function send(messages, sessionId) {
+  const response = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": sessionId,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify({ model: MODEL, max_tokens: 2048, stream: true, tools: [READ_TOOL], messages }),
+  })
+  return { status: response.status, events: parseSSE(await response.text()) }
+}
+
+/**
+ * What did the client actually receive? Mirrors classifyTurnOutcome — text
+ * DELTAS, not text blocks, because an empty text block is the defect's shape.
+ */
+function inspect(events) {
+  let textDeltas = 0
+  const toolUses = []
+  let stopReason
+  let errorEvent
+  let messageStops = 0
+  let sawErrorBeforeStop = false
+
+  for (const { event, data } of events) {
+    if (event === "content_block_delta" && data?.delta?.type === "text_delta") textDeltas += 1
+    if (event === "content_block_start" && data?.content_block?.type === "tool_use") {
+      toolUses.push({ id: data.content_block.id, name: data.content_block.name })
+    }
+    if (event === "message_delta" && data?.delta?.stop_reason) stopReason = data.delta.stop_reason
+    if (event === "message_stop") messageStops += 1
+    if (event === "error") {
+      errorEvent = data?.error
+      if (messageStops === 0) sawErrorBeforeStop = true
+    }
+  }
+  return {
+    textDeltas,
+    toolUses,
+    stopReason,
+    errorEvent,
+    messageStops,
+    sawErrorBeforeStop,
+    actionable: textDeltas > 0 || toolUses.length > 0,
+  }
+}
+
+const results = []
+let failures = 0
+
+for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+  const session = `e2e-silent-${Date.now()}-${attempt}`
+  const diagFrom = diag.length
+
+  // Turn 1 — provoke a tool call. Fresh session every attempt, so the answer
+  // below is always a second turn.
+  const first = await send(
+    [{ role: "user", content: "Read /etc/hostname and then tell me what it contains." }],
+    session,
+  )
+  const t1 = inspect(first.events)
+
+  if (t1.toolUses.length === 0) {
+    // Not a pass or a fail of the invariant — the attempt never reached the
+    // shape under test. Reported rather than silently averaged away.
+    results.push({ attempt, verdict: "no-tool-call", t1, t2: null })
+    console.log(`  ${attempt}: skipped — the model answered without calling a tool`)
+    continue
+  }
+
+  // Turn 2 — the shape that broke. Client executed the tool; its result comes
+  // back and MUST be answered.
+  const assistantBlocks = t1.toolUses.map((tu) => ({
+    type: "tool_use", id: tu.id, name: tu.name, input: { file_path: "/etc/hostname" },
+  }))
+  const second = await send(
+    [
+      { role: "user", content: "Read /etc/hostname and then tell me what it contains." },
+      { role: "assistant", content: assistantBlocks },
+      {
+        role: "user",
+        content: t1.toolUses.map((tu) => ({
+          type: "tool_result", tool_use_id: tu.id, content: "e2e-test-host\n",
+        })),
+      },
+    ],
+    session,
+  )
+  const t2 = inspect(second.events)
+
+  const attemptDiag = diag.slice(diagFrom)
+  // Count the session-level silent_turn lines only (the claudeLog mock is off in
+  // this harness, so telemetry lines do not appear here). The recovery verdict
+  // is a field on that same line: `recovery=succeeded|failed|off`.
+  const silentLines = attemptDiag.filter((l) => l.includes("silent_turn reason="))
+  const silences = silentLines.length
+  const recovered = silentLines.filter((l) => l.includes("recovery=succeeded")).length
+
+  const verdict = t2.actionable ? "pass" : "FAIL"
+  if (!t2.actionable) failures += 1
+  results.push({ attempt, verdict, t1, t2, silences, recovered })
+
+  console.log(
+    `  ${attempt}: ${verdict} — turn2 text=${t2.textDeltas} tools=${t2.toolUses.length} ` +
+    `stop=${t2.stopReason} silent_turn_logs=${silences} recovered=${recovered}`,
+  )
+}
+
+// Envelope hygiene across every turn: exactly one message_stop, and any error
+// ahead of it. An error behind message_stop is unreachable — that is how a
+// failed turn came to look successful.
+const envelopeProblems = []
+for (const r of results) {
+  for (const [label, t] of [["turn1", r.t1], ["turn2", r.t2]]) {
+    if (!t) continue
+    if (t.messageStops !== 1) {
+      envelopeProblems.push(`attempt ${r.attempt} ${label}: ${t.messageStops} message_stop events`)
+    }
+    if (t.errorEvent && !t.sawErrorBeforeStop) {
+      envelopeProblems.push(`attempt ${r.attempt} ${label}: error queued after message_stop (unreachable)`)
+    }
+    // A turn with no text must not claim it finished speaking.
+    if (t.errorEvent && t.textDeltas === 0 && t.stopReason === "end_turn") {
+      envelopeProblems.push(`attempt ${r.attempt} ${label}: failed turn claims stop_reason=end_turn`)
+    }
+  }
+}
+
+const attempted = results.filter((r) => r.verdict !== "no-tool-call").length
+const skipped = results.length - attempted
+const totalSilences = results.reduce((n, r) => n + (r.silences ?? 0), 0)
+const totalRecovered = results.reduce((n, r) => n + (r.recovered ?? 0), 0)
+
+console.log("")
+console.log(`attempts:   ${attempted}${skipped ? ` (${skipped} skipped — no tool call)` : ""}`)
+console.log(`silent:     ${failures}   (client received nothing actionable)`)
+console.log(`upstream:   ${totalSilences} silent turns detected, ${totalRecovered} recovered`)
+console.log(`recovery:   ${process.env.MERIDIAN_SILENT_TURN_RECOVERY === "0" ? "OFF (baseline)" : "ON"}`)
+
+if (envelopeProblems.length > 0) {
+  console.log("")
+  console.log("envelope problems:")
+  for (const p of envelopeProblems) console.log(`  - ${p}`)
+}
+
+await inst.stop?.()
+
+if (failures > 0 || envelopeProblems.length > 0) {
+  console.log("")
+  console.log("FAILED — a turn reached the client with nothing to act on, or its envelope hid a failure.")
+  process.exit(1)
+}
+console.log("")
+console.log("OK — every turn under test carried text or a tool call.")

--- a/src/__tests__/announce-turn-recovery.test.ts
+++ b/src/__tests__/announce-turn-recovery.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Announce-turn recovery through the HTTP layer, mocked SDK.
+ *
+ * The unit tests pin the classification window; this pins the wiring the
+ * window depends on and that no unit can reach: the deny boundary must be
+ * ARMED from the session cache (stored by the early stop of the previous
+ * request), the recovery must ask with the announce nudge — not the silent
+ * one, whose "no visible output" would be false — and the recovered text must
+ * reach the client as normal deltas.
+ *
+ * Request 1 forwards a tool call and observes its deny (early stop stores the
+ * boundary). Request 2 is the continuation that answers the tool results with
+ * one short announce-shaped text and no tool calls — the live a342c863 shape.
+ */
+import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import {
+  messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop,
+  toolUseBlockStart, inputJsonDelta, assistantMessage,
+} from "./helpers"
+import { ANNOUNCE_TURN_NUDGE } from "../proxy/turnOutcome"
+
+let queryCalls: any[] = []
+let scripted: any[][] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    queryCalls.push(params)
+    const messages = scripted.shift() ?? []
+    return (async function* () {
+      for (const m of messages) yield m
+    })()
+  },
+  createSdkMcpServer: () => ({
+    type: "sdk", name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({
+    type: "sdk", name: "opencode",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+
+const DENY_UUID = "deny-boundary-uuid-1"
+
+function userDenyMessage(toolUseId: string) {
+  return {
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: "forwarded to client", is_error: true }],
+    },
+    parent_tool_use_id: null,
+    uuid: DENY_UUID,
+    session_id: "test-session",
+  }
+}
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file",
+  input_schema: { type: "object", properties: { file_path: { type: "string" } }, required: ["file_path"] },
+}
+
+/** Request 1's script: one forwarded tool call, then its persisted deny. */
+const toolTurnThenDeny = () => [
+  messageStart("msg_t1"),
+  toolUseBlockStart(0, "read", "tu1"),
+  inputJsonDelta(0, '{"file_path":"x"}'),
+  blockStop(0),
+  messageDelta("tool_use"),
+  assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
+  userDenyMessage("tu1"),
+]
+
+/** The live announce shape: one short text, no tool calls, clean end_turn. */
+const announceTurn = (text: string) => [
+  messageStart("msg_a1"),
+  textBlockStart(0),
+  textDelta(0, text),
+  blockStop(0),
+  messageDelta("end_turn"),
+  messageStop(),
+]
+
+const recoveryTurn = (text: string) => [
+  messageStart("msg_r1"),
+  textBlockStart(0),
+  textDelta(0, text),
+  blockStop(0),
+  messageDelta("end_turn"),
+  messageStop(),
+]
+
+async function post(app: any, body: any, session: string) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": session,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify(body),
+  }))
+}
+
+/** Run the boundary-arming request and wait for its background drain+abort. */
+async function armDenyBoundary(app: any, session: string) {
+  const first = await post(app, {
+    model: "claude-sonnet-4-5",
+    max_tokens: 400,
+    stream: true,
+    tools: [READ_TOOL],
+    messages: [{ role: "user", content: "read x" }],
+  }, session)
+  expect(first.status).toBe(200)
+  await first.text()
+  const armingCall = queryCalls[queryCalls.length - 1]
+  const deadline = Date.now() + 2000
+  while (!armingCall.options.abortController?.signal?.aborted && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  expect(armingCall.options.abortController?.signal?.aborted).toBe(true)
+}
+
+/** The continuation body: the client returns tu1's result — 3 messages, inside
+ *  the announce risk window. */
+const continuationBody = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 400,
+  stream: true,
+  tools: [READ_TOOL],
+  messages: [
+    { role: "user", content: "read x" },
+    { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "file contents" }] },
+  ],
+}
+
+describe("announce-turn recovery", () => {
+  let app: any
+  let savedPassthrough: string | undefined
+  let savedEarlyStop: string | undefined
+  let savedRecovery: string | undefined
+
+  beforeAll(() => {
+    const { app: a } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    app = a
+  })
+
+  beforeEach(() => {
+    savedPassthrough = process.env.MERIDIAN_PASSTHROUGH
+    savedEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    savedRecovery = process.env.MERIDIAN_SILENT_TURN_RECOVERY
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    delete process.env.MERIDIAN_SILENT_TURN_RECOVERY
+    queryCalls = []
+    scripted = []
+  })
+
+  afterEach(() => {
+    if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    if (savedEarlyStop !== undefined) process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = savedEarlyStop
+    else delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    if (savedRecovery !== undefined) process.env.MERIDIAN_SILENT_TURN_RECOVERY = savedRecovery
+    else delete process.env.MERIDIAN_SILENT_TURN_RECOVERY
+  })
+
+  it("recovers an announce-only continuation with the announce nudge", async () => {
+    scripted = [
+      toolTurnThenDeny(),
+      announceTurn("I'll start by auditing the current state and read the configs in parallel."),
+      recoveryTurn("ANNOUNCE_RECOVERY_TEXT"),
+    ]
+
+    await armDenyBoundary(app, "ann-recover")
+    const second = await post(app, continuationBody, "ann-recover")
+    expect(second.status).toBe(200)
+    const body = await second.text()
+
+    expect(queryCalls.length).toBe(3)
+    // The window is armed by the boundary the previous request stored.
+    expect(queryCalls[1].options.resumeSessionAt).toBe(DENY_UUID)
+    // The announce stall gets its own words — "no visible output" would be
+    // false, the client saw the announcement.
+    expect(queryCalls[2].prompt).toBe(ANNOUNCE_TURN_NUDGE)
+    // The recovered answer reaches the client as a normal text delta.
+    expect(body).toContain("ANNOUNCE_RECOVERY_TEXT")
+  })
+
+  it("leaves a long answer on the same boundary alone", async () => {
+    scripted = [
+      toolTurnThenDeny(),
+      announceTurn("The audit is complete. ".repeat(30)),
+      recoveryTurn("MUST_NOT_BE_REQUESTED"),
+    ]
+
+    await armDenyBoundary(app, "ann-long")
+    const second = await post(app, continuationBody, "ann-long")
+    const body = await second.text()
+
+    expect(queryCalls.length).toBe(2)
+    expect(body).not.toContain("MUST_NOT_BE_REQUESTED")
+  })
+
+  it("leaves a short text alone when there is no deny boundary", async () => {
+    scripted = [
+      announceTurn("Short but a real answer."),
+      recoveryTurn("MUST_NOT_BE_REQUESTED"),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      messages: [{ role: "user", content: "quick question" }],
+    }, "ann-fresh")
+    const body = await response.text()
+
+    expect(queryCalls.length).toBe(1)
+    expect(body).not.toContain("MUST_NOT_BE_REQUESTED")
+  })
+})

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { frameReplayTurns, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall, extractSystemText } from "../proxy/messages"
+import { frameReplayTurns, framePassthroughContinuation, PASSTHROUGH_CONTINUATION_LEAD_IN, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall, extractSystemText } from "../proxy/messages"
 
 const img = (id: string) => ({ type: "image", source: { type: "base64", media_type: "image/png", data: id } })
 function userMsg(content: unknown) {
@@ -452,6 +452,34 @@ describe("frameReplayTurns (#619)", () => {
     expect(out).not.toContain("Human:")
     expect(out).toEndWith("final question")
     expect(out).toContain("[your bash ls]:")
+  })
+})
+
+describe("framePassthroughContinuation", () => {
+  // The deny boundary fork places the spent "end your turn now" deny
+  // immediately before this delta. Without the lead-in the model obeys it and
+  // answers with an empty text block (see the doc comment on the constant).
+  const delta = "[your shell ls]:\nfile.txt"
+
+  it("puts the lead-in ahead of the delta and keeps the delta terminal", () => {
+    const out = framePassthroughContinuation(delta)
+    expect(out).toStartWith(PASSTHROUGH_CONTINUATION_LEAD_IN)
+    expect(out).toEndWith(delta)
+  })
+
+  it("says the end-turn instruction is discharged", () => {
+    expect(framePassthroughContinuation(delta).toLowerCase()).toContain("discharged")
+  })
+
+  it("leaves an empty delta alone — the lead-in must never be the whole turn", () => {
+    expect(framePassthroughContinuation("")).toBe("")
+  })
+
+  it("adds no transcript markers for the model to imitate (#496)", () => {
+    const out = framePassthroughContinuation(delta)
+    expect(out).not.toContain("Human:")
+    expect(out).not.toContain("[Assistant:")
+    expect(out).not.toContain("<conversation_history>")
   })
 })
 

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
 import { assistantMessage, messageStart, toolUseBlockStart, inputJsonDelta, blockStop, messageDelta } from "./helpers"
+import { PASSTHROUGH_CONTINUATION_LEAD_IN } from "../proxy/messages"
 
 let mockMessages: any[] = []
 let yieldedCount = 0
@@ -161,6 +162,76 @@ describe("Integration: passthrough early stop", () => {
     expect(second.status).toBe(200)
     // Resume proof: the SDK was invoked with the stored session id.
     expect(capturedQueryParams.options.resume).toBe("test-session")
+  })
+
+  it("non-stream: a deny-boundary continuation tells the model the end-turn deny is spent", async () => {
+    // The fork puts the persisted deny — "do not generate further text, end
+    // your turn now" — immediately before this delta, where it is the nearest
+    // instruction in context. Live, the model obeyed it and returned an empty
+    // text block with stop_reason end_turn, three times in 500 requests, each
+    // on a session's second turn. The prompt has to say the deny is discharged.
+    mockMessages = [
+      assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
+      userDenyMessage("tu1"),
+    ]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-lead-in")
+    expect(first.status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says hi" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "hi" }] },
+      ],
+    }, "es-lead-in")
+    expect(second.status).toBe(200)
+    // Forked from the boundary, and the prompt carries the discharge.
+    expect(capturedQueryParams.options.resumeSessionAt).toBeTruthy()
+    const prompt = capturedQueryParams.prompt as string
+    expect(prompt).toContain(PASSTHROUGH_CONTINUATION_LEAD_IN)
+    // The tool result stays terminal — the lead-in is framing, not the answer.
+    expect(prompt.indexOf(PASSTHROUGH_CONTINUATION_LEAD_IN)).toBeLessThan(prompt.indexOf("hi"))
+  })
+
+  it("non-stream: a plain resume with no deny boundary stays bare", async () => {
+    // No forwarded tool call, so no deny is persisted and nothing needs
+    // discharging — the delta must not grow a preamble on every ordinary turn.
+    mockMessages = [assistantMessage([{ type: "text", text: "first answer" }])]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "just talk" }],
+    }, "es-no-boundary")
+    expect(first.status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "second answer" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "just talk" },
+        { role: "assistant", content: [{ type: "text", text: "first answer" }] },
+        { role: "user", content: "and again" },
+      ],
+    }, "es-no-boundary")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBe("test-session")
+    expect(capturedQueryParams.prompt as string).not.toContain(PASSTHROUGH_CONTINUATION_LEAD_IN)
   })
 
   it("non-stream: waits for ALL parallel denies before stopping", async () => {

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -16,6 +16,7 @@ import {
   isClientForwardedToolUse,
   noteAssistantContent,
   noteUserContent,
+  resumeBoundaryUuid,
   shouldEarlyStop,
 } from "../proxy/passthroughEarlyStop"
 
@@ -56,6 +57,41 @@ describe("isClientForwardedToolUse", () => {
 
   it("excludes tool_use blocks with no id (can't be tracked)", () => {
     expect(isClientForwardedToolUse({ type: "tool_use", name: "read" })).toBe(false)
+  })
+})
+
+describe("resumeBoundaryUuid", () => {
+  const userMsg = (uuid: unknown, content: unknown) => ({
+    type: "user",
+    uuid,
+    message: { role: "user", content },
+  })
+
+  it("returns the uuid of a user message carrying a tool_result", () => {
+    expect(resumeBoundaryUuid(userMsg("u1", [toolResult("t1")]))).toBe("u1")
+  })
+
+  it("returns the uuid when tool_results mix with other blocks", () => {
+    expect(resumeBoundaryUuid(userMsg("u2", [{ type: "text", text: "hi" }, toolResult("t1")]))).toBe("u2")
+  })
+
+  it("ignores assistant messages", () => {
+    expect(resumeBoundaryUuid({ type: "assistant", uuid: "a1", message: { content: [toolResult("t1")] } })).toBeUndefined()
+  })
+
+  it("ignores user messages without tool_results", () => {
+    expect(resumeBoundaryUuid(userMsg("u3", [{ type: "text", text: "hi" }]))).toBeUndefined()
+  })
+
+  it("ignores messages with no usable uuid", () => {
+    expect(resumeBoundaryUuid(userMsg(undefined, [toolResult("t1")]))).toBeUndefined()
+    expect(resumeBoundaryUuid(userMsg("", [toolResult("t1")]))).toBeUndefined()
+  })
+
+  it("tolerates malformed content", () => {
+    expect(resumeBoundaryUuid(userMsg("u4", "just a string"))).toBeUndefined()
+    expect(resumeBoundaryUuid(null)).toBeUndefined()
+    expect(resumeBoundaryUuid({})).toBeUndefined()
   })
 })
 

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -12,6 +12,7 @@
  */
 import { describe, it, expect } from "bun:test"
 import {
+  clientAbortDisposition,
   createEarlyStopTracker,
   isClientForwardedToolUse,
   noteAssistantContent,
@@ -57,6 +58,43 @@ describe("isClientForwardedToolUse", () => {
 
   it("excludes tool_use blocks with no id (can't be tracked)", () => {
     expect(isClientForwardedToolUse({ type: "tool_use", name: "read" })).toBe(false)
+  })
+})
+
+describe("clientAbortDisposition", () => {
+  const base = {
+    isIndependentSession: false,
+    profileSessionId: "s1",
+    currentSessionId: "claude-1",
+    sawDuplicateToolUse: false,
+    resumeBoundaryUuid: "u1",
+  }
+
+  it("stores the boundary when one was persisted before the abort", () => {
+    expect(clientAbortDisposition(base)).toEqual({ action: "store", resumeUuid: "u1" })
+  })
+
+  it("evicts when no deny was persisted — nothing is safe to resume from", () => {
+    // The interrupted tail would make the SDK synthesize a continuation the
+    // model answers with an empty turn, and every empty turn becomes the next
+    // tail. A fresh replay is the cost of not wedging the conversation.
+    expect(clientAbortDisposition({ ...base, resumeBoundaryUuid: undefined })).toEqual({ action: "evict" })
+  })
+
+  it("evicts when the SDK session id never arrived", () => {
+    expect(clientAbortDisposition({ ...base, currentSessionId: undefined })).toEqual({ action: "evict" })
+  })
+
+  it("evicts on a duplicate-aborted history (#552) even with a boundary", () => {
+    expect(clientAbortDisposition({ ...base, sawDuplicateToolUse: true })).toEqual({ action: "evict" })
+  })
+
+  it("does nothing for fork/subagent requests — they never write the cache", () => {
+    expect(clientAbortDisposition({ ...base, isIndependentSession: true })).toEqual({ action: "none" })
+  })
+
+  it("does nothing without a session key", () => {
+    expect(clientAbortDisposition({ ...base, profileSessionId: undefined })).toEqual({ action: "none" })
   })
 })
 

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -105,6 +105,34 @@ describe("Shared session store", () => {
     expect(byClaudeId?.messageBlockHashes).toEqual([["block-hash-a", "block-hash-b"]])
   })
 
+  it("should persist and clear the passthrough resume boundary", () => {
+    storeSharedSession(
+      "session-boundary",
+      "claude-sess-boundary",
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "deny-uuid"
+    )
+    expect(lookupSharedSession("session-boundary")?.passthroughResumeUuid).toBe("deny-uuid")
+
+    storeSharedSession(
+      "session-boundary",
+      "claude-sess-boundary",
+      2,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      null
+    )
+    expect(lookupSharedSession("session-boundary")?.passthroughResumeUuid).toBeUndefined()
+  })
+
   it("should return the freshest match when multiple keys share a Claude session ID", () => {
     storeSharedSession("session-old", "claude-shared")
     const first = lookupSharedSessionByClaudeId("claude-shared")

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -30,6 +30,9 @@ const PREFIX = "mcp__oc__"
 
 let capturedController: AbortController | undefined
 let capturedResume: string | undefined
+let capturedResumeSessionAt: string | undefined
+let capturedForkSession: boolean | undefined
+let denyUuids: string[] = []
 let timeline: string[] = []
 // Deny persistence delay — simulates the CLI's post-release deny latency that
 // makes the store land after the client response (the fast-client race).
@@ -56,11 +59,15 @@ const assistantMsg = (blocks: any[]) => ({
   message: { id: "m1", type: "message", role: "assistant", content: blocks, model: "claude-sonnet-4-5-20250929", stop_reason: "tool_use", usage: { input_tokens: 10, output_tokens: 30 } },
   parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
 })
-const denyMsg = (ids: string[]) => ({
-  type: "user",
-  message: { role: "user", content: ids.map((id) => ({ type: "tool_result", tool_use_id: id, is_error: true, content: "denied" })) },
-  parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
-})
+const denyMsg = (ids: string[]) => {
+  const uuid = crypto.randomUUID()
+  denyUuids.push(uuid)
+  return {
+    type: "user",
+    message: { role: "user", content: ids.map((id) => ({ type: "tool_result", tool_use_id: id, is_error: true, content: "denied" })) },
+    parent_tool_use_id: null, uuid, session_id: "test-session",
+  }
+}
 
 // CLI-faithful mock: per-block assistant messages, mid-stream hook dispatch,
 // CANCEL-ON-DENY when a deny resolves while generation is in flight.
@@ -68,6 +75,8 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedController = opts?.options?.abortController
     capturedResume = opts?.options?.resume
+    capturedResumeSessionAt = opts?.options?.resumeSessionAt
+    capturedForkSession = opts?.options?.forkSession
     const hook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
     return (async function* () {
       if (!hook) {
@@ -184,6 +193,9 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     denyDelayMs = 0
     capturedController = undefined
     capturedResume = undefined
+    capturedResumeSessionAt = undefined
+    capturedForkSession = undefined
+    denyUuids = []
     clearSessionCache()
   })
 
@@ -247,6 +259,9 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
         { type: "tool_result", tool_use_id: "tg1", content: "ok" },
       ]},
     ])
+    const resumeBoundary = denyUuids[1]
     expect(capturedResume ?? "(fresh)").toBe("test-session")
+    expect(capturedResumeSessionAt).toBe(resumeBoundary)
+    expect(capturedForkSession).toBe(true)
   })
 })

--- a/src/__tests__/proxy-stream-error-recovery.test.ts
+++ b/src/__tests__/proxy-stream-error-recovery.test.ts
@@ -1,10 +1,22 @@
 /**
  * Stream Error Recovery Tests
  *
- * When an error occurs mid-stream (after message_start has been emitted),
- * the proxy must emit message_delta + message_stop before the error event
- * so clients get a well-formed message lifecycle and don't crash accessing
- * usage.input_tokens on an incomplete response.
+ * When an error occurs mid-stream (after message_start has been emitted), the
+ * proxy must close the message lifecycle so clients don't crash accessing
+ * usage.input_tokens on an incomplete response (#168) — AND the error must
+ * reach them.
+ *
+ * Order changed deliberately: the error event now precedes message_stop. #168
+ * put it after, which satisfied the lifecycle but hid the failure — clients stop
+ * reading the body at message_stop, so the error was written into a stream
+ * nobody was consuming. A failed turn then looked exactly like a successful
+ * empty one, and an autonomous loop treated it as a completed turn. The
+ * lifecycle guarantee is unchanged; only the frame that carries the bad news
+ * moved ahead of the marker that ends the read.
+ *
+ * The failed turn also stops claiming stop_reason "end_turn" when it produced no
+ * text: a cut-off turn is truncated, and "max_tokens" is the wire's word for
+ * that.
  *
  * See: https://github.com/rynfar/meridian/issues/168
  */
@@ -84,7 +96,7 @@ describe("Stream error recovery after message_start", () => {
     clearSessionCache()
   })
 
-  it("should emit message_delta and message_stop before error when message_start was sent", async () => {
+  it("closes the message lifecycle and puts the error where the client will read it", async () => {
     mockMessages = [
       messageStart("msg_1"),
       textBlockStart(0),
@@ -109,10 +121,11 @@ describe("Stream error recovery after message_start", () => {
     expect(errorIdx).toBeGreaterThan(-1)
     expect(messageDeltaIdx).toBeLessThan(errorIdx)
 
-    // Should have message_stop before error
+    // message_stop comes AFTER the error: it is the marker at which clients
+    // stop reading, so anything queued behind it is never seen.
     const messageStopIdx = eventTypes.lastIndexOf("message_stop")
     expect(messageStopIdx).toBeGreaterThan(-1)
-    expect(messageStopIdx).toBeLessThan(errorIdx)
+    expect(messageStopIdx).toBeGreaterThan(errorIdx)
 
     // The recovery message_delta should have usage with output_tokens
     const recoveryDelta = events[messageDeltaIdx]
@@ -186,11 +199,16 @@ describe("Stream error recovery after message_start", () => {
     expect(eventTypes).toContain("message_stop")
     expect(eventTypes).toContain("error")
 
-    // message_delta and message_stop should come before error
+    // The lifecycle closes, but the error is reachable: delta, error, stop.
     const messageDeltaIdx = eventTypes.lastIndexOf("message_delta")
     const messageStopIdx = eventTypes.lastIndexOf("message_stop")
     const errorIdx = eventTypes.indexOf("error")
     expect(messageDeltaIdx).toBeLessThan(errorIdx)
-    expect(messageStopIdx).toBeLessThan(errorIdx)
+    expect(messageStopIdx).toBeGreaterThan(errorIdx)
+
+    // A turn that died before producing text must not claim it finished: that
+    // is the shape an autonomous loop reads as a completed, empty turn.
+    const delta = events[messageDeltaIdx]?.data as any
+    expect(delta.delta.stop_reason).toBe("max_tokens")
   })
 })

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -183,7 +183,7 @@ describe("buildQueryOptions", () => {
   it("sets fork options for undo", () => {
     const result = buildQueryOptions(makeContext({
       isUndo: true,
-      undoRollbackUuid: "uuid-abc",
+      resumeSessionAtUuid: "uuid-abc",
     }))
     expect((result.options as any).forkSession).toBe(true)
     expect((result.options as any).resumeSessionAt).toBe("uuid-abc")

--- a/src/__tests__/silent-turn-recovery.test.ts
+++ b/src/__tests__/silent-turn-recovery.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Silent-turn recovery through the HTTP layer, mocked SDK.
+ *
+ * The unit tests pin the decision; this pins the wiring, which is where the
+ * value is. A recovery that decides correctly and forwards nothing is worth
+ * exactly nothing to the autonomous run it exists for.
+ *
+ * The mock's first query answers the way all three production incidents did —
+ * thinking, then a text block with no delta in it — and its second query is the
+ * recovery turn.
+ */
+import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+
+let queryCalls: any[] = []
+let scripted: any[][] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    queryCalls.push(params)
+    const messages = scripted.shift() ?? []
+    return (async function* () {
+      for (const m of messages) yield m
+    })()
+  },
+  createSdkMcpServer: () => ({
+    type: "sdk", name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({
+    type: "sdk", name: "opencode",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+
+const ev = (event: any) => ({
+  type: "stream_event", event, parent_tool_use_id: null,
+  uuid: crypto.randomUUID(), session_id: "test-session",
+})
+const msgStart = () => ev({
+  type: "message_start",
+  message: {
+    id: "m1", type: "message", role: "assistant", content: [],
+    model: "claude-sonnet-4-5-20250929", stop_reason: null,
+    usage: { input_tokens: 10, output_tokens: 0 },
+  },
+})
+const thinkingBlock = () => [
+  ev({ type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } }),
+  ev({ type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "deliberating" } }),
+  ev({ type: "content_block_stop", index: 0 }),
+]
+/** A text block that never emits a delta — the exact production signature. */
+const emptyTextBlock = (index: number) => [
+  ev({ type: "content_block_start", index, content_block: { type: "text", text: "" } }),
+  ev({ type: "content_block_stop", index }),
+]
+const textBlock = (index: number, text: string) => [
+  ev({ type: "content_block_start", index, content_block: { type: "text", text: "" } }),
+  ev({ type: "content_block_delta", index, delta: { type: "text_delta", text } }),
+  ev({ type: "content_block_stop", index }),
+]
+const msgEnd = () => [
+  ev({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 40 } }),
+  ev({ type: "message_stop" }),
+]
+
+async function post(app: any, body: any, session = "silent-session") {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": session,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify(body),
+  }))
+}
+
+const read = async (response: Response) => await response.text()
+
+const REQUEST = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 400,
+  stream: true,
+  messages: [{ role: "user", content: "summarise the tool output" }],
+}
+
+describe("silent-turn recovery", () => {
+  let app: any
+  let savedSwitch: string | undefined
+
+  beforeAll(() => {
+    const { app: a } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    app = a
+  })
+
+  beforeEach(() => {
+    savedSwitch = process.env.MERIDIAN_SILENT_TURN_RECOVERY
+    delete process.env.MERIDIAN_SILENT_TURN_RECOVERY
+    queryCalls = []
+    scripted = []
+  })
+
+  afterEach(() => {
+    if (savedSwitch !== undefined) process.env.MERIDIAN_SILENT_TURN_RECOVERY = savedSwitch
+    else delete process.env.MERIDIAN_SILENT_TURN_RECOVERY
+  })
+
+  it("turns a thinking-only turn into a real answer the client receives", async () => {
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [msgStart(), ...textBlock(0, "Here is the summary."), ...msgEnd()],
+    ]
+
+    const body = await read(await post(app, REQUEST, "silent-recovered"))
+
+    expect(queryCalls.length).toBe(2)
+    expect(body).toContain("Here is the summary.")
+    // Recovery text must arrive as a normal text delta, or the client will not
+    // render it however correct the recovery was.
+    expect(body).toContain("text_delta")
+  })
+
+  it("asks the model in a way that discharges the instruction that silenced it", async () => {
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [msgStart(), ...textBlock(0, "recovered"), ...msgEnd()],
+    ]
+
+    await read(await post(app, REQUEST, "silent-prompt"))
+
+    const nudge = queryCalls[1].prompt as string
+    expect(nudge.toLowerCase()).toContain("no visible output")
+    expect(nudge.toLowerCase()).toContain("discharged")
+  })
+
+  it("forks instead of extending — an empty tail must not become the session", async () => {
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [msgStart(), ...textBlock(0, "recovered"), ...msgEnd()],
+    ]
+
+    await read(await post(app, REQUEST, "silent-fork"))
+
+    expect(queryCalls[1].options.forkSession).toBe(true)
+    expect(queryCalls[1].options.resume).toBeTruthy()
+  })
+
+  it("leaves a productive turn alone — no second query, no extra spend", async () => {
+    scripted = [[msgStart(), ...textBlock(0, "a normal answer"), ...msgEnd()]]
+
+    const body = await read(await post(app, REQUEST, "silent-productive"))
+
+    expect(queryCalls.length).toBe(1)
+    expect(body).toContain("a normal answer")
+  })
+
+  it("gives up after one attempt rather than looping", async () => {
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [msgStart(), ...emptyTextBlock(0), ...msgEnd()],
+    ]
+
+    await read(await post(app, REQUEST, "silent-once"))
+
+    expect(queryCalls.length).toBe(2)
+  })
+
+  it("still answers the client when the recovery turn itself throws", async () => {
+    scripted = [[msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()]]
+    // No second script entry: the mock yields nothing, standing in for a
+    // recovery that produced no content. The client must still get its
+    // envelope rather than a 500.
+    const response = await post(app, REQUEST, "silent-throws")
+    const body = await read(response)
+
+    expect(response.status).toBe(200)
+    expect(body).toContain("message_stop")
+  })
+
+  it("kill switch keeps detection but skips the extra turn", async () => {
+    process.env.MERIDIAN_SILENT_TURN_RECOVERY = "0"
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [msgStart(), ...textBlock(0, "must not be requested"), ...msgEnd()],
+    ]
+
+    const body = await read(await post(app, REQUEST, "silent-killswitch"))
+
+    expect(queryCalls.length).toBe(1)
+    expect(body).not.toContain("must not be requested")
+  })
+})

--- a/src/__tests__/turn-outcome.test.ts
+++ b/src/__tests__/turn-outcome.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from "bun:test"
 import {
+  ANNOUNCE_TURN_NUDGE,
   classifyTurnOutcome,
   shouldAttemptRecovery,
   SILENT_TURN_NUDGE,
@@ -43,6 +44,52 @@ describe("classifyTurnOutcome", () => {
   // reason the input is textEvents and not textBlocks.
   it("does not accept an empty text block as text", () => {
     expect(classifyTurnOutcome({ textEvents: 0, toolUses: 0, blocksForwarded: 2 }).kind)
+      .toBe("silent")
+  })
+})
+
+describe("classifyTurnOutcome: the announce window", () => {
+  // The live case that slipped past the silent invariant (request a342c863,
+  // 2026-08-11 10:54 UTC): a deny-boundary continuation on a session's second
+  // exchange — thinking, then one short text that only announced the work
+  // ("I'll start by auditing…", 131 chars), zero tool calls, end_turn. Text
+  // arrived, so silence detection stays quiet; only the length test inside
+  // the narrow window can see it.
+  const announceTurn = {
+    textEvents: 2,
+    toolUses: 0,
+    blocksForwarded: 4,
+    textChars: 131,
+    denyBoundaryContinuation: true,
+    clientMessageCount: 3,
+  }
+
+  it("classifies the observed announce-then-stop turn as announce", () => {
+    expect(classifyTurnOutcome(announceTurn)).toEqual({ kind: "announce" })
+  })
+
+  it("a tool call makes the same turn productive — the client has work to do", () => {
+    expect(classifyTurnOutcome({ ...announceTurn, toolUses: 1 }))
+      .toEqual({ kind: "productive" })
+  })
+
+  it("a long text inside the window is an answer, not an announce", () => {
+    expect(classifyTurnOutcome({ ...announceTurn, textChars: 601 }))
+      .toEqual({ kind: "productive" })
+  })
+
+  it("outside the deny boundary a short text is an answer", () => {
+    expect(classifyTurnOutcome({ ...announceTurn, denyBoundaryContinuation: false }))
+      .toEqual({ kind: "productive" })
+  })
+
+  it("a longer conversation never gets the announce classification", () => {
+    expect(classifyTurnOutcome({ ...announceTurn, clientMessageCount: 5 }))
+      .toEqual({ kind: "productive" })
+  })
+
+  it("no text at all is still silent, boundary or not", () => {
+    expect(classifyTurnOutcome({ ...announceTurn, textEvents: 0, textChars: 0 }).kind)
       .toBe("silent")
   })
 })

--- a/src/__tests__/turn-outcome.test.ts
+++ b/src/__tests__/turn-outcome.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The silent-turn invariant: a terminal envelope must carry text or a tool call.
+ *
+ * These tests pin the three production shapes that motivated the module, using
+ * the numbers actually recorded in telemetry for each. If a future change makes
+ * any of them classify as productive, the guard stops guarding and the class of
+ * defect goes invisible again.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  classifyTurnOutcome,
+  shouldAttemptRecovery,
+  SILENT_TURN_NUDGE,
+  type TurnOutcome,
+} from "../proxy/turnOutcome"
+
+describe("classifyTurnOutcome", () => {
+  it("counts prose as productive", () => {
+    expect(classifyTurnOutcome({ textEvents: 12, toolUses: 0, blocksForwarded: 3 }))
+      .toEqual({ kind: "productive" })
+  })
+
+  it("counts a tool call with no prose as productive — the client has work to do", () => {
+    expect(classifyTurnOutcome({ textEvents: 0, toolUses: 2, blocksForwarded: 5 }))
+      .toEqual({ kind: "productive" })
+  })
+
+  // The spent-deny signature: 61 blocks, 667 output tokens, zero text events
+  // (request abf94a0a, 2026-08-10 13:04 UTC). All of it thinking plus an empty
+  // text block. This is the case that must never read as healthy.
+  it("calls thinking with an empty text block silent, however many blocks it spent", () => {
+    expect(classifyTurnOutcome({ textEvents: 0, toolUses: 0, blocksForwarded: 61 }))
+      .toEqual({ kind: "silent", reason: "no_actionable_content" })
+  })
+
+  it("distinguishes a turn that forwarded nothing at all", () => {
+    expect(classifyTurnOutcome({ textEvents: 0, toolUses: 0, blocksForwarded: 0 }))
+      .toEqual({ kind: "silent", reason: "no_blocks" })
+  })
+
+  // An empty text BLOCK yields a start and a stop with no delta between them,
+  // so block counting cannot see it — only delta counting can. Guards the
+  // reason the input is textEvents and not textBlocks.
+  it("does not accept an empty text block as text", () => {
+    expect(classifyTurnOutcome({ textEvents: 0, toolUses: 0, blocksForwarded: 2 }).kind)
+      .toBe("silent")
+  })
+})
+
+describe("shouldAttemptRecovery", () => {
+  const silent: TurnOutcome = { kind: "silent", reason: "no_actionable_content" }
+  const base = {
+    outcome: silent,
+    alreadyAttempted: false,
+    clientGone: false,
+    sessionId: "sdk-session-1",
+    enabled: true,
+  }
+
+  it("recovers a silent turn once", () => {
+    expect(shouldAttemptRecovery(base)).toBe(true)
+  })
+
+  it("never recovers a productive turn", () => {
+    expect(shouldAttemptRecovery({ ...base, outcome: { kind: "productive" } })).toBe(false)
+  })
+
+  // One attempt, not a loop. A model that answers empty twice is not going to
+  // be argued into answering, and each attempt is a billed turn.
+  it("does not retry a second time", () => {
+    expect(shouldAttemptRecovery({ ...base, alreadyAttempted: true })).toBe(false)
+  })
+
+  it("does not spend a turn writing into a closed socket", () => {
+    expect(shouldAttemptRecovery({ ...base, clientGone: true })).toBe(false)
+  })
+
+  it("needs a session to continue from", () => {
+    expect(shouldAttemptRecovery({ ...base, sessionId: undefined })).toBe(false)
+  })
+
+  it("honours the kill switch", () => {
+    expect(shouldAttemptRecovery({ ...base, enabled: false })).toBe(false)
+  })
+})
+
+describe("SILENT_TURN_NUDGE", () => {
+  // The CLI's own nudge failed on all three observed cases because it left the
+  // offending instruction standing. This one has to discharge it, or it is the
+  // same failed move under a new name.
+  it("discharges the end-turn instruction rather than just asking again", () => {
+    expect(SILENT_TURN_NUDGE.toLowerCase()).toContain("discharged")
+    expect(SILENT_TURN_NUDGE.toLowerCase()).toContain("applied only to")
+  })
+
+  it("allows a tool call as a valid answer, not only prose", () => {
+    expect(SILENT_TURN_NUDGE.toLowerCase()).toContain("tool call")
+  })
+
+  it("adds no transcript markers for the model to imitate (#496)", () => {
+    expect(SILENT_TURN_NUDGE).not.toContain("Human:")
+    expect(SILENT_TURN_NUDGE).not.toContain("[Assistant:")
+  })
+})

--- a/src/__tests__/turn-outcome.test.ts
+++ b/src/__tests__/turn-outcome.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from "bun:test"
 import {
   ANNOUNCE_TURN_NUDGE,
   classifyTurnOutcome,
+  createRecoveryLifter,
   shouldAttemptRecovery,
   SILENT_TURN_NUDGE,
   type TurnOutcome,
@@ -147,5 +148,61 @@ describe("SILENT_TURN_NUDGE", () => {
   it("adds no transcript markers for the model to imitate (#496)", () => {
     expect(SILENT_TURN_NUDGE).not.toContain("Human:")
     expect(SILENT_TURN_NUDGE).not.toContain("[Assistant:")
+  })
+})
+
+describe("createRecoveryLifter", () => {
+  const textStart = { type: "content_block_start", content_block: { type: "text" } }
+  const delta = (text: string) => ({ type: "content_block_delta", delta: { type: "text_delta", text } })
+  const stop = { type: "content_block_stop" }
+
+  const lifterAt = (first: number) => {
+    let next = first
+    return createRecoveryLifter(() => next++)
+  }
+
+  it("allocates the block index from the caller's space, so the recovery block continues the open message's numbering", () => {
+    expect(lifterAt(7).lift(textStart)).toEqual({
+      kind: "block_start",
+      frame: { type: "content_block_start", index: 7, content_block: { type: "text", text: "" } },
+    })
+  })
+
+  it("rewrites deltas onto the allocated index and reports their length", () => {
+    const lifter = lifterAt(7)
+    lifter.lift(textStart)
+    expect(lifter.lift(delta("done"))).toEqual({
+      kind: "text_delta",
+      frame: { type: "content_block_delta", index: 7, delta: { type: "text_delta", text: "done" } },
+      textChars: 4,
+    })
+  })
+
+  it("drops a delta arriving before any text block opened — emitting it would be malformed SSE", () => {
+    expect(lifterAt(0).lift(delta("orphan"))).toBeUndefined()
+  })
+
+  it("releases the index on stop and drops trailing deltas and stops", () => {
+    const lifter = lifterAt(3)
+    lifter.lift(textStart)
+    expect(lifter.lift(stop)).toEqual({ kind: "block_stop", frame: { type: "content_block_stop", index: 3 } })
+    expect(lifter.lift(delta("late"))).toBeUndefined()
+    expect(lifter.lift(stop)).toBeUndefined()
+  })
+
+  it("ignores non-text blocks entirely — a tool call is not lifted", () => {
+    const lifter = lifterAt(0)
+    expect(lifter.lift({ type: "content_block_start", content_block: { type: "tool_use" } })).toBeUndefined()
+    expect(lifter.lift(delta("x"))).toBeUndefined()
+  })
+
+  it("gives a second text block a fresh index", () => {
+    const lifter = lifterAt(5)
+    lifter.lift(textStart)
+    lifter.lift(stop)
+    expect(lifter.lift(textStart)).toEqual({
+      kind: "block_start",
+      frame: { type: "content_block_start", index: 6, content_block: { type: "text", text: "" } },
+    })
   })
 })

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -180,6 +180,42 @@ export function frameReplayTurns(turns: Array<{ role: string; text: string }>): 
 }
 
 /**
+ * Lead-in for a passthrough continuation that forks from a deny boundary.
+ *
+ * Every forwarded tool call is denied with "do not generate further text —
+ * end your turn now" (the nudge that stops the model fabricating results for
+ * calls the client will execute). That deny is persisted as the tool_result,
+ * and the deny boundary fork puts it IMMEDIATELY before the continuation's
+ * user turn. So the last instruction in the model's context tells it to emit
+ * no text — and the next thing it must do is answer. Observed live: the model
+ * obeys the nearer instruction and returns thinking plus an EMPTY text block
+ * with stop_reason "end_turn"; the CLI's own "previous response had no visible
+ * output" nudge does not help, because the deny is still there. The proxy
+ * forwards zero text deltas, reports 200, and the client's run goes quiet with
+ * the tool results unanswered (three occurrences in 500 requests, all on a
+ * session's second turn — where the deny is the largest thing in context).
+ *
+ * The deny cannot be rewritten after the fact: it lives in the CLI's session
+ * file. So the continuation says plainly that the instruction is spent. Framing
+ * only — no transcript markers, nothing for the model to imitate (#496/#619).
+ */
+export const PASSTHROUGH_CONTINUATION_LEAD_IN =
+  "The tool calls from your previous turn were forwarded to the client, which has now executed them — " +
+  "their results follow. The instruction to end that turn without further text applied to it alone and " +
+  "is now discharged: continue the work and respond."
+
+/**
+ * Prefix a passthrough continuation delta with the lead-in above.
+ *
+ * An empty delta is returned unchanged — there is nothing to answer, so the
+ * lead-in would be the only content and would read as the user's own turn.
+ */
+export function framePassthroughContinuation(delta: string): string {
+  if (!delta) return delta
+  return `${PASSTHROUGH_CONTINUATION_LEAD_IN}\n\n${delta}`
+}
+
+/**
  * Remove fields the Claude Agent SDK attaches to streamed events that are not
  * part of the public Anthropic streaming schema.
  *

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -105,3 +105,21 @@ export function shouldEarlyStop(tracker: EarlyStopTracker): boolean {
   tracker.fired = true
   return true
 }
+
+/**
+ * Resume boundary of an early-stopped session: the uuid of a persisted `user`
+ * message carrying tool_results. The last one before the abort is the final
+ * deny — continuations fork there instead of resuming the interrupted tail.
+ */
+export function resumeBoundaryUuid(message: unknown): string | undefined {
+  const m = message as { type?: unknown; uuid?: unknown; message?: { content?: unknown } } | null | undefined
+  if (m?.type !== "user") return undefined
+  if (typeof m.uuid !== "string" || m.uuid.length === 0) return undefined
+  const content = m.message?.content
+  if (!Array.isArray(content)) return undefined
+  const hasResult = content.some((block) => {
+    const b = block as { type?: unknown } | null | undefined
+    return b?.type === "tool_result"
+  })
+  return hasResult ? m.uuid : undefined
+}

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -106,6 +106,51 @@ export function shouldEarlyStop(tracker: EarlyStopTracker): boolean {
   return true
 }
 
+/** What a client-aborted stream must do with its session mapping. */
+export type ClientAbortDisposition =
+  | { action: "store"; resumeUuid: string }
+  | { action: "evict" }
+  | { action: "none" }
+
+/**
+ * Decide the fate of a session whose stream the CLIENT aborted (the user hit
+ * stop, or the connection dropped).
+ *
+ * A client abort leaves the SDK session ending in an interrupted tail — the
+ * same state the deny-boundary fix addresses for early stop. Resuming from
+ * that tail makes the SDK synthesize a "Continue from where you left off."
+ * turn, which the model answers with meta text ("No response requested.") or
+ * an empty turn. Each empty turn then becomes the next tail, so the session
+ * never recovers on its own: every following turn comes back empty until the
+ * lineage is discarded.
+ *
+ * An early stop is meridian's own doing and always has a persisted deny to
+ * fork from; a user interrupt is not an early stop and may have none. So:
+ *
+ * - a boundary was persisted → store it, and the next continuation forks
+ *   there (lineage and prompt cache survive);
+ * - no boundary → nothing is safe to resume from, so drop the mapping and let
+ *   the next request replay into a fresh SDK session. A cache-miss replay is
+ *   the cost of not wedging the conversation.
+ *
+ * `sawDuplicateToolUse` keeps the #552 rule: such a history holds a dangling
+ * dropped call that diverges from the client's view and is never resumable.
+ */
+export function clientAbortDisposition(input: {
+  isIndependentSession: boolean
+  profileSessionId?: string
+  currentSessionId?: string
+  sawDuplicateToolUse: boolean
+  resumeBoundaryUuid?: string
+}): ClientAbortDisposition {
+  // Fork/subagent requests never write the cache, so they have nothing to undo.
+  if (input.isIndependentSession || !input.profileSessionId) return { action: "none" }
+  if (input.currentSessionId && !input.sawDuplicateToolUse && input.resumeBoundaryUuid) {
+    return { action: "store", resumeUuid: input.resumeBoundaryUuid }
+  }
+  return { action: "evict" }
+}
+
 /**
  * Resume boundary of an early-stopped session: the uuid of a persisted `user`
  * message carrying tool_results. The last one before the abort is the final

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -91,8 +91,9 @@ export interface QueryContext {
   resumeSessionId?: string
   /** Whether this is an undo operation */
   isUndo: boolean
-  /** UUID to rollback to for undo operations */
-  undoRollbackUuid?: string
+  /** Fork the resumed session at this SDK message UUID (undo rollback point
+   *  or passthrough deny boundary). Maps to the SDK's resumeSessionAt. */
+  resumeSessionAtUuid?: string
   /** Fork the resumed session instead of attaching to it (#630 busy-session
    *  fallback — the original stays registered as a bg agent; the fork gets a
    *  fresh id with the full history). */
@@ -298,7 +299,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
   const {
     prompt, model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv, hasDeferredTools,
-    resumeSessionId, isUndo, undoRollbackUuid, forkSession, sdkHooks, blockedTools, incompatibleTools,
+    resumeSessionId, isUndo, resumeSessionAtUuid, forkSession, sdkHooks, blockedTools, incompatibleTools,
     mcpServerName, allowedMcpTools, onStderr,
     effort, thinking, taskBudget, outputFormat, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
     memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
@@ -428,7 +429,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
       ...(isUndo || forkSession ? { forkSession: true } : {}),
-      ...(isUndo && undoRollbackUuid ? { resumeSessionAt: undoRollbackUuid } : {}),
+      ...(resumeSessionAtUuid ? { resumeSessionAt: resumeSessionAtUuid } : {}),
       ...(sdkHooks ? { hooks: sdkHooks } : {}),
       ...(effort ? { effort } : {}),
       ...(thinking ? { thinking } : {}),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -67,7 +67,7 @@ import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
 import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
-import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
+import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns, framePassthroughContinuation, PASSTHROUGH_CONTINUATION_LEAD_IN } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -1288,6 +1288,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (structuredMessages.length > 1) {
           structuredMessages = consolidateMultimodalOntoLastUser(structuredMessages)
         }
+
+        // Same spent-deny problem as the text path — see
+        // framePassthroughContinuation. Carried as its own leading user turn so
+        // the multimodal blocks of the real delta are left untouched.
+        if (passthroughResumeUuid && structuredMessages.length > 0) {
+          structuredMessages.unshift({
+            type: "user" as const,
+            message: { role: "user" as const, content: PASSTHROUGH_CONTINUATION_LEAD_IN },
+            parent_tool_use_id: null,
+          })
+        }
       } else {
         // Text prompt — convert messages to string.
         // Sanitize each text block before flattening to strip orchestration
@@ -1317,9 +1328,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           })
         // Fresh (non-resume) replays get the #619 anti-self-play envelope:
         // history framed as context-only, the live user message terminal.
-        // Resume deltas are tail-only and stay bare.
+        // Resume deltas are tail-only and stay bare — except when the resume
+        // forks from a deny boundary, where the spent "end your turn now" deny
+        // is the nearest instruction in context and silences the answer (see
+        // framePassthroughContinuation).
+        const resumeDelta = promptTurns.map((t: { text: string }) => t.text).filter(Boolean).join("\n\n") || ""
         textPrompt = isResume
-          ? promptTurns.map((t: { text: string }) => t.text).filter(Boolean).join("\n\n") || ""
+          ? (passthroughResumeUuid ? framePassthroughContinuation(resumeDelta) : resumeDelta)
           : frameReplayTurns(promptTurns)
       }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, compute
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
-import { classifyTurnOutcome, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
+import { ANNOUNCE_TURN_NUDGE, classifyTurnOutcome, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -2363,6 +2363,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             let streamEventsSeen = 0
             let eventsForwarded = 0
             let textEventsForwarded = 0
+            // Characters of forwarded text — the announce classification is a
+            // length test (see turnOutcome.ts).
+            let textCharsForwarded = 0
             let bytesSent = 0
             let streamClosed = false
             // Early-stop drain: after the client stream closes at turn-1's
@@ -3113,6 +3116,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       const delta = (event as any).delta
                       if (delta?.type === "text_delta") {
                         textEventsForwarded += 1
+                        if (typeof delta.text === "string") textCharsForwarded += delta.text.length
                       }
                     }
                   }
@@ -3172,6 +3176,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 messageStartEmitted = true
                 eventsForwarded += 5
                 textEventsForwarded += 1
+                textCharsForwarded += text.length
               }
 
               if (passthrough) {
@@ -3228,6 +3233,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 textEvents: textEventsForwarded,
                 toolUses: streamedToolUseIds.size,
                 blocksForwarded: eventsForwarded,
+                textChars: textCharsForwarded,
+                denyBoundaryContinuation: Boolean(passthroughResumeUuid),
+                clientMessageCount: allMessages.length,
               })
               //
               // `messageStartEmitted` is a hard precondition, not a heuristic:
@@ -3248,14 +3256,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 })
               ) {
                 silentTurnRecoveryAttempted = true
+                const capturedBeforeRecovery = capturedToolUses.length
                 claudeLog("response.silent_turn_recovery", {
                   mode: "stream",
+                  kind: preRecoveryOutcome.kind,
                   reason: preRecoveryOutcome.kind === "silent" ? preRecoveryOutcome.reason : undefined,
                   sdkSessionId: currentSessionId || resumeSessionId,
                 })
                 try {
                   for await (const event of query(buildQueryOptions({
-                    prompt: SILENT_TURN_NUDGE,
+                    // The announce stall needs its own words: "no visible
+                    // output" would be false — the client saw the announcement.
+                    prompt: preRecoveryOutcome.kind === "announce" ? ANNOUNCE_TURN_NUDGE : SILENT_TURN_NUDGE,
                     model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     // The nudge asks for prose, but a tool call is an equally
                     // valid answer — so the tool surface has to stay identical.
@@ -3318,6 +3330,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         })}\n\n`
                       ), "silent_recovery_text_delta")
                       textEventsForwarded += 1
+                      if (typeof inner.delta.text === "string") textCharsForwarded += inner.delta.text.length
                       silentTurnRecovered = true
                     } else if (innerType === "content_block_stop" && recoveryBlockIndex !== undefined) {
                       safeEnqueue(encoder.encode(
@@ -3337,6 +3350,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     mode: "stream",
                     error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
                   })
+                }
+                // Tool calls made in the recovery turn are captured by the
+                // shared PreToolUse hook and delivered through the unseen-
+                // capture emission below — an equally valid recovery, and for
+                // an announce stall the expected one.
+                if (capturedToolUses.length > capturedBeforeRecovery) {
+                  silentTurnRecovered = true
                 }
                 claudeLog("response.silent_turn_recovery_result", {
                   mode: "stream",
@@ -3518,7 +3538,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   textEvents: textEventsForwarded,
                   toolUses: streamedToolUseIds.size,
                   blocksForwarded: eventsForwarded,
+                  textChars: textCharsForwarded,
+                  denyBoundaryContinuation: Boolean(passthroughResumeUuid),
+                  clientMessageCount: allMessages.length,
                 })
+                if (turnOutcome.kind === "announce") {
+                  claudeLog("response.announce_turn", {
+                    model,
+                    textChars: textCharsForwarded,
+                    outputTokens: lastUsage?.output_tokens,
+                    recovered: silentTurnRecovered,
+                    recoveryAttempted: silentTurnRecoveryAttempted,
+                  })
+                  diagnosticLog.session(
+                    `${requestMeta.requestId} announce_turn chars=${textCharsForwarded} ` +
+                    `recovery=${silentTurnRecoveryAttempted ? (silentTurnRecovered ? "succeeded" : "failed") : "off"}`,
+                    requestMeta.requestId,
+                  )
+                }
                 if (turnOutcome.kind === "silent") {
                   claudeLog("response.silent_turn", {
                     model,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -42,7 +42,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { clientAbortDisposition, createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
@@ -2481,8 +2481,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               openClientBlocks.clear()
             }
 
+            // Hoisted out of the try so the client-abort branch of the catch
+            // below can settle this session (see clientAbortDisposition).
+            let currentSessionId: string | undefined
             try {
-              let currentSessionId: string | undefined
               // Same transparent retry wrapper as the non-streaming path.
               // Rate-limit retry strategy:
               //   1. Strip [1m] context (immediate, different model tier)
@@ -3354,6 +3356,33 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   textEventsForwarded,
                   durationMs: Date.now() - requestStartAt
                 })
+                // This was the only terminal path that returned without
+                // settling the session: the mapping stayed pointed at the
+                // interrupted tail (every following turn then came back empty)
+                // and follow-ups waited on a promise nobody resolved. Both
+                // obligations are met before returning.
+                const disposition = clientAbortDisposition({
+                  isIndependentSession,
+                  profileSessionId,
+                  currentSessionId,
+                  sawDuplicateToolUse,
+                  resumeBoundaryUuid: nextPassthroughResumeUuid,
+                })
+                if (disposition.action === "store" && currentSessionId) {
+                  storeSession(
+                    profileSessionId,
+                    body.messages || [],
+                    currentSessionId,
+                    profileScopedCwd,
+                    sdkUuidMap,
+                    lastUsage,
+                    disposition.resumeUuid
+                  )
+                } else if (disposition.action === "evict") {
+                  evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                }
+                claudeLog("passthrough.client_abort_settled", { action: disposition.action })
+                resolvePendingStore()
                 return
               }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,6 +44,7 @@ import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, compute
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
+import { classifyTurnOutcome, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -2409,6 +2410,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             let hasStructuredOutput = false
             let structuredOutput: unknown
             let nextPassthroughResumeUuid: string | undefined
+            // Silent-turn recovery state (see turnOutcome.ts). Kill switch:
+            // MERIDIAN_SILENT_TURN_RECOVERY=0 leaves the detection and the
+            // telemetry in place and skips only the extra model turn — so an
+            // operator who does not want the spend still keeps the visibility.
+            const silentTurnRecoveryEnabled = process.env.MERIDIAN_SILENT_TURN_RECOVERY !== "0"
+            let silentTurnRecoveryAttempted = false
+            let silentTurnRecovered = false
+            let recoveryBlockIndex: number | undefined
             // Hoisted out of the inner streaming loop so the outer catch can
             // dedupe captured tool_uses against what was already forwarded
             // when recovering gracefully from max_turns (see catch below).
@@ -3025,6 +3034,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       }
                     }
 
+                    // Debug fault injection: swallow this turn's text so the
+                    // silent-turn guard can be exercised on demand instead of
+                    // waiting for a ~3-in-500 live occurrence (see
+                    // shouldInjectSilentTurn). Drops only text deltas — the
+                    // block start and stop still go out, which is precisely the
+                    // production shape: an empty text block.
+                    if (
+                      eventType === "content_block_delta" &&
+                      (event as any).delta?.type === "text_delta" &&
+                      shouldInjectSilentTurn({
+                        raw: process.env.MERIDIAN_DEBUG_FORCE_SILENT_TURN,
+                        sessionId: agentSessionId,
+                      })
+                    ) {
+                      claudeLog("debug.silent_turn_injected", { sessionId: agentSessionId })
+                      continue
+                    }
+
                     // Forward all other events (text, non-MCP tool_use like Task, message events).
                     // Strip SDK-only fields (context_management on message_delta) that stock
                     // Anthropic clients crash on — the real API never returns them (#525).
@@ -3189,6 +3216,135 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }
               resolvePendingStore()
 
+              // Last chance to save a silent turn. The three known causes are
+              // fixed; this catches the class — including causes not yet found —
+              // one turn before the client is told the request succeeded.
+              //
+              // Runs only where recovery is still possible: the stream is open,
+              // so the recovered answer can actually be forwarded. A turn that
+              // already closed (early stop, turn-2 suppression) carries tool
+              // calls by construction and is never silent.
+              const preRecoveryOutcome = classifyTurnOutcome({
+                textEvents: textEventsForwarded,
+                toolUses: streamedToolUseIds.size,
+                blocksForwarded: eventsForwarded,
+              })
+              //
+              // `messageStartEmitted` is a hard precondition, not a heuristic:
+              // recovery works by appending a text block to the message already
+              // open on the wire. With no message_start there is nothing to
+              // append to, and emitting blocks would be malformed SSE. That case
+              // — the SDK yielding nothing client-visible at all — is already
+              // covered by the retry wrapper's didYieldClientEvent check.
+              if (
+                !streamClosed &&
+                messageStartEmitted &&
+                shouldAttemptRecovery({
+                  outcome: preRecoveryOutcome,
+                  alreadyAttempted: silentTurnRecoveryAttempted,
+                  clientGone: streamClosed,
+                  sessionId: currentSessionId || resumeSessionId,
+                  enabled: silentTurnRecoveryEnabled,
+                })
+              ) {
+                silentTurnRecoveryAttempted = true
+                claudeLog("response.silent_turn_recovery", {
+                  mode: "stream",
+                  reason: preRecoveryOutcome.kind === "silent" ? preRecoveryOutcome.reason : undefined,
+                  sdkSessionId: currentSessionId || resumeSessionId,
+                })
+                try {
+                  for await (const event of query(buildQueryOptions({
+                    prompt: SILENT_TURN_NUDGE,
+                    model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
+                    // The nudge asks for prose, but a tool call is an equally
+                    // valid answer — so the tool surface has to stay identical.
+                    passthrough, stream: true, sdkAgents, passthroughMcp,
+                    cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                    resumeSessionId: currentSessionId || resumeSessionId,
+                    isUndo: false,
+                    // Fork rather than extend: the silent turn is now this
+                    // session's tail, and appending to it is what compounds an
+                    // empty turn into an empty session (#768 client-abort).
+                    resumeSessionAtUuid: nextPassthroughResumeUuid,
+                    forkSession: true,
+                    sdkHooks, blockedTools: pipelineCtx.blockedTools,
+                    incompatibleTools: pipelineCtx.incompatibleTools,
+                    mcpServerName: adapter.getMcpServerName(),
+                    allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    effort, thinking, taskBudget, outputFormat, betas, settingSources,
+                    codeSystemPrompt: sdkFeatures.codeSystemPrompt,
+                    clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
+                    memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming,
+                    sharedMemory: sdkFeatures.sharedMemory,
+                    webFetchPreflight: sdkFeatures.webFetchPreflight,
+                    claudeAiConnectors: sdkFeatures.claudeAiConnectors,
+                    maxBudgetUsd: sdkFeatures.maxBudgetUsd,
+                    fallbackModel: sdkFeatures.fallbackModel,
+                    sdkDebug: sdkFeatures.sdkDebug,
+                    additionalDirectories: sdkFeatures.additionalDirectories
+                      ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
+                      : undefined,
+                    advisorModel,
+                  }, requestAbort.controller))) {
+                    if ((event as any).type !== "stream_event") continue
+                    const inner = (event as any).event
+                    const innerType = inner?.type
+                    // Only text is lifted into the already-open message. A tool
+                    // call arriving here would need its own block index space and
+                    // the client's turn boundary to match — out of scope for a
+                    // recovery, and it still counts as a productive turn below.
+                    if (innerType === "content_block_start" && inner.content_block?.type === "text") {
+                      const idx = nextClientBlockIndex++
+                      recoveryBlockIndex = idx
+                      safeEnqueue(encoder.encode(
+                        `event: content_block_start\ndata: ${JSON.stringify({
+                          type: "content_block_start",
+                          index: idx,
+                          content_block: { type: "text", text: "" },
+                        })}\n\n`
+                      ), "silent_recovery_block_start")
+                      eventsForwarded += 1
+                    } else if (
+                      innerType === "content_block_delta" &&
+                      inner.delta?.type === "text_delta" &&
+                      recoveryBlockIndex !== undefined
+                    ) {
+                      safeEnqueue(encoder.encode(
+                        `event: content_block_delta\ndata: ${JSON.stringify({
+                          type: "content_block_delta",
+                          index: recoveryBlockIndex,
+                          delta: { type: "text_delta", text: inner.delta.text },
+                        })}\n\n`
+                      ), "silent_recovery_text_delta")
+                      textEventsForwarded += 1
+                      silentTurnRecovered = true
+                    } else if (innerType === "content_block_stop" && recoveryBlockIndex !== undefined) {
+                      safeEnqueue(encoder.encode(
+                        `event: content_block_stop\ndata: ${JSON.stringify({
+                          type: "content_block_stop",
+                          index: recoveryBlockIndex,
+                        })}\n\n`
+                      ), "silent_recovery_block_stop")
+                      recoveryBlockIndex = undefined
+                    }
+                  }
+                } catch (recoveryError) {
+                  // A failed recovery must never turn a delivered turn into a
+                  // failed request: the client still gets the original envelope,
+                  // and the attempt is recorded for the operator.
+                  claudeLog("response.silent_turn_recovery_failed", {
+                    mode: "stream",
+                    error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+                  })
+                }
+                claudeLog("response.silent_turn_recovery_result", {
+                  mode: "stream",
+                  recovered: silentTurnRecovered,
+                  textEvents: textEventsForwarded,
+                })
+              }
+
               if (!streamClosed) {
                 // In passthrough mode, emit captured tool_use blocks as stream events
                 // Skip any that were already forwarded during the stream (dedup by ID)
@@ -3352,13 +3508,36 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   ...(envelopeViolations.length > 0 ? { envelopeViolations: [...envelopeViolations] } : {}),
                 })
 
-                if (textEventsForwarded === 0) {
-                  claudeLog("response.empty_stream", {
+                // The silent-turn invariant (see turnOutcome.ts): a terminal
+                // envelope must carry text or a tool call. The old check only
+                // logged missing text, which said nothing about whether the
+                // client got anything actionable — a tool-only turn tripped it
+                // while being perfectly healthy, and a thinking-only turn
+                // looked identical to one.
+                const turnOutcome = classifyTurnOutcome({
+                  textEvents: textEventsForwarded,
+                  toolUses: streamedToolUseIds.size,
+                  blocksForwarded: eventsForwarded,
+                })
+                if (turnOutcome.kind === "silent") {
+                  claudeLog("response.silent_turn", {
                     model,
+                    reason: turnOutcome.reason,
                     streamEventsSeen,
                     eventsForwarded,
-                    reason: "no_text_deltas_forwarded"
+                    outputTokens: lastUsage?.output_tokens,
+                    recovered: silentTurnRecovered,
+                    recoveryAttempted: silentTurnRecoveryAttempted,
                   })
+                  // Named at session level too: an autonomous run has nobody to
+                  // notice a quiet telemetry row, and this is the one event that
+                  // means "the loop just lost a turn".
+                  diagnosticLog.session(
+                    `${requestMeta.requestId} silent_turn reason=${turnOutcome.reason} ` +
+                    `blocks=${eventsForwarded} out=${lastUsage?.output_tokens ?? 0} ` +
+                    `recovery=${silentTurnRecoveryAttempted ? (silentTurnRecovered ? "succeeded" : "failed") : "off"}`,
+                    requestMeta.requestId,
+                  )
                 }
               }
             } catch (error) {
@@ -3596,23 +3775,59 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               // If we already emitted message_start, close the message cleanly so
               // clients that access usage.input_tokens don't crash on the incomplete response.
+              //
+              // The stop_reason here is load-bearing. This path runs when the
+              // turn FAILED, and it used to send "end_turn" — the wire's word
+              // for "the model finished and had nothing more to say". A client
+              // cannot distinguish that from success, so it does not retry, and
+              // an autonomous loop treats a crashed turn as a completed one.
+              // The error event that follows arrives AFTER message_stop, which
+              // most clients have already stopped reading.
+              //
+              // A turn cut off mid-generation is exactly what "max_tokens"
+              // describes on the wire — truncated, not finished — and every
+              // Anthropic-compatible client already handles it. Reserve
+              // "end_turn" for the case where the model really did produce a
+              // complete answer before the failure.
               if (messageStartEmitted) {
+                const errorStopReason = textEventsForwarded > 0 ? "end_turn" : "max_tokens"
+                claudeLog("response.error_envelope", {
+                  mode: "stream",
+                  stopReason: errorStopReason,
+                  textEvents: textEventsForwarded,
+                  classified: streamErr.type,
+                })
                 safeEnqueue(encoder.encode(
                   `event: message_delta\ndata: ${JSON.stringify({
                     type: "message_delta",
-                    delta: { stop_reason: "end_turn", stop_sequence: null },
+                    delta: { stop_reason: errorStopReason, stop_sequence: null },
                     usage: { output_tokens: 0 }
                   })}\n\n`
                 ), "error_message_delta")
+                // The error goes out BEFORE message_stop, not after.
+                //
+                // message_stop is the wire's end-of-message marker: clients stop
+                // reading the body at it, so an error event queued afterwards was
+                // written into a stream nobody was still consuming. That is how a
+                // failed turn arrived looking like a successful one — the
+                // incompleteness existed in the SSE, one frame too late to be
+                // seen. Ordering it first is what makes the failure reach the
+                // client at all.
+                safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
+                  type: "error",
+                  error: { type: streamErr.type, message: streamErr.message }
+                })}\n\n`), "error_event_before_stop")
                 safeEnqueue(encoder.encode(
                   `event: message_stop\ndata: {"type":"message_stop"}\n\n`
                 ), "error_message_stop")
+              } else {
+                // No message_start was ever emitted, so there is no message to
+                // close — the error event is the whole response.
+                safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
+                  type: "error",
+                  error: { type: streamErr.type, message: streamErr.message }
+                })}\n\n`), "error_event")
               }
-
-              safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
-                type: "error",
-                error: { type: streamErr.type, message: streamErr.message }
-              })}\n\n`), "error_event")
               if (!streamClosed) {
                 try { controller.close() } catch {}
                 streamClosed = true

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -42,7 +42,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { createEarlyStopTracker, noteAssistantContent, noteUserContent, shouldEarlyStop } from "./passthroughEarlyStop"
+import { createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
@@ -1105,6 +1105,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         const resumeSessionId = cachedSession?.claudeSessionId
+        // --- Passthrough mode ---
+        // When enabled, ALL tool execution is forwarded to OpenCode instead of
+        // being handled internally. This enables multi-model agent delegation
+        // (e.g., oracle on GPT-5.2, explore on Gemini via oh-my-opencode).
+        // Adapter can override the global passthrough env var per-agent.
+        // Droid always uses internal mode; OpenCode defers to the env var.
+        // Instance passthrough override (#476) beats the adapter transform's
+        // default, which beats the global env var.
+        const passthrough = adapter.instancePassthrough !== undefined
+          ? adapter.instancePassthrough
+          : pipelineCtx.passthrough !== undefined
+            ? pipelineCtx.passthrough
+            : envBool("PASSTHROUGH")
         const resumeFrom = lineageResult.type === "continuation" || lineageResult.type === "compaction"
           ? lineageResult.resumeFrom
           : undefined
@@ -1113,6 +1126,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
+        // Early-stopped sessions resume from the persisted deny boundary, not the interrupted tail.
+        const passthroughResumeUuid = passthrough && isResume ? cachedSession?.passthroughResumeUuid : undefined
 
         // Debug: log request details
         const msgSummary = body.messages?.map((m: any) => {
@@ -1307,19 +1322,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         return textPrompt!
       }
 
-      // --- Passthrough mode ---
-      // When enabled, ALL tool execution is forwarded to OpenCode instead of
-      // being handled internally. This enables multi-model agent delegation
-      // (e.g., oracle on GPT-5.2, explore on Gemini via oh-my-opencode).
-      // Adapter can override the global passthrough env var per-agent.
-      // Droid always uses internal mode; OpenCode defers to the env var.
-      // Instance passthrough override (#476) beats the adapter transform's
-      // default, which beats the global env var.
-      const passthrough = adapter.instancePassthrough !== undefined
-        ? adapter.instancePassthrough
-        : pipelineCtx.passthrough !== undefined
-          ? pipelineCtx.passthrough
-          : envBool("PASSTHROUGH")
       // SDK setting sources — controls CLAUDE.md and user settings loading.
       const settingSources: import("@anthropic-ai/claude-agent-sdk").SettingSource[] =
         envBool("LOAD_CONTEXT") || sdkFeatures.claudeMd === "full"
@@ -1676,6 +1678,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
           let lastStopReason: string | undefined
+          let nextPassthroughResumeUuid: string | undefined
 
           try {
             // Lazy-resolve executable if not already set (e.g. when using createProxyServer directly)
@@ -1725,7 +1728,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   for await (const event of query(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                    resumeSessionId, isUndo, undoRollbackUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughResumeUuid, forkSession: busySessionFork || Boolean(passthroughResumeUuid) || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -1802,7 +1805,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                      resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -1852,7 +1855,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                      resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -1941,6 +1944,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (message.type === "assistant") {
                   noteAssistantContent(earlyStop, (message as any).message?.content)
                 } else if (message.type === "user") {
+                  nextPassthroughResumeUuid = resumeBoundaryUuid(message) ?? nextPassthroughResumeUuid
                   noteUserContent(earlyStop, (message as any).message?.content)
                   if (shouldEarlyStop(earlyStop)) {
                     earlyStopFired = true
@@ -2288,7 +2292,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // the stream (already persisted), so the history is coherent and the
           // session is safe to store and resume.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
-                storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
+                storeSession(
+                  profileSessionId,
+                  body.messages || [],
+                  currentSessionId,
+                  profileScopedCwd,
+                  sdkUuidMap,
+                  lastUsage,
+                  earlyStopFired ? nextPassthroughResumeUuid : null
+                )
               }
 
               const responseSessionId = currentSessionId || resumeSessionId || `session_${Date.now()}`
@@ -2371,6 +2383,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             let lastUsage: TokenUsage | undefined
             let hasStructuredOutput = false
             let structuredOutput: unknown
+            let nextPassthroughResumeUuid: string | undefined
             // Hoisted out of the inner streaming loop so the outer catch can
             // dedupe captured tool_uses against what was already forwarded
             // when recovering gracefully from max_turns (see catch below).
@@ -2493,7 +2506,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     for await (const event of query(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                      resumeSessionId, isUndo, undoRollbackUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughResumeUuid, forkSession: busySessionFork || Boolean(passthroughResumeUuid) || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2555,7 +2568,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                        resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                        resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2601,7 +2614,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                        resumeSessionId: undefined, isUndo: false, undoRollbackUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                        resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2722,6 +2735,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   if (message.type === "assistant" && (message as any).uuid) {
                     sdkUuidMap.push((message as any).uuid)
                   }
+                  nextPassthroughResumeUuid = resumeBoundaryUuid(message) ?? nextPassthroughResumeUuid
                   // Early stop: abort before the digest turn generates (see the
                   // earlyStop declaration above). By deny time the client has
                   // already received all turn-1 blocks and the stop_reason
@@ -3136,7 +3150,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // aborts are safe to store: every deny was persisted before the
               // abort. See the non-stream store above.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
-                storeSession(profileSessionId, body.messages || [], currentSessionId, profileScopedCwd, sdkUuidMap, lastUsage)
+                storeSession(
+                  profileSessionId,
+                  body.messages || [],
+                  currentSessionId,
+                  profileScopedCwd,
+                  sdkUuidMap,
+                  lastUsage,
+                  earlyStopFired ? nextPassthroughResumeUuid : null
+                )
               }
               resolvePendingStore()
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, compute
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
-import { ANNOUNCE_TURN_NUDGE, classifyTurnOutcome, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
+import { ANNOUNCE_TURN_NUDGE, classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
 import { LRUMap } from "../utils/lruMap"
 
@@ -2420,7 +2420,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const silentTurnRecoveryEnabled = process.env.MERIDIAN_SILENT_TURN_RECOVERY !== "0"
             let silentTurnRecoveryAttempted = false
             let silentTurnRecovered = false
-            let recoveryBlockIndex: number | undefined
             // Hoisted out of the inner streaming loop so the outer catch can
             // dedupe captured tool_uses against what was already forwarded
             // when recovering gracefully from max_turns (see catch below).
@@ -3229,7 +3228,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // so the recovered answer can actually be forwarded. A turn that
               // already closed (early stop, turn-2 suppression) carries tool
               // calls by construction and is never silent.
-              const preRecoveryOutcome = classifyTurnOutcome({
+              //
+              // One classification, read twice: here, to decide whether a
+              // recovery spend is warranted, and again for the final envelope's
+              // telemetry. The counters mutate in between — a closure, not a
+              // snapshot.
+              const classifyNow = () => classifyTurnOutcome({
                 textEvents: textEventsForwarded,
                 toolUses: streamedToolUseIds.size,
                 blocksForwarded: eventsForwarded,
@@ -3237,6 +3241,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 denyBoundaryContinuation: Boolean(passthroughResumeUuid),
                 clientMessageCount: allMessages.length,
               })
+              const preRecoveryOutcome = classifyNow()
               //
               // `messageStartEmitted` is a hard precondition, not a heuristic:
               // recovery works by appending a text block to the message already
@@ -3263,6 +3268,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   reason: preRecoveryOutcome.kind === "silent" ? preRecoveryOutcome.reason : undefined,
                   sdkSessionId: currentSessionId || resumeSessionId,
                 })
+                const recoveryLifter = createRecoveryLifter(() => nextClientBlockIndex++)
                 try {
                   for await (const event of query(buildQueryOptions({
                     // The announce stall needs its own words: "no visible
@@ -3300,46 +3306,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     advisorModel,
                   }, requestAbort.controller))) {
                     if ((event as any).type !== "stream_event") continue
-                    const inner = (event as any).event
-                    const innerType = inner?.type
-                    // Only text is lifted into the already-open message. A tool
-                    // call arriving here would need its own block index space and
-                    // the client's turn boundary to match — out of scope for a
-                    // recovery, and it still counts as a productive turn below.
-                    if (innerType === "content_block_start" && inner.content_block?.type === "text") {
-                      const idx = nextClientBlockIndex++
-                      recoveryBlockIndex = idx
-                      safeEnqueue(encoder.encode(
-                        `event: content_block_start\ndata: ${JSON.stringify({
-                          type: "content_block_start",
-                          index: idx,
-                          content_block: { type: "text", text: "" },
-                        })}\n\n`
-                      ), "silent_recovery_block_start")
+                    // Only text is lifted into the already-open message; the
+                    // re-indexing handshake lives in createRecoveryLifter. A
+                    // tool call arriving here still counts as a productive
+                    // recovery, through the shared PreToolUse capture below.
+                    const lifted = recoveryLifter.lift((event as any).event)
+                    if (!lifted) continue
+                    safeEnqueue(encoder.encode(
+                      `event: ${lifted.frame.type}\ndata: ${JSON.stringify(lifted.frame)}\n\n`
+                    ), `silent_recovery_${lifted.kind}`)
+                    if (lifted.kind === "block_start") {
                       eventsForwarded += 1
-                    } else if (
-                      innerType === "content_block_delta" &&
-                      inner.delta?.type === "text_delta" &&
-                      recoveryBlockIndex !== undefined
-                    ) {
-                      safeEnqueue(encoder.encode(
-                        `event: content_block_delta\ndata: ${JSON.stringify({
-                          type: "content_block_delta",
-                          index: recoveryBlockIndex,
-                          delta: { type: "text_delta", text: inner.delta.text },
-                        })}\n\n`
-                      ), "silent_recovery_text_delta")
+                    } else if (lifted.kind === "text_delta") {
                       textEventsForwarded += 1
-                      if (typeof inner.delta.text === "string") textCharsForwarded += inner.delta.text.length
+                      textCharsForwarded += lifted.textChars
                       silentTurnRecovered = true
-                    } else if (innerType === "content_block_stop" && recoveryBlockIndex !== undefined) {
-                      safeEnqueue(encoder.encode(
-                        `event: content_block_stop\ndata: ${JSON.stringify({
-                          type: "content_block_stop",
-                          index: recoveryBlockIndex,
-                        })}\n\n`
-                      ), "silent_recovery_block_stop")
-                      recoveryBlockIndex = undefined
                     }
                   }
                 } catch (recoveryError) {
@@ -3534,14 +3515,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // client got anything actionable — a tool-only turn tripped it
                 // while being perfectly healthy, and a thinking-only turn
                 // looked identical to one.
-                const turnOutcome = classifyTurnOutcome({
-                  textEvents: textEventsForwarded,
-                  toolUses: streamedToolUseIds.size,
-                  blocksForwarded: eventsForwarded,
-                  textChars: textCharsForwarded,
-                  denyBoundaryContinuation: Boolean(passthroughResumeUuid),
-                  clientMessageCount: allMessages.length,
-                })
+                const turnOutcome = classifyNow()
                 if (turnOutcome.kind === "announce") {
                   claudeLog("response.announce_turn", {
                     model,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -13,7 +13,7 @@ import { fetchOAuthUsage, explainMissingOAuthUsage } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
-import { env, envBool } from "../env"
+import { env, envBool, envInt } from "../env"
 import type { ProxyConfig, ProxyInstance, ProxyServer } from "./types"
 export type { ProxyConfig, ProxyInstance, ProxyServer }
 // Public plugin-authoring types. Plugins import these to type their
@@ -122,7 +122,17 @@ let claudeExecutable = ""
 // Must be > slowest legitimate TTFB / server-side thinking pause, and < the
 // "feels dead" threshold. Pylon's turn watchdog (120s warn / 180s abort) is the
 // looser backstop, so this fires first.
-const UPSTREAM_IDLE_MS = 90_000
+//
+// Overridable via MERIDIAN_UPSTREAM_IDLE_MS because the 90s default is not
+// always above the "slowest legitimate thinking pause" it assumes: a deep
+// agentic turn that reasons for a long stretch before emitting anything gets
+// killed mid-turn, and the kill reaches the client as a finished-but-empty
+// message (termination reason is `unknown`, so the tool_use recovery path
+// cannot fire). The default is left at 90s so upstream behaviour is unchanged;
+// keep any override BELOW Pylon's STALL_ABORT_MS (180s), or the two layers race
+// to abort the same hung model — see the coordination contract in
+// streamIdleGuard.ts.
+const UPSTREAM_IDLE_MS = envInt("UPSTREAM_IDLE_MS", 90_000)
 
 function credentialStoreForProfile(profile: ResolvedProfile): CredentialStore | undefined {
   if (profile.type !== "claude-max") return undefined

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -182,6 +182,7 @@ export function lookupSession(
         messageHashes: shared.messageHashes,
         messageBlockHashes: shared.messageBlockHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
+        passthroughResumeUuid: shared.passthroughResumeUuid,
         contextUsage: shared.contextUsage,
       }
       const result = classifyLineage(state, messages, sessionId)
@@ -211,6 +212,7 @@ export function lookupSession(
         messageHashes: shared.messageHashes,
         messageBlockHashes: shared.messageBlockHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
+        passthroughResumeUuid: shared.passthroughResumeUuid,
         contextUsage: shared.contextUsage,
       }
       const result = classifyLineage(state, messages, fp)
@@ -249,6 +251,7 @@ export function getSessionByClaudeId(claudeSessionId: string): SessionState | un
       messageHashes: shared.messageHashes,
       messageBlockHashes: shared.messageBlockHashes,
       sdkMessageUuids: shared.sdkMessageUuids,
+      passthroughResumeUuid: shared.passthroughResumeUuid,
       contextUsage: shared.contextUsage,
     })
   }
@@ -266,7 +269,8 @@ export function storeSession(
   claudeSessionId: string,
   workingDirectory?: string,
   sdkMessageUuids?: Array<string | null>,
-  contextUsage?: TokenUsage
+  contextUsage?: TokenUsage,
+  passthroughResumeUuid?: string | null
 ) {
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
@@ -280,6 +284,7 @@ export function storeSession(
     messageHashes,
     messageBlockHashes,
     sdkMessageUuids,
+    ...(passthroughResumeUuid ? { passthroughResumeUuid } : {}),
     ...(contextUsage ? { contextUsage } : {}),
   }
   // In-memory cache
@@ -302,7 +307,9 @@ export function storeSession(
       messageHashes,
       sdkMessageUuids,
       contextUsage,
-      messageBlockHashes
+      messageBlockHashes,
+      // undefined would preserve the stored boundary; a full store must rewrite it.
+      passthroughResumeUuid ?? null
     )
   }
 }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -56,6 +56,8 @@ export interface SessionState {
    *  Only assistant messages have UUIDs (user messages are null).
    *  Used to find the rollback point for undo. */
   sdkMessageUuids?: Array<string | null>
+  /** Last persisted passthrough deny — continuations of an early-stopped session fork here. */
+  passthroughResumeUuid?: string
   /** Last observed token usage for this session (from SDK message_start / message_delta events) */
   contextUsage?: TokenUsage
 }

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -38,6 +38,8 @@ export interface StoredSession {
   messageBlockHashes?: string[][]
   /** Per-message SDK assistant UUIDs for undo rollback (null for user messages) */
   sdkMessageUuids?: Array<string | null>
+  /** Uuid of the last persisted passthrough deny — resume boundary after an early stop. */
+  passthroughResumeUuid?: string
   /** Last observed token usage for this Claude session */
   contextUsage?: TokenUsage
   /** Previous Claude session ID preserved when the session mapping is replaced.
@@ -205,7 +207,8 @@ export function storeSharedSession(
   messageHashes?: string[],
   sdkMessageUuids?: Array<string | null>,
   contextUsage?: TokenUsage,
-  messageBlockHashes?: string[][]
+  messageBlockHashes?: string[][],
+  passthroughResumeUuid?: string | null
 ): void {
   const path = getStorePath()
   const lockPath = `${path}.lock`
@@ -232,6 +235,9 @@ export function storeSharedSession(
       messageHashes: messageHashes ?? existing?.messageHashes,
       messageBlockHashes: messageBlockHashes ?? existing?.messageBlockHashes,
       sdkMessageUuids: sdkMessageUuids ?? existing?.sdkMessageUuids,
+      passthroughResumeUuid: passthroughResumeUuid === undefined
+        ? existing?.passthroughResumeUuid
+        : passthroughResumeUuid ?? undefined,
       contextUsage: contextUsage ?? existing?.contextUsage,
       ...(previousClaudeSessionId ? { previousClaudeSessionId } : {}),
     }

--- a/src/proxy/turnOutcome.ts
+++ b/src/proxy/turnOutcome.ts
@@ -23,6 +23,18 @@
  * with an empty text block — counting it as content would classify the exact
  * defect this module exists to catch as healthy.
  *
+ * Text alone is not always an answer either. Observed live one step past the
+ * silence invariant: on a deny-boundary continuation (a session's second turn,
+ * cold cache) the model produced an empty thinking block plus one short text
+ * that only ANNOUNCED the work — "Let me read the config…" — and ended the
+ * turn with
+ * zero tool calls. The same stall for the client, now wearing a
+ * plausible-looking sentence. Unlike silence this cannot be a hard invariant
+ * (a short text final is sometimes a real answer), so it is scoped to the
+ * narrow window where every observed case lived: a deny-boundary continuation
+ * of a short conversation, with a short text. A false positive costs one
+ * redundant closing turn; a false negative costs the conversation.
+ *
  * Pure module — no I/O, no imports from server.ts or session/.
  */
 
@@ -30,6 +42,9 @@
 export type TurnOutcome =
   | { kind: "productive" }
   | { kind: "silent"; reason: SilentReason }
+  /** Text arrived, but inside the announce risk window and with no tool call —
+   *  the announce-then-stop stall (see the module header). */
+  | { kind: "announce" }
 
 /**
  * Why a turn is silent. Both shapes reach the client identically; they are
@@ -41,6 +56,15 @@ export type SilentReason =
   | "no_blocks"
   /** Blocks were forwarded, but none of them carried text or a tool call. */
   | "no_actionable_content"
+
+/** Announce stalls cluster on a session's opening exchanges, where the spent
+ *  deny dominates the context. Longer conversations never get the announce
+ *  classification — their text-only finals are almost always real answers. */
+export const ANNOUNCE_RISK_MAX_CLIENT_MESSAGES = 4
+
+/** An announcement runs a sentence or two; a real answer usually runs longer.
+ *  Texts above this length are taken as answers even inside the window. */
+export const ANNOUNCE_RISK_MAX_TEXT_CHARS = 600
 
 /**
  * Classify a turn by what actually reached the client.
@@ -56,8 +80,28 @@ export function classifyTurnOutcome(input: {
   toolUses: number
   /** Blocks forwarded in total, including thinking. */
   blocksForwarded: number
+  /** Characters of text forwarded — the announce test is a length test. */
+  textChars?: number
+  /** This request forked from a persisted deny boundary — the spent
+   *  "end your turn now" sits immediately before the live prompt. */
+  denyBoundaryContinuation?: boolean
+  /** Messages in the client's conversation (request body). */
+  clientMessageCount?: number
 }): TurnOutcome {
-  if (input.textEvents > 0 || input.toolUses > 0) return { kind: "productive" }
+  if (input.toolUses > 0) return { kind: "productive" }
+  if (input.textEvents > 0) {
+    if (
+      input.denyBoundaryContinuation &&
+      input.textChars !== undefined &&
+      input.textChars > 0 &&
+      input.textChars <= ANNOUNCE_RISK_MAX_TEXT_CHARS &&
+      input.clientMessageCount !== undefined &&
+      input.clientMessageCount <= ANNOUNCE_RISK_MAX_CLIENT_MESSAGES
+    ) {
+      return { kind: "announce" }
+    }
+    return { kind: "productive" }
+  }
   return {
     kind: "silent",
     reason: input.blocksForwarded > 0 ? "no_actionable_content" : "no_blocks",
@@ -81,6 +125,20 @@ export const SILENT_TURN_NUDGE =
   "nothing to act on. Any earlier instruction to end your turn without further text applied only to " +
   "that turn and is now discharged. Answer now, in text, addressing the most recent request and any " +
   "tool results above it. If a tool call is still required, make it."
+
+/**
+ * The nudge for an announce-shaped stall — text arrived, but it only promised
+ * the work. It cannot borrow SILENT_TURN_NUDGE's words: "no visible output"
+ * would be false (the client saw the announcement), and a model told something
+ * false about its own turn tends to argue rather than act. It names what the
+ * turn actually did and discharges the same spent instruction, because every
+ * observed announce lived on the same deny boundary.
+ */
+export const ANNOUNCE_TURN_NUDGE =
+  "Your previous turn ended after only announcing what you were about to do — no tool calls were " +
+  "made, so the client received nothing to act on. Any earlier instruction to end your turn without " +
+  "further text applied only to that turn and is now discharged. Do the announced work now: make the " +
+  "tool calls the task needs. If the work is already complete, state the final result in text."
 
 /**
  * Fault injection: swallow the upstream text of this request's turn.
@@ -117,9 +175,10 @@ export function shouldInjectSilentTurn(input: {
 /**
  * Is one in-session recovery attempt worth making?
  *
- * Only for a genuinely silent turn, at most once, and never when the client is
- * already gone — a disconnected client cannot receive the recovered answer, and
- * spending a model turn to write into a closed socket is pure waste.
+ * Only for a stalled turn — silent or announce — at most once, and never when
+ * the client is already gone: a disconnected client cannot receive the
+ * recovered answer, and spending a model turn to write into a closed socket is
+ * pure waste.
  */
 export function shouldAttemptRecovery(input: {
   outcome: TurnOutcome
@@ -130,7 +189,7 @@ export function shouldAttemptRecovery(input: {
   enabled: boolean
 }): boolean {
   if (!input.enabled) return false
-  if (input.outcome.kind !== "silent") return false
+  if (input.outcome.kind === "productive") return false
   if (input.alreadyAttempted) return false
   if (input.clientGone) return false
   return Boolean(input.sessionId)

--- a/src/proxy/turnOutcome.ts
+++ b/src/proxy/turnOutcome.ts
@@ -1,0 +1,137 @@
+/**
+ * Was a turn productive, or did it come back silent?
+ *
+ * Three separate defects have now ended the same way: the proxy hands the
+ * client a well-formed terminal envelope — `stop_reason: "end_turn"`, HTTP 200,
+ * `error: null` — carrying nothing the client can act on. An interrupted tail
+ * (#768), an unsettled client abort (#768), a spent deny at the boundary seam
+ * (#768). Each was found by tracing its own cause; each was invisible until
+ * someone read a transcript.
+ *
+ * The causes differ, the shape does not. So this module states the shape as an
+ * invariant instead of chasing the next cause:
+ *
+ *   A terminal envelope must carry text or a tool call.
+ *
+ * Anything else is a silent turn, and a silent turn is a defect — never a
+ * successful response. In an interactive session it costs a confused user and a
+ * retyped prompt. In an autonomous run there is nobody to retype: the loop sees
+ * a finished turn with no work in it and stops, or worse, reads its own
+ * unfulfilled promise on the next turn and reports the failure as its own.
+ *
+ * `thinking` deliberately does not count. The empty-turn signature IS thinking
+ * with an empty text block — counting it as content would classify the exact
+ * defect this module exists to catch as healthy.
+ *
+ * Pure module — no I/O, no imports from server.ts or session/.
+ */
+
+/** What a completed turn delivered to the client. */
+export type TurnOutcome =
+  | { kind: "productive" }
+  | { kind: "silent"; reason: SilentReason }
+
+/**
+ * Why a turn is silent. Both shapes reach the client identically; they are
+ * distinguished so telemetry can tell "the model said nothing" from "the model
+ * said nothing and we never even opened a message".
+ */
+export type SilentReason =
+  /** Nothing at all — no blocks were forwarded. */
+  | "no_blocks"
+  /** Blocks were forwarded, but none of them carried text or a tool call. */
+  | "no_actionable_content"
+
+/**
+ * Classify a turn by what actually reached the client.
+ *
+ * `textEvents` counts forwarded text deltas, not text blocks: an EMPTY text
+ * block produces a block start and stop with no delta between them, which is
+ * precisely the shape a spent-deny turn takes. Counting blocks would miss it.
+ */
+export function classifyTurnOutcome(input: {
+  /** Forwarded `text_delta` events (or, non-streaming, non-empty text blocks). */
+  textEvents: number
+  /** Tool calls the client will execute — actionable even with no prose. */
+  toolUses: number
+  /** Blocks forwarded in total, including thinking. */
+  blocksForwarded: number
+}): TurnOutcome {
+  if (input.textEvents > 0 || input.toolUses > 0) return { kind: "productive" }
+  return {
+    kind: "silent",
+    reason: input.blocksForwarded > 0 ? "no_actionable_content" : "no_blocks",
+  }
+}
+
+/**
+ * The nudge sent to recover a silent turn, in the same SDK session.
+ *
+ * Deliberately not the CLI's own nudge ("your previous response had no visible
+ * output"). That one is issued INSIDE the session with the offending
+ * instruction still in context, so on the observed cases the model obeyed the
+ * instruction a second time and answered empty again. This one names the
+ * contradiction and discharges it, the same move that fixed the boundary seam.
+ *
+ * Says nothing about which defect caused the silence: the recovery is for the
+ * class, and the model does not need our diagnosis to answer.
+ */
+export const SILENT_TURN_NUDGE =
+  "Your previous turn produced no visible output — no text and no tool call — so the client received " +
+  "nothing to act on. Any earlier instruction to end your turn without further text applied only to " +
+  "that turn and is now discharged. Answer now, in text, addressing the most recent request and any " +
+  "tool results above it. If a tool call is still required, make it."
+
+/**
+ * Fault injection: swallow the upstream text of this request's turn.
+ *
+ * The defect's live rate is roughly three in five hundred requests, all on a
+ * session's second turn. A harness cannot wait for that — a ten-attempt run
+ * expects 0.06 occurrences — so without injection a green E2E is ambiguous:
+ * the guard works, or the defect simply did not happen. That ambiguity is
+ * exactly what let two earlier "verified" fixes ship broken.
+ *
+ * So the shape is reproduced on demand: drop the text the upstream turn
+ * produced, leaving its block start and stop in place — an EMPTY text block,
+ * which is the production signature exactly. Everything downstream (detection,
+ * recovery, envelope, telemetry) then runs for real against a real model; only
+ * the trigger is synthetic.
+ *
+ * EVERY text delta of the turn is dropped, not just the first: one surviving
+ * delta makes the turn productive and the guard never engages. The recovery
+ * turn is unaffected because it forwards through its own path, not the upstream
+ * forward site this gates.
+ *
+ * Off unless MERIDIAN_DEBUG_FORCE_SILENT_TURN names a session id (or `1` for
+ * every session). Debug-only — never a production path.
+ */
+export function shouldInjectSilentTurn(input: {
+  raw: string | undefined
+  sessionId: string | undefined
+}): boolean {
+  if (!input.raw) return false
+  if (input.raw === "1") return true
+  return Boolean(input.sessionId && input.raw === input.sessionId)
+}
+
+/**
+ * Is one in-session recovery attempt worth making?
+ *
+ * Only for a genuinely silent turn, at most once, and never when the client is
+ * already gone — a disconnected client cannot receive the recovered answer, and
+ * spending a model turn to write into a closed socket is pure waste.
+ */
+export function shouldAttemptRecovery(input: {
+  outcome: TurnOutcome
+  alreadyAttempted: boolean
+  clientGone: boolean
+  /** The SDK session to resume; without it there is nothing to continue from. */
+  sessionId?: string
+  enabled: boolean
+}): boolean {
+  if (!input.enabled) return false
+  if (input.outcome.kind !== "silent") return false
+  if (input.alreadyAttempted) return false
+  if (input.clientGone) return false
+  return Boolean(input.sessionId)
+}

--- a/src/proxy/turnOutcome.ts
+++ b/src/proxy/turnOutcome.ts
@@ -173,6 +173,75 @@ export function shouldInjectSilentTurn(input: {
 }
 
 /**
+ * One frame of a recovery turn, re-indexed for the client's wire. `kind`
+ * doubles as the enqueue label suffix, so telemetry keeps the exact names the
+ * recovery has always logged (silent_recovery_block_start, …).
+ */
+export type RecoveryLift =
+  | {
+      kind: "block_start"
+      frame: { type: "content_block_start"; index: number; content_block: { type: "text"; text: string } }
+    }
+  | {
+      kind: "text_delta"
+      frame: { type: "content_block_delta"; index: number; delta: { type: "text_delta"; text: unknown } }
+      /** Characters delivered — 0 when the delta carried a non-string text. */
+      textChars: number
+    }
+  | { kind: "block_stop"; frame: { type: "content_block_stop"; index: number } }
+
+/**
+ * Lift a recovery turn's stream events into the message already open on the
+ * client's wire.
+ *
+ * Only text is lifted. A tool call arriving in the recovery turn would need
+ * its own block index space and the client's turn boundary to match — out of
+ * scope for a recovery; it still counts as one, through the shared PreToolUse
+ * capture at the recovery site in server.ts.
+ *
+ * The lifter owns the re-indexing handshake: a text block start allocates a
+ * client index from the caller's space — so the recovery block continues the
+ * open message's numbering instead of colliding with it — deltas are rewritten
+ * onto that index, and stop releases it. Deltas and stops outside an open
+ * block are dropped: emitting them would be malformed SSE.
+ */
+export function createRecoveryLifter(allocateBlockIndex: () => number): {
+  lift(innerEvent: unknown): RecoveryLift | undefined
+} {
+  let blockIndex: number | undefined
+  return {
+    lift(innerEvent) {
+      const inner = innerEvent as
+        | { type?: unknown; content_block?: { type?: unknown }; delta?: { type?: unknown; text?: unknown } }
+        | null
+        | undefined
+      if (!inner) return undefined
+      if (inner.type === "content_block_start" && inner.content_block?.type === "text") {
+        blockIndex = allocateBlockIndex()
+        return {
+          kind: "block_start",
+          frame: { type: "content_block_start", index: blockIndex, content_block: { type: "text", text: "" } },
+        }
+      }
+      if (inner.type === "content_block_delta" && inner.delta?.type === "text_delta" && blockIndex !== undefined) {
+        const text = inner.delta.text
+        return {
+          kind: "text_delta",
+          frame: { type: "content_block_delta", index: blockIndex, delta: { type: "text_delta", text } },
+          textChars: typeof text === "string" ? text.length : 0,
+        }
+      }
+      if (inner.type === "content_block_stop" && blockIndex !== undefined) {
+        const index = blockIndex
+        blockIndex = undefined
+        return { kind: "block_stop", frame: { type: "content_block_stop", index } }
+      }
+      return undefined
+    },
+  }
+}
+
+/**
  * Is one in-session recovery attempt worth making?
  *
  * Only for a stalled turn — silent or announce — at most once, and never when


### PR DESCRIPTION
## Problem

A passthrough turn can complete as a success — `end_turn`, HTTP 200, `error: null` — while delivering nothing the client can act on. Four causes:

1. **Early stop** leaves the stored session on an interrupted tail; resuming it yields meta text (`No response requested.`) or nothing.
2. **Client abort** never settled the session; every following continuation came back empty, each empty turn becoming the next tail.
3. **Spent deny at the boundary seam**: the persisted `end your turn now` deny sits immediately before the continuation's user turn, and the model obeys it — empty text block, clean `end_turn`.
4. **90s idle limit** kills a long-thinking turn; the kill is classified `unknown`, captured tool calls are dropped, the client gets a finished empty message.

## Fix

- **Boundary capture** — store the uuid of the last persisted deny; continuations fork there (`resumeSessionAtUuid`) instead of attaching to the interrupted tail. Prompt cache survives (91–99% hit).
- **Settlement** — the client-abort path now stores or evicts the session and resolves the pending store (`clientAbortDisposition`, pure).
- **Discharge** — boundary continuations get a lead-in stating the deny is spent (`framePassthroughContinuation`); bare resumes are byte-identical to today.
- **Idle limit override** — `MERIDIAN_UPSTREAM_IDLE_MS`, default unchanged (90s).
- **Outcome guard** — every completed turn is classified in `turnOutcome.ts`: a terminal envelope must carry text or a tool call; `thinking` doesn't count. A silent turn — or an announce-only one on a deny-boundary continuation of a short conversation — gets one recovery turn, forked from the boundary, with a nudge that discharges the deny. Kill switch `MERIDIAN_SILENT_TURN_RECOVERY=0`. Failed turns now emit the error before `message_stop` and report `max_tokens` instead of claiming `end_turn`.

Telemetry: `response.silent_turn`, `response.announce_turn`, `passthrough.client_abort_settled`.

## Verification

Early stop reproduced on a harness (Sonnet 10/10 degenerate → 0/20 fixed). Causes 2–4 diagnosed from production transcripts and telemetry, unit-tested at their decision points. The guard has an injection E2E (`MERIDIAN_DEBUG_FORCE_SILENT_TURN`, `scripts/e2e-silent-turn.mjs`): recovery off — 2/2 fail, on — 2/2 recover. Full suite, typecheck, build green.
