### PR TITLE
fix(config): make MERIDIAN_CONFIG_DIR relocate the directory, not one file in it

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_PROFILE_ORDER` | — | *(config order)* | Priority-mode pool order, comma-separated, highest priority first (e.g. `work,personal`). Also editable at `/settings`. |
 | `MERIDIAN_PASSTHROUGH_EARLY_STOP` | — | `1` | Set to `0` to disable [digest-turn elimination](#how-tool-calling-works-in-passthrough) and restore the old end-of-turn behavior |
 | `MERIDIAN_SUPPRESS_SCRATCHPAD` | — | `1` | Set to `0` to let the SDK advertise its proxy-host scratchpad directory in passthrough mode |
+| `MERIDIAN_CONFIG_DIR` | — | `~/.config/meridian` | Meridian's own config directory. Moving it moves everything inside it — see [below](#relocating-the-config-directory). |
 | `MERIDIAN_PRICING_CONFIG` | `CLAUDE_PROXY_PRICING_CONFIG` | `~/.config/meridian/model-pricing.json` | Path to the model pricing overrides file used by cost estimation |
 | `MERIDIAN_PROFILES` | — | unset | JSON array of profile configs (overrides disk discovery). See [Multi-Profile Support](profiles.md). |
 | `MERIDIAN_DEFER_TOOL_THRESHOLD` | — | `15` | Number of tools before non-core tools are deferred via ToolSearch. Set to `0` to disable. |
@@ -46,6 +47,44 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_PLUGIN_CONFIG` | — | `~/.config/meridian/plugins.json` | Plugin manifest path |
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost. Fable 1M is also included at no Extra Usage cost, verified live on both Max and Team.
+
+### Relocating the config directory
+
+`MERIDIAN_CONFIG_DIR` moves the directory Meridian keeps its own state in, so a
+second instance pointed at an empty directory starts genuinely empty:
+
+| File | Holds |
+|---|---|
+| `settings.json` | Active profile, routing mode, priority order |
+| `profiles.json` | Configured profiles ([Multi-Profile Support](profiles.md)) |
+| `profiles/<id>/` | Per-profile `CLAUDE_CONFIG_DIR` (credentials, SDK state) |
+| `adapter-instances.json` | [Adapter instances](agents.md#adapter-instances) |
+| `sdk-features.json` | Per-adapter [SDK feature toggles](#sdk-feature-toggles-experimental) |
+| `model-pricing.json` | Cost-estimation overrides |
+| `telemetry.db` | Persisted telemetry, when enabled |
+
+`MERIDIAN_PRICING_CONFIG` and `MERIDIAN_TELEMETRY_DB` still win for their own
+file when set. `XDG_CONFIG_HOME` is deliberately ignored: honouring it would
+relocate the configuration of everyone who has it set, without them asking.
+
+Two paths do **not** follow it yet — plugins (`plugins/`, `plugins.json`) and
+`design-token.json` still default under `~/.config/meridian` whatever this is set
+to. Point a second instance's plugins elsewhere with `MERIDIAN_PLUGIN_DIR` /
+`MERIDIAN_PLUGIN_CONFIG` / `MERIDIAN_DESIGN_TOKEN_PATH` in the meantime.
+
+Running a second instance beside your usual one:
+
+```bash
+mkdir -p ~/.config/meridian-dev
+MERIDIAN_CONFIG_DIR=~/.config/meridian-dev MERIDIAN_PORT=3457 meridian
+```
+
+That instance has no profiles until you add them (`MERIDIAN_CONFIG_DIR=... meridian
+profile add ...`), and switching its active profile cannot disturb the other one.
+Upgrading from a version where the variable moved `settings.json` alone? Your
+profiles stay where they are — copy `profiles.json` and `profiles/` across, or
+unset the variable. Meridian says so once at startup if it finds the new location
+empty and the default one populated.
 
 ### Subprocess traffic
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -131,7 +131,7 @@ Profile shapes:
 - `apiKey` (with optional `baseUrl`) — direct Anthropic API access; sets `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`
 - `oauthToken` — long-lived token from `claude setup-token`; sets `CLAUDE_CODE_OAUTH_TOKEN`, no config dir needed
 
-When `MERIDIAN_PROFILES` is set, it takes precedence over disk-configured profiles. When unset, Meridian auto-discovers profiles from `~/.config/meridian/profiles.json` on each request.
+When `MERIDIAN_PROFILES` is set, it takes precedence over disk-configured profiles. When unset, Meridian auto-discovers profiles from `~/.config/meridian/profiles.json` on each request. `MERIDIAN_CONFIG_DIR` moves that file and the `profiles/` directory beside it, so a second instance can keep its own accounts — see [Relocating the config directory](configuration.md#relocating-the-config-directory).
 
 Related environment variables:
 

--- a/src/__tests__/config-dir.test.ts
+++ b/src/__tests__/config-dir.test.ts
@@ -1,0 +1,228 @@
+/**
+ * MERIDIAN_CONFIG_DIR relocates the whole config directory.
+ *
+ * Two properties are under test. The first is that with the variable unset
+ * every path is byte-identical to what it has always been — a regression here
+ * moves every existing install's configuration. The second is that with it set
+ * to a fresh directory the instance is genuinely separate: its own profiles,
+ * its own adapter instances, its own feature toggles, and no way to reach the
+ * default directory's copies by accident.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { homedir, tmpdir } from "node:os"
+import { configDir, configPath, defaultConfigDir } from "../configDir"
+import {
+  loadProfilesFromDisk,
+  profilesRelocationNotice,
+  resolveProfile,
+  resetActiveProfile,
+} from "../proxy/profiles"
+import { loadAdapterInstances } from "../proxy/adapterInstances"
+import { getPricingOverrides, setPricingOverride } from "../telemetry/pricingStore"
+
+const legacyDir = join(homedir(), ".config", "meridian")
+const root = join(tmpdir(), `meridian-config-dir-${process.pid}`)
+
+/**
+ * A fresh pair of directories per test. loadProfilesFromDisk caches for 5s
+ * keyed by the resolved path, so two tests sharing one path would have the
+ * second served from the first's cache — green, or red, for the wrong reason.
+ */
+let dirA = ""
+let dirB = ""
+let testCase = 0
+
+let savedConfigDir: string | undefined
+
+beforeEach(() => {
+  savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+  testCase++
+  dirA = join(root, `a${testCase}`)
+  dirB = join(root, `b${testCase}`)
+  mkdirSync(dirA, { recursive: true })
+  mkdirSync(dirB, { recursive: true })
+  resetActiveProfile()
+})
+
+afterEach(() => {
+  if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+  else delete process.env.MERIDIAN_CONFIG_DIR
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe("configDir", () => {
+  test("unset — resolves to the directory it always has", () => {
+    delete process.env.MERIDIAN_CONFIG_DIR
+    expect(configDir()).toBe(legacyDir)
+    expect(configPath("profiles.json")).toBe(join(legacyDir, "profiles.json"))
+    expect(configPath("settings.json")).toBe(join(legacyDir, "settings.json"))
+    expect(configPath("profiles", "work")).toBe(join(legacyDir, "profiles", "work"))
+    expect(configPath("adapter-instances.json")).toBe(join(legacyDir, "adapter-instances.json"))
+    expect(configPath("sdk-features.json")).toBe(join(legacyDir, "sdk-features.json"))
+    expect(configPath("model-pricing.json")).toBe(join(legacyDir, "model-pricing.json"))
+    expect(configPath("telemetry.db")).toBe(join(legacyDir, "telemetry.db"))
+  })
+
+  test("empty string is treated as unset rather than as the filesystem root", () => {
+    process.env.MERIDIAN_CONFIG_DIR = ""
+    expect(configDir()).toBe(legacyDir)
+  })
+
+  test("set — every path moves under it", () => {
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(configDir()).toBe(dirA)
+    expect(configPath("profiles.json")).toBe(join(dirA, "profiles.json"))
+    expect(configPath("profiles", "work")).toBe(join(dirA, "profiles", "work"))
+  })
+
+  test("resolved per call, so a change mid-process is seen", () => {
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(configDir()).toBe(dirA)
+    process.env.MERIDIAN_CONFIG_DIR = dirB
+    expect(configDir()).toBe(dirB)
+  })
+
+  test("XDG_CONFIG_HOME is deliberately ignored", () => {
+    delete process.env.MERIDIAN_CONFIG_DIR
+    const savedXdg = process.env.XDG_CONFIG_HOME
+    process.env.XDG_CONFIG_HOME = dirA
+    try {
+      expect(configDir()).toBe(legacyDir)
+      expect(defaultConfigDir()).toBe(legacyDir)
+    } finally {
+      if (savedXdg !== undefined) process.env.XDG_CONFIG_HOME = savedXdg
+      else delete process.env.XDG_CONFIG_HOME
+    }
+  })
+})
+
+describe("profiles.json follows the config directory", () => {
+  test("a fresh empty directory has no profiles", () => {
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(loadProfilesFromDisk()).toEqual([])
+  })
+
+  test("profiles are read from the configured directory", () => {
+    writeFileSync(join(dirA, "profiles.json"), JSON.stringify([{ id: "from-a" }]))
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(loadProfilesFromDisk().map(p => p.id)).toEqual(["from-a"])
+  })
+
+  test("the 5s cache does not serve one directory's profiles to another", () => {
+    // Without keying the cache by path, the second read lands inside the TTL
+    // of the first and returns dirA's list — the isolation failure this
+    // whole change exists to prevent, passing for the wrong reason.
+    writeFileSync(join(dirA, "profiles.json"), JSON.stringify([{ id: "from-a" }]))
+    writeFileSync(join(dirB, "profiles.json"), JSON.stringify([{ id: "from-b" }]))
+
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(loadProfilesFromDisk().map(p => p.id)).toEqual(["from-a"])
+
+    process.env.MERIDIAN_CONFIG_DIR = dirB
+    expect(loadProfilesFromDisk().map(p => p.id)).toEqual(["from-b"])
+
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(loadProfilesFromDisk().map(p => p.id)).toEqual(["from-a"])
+  })
+
+  test("an empty directory does not fall back to the previous one", () => {
+    writeFileSync(join(dirA, "profiles.json"), JSON.stringify([{ id: "from-a" }]))
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(loadProfilesFromDisk()).toHaveLength(1)
+
+    process.env.MERIDIAN_CONFIG_DIR = dirB
+    expect(loadProfilesFromDisk()).toEqual([])
+  })
+})
+
+describe("oauth-token isolation dir follows the config directory", () => {
+  const oauthProfile = [{ id: "ci", oauthToken: "sk-ant-oat01-test" }]
+
+  test("unset — the path is unchanged", () => {
+    delete process.env.MERIDIAN_CONFIG_DIR
+    const resolved = resolveProfile(oauthProfile, undefined)
+    expect(resolved.env.CLAUDE_CONFIG_DIR).toBe(join(legacyDir, "profiles", "ci"))
+  })
+
+  test("set — the isolation dir moves with it", () => {
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    const resolved = resolveProfile(oauthProfile, undefined)
+    expect(resolved.env.CLAUDE_CONFIG_DIR).toBe(join(dirA, "profiles", "ci"))
+  })
+})
+
+describe("adapter-instances.json follows the config directory", () => {
+  const savedEnvInstances = process.env.MERIDIAN_ADAPTER_INSTANCES
+
+  beforeEach(() => {
+    delete process.env.MERIDIAN_ADAPTER_INSTANCES
+  })
+
+  afterEach(() => {
+    if (savedEnvInstances !== undefined) process.env.MERIDIAN_ADAPTER_INSTANCES = savedEnvInstances
+  })
+
+  test("instances are read from the configured directory, per directory", () => {
+    writeFileSync(join(dirA, "adapter-instances.json"), JSON.stringify({ "inst-a": { base: "opencode" } }))
+    writeFileSync(join(dirB, "adapter-instances.json"), JSON.stringify({ "inst-b": { base: "opencode" } }))
+
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(Object.keys(loadAdapterInstances())).toEqual(["inst-a"])
+
+    process.env.MERIDIAN_CONFIG_DIR = dirB
+    expect(Object.keys(loadAdapterInstances())).toEqual(["inst-b"])
+  })
+
+  test("a fresh empty directory has no instances", () => {
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    expect(loadAdapterInstances()).toEqual({})
+  })
+})
+
+describe("model-pricing.json follows the config directory", () => {
+  const rate = { inputPerMTok: 1, outputPerMTok: 2, cacheReadPerMTok: 0.1, cacheWritePerMTok: 1.25 }
+  let savedPricingConfig: string | undefined
+
+  beforeEach(() => {
+    savedPricingConfig = process.env.MERIDIAN_PRICING_CONFIG
+    delete process.env.MERIDIAN_PRICING_CONFIG
+  })
+
+  afterEach(() => {
+    if (savedPricingConfig !== undefined) process.env.MERIDIAN_PRICING_CONFIG = savedPricingConfig
+  })
+
+  test("writes land in the configured directory and are not visible from another", () => {
+    process.env.MERIDIAN_CONFIG_DIR = dirA
+    setPricingOverride("some-custom-model", rate)
+    expect(existsSync(join(dirA, "model-pricing.json"))).toBe(true)
+    expect(getPricingOverrides()["some-custom-model"]).toEqual(rate)
+
+    process.env.MERIDIAN_CONFIG_DIR = dirB
+    expect(existsSync(join(dirB, "model-pricing.json"))).toBe(false)
+    expect(getPricingOverrides()).toEqual({})
+  })
+})
+
+describe("profilesRelocationNotice", () => {
+  const configured = join(root, "relocated", "profiles.json")
+  const fallback = join(legacyDir, "profiles.json")
+
+  test("silent when not relocated, whatever the default holds", () => {
+    expect(profilesRelocationNotice(fallback, fallback, true)).toBeUndefined()
+    expect(profilesRelocationNotice(fallback, fallback, false)).toBeUndefined()
+  })
+
+  test("silent when relocated and the default has nothing to leave behind", () => {
+    expect(profilesRelocationNotice(configured, fallback, false)).toBeUndefined()
+  })
+
+  test("names both paths when relocated away from an existing profile list", () => {
+    const notice = profilesRelocationNotice(configured, fallback, true)
+    expect(notice).toContain(configured)
+    expect(notice).toContain(fallback)
+    expect(notice).toContain("MERIDIAN_CONFIG_DIR")
+  })
+})

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -2,8 +2,7 @@
  * Unit tests for profiles.ts — pure function tests (no mocks needed).
  */
 import { describe, test, expect, beforeEach } from "bun:test"
-import { join } from "node:path"
-import { homedir } from "node:os"
+import { configPath } from "../configDir"
 import {
   resolveProfile,
   listProfiles,
@@ -107,7 +106,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-foo")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      configPath("profiles", "ci"),
     )
   })
 
@@ -117,7 +116,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-bar")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      configPath("profiles", "ci"),
     )
   })
 
@@ -129,7 +128,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-baz")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      configPath("profiles", "ci"),
     )
     expect(result.env.CLAUDE_CONFIG_DIR).not.toBe("/ignored")
   })
@@ -160,7 +159,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-qux")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      configPath("profiles", "ci"),
     )
   })
 })

--- a/src/configDir.ts
+++ b/src/configDir.ts
@@ -1,0 +1,41 @@
+/**
+ * Where Meridian keeps its own configuration.
+ *
+ * One directory holds everything Meridian persists for itself — settings.json,
+ * profiles.json, the per-profile CLAUDE_CONFIG_DIRs under profiles/,
+ * adapter-instances.json, sdk-features.json, model-pricing.json, telemetry.db.
+ * `MERIDIAN_CONFIG_DIR` moves that directory, so a second instance pointed at
+ * an empty one gets its own everything rather than inheriting the first
+ * instance's accounts.
+ *
+ * Resolved per call, never frozen at import time. A module-level constant is
+ * computed before the CLI has parsed argv or a test has set the variable, and
+ * can then be changed by neither.
+ *
+ * NOTE: deliberately does NOT honour XDG_CONFIG_HOME — anyone who has that set
+ * would silently relocate to a different config directory and appear to lose
+ * everything in it.
+ *
+ * NOTE: read straight from process.env rather than through env.ts, which would
+ * also accept a CLAUDE_PROXY_CONFIG_DIR alias. This variable postdates that
+ * prefix, so there is no legacy deployment to stay compatible with and no
+ * reason to start accepting a second name for it.
+ */
+
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+/** The directory used when MERIDIAN_CONFIG_DIR is unset. */
+export function defaultConfigDir(): string {
+  return join(homedir(), ".config", "meridian")
+}
+
+/** The directory Meridian's configuration lives in. */
+export function configDir(): string {
+  return process.env.MERIDIAN_CONFIG_DIR || defaultConfigDir()
+}
+
+/** A path inside the config directory, e.g. `configPath("profiles.json")`. */
+export function configPath(...segments: string[]): string {
+  return join(configDir(), ...segments)
+}

--- a/src/proxy/adapterInstances.ts
+++ b/src/proxy/adapterInstances.ts
@@ -17,7 +17,7 @@
  *
  * Config sources (first wins):
  *   1. MERIDIAN_ADAPTER_INSTANCES env var (JSON string)
- *   2. ~/.config/meridian/adapter-instances.json (5s TTL cache)
+ *   2. adapter-instances.json in the config directory (5s TTL cache)
  *
  * With no instances configured, adapter detection is byte-identical to the
  * built-in chain. Built-in adapter names cannot be shadowed.
@@ -26,11 +26,8 @@
  */
 
 import { existsSync, readFileSync } from "node:fs"
-import { join } from "node:path"
-import { homedir } from "node:os"
+import { configPath } from "../configDir"
 import type { AdapterFeatures } from "./sdkFeatures"
-
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "adapter-instances.json")
 
 export interface AdapterInstanceMatch {
   /** Exact header values — ALL listed headers must match (case-insensitive names). */
@@ -97,6 +94,9 @@ export function parseAdapterInstances(raw: string | undefined): AdapterInstanceM
 const DISK_CACHE_TTL_MS = 5_000
 let diskCache: AdapterInstanceMap = {}
 let diskCacheAt = 0
+/** Keyed by path so a changed MERIDIAN_CONFIG_DIR misses instead of serving
+ *  the previous directory's instances for 5s. */
+let diskCachePath = ""
 
 /**
  * Load the configured instance map. Env var wins over the disk file.
@@ -107,11 +107,13 @@ export function loadAdapterInstances(): AdapterInstanceMap {
   const fromEnv = process.env.MERIDIAN_ADAPTER_INSTANCES
   if (fromEnv) return parseAdapterInstances(fromEnv)
 
-  if (diskCacheAt > 0 && Date.now() - diskCacheAt < DISK_CACHE_TTL_MS) return diskCache
+  const file = configPath("adapter-instances.json")
+  if (diskCachePath === file && diskCacheAt > 0 && Date.now() - diskCacheAt < DISK_CACHE_TTL_MS) return diskCache
+  diskCachePath = file
   try {
-    diskCache = existsSync(CONFIG_FILE) ? parseAdapterInstances(readFileSync(CONFIG_FILE, "utf-8")) : {}
+    diskCache = existsSync(file) ? parseAdapterInstances(readFileSync(file, "utf-8")) : {}
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     diskCache = {}
   }
   diskCacheAt = Date.now()

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -1,7 +1,7 @@
 /**
  * CLI commands for profile management.
  *
- * Browser-login profiles are stored under ~/.config/meridian/profiles/{id}/
+ * Browser-login profiles are stored under <config dir>/profiles/{id}/
  * — each directory is a standalone CLAUDE_CONFIG_DIR with its own OAuth
  * tokens. OAuth-token profiles (added via `--oauth-token`) live entirely in
  * profiles.json — no per-profile config dir.
@@ -14,13 +14,12 @@ import { createHash, randomBytes } from "node:crypto"
 import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { configPath } from "../configDir"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
 import { createPlatformCredentialStore } from "./tokenRefresh"
 
-const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -34,12 +33,16 @@ const OAUTH_SCOPES = [
   "user:file_upload",
 ]
 
+function profilesConfigFile(): string {
+  return configPath("profiles.json")
+}
+
 function ensureProfilesDir(): void {
-  mkdirSync(PROFILES_DIR, { recursive: true })
+  mkdirSync(configPath("profiles"), { recursive: true })
 }
 
 function getProfileDir(id: string): string {
-  return join(PROFILES_DIR, id)
+  return configPath("profiles", id)
 }
 
 interface AuthLoginOptions {
@@ -116,18 +119,19 @@ export function parseAuthorizationCodeInput(input: string): ParsedAuthorizationC
 }
 
 function loadProfileConfig(): ProfileConfig[] {
-  if (!existsSync(CONFIG_FILE)) return []
+  const file = profilesConfigFile()
+  if (!existsSync(file)) return []
   try {
-    return JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
+    return JSON.parse(readFileSync(file, "utf-8"))
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     return []
   }
 }
 
 function saveProfileConfig(profiles: ProfileConfig[]): void {
   ensureProfilesDir()
-  writeFileSync(CONFIG_FILE, `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
+  writeFileSync(profilesConfigFile(), `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
 }
 
 function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; subscriptionType?: string } {
@@ -422,7 +426,7 @@ export function profileRemove(id: string): void {
     console.error(`\x1b[31m✗ Profile "${id}" not found.\x1b[0m`)
     process.exit(1)
   }
-  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, PROFILES_DIR)
+  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, configPath("profiles"))
   profiles.splice(idx, 1)
   saveProfileConfig(profiles)
 
@@ -576,7 +580,7 @@ function promptToken(question: string): string {
 }
 
 function printEnvHint(_profiles: ProfileConfig[]): void {
-  console.log(`\x1b[90mConfig: ${CONFIG_FILE}\x1b[0m`)
+  console.log(`\x1b[90mConfig: ${profilesConfigFile()}\x1b[0m`)
   console.log("\x1b[90mProfiles are picked up automatically — no restart needed.\x1b[0m")
 }
 

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -16,36 +16,80 @@
 
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
-import { homedir } from "node:os"
+import { configPath, defaultConfigDir } from "../configDir"
 import { setSetting, getSetting } from "./settings"
 import { pickStickyProfile, type RoutingMode } from "./routing"
-
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 
 /** Disk profile cache with short TTL so new profiles are picked up quickly */
 const DISK_CACHE_TTL_MS = 5_000
 let diskProfilesCache: ProfileConfig[] = []
 let diskProfilesCacheAt = 0
+/** Which file the cache holds, so a changed MERIDIAN_CONFIG_DIR is a miss
+ *  rather than the previous directory's profile list served for 5s. */
+let diskProfilesCachePath = ""
 
 /**
- * Load profiles from ~/.config/meridian/profiles.json.
+ * Pure: what to say when the configured profiles.json is absent — a message,
+ * or undefined when there is nothing worth saying.
+ *
+ * MERIDIAN_CONFIG_DIR used to move settings.json alone, so anyone who already
+ * set it kept getting their profile list from the default directory. Now that
+ * it moves the whole directory that list is gone from their instance, which
+ * reads as profiles lost rather than profiles left where they always were.
+ * Only relocation can produce that, hence the first condition: with the
+ * variable unset both paths are the same file and this stays silent.
+ */
+export function profilesRelocationNotice(
+  configuredFile: string,
+  defaultFile: string,
+  defaultFileExists: boolean,
+): string | undefined {
+  if (configuredFile === defaultFile || !defaultFileExists) return undefined
+  return `[meridian] No profiles at ${configuredFile}, but ${defaultFile} exists. ` +
+    `MERIDIAN_CONFIG_DIR moves the whole config directory, not settings.json alone — ` +
+    `copy profiles.json (and profiles/) across, or unset the variable to use the default.`
+}
+
+/** The notice must not repeat on every 5s cache miss. */
+let warnedProfilesLeftBehind = false
+
+function warnIfProfilesLeftBehind(configuredFile: string): void {
+  // Only a disk-discovering instance can be surprised by an empty list —
+  // with MERIDIAN_PROFILES set the profiles come from there instead.
+  if (warnedProfilesLeftBehind || !diskDiscoveryEnabled) return
+  const defaultFile = join(defaultConfigDir(), "profiles.json")
+  const notice = profilesRelocationNotice(configuredFile, defaultFile, existsSync(defaultFile))
+  if (!notice) return
+  warnedProfilesLeftBehind = true
+  console.warn(notice)
+}
+
+/**
+ * Load profiles from profiles.json in the config directory.
  * Cached with a 5s TTL so new profiles are picked up without restart,
  * while avoiding synchronous disk I/O on every request.
  */
 export function loadProfilesFromDisk(): ProfileConfig[] {
-  if (diskProfilesCacheAt > 0 && Date.now() - diskProfilesCacheAt < DISK_CACHE_TTL_MS) {
+  const file = configPath("profiles.json")
+  if (
+    diskProfilesCachePath === file &&
+    diskProfilesCacheAt > 0 &&
+    Date.now() - diskProfilesCacheAt < DISK_CACHE_TTL_MS
+  ) {
     return diskProfilesCache
   }
+  diskProfilesCachePath = file
   try {
-    if (!existsSync(CONFIG_FILE)) {
+    if (!existsSync(file)) {
+      warnIfProfilesLeftBehind(file)
       diskProfilesCache = []
     } else {
-      diskProfilesCache = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
+      diskProfilesCache = JSON.parse(readFileSync(file, "utf-8"))
     }
     diskProfilesCacheAt = Date.now()
     return diskProfilesCache
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     diskProfilesCacheAt = Date.now()
     diskProfilesCache = []
     return []
@@ -88,7 +132,7 @@ let activeProfileId: string | undefined
 
 /**
  * Set the active profile. All requests without an explicit x-meridian-profile
- * header will use this profile. Persisted to ~/.config/meridian/settings.json.
+ * header will use this profile. Persisted to settings.json in the config directory.
  */
 export function setActiveProfile(profileId: string): void {
   activeProfileId = profileId
@@ -137,7 +181,7 @@ let diskDiscoveryEnabled = false
 
 /** Enable disk auto-discovery of profiles. Called by the CLI when
  *  no MERIDIAN_PROFILES env var is set, so the server picks up
- *  profiles from ~/.config/meridian/profiles.json dynamically. */
+ *  profiles from profiles.json in the config directory dynamically. */
 export function enableDiskProfileDiscovery(): void {
   diskDiscoveryEnabled = true
 }
@@ -222,7 +266,7 @@ function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
       // silently reads host creds from disk and swaps a refreshed token in
       // for our env value, masking token failures. Path must not collapse
       // to ~/.claude — see query.ts re: upstream claude-code#20553.
-      env.CLAUDE_CONFIG_DIR = join(homedir(), ".config", "meridian", "profiles", profile.id)
+      env.CLAUDE_CONFIG_DIR = configPath("profiles", profile.id)
     }
     return { id: profile.id, type: "oauth-token", env }
   }

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -1,13 +1,12 @@
 /**
  * SDK feature toggles — per-adapter configuration for Claude Code features.
  *
- * Persisted to ~/.config/meridian/sdk-features.json.
+ * Persisted to sdk-features.json in the config directory (see configDir.ts).
  * Read at request time (no restart needed to pick up changes).
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs"
-import { join } from "node:path"
-import { homedir } from "node:os"
+import { configDir, configPath } from "../configDir"
 
 export interface AdapterFeatures {
   /** Use the Claude Code system prompt preset (tool instructions, safety rules) */
@@ -112,20 +111,22 @@ const ADAPTER_DEFAULTS: Record<string, Partial<AdapterFeatures>> = {
 }
 
 function getConfigPath(): string {
-  const dir = join(homedir(), ".config", "meridian")
+  const dir = configDir()
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-  return join(dir, "sdk-features.json")
+  return configPath("sdk-features.json")
 }
 
 let cachedConfig: FeatureConfig | null = null
+let cachedConfigPath: string | null = null
 let lastReadTime = 0
 const CACHE_TTL_MS = 5000
 
 function readConfig(): FeatureConfig {
   const now = Date.now()
-  if (cachedConfig && now - lastReadTime < CACHE_TTL_MS) return cachedConfig
-
   const path = getConfigPath()
+  if (cachedConfig && cachedConfigPath === path && now - lastReadTime < CACHE_TTL_MS) return cachedConfig
+
+  cachedConfigPath = path
   try {
     if (existsSync(path)) {
       cachedConfig = JSON.parse(readFileSync(path, "utf-8")) as FeatureConfig
@@ -146,6 +147,7 @@ function writeConfig(config: FeatureConfig): void {
     writeFileSync(tmp, JSON.stringify(config, null, 2))
     renameSync(tmp, path)
     cachedConfig = config
+    cachedConfigPath = path
     lastReadTime = Date.now()
   } catch (e) {
     console.error("[sdk-features] write failed:", (e as Error).message)

--- a/src/proxy/settings.ts
+++ b/src/proxy/settings.ts
@@ -1,7 +1,8 @@
 /**
  * Persistent server settings.
  *
- * Stored in ~/.config/meridian/settings.json. Survives proxy restarts.
+ * Stored in ~/.config/meridian/settings.json (MERIDIAN_CONFIG_DIR moves the
+ * directory). Survives proxy restarts.
  * Shared between CLI, UI, and API — browser localStorage is only used
  * for client-only preferences (theme, collapsed sections, etc.).
  *
@@ -9,8 +10,8 @@
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs"
-import { join, dirname } from "node:path"
-import { homedir } from "node:os"
+import { dirname } from "node:path"
+import { configPath } from "../configDir"
 
 /**
  * Resolve the settings file path.
@@ -18,17 +19,10 @@ import { homedir } from "node:os"
  * Resolved per call rather than frozen at import time so tests can redirect
  * it via MERIDIAN_CONFIG_DIR (see `src/__tests__/preload.ts`). Without the
  * override the path is exactly what it has always been, so existing installs
- * are unaffected.
- *
- * NOTE: deliberately does NOT honour XDG_CONFIG_HOME — anyone who has that
- * set would silently relocate to a different settings file and appear to
- * lose their configuration.
+ * are unaffected. See configDir.ts for the resolution rule itself.
  */
 function settingsFile(): string {
-  const override = process.env.MERIDIAN_CONFIG_DIR
-  return override
-    ? join(override, "settings.json")
-    : join(homedir(), ".config", "meridian", "settings.json")
+  return configPath("settings.json")
 }
 
 export interface MeridianSettings {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,12 +1,11 @@
-import { join } from "node:path"
-import { homedir } from "node:os"
+import { configPath } from "../configDir"
 import { envBool, env, envInt } from "../env"
 import { MemoryTelemetryStore } from "./store"
 import { MemoryDiagnosticLogStore } from "./logStore"
 import type { ITelemetryStore, IDiagnosticLogStore } from "./types"
 
 function getDefaultDbPath(): string {
-  return join(homedir(), ".config", "meridian", "telemetry.db")
+  return configPath("telemetry.db")
 }
 
 function createStores(): { telemetry: ITelemetryStore; diagnostics: IDiagnosticLogStore } {

--- a/src/telemetry/pricingStore.ts
+++ b/src/telemetry/pricingStore.ts
@@ -5,15 +5,15 @@
  * static table in pricing.ts doesn't know about (custom routers, brand-new
  * releases). Overrides win over the built-in table in resolveModelPricing.
  *
- * Persisted to ~/.config/meridian/model-pricing.json (override the path with
- * MERIDIAN_PRICING_CONFIG). Read at request time with a short cache, so
+ * Persisted to model-pricing.json in the config directory (override the path
+ * with MERIDIAN_PRICING_CONFIG). Read at request time with a short cache, so
  * settings-page edits show up on the next dashboard refresh without a proxy
  * restart. Mirrors the sdkFeatures.ts persistence pattern.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from "node:fs"
-import { join, dirname } from "node:path"
-import { homedir } from "node:os"
+import { dirname } from "node:path"
+import { configPath } from "../configDir"
 import { env } from "../env"
 import {
   CACHE_READ_MULTIPLIER,
@@ -29,8 +29,7 @@ const MAX_MODEL_KEY_LENGTH = 200
 function getConfigPath(): string {
   const explicit = env("PRICING_CONFIG")
   if (explicit) return explicit
-  const dir = join(homedir(), ".config", "meridian")
-  return join(dir, "model-pricing.json")
+  return configPath("model-pricing.json")
 }
 
 let cachedOverrides: PricingOverrides | null = null


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

I am still working on this branch. Opening it early so the diff is visible and
so a maintainer can say "no thank you" before more effort goes into it. I will
remove this banner when it is ready for review.

---

## The problem

`MERIDIAN_CONFIG_DIR` is named for a directory and moves one file in it.

`settingsFile()` (`src/proxy/settings.ts`) honours it. Nothing else does, and
the most consequential omission is `profiles.json`, which is a **module-level
constant** in `src/proxy/profiles.ts`:

```ts
const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
```

Computed at import, so it is fixed before anything can set the variable, and
unsettable by a test afterwards.

The consequence is that a second Meridian pointed at a fresh directory **is not
a second instance**. It still reads the production profile list, the per-profile
`claudeConfigDir` paths, the adapter instances and the feature toggles from
`~/.config/meridian`. A development build running beside a packaged one holds
the production account list and is one `profile switch` away from moving that
traffic.

That is how I found it: I wanted a dev instance to work on the profile UI, and
discovered there is no supported way to give one a different profile set.

## What this changes

Resolution moves into one module, `src/proxy/configDir.ts`, read from
`process.env` **per call**. `settings.ts` uses it too, so there is a single
definition of where the directory is rather than two that can drift.

Now relocated: `profiles.json`, `profiles/<id>`, `adapter-instances.json`,
`sdk-features.json`, `model-pricing.json`, `telemetry.db` — and `settings.json`,
whose behaviour is unchanged. Only the **defaults** move;
`MERIDIAN_PRICING_CONFIG` and `MERIDIAN_TELEMETRY_DB` still win for their own
file.

**Each 5s disk cache is keyed by the resolved path.** Without that, a reader
that changes the variable gets the previous directory's list served from a warm
cache — which is the isolation failure this change exists to prevent, passing
for the wrong reason.

## Deliberately left alone

- `~/.cache/meridian` — a cache, with its own `MERIDIAN_SESSION_DIR`.
- `~/.claude` and any explicit `claudeConfigDir` — Claude Code's directories,
  not Meridian's.
- `~/.config/opencode` — another tool's config that `meridian setup` writes.
- `plugins/`, `plugins.json` and `design-token.json` **do** belong to this
  directory and should follow it, but they resolve in `server.ts` and
  `design.ts`. Keeping the diff to the modules that decide where the directory
  *is* seemed the better trade for review; `MERIDIAN_PLUGIN_DIR`,
  `MERIDIAN_PLUGIN_CONFIG` and `MERIDIAN_DESIGN_TOKEN_PATH` relocate them
  individually today, and `docs/configuration.md` now names the gap rather than
  implying it is not one. Happy to fold them in if you would rather have it in
  one piece.

`XDG_CONFIG_HOME` is still not honoured, for the reason `settings.ts` already
gives: it would relocate the configuration of everyone who has it set.

## The migration hazard, warned about rather than papered over

Anyone already setting this variable **kept their profiles precisely because
only `settings.json` moved**. After this change their instance starts with none,
which reads as profiles lost rather than left where they always were.

So: on the first disk read that finds no `profiles.json` at the configured
location while the default location has one, Meridian says so once and names
both paths. It stays silent when the variable is unset (both paths are then the
same file) and under `MERIDIAN_PROFILES`, where disk discovery is off and an
empty list is expected. The decision is a pure function, so all four outcomes
are unit tested without touching either location.

## What this does not fix

Two instances sharing **one** directory are still not safe: profiles resolving
to the same `claudeConfigDir` share credential files, and either instance will
refresh those tokens. That is #772's subject. What this fixes is narrower and
was the blocker — a second instance can now have its own profile list at all.

## Verification

- `bun run test` — **2510 pass, 0 fail**, using the repo's own script (which
  runs several files in separate processes).
- `bunx tsc --noEmit` — exit 0, zero errors.
- New unit tests cover the resolver, the per-path cache keying, and all four
  outcomes of the migration notice.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
