### PR TITLE
feat(dev): MERIDIAN_CREDENTIALS_READONLY, for a second instance on shared credentials

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,75 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_SILENT` | `CLAUDE_PROXY_SILENT` | unset | Set to `1` to suppress startup output (used by embedding plugins) |
 | `MERIDIAN_PLUGIN_DIR` | — | `~/.config/meridian/plugins` | Plugin auto-discovery directory |
 | `MERIDIAN_PLUGIN_CONFIG` | — | `~/.config/meridian/plugins.json` | Plugin manifest path |
+| `MERIDIAN_CREDENTIALS_READONLY` | `CLAUDE_PROXY_CREDENTIALS_READONLY` | unset | Set to `1` to forbid this instance from refreshing or writing OAuth credentials. For a second instance sharing another's credential files — see [Read-only credentials](#read-only-credentials). |
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost. Fable 1M is also included at no Extra Usage cost, verified live on both Max and Team.
+
+### Read-only credentials
+
+`MERIDIAN_CREDENTIALS_READONLY=1` makes an instance incapable of modifying
+credentials. It exists so a second instance — a development build, a staging
+copy — can run beside a production one **against the same credential files**
+without being able to corrupt them.
+
+The hazard is two instances holding the same OAuth refresh token. Meridian
+refreshes proactively on boot and every 45s. If Anthropic rotates a refresh
+token on use, whichever instance refreshes first can invalidate the other's
+copy, and the only recovery is an interactive `claude login` per account.
+
+Sharing the files is usually not a choice. `profiles.json` is read from
+`~/.config/meridian/` unconditionally — `MERIDIAN_CONFIG_DIR` relocates
+`settings.json` only — so any second instance sees the same profile list
+pointing at the same credential directories. This flag is what makes that
+safe.
+
+With it set:
+
+| Behaviour | Effect |
+|---|---|
+| Proactive refresh on boot and every 45s | Not scheduled |
+| Auth keepalive every 45s | Not scheduled |
+| Auth-status cache (60s TTL) | Also invalidated when the credential file's mtime changes, so a rotation by the other instance is picked up on the next tick |
+| Any credential write | Refused at the credential store, and logged to stderr |
+| Any OAuth refresh request | Not sent — the grant would rotate the token server-side even if the result were never written |
+
+The instance announces the mode once at startup. Reads are untouched: it
+re-reads credentials from disk, which is how a refresh performed by the other
+instance is picked up.
+
+The refusal sits at the credential store rather than only on the two timers,
+so a write path nobody anticipated fails loudly instead of silently corrupting
+a token file the other instance depends on. If you see
+`REFUSED credential write` in the log, a call path is missing a guard — the
+message names the operation and the store, never a credential value.
+
+**Limit — the SDK subprocess is outside this guarantee.** Meridian shells out
+to the Claude Agent SDK with `CLAUDE_CONFIG_DIR` pointing at the profile's
+directory. Anything that subprocess writes happens outside this process and
+cannot be intercepted by a flag in it.
+
+Measured on 2026-08-07 against a live proxy (Linux, Claude Code 2.1.198,
+`claude-haiku-4-5`), hashing one profile's `.credentials.json` before and after
+a single request routed to it:
+
+- A control window spanning two 45s refresh ticks left the file unchanged,
+  establishing a quiescent baseline.
+- After the request (HTTP 200, a genuine SDK round trip), the file was
+  **byte-identical** — same SHA-256, same mtime, same size.
+- The subprocess is demonstrably willing to write to that directory: the same
+  request updated `.claude.json`, `policy-limits.json`, `remote-settings.json`,
+  `backups/`, `jobs/` and `sessions/`. It simply did not touch
+  `.credentials.json`.
+
+So on the path that matters in practice — the access token still valid, the
+proxy having refreshed it earlier — the SDK does not write credentials back.
+
+**Not measured:** whether the SDK writes the file when it has to refresh an
+*expired* access token itself. Reproducing that requires either waiting out an
+~8h token lifetime or editing a live credential file, and in this deployment
+the proxy's own refresh (5-minute buffer) reaches it first. If the SDK does
+write on that path, this flag cannot prevent it. Treat the guarantee as
+covering everything Meridian does, not everything the subprocess might do.
 
 ### Subprocess traffic
 

--- a/src/__tests__/credentials-readonly.test.ts
+++ b/src/__tests__/credentials-readonly.test.ts
@@ -1,0 +1,332 @@
+/**
+ * MERIDIAN_CREDENTIALS_READONLY — a second instance running beside a
+ * production one against the SAME credential files must never be able to
+ * corrupt them.
+ *
+ * Every test injects its own credential store or a throwaway config dir.
+ * Nothing here may touch the developer's real ~/.claude credentials: the
+ * no-argument forms of refreshOAuthToken/ensureFreshToken/startBackgroundRefresh
+ * resolve the REAL platform store and would refresh live tokens, so they are
+ * never called without an explicit store.
+ *
+ * Credential values throughout are fabricated placeholders.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  isCredentialsReadOnly,
+  logCredentialsModeBanner,
+  resetCredentialsModeBanner,
+} from "../proxy/credentialsMode"
+import {
+  createPlatformCredentialStore,
+  ensureFreshToken,
+  isBackgroundRefreshActive,
+  refreshOAuthToken,
+  resetInflightRefresh,
+  startBackgroundRefresh,
+  stopBackgroundRefresh,
+  type CredentialStore,
+} from "../proxy/tokenRefresh"
+import { createFileDesignTokenStore } from "../proxy/design"
+
+const FLAG = "MERIDIAN_CREDENTIALS_READONLY"
+
+const FAKE_CREDENTIALS = {
+  claudeAiOauth: {
+    accessToken: "placeholder-access-token",
+    refreshToken: "placeholder-refresh-token",
+    expiresAt: Date.now() + 60 * 60 * 1000,
+  },
+}
+
+function tempDir(label: string): string {
+  return mkdtempSync(join(tmpdir(), `meridian-readonly-${label}-`))
+}
+
+/** Capture console.error/warn so the loud refusal can be asserted on. */
+function captureConsole() {
+  const originalError = console.error
+  const originalWarn = console.warn
+  const errors: string[] = []
+  const warns: string[] = []
+  console.error = (...args: unknown[]) => { errors.push(args.join(" ")) }
+  console.warn = (...args: unknown[]) => { warns.push(args.join(" ")) }
+  return {
+    errors,
+    warns,
+    restore() { console.error = originalError; console.warn = originalWarn },
+  }
+}
+
+describe("isCredentialsReadOnly", () => {
+  afterEach(() => {
+    delete process.env[FLAG]
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+  })
+
+  it("is off when the variable is unset", () => {
+    expect(isCredentialsReadOnly()).toBe(false)
+  })
+
+  it("is on for the documented truthy spellings", () => {
+    for (const value of ["1", "true", "yes"]) {
+      process.env[FLAG] = value
+      expect(isCredentialsReadOnly()).toBe(true)
+    }
+  })
+
+  it("is off for falsy and unrecognized values", () => {
+    for (const value of ["0", "false", "no", "", "maybe"]) {
+      process.env[FLAG] = value
+      expect(isCredentialsReadOnly()).toBe(false)
+    }
+  })
+
+  it("honours the legacy CLAUDE_PROXY_ alias like every other MERIDIAN_ var", () => {
+    process.env.CLAUDE_PROXY_CREDENTIALS_READONLY = "1"
+    expect(isCredentialsReadOnly()).toBe(true)
+  })
+})
+
+describe("credential store write refusal", () => {
+  let dir: string
+
+  beforeEach(() => { dir = tempDir("store") })
+
+  afterEach(() => {
+    delete process.env[FLAG]
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it("refuses the write, leaves the file untouched, and logs loudly", async () => {
+    const file = join(dir, ".credentials.json")
+    const onDisk = JSON.stringify(FAKE_CREDENTIALS)
+    writeFileSync(file, onDisk)
+
+    process.env[FLAG] = "1"
+    const store = createPlatformCredentialStore({ claudeConfigDir: dir })
+    const cap = captureConsole()
+    let written: boolean
+    try {
+      written = await store.write({
+        claudeAiOauth: { ...FAKE_CREDENTIALS.claudeAiOauth, accessToken: "replacement-token" },
+      })
+    } finally {
+      cap.restore()
+    }
+
+    expect(written).toBe(false)
+    expect(readFileSync(file, "utf-8")).toBe(onDisk)
+    expect(cap.errors.length).toBe(1)
+    expect(cap.errors[0]).toContain("REFUSED credential write")
+    expect(cap.errors[0]).toContain(FLAG)
+  })
+
+  it("never names a credential value in the refusal", async () => {
+    writeFileSync(join(dir, ".credentials.json"), JSON.stringify(FAKE_CREDENTIALS))
+    process.env[FLAG] = "1"
+    const store = createPlatformCredentialStore({ claudeConfigDir: dir })
+    const cap = captureConsole()
+    try {
+      await store.write(FAKE_CREDENTIALS)
+    } finally {
+      cap.restore()
+    }
+
+    const logged = cap.errors.join("\n")
+    expect(logged).not.toContain(FAKE_CREDENTIALS.claudeAiOauth.accessToken)
+    expect(logged).not.toContain(FAKE_CREDENTIALS.claudeAiOauth.refreshToken)
+  })
+
+  it("still reads — that is how a rotation by the other instance is picked up", async () => {
+    writeFileSync(join(dir, ".credentials.json"), JSON.stringify(FAKE_CREDENTIALS))
+    process.env[FLAG] = "1"
+    const store = createPlatformCredentialStore({ claudeConfigDir: dir })
+
+    const read = await store.read()
+    expect(read?.claudeAiOauth?.accessToken).toBe(FAKE_CREDENTIALS.claudeAiOauth.accessToken)
+  })
+
+  it("writes normally when the flag is absent", async () => {
+    const file = join(dir, ".credentials.json")
+    const store = createPlatformCredentialStore({ claudeConfigDir: dir })
+
+    expect(await store.write(FAKE_CREDENTIALS)).toBe(true)
+    expect(existsSync(file)).toBe(true)
+  })
+})
+
+describe("refresh initiation", () => {
+  let originalFetch: typeof globalThis.fetch
+  let fetchCalls: number
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    fetchCalls = 0
+    globalThis.fetch = ((..._args: unknown[]): Promise<Response> => {
+      fetchCalls++
+      throw new Error("no test may reach Anthropic's OAuth endpoint")
+    }) as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env[FLAG]
+    resetInflightRefresh()
+    stopBackgroundRefresh()
+  })
+
+  function expiredStore(): CredentialStore {
+    return {
+      refreshKey: "file:/nonexistent/test-store",
+      async read() {
+        return { claudeAiOauth: { ...FAKE_CREDENTIALS.claudeAiOauth, expiresAt: Date.now() - 1000 } }
+      },
+      async write() { return true },
+    }
+  }
+
+  it("refreshOAuthToken makes no network call at all", async () => {
+    process.env[FLAG] = "1"
+    const cap = captureConsole()
+    let result: boolean
+    try {
+      result = await refreshOAuthToken(expiredStore())
+    } finally {
+      cap.restore()
+    }
+
+    expect(result).toBe(false)
+    // The refusal must sit ABOVE the round trip: a refresh_token grant rotates
+    // the token server-side, so merely calling the endpoint could invalidate
+    // the copy the other instance is using.
+    expect(fetchCalls).toBe(0)
+    expect(cap.errors[0]).toContain("REFUSED credential write")
+  })
+
+  it("ensureFreshToken reports staleness instead of refreshing, and stays quiet", async () => {
+    process.env[FLAG] = "1"
+    const cap = captureConsole()
+    let result: boolean
+    try {
+      result = await ensureFreshToken(expiredStore())
+    } finally {
+      cap.restore()
+    }
+
+    expect(result).toBe(false)
+    expect(fetchCalls).toBe(0)
+    // Runs before every SDK request — must not log per request.
+    expect(cap.errors.length).toBe(0)
+  })
+
+  it("ensureFreshToken still confirms a token that is simply valid", async () => {
+    process.env[FLAG] = "1"
+    const store: CredentialStore = {
+      refreshKey: "file:/nonexistent/test-store",
+      async read() { return FAKE_CREDENTIALS },
+      async write() { return true },
+    }
+    expect(await ensureFreshToken(store)).toBe(true)
+    expect(fetchCalls).toBe(0)
+  })
+
+  it("startBackgroundRefresh does not arm the scheduler", () => {
+    process.env[FLAG] = "1"
+    startBackgroundRefresh(expiredStore())
+    expect(isBackgroundRefreshActive()).toBe(false)
+  })
+
+  it("startBackgroundRefresh arms normally when the flag is absent", () => {
+    const store: CredentialStore = {
+      refreshKey: "file:/nonexistent/test-store",
+      async read() { return FAKE_CREDENTIALS },
+      async write() { return true },
+    }
+    startBackgroundRefresh(store)
+    expect(isBackgroundRefreshActive()).toBe(true)
+    stopBackgroundRefresh()
+    expect(isBackgroundRefreshActive()).toBe(false)
+  })
+})
+
+describe("design token store", () => {
+  let dir: string
+
+  beforeEach(() => { dir = tempDir("design") })
+
+  afterEach(() => {
+    delete process.env[FLAG]
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  // defaultDesignTokenPath() ignores MERIDIAN_CONFIG_DIR, so a second instance
+  // writes the FIRST instance's design token however its config dir is set.
+  it("refuses the write and leaves no file behind", async () => {
+    const file = join(dir, "design-token.json")
+    process.env[FLAG] = "1"
+    const store = createFileDesignTokenStore(file)
+
+    const cap = captureConsole()
+    try {
+      await store.write({ accessToken: "placeholder-design-token", expiresAt: Date.now() + 3600_000 })
+    } finally {
+      cap.restore()
+    }
+
+    expect(existsSync(file)).toBe(false)
+    expect(cap.errors[0]).toContain("REFUSED credential write")
+  })
+
+  it("writes normally when the flag is absent", async () => {
+    const file = join(dir, "design-token.json")
+    const store = createFileDesignTokenStore(file)
+    await store.write({ accessToken: "placeholder-design-token", expiresAt: Date.now() + 3600_000 })
+    expect(existsSync(file)).toBe(true)
+  })
+})
+
+describe("startup banner", () => {
+  afterEach(() => {
+    delete process.env[FLAG]
+    resetCredentialsModeBanner()
+  })
+
+  it("announces the mode once", () => {
+    process.env[FLAG] = "1"
+    resetCredentialsModeBanner()
+    const cap = captureConsole()
+    try {
+      logCredentialsModeBanner()
+      logCredentialsModeBanner()
+    } finally {
+      cap.restore()
+    }
+
+    expect(cap.warns.length).toBe(1)
+    expect(cap.warns[0]).toContain("CREDENTIALS READ-ONLY MODE")
+    expect(cap.warns[0]).toContain(FLAG)
+  })
+
+  it("says nothing when the flag is absent", () => {
+    resetCredentialsModeBanner()
+    const cap = captureConsole()
+    try {
+      logCredentialsModeBanner()
+    } finally {
+      cap.restore()
+    }
+    expect(cap.warns.length).toBe(0)
+  })
+})
+
+// The fourth gated behaviour — auth-status cache invalidation on credential
+// mtime — is tested in models-auth-status.test.ts, which runs as its own
+// `bun test` invocation. It has to: four files in the main run replace
+// ../proxy/models via the globally-scoped mock.module, so the real cache is
+// only observable in an isolated invocation.

--- a/src/__tests__/models-auth-status.test.ts
+++ b/src/__tests__/models-auth-status.test.ts
@@ -19,7 +19,10 @@
  *     gives isolation without any shared-singleton race — which is what drove
  *     the reimplementation in the first place.
  */
-import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test"
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun:test"
+import { mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 /** Controls what the mocked `claude auth status` does on the next call. */
 let authBehavior: "success" | "fail" = "success"
@@ -181,5 +184,84 @@ describe("getClaudeAuthStatusAsync — real implementation", () => {
       lastSuccessAt: 0,
       isFailure: false,
     })
+  })
+})
+
+/**
+ * Credential-file mtime invalidation under MERIDIAN_CREDENTIALS_READONLY.
+ *
+ * A read-only instance never refreshes its own tokens, so the only thing that
+ * ever changes its auth status is a rotation performed by the instance that
+ * owns them. Time-based expiry alone would keep serving the pre-rotation
+ * answer for up to a full TTL after one lands.
+ *
+ * Lives here rather than in credentials-readonly.test.ts because it asserts on
+ * the real auth-status cache: four files in the main `bun test` run call
+ * `mock.module("../proxy/models", …)`, which is global, so those assertions
+ * only hold in this file's own isolated invocation.
+ */
+describe("auth-status cache — credential mtime invalidation", () => {
+  let dir: string
+  let credFile: string
+
+  beforeEach(() => {
+    authBehavior = "success"
+    execFileCalls = 0
+    resetCachedClaudeAuthStatus()
+    dir = mkdtempSync(join(tmpdir(), "meridian-readonly-mtime-"))
+    credFile = join(dir, ".credentials.json")
+    // Fabricated placeholder — only the file's mtime matters here.
+    writeFileSync(credFile, JSON.stringify({ claudeAiOauth: { accessToken: "placeholder" } }))
+  })
+
+  afterEach(() => {
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  /** Push mtime forward a whole second so the change is unambiguous. */
+  function ageCredentialFile(): void {
+    const next = new Date(statSync(credFile).mtimeMs + 1000)
+    utimesSync(credFile, next, next)
+  }
+
+  it("re-reads when the other instance rotates the credential file", async () => {
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    const p = nextProfile()
+    const overrides = { CLAUDE_CONFIG_DIR: dir }
+
+    await getClaudeAuthStatusAsync(p, overrides)
+    expect(execFileCalls).toBe(1)
+
+    await getClaudeAuthStatusAsync(p, overrides)
+    expect(execFileCalls).toBe(1)
+
+    ageCredentialFile()
+    await getClaudeAuthStatusAsync(p, overrides)
+    expect(execFileCalls).toBe(2)
+  })
+
+  it("picks up the rotated payload rather than the cached one", async () => {
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    const p = nextProfile()
+    const overrides = { CLAUDE_CONFIG_DIR: dir }
+
+    await getClaudeAuthStatusAsync(p, overrides)
+    currentPayload = { loggedIn: true, email: "rotated@test.com", subscriptionType: "max" }
+
+    ageCredentialFile()
+    expect(await getClaudeAuthStatusAsync(p, overrides)).toEqual(currentPayload)
+  })
+
+  it("leaves the time-based cache untouched when the flag is absent", async () => {
+    const p = nextProfile()
+    const overrides = { CLAUDE_CONFIG_DIR: dir }
+
+    await getClaudeAuthStatusAsync(p, overrides)
+    expect(execFileCalls).toBe(1)
+
+    ageCredentialFile()
+    await getClaudeAuthStatusAsync(p, overrides)
+    expect(execFileCalls).toBe(1)
   })
 })

--- a/src/proxy/credentialsMode.ts
+++ b/src/proxy/credentialsMode.ts
@@ -1,0 +1,104 @@
+/**
+ * Read-only credential mode — `MERIDIAN_CREDENTIALS_READONLY`.
+ *
+ * Lets a second Meridian instance run beside a production one against the
+ * SAME credential files without being able to corrupt them. When set, the
+ * instance never initiates a token refresh and never writes a credential; it
+ * re-reads credentials from disk so refreshes performed by the OTHER instance
+ * are picked up.
+ *
+ * The hazard this exists for: two instances holding the same OAuth refresh
+ * token. Meridian refreshes proactively on boot and on a 45s cadence. If
+ * Anthropic rotates the refresh token on use, whichever instance refreshes
+ * first invalidates the other's copy, and recovery is an interactive
+ * `claude login` per account.
+ *
+ * Sharing is not a choice the operator makes, which is why this is the only
+ * defence rather than one layer of several. `MERIDIAN_CONFIG_DIR` relocates
+ * `settings.json` and nothing else: `profiles.json` is a module-level constant
+ * in `profiles.ts`, so every instance on a machine reads the same profile
+ * list, pointing at the same `claudeConfigDir` credential directories. There
+ * is no supported way to give a second instance a different profile set, so
+ * any second instance holds the first one's real accounts from the moment it
+ * boots. This flag is what stops it writing to them.
+ *
+ * Env var rather than a settings key on purpose: settings are editable from
+ * the web UI, and switching this on for the production instance by accident
+ * would silently stop it refreshing its own tokens. The systemd unit is
+ * already where the two instances differ.
+ *
+ * Leaf module — no imports from server.ts or session/.
+ */
+
+import { envBool } from "../env"
+
+/**
+ * Whether this instance is forbidden from refreshing or writing credentials.
+ *
+ * Resolved per call rather than frozen at import time, matching
+ * `settings.ts`'s treatment of MERIDIAN_CONFIG_DIR: module-level credential
+ * stores are constructed at import, so a value captured then would be fixed
+ * before any test (or embedding host) could set it.
+ */
+export function isCredentialsReadOnly(): boolean {
+  return envBool("CREDENTIALS_READONLY")
+}
+
+/**
+ * Report a refused credential write, loudly, and return false so the caller
+ * takes its existing write-failed path.
+ *
+ * Deliberately `console.error` and not `claudeLog`: the latter is gated behind
+ * OPENCODE_CLAUDE_PROVIDER_DEBUG, so in a normal deployment it prints nothing.
+ *
+ * Why failing LOUDLY beats failing safe here: this refusal is the backstop for
+ * a write path nobody thought of. Silently swallowing it would leave an
+ * operator believing the guarantee held while some future call site quietly
+ * did nothing — and the failure it is protecting against (a corrupted token
+ * file that a production instance depends on, costing an interactive
+ * `claude login` across every account, including borrowed ones) is expensive
+ * and manual to recover from. A noisy log that turns out to be benign costs a
+ * grep; a silent one costs the fleet. If this line ever appears, the correct
+ * response is to find the call site and gate it upstream of the store.
+ *
+ * @param operation  short label for the call site (e.g. "oauth-refresh")
+ * @param target     store identity — a path or keychain service, NEVER a value
+ */
+export function refuseCredentialWrite(operation: string, target: string): false {
+  console.error(
+    `[PROXY] REFUSED credential write (${operation} → ${target}): ` +
+    `MERIDIAN_CREDENTIALS_READONLY is set, so this instance must not modify credentials. ` +
+    `If this is unexpected, the calling code path is missing a read-only guard.`
+  )
+  return false
+}
+
+/** Startup banner state — the mode is announced once per process. */
+let bannerLogged = false
+
+/**
+ * Announce the mode once at startup, unmistakably.
+ *
+ * An instance silently in read-only mode when you thought it was normal is a
+ * confusing bug — tokens quietly stop being refreshed. An instance loudly in
+ * it is self-documenting.
+ *
+ * Not gated on `silent`, unlike the rest of the startup output: MERIDIAN_SILENT
+ * suppresses routine chatter, and this is not routine — it is a non-default
+ * operating mode that changes what the process is allowed to do. One line,
+ * once, and only when the flag is actually set.
+ */
+export function logCredentialsModeBanner(): void {
+  if (bannerLogged || !isCredentialsReadOnly()) return
+  bannerLogged = true
+  console.warn(
+    `[PROXY] CREDENTIALS READ-ONLY MODE (MERIDIAN_CREDENTIALS_READONLY): ` +
+    `this instance will not refresh or write OAuth credentials. ` +
+    `Token rotation is another instance's job; credentials are re-read from disk.`
+  )
+}
+
+/** Reset the once-per-process banner — for testing only. */
+export function resetCredentialsModeBanner(): void {
+  bannerLogged = false
+}

--- a/src/proxy/design.ts
+++ b/src/proxy/design.ts
@@ -17,6 +17,7 @@ import { homedir } from "node:os"
 import { join, dirname } from "node:path"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import type { CredentialStore } from "./tokenRefresh"
+import { isCredentialsReadOnly, refuseCredentialWrite } from "./credentialsMode"
 import {
   createManualOAuthSession,
   parseAuthorizationCodeInput,
@@ -65,6 +66,16 @@ export function createFileDesignTokenStore(path: string = defaultDesignTokenPath
       }
     },
     async write(data) {
+      // Second credential store, guarded for the same reason as the OAuth one
+      // — and a live example of the call site nobody thought of.
+      // `defaultDesignTokenPath()` does NOT honour MERIDIAN_CONFIG_DIR, so a
+      // second instance writes the FIRST instance's design token no matter
+      // how its config dir is set, and this token carries a refresh token that
+      // rotates on use (see getDesignAccessToken).
+      if (isCredentialsReadOnly()) {
+        refuseCredentialWrite("design-token-store", path)
+        return
+      }
       await mkdir(dirname(path), { recursive: true })
       await writeFile(path, JSON.stringify(data), { mode: 0o600 })
     },
@@ -92,6 +103,15 @@ export async function getDesignAccessToken(opts: {
   if (!data) return null
   if (isDesignTokenFresh(data, now)) return data.accessToken
   if (!data.refreshToken) return null
+
+  // Same hazard as the OAuth refresh: the grant below rotates the token
+  // server-side, so making the call at all can invalidate the copy the other
+  // instance is using. Null is this function's existing refresh-failed
+  // contract — callers fall back to profile credentials.
+  if (isCredentialsReadOnly()) {
+    refuseCredentialWrite("design-token-refresh", "design-token")
+    return null
+  }
 
   let response: Response
   try {

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from "url"
 import { join, dirname } from "path"
 import { promisify } from "util"
 import { env } from "../env"
+import { isCredentialsReadOnly } from "./credentialsMode"
+import { credentialsFilePathForProfile } from "./tokenRefresh"
 
 const exec = promisify(execCallback)
 const execFile = promisify(execFileCallback)
@@ -104,6 +106,36 @@ let lastKnownGoodAuthStatus: ClaudeAuthStatus | null = null
 let cachedAuthStatusAt = 0
 let cachedAuthStatusIsFailure = false
 let cachedAuthStatusPromise: Promise<ClaudeAuthStatus | null> | null = null
+let cachedAuthStatusCredMtimeMs = 0
+
+/**
+ * Credential-file mtime used to invalidate the auth-status cache, or 0 when
+ * that invalidation does not apply.
+ *
+ * Only consulted under MERIDIAN_CREDENTIALS_READONLY. A read-only instance
+ * never refreshes its own tokens, so a rotation performed by the instance that
+ * DOES own them is the only thing that ever changes this answer — and with
+ * time-based expiry alone the cache would keep serving the pre-rotation status
+ * for up to a full TTL after one lands. Comparing mtime picks it up on the
+ * next tick instead.
+ *
+ * With the flag unset this returns 0 unconditionally, so every comparison is
+ * equal and production keeps exactly the time-based path it has today — no
+ * behaviour change and no extra stat() per call.
+ *
+ * 0 doubles as "unknown": no credential file, or macOS, where credentials live
+ * in the Keychain and have no mtime. Unknown compares equal to unknown, so
+ * those setups degrade to the time-based TTL rather than invalidating on every
+ * call.
+ */
+function credentialFileMtimeMs(envOverrides?: Record<string, string>): number {
+  if (!isCredentialsReadOnly()) return 0
+  try {
+    return statSync(credentialsFilePathForProfile(envOverrides?.CLAUDE_CONFIG_DIR)).mtimeMs
+  } catch {
+    return 0
+  }
+}
 
 /** Env var names already warned about for an unrecognized per-tier 1M
  *  opt-out value (#702) — ensures the warning fires at most once per
@@ -317,6 +349,7 @@ interface AuthCache {
   isFailure: boolean
   promise: Promise<ClaudeAuthStatus | null> | null
   lastSuccessAt: number
+  credMtimeMs: number
 }
 const profileAuthCaches = new Map<string, AuthCache>()
 
@@ -334,7 +367,7 @@ export function getAuthCacheInfo(profileId?: string): { lastCheckedAt: number; l
 function getAuthCache(key: string): AuthCache {
   let cache = profileAuthCaches.get(key)
   if (!cache) {
-    cache = { status: null, lastKnownGood: null, at: 0, isFailure: false, promise: null, lastSuccessAt: 0 }
+    cache = { status: null, lastKnownGood: null, at: 0, isFailure: false, promise: null, lastSuccessAt: 0, credMtimeMs: 0 }
     profileAuthCaches.set(key, cache)
   }
   return cache
@@ -358,8 +391,14 @@ export async function getClaudeAuthStatusAsync(profileId?: string, envOverrides?
   const c_isFailure = cache ? cache.isFailure : cachedAuthStatusIsFailure
   let c_promise = cache ? cache.promise : cachedAuthStatusPromise
 
+  const c_credMtime = cache ? cache.credMtimeMs : cachedAuthStatusCredMtimeMs
+
   const ttl = c_isFailure ? AUTH_STATUS_FAILURE_TTL_MS : AUTH_STATUS_CACHE_TTL_MS
-  if (c_at > 0 && Date.now() - c_at < ttl) {
+  // A changed credential file means the other instance rotated the token, so
+  // the cached answer predates it regardless of how recently it was taken.
+  // Always 0 === 0 unless MERIDIAN_CREDENTIALS_READONLY is set.
+  const credMtime = credentialFileMtimeMs(envOverrides)
+  if (c_at > 0 && Date.now() - c_at < ttl && credMtime === c_credMtime) {
     return c_status ?? c_lastKnownGood
   }
   if (c_promise) return c_promise
@@ -384,18 +423,22 @@ export async function getClaudeAuthStatusAsync(profileId?: string, envOverrides?
       if (cache) {
         cache.status = parsed; cache.lastKnownGood = parsed
         cache.at = Date.now(); cache.isFailure = false; cache.lastSuccessAt = Date.now()
+        cache.credMtimeMs = credMtime
       } else {
         cachedAuthStatus = parsed; lastKnownGoodAuthStatus = parsed
         cachedAuthStatusAt = Date.now(); cachedAuthStatusIsFailure = false
+        cachedAuthStatusCredMtimeMs = credMtime
       }
       return parsed
     } catch {
       if (cache) {
         cache.isFailure = true; cache.at = Date.now(); cache.status = null
+        cache.credMtimeMs = credMtime
         return cache.lastKnownGood
       } else {
         cachedAuthStatusIsFailure = true; cachedAuthStatusAt = Date.now()
         cachedAuthStatus = null
+        cachedAuthStatusCredMtimeMs = credMtime
         return lastKnownGoodAuthStatus
       }
     }
@@ -697,6 +740,7 @@ export function resetCachedClaudeAuthStatus(): void {
   cachedAuthStatusAt = 0
   cachedAuthStatusIsFailure = false
   cachedAuthStatusPromise = null
+  cachedAuthStatusCredMtimeMs = 0
   profileAuthCaches.clear()
 }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -54,6 +54,7 @@ import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, rend
 import type { RequestMetric } from "../telemetry"
 import { canRecoverCapturedToolUses, classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
+import { isCredentialsReadOnly, logCredentialsModeBanner } from "./credentialsMode"
 import {
   createFileDesignTokenStore,
   createDesignLogin,
@@ -5575,6 +5576,7 @@ export function installProxyProcessErrorHandlers(): void {
 }
 
 export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promise<ProxyInstance> {
+  logCredentialsModeBanner()
   claudeExecutable = await resolveClaudeExecutableAsync()
   const { app, config: finalConfig, initPlugins, beginDrain, getInFlightCount } = createProxyServer(config)
   if (initPlugins) await initPlugins()
@@ -5633,18 +5635,32 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
   // watches the default Claude credential store. Multi-profile credentials
   // live under each profile's CLAUDE_CONFIG_DIR, so poll the discovered
   // profile list and refresh any browser-login profile that is near expiry.
+  //
+  // Both timers below are skipped under MERIDIAN_CREDENTIALS_READONLY. The
+  // refresh one obviously so. The keepalive is less obvious but no less
+  // important: it shells out to `claude auth status`, which runs the Claude
+  // CLI against the profile's CLAUDE_CONFIG_DIR and so is the CLI's own
+  // opportunity to rotate and rewrite the credential file — a write this
+  // process cannot intercept, because it happens in a subprocess. Not arming
+  // the timer is the only way to prevent it. (startBackgroundRefresh above
+  // self-gates; see its own guard.)
+  const credentialsReadOnly = isCredentialsReadOnly()
+
   const PROFILE_TOKEN_REFRESH_MS = 45_000
-  void ensureFreshTokenForProfiles(finalConfig)
-  const profileTokenRefreshInterval = setInterval(() => {
+  let profileTokenRefreshInterval: ReturnType<typeof setInterval> | undefined
+  if (!credentialsReadOnly) {
     void ensureFreshTokenForProfiles(finalConfig)
-  }, PROFILE_TOKEN_REFRESH_MS)
-  if (profileTokenRefreshInterval.unref) profileTokenRefreshInterval.unref()
+    profileTokenRefreshInterval = setInterval(() => {
+      void ensureFreshTokenForProfiles(finalConfig)
+    }, PROFILE_TOKEN_REFRESH_MS)
+    if (profileTokenRefreshInterval.unref) profileTokenRefreshInterval.unref()
+  }
 
   // Background auth keepalive: periodically refresh auth status for all
   // configured profiles so switching is instant (no stale token delay).
   let authKeepaliveInterval: ReturnType<typeof setInterval> | undefined
   const effectiveProfiles = getEffectiveProfiles(finalConfig.profiles)
-  if (effectiveProfiles.length > 0) {
+  if (!credentialsReadOnly && effectiveProfiles.length > 0) {
     const AUTH_KEEPALIVE_MS = 45_000 // 45s — well within the 60s TTL
     authKeepaliveInterval = setInterval(async () => {
       // Re-read effective profiles on each tick (picks up new profiles from disk)
@@ -5668,7 +5684,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     config: finalConfig,
     close() {
       closePromise ??= (async () => {
-        clearInterval(profileTokenRefreshInterval)
+        if (profileTokenRefreshInterval) clearInterval(profileTokenRefreshInterval)
         if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
         stopBackgroundRefresh()
 

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -21,6 +21,7 @@ import { homedir, platform, userInfo } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { claudeLog } from "../logger"
+import { isCredentialsReadOnly, refuseCredentialWrite } from "./credentialsMode"
 
 const execFile = promisify(execFileCb)
 
@@ -87,6 +88,35 @@ export interface CredentialStore {
 }
 
 /**
+ * Wrap a store so that, under MERIDIAN_CREDENTIALS_READONLY, `write()` refuses
+ * and logs instead of touching the backend. Reads are untouched — re-reading
+ * is how this instance picks up a rotation performed by the other one.
+ *
+ * Applied inside the two builders rather than at `createPlatformCredentialStore`
+ * so that EVERY store this module can hand out is guarded, including the
+ * module-level singletons and any backend added later. That is the point of
+ * putting the refusal at the store seam: a caller nobody anticipated (a new
+ * route, a CLI command, a plugin reaching through an exported store) fails
+ * loudly here rather than silently corrupting a token file that a production
+ * instance depends on.
+ *
+ * Returning false rather than throwing keeps every existing caller on the
+ * write-failed path it already handles (`doRefresh` returns false, the CLI
+ * prints its failure, callers fall back to the token on disk).
+ */
+function guardCredentialWrites(store: CredentialStore): CredentialStore {
+  return {
+    ...store,
+    async write(credentials) {
+      if (isCredentialsReadOnly()) {
+        return refuseCredentialWrite("credential-store", store.refreshKey ?? "unknown-store")
+      }
+      return store.write(credentials)
+    },
+  }
+}
+
+/**
  * Serialize a credentials object to the on-disk / Keychain format Claude Code
  * expects.
  *
@@ -128,7 +158,7 @@ function parseKeychainValue(raw: string): { credentials: CredentialsFile; wasHex
 const keychainWasHexByService = new Map<string, boolean>()
 
 function buildMacosStore(serviceName: string): CredentialStore {
-  return {
+  return guardCredentialWrites({
     refreshKey: `keychain:${serviceName}`,
 
     async read() {
@@ -165,7 +195,7 @@ function buildMacosStore(serviceName: string): CredentialStore {
         return false
       }
     },
-  }
+  })
 }
 
 const macosStore: CredentialStore = buildMacosStore(KEYCHAIN_SERVICE)
@@ -176,7 +206,7 @@ const macosStore: CredentialStore = buildMacosStore(KEYCHAIN_SERVICE)
 
 function buildFileStore(filePath: string): CredentialStore {
   const absPath = resolve(filePath)
-  return {
+  return guardCredentialWrites({
     refreshKey: `file:${absPath}`,
 
     async read() {
@@ -200,7 +230,7 @@ function buildFileStore(filePath: string): CredentialStore {
         return false
       }
     },
-  }
+  })
 }
 
 
@@ -250,6 +280,19 @@ const inflightRefreshByStore = new WeakMap<CredentialStore, Promise<boolean>>()
  */
 export async function refreshOAuthToken(store?: CredentialStore): Promise<boolean> {
   const s = store ?? createPlatformCredentialStore()
+
+  // Refusing the WRITE is not sufficient, and stopping here is not merely an
+  // optimisation. A refresh_token grant rotates the token server-side: the
+  // moment this instance calls the endpoint, the refresh token on disk can
+  // stop working — and having refused to persist the replacement, we would
+  // have invalidated the other instance's credentials AND thrown away the
+  // only thing that could have repaired them. Not making the call is the
+  // only safe behaviour, so the refusal has to sit above the network round
+  // trip rather than at the store.
+  if (isCredentialsReadOnly()) {
+    return refuseCredentialWrite("oauth-refresh", s.refreshKey ?? "unknown-store")
+  }
+
   const refreshKey = s.refreshKey
   if (refreshKey) {
     const inflight = inflightRefreshByKey.get(refreshKey)
@@ -386,6 +429,13 @@ export async function ensureFreshToken(
   const expiresAt = credentials?.claudeAiOauth?.expiresAt
   if (!expiresAt) return false
   if (expiresAt - Date.now() > bufferMs) return true
+  // Read-only instances report the token as they found it instead of routing
+  // into a refusal. This runs before every SDK request, so the refusal log
+  // would repeat per request for the whole buffer window; the refusal belongs
+  // on deliberate refresh attempts. False is already the documented non-fatal
+  // result — the caller proceeds with the on-disk token, which the instance
+  // that OWNS the refresh keeps current.
+  if (isCredentialsReadOnly()) return false
   return refreshOAuthToken(s)
 }
 
@@ -561,6 +611,11 @@ export function startBackgroundRefresh(
   bufferMs = 5 * 60 * 1000,
   failureRetryMs = 5 * 60 * 1000,
 ): void {
+  // Refreshing on a timer regardless of traffic is precisely what a read-only
+  // instance must never do. Never arming the scheduler — rather than arming it
+  // and refusing on each tick — keeps isBackgroundRefreshActive() an honest
+  // answer to "is this process refreshing tokens?".
+  if (isCredentialsReadOnly()) return
   if (scheduledRefreshActive) return
   scheduledRefreshActive = true
   const gen = ++scheduledRefreshGeneration


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Nowaker is still iterating on this. It is opened early so the diff is visible;
it will be marked ready when it is actually ready.

---

`MERIDIAN_CREDENTIALS_READONLY=1` lets a **development** instance run beside a
production one, against the same credential files, without being able to
corrupt them.

### The hazard

Two Meridian processes holding the same OAuth refresh token. Refresh happens
proactively on boot and every 45s, and a `refresh_token` grant rotates the
token server-side - so whichever process refreshes first can invalidate the
other's copy. Recovery is an interactive `claude login` per account.

**Sharing the credential files is not opt-in.** `MERIDIAN_CONFIG_DIR`
relocates `settings.json` only; `profiles.json` is a module-level constant in
`profiles.ts`, so every instance on a machine reads the same profile list
pointing at the same `claudeConfigDir` directories. Any second instance
therefore holds the first one's real accounts from the moment it boots. This
flag is what stops it writing to them.

*(A separate change making `MERIDIAN_CONFIG_DIR` relocate the whole directory
is in progress and will be its own PR. It reduces the blast radius but does
not remove the need for this: a dev instance that deliberately shares
credentials is exactly the case this exists for.)*

### What the flag does

- The background refresh scheduler is **never armed** - never-arm rather than
  arm-and-refuse, so `isBackgroundRefreshActive()` stays an honest answer.
- The profile refresh loop and the auth keepalive are not scheduled. The
  keepalive matters despite looking read-only: it shells out to
  `claude auth status` against the profile's `CLAUDE_CONFIG_DIR`, which is the
  CLI's own opportunity to rotate and rewrite the credential file, in a
  subprocess this process cannot intercept.
- `refreshOAuthToken` and `ensureFreshToken` return before the network call.
  Refusing only the *write* is insufficient: the grant rotates the token
  server-side, so calling the endpoint and then declining to persist the
  replacement would invalidate the other instance's credentials **and** discard
  the only thing that could repair them.
- Every credential write is refused **at the store seam** and logged to stderr.
  The guard wraps both builders in `tokenRefresh.ts` and the design token
  store, so a call site nobody anticipated fails loudly rather than silently
  corrupting a token file the other instance depends on. The log names the
  operation and the store, never a value.
- The auth-status cache is additionally invalidated when the credential file's
  mtime changes, so a rotation performed by the *owning* instance is picked up
  on the next tick instead of up to a TTL later.
- The mode is announced once at startup.

`design.ts` is included because `defaultDesignTokenPath()` ignores
`MERIDIAN_CONFIG_DIR` entirely: a second instance writes the first's design
token no matter how its config dir is set, and that token carries a refresh
token that rotates on use. It is the concrete example of why the refusal
belongs at the store rather than on the timers.

**With the flag absent, behaviour is unchanged.** The mtime helper returns 0
without `stat()`ing, so every comparison is equal and the cache keeps exactly
its current time-based path.

### Measured, not assumed

Whether the Claude Agent SDK subprocess writes a rotated token back is outside
any guarantee this flag can make, so it was tested rather than reasoned about.

On 2026-08-07, against a live proxy (Linux, Claude Code 2.1.198,
`claude-haiku-4-5`), hashing one profile's `.credentials.json` around a single
request routed to it:

| | result |
|---|---|
| control window spanning two 45s ticks | file unchanged |
| after a real request (HTTP 200, genuine SDK round trip) | byte-identical - same SHA-256, mtime and size |

The subprocess is demonstrably willing to write that directory - the same
request updated `.claude.json`, `policy-limits.json`, `remote-settings.json`,
`backups/`, `jobs/` and `sessions/` - it simply did not touch
`.credentials.json`.

**Not measured:** whether it writes when refreshing an expired access token
itself, which needs either an ~8h wait or edits to a live credential file, and
which the proxy's own 5-minute refresh buffer reaches first in this
deployment. Documented as a stated limit in `docs/configuration.md` rather
than papered over.

### Tests

The flag skips both timers, the store refuses a direct write and logs, the
OAuth request is never sent, and the mtime change re-reads.

The mtime tests live in `models-auth-status.test.ts` because four files in the
main run call `mock.module("../proxy/models")`, which is global; that file
already runs as its own isolated invocation for the same reason.

```
bun test src/__tests__/credentials-readonly.test.ts   17 pass, 0 fail
bun test src/__tests__/models-auth-status.test.ts     15 pass, 0 fail
bun run test                                          full chain, 0 fail
tsc --noEmit                                          exit 0
```

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
