### PR TITLE
feat(profile): create the profile when `profile login` names an unknown one

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ ANTHROPIC_API_KEY=your-secret-key ANTHROPIC_BASE_URL=http://meridian-host:3456 o
 | `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |
 | `meridian profile list` (alias `profile ls`) | List all profiles and their auth status |
 | `meridian profile switch <name>` | Switch the active profile (requires running proxy) |
-| `meridian profile login <name> [--headless]` | Re-authenticate an expired profile (browser-login profiles only); `--headless` uses the URL/code flow |
+| `meridian profile login <name> [--headless]` | Re-authenticate an expired profile, adding it first if that name has no profile yet (browser-login profiles only); `--headless` uses the URL/code flow |
 | `meridian profile remove <name>` | Remove a profile and its credentials |
 | `meridian refresh-token` | Manually refresh the Claude OAuth token (exits 0/1) |
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -98,7 +98,7 @@ MERIDIAN_ROUTING=priority MERIDIAN_PROFILE_ORDER=work,personal meridian
 | `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |
 | `meridian profile list` | List profiles and auth status |
 | `meridian profile switch <name>` | Switch the active profile (requires running proxy) |
-| `meridian profile login <name> [--headless]` | Re-authenticate an expired profile (browser-login profiles only); `--headless` uses the URL/code flow |
+| `meridian profile login <name> [--headless]` | Re-authenticate an expired profile, adding it first if that name has no profile yet (browser-login profiles only); `--headless` uses the URL/code flow |
 | `meridian profile remove <name>` | Remove a profile and its credentials |
 
 ### How it works

--- a/src/__tests__/profile-login-plan.test.ts
+++ b/src/__tests__/profile-login-plan.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for the `meridian profile login <id>` decision layer — pure
+ * function tests (no mocks, no disk access, no `claude auth login`).
+ */
+import { describe, test, expect } from "bun:test"
+import { isValidProfileId, planProfileLogin } from "../proxy/profileCli"
+import type { ProfileConfig } from "../proxy/profiles"
+
+const profiles: ProfileConfig[] = [
+  { id: "personal", type: "claude-max", claudeConfigDir: "/home/.config/meridian/profiles/personal" },
+  { id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-xxx" },
+  { id: "ci-inferred", oauthToken: "sk-ant-oat01-yyy" },
+]
+
+describe("isValidProfileId", () => {
+  test("accepts letters, digits, hyphens and underscores", () => {
+    for (const id of ["work", "work-2", "work_2", "Work2", "a"]) {
+      expect(isValidProfileId(id)).toBe(true)
+    }
+  })
+
+  test("refuses path separators, traversal segments and empty input", () => {
+    for (const id of ["", ".", "..", "../../etc", "a/b", "a\\b", "~", "with space", "dollar$"]) {
+      expect(isValidProfileId(id)).toBe(false)
+    }
+  })
+})
+
+describe("planProfileLogin", () => {
+  test("an unknown ID is a request to add that profile, not an error", () => {
+    expect(planProfileLogin("brand-new", profiles)).toEqual({ action: "create" })
+  })
+
+  test("an unknown ID with nothing configured yet still adds", () => {
+    expect(planProfileLogin("first", [])).toEqual({ action: "create" })
+  })
+
+  test("refuses to turn a traversal ID into a profile directory", () => {
+    expect(planProfileLogin("../../etc", profiles)).toEqual({ action: "reject-invalid-id" })
+    expect(planProfileLogin("a/b", profiles)).toEqual({ action: "reject-invalid-id" })
+    expect(planProfileLogin("", profiles)).toEqual({ action: "reject-invalid-id" })
+  })
+
+  test("GOLDEN: a known browser-login profile logs in, unchanged", () => {
+    expect(planProfileLogin("personal", profiles)).toEqual({ action: "login", profile: profiles[0]! })
+  })
+
+  test("GOLDEN: an oauth-token profile is still refused, by type and by inference", () => {
+    expect(planProfileLogin("ci", profiles)).toEqual({ action: "reject-oauth-token" })
+    expect(planProfileLogin("ci-inferred", profiles)).toEqual({ action: "reject-oauth-token" })
+  })
+
+  test("an existing profile is never re-validated — login keeps working on hand-written IDs", () => {
+    const handWritten: ProfileConfig[] = [{ id: "legacy.name", claudeConfigDir: "/somewhere" }]
+    expect(planProfileLogin("legacy.name", handWritten)).toEqual({ action: "login", profile: handWritten[0]! })
+  })
+})

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -42,6 +42,22 @@ function getProfileDir(id: string): string {
   return join(PROFILES_DIR, id)
 }
 
+/**
+ * Pure: is this ID safe to use as a profile name?
+ *
+ * A profile ID becomes a directory name under PROFILES_DIR, so anything
+ * carrying a path separator or a `..` segment would escape that directory.
+ * Restricting to plain identifiers keeps IDs both safe and shell-friendly.
+ */
+export function isValidProfileId(id: string): boolean {
+  return Boolean(id) && !/[^a-zA-Z0-9_-]/.test(id)
+}
+
+/** Red text — plain when stdout is piped, where escape codes are noise. */
+function red(text: string): string {
+  return process.stdout.isTTY ? `\x1b[31m${text}\x1b[0m` : text
+}
+
 interface AuthLoginOptions {
   headless?: boolean
 }
@@ -227,7 +243,7 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {
-  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+  if (!isValidProfileId(id)) {
     console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
@@ -333,7 +349,7 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
 }
 
 export async function profileAddOauthToken(id: string, tokenArg: string | undefined): Promise<void> {
-  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+  if (!isValidProfileId(id)) {
     console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
@@ -462,19 +478,51 @@ export async function profileSwitch(id: string): Promise<void> {
   }
 }
 
-export async function profileLogin(id: string, options: AuthLoginOptions = {}): Promise<void> {
-  const profiles = loadProfileConfig()
+export type ProfileLoginPlan =
+  | { action: "create" }
+  | { action: "reject-invalid-id" }
+  | { action: "reject-oauth-token" }
+  | { action: "login"; profile: ProfileConfig }
+
+/**
+ * Pure: decide what `meridian profile login <id>` should do.
+ *
+ * An unknown ID is a request to create that profile, not an error — the ID is
+ * validated first because only this branch turns it into a directory. A profile
+ * that already exists is never re-validated: it was written by an earlier `add`
+ * (or by hand), and login must keep working on it either way.
+ *
+ * Caller performs the login itself — this returns the decision only.
+ */
+export function planProfileLogin(id: string, profiles: ProfileConfig[]): ProfileLoginPlan {
   const profile = profiles.find(p => p.id === id)
-  if (!profile) {
-    console.error(`\x1b[31m✗ Profile "${id}" not found.\x1b[0m Run: meridian profile add ${id}`)
+  if (!profile) return isValidProfileId(id) ? { action: "create" } : { action: "reject-invalid-id" }
+  if (profile.oauthToken || profile.type === "oauth-token") return { action: "reject-oauth-token" }
+  return { action: "login", profile }
+}
+
+export async function profileLogin(id: string, options: AuthLoginOptions = {}): Promise<void> {
+  const plan = planProfileLogin(id, loadProfileConfig())
+
+  if (plan.action === "reject-invalid-id") {
+    console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
 
-  if (profile.oauthToken || profile.type === "oauth-token") {
+  if (plan.action === "reject-oauth-token") {
     console.error(`\x1b[31m✗ Profile "${id}" uses an OAuth token; \`claude auth login\` does not apply.\x1b[0m`)
     console.error(`  To replace the token: meridian profile remove ${id} && meridian profile add ${id} --oauth-token`)
     process.exit(1)
   }
+
+  if (plan.action === "create") {
+    console.log(red(`⚠ Profile "${id}" does not exist yet — adding it first.`))
+    console.log()
+    await profileAdd(id, options)
+    return
+  }
+
+  const profile = plan.profile
 
   console.log(`\x1b[36mRe-authenticating profile: ${id}\x1b[0m`)
   console.log()
@@ -590,7 +638,8 @@ Commands:
   meridian profile list                             List profiles and auth status
   meridian profile remove <name>                    Remove a profile
   meridian profile switch <name>                    Switch the active profile (requires running proxy)
-  meridian profile login <name> [--headless]        Re-authenticate an existing profile (claude-max only)
+  meridian profile login <name> [--headless]        Re-authenticate a profile, adding it first if it does not
+                                                    exist yet (claude-max only)
 
 Examples:
   meridian profile add personal                     # Add personal account (browser login)


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Nowaker is still iterating on this. It is opened early so the diff is visible;
it will be marked ready when it is actually ready.

---

`meridian profile login weekend-account` currently exits 1 with:

```
Profile not found. Run: meridian profile add weekend-account
```

Two commands for one intention, and the error does not say that the second
one is what you meant. This makes `login` create the profile when it names
an unknown one, after printing a red notice saying so.

### What it does

- An unknown ID prints a notice and falls straight into `profileAdd`, which
  stays the **single creation path** - config dir, `profiles.json` entry,
  auth flow and verification keep one definition of what a profile is made
  of, rather than gaining a second one that can drift.
- A **known** profile is unchanged, `oauth-token` profiles are unchanged.
  Both are covered by golden tests.
- The notice is red only on a TTY; piped output stays free of escape codes.

### The ID validation, and why it is on one branch only

`login <id>` on an unknown ID is the only path that turns an ID into a
directory under `~/.config/meridian/profiles`, so `login ../../etc` must not
become one. Validation therefore happens on that branch, before anything is
created.

`profileAdd` already had that check; it is now a shared `isValidProfileId`
rather than a third copy of the regex. An ID that **already** has a profile
is deliberately not re-validated, so `login` keeps working on entries written
by hand.

### Tests

The decision is a pure `planProfileLogin`, so all four outcomes are unit
tested without spawning `claude auth login`.

```
bun test src/__tests__/profile-login-plan.test.ts   8 pass, 0 fail
bun run test                                        full chain, 0 fail
tsc --noEmit                                        exit 0
```

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
