### PR TITLE
feat(profiles): reorder the profile pool by drag or keyboard, on both pages

### DIFF
--- a/src/__tests__/profile-order.test.ts
+++ b/src/__tests__/profile-order.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the profile-reordering helpers — pure functions, no mocks.
+ */
+import { describe, expect, it } from "bun:test"
+import { moveInOrder, sortByOrder } from "../telemetry/profileOrder"
+
+describe("moveInOrder", () => {
+  const base = ["a", "b", "c", "d"]
+
+  it("moves an item down", () => {
+    expect(moveInOrder(base, 0, 2)).toEqual(["b", "c", "a", "d"])
+  })
+
+  it("moves an item up", () => {
+    expect(moveInOrder(base, 3, 1)).toEqual(["a", "d", "b", "c"])
+  })
+
+  it("moves to the ends", () => {
+    expect(moveInOrder(base, 2, 0)).toEqual(["c", "a", "b", "d"])
+    expect(moveInOrder(base, 0, 3)).toEqual(["b", "c", "d", "a"])
+  })
+
+  it("returns an unchanged copy for a no-op move", () => {
+    const out = moveInOrder(base, 1, 1)
+    expect(out).toEqual(base)
+    expect(out).not.toBe(base)
+  })
+
+  it("ignores out-of-range indices instead of corrupting the order", () => {
+    expect(moveInOrder(base, -1, 2)).toEqual(base)
+    expect(moveInOrder(base, 0, 9)).toEqual(base)
+    expect(moveInOrder(base, 9, 0)).toEqual(base)
+    expect(moveInOrder(base, 0, -1)).toEqual(base)
+  })
+
+  it("never mutates the input", () => {
+    const input = ["a", "b", "c"]
+    moveInOrder(input, 0, 2)
+    expect(input).toEqual(["a", "b", "c"])
+  })
+
+  it("handles empty and single-item lists", () => {
+    expect(moveInOrder([], 0, 0)).toEqual([])
+    expect(moveInOrder(["only"], 0, 0)).toEqual(["only"])
+  })
+})
+
+describe("sortByOrder", () => {
+  const profiles = [{ id: "alpha" }, { id: "beta" }, { id: "gamma" }]
+
+  it("applies the saved order", () => {
+    expect(sortByOrder(profiles, ["gamma", "alpha", "beta"]).map((p) => p.id))
+      .toEqual(["gamma", "alpha", "beta"])
+  })
+
+  it("keeps config order when nothing is saved", () => {
+    expect(sortByOrder(profiles, []).map((p) => p.id)).toEqual(["alpha", "beta", "gamma"])
+  })
+
+  it("appends profiles missing from the saved order, in their original order", () => {
+    // "beta" was added after the order was last saved.
+    expect(sortByOrder(profiles, ["gamma", "alpha"]).map((p) => p.id))
+      .toEqual(["gamma", "alpha", "beta"])
+  })
+
+  it("ignores ids in the order that no longer exist", () => {
+    expect(sortByOrder(profiles, ["deleted", "beta", "alpha", "gamma"]).map((p) => p.id))
+      .toEqual(["beta", "alpha", "gamma"])
+  })
+
+  it("ignores a duplicated id rather than rendering the profile twice", () => {
+    const out = sortByOrder(profiles, ["beta", "beta", "alpha"])
+    expect(out.map((p) => p.id)).toEqual(["beta", "alpha", "gamma"])
+    expect(out.length).toBe(3)
+  })
+
+  it("never mutates the input", () => {
+    const input = [{ id: "alpha" }, { id: "beta" }]
+    sortByOrder(input, ["beta", "alpha"])
+    expect(input.map((p) => p.id)).toEqual(["alpha", "beta"])
+  })
+})

--- a/src/__tests__/profile-order.test.ts
+++ b/src/__tests__/profile-order.test.ts
@@ -2,7 +2,16 @@
  * Unit tests for the profile-reordering helpers — pure functions, no mocks.
  */
 import { describe, expect, it } from "bun:test"
-import { moveInOrder, sortByOrder } from "../telemetry/profileOrder"
+import {
+  EDGE_ZONE_PX,
+  MAX_SCROLL_PX_PER_FRAME,
+  edgeScrollVelocity,
+  moveInOrder,
+  reorderClientJs,
+  sortByOrder,
+} from "../telemetry/profileOrder"
+import { landingHtml } from "../telemetry/landing"
+import { profilePageHtml } from "../telemetry/profilePage"
 
 describe("moveInOrder", () => {
   const base = ["a", "b", "c", "d"]
@@ -78,5 +87,79 @@ describe("sortByOrder", () => {
     const input = [{ id: "alpha" }, { id: "beta" }]
     sortByOrder(input, ["beta", "alpha"])
     expect(input.map((p) => p.id)).toEqual(["alpha", "beta"])
+  })
+})
+
+describe("edgeScrollVelocity", () => {
+  const H = 800
+
+  it("holds still through the middle of the viewport", () => {
+    expect(edgeScrollVelocity(H / 2, H)).toBe(0)
+    expect(edgeScrollVelocity(EDGE_ZONE_PX, H)).toBe(0)
+    expect(edgeScrollVelocity(H - EDGE_ZONE_PX, H)).toBe(0)
+  })
+
+  it("scrolls up near the top edge and down near the bottom", () => {
+    expect(edgeScrollVelocity(10, H)).toBeLessThan(0)
+    expect(edgeScrollVelocity(H - 10, H)).toBeGreaterThan(0)
+  })
+
+  it("ramps with depth into the zone, so a nudge and a fast travel both work", () => {
+    const shallow = Math.abs(edgeScrollVelocity(EDGE_ZONE_PX - 8, H))
+    const deep = Math.abs(edgeScrollVelocity(8, H))
+    expect(shallow).toBeGreaterThan(0)
+    expect(deep).toBeGreaterThan(shallow)
+    expect(deep).toBeLessThanOrEqual(MAX_SCROLL_PX_PER_FRAME)
+  })
+
+  it("clamps at full speed when the pointer leaves the viewport", () => {
+    // Dragging past the edge reports a clientY outside the window; the speed
+    // must cap rather than grow without bound.
+    expect(edgeScrollVelocity(-400, H)).toBe(-MAX_SCROLL_PX_PER_FRAME)
+    expect(edgeScrollVelocity(H + 400, H)).toBe(MAX_SCROLL_PX_PER_FRAME)
+  })
+
+  it("never lets the two zones overlap on a short viewport", () => {
+    // With a 100px window the raw 96px zones would both claim the middle and
+    // the direction would depend on which branch ran first.
+    const short = 100
+    expect(edgeScrollVelocity(short / 2, short)).toBe(0)
+    expect(edgeScrollVelocity(2, short)).toBeLessThan(0)
+    expect(edgeScrollVelocity(short - 2, short)).toBeGreaterThan(0)
+  })
+
+  it("returns 0 rather than NaN for a degenerate viewport", () => {
+    expect(edgeScrollVelocity(10, 0)).toBe(0)
+    expect(edgeScrollVelocity(Number.NaN, H)).toBe(0)
+    expect(edgeScrollVelocity(10, Number.NaN)).toBe(0)
+  })
+})
+
+describe("one gesture implementation, shared by both pages", () => {
+  // The defect being fixed was two pages disagreeing about the order. A second
+  // transcription of the gesture is how that comes back, so assert the pages
+  // interpolate the module rather than carrying their own copies.
+  const marker = "window.meridianReorder = (function () {"
+
+  it("both pages embed the shared client module exactly once", () => {
+    for (const [name, html] of [["landing", landingHtml], ["profiles", profilePageHtml]] as const) {
+      expect(html.split(marker).length - 1, `${name} should embed the gesture once`).toBe(1)
+      expect(html, `${name} should call init`).toContain("meridianReorder.init(")
+      expect(html, `${name} should sort by the persisted order`).toContain("meridianReorder.sortProfiles(")
+    }
+  })
+
+  it("both pages render the drag handle and the live region", () => {
+    for (const [name, html] of [["landing", landingHtml], ["profiles", profilePageHtml]] as const) {
+      expect(html, `${name} needs the handle`).toContain("drag-handle")
+      expect(html, `${name} needs the announcement target`).toContain('id="orderStatus"')
+    }
+  })
+
+  it("the shared module carries the auto-scroll, so both pages get it", () => {
+    expect(reorderClientJs).toContain("edgeScrollVelocity")
+    expect(reorderClientJs).toContain("requestAnimationFrame")
+    expect(reorderClientJs).toContain(`var EDGE_ZONE_PX = ${EDGE_ZONE_PX};`)
+    expect(reorderClientJs).toContain(`var MAX_SCROLL_PX_PER_FRAME = ${MAX_SCROLL_PX_PER_FRAME};`)
   })
 })

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -9,6 +9,7 @@
  */
 
 import { profileBarCss, profileBarHtml, profileBarJs, themeCss } from "./profileBar"
+import { reorderClientJs, reorderCss, reorderLiveRegionHtml } from "./profileOrder"
 
 export const landingHtml = `<!DOCTYPE html>
 <html lang="en">
@@ -41,6 +42,7 @@ export const landingHtml = `<!DOCTYPE html>
   .profile-card.switchable { cursor: pointer; }
   .profile-card.switchable:hover { border-color: var(--accent); }
   .profile-card.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+  ${reorderCss}
   .profile-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 4px; }
   .profile-name { font-size: 13px; font-weight: 600; letter-spacing: 0.5px; display: flex; align-items: center; gap: 8px; }
   .profile-name .prof-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--border); }
@@ -93,6 +95,7 @@ export const landingHtml = `<!DOCTYPE html>
 ` + profileBarHtml + `
 <div class="container">
   <div id="content"><div style="color:var(--muted);padding:40px;text-align:center">Loading…</div></div>
+  ${reorderLiveRegionHtml}
 </div>
 <script>
 function ms(v){if(v==null||v===0)return '—';return v<1000?v+'ms':(v/1000).toFixed(1)+'s'}
@@ -127,6 +130,8 @@ function paceColor(pc){return pc.status==='over'?'var(--red)':pc.status==='ahead
 
 function resetIn(ts){if(ts==null)return '';var d=ts-Date.now();if(d<=0)return 'resetting…';var m=Math.ceil(d/60000);if(m<60)return 'in '+m+'m';var h=Math.floor(m/60);if(h<24)return 'in '+h+'h'+(m%60?' '+(m%60)+'m':'');var days=Math.floor(h/24);return 'in '+days+'d'+(h%24?' '+(h%24)+'h':'')}
 
+${reorderClientJs}
+
 function introSection(h){
   var meta=[];
   if(h.auth&&h.auth.loggedIn)meta.push(esc(h.auth.email||'')+(h.auth.subscriptionType?' ('+esc(h.auth.subscriptionType)+')':''));
@@ -158,7 +163,12 @@ function profileSection(q,s,pl,h){
     for(var k in byProfile){if(!seen[k])profs.push({id:k,label:k==='default'?(email||'account'):k,configured:false});seen[k]=1}
   }
   if(profs.length===0)return '';
+  // The persisted order is the base order everywhere. /profiles writes it;
+  // this page read config order instead, so the two disagreed after a drag.
+  profs=meridianReorder.sortProfiles(profs);
+  var reorderable=multi&&!meridianReorder.envPinned();
   var cards='';
+  var pos=0;
   for(var i=0;i<profs.length;i++){
     var p=profs[i];var cost=byProfile[p.id];
     var wins=(quotaByProfile[p.id]||[]).filter(function(w){return w.utilization!=null});
@@ -195,14 +205,20 @@ function profileSection(q,s,pl,h){
       var exh=(pl.exhausted||[]).filter(function(e){return e.id===p.id})[0];
       if(exh)badge+=' <span class="pool-chip exhausted">exhausted · resets '+resetIn(exh.until)+'</span>';
     }
-    cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+'"'+(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
-      +'<div class="profile-head"><span class="profile-name"><span class="prof-dot"></span>'+esc(p.label||p.id)+' '+badge+'</span>'
+    var draggable=reorderable&&p.configured;
+    cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+'"'
+      +(p.configured?' data-id="'+esc(p.id)+'" data-index="'+pos+'"':'')
+      +(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
+      +'<div class="profile-head"><span class="profile-name">'+(draggable?meridianReorder.handleHtml(p.id,pos,profs.length):'')+'<span class="prof-dot"></span>'+esc(p.label||p.id)+' '+badge+'</span>'
       +'<span class="profile-cost">'+usd(cost?cost.estimatedUsd:0)+'</span></div>'
       +'<div class="profile-sub">'+(cost?cost.requests+' request'+(cost.requests===1?'':'s')+' · est. API value · 24h':'no traffic · 24h')+'</div>'
       +rows+'</div>';
+    if(p.configured)pos++;
   }
   if(!cards)return '';
-  return '<div class="section"><div class="section-title">'+(profs.length===1?'Account':'Accounts')+'</div><div class="profile-grid">'+cards+'</div></div>';
+  return '<div class="section"><div class="section-title">'+(profs.length===1?'Account':'Accounts')+'</div>'
+    +(multi?meridianReorder.noteHtml(reorderable):'')
+    +'<div class="profile-grid">'+cards+'</div></div>';
 }
 
 function strip(items){
@@ -215,12 +231,14 @@ function strip(items){
 
 async function refresh(){
   try{
-    const [health,stats,quota,profiles]=await Promise.all([
+    const [health,stats,quota,profiles,routing]=await Promise.all([
       fetch('/health').then(r=>r.json()),
       fetch('/telemetry/summary?window=86400000').then(r=>r.json()),
       fetch('/v1/usage/quota/all').then(r=>r.json()).catch(function(){return null}),
-      fetch('/profiles/list').then(r=>r.json()).catch(function(){return null})
+      fetch('/profiles/list').then(r=>r.json()).catch(function(){return null}),
+      fetch('/settings/api/routing').then(r=>r.json()).catch(function(){return null})
     ]);
+    meridianReorder.adopt(routing);
     render(health,stats,quota,profiles);
   }catch(e){document.getElementById('content').innerHTML='<div style="color:var(--red);padding:40px;text-align:center">Could not connect</div>'}
 }
@@ -228,6 +246,7 @@ async function refresh(){
 function tokens(v){if(v==null)return '—';if(v>=1e6)return (v/1e6).toFixed(1)+'M';if(v>=1e3)return (v/1e3).toFixed(1)+'k';return String(v)}
 
 function render(h,s,q,pl){
+  var refocusId=meridianReorder.focusAnchor();
   let o='';
   o+=introSection(h);
 
@@ -252,6 +271,7 @@ function render(h,s,q,pl){
 
   o+='<div class="footer">Meridian · <a href="https://github.com/rynfar/meridian">GitHub</a> · Built on the <a href="https://github.com/anthropics/claude-agent-sdk-typescript">Claude Agent SDK</a></div>';
   document.getElementById('content').innerHTML=o;
+  meridianReorder.restoreFocus(refocusId);
 }
 
 function switchProfile(id){
@@ -260,16 +280,23 @@ function switchProfile(id){
     .then(function(data){if(data.success){refresh();if(window.meridianHeaderRefresh)window.meridianHeaderRefresh()}})
     .catch(function(){});
 }
+// The handle sits inside a card that is itself a switch button, so without
+// this every grab of the handle would also change the active account.
+function onHandle(e){return !!(e.target.closest&&e.target.closest('.drag-handle'))}
 document.getElementById('content').addEventListener('click',function(e){
+  if(onHandle(e))return;
   var card=e.target.closest('.profile-card.switchable');
   if(card&&card.dataset.profile)switchProfile(card.dataset.profile);
 });
 document.getElementById('content').addEventListener('keydown',function(e){
   if(e.key!=='Enter'&&e.key!==' ')return;
+  if(onHandle(e))return;
   var card=e.target.closest('.profile-card.switchable');
   if(card&&card.dataset.profile){e.preventDefault();switchProfile(card.dataset.profile)}
 });
-refresh();setInterval(refresh,10000);
+meridianReorder.init({onSaved:refresh});
+refresh();
+setInterval(function(){if(!meridianReorder.dragging())refresh()},10000);
 ` + profileBarJs + `
 </script>
 </body>

--- a/src/telemetry/profileOrder.ts
+++ b/src/telemetry/profileOrder.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for reordering profiles on the Profiles page.
+ *
+ * The order itself already has a home: `PUT /settings/api/routing` persists
+ * it as the `profileOrder` setting, and `resolvePriorityOrder()` in
+ * src/proxy/routing.ts is what consumes it. These helpers only compute the
+ * *next* order from a drag or a keyboard move, and apply a saved order to a
+ * list of profiles for display.
+ *
+ * Mirrored by the inline browser script in profilePage.ts — the same house
+ * pattern profileUsage.ts uses, and for the same reason: the page is one
+ * template literal that runs in the browser, so it cannot import at runtime.
+ * These TS versions are the tested source of truth (profile-order.test.ts).
+ */
+
+/**
+ * Move the item at `from` to index `to`, returning a new array.
+ *
+ * Out-of-range indices (and a no-op move) return an unchanged copy rather
+ * than throwing — the caller is a drag handler, and a drop outside the list
+ * must not corrupt the order.
+ */
+export function moveInOrder<T>(order: readonly T[], from: number, to: number): T[] {
+  const next = order.slice()
+  if (from < 0 || from >= next.length) return next
+  if (to < 0 || to >= next.length) return next
+  if (from === to) return next
+  const [moved] = next.splice(from, 1)
+  next.splice(to, 0, moved as T)
+  return next
+}
+
+/**
+ * Sort `items` by the id sequence in `order`.
+ *
+ * Ids in `order` come first, in that order. Anything not listed keeps its
+ * original relative position at the end — a profile added since the order
+ * was saved must still render, and it must render somewhere predictable.
+ * This mirrors resolvePriorityOrder()'s "unlisted profiles appended in
+ * config order" rule so the page and the router agree on what the order is.
+ */
+export function sortByOrder<T extends { id: string }>(items: readonly T[], order: readonly string[]): T[] {
+  const rank = new Map<string, number>()
+  for (let i = 0; i < order.length; i++) {
+    if (!rank.has(order[i]!)) rank.set(order[i]!, i)
+  }
+  return items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const ra = rank.get(a.item.id) ?? Number.MAX_SAFE_INTEGER
+      const rb = rank.get(b.item.id) ?? Number.MAX_SAFE_INTEGER
+      if (ra !== rb) return ra - rb
+      return a.index - b.index
+    })
+    .map((entry) => entry.item)
+}

--- a/src/telemetry/profileOrder.ts
+++ b/src/telemetry/profileOrder.ts
@@ -1,16 +1,17 @@
 /**
- * Pure helpers for reordering profiles on the Profiles page.
+ * Profile ordering, shared by every page that renders the account list.
  *
  * The order itself already has a home: `PUT /settings/api/routing` persists
  * it as the `profileOrder` setting, and `resolvePriorityOrder()` in
- * src/proxy/routing.ts is what consumes it. These helpers only compute the
- * *next* order from a drag or a keyboard move, and apply a saved order to a
- * list of profiles for display.
+ * src/proxy/routing.ts is what consumes it. This module owns the *display*
+ * half — applying that saved order, computing the next order from a drag or
+ * a keyboard move, and the drag gesture itself.
  *
- * Mirrored by the inline browser script in profilePage.ts — the same house
- * pattern profileUsage.ts uses, and for the same reason: the page is one
- * template literal that runs in the browser, so it cannot import at runtime.
- * These TS versions are the tested source of truth (profile-order.test.ts).
+ * The pure functions are the tested source of truth (profile-order.test.ts).
+ * `reorderCss` / `reorderClientJs` are the single browser-side copy: the
+ * pages are template literals that cannot import at runtime, so instead of
+ * each pasting its own transcription they interpolate these, and there is
+ * exactly one implementation of the gesture in the codebase.
  */
 
 /**
@@ -37,7 +38,7 @@ export function moveInOrder<T>(order: readonly T[], from: number, to: number): T
  * original relative position at the end — a profile added since the order
  * was saved must still render, and it must render somewhere predictable.
  * This mirrors resolvePriorityOrder()'s "unlisted profiles appended in
- * config order" rule so the page and the router agree on what the order is.
+ * config order" rule so every page and the router agree on what the order is.
  */
 export function sortByOrder<T extends { id: string }>(items: readonly T[], order: readonly string[]): T[] {
   const rank = new Map<string, number>()
@@ -54,3 +55,343 @@ export function sortByOrder<T extends { id: string }>(items: readonly T[], order
     })
     .map((entry) => entry.item)
 }
+
+/** Distance from a viewport edge at which a drag starts scrolling the page. */
+export const EDGE_ZONE_PX = 96
+/** Scroll step at the very edge, in px per animation frame (~60/s). */
+export const MAX_SCROLL_PX_PER_FRAME = 20
+
+/**
+ * How far to scroll the page during a drag, given the pointer's viewport
+ * position. Negative scrolls up, positive down, zero holds still.
+ *
+ * HTML5 drag-and-drop does not scroll the page for you once the list is
+ * taller than the viewport, so a drag can only reach targets that were
+ * already on screen. Ramping the speed with depth into the edge zone is
+ * what makes both a nudge and a fast travel possible from one gesture.
+ *
+ * A pointer dragged past the edge reports a clientY outside the viewport;
+ * that clamps to full speed rather than accelerating without bound. The
+ * zone is capped at half the viewport so the two zones cannot overlap and
+ * fight on a short window.
+ */
+export function edgeScrollVelocity(
+  clientY: number,
+  viewportHeight: number,
+  edge: number = EDGE_ZONE_PX,
+  maxSpeed: number = MAX_SCROLL_PX_PER_FRAME,
+): number {
+  if (!Number.isFinite(clientY) || !Number.isFinite(viewportHeight)) return 0
+  if (viewportHeight <= 0) return 0
+  const zone = Math.min(edge, viewportHeight / 2)
+  if (zone <= 0) return 0
+  if (clientY < zone) {
+    return -Math.round(maxSpeed * Math.min(1, (zone - clientY) / zone))
+  }
+  const fromBottom = viewportHeight - clientY
+  if (fromBottom < zone) {
+    return Math.round(maxSpeed * Math.min(1, (zone - fromBottom) / zone))
+  }
+  return 0
+}
+
+/** Reorder affordances. Interpolated by every page that renders the list. */
+export const reorderCss = `
+  .profile-card.dragging { opacity: 0.45; border-color: var(--accent); }
+  .profile-card.drop-target { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+  .drag-handle {
+    background: none; border: 1px solid transparent; border-radius: 6px;
+    color: var(--muted); cursor: grab; padding: 2px 6px; font-size: 15px;
+    line-height: 1; user-select: none; flex-shrink: 0;
+  }
+  .drag-handle:hover { color: var(--accent); border-color: var(--border); }
+  .drag-handle:focus-visible { outline: none; color: var(--accent); border-color: var(--accent); }
+  .drag-handle:active { cursor: grabbing; }
+  .order-index {
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 11px;
+    color: var(--muted); min-width: 16px; text-align: right; flex-shrink: 0;
+  }
+  .order-note { font-size: 12px; color: var(--muted); margin-bottom: 12px; max-width: 620px; }
+  .order-note code {
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 11px;
+    background: var(--bg); padding: 1px 5px; border-radius: 4px; color: var(--accent2);
+  }
+  .order-note.locked { color: var(--yellow); }
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+  }
+`
+
+/** The live region the gesture announces moves into. Both pages embed it. */
+export const reorderLiveRegionHtml = `<div id="orderStatus" class="sr-only" role="status" aria-live="polite"></div>`
+
+/**
+ * The browser half, as `window.meridianReorder`. Interpolated verbatim into
+ * each page's inline script; see the module doc for why it is a string.
+ *
+ * Contract with the page: cards are `.profile-card[data-id]` inside
+ * `#content`, rendered in the order `sortProfiles()` returned, and
+ * `init({ onSaved })` is called once with a re-render callback.
+ */
+export const reorderClientJs = `
+window.meridianReorder = (function () {
+  function moveInOrder(order, from, to) {
+    var next = order.slice();
+    if (from < 0 || from >= next.length) return next;
+    if (to < 0 || to >= next.length) return next;
+    if (from === to) return next;
+    var moved = next.splice(from, 1)[0];
+    next.splice(to, 0, moved);
+    return next;
+  }
+
+  function sortByOrder(items, order) {
+    // Null-prototype: a profile called "constructor" or "toString" would
+    // otherwise test true against Object.prototype and rank as position 0.
+    var rank = Object.create(null);
+    for (var i = 0; i < order.length; i++) {
+      if (!(order[i] in rank)) rank[order[i]] = i;
+    }
+    return items
+      .map(function (item, index) { return { item: item, index: index }; })
+      .sort(function (a, b) {
+        var ra = a.item.id in rank ? rank[a.item.id] : Number.MAX_SAFE_INTEGER;
+        var rb = b.item.id in rank ? rank[b.item.id] : Number.MAX_SAFE_INTEGER;
+        if (ra !== rb) return ra - rb;
+        return a.index - b.index;
+      })
+      .map(function (entry) { return entry.item; });
+  }
+
+  // Escapes the attribute delimiter too. The profiles page's own esc() goes
+  // through textContent, which leaves a double quote intact and would break
+  // out of the aria-label this builds.
+  function escAttr(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (ch) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch];
+    });
+  }
+
+  var EDGE_ZONE_PX = ${EDGE_ZONE_PX};
+  var MAX_SCROLL_PX_PER_FRAME = ${MAX_SCROLL_PX_PER_FRAME};
+
+  // Mirrors edgeScrollVelocity in src/telemetry/profileOrder.ts, unit-tested
+  // in profile-order.test.ts.
+  function edgeScrollVelocity(clientY, viewportHeight) {
+    if (!isFinite(clientY) || !isFinite(viewportHeight) || viewportHeight <= 0) return 0;
+    var zone = Math.min(EDGE_ZONE_PX, viewportHeight / 2);
+    if (zone <= 0) return 0;
+    if (clientY < zone) return -Math.round(MAX_SCROLL_PX_PER_FRAME * Math.min(1, (zone - clientY) / zone));
+    var fromBottom = viewportHeight - clientY;
+    if (fromBottom < zone) return Math.round(MAX_SCROLL_PX_PER_FRAME * Math.min(1, (zone - fromBottom) / zone));
+    return 0;
+  }
+
+  var velocity = 0;
+  var frame = null;
+  var pointerSeenAt = 0;
+  // A drag that leaves the window stops producing dragover events while the
+  // last velocity is still in force, which would scroll to the end on its
+  // own. dragend covers the ordinary paths; this covers the rest.
+  var POINTER_STALE_MS = 700;
+
+  function step() {
+    frame = null;
+    if (velocity === 0) return;
+    if (Date.now() - pointerSeenAt > POINTER_STALE_MS) { velocity = 0; return; }
+    window.scrollBy(0, velocity);
+    frame = window.requestAnimationFrame(step);
+  }
+
+  function trackPointer(e) {
+    if (fromIndex === null) return;
+    pointerSeenAt = Date.now();
+    velocity = edgeScrollVelocity(e.clientY, window.innerHeight);
+    if (velocity !== 0 && frame === null) frame = window.requestAnimationFrame(step);
+  }
+
+  function stopAutoScroll() {
+    velocity = 0;
+    if (frame !== null) { window.cancelAnimationFrame(frame); frame = null; }
+  }
+
+  var state = { order: [], envPinned: false };
+  var fromIndex = null;
+  var pendingFocusId = null;
+  var onSaved = function () {};
+
+  function adopt(cfg) {
+    if (!cfg) return;
+    if (Array.isArray(cfg.profileOrder)) state.order = cfg.profileOrder;
+    state.envPinned = !!(cfg.envOverride && cfg.envOverride.profileOrder);
+  }
+
+  function sortProfiles(items) { return sortByOrder(items || [], state.order || []); }
+
+  function announce(message) {
+    var live = document.getElementById('orderStatus');
+    if (live) live.textContent = message;
+  }
+
+  function noteHtml(reorderable) {
+    return reorderable
+      ? '<div class="order-note">Drag a card by its handle to reorder, or focus a handle and press \\u2191 / \\u2193. '
+        + 'The order is saved, and drives <a href="/settings" style="color:var(--accent)">Priority routing</a> \\u2014 the pool drains from the top.</div>'
+      : '<div class="order-note locked">Order is pinned by the <code>MERIDIAN_PROFILE_ORDER</code> environment variable. Unset it to reorder from here.</div>';
+  }
+
+  function handleHtml(id, index, total) {
+    return '<span class="order-index">' + (index + 1) + '</span>'
+      + '<button type="button" class="drag-handle" draggable="true" data-index="' + index + '"'
+      + ' title="Drag to reorder, or press \\u2191 / \\u2193"'
+      + ' aria-label="Reorder ' + escAttr(id) + ', position ' + (index + 1) + ' of ' + total
+      + '. Press arrow up or arrow down to move.">\\u283f</button>';
+  }
+
+  // The rendered order is the truth the server must agree with — read it back
+  // off the DOM rather than from the cached config, which may list ids the
+  // current /profiles/list no longer has (PUT rejects unknown ids outright).
+  function currentOrderIds() {
+    var ids = [];
+    var cards = document.querySelectorAll('.profile-card[data-id]');
+    for (var i = 0; i < cards.length; i++) ids.push(cards[i].dataset.id);
+    return ids;
+  }
+
+  function clearMarks() {
+    var marked = document.querySelectorAll('.profile-card.dragging, .profile-card.drop-target');
+    for (var i = 0; i < marked.length; i++) marked[i].classList.remove('dragging', 'drop-target');
+  }
+
+  function save(order, message) {
+    var previous = state.order;
+    state.order = order;
+    return fetch('/settings/api/routing', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profileOrder: order })
+    }).catch(function () { return null; }).then(function (res) {
+      if (!res || !res.ok) {
+        state.order = previous;
+        announce('Could not save the new order.');
+      } else if (message) {
+        announce(message);
+      }
+      return onSaved();
+    });
+  }
+
+  function moveTo(from, to) {
+    var order = currentOrderIds();
+    if (to < 0 || to >= order.length || from === to) return;
+    save(moveInOrder(order, from, to), order[from] + ' moved to position ' + (to + 1) + ' of ' + order.length + '.');
+  }
+
+  function init(opts) {
+    if (opts && opts.onSaved) onSaved = opts.onSaved;
+    var content = document.getElementById('content');
+
+    content.addEventListener('dragstart', function (e) {
+      var handle = e.target.closest && e.target.closest('.drag-handle');
+      if (!handle) return;
+      var card = handle.closest('.profile-card');
+      fromIndex = Number(handle.dataset.index);
+      pointerSeenAt = Date.now();
+      e.dataTransfer.effectAllowed = 'move';
+      // Firefox will not start a drag at all unless the payload is set.
+      e.dataTransfer.setData('text/plain', card.dataset.id || '');
+      if (e.dataTransfer.setDragImage) e.dataTransfer.setDragImage(card, 24, 24);
+      card.classList.add('dragging');
+    });
+
+    content.addEventListener('dragover', function (e) {
+      if (fromIndex === null) return;
+      var card = e.target.closest && e.target.closest('.profile-card');
+      if (!card) return;
+      // preventDefault is what makes an element a drop target at all.
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      var marked = document.querySelectorAll('.profile-card.drop-target');
+      for (var i = 0; i < marked.length; i++) marked[i].classList.remove('drop-target');
+      if (Number(card.dataset.index) !== fromIndex) card.classList.add('drop-target');
+    });
+
+    content.addEventListener('drop', function (e) {
+      if (fromIndex === null) return;
+      var card = e.target.closest && e.target.closest('.profile-card');
+      if (!card) return;
+      e.preventDefault();
+      var from = fromIndex;
+      var to = Number(card.dataset.index);
+      fromIndex = null;
+      stopAutoScroll();
+      clearMarks();
+      moveTo(from, to);
+    });
+
+    content.addEventListener('keydown', function (e) {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      var handle = e.target.closest && e.target.closest('.drag-handle');
+      if (!handle) return;
+      e.preventDefault();
+      var order = currentOrderIds();
+      var from = Number(handle.dataset.index);
+      var to = e.key === 'ArrowUp' ? from - 1 : from + 1;
+      if (to < 0 || to >= order.length) return;
+      pendingFocusId = order[from];
+      moveTo(from, to);
+    });
+
+    // The page scrolls only while the pointer sits near a viewport edge, and
+    // the pointer is over the header or the gap between cards as often as it
+    // is over one — so this listens on the document, not on #content.
+    document.addEventListener('dragover', trackPointer);
+    document.addEventListener('dragend', function () {
+      fromIndex = null;
+      stopAutoScroll();
+      clearMarks();
+    });
+    document.addEventListener('drop', stopAutoScroll);
+  }
+
+  // A poll landing mid-drag would replace the very cards being dragged.
+  function dragging() { return fromIndex !== null; }
+
+  // A re-render replaces the focused handle; without this the keyboard path
+  // loses focus mid-reorder and the next arrow key goes nowhere.
+  function focusAnchor() {
+    var pending = pendingFocusId;
+    pendingFocusId = null;
+    if (pending) return pending;
+    var active = document.activeElement;
+    if (!active || !active.closest || !active.closest('.drag-handle')) return null;
+    var card = active.closest('.profile-card');
+    return card ? card.dataset.id : null;
+  }
+
+  function restoreFocus(id) {
+    if (!id) return;
+    var cards = document.querySelectorAll('.profile-card[data-id]');
+    for (var i = 0; i < cards.length; i++) {
+      if (cards[i].dataset.id !== id) continue;
+      var handle = cards[i].querySelector('.drag-handle');
+      if (handle) handle.focus();
+      return;
+    }
+  }
+
+  return {
+    adopt: adopt,
+    sortProfiles: sortProfiles,
+    envPinned: function () { return state.envPinned; },
+    noteHtml: noteHtml,
+    handleHtml: handleHtml,
+    init: init,
+    dragging: dragging,
+    focusAnchor: focusAnchor,
+    restoreFocus: restoreFocus,
+    announce: announce
+  };
+})();
+`

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -4,6 +4,7 @@
  */
 
 import { profileBarCss, profileBarHtml, profileBarJs, themeCss } from "./profileBar"
+import { reorderClientJs, reorderCss, reorderLiveRegionHtml } from "./profileOrder"
 import { WINDOW_LABELS } from "./profileUsage"
 
 export const profilePageHtml = `<!DOCTYPE html>
@@ -29,35 +30,8 @@ export const profilePageHtml = `<!DOCTYPE html>
     padding: 20px; margin-bottom: 12px; transition: border-color 0.2s;
   }
   .profile-card.active { border-color: var(--accent); }
-  .profile-card.dragging { opacity: 0.45; border-color: var(--accent); }
-  .profile-card.drop-target { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
   .profile-card-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
-
-  /* Reorder affordances. The order this list is in IS the Priority-routing
-     pool order (persisted by PUT /settings/api/routing), so the handle is a
-     real control, not decoration. */
-  .drag-handle {
-    background: none; border: 1px solid transparent; border-radius: 6px;
-    color: var(--muted); cursor: grab; padding: 2px 6px; font-size: 15px;
-    line-height: 1; user-select: none; flex-shrink: 0;
-  }
-  .drag-handle:hover { color: var(--accent); border-color: var(--border); }
-  .drag-handle:focus-visible { outline: none; color: var(--accent); border-color: var(--accent); }
-  .drag-handle:active { cursor: grabbing; }
-  .order-index {
-    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 11px;
-    color: var(--muted); min-width: 16px; text-align: right; flex-shrink: 0;
-  }
-  .order-note { font-size: 12px; color: var(--muted); margin-bottom: 12px; max-width: 620px; }
-  .order-note code {
-    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 11px;
-    background: var(--bg); padding: 1px 5px; border-radius: 4px; color: var(--accent2);
-  }
-  .order-note.locked { color: var(--yellow); }
-  .sr-only {
-    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
-    overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
-  }
+  ${reorderCss}
   .profile-name { font-size: 16px; font-weight: 600; }
   .profile-badge {
     font-size: 10px; padding: 2px 8px; border-radius: 4px; text-transform: uppercase;
@@ -169,7 +143,7 @@ export const profilePageHtml = `<!DOCTYPE html>
 <div class="subtitle">Manage Claude account profiles</div>
 
 <div id="content"><div style="color:var(--muted);padding:40px;text-align:center">Loading\u2026</div></div>
-<div id="orderStatus" class="sr-only" role="status" aria-live="polite"></div>
+${reorderLiveRegionHtml}
 
 <div class="section" style="margin-top:32px">
   <div class="section-title">Setup Guide</div>
@@ -263,44 +237,11 @@ function formatExtraUsage(eu) {
   };
 }
 
-// Inlined from src/telemetry/profileOrder.ts, unit-tested in
-// profile-order.test.ts — same arrangement as the usage helpers above.
-function moveInOrder(order, from, to) {
-  var next = order.slice();
-  if (from < 0 || from >= next.length) return next;
-  if (to < 0 || to >= next.length) return next;
-  if (from === to) return next;
-  var moved = next.splice(from, 1)[0];
-  next.splice(to, 0, moved);
-  return next;
-}
-
-function sortByOrder(items, order) {
-  // Null-prototype: a profile called "constructor" or "toString" would
-  // otherwise test true against Object.prototype and rank as position 0.
-  var rank = Object.create(null);
-  for (var i = 0; i < order.length; i++) {
-    if (!(order[i] in rank)) rank[order[i]] = i;
-  }
-  return items
-    .map(function (item, index) { return { item: item, index: index }; })
-    .sort(function (a, b) {
-      var ra = a.item.id in rank ? rank[a.item.id] : Number.MAX_SAFE_INTEGER;
-      var rb = b.item.id in rank ? rank[b.item.id] : Number.MAX_SAFE_INTEGER;
-      if (ra !== rb) return ra - rb;
-      return a.index - b.index;
-    })
-    .map(function (entry) { return entry.item; });
-}
+${reorderClientJs}
 
 // Cache the last seen quota response so the /profiles/list refresh can
 // keep showing usage even if a single /v1/usage/quota/all call fails.
 var lastQuota = null;
-// The saved pool order, from the same endpoint /settings writes to — there
-// is one order, not a page-local copy of one.
-var routingCfg = { profileOrder: [], envOverride: {} };
-var dragFromIndex = null;
-var pendingFocusId = null;
 
 async function refresh() {
   try {
@@ -316,7 +257,7 @@ async function refresh() {
     }
     if (quota) lastQuota = quota;
     if (routingRes && routingRes.ok) {
-      try { routingCfg = await routingRes.json(); } catch (_) { /* keep the last good order */ }
+      try { meridianReorder.adopt(await routingRes.json()); } catch (_) { /* keep the last good order */ }
     }
     render(profiles, lastQuota);
   } catch {
@@ -391,15 +332,9 @@ function renderUsageSection(profileQuota) {
 }
 
 function render(data, quotaData) {
-  const profiles = sortByOrder(data.profiles || [], routingCfg.profileOrder || []);
+  const profiles = meridianReorder.sortProfiles(data.profiles || []);
   const active = data.activeProfile;
-  // A poll every 10s replaces this DOM wholesale; without this the keyboard
-  // path loses focus mid-reorder and the next arrow key goes nowhere.
-  const focusedCard = document.activeElement && document.activeElement.closest
-    ? document.activeElement.closest('.drag-handle') && document.activeElement.closest('.profile-card')
-    : null;
-  const refocusId = pendingFocusId || (focusedCard ? focusedCard.dataset.id : null);
-  pendingFocusId = null;
+  const refocusId = meridianReorder.focusAnchor();
   // Build quick lookup: profileId -> per-profile quota entry from
   // /v1/usage/quota/all. Endpoint may be unavailable (older Meridian)
   // or have errored — in that case quotaById is empty and the per-card
@@ -419,29 +354,17 @@ function render(data, quotaData) {
     return;
   }
 
-  const orderPinnedByEnv = !!(routingCfg.envOverride && routingCfg.envOverride.profileOrder);
-  const reorderable = profiles.length > 1 && !orderPinnedByEnv;
+  const reorderable = profiles.length > 1 && !meridianReorder.envPinned();
 
   let html = '<div class="section"><div class="section-title">Configured Profiles</div>';
-  if (profiles.length > 1) {
-    html += reorderable
-      ? '<div class="order-note">Drag a card by its handle to reorder, or focus a handle and press \u2191 / \u2193. '
-        + 'The order is saved, and drives <a href="/settings" style="color:var(--accent)">Priority routing</a> \u2014 the pool drains from the top.</div>'
-      : '<div class="order-note locked">Order is pinned by the <code>MERIDIAN_PROFILE_ORDER</code> environment variable. Unset it to reorder from here.</div>';
-  }
+  if (profiles.length > 1) html += meridianReorder.noteHtml(reorderable);
 
   for (let idx = 0; idx < profiles.length; idx++) {
     const p = profiles[idx];
     const isActive = p.id === active;
     html += '<div class="profile-card' + (isActive ? ' active' : '') + '" data-id="' + esc(p.id) + '" data-index="' + idx + '">';
     html += '<div class="profile-card-header">';
-    if (reorderable) {
-      html += '<span class="order-index">' + (idx + 1) + '</span>';
-      html += '<button type="button" class="drag-handle" draggable="true" data-index="' + idx + '"'
-        + ' title="Drag to reorder, or press \u2191 / \u2193"'
-        + ' aria-label="Reorder ' + esc(p.id) + ', position ' + (idx + 1) + ' of ' + profiles.length
-        + '. Press arrow up or arrow down to move.">\u283f</button>';
-    }
+    if (reorderable) html += meridianReorder.handleHtml(p.id, idx, profiles.length);
     html += '<span class="profile-name">' + esc(p.id) + '</span>';
     if (isActive) html += '<span class="profile-badge badge-active">active</span>';
     html += '<span class="profile-badge badge-type">' + esc(p.type || 'claude-max') + '</span>';
@@ -497,112 +420,8 @@ function render(data, quotaData) {
 
   html += '</div>';
   document.getElementById('content').innerHTML = html;
-
-  if (refocusId) {
-    var cards = document.querySelectorAll('.profile-card');
-    for (var ci = 0; ci < cards.length; ci++) {
-      if (cards[ci].dataset.id !== refocusId) continue;
-      var handle = cards[ci].querySelector('.drag-handle');
-      if (handle) handle.focus();
-      break;
-    }
-  }
+  meridianReorder.restoreFocus(refocusId);
 }
-
-function announce(message) {
-  var live = document.getElementById('orderStatus');
-  if (live) live.textContent = message;
-}
-
-// The rendered order is the truth the server must agree with — read it back
-// off the DOM rather than from routingCfg, which may list ids the current
-// /profiles/list no longer has (PUT rejects unknown ids outright).
-function currentOrderIds() {
-  var ids = [];
-  var cards = document.querySelectorAll('.profile-card[data-id]');
-  for (var i = 0; i < cards.length; i++) ids.push(cards[i].dataset.id);
-  return ids;
-}
-
-async function saveOrder(order, message) {
-  var previous = routingCfg.profileOrder;
-  routingCfg.profileOrder = order;
-  var res = await fetch('/settings/api/routing', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ profileOrder: order })
-  }).catch(function () { return null; });
-  if (!res || !res.ok) {
-    routingCfg.profileOrder = previous;
-    announce('Could not save the new order.');
-  } else if (message) {
-    announce(message);
-  }
-  await refresh();
-}
-
-function clearDragMarks() {
-  var marked = document.querySelectorAll('.profile-card.dragging, .profile-card.drop-target');
-  for (var i = 0; i < marked.length; i++) marked[i].classList.remove('dragging', 'drop-target');
-}
-
-var content = document.getElementById('content');
-
-content.addEventListener('dragstart', function (e) {
-  var handle = e.target.closest && e.target.closest('.drag-handle');
-  if (!handle) return;
-  var card = handle.closest('.profile-card');
-  dragFromIndex = Number(handle.dataset.index);
-  e.dataTransfer.effectAllowed = 'move';
-  // Firefox will not start a drag at all unless the payload is set.
-  e.dataTransfer.setData('text/plain', card.dataset.id || '');
-  if (e.dataTransfer.setDragImage) e.dataTransfer.setDragImage(card, 24, 24);
-  card.classList.add('dragging');
-});
-
-content.addEventListener('dragend', function () {
-  dragFromIndex = null;
-  clearDragMarks();
-});
-
-content.addEventListener('dragover', function (e) {
-  if (dragFromIndex === null) return;
-  var card = e.target.closest && e.target.closest('.profile-card');
-  if (!card) return;
-  // preventDefault is what makes an element a drop target at all.
-  e.preventDefault();
-  e.dataTransfer.dropEffect = 'move';
-  var marked = document.querySelectorAll('.profile-card.drop-target');
-  for (var i = 0; i < marked.length; i++) marked[i].classList.remove('drop-target');
-  if (Number(card.dataset.index) !== dragFromIndex) card.classList.add('drop-target');
-});
-
-content.addEventListener('drop', function (e) {
-  if (dragFromIndex === null) return;
-  var card = e.target.closest && e.target.closest('.profile-card');
-  if (!card) return;
-  e.preventDefault();
-  var from = dragFromIndex;
-  var to = Number(card.dataset.index);
-  dragFromIndex = null;
-  clearDragMarks();
-  if (from === to) return;
-  var order = currentOrderIds();
-  saveOrder(moveInOrder(order, from, to), order[from] + ' moved to position ' + (to + 1) + ' of ' + order.length + '.');
-});
-
-content.addEventListener('keydown', function (e) {
-  if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
-  var handle = e.target.closest && e.target.closest('.drag-handle');
-  if (!handle) return;
-  e.preventDefault();
-  var order = currentOrderIds();
-  var from = Number(handle.dataset.index);
-  var to = e.key === 'ArrowUp' ? from - 1 : from + 1;
-  if (to < 0 || to >= order.length) return;
-  pendingFocusId = order[from];
-  saveOrder(moveInOrder(order, from, to), order[from] + ' moved to position ' + (to + 1) + ' of ' + order.length + '.');
-});
 
 function timeAgo(ts) {
   if (!ts) return '\u2014';
@@ -635,9 +454,9 @@ async function switchProfile(id) {
   if (data.success) refresh();
 }
 
+meridianReorder.init({ onSaved: refresh });
 refresh();
-// A poll landing mid-drag would replace the cards being dragged.
-setInterval(function () { if (dragFromIndex === null) refresh(); }, 10000);
+setInterval(function () { if (!meridianReorder.dragging()) refresh(); }, 10000);
 ` + profileBarJs + `
 </script>
 </body>

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -29,7 +29,35 @@ export const profilePageHtml = `<!DOCTYPE html>
     padding: 20px; margin-bottom: 12px; transition: border-color 0.2s;
   }
   .profile-card.active { border-color: var(--accent); }
+  .profile-card.dragging { opacity: 0.45; border-color: var(--accent); }
+  .profile-card.drop-target { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
   .profile-card-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+
+  /* Reorder affordances. The order this list is in IS the Priority-routing
+     pool order (persisted by PUT /settings/api/routing), so the handle is a
+     real control, not decoration. */
+  .drag-handle {
+    background: none; border: 1px solid transparent; border-radius: 6px;
+    color: var(--muted); cursor: grab; padding: 2px 6px; font-size: 15px;
+    line-height: 1; user-select: none; flex-shrink: 0;
+  }
+  .drag-handle:hover { color: var(--accent); border-color: var(--border); }
+  .drag-handle:focus-visible { outline: none; color: var(--accent); border-color: var(--accent); }
+  .drag-handle:active { cursor: grabbing; }
+  .order-index {
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 11px;
+    color: var(--muted); min-width: 16px; text-align: right; flex-shrink: 0;
+  }
+  .order-note { font-size: 12px; color: var(--muted); margin-bottom: 12px; max-width: 620px; }
+  .order-note code {
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 11px;
+    background: var(--bg); padding: 1px 5px; border-radius: 4px; color: var(--accent2);
+  }
+  .order-note.locked { color: var(--yellow); }
+  .sr-only {
+    position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+    overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+  }
   .profile-name { font-size: 16px; font-weight: 600; }
   .profile-badge {
     font-size: 10px; padding: 2px 8px; border-radius: 4px; text-transform: uppercase;
@@ -141,6 +169,7 @@ export const profilePageHtml = `<!DOCTYPE html>
 <div class="subtitle">Manage Claude account profiles</div>
 
 <div id="content"><div style="color:var(--muted);padding:40px;text-align:center">Loading\u2026</div></div>
+<div id="orderStatus" class="sr-only" role="status" aria-live="polite"></div>
 
 <div class="section" style="margin-top:32px">
   <div class="section-title">Setup Guide</div>
@@ -234,15 +263,51 @@ function formatExtraUsage(eu) {
   };
 }
 
+// Inlined from src/telemetry/profileOrder.ts, unit-tested in
+// profile-order.test.ts — same arrangement as the usage helpers above.
+function moveInOrder(order, from, to) {
+  var next = order.slice();
+  if (from < 0 || from >= next.length) return next;
+  if (to < 0 || to >= next.length) return next;
+  if (from === to) return next;
+  var moved = next.splice(from, 1)[0];
+  next.splice(to, 0, moved);
+  return next;
+}
+
+function sortByOrder(items, order) {
+  // Null-prototype: a profile called "constructor" or "toString" would
+  // otherwise test true against Object.prototype and rank as position 0.
+  var rank = Object.create(null);
+  for (var i = 0; i < order.length; i++) {
+    if (!(order[i] in rank)) rank[order[i]] = i;
+  }
+  return items
+    .map(function (item, index) { return { item: item, index: index }; })
+    .sort(function (a, b) {
+      var ra = a.item.id in rank ? rank[a.item.id] : Number.MAX_SAFE_INTEGER;
+      var rb = b.item.id in rank ? rank[b.item.id] : Number.MAX_SAFE_INTEGER;
+      if (ra !== rb) return ra - rb;
+      return a.index - b.index;
+    })
+    .map(function (entry) { return entry.item; });
+}
+
 // Cache the last seen quota response so the /profiles/list refresh can
 // keep showing usage even if a single /v1/usage/quota/all call fails.
 var lastQuota = null;
+// The saved pool order, from the same endpoint /settings writes to — there
+// is one order, not a page-local copy of one.
+var routingCfg = { profileOrder: [], envOverride: {} };
+var dragFromIndex = null;
+var pendingFocusId = null;
 
 async function refresh() {
   try {
-    var [profilesRes, quotaRes] = await Promise.all([
+    var [profilesRes, quotaRes, routingRes] = await Promise.all([
       fetch('/profiles/list'),
       fetch('/v1/usage/quota/all').catch(function () { return null; }),
+      fetch('/settings/api/routing').catch(function () { return null; }),
     ]);
     var profiles = await profilesRes.json();
     var quota = null;
@@ -250,6 +315,9 @@ async function refresh() {
       try { quota = await quotaRes.json(); } catch (_) { quota = null; }
     }
     if (quota) lastQuota = quota;
+    if (routingRes && routingRes.ok) {
+      try { routingCfg = await routingRes.json(); } catch (_) { /* keep the last good order */ }
+    }
     render(profiles, lastQuota);
   } catch {
     document.getElementById('content').innerHTML = '<div class="empty-state"><h2>Could not load profiles</h2><p>Is Meridian running?</p></div>';
@@ -323,8 +391,15 @@ function renderUsageSection(profileQuota) {
 }
 
 function render(data, quotaData) {
-  const profiles = data.profiles || [];
+  const profiles = sortByOrder(data.profiles || [], routingCfg.profileOrder || []);
   const active = data.activeProfile;
+  // A poll every 10s replaces this DOM wholesale; without this the keyboard
+  // path loses focus mid-reorder and the next arrow key goes nowhere.
+  const focusedCard = document.activeElement && document.activeElement.closest
+    ? document.activeElement.closest('.drag-handle') && document.activeElement.closest('.profile-card')
+    : null;
+  const refocusId = pendingFocusId || (focusedCard ? focusedCard.dataset.id : null);
+  pendingFocusId = null;
   // Build quick lookup: profileId -> per-profile quota entry from
   // /v1/usage/quota/all. Endpoint may be unavailable (older Meridian)
   // or have errored — in that case quotaById is empty and the per-card
@@ -344,12 +419,29 @@ function render(data, quotaData) {
     return;
   }
 
-  let html = '<div class="section"><div class="section-title">Configured Profiles</div>';
+  const orderPinnedByEnv = !!(routingCfg.envOverride && routingCfg.envOverride.profileOrder);
+  const reorderable = profiles.length > 1 && !orderPinnedByEnv;
 
-  for (const p of profiles) {
+  let html = '<div class="section"><div class="section-title">Configured Profiles</div>';
+  if (profiles.length > 1) {
+    html += reorderable
+      ? '<div class="order-note">Drag a card by its handle to reorder, or focus a handle and press \u2191 / \u2193. '
+        + 'The order is saved, and drives <a href="/settings" style="color:var(--accent)">Priority routing</a> \u2014 the pool drains from the top.</div>'
+      : '<div class="order-note locked">Order is pinned by the <code>MERIDIAN_PROFILE_ORDER</code> environment variable. Unset it to reorder from here.</div>';
+  }
+
+  for (let idx = 0; idx < profiles.length; idx++) {
+    const p = profiles[idx];
     const isActive = p.id === active;
-    html += '<div class="profile-card' + (isActive ? ' active' : '') + '">';
+    html += '<div class="profile-card' + (isActive ? ' active' : '') + '" data-id="' + esc(p.id) + '" data-index="' + idx + '">';
     html += '<div class="profile-card-header">';
+    if (reorderable) {
+      html += '<span class="order-index">' + (idx + 1) + '</span>';
+      html += '<button type="button" class="drag-handle" draggable="true" data-index="' + idx + '"'
+        + ' title="Drag to reorder, or press \u2191 / \u2193"'
+        + ' aria-label="Reorder ' + esc(p.id) + ', position ' + (idx + 1) + ' of ' + profiles.length
+        + '. Press arrow up or arrow down to move.">\u283f</button>';
+    }
     html += '<span class="profile-name">' + esc(p.id) + '</span>';
     if (isActive) html += '<span class="profile-badge badge-active">active</span>';
     html += '<span class="profile-badge badge-type">' + esc(p.type || 'claude-max') + '</span>';
@@ -405,7 +497,112 @@ function render(data, quotaData) {
 
   html += '</div>';
   document.getElementById('content').innerHTML = html;
+
+  if (refocusId) {
+    var cards = document.querySelectorAll('.profile-card');
+    for (var ci = 0; ci < cards.length; ci++) {
+      if (cards[ci].dataset.id !== refocusId) continue;
+      var handle = cards[ci].querySelector('.drag-handle');
+      if (handle) handle.focus();
+      break;
+    }
+  }
 }
+
+function announce(message) {
+  var live = document.getElementById('orderStatus');
+  if (live) live.textContent = message;
+}
+
+// The rendered order is the truth the server must agree with — read it back
+// off the DOM rather than from routingCfg, which may list ids the current
+// /profiles/list no longer has (PUT rejects unknown ids outright).
+function currentOrderIds() {
+  var ids = [];
+  var cards = document.querySelectorAll('.profile-card[data-id]');
+  for (var i = 0; i < cards.length; i++) ids.push(cards[i].dataset.id);
+  return ids;
+}
+
+async function saveOrder(order, message) {
+  var previous = routingCfg.profileOrder;
+  routingCfg.profileOrder = order;
+  var res = await fetch('/settings/api/routing', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ profileOrder: order })
+  }).catch(function () { return null; });
+  if (!res || !res.ok) {
+    routingCfg.profileOrder = previous;
+    announce('Could not save the new order.');
+  } else if (message) {
+    announce(message);
+  }
+  await refresh();
+}
+
+function clearDragMarks() {
+  var marked = document.querySelectorAll('.profile-card.dragging, .profile-card.drop-target');
+  for (var i = 0; i < marked.length; i++) marked[i].classList.remove('dragging', 'drop-target');
+}
+
+var content = document.getElementById('content');
+
+content.addEventListener('dragstart', function (e) {
+  var handle = e.target.closest && e.target.closest('.drag-handle');
+  if (!handle) return;
+  var card = handle.closest('.profile-card');
+  dragFromIndex = Number(handle.dataset.index);
+  e.dataTransfer.effectAllowed = 'move';
+  // Firefox will not start a drag at all unless the payload is set.
+  e.dataTransfer.setData('text/plain', card.dataset.id || '');
+  if (e.dataTransfer.setDragImage) e.dataTransfer.setDragImage(card, 24, 24);
+  card.classList.add('dragging');
+});
+
+content.addEventListener('dragend', function () {
+  dragFromIndex = null;
+  clearDragMarks();
+});
+
+content.addEventListener('dragover', function (e) {
+  if (dragFromIndex === null) return;
+  var card = e.target.closest && e.target.closest('.profile-card');
+  if (!card) return;
+  // preventDefault is what makes an element a drop target at all.
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+  var marked = document.querySelectorAll('.profile-card.drop-target');
+  for (var i = 0; i < marked.length; i++) marked[i].classList.remove('drop-target');
+  if (Number(card.dataset.index) !== dragFromIndex) card.classList.add('drop-target');
+});
+
+content.addEventListener('drop', function (e) {
+  if (dragFromIndex === null) return;
+  var card = e.target.closest && e.target.closest('.profile-card');
+  if (!card) return;
+  e.preventDefault();
+  var from = dragFromIndex;
+  var to = Number(card.dataset.index);
+  dragFromIndex = null;
+  clearDragMarks();
+  if (from === to) return;
+  var order = currentOrderIds();
+  saveOrder(moveInOrder(order, from, to), order[from] + ' moved to position ' + (to + 1) + ' of ' + order.length + '.');
+});
+
+content.addEventListener('keydown', function (e) {
+  if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+  var handle = e.target.closest && e.target.closest('.drag-handle');
+  if (!handle) return;
+  e.preventDefault();
+  var order = currentOrderIds();
+  var from = Number(handle.dataset.index);
+  var to = e.key === 'ArrowUp' ? from - 1 : from + 1;
+  if (to < 0 || to >= order.length) return;
+  pendingFocusId = order[from];
+  saveOrder(moveInOrder(order, from, to), order[from] + ' moved to position ' + (to + 1) + ' of ' + order.length + '.');
+});
 
 function timeAgo(ts) {
   if (!ts) return '\u2014';
@@ -439,7 +636,8 @@ async function switchProfile(id) {
 }
 
 refresh();
-setInterval(refresh, 10000);
+// A poll landing mid-drag would replace the cards being dragged.
+setInterval(function () { if (dragFromIndex === null) refresh(); }, 10000);
 ` + profileBarJs + `
 </script>
 </body>


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Adds drag-and-drop and keyboard reordering of the profile pool to `/profiles` **and** the home page, with one shared implementation and one shared order.

## Why

The order is load-bearing. `profileOrder` is what `resolvePriorityOrder()` consumes, so with `routing = "priority"` it decides which account serves a request and which one takes over when that account runs out.

Until now the only way to change it was the ↑/↓ list on `/settings`, which lives inside `#routing-order-wrap` and is therefore `display:none` **unless the mode is already `priority`** — so the order could not be arranged *before* switching to the mode that uses it. Meanwhile `/profiles`, the page named after these objects, rendered them in config order and offered no control at all.

## What it does

- Every card gets a real `<button>` drag handle, so it is in the tab order by default rather than by a `tabindex` somebody has to maintain.
- Dragging reorders and saves.
- **↑/↓ on a focused handle** moves that card one position and saves — the whole feature without a pointer, and the only path that works on touch, where HTML5 drag events do not fire at all.
- **Dragging near the top or bottom edge of the viewport scrolls the page** and keeps scrolling while the pointer stays there.

**No new endpoint.** `PUT /settings/api/routing` already accepts `profileOrder`, validates every id against the configured set, and persists through `setSetting`. This is a second client for it. The `/settings` list keeps working unchanged and every surface reads back the same saved order.

## The three defects fixed by the second commit

Reported against the first commit, from a live twelve-account fleet.

### 1. A drag could not reach past the current viewport

HTML5 drag-and-drop does not auto-scroll the page. Once the list is taller than the window — which twelve accounts comfortably are — the only reachable drop targets are the ones already on screen, so an item could be moved one or two positions and no further.

`edgeScrollVelocity(clientY, viewportHeight)` returns a per-frame scroll delta, ramped by how deep into the edge zone the pointer is, so one gesture serves both a nudge and a fast travel. It is a pure function with unit tests. Three details that are not guesses:

- A pointer dragged *past* the window edge reports a `clientY` outside the viewport, which **clamps** to full speed rather than accelerating without bound.
- The zone is capped at **half the viewport**, so on a short window the two zones cannot overlap and fight over the direction.
- Scrolling stops if no `dragover` has arrived for 700ms. `dragend` covers the ordinary paths, but a drag that leaves the window stops producing events while the last velocity is still in force, which would otherwise scroll to the end on its own.

The listener is on `document`, not `#content`: the pointer is over the header or the gap between cards as often as it is over a card.

### 2. The two pages disagreed about the order

`/profiles` sorted by the persisted `profileOrder`. The home page rendered `/profiles/list` in raw config order and never fetched the routing config at all — so a reorder took effect on one page and was invisible on the other. This was a read-path bug on `/`, not a write-path bug.

The persisted order is now the base order on every page: `/` fetches `/settings/api/routing` alongside its other calls and applies the same `sortByOrder`.

### 3. The home page had no drag at all

It has the same handles, the same gesture, the same auto-scroll and the same persistence, because it is the same code.

One home-page-specific guard: the card there is itself a click-to-switch button, so without a handle check every *grab* of a handle would also change the active account.

## Structure — one implementation, not two that agree today

The first commit followed the house pattern of transcribing helpers into the page's inline script, as `profileUsage.ts` does. That is exactly how defect 2 happened, and a second page would have doubled it.

`src/telemetry/profileOrder.ts` now owns the whole display half and exports the browser code as `reorderCss` / `reorderClientJs` / `reorderLiveRegionHtml`, which both pages interpolate. There is one copy of the gesture in the codebase; `profilePage.ts` goes from 644 lines to 463. A test asserts both pages interpolate the module rather than carrying their own transcriptions.

The pure parts (`moveInOrder`, `sortByOrder`, `edgeScrollVelocity`) stay directly unit-tested. `sortByOrder` appends unlisted profiles at the end in their original order, matching `resolvePriorityOrder()`, so a profile added after the order was saved renders where the router would put it.

## Two things that are still not obvious from the diff

- **The 10s poll is suspended while a drag is in flight**, and the drop handler reads the order back off the DOM rather than from the cached routing config. A poll landing mid-drag would replace the very cards being dragged; and the cached config can name a profile `/profiles/list` no longer returns, which the endpoint rejects as an unknown id.
- **When `MERIDIAN_PROFILE_ORDER` is set the handles are not rendered** and the list says so, because the env var wins over the setting. Offering a control that silently does nothing is worse than not offering it.

## Decision: dragging while a temporary view sort is active

This branch's home page has no sort control, so the case cannot arise in this diff. It arises the moment this meets #777, which adds a temporary "most spent / least spent" view sort to the same page.

**The rule is that dragging is offered only while the persisted order is the one on screen.** The drag persists whatever sequence the cards are currently in, so a drag under a spent-ranked view would silently overwrite the routing pool order with the spent ranking — an ordering the user never chose and cannot see they have chosen.

Mechanically the gate is one condition on the `reorderable` line in `landing.ts`: `multi && !meridianReorder.envPinned() && viewSort === 'configured'`, with the existing `noteHtml` explaining why the handles are absent, exactly as it already does for the env-var case. Whichever of the two PRs merges second owns that line.

## Accessibility

The `aria-label` names the profile and reads "position N of M", so the order is available without seeing the list; each move is announced through an `aria-live="polite"` region, because the visual result of a move is a reordered list a screen-reader user has no reason to re-read; and focus is restored to the same profile's handle after the re-render, so a run of ↑ presses moves one card repeatedly instead of moving one card and then whatever landed under the cursor.

Keyboard reorder is unaffected by defect 1 — it never needed the viewport — so the feature remained usable on a long list throughout.

## Verification

- `bunx tsc --noEmit` exit 0.
- `bun run test` (the project's own chain) — **2515 pass, 0 fail**, pipeline exit 0.
- Driven in a real browser (headless Chromium over CDP) against a development instance on its own port and its own config dir, with an eleven-account list and a 700×600 viewport so both pages overflowed:

| check | result |
|---|---|
| `/` renders the persisted order | matches `profileOrder` exactly, and differs from the raw `/profiles/list` order it used to render |
| edge auto-scroll, `/` (1708px page) | bottom → top edge scrolled 1108 → 633 in 400ms; top → bottom edge scrolled 0 → 475 |
| edge auto-scroll, `/profiles` (4987px page) | 4387 → 3912 in 400ms |
| scrolling stops | `dragend` halts it with no drift; a `dragover` in the middle of the viewport holds position |
| drag on `/` | moved a card from position 11 to 1, announced it, persisted to `settings.json` on disk |
| grabbing a handle on `/` | active profile unchanged |
| keyboard move on `/profiles` | moved, announced, focus kept on the moved card |
| round trip | a reorder on `/` showed up on `/profiles` and vice versa |
| console | no errors |

This PR is AI generated, but under direct supervision and on request of Nowaker.
