### PR TITLE
feat(dashboard): dim spent accounts on the home page

### DIFF
--- a/src/__tests__/profile-spent.test.ts
+++ b/src/__tests__/profile-spent.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the shared "how spent is this account?" classifier —
+ * pure functions, no mocks.
+ */
+import { describe, expect, it } from "bun:test"
+import {
+  FADE_FROM,
+  SPENT_AT,
+  computeProfileSpend,
+  generalUtilization,
+  isUnusable,
+} from "../telemetry/profileSpent"
+
+const win = (type: string, utilization: number | null) => ({ type, utilization })
+
+describe("generalUtilization", () => {
+  it("takes the worse of the five-hour and general weekly windows", () => {
+    expect(generalUtilization([win("five_hour", 0.2), win("seven_day", 0.8)])).toBe(0.8)
+    expect(generalUtilization([win("five_hour", 0.9), win("seven_day", 0.1)])).toBe(0.9)
+  })
+
+  it("ignores per-model caps, seven_day_fable above all", () => {
+    // The observed case: 94% Fable, general windows barely touched. Folding
+    // Fable in would call a usable account spent.
+    expect(
+      generalUtilization([win("five_hour", 0.05), win("seven_day", 0.1), win("seven_day_fable", 0.94)]),
+    ).toBe(0.1)
+    expect(
+      generalUtilization([win("seven_day", 0.2), win("seven_day_opus", 1), win("seven_day_sonnet", 1)]),
+    ).toBe(0.2)
+  })
+
+  it("returns null when no general window carries a number", () => {
+    expect(generalUtilization([])).toBeNull()
+    expect(generalUtilization(null)).toBeNull()
+    expect(generalUtilization(undefined)).toBeNull()
+    expect(generalUtilization([win("five_hour", null)])).toBeNull()
+    expect(generalUtilization([win("seven_day_fable", 0.9)])).toBeNull()
+    expect(generalUtilization([win("five_hour", Number.NaN)])).toBeNull()
+  })
+
+  it("clamps out-of-range utilization", () => {
+    expect(generalUtilization([win("seven_day", 1.4)])).toBe(1)
+    expect(generalUtilization([win("seven_day", -0.2)])).toBe(0)
+  })
+})
+
+describe("isUnusable", () => {
+  it("is true for a profile with no token or a failed login", () => {
+    expect(isUnusable({ error: "no_token" })).toBe(true)
+    expect(isUnusable({ loggedIn: false })).toBe(true)
+  })
+
+  it("is false for an API-key profile, which has no OAuth quota but works", () => {
+    expect(isUnusable({ error: "not_oauth", loggedIn: true })).toBe(false)
+  })
+
+  it("is false for a healthy profile", () => {
+    expect(isUnusable({ error: null, loggedIn: true, windows: [win("seven_day", 0.3)] })).toBe(false)
+    expect(isUnusable({})).toBe(false)
+  })
+})
+
+describe("computeProfileSpend", () => {
+  it("reports a profile that needs a human as fully spent, with its own reason", () => {
+    const s = computeProfileSpend({ error: "no_token", windows: [] })
+    expect(s.fraction).toBe(1)
+    expect(s.state).toBe("spent")
+    expect(s.reason).toBe("unusable")
+  })
+
+  it("does not fade a profile that needs a human, however spent it is", () => {
+    // Fading says "come back later"; a missing login says "do something".
+    expect(computeProfileSpend({ error: "no_token", windows: [] }).fade).toBe(0)
+    expect(computeProfileSpend({ loggedIn: false, windows: [win("seven_day", 0.99)] }).fade).toBe(0)
+  })
+
+  it("does not confuse an unusable profile with a pristine one", () => {
+    // No windows at all is what a broken profile reports — it must not read
+    // as 0% used.
+    const broken = computeProfileSpend({ error: "no_token", windows: [] })
+    const fresh = computeProfileSpend({ windows: [win("five_hour", 0), win("seven_day", 0)] })
+    expect(broken.fraction).toBe(1)
+    expect(fresh.fraction).toBe(0)
+    expect(fresh.state).toBe("available")
+  })
+
+  it("is 'unknown' with no quota data, which is not the same as unused", () => {
+    const s = computeProfileSpend({ windows: [], loggedIn: true })
+    expect(s.fraction).toBeNull()
+    expect(s.state).toBe("unknown")
+    expect(s.fade).toBe(0)
+    expect(s.reason).toBeNull()
+  })
+
+  it("leaves a comfortable profile alone", () => {
+    const s = computeProfileSpend({ windows: [win("five_hour", 0.4), win("seven_day", 0.6)] })
+    expect(s.state).toBe("available")
+    expect(s.fade).toBe(0)
+  })
+
+  it("ramps the fade across the 85–95% band", () => {
+    expect(computeProfileSpend({ windows: [win("seven_day", FADE_FROM)] }).fade).toBe(0)
+    expect(computeProfileSpend({ windows: [win("seven_day", 0.9)] }).fade).toBeCloseTo(0.5, 5)
+    expect(computeProfileSpend({ windows: [win("seven_day", 0.94)] }).fade).toBeCloseTo(0.9, 5)
+    expect(computeProfileSpend({ windows: [win("seven_day", 0.9)] }).state).toBe("fading")
+  })
+
+  it("is fully spent at the threshold and beyond", () => {
+    for (const u of [SPENT_AT, 0.99, 1]) {
+      const s = computeProfileSpend({ windows: [win("seven_day", u)] })
+      expect(s.state).toBe("spent")
+      expect(s.fade).toBe(1)
+      expect(s.reason).toBe("usage")
+    }
+  })
+
+  it("spends on the worse window, so a hot 5h counts even with a cold week", () => {
+    const s = computeProfileSpend({ windows: [win("five_hour", 0.97), win("seven_day", 0.05)] })
+    expect(s.state).toBe("spent")
+    expect(s.fraction).toBe(0.97)
+  })
+})

--- a/src/__tests__/site-header.test.ts
+++ b/src/__tests__/site-header.test.ts
@@ -98,6 +98,22 @@ describe("landing page layout", () => {
     expect(landingHtml).toContain("needs login")
   })
 
+  test("the fade never reaches the card itself, so the active ring survives it", () => {
+    // filter and opacity apply to an element's OWN border and box-shadow, so
+    // fading .profile-card greys out the accent ring on .profile-card.active -
+    // the one mark saying which account is serving requests, gone exactly when
+    // that account hits 95% and somebody comes looking for it. A descendant
+    // cannot undo an ancestor's filter, so the fade must be scoped to the
+    // card's children.
+    expect(landingHtml).toContain(".profile-card.spend-fading > *, .profile-card.spend-spent > *")
+    expect(landingHtml).toContain(
+      ".profile-card.spend-fading:hover > *, .profile-card.spend-spent:hover > *",
+    )
+    // ...and never as a rule on the card itself, in either state.
+    expect(landingHtml).not.toContain(".profile-card.spend-fading, .profile-card.spend-spent {")
+    expect(landingHtml).not.toContain(".profile-card.spend-fading:hover, .profile-card.spend-spent:hover {")
+  })
+
   test("account cards come from configured profiles, not synthetic cost buckets", () => {
     // With profiles configured, only pl.profiles render (no "default" card);
     // the single-account fallback labels the card with the login email.

--- a/src/__tests__/site-header.test.ts
+++ b/src/__tests__/site-header.test.ts
@@ -14,6 +14,7 @@ import { settingsPageHtml } from "../telemetry/settingsPage"
 import { profilePageHtml } from "../telemetry/profilePage"
 import { pluginPageHtml } from "../proxy/plugins/pluginPage"
 import { profileBarHtml, profileBarJs } from "../telemetry/profileBar"
+import { FADE_FROM, GENERAL_WINDOW_TYPES, SPENT_AT } from "../telemetry/profileSpent"
 
 const allPages: Array<[string, string]> = [
   ["landing", landingHtml],
@@ -85,6 +86,16 @@ describe("landing page layout", () => {
     expect(landingHtml).not.toContain("Median TTFB")
     // Envelope violations render only when noteworthy
     expect(landingHtml).toContain("envelopeViolationCount>0")
+  })
+
+  test("spent accounts recede and unusable ones are flagged instead", () => {
+    // The page carries a copy of the classifier's arithmetic, so its
+    // thresholds are interpolated from the tested module rather than retyped.
+    expect(landingHtml).toContain(`var FADE_FROM=${FADE_FROM}`)
+    expect(landingHtml).toContain(`var SPENT_AT=${SPENT_AT}`)
+    expect(landingHtml).toContain(`var GENERAL_WINDOW_TYPES=${JSON.stringify(GENERAL_WINDOW_TYPES)}`)
+    expect(landingHtml).toContain("--spend-fade")
+    expect(landingHtml).toContain("needs login")
   })
 
   test("account cards come from configured profiles, not synthetic cost buckets", () => {

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -38,8 +38,7 @@ export const landingHtml = `<!DOCTYPE html>
   /* Profile cards — the centerpiece: usage + cost per account, click to switch */
   .profile-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; margin-bottom: 24px; }
   .profile-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
-    padding: 18px 20px; position: relative;
-    transition: border-color 0.15s, filter 0.2s, opacity 0.2s; }
+    padding: 18px 20px; position: relative; transition: border-color 0.15s; }
   .profile-card.switchable { cursor: pointer; }
   .profile-card.switchable:hover { border-color: var(--accent); }
   .profile-card.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
@@ -47,11 +46,22 @@ export const landingHtml = `<!DOCTYPE html>
   /* Spent accounts recede. --spend-fade is set per card (0..1) from the
      shared classifier; hovering restores the card so a dimmed one can still
      be read. An account that needs a login is NOT dimmed — it needs
-     attention, not fading, so it keeps full contrast and turns red. */
-  .profile-card.spend-fading, .profile-card.spend-spent {
+     attention, not fading, so it keeps full contrast and turns red.
+
+     The fade is on the card's CONTENTS and never on the card, because
+     filter and opacity apply to an element's OWN border and box-shadow.
+     Fading .profile-card therefore greyed out the accent ring on
+     .profile-card.active - the one mark on the page saying which account is
+     serving requests - so the active profile became unfindable the moment it
+     passed 95%, which is precisely when somebody comes looking for it. A
+     descendant cannot undo an ancestor's filter or opacity, so scoping the
+     fade to the children is the only thing that leaves the ring alone; the
+     "Active" pill sits inside those contents and fades with them. */
+  .profile-card.spend-fading > *, .profile-card.spend-spent > * {
     filter: grayscale(var(--spend-fade, 0));
-    opacity: calc(1 - 0.55 * var(--spend-fade, 0)); }
-  .profile-card.spend-fading:hover, .profile-card.spend-spent:hover { filter: none; opacity: 1; }
+    opacity: calc(1 - 0.55 * var(--spend-fade, 0));
+    transition: filter 0.2s, opacity 0.2s; }
+  .profile-card.spend-fading:hover > *, .profile-card.spend-spent:hover > * { filter: none; opacity: 1; }
   .profile-card.needs-login { border-color: var(--red); }
   .profile-card.needs-login .prof-dot { background: var(--red); }
   .spend-pill { font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -9,6 +9,7 @@
  */
 
 import { profileBarCss, profileBarHtml, profileBarJs, themeCss } from "./profileBar"
+import { FADE_FROM, GENERAL_WINDOW_TYPES, SPENT_AT } from "./profileSpent"
 
 export const landingHtml = `<!DOCTYPE html>
 <html lang="en">
@@ -37,10 +38,27 @@ export const landingHtml = `<!DOCTYPE html>
   /* Profile cards — the centerpiece: usage + cost per account, click to switch */
   .profile-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; margin-bottom: 24px; }
   .profile-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
-    padding: 18px 20px; position: relative; transition: border-color 0.15s; }
+    padding: 18px 20px; position: relative;
+    transition: border-color 0.15s, filter 0.2s, opacity 0.2s; }
   .profile-card.switchable { cursor: pointer; }
   .profile-card.switchable:hover { border-color: var(--accent); }
   .profile-card.active { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+
+  /* Spent accounts recede. --spend-fade is set per card (0..1) from the
+     shared classifier; hovering restores the card so a dimmed one can still
+     be read. An account that needs a login is NOT dimmed — it needs
+     attention, not fading, so it keeps full contrast and turns red. */
+  .profile-card.spend-fading, .profile-card.spend-spent {
+    filter: grayscale(var(--spend-fade, 0));
+    opacity: calc(1 - 0.55 * var(--spend-fade, 0)); }
+  .profile-card.spend-fading:hover, .profile-card.spend-spent:hover { filter: none; opacity: 1; }
+  .profile-card.needs-login { border-color: var(--red); }
+  .profile-card.needs-login .prof-dot { background: var(--red); }
+  .spend-pill { font-size: 9px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px;
+    color: var(--muted); background: var(--surface2); border: 1px solid var(--border);
+    border-radius: 10px; padding: 1px 8px; }
+  .spend-pill.needs-login { color: var(--red); background: rgba(248,81,73,0.12);
+    border-color: rgba(248,81,73,0.35); }
   .profile-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 4px; }
   .profile-name { font-size: 13px; font-weight: 600; letter-spacing: 0.5px; display: flex; align-items: center; gap: 8px; }
   .profile-name .prof-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--border); }
@@ -127,6 +145,32 @@ function paceColor(pc){return pc.status==='over'?'var(--red)':pc.status==='ahead
 
 function resetIn(ts){if(ts==null)return '';var d=ts-Date.now();if(d<=0)return 'resetting…';var m=Math.ceil(d/60000);if(m<60)return 'in '+m+'m';var h=Math.floor(m/60);if(h<24)return 'in '+h+'h'+(m%60?' '+(m%60)+'m':'');var days=Math.floor(h/24);return 'in '+days+'d'+(h%24?' '+(h%24)+'h':'')}
 
+// Inlined from src/telemetry/profileSpent.ts, unit-tested in
+// profile-spent.test.ts — same arrangement as weeklyPace above.
+var GENERAL_WINDOW_TYPES=${JSON.stringify(GENERAL_WINDOW_TYPES)};
+var FADE_FROM=${FADE_FROM};
+var SPENT_AT=${SPENT_AT};
+function isUnusable(p){if(p.loggedIn===false)return true;return p.error==='no_token'}
+function generalUtilization(windows){
+  var worst=null;
+  for(var i=0;i<(windows||[]).length;i++){
+    var w=windows[i];
+    if(GENERAL_WINDOW_TYPES.indexOf(w.type)<0)continue;
+    if(w.utilization==null||!isFinite(w.utilization))continue;
+    var c=Math.max(0,Math.min(1,w.utilization));
+    if(worst==null||c>worst)worst=c;
+  }
+  return worst;
+}
+function computeProfileSpend(p){
+  if(isUnusable(p))return {fraction:1,state:'spent',fade:0,reason:'unusable'};
+  var f=generalUtilization(p.windows);
+  if(f==null)return {fraction:null,state:'unknown',fade:0,reason:null};
+  if(f>=SPENT_AT)return {fraction:f,state:'spent',fade:1,reason:'usage'};
+  if(f>=FADE_FROM)return {fraction:f,state:'fading',fade:(f-FADE_FROM)/(SPENT_AT-FADE_FROM),reason:null};
+  return {fraction:f,state:'available',fade:0,reason:null};
+}
+
 function introSection(h){
   var meta=[];
   if(h.auth&&h.auth.loggedIn)meta.push(esc(h.auth.email||'')+(h.auth.subscriptionType?' ('+esc(h.auth.subscriptionType)+')':''));
@@ -142,7 +186,7 @@ function introSection(h){
 function profileSection(q,s,pl,h){
   var byProfile=(s&&s.costEstimate&&s.costEstimate.byProfile)||{};
   var quotaByProfile={};
-  if(q&&Array.isArray(q.profiles))for(var i=0;i<q.profiles.length;i++){var qid=q.profiles[i].id||q.profiles[i].profile||'default';quotaByProfile[qid]=q.profiles[i].windows||[]}
+  if(q&&Array.isArray(q.profiles))for(var i=0;i<q.profiles.length;i++){var qid=q.profiles[i].id||q.profiles[i].profile||'default';quotaByProfile[qid]=q.profiles[i]}
   var profs=[];var seen={};
   var configured=(pl&&Array.isArray(pl.profiles))?pl.profiles:[];
   var multi=configured.length>1;
@@ -150,7 +194,7 @@ function profileSection(q,s,pl,h){
     // Real profiles exist: show exactly those. Traffic that predates
     // per-profile attribution (the synthetic "default" bucket) still
     // counts in the totals strip but doesn't render as a fake account.
-    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,configured:true});seen[p.id]=1}
+    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,loggedIn:p.loggedIn,configured:true});seen[p.id]=1}
   }else{
     // Single-account setup: one card, labeled with the logged-in email.
     var email=(h&&h.auth&&h.auth.loggedIn&&h.auth.email)||'';
@@ -161,7 +205,9 @@ function profileSection(q,s,pl,h){
   var cards='';
   for(var i=0;i<profs.length;i++){
     var p=profs[i];var cost=byProfile[p.id];
-    var wins=(quotaByProfile[p.id]||[]).filter(function(w){return w.utilization!=null});
+    var quota=quotaByProfile[p.id]||{};
+    var wins=(quota.windows||[]).filter(function(w){return w.utilization!=null});
+    var spend=computeProfileSpend({windows:quota.windows,error:quota.error,loggedIn:p.loggedIn});
     if(!p.configured&&wins.length===0&&!cost)continue;
     var rows='';
     for(var j=0;j<wins.length;j++){
@@ -195,7 +241,13 @@ function profileSection(q,s,pl,h){
       var exh=(pl.exhausted||[]).filter(function(e){return e.id===p.id})[0];
       if(exh)badge+=' <span class="pool-chip exhausted">exhausted · resets '+resetIn(exh.until)+'</span>';
     }
-    cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+'"'+(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
+    if(spend.reason==='unusable')badge+=' <span class="spend-pill needs-login">needs login</span>';
+    else if(spend.state==='spent')badge+=' <span class="spend-pill">spent</span>';
+    var spendClass=spend.reason==='unusable'?' needs-login':spend.fade>0?' spend-'+spend.state:'';
+    var spendStyle=spend.fade>0?' style="--spend-fade:'+spend.fade.toFixed(2)+'"':'';
+    var spendTip=spend.reason==='unusable'?' title="Cannot serve requests \u2014 run: meridian profile login '+esc(p.id)+'"'
+      :spend.fraction!=null&&spend.fade>0?' title="'+Math.round(spend.fraction*100)+'% of this account\u2019s 5h / 7d allowance is used"':'';
+    cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+spendClass+'"'+spendStyle+spendTip+(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
       +'<div class="profile-head"><span class="profile-name"><span class="prof-dot"></span>'+esc(p.label||p.id)+' '+badge+'</span>'
       +'<span class="profile-cost">'+usd(cost?cost.estimatedUsd:0)+'</span></div>'
       +'<div class="profile-sub">'+(cost?cost.requests+' request'+(cost.requests===1?'':'s')+' · est. API value · 24h':'no traffic · 24h')+'</div>'

--- a/src/telemetry/profileSpent.ts
+++ b/src/telemetry/profileSpent.ts
@@ -1,0 +1,109 @@
+/**
+ * How spent a Claude account is — one definition, so every surface that
+ * asks "can this account still do work?" gets the same answer.
+ *
+ * Mirrored by the inline browser script in landing.ts, the same house
+ * pattern profileUsage.ts uses: the page is one template literal that runs
+ * in the browser and cannot import at runtime, so this TS module is the
+ * tested source of truth (profile-spent.test.ts) and the page carries a
+ * copy of the arithmetic.
+ */
+
+/**
+ * Windows that describe the account as a whole. Anthropic also reports
+ * per-model caps (seven_day_opus, seven_day_sonnet, seven_day_fable, …);
+ * those are deliberately excluded, because hitting one leaves the rest of
+ * the account working. seven_day_fable is the concrete case: a profile on
+ * the author's fleet sat at 94% Fable with its general windows nearly
+ * untouched, and folding that in would have greyed out a usable account.
+ */
+export const GENERAL_WINDOW_TYPES: readonly string[] = ["five_hour", "seven_day"]
+
+/** Where the gradient starts — below this a profile reads as untouched. */
+export const FADE_FROM = 0.85
+/** At or above this a profile is spent, whatever the exact number. */
+export const SPENT_AT = 0.95
+
+export interface SpendWindow {
+  type: string
+  utilization?: number | null
+}
+
+export interface SpendInput {
+  /** `windows` for this profile from /v1/usage/quota/all. */
+  windows?: readonly SpendWindow[] | null
+  /** `error` for this profile from /v1/usage/quota/all. */
+  error?: string | null
+  /** `loggedIn` for this profile from /profiles/list. */
+  loggedIn?: boolean | null
+}
+
+export type SpendState = "unknown" | "available" | "fading" | "spent"
+
+export interface ProfileSpend {
+  /** 0..1 — the worse of the general windows; null when nothing is known. */
+  fraction: number | null
+  state: SpendState
+  /**
+   * 0..1 — how far to grey the account out. Zero for an unusable one even
+   * though it is fully spent: fading is for an account that will come back
+   * on its own, and that is the opposite of what a missing login needs.
+   * Callers give `reason: "unusable"` its own, louder treatment.
+   */
+  fade: number
+  /** Why it is spent. "unusable" needs a human; "usage" only needs time. */
+  reason: "usage" | "unusable" | null
+}
+
+/**
+ * A profile that cannot serve a request at all, measured rather than
+ * assumed: a request carrying `x-meridian-profile` for a profile whose
+ * quota entry reports `no_token` comes back 401.
+ *
+ * `not_oauth` is explicitly NOT this. It is how /v1/usage/quota/all reports
+ * an API-key profile, which has no OAuth quota to report and works fine —
+ * treating that error like the others would grey out a healthy account.
+ */
+export function isUnusable(input: SpendInput): boolean {
+  if (input.loggedIn === false) return true
+  return input.error === "no_token"
+}
+
+/**
+ * The worse of the general windows, or null when none of them carries a
+ * number. Null means "no evidence", which is not the same as zero and must
+ * not render as a pristine account.
+ */
+export function generalUtilization(windows: readonly SpendWindow[] | null | undefined): number | null {
+  let worst: number | null = null
+  for (const w of windows ?? []) {
+    if (!GENERAL_WINDOW_TYPES.includes(w.type)) continue
+    const u = w.utilization
+    if (u == null || !Number.isFinite(u)) continue
+    const clamped = Math.max(0, Math.min(1, u))
+    if (worst == null || clamped > worst) worst = clamped
+  }
+  return worst
+}
+
+export function computeProfileSpend(input: SpendInput): ProfileSpend {
+  if (isUnusable(input)) {
+    return { fraction: 1, state: "spent", fade: 0, reason: "unusable" }
+  }
+  const fraction = generalUtilization(input.windows)
+  if (fraction == null) {
+    return { fraction: null, state: "unknown", fade: 0, reason: null }
+  }
+  if (fraction >= SPENT_AT) {
+    return { fraction, state: "spent", fade: 1, reason: "usage" }
+  }
+  if (fraction >= FADE_FROM) {
+    return {
+      fraction,
+      state: "fading",
+      fade: (fraction - FADE_FROM) / (SPENT_AT - FADE_FROM),
+      reason: null,
+    }
+  }
+  return { fraction, state: "available", fade: 0, reason: null }
+}


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Dims accounts on the home page once they are spent, so picking one with capacity is a glance rather than a comparison.

## Why

Every account card renders identically whether the account can still serve a request or not. With a pool of any size, choosing one means reading two percentages per card and doing the comparison by eye.

## What it does

Spent accounts recede: grayscale and opacity ramp across **85-95%** and hold at **95%+**, where the card also gets a `spent` pill. **Hovering restores the card**, so a dimmed one is still readable rather than merely dark.

## What "spent" means, and what it deliberately excludes

The worse of `five_hour` and `seven_day`.

**Per-model caps are excluded, `seven_day_fable` above all.** A profile on the author's fleet sat at **94% Fable with its general windows barely touched** — folding that in would have greyed out an account with nearly all of its real capacity intact. Hitting a per-model cap leaves the rest of the account working; hitting a general window does not.

**A profile reporting `no_token`, or `loggedIn: false`, counts as fully spent.** Measured: a request carrying `x-meridian-profile` for such a profile comes back `401`, so rendering it as a pristine 0% account is a lie — and it is the account most likely to be picked by someone scanning for a low number.

**It is not dimmed, though.** Fading says "come back later", which is right for an account that refills on its own and wrong for one waiting on a human. That case keeps full contrast, turns red, and says `needs login`.

`not_oauth` is explicitly *not* this: it is how the quota endpoint reports an API-key profile, which has no OAuth quota and works fine.

## Structure

The classifier lives in `src/telemetry/profileSpent.ts` with unit tests. The landing page is one template literal that cannot import at runtime, so it carries a copy of the arithmetic — the arrangement `profileUsage.ts` already uses — but the thresholds and window list are **interpolated from the module** rather than retyped, so the two cannot drift apart.

## Verification

- `bunx tsc --noEmit` exit 0.
- `bun run test` (the project's own chain) — **2509 pass, 0 fail**, pipeline exit 0.
- Driven in a real browser against a development instance on its own port and config dir.

## Note on overlap

`src/telemetry/profileSpent.ts` is byte-identical to the copy in the companion sort PR. The two are deliberately independent so either can be taken alone; whichever merges second is a trivial identical-content conflict.

This PR is AI generated, but under direct supervision and on request of Nowaker.
