### PR TITLE
feat(cli): print the dashboard when the port is already serving Meridian

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,7 @@ src/
 │   ├── sessionStore.ts        ← Shared file store (cross-proxy session resume)
 │   ├── profiles.ts            ← Multi-profile support: resolve, list, switch auth contexts (leaf)
 │   ├── profileCli.ts          ← CLI commands for profile management (leaf, I/O)
+│   ├── statusProbe.ts         ← Asks a busy port whether it is Meridian, and collects what / shows
 │   ├── agentDefs.ts           ← Subagent definition extraction from tool descriptions
 │   ├── agentMatch.ts          ← Fuzzy agent name matching
 │   ├── design.ts              ← Claude Design MCP proxy (token store/refresh, auth precedence, login flow)
@@ -74,6 +75,7 @@ src/
 │   ├── pricingStore.ts        ← User pricing overrides (persisted JSON)
 │   ├── profileBar.ts          ← Shared profile switcher bar (injected into HTML pages)
 │   ├── profilePage.ts         ← Profile management page HTML
+│   ├── cliDashboard.ts        ← The landing page rendered for a terminal (pure)
 │   └── types.ts               ← Telemetry types
 └── plugin/
     └── claude-max-headers.ts  ← OpenCode plugin for session header injection

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -25,6 +25,7 @@ Usage: meridian [command] [options]
 
 Commands:
   (default)        Start the proxy server
+  status           Show what a running instance is doing (the / page, in the terminal)
   setup            Configure the OpenCode plugin (run once after install)
   profile          Manage Claude account profiles (add, list, switch, remove)
   refresh-token    Refresh the Claude Code OAuth token
@@ -128,6 +129,32 @@ const idleTimeoutSeconds = parseInt(process.env.MERIDIAN_IDLE_TIMEOUT_SECONDS ??
 const pluginDir = process.env.MERIDIAN_PLUGIN_DIR
 const pluginConfigPath = process.env.MERIDIAN_PLUGIN_CONFIG
 
+/**
+ * Print the dashboard for the instance on `host:port`, if that is what is
+ * there. Returns the probe result so each caller can decide what a
+ * non-Meridian answer means — a bad `status` invocation, or a genuine
+ * port conflict.
+ */
+async function printRunningInstance() {
+  const { probeMeridian } = await import("../src/proxy/statusProbe")
+  const result = await probeMeridian(host, port, { apiKey: process.env.MERIDIAN_API_KEY })
+  if (result.kind === "meridian") {
+    const { renderCliDashboard } = await import("../src/telemetry/cliDashboard")
+    process.stdout.write(
+      renderCliDashboard({ host, port, ...result.snapshot }, { color: process.stdout.isTTY === true }),
+    )
+  }
+  return result
+}
+
+if (args[0] === "status") {
+  const result = await printRunningInstance()
+  if (result.kind === "meridian") process.exit(0)
+  const { formatStatusMessage } = await import("../src/proxy/statusProbe")
+  console.error(formatStatusMessage(result, host, port))
+  process.exit(1)
+}
+
 // Load profile configuration:
 //   1. MERIDIAN_PROFILES env var (JSON array) — takes precedence
 //   2. ~/.config/meridian/profiles.json — written by `meridian profile add`
@@ -215,5 +242,19 @@ export async function runCli(
 }
 
 if (import.meta.main) {
+  // Ask before starting, because the answer changes what "port in use" means.
+  // The port that Meridian wants is usually held by Meridian, and being told
+  // so is not an error — it is the question `meridian status` answers, asked
+  // by accident. Checking here rather than from the EADDRINUSE handler keeps
+  // the dashboard as the whole output: by the time a bind fails, the
+  // pre-flight auth check and the plugin loader have already printed.
+  const { isPortAvailable } = await import("../src/proxy/statusProbe")
+  if (!(await isPortAvailable(host, port))) {
+    const result = await printRunningInstance()
+    if (result.kind === "meridian") process.exit(0)
+    const { formatConflictMessage } = await import("../src/proxy/statusProbe")
+    console.error(formatConflictMessage(result, host, port))
+    process.exit(1)
+  }
   await runCli()
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,7 +142,8 @@ ANTHROPIC_API_KEY=your-secret-key ANTHROPIC_BASE_URL=http://meridian-host:3456 o
 
 | Command | Description |
 |---------|-------------|
-| `meridian` | Start the proxy server |
+| `meridian` | Start the proxy server. When the port is already serving Meridian, prints `meridian status` and exits 0 instead of failing |
+| `meridian status` | Print what the running instance is doing — the `/` page rendered for a terminal. Reads `MERIDIAN_HOST`/`MERIDIAN_PORT`; exits 1 when nothing of ours is there |
 | `meridian setup` | Configure the OpenCode plugin in `~/.config/opencode/opencode.json` |
 | `meridian profile add <name> [--headless]` | Add a profile and authenticate via Claude OAuth; `--headless` prints a URL, prompts for the returned code, and stores the exchanged credentials |
 | `meridian profile add <name> --oauth-token [TOKEN]` | Add a headless profile from a `claude setup-token` value (prompts when `TOKEN` is omitted) |

--- a/src/__tests__/cli-dashboard.test.ts
+++ b/src/__tests__/cli-dashboard.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for cliDashboard.ts — a pure renderer, so no server and no mocks.
+ *
+ * The fixtures are the response shapes of the four routes the landing page
+ * fetches (/health, /profiles/list, /v1/usage/quota/all, /telemetry/summary),
+ * with invented account ids: an upstream fixture must not carry real
+ * addresses, and the renderer cannot tell the difference.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  renderCliDashboard,
+  type CliDashboardInput,
+  type ProfileListPayload,
+  type QuotaPayload,
+  type SummaryPayload,
+} from "../telemetry/cliDashboard"
+
+const NOW = 1_754_600_000_000
+const HOUR = 3_600_000
+const DAY = 86_400_000
+
+const health = {
+  status: "healthy",
+  auth: { loggedIn: true, email: "someone@example.com", subscriptionType: "max" },
+  mode: "internal",
+}
+
+const profileList: ProfileListPayload = {
+  profiles: [
+    { id: "primary", type: "claude-max", isActive: true },
+    { id: "weekend", type: "claude-max", isActive: false },
+    { id: "borrowed", type: "claude-max", isActive: false },
+  ],
+  routing: "sticky",
+}
+
+const quota: QuotaPayload = {
+  profiles: [
+    {
+      id: "primary",
+      windows: [
+        { type: "five_hour", utilization: 0.66, resetsAt: NOW + 2 * HOUR + 14 * 60_000 },
+        { type: "seven_day", utilization: 0.74, resetsAt: NOW + 3 * DAY + 6 * HOUR },
+      ],
+    },
+    // The state this machine is actually in: no credentials for the profile.
+    // /v1/usage/quota/all reports it as an error and returns no windows; the
+    // page does not read the error field, so it must read as "no usage data
+    // yet" rather than as a zeroed-out account.
+    { id: "weekend", windows: [], error: "no_token" },
+    {
+      id: "borrowed",
+      windows: [
+        { type: "seven_day", utilization: 0.3, resetsAt: NOW + DAY },
+        { type: "seven_day_opus", utilization: 0.91, resetsAt: NOW + DAY },
+      ],
+    },
+  ],
+}
+
+const summary: SummaryPayload = {
+  totalRequests: 1714,
+  errorCount: 3,
+  envelopeViolationCount: 0,
+  totalDuration: { p50: 4200, p95: 18_300 },
+  tokenUsage: { totalInputTokens: 1_240_000, totalOutputTokens: 2_300_000, avgCacheHitRate: 0.87 },
+  costEstimate: {
+    totalUsd: 312.45,
+    byProfile: {
+      primary: { requests: 1700, estimatedUsd: 310.2 },
+      borrowed: { requests: 14, estimatedUsd: 2.25 },
+    },
+  },
+}
+
+const healthyFleet: CliDashboardInput = {
+  host: "127.0.0.1",
+  port: 3456,
+  health,
+  profileList,
+  quota,
+  summary,
+  now: NOW,
+}
+
+describe("renderCliDashboard — a healthy fleet", () => {
+  const out = renderCliDashboard(healthyFleet)
+
+  it("names every configured profile", () => {
+    expect(out).toContain("primary")
+    expect(out).toContain("weekend")
+    expect(out).toContain("borrowed")
+  })
+
+  it("marks exactly the active profile", () => {
+    expect(out.match(/ACTIVE/g)).toHaveLength(1)
+    const activeLine = out.split("\n").find((l) => l.includes("ACTIVE"))
+    expect(activeLine).toContain("primary")
+  })
+
+  it("renders the header pill from /health status", () => {
+    expect(out).toContain("Operational")
+    expect(out).toContain("primary claude-max")
+  })
+
+  it("renders the endpoint and the page's meta line", () => {
+    expect(out).toContain("ANTHROPIC_BASE_URL=http://127.0.0.1:3456")
+    expect(out).toContain("someone@example.com (max) · internal · port 3456")
+  })
+
+  it("labels windows the way the page does", () => {
+    expect(out).toContain("5h")
+    expect(out).toContain("7d")
+    expect(out).toContain("7d Opus")
+  })
+
+  it("renders utilization percentages", () => {
+    expect(out).toContain("66%")
+    expect(out).toContain("74%")
+    expect(out).toContain("91%")
+  })
+
+  it("promotes a pace whose projection reaches the cap to 'runs out before reset'", () => {
+    // primary: 74% used with ~54% of the week elapsed projects to 138%.
+    expect(out).toContain("138%")
+    expect(out).toContain("runs out before reset")
+  })
+
+  it("renders an under-pace profile with a signed delta and a projection", () => {
+    // borrowed: 30% used with ~86% elapsed — 56 points under an even pace.
+    expect(out).toContain("-56%")
+    expect(out).toContain("~35% by reset")
+  })
+
+  it("aligns the figure column across every account", () => {
+    const rowLines = out.split("\n").filter((l) => /[░█]/.test(l))
+    expect(rowLines.length).toBeGreaterThan(3)
+    const columns = new Set(rowLines.map((l) => l.indexOf("%")))
+    expect(columns.size).toBe(1)
+  })
+
+  it("renders the 24h strip, total uncoloured and errors on the detail line", () => {
+    expect(out).toContain("1714")
+    expect(out).toContain("3 errors")
+    expect(out).toContain("2.3M")
+    expect(out).toContain("1.2M in")
+    expect(out).toContain("87%")
+    // usd() rounds at and above $100, cents only below it — landing.ts's rule.
+    expect(out).toContain("$312")
+    expect(out).toContain("4.2s")
+    expect(out).toContain("p95 18.3s")
+  })
+
+  it("omits the envelope item when the wire contract is clean", () => {
+    expect(out).not.toContain("wire-contract violations")
+  })
+
+  it("shows per-profile cost and request counts", () => {
+    expect(out).toContain("$310")
+    expect(out).toContain("1700 requests · est. API value · 24h")
+    expect(out).toContain("14 requests · est. API value · 24h")
+  })
+})
+
+describe("renderCliDashboard — a profile with no token", () => {
+  it("renders it the way the page does, not as a zeroed account", () => {
+    const out = renderCliDashboard(healthyFleet)
+    const lines = out.split("\n")
+    const weekendIdx = lines.findIndex((l) => l.includes("weekend"))
+    expect(weekendIdx).toBeGreaterThan(-1)
+    expect(lines.slice(weekendIdx, weekendIdx + 3).join("\n")).toContain("no usage data yet")
+  })
+
+  it("shows no traffic rather than a zero request count", () => {
+    const out = renderCliDashboard(healthyFleet)
+    expect(out).toContain("no traffic · 24h")
+  })
+})
+
+describe("renderCliDashboard — missing fields", () => {
+  const sparse: CliDashboardInput = {
+    host: "127.0.0.1",
+    port: 3456,
+    health: { status: "degraded" },
+    profileList: { profiles: [{ id: "primary", isActive: true }] },
+    quota: { profiles: [{ id: "primary", windows: [] }] },
+    summary: { errorCount: 0, tokenUsage: { avgCacheHitRate: null } },
+    now: NOW,
+  }
+  const out = renderCliDashboard(sparse)
+
+  it("renders an absent count as an explicit unknown, never as 0", () => {
+    const requests = out.split("\n").find((l) => l.includes("Requests"))
+    expect(requests).toContain("—")
+    expect(requests).not.toMatch(/\b0\b/)
+  })
+
+  it("renders absent timings and a null cache rate as unknown", () => {
+    expect(out).toContain("Median Response  —")
+    expect(out).toContain("p95 —")
+    const cache = out.split("\n").find((l) => l.includes("Cache Hit"))
+    expect(cache).toContain("—")
+  })
+
+  it("degrades the health pill rather than claiming health", () => {
+    expect(out).toContain("Degraded")
+  })
+
+  it("still renders a configured profile that reports nothing", () => {
+    expect(out).toContain("primary")
+    expect(out).toContain("no usage data yet")
+  })
+})
+
+describe("renderCliDashboard — unreadable sections", () => {
+  it("says why a section is missing instead of showing it empty", () => {
+    const out = renderCliDashboard({
+      host: "127.0.0.1",
+      port: 3456,
+      health,
+      profileList: null,
+      quota: null,
+      summary: null,
+      unavailable: {
+        accounts: "accounts unavailable — the running instance requires an API key",
+        traffic: "traffic unavailable — the running instance requires an API key",
+      },
+      now: NOW,
+    })
+    expect(out).toContain("accounts unavailable")
+    expect(out).toContain("traffic unavailable")
+    expect(out).not.toContain("$0.00")
+  })
+})
+
+describe("renderCliDashboard — priority routing", () => {
+  it("renders pool position and exhaustion instead of an active pill", () => {
+    const out = renderCliDashboard({
+      ...healthyFleet,
+      profileList: { ...profileList, routing: "priority", profileOrder: ["borrowed", "primary", "weekend"], exhausted: [{ id: "primary", until: NOW + 2 * HOUR }] },
+    })
+    expect(out).toContain("#1 in pool")
+    expect(out).toContain("#2 in pool")
+    expect(out).toContain("exhausted · resets in 2h")
+    expect(out).not.toContain("ACTIVE")
+  })
+})
+
+describe("renderCliDashboard — colour", () => {
+  it("emits no escape bytes when colour is off", () => {
+    const out = renderCliDashboard(healthyFleet, { color: false })
+    expect(out).not.toContain("\x1b")
+  })
+
+  it("defaults to no colour, so a caller that forgets cannot corrupt a pipe", () => {
+    expect(renderCliDashboard(healthyFleet)).not.toContain("\x1b")
+  })
+
+  it("emits colour when asked, and the same text underneath", () => {
+    const colored = renderCliDashboard(healthyFleet, { color: true })
+    expect(colored).toContain("\x1b[38;5;")
+    // eslint-disable-next-line no-control-regex
+    const stripped = colored.replace(/\x1b\[[0-9;]*m/g, "")
+    expect(stripped).toBe(renderCliDashboard(healthyFleet, { color: false }))
+  })
+
+  it("colours a hot window red and a comfortable one green", () => {
+    const colored = renderCliDashboard(healthyFleet, { color: true })
+    const hot = colored.split("\n").find((l) => l.includes("91%"))
+    const cool = colored.split("\n").find((l) => l.includes("-56%"))
+    expect(hot).toContain("\x1b[38;5;203m")
+    expect(cool).toContain("\x1b[38;5;71m")
+  })
+})

--- a/src/__tests__/status-probe.test.ts
+++ b/src/__tests__/status-probe.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for statusProbe.ts. The HTTP calls go through an injected
+ * fetch, so nothing here binds a port or talks to a running instance.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  describeForeignResponse,
+  formatConflictMessage,
+  formatStatusMessage,
+  isMeridianHealthBody,
+  isPortAvailable,
+  probeMeridian,
+  probeUrlBase,
+} from "../proxy/statusProbe"
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  })
+}
+
+/** A fetch that answers from a path -> Response table and records the calls. */
+function stubFetch(routes: Record<string, () => Response | Promise<Response>>) {
+  const calls: { url: string; apiKey: string | null }[] = []
+  const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    const headers = new Headers(init?.headers)
+    calls.push({ url, apiKey: headers.get("x-api-key") })
+    const path = new URL(url).pathname
+    const route = routes[path]
+    if (!route) throw new Error(`connect ECONNREFUSED ${url}`)
+    return route()
+  }) as unknown as typeof fetch
+  return { impl, calls }
+}
+
+const HEALTH_BODY = {
+  status: "healthy",
+  version: "1.60.0",
+  auth: { loggedIn: true, email: "someone@example.com", subscriptionType: "max" },
+  mode: "internal",
+}
+
+describe("probeUrlBase", () => {
+  it("keeps an ordinary host", () => {
+    expect(probeUrlBase("127.0.0.1", 3456)).toBe("http://127.0.0.1:3456")
+  })
+
+  it("connects to loopback for a wildcard bind, which is not itself connectable", () => {
+    expect(probeUrlBase("0.0.0.0", 3456)).toBe("http://127.0.0.1:3456")
+    expect(probeUrlBase("::", 3456)).toBe("http://[::1]:3456")
+  })
+
+  it("brackets an IPv6 literal", () => {
+    expect(probeUrlBase("::1", 3456)).toBe("http://[::1]:3456")
+  })
+
+  it("honours a non-default port", () => {
+    expect(probeUrlBase("127.0.0.1", 3457)).toBe("http://127.0.0.1:3457")
+  })
+})
+
+describe("isMeridianHealthBody", () => {
+  it("accepts a healthy instance", () => {
+    expect(isMeridianHealthBody(HEALTH_BODY)).toBe(true)
+  })
+
+  it("accepts a logged-out instance, which answers 503 with the same shape", () => {
+    expect(isMeridianHealthBody({ status: "unhealthy", version: "1.60.0", auth: { loggedIn: false } })).toBe(true)
+  })
+
+  it("accepts a degraded instance", () => {
+    expect(isMeridianHealthBody({ status: "degraded", version: "1.60.0" })).toBe(true)
+  })
+
+  it("accepts Meridian's own auth rejection", () => {
+    expect(isMeridianHealthBody({ type: "error", error: { type: "authentication_error", message: "nope" } })).toBe(true)
+  })
+
+  it("rejects anything else", () => {
+    expect(isMeridianHealthBody(null)).toBe(false)
+    expect(isMeridianHealthBody("ok")).toBe(false)
+    expect(isMeridianHealthBody({ status: "ok" })).toBe(false)
+    expect(isMeridianHealthBody({ status: "healthy" })).toBe(false)
+    expect(isMeridianHealthBody({ version: "1.0.0" })).toBe(false)
+  })
+})
+
+describe("describeForeignResponse", () => {
+  it("reports status, server and content type — never a body", () => {
+    const headers = new Headers({ server: "SimpleHTTP/0.6 Python/3.13.1", "content-type": "text/html; charset=utf-8" })
+    expect(describeForeignResponse(200, "OK", headers)).toBe("HTTP 200 OK, server: SimpleHTTP/0.6 Python/3.13.1, text/html")
+  })
+
+  it("copes with a bare response", () => {
+    expect(describeForeignResponse(404, "", new Headers())).toBe("HTTP 404")
+  })
+})
+
+describe("probeMeridian", () => {
+  it("identifies Meridian and collects what the page shows", async () => {
+    const { impl } = stubFetch({
+      "/health": () => jsonResponse(HEALTH_BODY),
+      "/profiles/list": () => jsonResponse({ profiles: [{ id: "primary", isActive: true }] }),
+      "/v1/usage/quota/all": () => jsonResponse({ profiles: [] }),
+      "/telemetry/summary": () => jsonResponse({ totalRequests: 12 }),
+    })
+    const result = await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl })
+    expect(result.kind).toBe("meridian")
+    if (result.kind !== "meridian") throw new Error("unreachable")
+    expect(result.snapshot.health?.mode).toBe("internal")
+    expect(result.snapshot.summary?.totalRequests).toBe(12)
+    expect(result.snapshot.unavailable).toBeUndefined()
+  })
+
+  it("identifies a logged-out instance from a 503, which is not 'not Meridian'", async () => {
+    const { impl } = stubFetch({
+      "/health": () => jsonResponse({ status: "unhealthy", version: "1.60.0", auth: { loggedIn: false } }, 503),
+      "/profiles/list": () => jsonResponse({ profiles: [] }),
+      "/v1/usage/quota/all": () => jsonResponse({ profiles: [] }),
+      "/telemetry/summary": () => jsonResponse({}),
+    })
+    const result = await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl })
+    expect(result.kind).toBe("meridian")
+  })
+
+  it("probes the port it was told to, not the default", async () => {
+    const { impl, calls } = stubFetch({
+      "/health": () => jsonResponse(HEALTH_BODY),
+      "/profiles/list": () => jsonResponse({}),
+      "/v1/usage/quota/all": () => jsonResponse({}),
+      "/telemetry/summary": () => jsonResponse({}),
+    })
+    await probeMeridian("127.0.0.1", 3457, { fetchImpl: impl })
+    expect(calls.every((c) => c.url.startsWith("http://127.0.0.1:3457/"))).toBe(true)
+  })
+
+  it("sends the API key on the gated reads", async () => {
+    const { impl, calls } = stubFetch({
+      "/health": () => jsonResponse(HEALTH_BODY),
+      "/profiles/list": () => jsonResponse({}),
+      "/v1/usage/quota/all": () => jsonResponse({}),
+      "/telemetry/summary": () => jsonResponse({}),
+    })
+    await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl, apiKey: "secret" })
+    expect(calls.every((c) => c.apiKey === "secret")).toBe(true)
+  })
+
+  it("still identifies an instance that refuses the gated reads, and says why", async () => {
+    const rejection = { type: "error", error: { type: "authentication_error", message: "Invalid or missing API key" } }
+    const { impl } = stubFetch({
+      "/health": () => jsonResponse(HEALTH_BODY),
+      "/profiles/list": () => jsonResponse(rejection, 401),
+      "/v1/usage/quota/all": () => jsonResponse(rejection, 401),
+      "/telemetry/summary": () => jsonResponse(rejection, 401),
+    })
+    const result = await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl })
+    expect(result.kind).toBe("meridian")
+    if (result.kind !== "meridian") throw new Error("unreachable")
+    expect(result.snapshot.unavailable?.accounts).toContain("MERIDIAN_API_KEY")
+    expect(result.snapshot.unavailable?.traffic).toContain("MERIDIAN_API_KEY")
+  })
+
+  it("identifies Meridian even when /health itself is gated", async () => {
+    const rejection = { type: "error", error: { type: "authentication_error", message: "Invalid or missing API key" } }
+    const { impl } = stubFetch({
+      "/health": () => jsonResponse(rejection, 401),
+      "/profiles/list": () => jsonResponse(rejection, 401),
+      "/v1/usage/quota/all": () => jsonResponse(rejection, 401),
+      "/telemetry/summary": () => jsonResponse(rejection, 401),
+    })
+    const result = await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl })
+    expect(result.kind).toBe("meridian")
+    if (result.kind !== "meridian") throw new Error("unreachable")
+    expect(result.snapshot.health).toBeNull()
+  })
+
+  it("reports a foreign listener without quoting its body", async () => {
+    const { impl } = stubFetch({
+      "/health": () =>
+        new Response("<html>Directory listing</html>", {
+          status: 404,
+          statusText: "File not found",
+          headers: { server: "SimpleHTTP/0.6 Python/3.13.1", "content-type": "text/html" },
+        }),
+    })
+    const result = await probeMeridian("127.0.0.1", 8000, { fetchImpl: impl })
+    expect(result.kind).toBe("foreign")
+    if (result.kind !== "foreign") throw new Error("unreachable")
+    expect(result.description).toContain("HTTP 404")
+    expect(result.description).toContain("SimpleHTTP")
+    expect(result.description).not.toContain("Directory listing")
+  })
+
+  it("treats a JSON server that is not Meridian as foreign", async () => {
+    const { impl } = stubFetch({ "/health": () => jsonResponse({ status: "UP", db: "ok" }) })
+    const result = await probeMeridian("127.0.0.1", 8080, { fetchImpl: impl })
+    expect(result.kind).toBe("foreign")
+  })
+
+  it("treats a refused or wedged port as unreachable", async () => {
+    const { impl } = stubFetch({})
+    const result = await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl })
+    expect(result.kind).toBe("unreachable")
+    if (result.kind !== "unreachable") throw new Error("unreachable")
+    expect(result.description).toContain("ECONNREFUSED")
+  })
+
+  it("does not hang on a port that accepts and never answers", async () => {
+    const impl = (async (_input: unknown, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("The operation timed out.")))
+      })) as unknown as typeof fetch
+    const started = Date.now()
+    const result = await probeMeridian("127.0.0.1", 3456, { fetchImpl: impl, timeoutMs: 50 })
+    expect(result.kind).toBe("unreachable")
+    expect(Date.now() - started).toBeLessThan(2000)
+  })
+})
+
+describe("isPortAvailable", () => {
+  it("is true for a free port and false while one is held", async () => {
+    const { createServer } = await import("node:net")
+    const holder = createServer()
+    await new Promise<void>((resolve) => holder.listen(0, "127.0.0.1", resolve))
+    const address = holder.address()
+    if (address === null || typeof address === "string") throw new Error("expected a TCP address")
+
+    expect(await isPortAvailable("127.0.0.1", address.port)).toBe(false)
+    await new Promise<void>((resolve) => holder.close(() => resolve()))
+    expect(await isPortAvailable("127.0.0.1", address.port)).toBe(true)
+  })
+})
+
+describe("messages", () => {
+  it("says what it found on a busy port, and does not dump usage", () => {
+    const message = formatConflictMessage(
+      { kind: "foreign", description: "HTTP 200 OK, server: SimpleHTTP/0.6 Python/3.13.1, text/html" },
+      "127.0.0.1",
+      8000,
+    )
+    expect(message).toContain("127.0.0.1:8000 is already in use")
+    expect(message).toContain("it is not Meridian")
+    expect(message).toContain("SimpleHTTP")
+    expect(message).not.toContain("Usage:")
+    expect(message).not.toContain("Commands:")
+  })
+
+  it("distinguishes a silent holder from a talkative stranger", () => {
+    const message = formatConflictMessage(
+      { kind: "unreachable", description: "The operation timed out." },
+      "127.0.0.1",
+      3456,
+    )
+    expect(message).toContain("did not answer")
+  })
+
+  it("tells a bare `status` that nothing is running, rather than reporting a conflict", () => {
+    const message = formatStatusMessage({ kind: "unreachable", description: "ECONNREFUSED" }, "127.0.0.1", 3456)
+    expect(message).toContain("no Meridian instance is listening")
+    expect(message).not.toContain("already in use")
+  })
+
+  it("tells a `status` pointed at a stranger what it found", () => {
+    const message = formatStatusMessage({ kind: "foreign", description: "HTTP 200 OK, text/html" }, "127.0.0.1", 8000)
+    expect(message).toContain("is not Meridian")
+    expect(message).toContain("HTTP 200 OK")
+  })
+})

--- a/src/proxy/statusProbe.ts
+++ b/src/proxy/statusProbe.ts
@@ -1,0 +1,257 @@
+/**
+ * Ask what is listening on a port, before concluding anything about it.
+ *
+ * A busy port is not a usage error, and it is almost never a stranger: the
+ * thing holding Meridian's port is usually Meridian. So the CLI asks it,
+ * and only reports a conflict when the answer is no.
+ *
+ * ## What is probed, and why that endpoint
+ *
+ * `GET /health`. It is the only identifying route that is free of every
+ * complication:
+ *
+ *  - **It is public.** `createProxyServer` gates `/v1/*`, `/telemetry*`,
+ *    `/profiles*`, `/plugins*`, `/settings*`, `/metrics` and `/auth/*`
+ *    behind `requireAuth`, leaving `/` and `/health` open by design. So
+ *    identification never depends on holding the instance's API key.
+ *  - **It is cheap and side-effect free.** It reads cached auth status;
+ *    it spends no model quota, which matters when the accounts behind the
+ *    running instance are not all ours to spend.
+ *  - **It echoes nothing secret.** It returns a status, a version, a mode
+ *    and the logged-in account — never tokens, never `profiles.json`.
+ *
+ * The status code is deliberately not the signal: `/health` answers 503
+ * when the account is logged out, and a 401 would still be Meridian's own
+ * error envelope. Identification is by *shape* — a JSON body carrying a
+ * recognised `status` and a `version` — so a running-but-unhappy instance
+ * is still recognised as itself, which is precisely when someone runs the
+ * command to find out what is going on.
+ *
+ * `/` is not used: it is HTML that fetches its data client-side, so it
+ * proves nothing a `<title>` match would not, and matches less reliably.
+ */
+
+import { createServer } from "node:net"
+import type {
+  DashboardSnapshot,
+  HealthPayload,
+  ProfileListPayload,
+  QuotaPayload,
+  SummaryPayload,
+} from "../telemetry/cliDashboard"
+
+/** A wedged port must not hang the CLI: every request is bounded by this. */
+export const PROBE_TIMEOUT_MS = 2000
+
+export type ProbeResult =
+  | { kind: "meridian"; snapshot: DashboardSnapshot }
+  /** Something answered, and it was not Meridian. */
+  | { kind: "foreign"; description: string }
+  /** Nothing answered, or the probe timed out. Treated as not-Meridian. */
+  | { kind: "unreachable"; description: string }
+
+export interface ProbeOptions {
+  timeoutMs?: number
+  /**
+   * Sent as `x-api-key` on the gated reads. This invocation was about to
+   * start a server with `MERIDIAN_API_KEY`, and the instance already
+   * running is normally configured from the same environment — so the
+   * usual case authenticates without asking anyone for anything.
+   */
+  apiKey?: string
+  /** Injectable for tests; production callers omit it. */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Wildcard binds are not connectable addresses everywhere (`0.0.0.0` works
+ * on Linux and not on Windows), so probe the loopback the wildcard covers.
+ * IPv6 literals are bracketed for the URL.
+ */
+export function probeUrlBase(host: string, port: number): string {
+  let target = host
+  if (host === "0.0.0.0" || host === "") target = "127.0.0.1"
+  else if (host === "::" || host === "[::]") target = "::1"
+  const literal = target.includes(":") ? `[${target.replace(/^\[|\]$/g, "")}]` : target
+  return `http://${literal}:${port}`
+}
+
+const HEALTH_STATUSES = new Set(["healthy", "degraded", "unhealthy"])
+
+/**
+ * Is this body Meridian's `/health`, or Meridian's auth rejection?
+ *
+ * Both are accepted: a 401 carrying `authentication_error` can only have
+ * come from `requireAuth`, so it identifies the server even though it
+ * withholds the data.
+ */
+export function isMeridianHealthBody(body: unknown): boolean {
+  if (typeof body !== "object" || body === null) return false
+  const record = body as Record<string, unknown>
+  if (typeof record["status"] === "string" && HEALTH_STATUSES.has(record["status"]) && typeof record["version"] === "string") {
+    return true
+  }
+  const error = record["error"]
+  if (record["type"] === "error" && typeof error === "object" && error !== null) {
+    return (error as Record<string, unknown>)["type"] === "authentication_error"
+  }
+  return false
+}
+
+/** Describe a foreign listener from its response — headers only, never its body. */
+export function describeForeignResponse(status: number, statusText: string, headers: Headers): string {
+  const parts = [`HTTP ${status}${statusText ? ` ${statusText}` : ""}`]
+  const server = headers.get("server")
+  if (server) parts.push(`server: ${server}`)
+  const contentType = headers.get("content-type")
+  if (contentType) parts.push(contentType.split(";")[0]!.trim())
+  return parts.join(", ")
+}
+
+/**
+ * Whether a server could bind `host:port` right now.
+ *
+ * The same question `serve()` asks, asked first — so the answer arrives
+ * before the pre-flight auth check and the plugin loader have printed
+ * anything, and the dashboard can be the whole output. Losing the race
+ * between this and the real bind is harmless: `startProxyServer`'s own
+ * EADDRINUSE handler is still in place behind it.
+ */
+export function isPortAvailable(host: string, port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const probe = createServer()
+    probe.once("error", () => resolve(false))
+    probe.once("listening", () => probe.close(() => resolve(true)))
+    probe.listen(port, host)
+  })
+}
+
+async function readJson(
+  fetchImpl: typeof fetch,
+  url: string,
+  timeoutMs: number,
+  apiKey?: string,
+): Promise<
+  | { ok: true; status: number; statusText: string; body: unknown; headers: Headers }
+  | { ok: false; reason: string }
+> {
+  try {
+    const response = await fetchImpl(url, {
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: apiKey ? { "x-api-key": apiKey } : undefined,
+    })
+    let body: unknown = null
+    try {
+      body = await response.json()
+    } catch {
+      body = null
+    }
+    return { ok: true, status: response.status, statusText: response.statusText, body, headers: response.headers }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+/** Fetch a gated section, returning the reason when it cannot be read. */
+async function readSection<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  timeoutMs: number,
+  apiKey: string | undefined,
+): Promise<{ data: T | null; reason?: string }> {
+  const result = await readJson(fetchImpl, url, timeoutMs, apiKey)
+  if (!result.ok) return { data: null, reason: result.reason }
+  if (result.status === 401) {
+    return {
+      data: null,
+      reason: apiKey
+        ? "the running instance rejected this MERIDIAN_API_KEY"
+        : "the running instance requires an API key — set MERIDIAN_API_KEY",
+    }
+  }
+  if (result.status >= 400) return { data: null, reason: `HTTP ${result.status}` }
+  if (result.body == null) return { data: null, reason: "unreadable response" }
+  return { data: result.body as T }
+}
+
+/**
+ * Ask the thing on `host:port` whether it is Meridian, and if so collect
+ * everything the landing page shows.
+ *
+ * The four reads are the four the page itself makes. Each is independent:
+ * a gated section that cannot be read becomes a note on the rendered page
+ * rather than a failure or, worse, a section of zeroes.
+ */
+export async function probeMeridian(host: string, port: number, options: ProbeOptions = {}): Promise<ProbeResult> {
+  const timeoutMs = options.timeoutMs ?? PROBE_TIMEOUT_MS
+  const apiKey = options.apiKey || undefined
+  const fetchImpl = options.fetchImpl ?? fetch
+  const base = probeUrlBase(host, port)
+
+  const health = await readJson(fetchImpl, `${base}/health`, timeoutMs, apiKey)
+  if (!health.ok) return { kind: "unreachable", description: health.reason }
+  if (!isMeridianHealthBody(health.body)) {
+    return {
+      kind: "foreign",
+      description: describeForeignResponse(health.status, health.statusText, health.headers),
+    }
+  }
+
+  const authRejected = health.status === 401
+  const [profileList, quota, summary] = await Promise.all([
+    readSection<ProfileListPayload>(fetchImpl, `${base}/profiles/list`, timeoutMs, apiKey),
+    readSection<QuotaPayload>(fetchImpl, `${base}/v1/usage/quota/all`, timeoutMs, apiKey),
+    readSection<SummaryPayload>(fetchImpl, `${base}/telemetry/summary?window=86400000`, timeoutMs, apiKey),
+  ])
+
+  const unavailable: DashboardSnapshot["unavailable"] = {}
+  const accountsReason = profileList.reason ?? quota.reason
+  if (accountsReason) unavailable.accounts = `accounts unavailable — ${accountsReason}`
+  if (summary.reason) unavailable.traffic = `traffic unavailable — ${summary.reason}`
+
+  return {
+    kind: "meridian",
+    snapshot: {
+      health: authRejected ? null : (health.body as HealthPayload),
+      profileList: profileList.data,
+      quota: quota.data,
+      summary: summary.data,
+      ...(Object.keys(unavailable).length > 0 ? { unavailable } : {}),
+    },
+  }
+}
+
+export type ProbeFailure = Exclude<ProbeResult, { kind: "meridian" }>
+
+/** The message for `meridian status` when there is nothing of ours to show. */
+export function formatStatusMessage(result: ProbeFailure, host: string, port: number): string {
+  if (result.kind === "foreign") {
+    return [
+      `Error: http://${host}:${port} is not Meridian (${result.description}).`,
+      `  Something else owns that port. Point at the right one: MERIDIAN_PORT=<port> meridian status`,
+    ].join("\n")
+  }
+  return [
+    `Error: no Meridian instance is listening on http://${host}:${port}.`,
+    `  Start one with: meridian`,
+  ].join("\n")
+}
+
+/**
+ * The message for a busy port that is not Meridian. A conflict, so it goes
+ * to stderr and exits non-zero — but it says what it found, which is the
+ * part that was missing.
+ */
+export function formatConflictMessage(result: ProbeFailure, host: string, port: number): string {
+  const found =
+    result.kind === "foreign"
+      ? `Something is listening there, and it is not Meridian (${result.description}).`
+      : `Something is holding the port but did not answer (${result.description}).`
+  return [
+    `Error: ${host}:${port} is already in use.`,
+    found,
+    "",
+    `  Identify it with: lsof -i :${port}`,
+    `  Or use a different port: MERIDIAN_PORT=4567 meridian`,
+  ].join("\n")
+}

--- a/src/telemetry/cliDashboard.ts
+++ b/src/telemetry/cliDashboard.ts
@@ -1,0 +1,606 @@
+/**
+ * The landing page (`GET /`), rendered for a terminal.
+ *
+ * `meridian status` prints this, and so does `meridian` when the port it
+ * wanted is already serving Meridian — asking what is running is not an
+ * error, so the answer is the dashboard rather than a diagnostic.
+ *
+ * It is the *same page*: the same values, under the same conditions, with
+ * the same colour meanings as `src/telemetry/landing.ts`. When editing,
+ * read that file first — every value here exists there, and nothing here
+ * exists that does not. Two consequences worth stating, because both look
+ * like omissions:
+ *
+ *  - Browser-only affordances are dropped, not translated. The "Click to
+ *    activate" hint and the nav links are chrome, not facts; the pace
+ *    `title=` tooltip is shown on hover, which a terminal has no analogue
+ *    for. The visible facts they decorate are all still here.
+ *  - `/v1/usage/quota/all` reports `error: "no_token"` for a profile whose
+ *    credentials are missing, and the page does not read that field — such
+ *    a profile has no windows, so it renders "no usage data yet". This
+ *    prints the same thing rather than inventing an error line.
+ *
+ * Pure by construction: it takes the four payloads the page fetches and
+ * returns a string. Colour is a caller-supplied flag, so piped output can
+ * be checked for the absence of escape bytes, and there is no `process`
+ * access to make it environment-dependent.
+ *
+ * Not printing credentials falls out of the same rule. Profile records
+ * carry `email`, and profiles.json can carry `apiKey`; the page renders
+ * neither for a configured profile, so neither is read here.
+ */
+
+import {
+  WINDOW_LABELS,
+  classifyUtilization,
+  computeWeeklyPace,
+  formatResetCountdown,
+  type WeeklyPace,
+} from "./profileUsage"
+
+// --- palette ---------------------------------------------------------------
+
+/**
+ * The page's colours, mapped once.
+ *
+ * Keys name the CSS custom properties in `themeCss`
+ * (src/telemetry/profileBar.ts) and the comment carries the hex those
+ * properties hold, so a theme change is a one-line update here rather
+ * than a hunt through the renderer. Values are xterm-256 indices — the
+ * nearest cube (or greyscale) entry to the hex. 256 rather than truecolor
+ * because every colour terminal renders it, and at these sizes the
+ * difference is invisible.
+ */
+const PALETTE = {
+  green: 71, //  --green   #3fb950
+  yellow: 178, // --yellow  #d29922
+  red: 203, //   --red     #f85149
+  muted: 246, //  --muted   #8b949e
+  accent: 75, //  --accent  #58a6ff
+} as const
+
+export type PaletteColor = keyof typeof PALETTE
+
+type Paint = (text: string, color: PaletteColor) => string
+
+const colorPaint: Paint = (text, color) => `\x1b[38;5;${PALETTE[color]}m${text}\x1b[0m`
+const plainPaint: Paint = (text) => text
+
+// --- payloads --------------------------------------------------------------
+//
+// Every field is optional: these describe what the page *reads*, not what a
+// current server guarantees. An older instance, or one that answered only
+// some of the four requests, is a normal outcome — see `unavailable`.
+
+export interface HealthPayload {
+  status?: string
+  auth?: { loggedIn?: boolean; email?: string | null; subscriptionType?: string | null }
+  mode?: string
+}
+
+export interface UsageWindow {
+  type?: string
+  utilization?: number | null
+  resetsAt?: number | null
+}
+
+export interface QuotaPayload {
+  profiles?: {
+    id?: string
+    profile?: string
+    windows?: UsageWindow[]
+    /**
+     * `"no_token"` / `"not_oauth"`. Declared, and deliberately not read:
+     * the page ignores it, and such a profile arrives with no windows, so
+     * it renders "no usage data yet" like any other account with nothing
+     * to report. Reading it here would put a state on the terminal that
+     * the browser never shows.
+     */
+    error?: string | null
+  }[]
+}
+
+export interface ProfileListPayload {
+  profiles?: { id?: string; type?: string; isActive?: boolean }[]
+  routing?: string
+  profileOrder?: string[]
+  exhausted?: { id?: string; until?: number }[]
+}
+
+export interface SummaryPayload {
+  totalRequests?: number
+  errorCount?: number
+  envelopeViolationCount?: number
+  totalDuration?: { p50?: number; p95?: number }
+  tokenUsage?: {
+    totalInputTokens?: number
+    totalOutputTokens?: number
+    avgCacheHitRate?: number | null
+  }
+  costEstimate?: {
+    totalUsd?: number
+    byProfile?: Record<string, { requests?: number; estimatedUsd?: number }>
+  }
+}
+
+/** The four payloads, plus why any of them is missing. */
+export interface DashboardSnapshot {
+  health: HealthPayload | null
+  profileList: ProfileListPayload | null
+  quota: QuotaPayload | null
+  summary: SummaryPayload | null
+  /**
+   * Reason a source could not be read, keyed by the section it feeds.
+   * Rendered as an explicit note, so an unreadable endpoint never reads
+   * as a fleet with no accounts or a day with no traffic.
+   */
+  unavailable?: Partial<Record<"accounts" | "traffic", string>>
+}
+
+export interface CliDashboardInput extends DashboardSnapshot {
+  host: string
+  port: number
+  /** Injectable for tests; production callers omit it. */
+  now?: number
+}
+
+export interface CliDashboardOptions {
+  /** Emit ANSI colour. Callers pass `process.stdout.isTTY === true`. */
+  color?: boolean
+}
+
+// --- formatting (mirrors landing.ts) ---------------------------------------
+
+/** What the page prints when it has no value: `usd(null)`, `ms(0)`, `tokens(null)`. */
+const UNKNOWN = "—"
+
+function isNum(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v)
+}
+
+/** `usd()` in landing.ts. Locale pinned so the output does not move with $LANG. */
+function usd(v: number | null | undefined): string {
+  if (!isNum(v)) return UNKNOWN
+  if (v > 0 && v < 0.01) return `$${v.toFixed(4)}`
+  if (v < 100) return `$${v.toFixed(2)}`
+  return `$${Math.round(v).toLocaleString("en-US")}`
+}
+
+/** `tokens()` in landing.ts. */
+function tokens(v: number | null | undefined): string {
+  if (!isNum(v)) return UNKNOWN
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}k`
+  return String(v)
+}
+
+/** `ms()` in landing.ts — 0 is "no data", not "instant". */
+function millis(v: number | null | undefined): string {
+  if (!isNum(v) || v === 0) return UNKNOWN
+  return v < 1000 ? `${v}ms` : `${(v / 1000).toFixed(1)}s`
+}
+
+/**
+ * `winLabel()` in landing.ts. The known map is shared with the profile page;
+ * the fallback is the page's, which shortens an unnamed `seven_day_*` to
+ * "7d *" — profileUsage.ts's `labelForWindow` spells out "Seven Day" instead,
+ * and the point here is to match what the browser shows.
+ */
+function windowLabel(type: string): string {
+  const known = WINDOW_LABELS[type]
+  if (known) return known
+  return type
+    .replace(/^seven_day_/, "7d ")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+/** `utilColor()` in landing.ts, via the tested three-tier classifier. */
+function utilizationColor(utilization: number): PaletteColor {
+  const status = classifyUtilization(utilization)
+  return status === "high" ? "red" : status === "warn" ? "yellow" : "green"
+}
+
+type PaceStatus = WeeklyPace["status"] | "over"
+
+/**
+ * landing.ts promotes any pace whose projection reaches the cap to "over":
+ * "on track to run out" outranks merely being ahead of an even pace.
+ * `computeWeeklyPace` deliberately stops short of that judgement, so the
+ * promotion lives with the presentation, here and in the page.
+ */
+function paceStatus(pace: WeeklyPace): PaceStatus {
+  return pace.projectedPct != null && pace.projectedPct >= 100 ? "over" : pace.status
+}
+
+function paceColor(status: PaceStatus): PaletteColor {
+  return status === "over" ? "red" : status === "ahead" ? "yellow" : "green"
+}
+
+// --- bars ------------------------------------------------------------------
+
+const BAR_WIDTH = 28
+const BAR_FILL = "█"
+const BAR_TRACK = "░"
+/** The pace row's tick: where even consumption would have reached by now. */
+const BAR_MARKER = "┃"
+
+function clampPct(pct: number): number {
+  return Math.max(0, Math.min(100, pct))
+}
+
+/**
+ * One usage bar. `markerPct`, when given, overlays a tick at that position
+ * — the `.pace-marker` element on the page. Cells are grouped into runs
+ * before painting so a coloured bar costs two escape sequences, not 28.
+ */
+function renderBar(pct: number, color: PaletteColor, paint: Paint, markerPct?: number): string {
+  const filled = Math.round((clampPct(pct) / 100) * BAR_WIDTH)
+  const marker =
+    markerPct == null ? -1 : Math.min(Math.round((clampPct(markerPct) / 100) * BAR_WIDTH), BAR_WIDTH - 1)
+
+  type Role = "fill" | "track" | "marker"
+  const cells: { ch: string; role: Role }[] = []
+  for (let i = 0; i < BAR_WIDTH; i++) {
+    if (i === marker) cells.push({ ch: BAR_MARKER, role: "marker" })
+    else if (i < filled) cells.push({ ch: BAR_FILL, role: "fill" })
+    else cells.push({ ch: BAR_TRACK, role: "track" })
+  }
+
+  let out = ""
+  let i = 0
+  while (i < cells.length) {
+    const role = cells[i]!.role
+    let run = ""
+    while (i < cells.length && cells[i]!.role === role) {
+      run += cells[i]!.ch
+      i++
+    }
+    // The marker is the page's neutral tick (--text at reduced opacity):
+    // left unpainted so it reads against both the fill and the track.
+    out += role === "fill" ? paint(run, color) : role === "track" ? paint(run, "muted") : run
+  }
+  return out
+}
+
+// --- the model the renderer lays out ---------------------------------------
+
+interface UsageRow {
+  label: string
+  /** Bar fill, 0..n (clamped when drawn — utilization can exceed 100%). */
+  pct: number
+  /** Right-aligned figure: "38%" for a window, "+12%" for pace. */
+  figure: string
+  color: PaletteColor
+  /** Reset countdown, or the pace projection. */
+  note: string
+  markerPct?: number
+}
+
+interface Badge {
+  text: string
+  color?: PaletteColor
+}
+
+interface AccountBlock {
+  label: string
+  isActive: boolean
+  badges: Badge[]
+  cost: string
+  sub: string
+  rows: UsageRow[]
+}
+
+/**
+ * Which accounts to show, and what each one says — `profileSection()` in
+ * landing.ts, with its two modes preserved: configured profiles render
+ * exactly as configured, and a single-account install falls back to the
+ * quota/cost keys labelled with the logged-in email.
+ */
+function buildAccounts(input: CliDashboardInput, now: number): AccountBlock[] {
+  const byProfile = input.summary?.costEstimate?.byProfile ?? {}
+
+  const quotaByProfile: Record<string, UsageWindow[]> = {}
+  for (const entry of input.quota?.profiles ?? []) {
+    quotaByProfile[entry.id || entry.profile || "default"] = entry.windows ?? []
+  }
+
+  const configured = input.profileList?.profiles ?? []
+
+  interface Candidate {
+    id: string
+    label: string
+    isActive: boolean
+    configured: boolean
+  }
+  const candidates: Candidate[] = []
+
+  if (configured.length > 0) {
+    // Real profiles exist: show exactly those. Traffic that predates
+    // per-profile attribution (the synthetic "default" bucket) still counts
+    // in the totals below but does not render as an account that isn't there.
+    for (const p of configured) {
+      const id = p.id ?? "default"
+      candidates.push({ id, label: id, isActive: p.isActive === true, configured: true })
+    }
+  } else {
+    const auth = input.health?.auth
+    const email = (auth?.loggedIn && auth.email) || ""
+    const seen = new Set<string>()
+    for (const key of [...Object.keys(quotaByProfile), ...Object.keys(byProfile)]) {
+      if (seen.has(key)) continue
+      seen.add(key)
+      candidates.push({
+        id: key,
+        label: key === "default" ? email || "account" : key,
+        isActive: false,
+        configured: false,
+      })
+    }
+  }
+
+  const isPriority = input.profileList?.routing === "priority"
+  const blocks: AccountBlock[] = []
+
+  for (const candidate of candidates) {
+    const cost = byProfile[candidate.id]
+    const windows = (quotaByProfile[candidate.id] ?? []).filter((w) => w.utilization != null)
+    if (!candidate.configured && windows.length === 0 && !cost) continue
+
+    const rows: UsageRow[] = []
+    for (const w of windows) {
+      const utilization = w.utilization
+      if (!isNum(utilization)) continue
+      rows.push({
+        label: windowLabel(w.type ?? ""),
+        pct: Math.round(utilization * 100),
+        figure: `${Math.round(utilization * 100)}%`,
+        color: utilizationColor(utilization),
+        note: formatResetCountdown(w.resetsAt, now),
+      })
+    }
+
+    // The pace row reads the 7-day window; landing.ts takes the last match.
+    let weekly: UsageWindow | undefined
+    for (const w of windows) if (w.type === "seven_day") weekly = w
+    const pace = weekly ? computeWeeklyPace(weekly.utilization, weekly.resetsAt, now) : null
+    if (pace) {
+      const status = paceStatus(pace)
+      const projected = pace.projectedPct
+      const figure =
+        status === "over"
+          ? projected != null
+            ? `${projected}%`
+            : "100%"
+          : `${pace.deltaPct >= 0 ? "+" : "-"}${Math.abs(pace.deltaPct)}%`
+      rows.push({
+        label: "pace",
+        pct: pace.actualPct,
+        markerPct: pace.expectedPct,
+        figure,
+        color: paceColor(status),
+        note:
+          status === "over"
+            ? "runs out before reset"
+            : projected != null
+              ? `~${projected}% by reset`
+              : "",
+      })
+    }
+
+    const badges: Badge[] = []
+    if (isPriority) {
+      const order = input.profileList?.profileOrder ?? []
+      const idx = order.indexOf(candidate.id)
+      if (idx >= 0) badges.push({ text: `#${idx + 1} in pool`, color: "muted" })
+      const exhausted = (input.profileList?.exhausted ?? []).find((e) => e.id === candidate.id)
+      if (exhausted) {
+        badges.push({
+          text: `exhausted · resets ${formatResetCountdown(exhausted.until, now)}`,
+          color: "red",
+        })
+      }
+    } else if (candidate.isActive) {
+      // `.active-pill` — the one badge the page shows in the default mode.
+      // Its sibling, the "Click to activate" hover hint, is a browser
+      // affordance and has no terminal equivalent, so it is dropped.
+      badges.push({ text: "ACTIVE", color: "accent" })
+    }
+
+    const requests = cost?.requests
+    blocks.push({
+      label: candidate.label,
+      isActive: candidate.isActive,
+      badges,
+      cost: usd(cost ? cost.estimatedUsd : 0),
+      sub: isNum(requests)
+        ? `${requests} request${requests === 1 ? "" : "s"} · est. API value · 24h`
+        : "no traffic · 24h",
+      rows,
+    })
+  }
+
+  return blocks
+}
+
+// --- the 24h strip ---------------------------------------------------------
+
+interface StripItem {
+  label: string
+  value: string
+  valueColor?: PaletteColor
+  detail: string
+  detailColor?: PaletteColor
+}
+
+/** `render()`'s `items` array in landing.ts, in the same order. */
+function buildStrip(summary: SummaryPayload): StripItem[] {
+  const tu = summary.tokenUsage ?? {}
+  const hitRate = tu.avgCacheHitRate
+  const errors = summary.errorCount
+
+  const items: StripItem[] = [
+    {
+      // The big number is the TOTAL and is never error-coloured; the error
+      // signal lives on the detail line, exactly as on the page.
+      label: "Requests",
+      value: isNum(summary.totalRequests) ? String(summary.totalRequests) : UNKNOWN,
+      detail: !isNum(errors) ? UNKNOWN : errors > 0 ? `${errors} error${errors === 1 ? "" : "s"}` : "no errors",
+      detailColor: isNum(errors) && errors > 0 ? "red" : undefined,
+    },
+    {
+      label: "Tokens Out",
+      value: tokens(tu.totalOutputTokens),
+      detail: `${tokens(tu.totalInputTokens)} in`,
+    },
+    {
+      label: "Cache Hit",
+      value: isNum(hitRate) ? `${Math.round(hitRate * 100)}%` : UNKNOWN,
+      valueColor: isNum(hitRate) && hitRate >= 0.5 ? "green" : undefined,
+      detail: "prompt cache",
+    },
+    {
+      label: "Est. API Value",
+      value: usd(summary.costEstimate?.totalUsd),
+      detail: "list prices",
+    },
+    {
+      label: "Median Response",
+      value: millis(summary.totalDuration?.p50),
+      detail: `p95 ${millis(summary.totalDuration?.p95)}`,
+    },
+  ]
+
+  const violations = summary.envelopeViolationCount
+  if (isNum(violations) && violations > 0) {
+    items.push({
+      label: "Envelope",
+      value: String(violations),
+      valueColor: "red",
+      detail: "wire-contract violations",
+      detailColor: "red",
+    })
+  }
+
+  return items
+}
+
+// --- header ----------------------------------------------------------------
+
+/** The header's status pill: `loadHeader()` in profileBar.ts. */
+function healthPill(health: HealthPayload | null): { label: string; color: PaletteColor } {
+  const status = health?.status
+  if (status === "healthy") return { label: "Operational", color: "green" }
+  if (status === "degraded") return { label: "Degraded", color: "yellow" }
+  return { label: "Offline", color: "red" }
+}
+
+/** The header's profile chip: the active profile's id and type, or nothing. */
+function activeProfileChip(profileList: ProfileListPayload | null): string | null {
+  const active = (profileList?.profiles ?? []).find((p) => p.isActive === true)
+  if (!active?.id) return null
+  return active.type ? `${active.id} ${active.type}` : active.id
+}
+
+// --- renderer --------------------------------------------------------------
+
+const INDENT = "  "
+
+/**
+ * Render the dashboard.
+ *
+ * Returns a newline-terminated block. With `color: false` the result
+ * contains no escape bytes at all, which is what piped output gets.
+ */
+export function renderCliDashboard(input: CliDashboardInput, options: CliDashboardOptions = {}): string {
+  const paint = options.color ? colorPaint : plainPaint
+  const bold = options.color ? (t: string) => `\x1b[1m${t}\x1b[22m` : (t: string) => t
+  const now = input.now ?? Date.now()
+  const out: string[] = []
+
+  // Header — brand, health pill, active profile.
+  const pill = healthPill(input.health)
+  const chip = activeProfileChip(input.profileList)
+  out.push(
+    `${bold("MERIDIAN")}  ${paint("●", pill.color)} ${pill.label}` +
+      (chip ? `  ${paint("·", "muted")}  ${chip}` : ""),
+  )
+  out.push("")
+
+  // Intro — the endpoint agents point at, then the page's meta line.
+  out.push(`${INDENT}ANTHROPIC_BASE_URL=http://${input.host}:${input.port}`)
+  const meta: string[] = []
+  const auth = input.health?.auth
+  if (auth?.loggedIn) {
+    meta.push(`${auth.email ?? ""}${auth.subscriptionType ? ` (${auth.subscriptionType})` : ""}`)
+  }
+  meta.push(input.health?.mode ?? "internal")
+  meta.push(`port ${input.port}`)
+  out.push(`${INDENT}${paint(meta.join(" · "), "muted")}`)
+  out.push("")
+
+  // Accounts.
+  const accounts = buildAccounts(input, now)
+  const accountsNote = input.unavailable?.accounts
+  if (accounts.length > 0 || accountsNote) {
+    out.push(paint(accounts.length === 1 ? "ACCOUNT" : "ACCOUNTS", "muted"))
+    out.push("")
+    if (accountsNote) {
+      out.push(`${INDENT}${paint(accountsNote, "yellow")}`)
+      out.push("")
+    }
+
+    // Column widths are computed across the whole fleet, not per account, so
+    // the percentages line up down the page and can be compared by eye.
+    const allRows = accounts.flatMap((a) => a.rows)
+    const labelWidth = Math.max(0, ...allRows.map((r) => r.label.length))
+    const figureWidth = Math.max(0, ...allRows.map((r) => r.figure.length))
+    // Where the cost sits: the right edge of the figure column.
+    const costColumn = INDENT.length + 2 + labelWidth + 2 + BAR_WIDTH + 2 + figureWidth
+
+    for (const account of accounts) {
+      const dot = paint("●", account.isActive ? "accent" : "muted")
+      const badges = account.badges.map((b) => (b.color ? paint(b.text, b.color) : b.text)).join("  ")
+      const headLeft = `${account.label}${badges ? `  ${badges}` : ""}`
+      // Pad on the plain text; the painted string carries invisible bytes.
+      const headLeftPlain =
+        account.label + (account.badges.length > 0 ? `  ${account.badges.map((b) => b.text).join("  ")}` : "")
+      const gap = Math.max(1, costColumn - INDENT.length - 2 - headLeftPlain.length - account.cost.length)
+      out.push(`${INDENT}${dot} ${headLeft}${" ".repeat(gap)}${bold(account.cost)}`)
+      out.push(`${INDENT}  ${paint(account.sub, "muted")}`)
+
+      if (account.rows.length === 0) {
+        out.push(`${INDENT}  ${paint("no usage data yet", "muted")}`)
+      }
+      for (const row of account.rows) {
+        const label = row.label.padEnd(labelWidth)
+        const bar = renderBar(row.pct, row.color, paint, row.markerPct)
+        const figure = row.figure.padStart(figureWidth)
+        const note = row.note ? `  ${paint(row.note, "muted")}` : ""
+        out.push(`${INDENT}  ${paint(label, "muted")}  ${bar}  ${paint(figure, row.color)}${note}`)
+      }
+      out.push("")
+    }
+  }
+
+  // Last 24 hours.
+  const trafficNote = input.unavailable?.traffic
+  out.push(paint("LAST 24 HOURS", "muted"))
+  out.push("")
+  if (trafficNote) {
+    out.push(`${INDENT}${paint(trafficNote, "yellow")}`)
+  } else {
+    const items = buildStrip(input.summary ?? {})
+    const labelWidth = Math.max(...items.map((i) => i.label.length))
+    const valueWidth = Math.max(...items.map((i) => i.value.length))
+    for (const item of items) {
+      const label = paint(item.label.padEnd(labelWidth), "muted")
+      const valuePlain = item.value.padStart(valueWidth)
+      const value = item.valueColor ? paint(valuePlain, item.valueColor) : valuePlain
+      const detail = item.detailColor ? paint(item.detail, item.detailColor) : paint(item.detail, "muted")
+      out.push(`${INDENT}${label}  ${value}  ${detail}`)
+    }
+  }
+
+  return `${out.join("\n")}\n`
+}


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Opening this early so it is visible; I am still iterating on it. Please hold off
on review until this banner is gone.

---

## The problem

Running `meridian` on a machine where Meridian is already running prints a full
usage screen, then:

```
Error: Port 3456 is already in use

Another instance of Meridian may be running.
Try: meridian --port <other-port>
```

It says "another instance of Meridian **may** be running" without ever checking,
and then suggests moving out of its way. But asking what is running is not a
mistake, and on the overwhelmingly common path the process holding that port
*is* Meridian. So this answers instead: the `/` page, rendered for the terminal,
exit 0.

## What it does

**Probe before deciding.** On a port that will not bind, the CLI issues
`GET /health` against the host and port *this invocation* was going to use, so
`MERIDIAN_HOST` / `MERIDIAN_PORT` are honoured and a second config pointed at
3457 probes 3457.

`/health` is the right question because it is the only identifying route that is
public - `createProxyServer` gates `/v1/*`, `/telemetry*`, `/profiles*`,
`/plugins*`, `/settings*`, `/metrics` and `/auth/*` behind `requireAuth` and
deliberately leaves `/` and `/health` open - and because it is free: it reads
cached auth status, spends no model quota, and echoes no credential.

**Identification is by shape, not status code.** `/health` answers 503 when the
account is logged out and 401 when a key is required, and both are still
Meridian answering. A JSON body carrying a known `status` and a `version`, or
Meridian's own `authentication_error` envelope, is the instance identifying
itself - which matters most precisely when it is unhappy, because that is when
somebody runs the command to find out why.

**Three outcomes, kept distinct:**

| what answers the probe | result |
|---|---|
| Meridian | print the dashboard, **exit 0** |
| something else | an error naming what it found - status, `Server` header, content type, never the body - **exit 1** |
| nothing, within 2s | the same error, worded for a port held by something silent - **exit 1** |

A wedged listener cannot hang the CLI.

**The check runs before the server starts**, rather than from the `EADDRINUSE`
handler, so the dashboard is the whole output - by the time a bind fails, the
pre-flight auth check and the plugin loader have already printed.
`startProxyServer`'s own `EADDRINUSE` handler stays where it is and still covers
losing the race.

**Reachable on purpose too:** `meridian status` prints the same thing without
having to make a mistake first, and exits 1 with a fitting message when there is
nothing of ours on that port.

## The renderer

It is the same page, not a summary of it: same values, same conditions, and the
same colour meanings as `src/telemetry/landing.ts`, with the four payloads it
fetches as its only input.

- **Pure.** Colour is a caller-supplied flag, so piped output carries no escape
  bytes and the tests can assert that.
- The theme's four semantic tokens (`--ok`, `--warn`, `--err`, `--dim`) map to
  xterm-256 in one table rather than through the renderer.
- A field the instance does not return prints as an explicit unknown, **never as
  `0`**. A section that cannot be read says why instead of rendering empty.
- Not printing credentials falls out of the same rule: the page renders neither
  `email` for a configured profile nor anything from `apiKey`, so neither is
  read.

## Sample output

Against a live instance with ten profiles (values redacted where they identify
an account):

```
MERIDIAN  ● Operational  ·  corp3 claude-max

  ANTHROPIC_BASE_URL=http://127.0.0.1:3456
  … · passthrough · port 3456

ACCOUNTS

  ● corp3  ACTIVE                         $24.98
    30 requests · est. API value · 24h
    5h        ████████████░░░░░░░░░░░░░░░░   42%  in 3h 19m
    7d        █████████████░░░░░░░░░░░░░░░   46%  in 1d 14h
    7d Fable  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░    0%
    pace      █████████████░░░░░░░░░┃░░░░░  -31%  ~60% by reset

  ● randall-corp                           $0.00
    no traffic · 24h
    no usage data yet

LAST 24 HOURS

  Requests           1000  55 errors
  Tokens Out       905.7k  8.4k in
  Cache Hit           82%  prompt cache
  Est. API Value     $492  list prices
```

## Verification

Run against a real, live Meridian rather than only unit-tested:

| case | result |
|---|---|
| occupied port that IS Meridian (3456) | dashboard rendered, **exit 0** |
| occupied port that is NOT Meridian (a plain HTTP listener) | `Error: 127.0.0.1:34571 is already in use. Something is listening there, and it is not Meridian (HTTP 200 OK, text/plain).` **exit 1** |
| free port (34572) | proxy starts normally, unchanged |
| piped to a file | **0** escape-sequence lines |
| `bun test src/__tests__/cli-dashboard.test.ts` | 24 pass, 0 fail |
| `bun test src/__tests__/status-probe.test.ts` | 26 pass, 0 fail |
| `bunx tsc --noEmit` | exit 0, 0 error lines |

## Files

```
 ARCHITECTURE.md                     |   2 +
 bin/cli.ts                          |  41 +++
 docs/configuration.md               |   3 +-
 src/__tests__/cli-dashboard.test.ts | 275 ++++++++++
 src/__tests__/status-probe.test.ts  | 271 ++++++++++
 src/proxy/statusProbe.ts            | 257 +++++++++++
 src/telemetry/cliDashboard.ts       | 606 ++++++++++++++++++++++++++++
 7 files changed, 1454 insertions(+), 1 deletion(-)
```

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
