### PR TITLE
feat(dashboard): sort accounts by how spent they are

### DIFF
--- a/src/__tests__/profile-sort.test.ts
+++ b/src/__tests__/profile-sort.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the home page's view-only account ordering — pure
+ * functions, no mocks.
+ */
+import { describe, expect, it } from "bun:test"
+import {
+  DEFAULT_PROFILE_SORT,
+  PROFILE_SORT_MODES,
+  parseProfileSortMode,
+  sortProfilesForView,
+} from "../telemetry/profileSort"
+import { computeProfileSpend } from "../telemetry/profileSpent"
+
+interface Prof {
+  id: string
+  spent: number | null
+}
+const spentOf = (p: Prof) => p.spent
+const ids = (list: Prof[]) => list.map((p) => p.id).join(",")
+
+const fleet: Prof[] = [
+  { id: "a", spent: 0.4 },
+  { id: "b", spent: 0.95 },
+  { id: "c", spent: 0.1 },
+]
+
+describe("parseProfileSortMode", () => {
+  it("accepts every mode the control offers", () => {
+    for (const mode of PROFILE_SORT_MODES) {
+      expect(parseProfileSortMode(mode.id)).toBe(mode.id)
+    }
+  })
+
+  it("falls back to the configured order for anything else", () => {
+    expect(parseProfileSortMode("nonsense")).toBe(DEFAULT_PROFILE_SORT)
+    expect(parseProfileSortMode(null)).toBe(DEFAULT_PROFILE_SORT)
+    expect(parseProfileSortMode(undefined)).toBe(DEFAULT_PROFILE_SORT)
+    expect(DEFAULT_PROFILE_SORT).toBe("configured")
+  })
+})
+
+describe("sortProfilesForView", () => {
+  it("leaves the configured order alone", () => {
+    expect(ids(sortProfilesForView(fleet, "configured", spentOf))).toBe("a,b,c")
+  })
+
+  it("does not mutate the input", () => {
+    sortProfilesForView(fleet, "spent-desc", spentOf)
+    expect(ids(fleet)).toBe("a,b,c")
+  })
+
+  it("puts the account closest to running out first when sorting desc", () => {
+    expect(ids(sortProfilesForView(fleet, "spent-desc", spentOf))).toBe("b,a,c")
+  })
+
+  it("puts the account with the most capacity first when sorting asc", () => {
+    expect(ids(sortProfilesForView(fleet, "spent-asc", spentOf))).toBe("c,a,b")
+  })
+
+  it("sorts profiles with no reading last in both directions", () => {
+    // Null is absence of evidence, not a low number: at the front of
+    // "least spent" it would recommend the one account we know nothing about.
+    const withUnknown: Prof[] = [{ id: "unknown", spent: null }, ...fleet]
+    expect(ids(sortProfilesForView(withUnknown, "spent-asc", spentOf))).toBe("c,a,b,unknown")
+    expect(ids(sortProfilesForView(withUnknown, "spent-desc", spentOf))).toBe("b,a,c,unknown")
+  })
+
+  it("keeps configured order among equally spent profiles", () => {
+    const tied: Prof[] = [
+      { id: "x", spent: 0.5 },
+      { id: "y", spent: 0.5 },
+      { id: "z", spent: 0.5 },
+    ]
+    expect(ids(sortProfilesForView(tied, "spent-desc", spentOf))).toBe("x,y,z")
+    expect(ids(sortProfilesForView(tied, "spent-asc", spentOf))).toBe("x,y,z")
+  })
+
+  it("keeps configured order among several unknowns", () => {
+    const unknowns: Prof[] = [
+      { id: "p", spent: null },
+      { id: "q", spent: null },
+    ]
+    expect(ids(sortProfilesForView(unknowns, "spent-asc", spentOf))).toBe("p,q")
+  })
+
+  it("handles empty and single-item lists", () => {
+    expect(sortProfilesForView([], "spent-desc", spentOf)).toEqual([])
+    expect(ids(sortProfilesForView([fleet[0]!], "spent-desc", spentOf))).toBe("a")
+  })
+})
+
+describe("sorting on the shared spend classifier", () => {
+  // The contract Nowaker asked for: a spent weekly window ranks a profile as
+  // hard as a spent five-hour one, and a profile needing a login ranks with
+  // them rather than with the fresh accounts.
+  const quotaOf = (windows: Array<{ type: string; utilization: number }>, error?: string) => ({
+    id: "",
+    spent: computeProfileSpend({ windows, error: error ?? null, loggedIn: error ? false : true }).fraction,
+  })
+
+  it("ranks a spent week alongside a spent five-hour window", () => {
+    const weekGone = quotaOf([
+      { type: "five_hour", utilization: 0 },
+      { type: "seven_day", utilization: 1 },
+    ])
+    const hourGone = quotaOf([
+      { type: "five_hour", utilization: 1 },
+      { type: "seven_day", utilization: 0.1 },
+    ])
+    expect(weekGone.spent).toBe(1)
+    expect(hourGone.spent).toBe(1)
+  })
+
+  it("ranks a profile that needs a login with the spent ones, not the fresh ones", () => {
+    const list: Prof[] = [
+      { ...quotaOf([{ type: "seven_day", utilization: 0.2 }]), id: "healthy" },
+      { ...quotaOf([], "no_token"), id: "broken" },
+    ]
+    expect(ids(sortProfilesForView(list, "spent-desc", spentOf))).toBe("broken,healthy")
+    expect(ids(sortProfilesForView(list, "spent-asc", spentOf))).toBe("healthy,broken")
+  })
+
+  it("ignores per-model caps, so a Fable-capped profile is not ranked as spent", () => {
+    const fableCapped = quotaOf([
+      { type: "five_hour", utilization: 0.05 },
+      { type: "seven_day", utilization: 0.1 },
+      { type: "seven_day_fable", utilization: 0.94 },
+    ])
+    expect(fableCapped.spent).toBe(0.1)
+  })
+})

--- a/src/__tests__/profile-spent.test.ts
+++ b/src/__tests__/profile-spent.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the shared "how spent is this account?" classifier —
+ * pure functions, no mocks.
+ */
+import { describe, expect, it } from "bun:test"
+import {
+  FADE_FROM,
+  SPENT_AT,
+  computeProfileSpend,
+  generalUtilization,
+  isUnusable,
+} from "../telemetry/profileSpent"
+
+const win = (type: string, utilization: number | null) => ({ type, utilization })
+
+describe("generalUtilization", () => {
+  it("takes the worse of the five-hour and general weekly windows", () => {
+    expect(generalUtilization([win("five_hour", 0.2), win("seven_day", 0.8)])).toBe(0.8)
+    expect(generalUtilization([win("five_hour", 0.9), win("seven_day", 0.1)])).toBe(0.9)
+  })
+
+  it("ignores per-model caps, seven_day_fable above all", () => {
+    // The observed case: 94% Fable, general windows barely touched. Folding
+    // Fable in would call a usable account spent.
+    expect(
+      generalUtilization([win("five_hour", 0.05), win("seven_day", 0.1), win("seven_day_fable", 0.94)]),
+    ).toBe(0.1)
+    expect(
+      generalUtilization([win("seven_day", 0.2), win("seven_day_opus", 1), win("seven_day_sonnet", 1)]),
+    ).toBe(0.2)
+  })
+
+  it("returns null when no general window carries a number", () => {
+    expect(generalUtilization([])).toBeNull()
+    expect(generalUtilization(null)).toBeNull()
+    expect(generalUtilization(undefined)).toBeNull()
+    expect(generalUtilization([win("five_hour", null)])).toBeNull()
+    expect(generalUtilization([win("seven_day_fable", 0.9)])).toBeNull()
+    expect(generalUtilization([win("five_hour", Number.NaN)])).toBeNull()
+  })
+
+  it("clamps out-of-range utilization", () => {
+    expect(generalUtilization([win("seven_day", 1.4)])).toBe(1)
+    expect(generalUtilization([win("seven_day", -0.2)])).toBe(0)
+  })
+})
+
+describe("isUnusable", () => {
+  it("is true for a profile with no token or a failed login", () => {
+    expect(isUnusable({ error: "no_token" })).toBe(true)
+    expect(isUnusable({ loggedIn: false })).toBe(true)
+  })
+
+  it("is false for an API-key profile, which has no OAuth quota but works", () => {
+    expect(isUnusable({ error: "not_oauth", loggedIn: true })).toBe(false)
+  })
+
+  it("is false for a healthy profile", () => {
+    expect(isUnusable({ error: null, loggedIn: true, windows: [win("seven_day", 0.3)] })).toBe(false)
+    expect(isUnusable({})).toBe(false)
+  })
+})
+
+describe("computeProfileSpend", () => {
+  it("reports a profile that needs a human as fully spent, with its own reason", () => {
+    const s = computeProfileSpend({ error: "no_token", windows: [] })
+    expect(s.fraction).toBe(1)
+    expect(s.state).toBe("spent")
+    expect(s.reason).toBe("unusable")
+  })
+
+  it("does not fade a profile that needs a human, however spent it is", () => {
+    // Fading says "come back later"; a missing login says "do something".
+    expect(computeProfileSpend({ error: "no_token", windows: [] }).fade).toBe(0)
+    expect(computeProfileSpend({ loggedIn: false, windows: [win("seven_day", 0.99)] }).fade).toBe(0)
+  })
+
+  it("does not confuse an unusable profile with a pristine one", () => {
+    // No windows at all is what a broken profile reports — it must not read
+    // as 0% used.
+    const broken = computeProfileSpend({ error: "no_token", windows: [] })
+    const fresh = computeProfileSpend({ windows: [win("five_hour", 0), win("seven_day", 0)] })
+    expect(broken.fraction).toBe(1)
+    expect(fresh.fraction).toBe(0)
+    expect(fresh.state).toBe("available")
+  })
+
+  it("is 'unknown' with no quota data, which is not the same as unused", () => {
+    const s = computeProfileSpend({ windows: [], loggedIn: true })
+    expect(s.fraction).toBeNull()
+    expect(s.state).toBe("unknown")
+    expect(s.fade).toBe(0)
+    expect(s.reason).toBeNull()
+  })
+
+  it("leaves a comfortable profile alone", () => {
+    const s = computeProfileSpend({ windows: [win("five_hour", 0.4), win("seven_day", 0.6)] })
+    expect(s.state).toBe("available")
+    expect(s.fade).toBe(0)
+  })
+
+  it("ramps the fade across the 85–95% band", () => {
+    expect(computeProfileSpend({ windows: [win("seven_day", FADE_FROM)] }).fade).toBe(0)
+    expect(computeProfileSpend({ windows: [win("seven_day", 0.9)] }).fade).toBeCloseTo(0.5, 5)
+    expect(computeProfileSpend({ windows: [win("seven_day", 0.94)] }).fade).toBeCloseTo(0.9, 5)
+    expect(computeProfileSpend({ windows: [win("seven_day", 0.9)] }).state).toBe("fading")
+  })
+
+  it("is fully spent at the threshold and beyond", () => {
+    for (const u of [SPENT_AT, 0.99, 1]) {
+      const s = computeProfileSpend({ windows: [win("seven_day", u)] })
+      expect(s.state).toBe("spent")
+      expect(s.fade).toBe(1)
+      expect(s.reason).toBe("usage")
+    }
+  })
+
+  it("spends on the worse window, so a hot 5h counts even with a cold week", () => {
+    const s = computeProfileSpend({ windows: [win("five_hour", 0.97), win("seven_day", 0.05)] })
+    expect(s.state).toBe("spent")
+    expect(s.fraction).toBe(0.97)
+  })
+})

--- a/src/__tests__/site-header.test.ts
+++ b/src/__tests__/site-header.test.ts
@@ -14,6 +14,7 @@ import { settingsPageHtml } from "../telemetry/settingsPage"
 import { profilePageHtml } from "../telemetry/profilePage"
 import { pluginPageHtml } from "../proxy/plugins/pluginPage"
 import { profileBarHtml, profileBarJs } from "../telemetry/profileBar"
+import { DEFAULT_PROFILE_SORT, PROFILE_SORT_MODES } from "../telemetry/profileSort"
 
 const allPages: Array<[string, string]> = [
   ["landing", landingHtml],
@@ -85,6 +86,16 @@ describe("landing page layout", () => {
     expect(landingHtml).not.toContain("Median TTFB")
     // Envelope violations render only when noteworthy
     expect(landingHtml).toContain("envelopeViolationCount>0")
+  })
+
+  test("accounts can be re-sorted for viewing without touching the saved order", () => {
+    // The page carries a copy of the comparator, so the modes it offers are
+    // interpolated from the tested module rather than retyped.
+    expect(landingHtml).toContain(`var PROFILE_SORT_MODES=${JSON.stringify(PROFILE_SORT_MODES)}`)
+    expect(landingHtml).toContain(`var viewSort=${JSON.stringify(DEFAULT_PROFILE_SORT)}`)
+    expect(landingHtml).toContain("sort-tab")
+    // View-only: the durable pool order has one writer, and it is not here.
+    expect(landingHtml).not.toContain("/settings/api/routing")
   })
 
   test("account cards come from configured profiles, not synthetic cost buckets", () => {

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -9,6 +9,8 @@
  */
 
 import { profileBarCss, profileBarHtml, profileBarJs, themeCss } from "./profileBar"
+import { DEFAULT_PROFILE_SORT, PROFILE_SORT_MODES } from "./profileSort"
+import { FADE_FROM, GENERAL_WINDOW_TYPES, SPENT_AT } from "./profileSpent"
 
 export const landingHtml = `<!DOCTYPE html>
 <html lang="en">
@@ -83,6 +85,19 @@ export const landingHtml = `<!DOCTYPE html>
   .section-title { font-size: 12px; font-weight: 600; color: var(--muted); text-transform: uppercase;
     letter-spacing: 1px; margin-bottom: 12px; }
 
+  /* Tabs rather than a dropdown: the current order stays legible without
+     opening anything, which is the whole job of this page. */
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+    gap: 12px; margin-bottom: 12px; }
+  .section-head .section-title { margin-bottom: 0; }
+  .sort-tabs { display: flex; gap: 2px; flex-shrink: 0; }
+  .sort-tab { background: none; border: none; border-bottom: 2px solid transparent;
+    color: var(--muted); font-family: inherit; font-size: 11px; font-weight: 500;
+    letter-spacing: 0.3px; padding: 2px 8px 3px; cursor: pointer; }
+  .sort-tab:hover { color: var(--text); }
+  .sort-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .sort-tab:focus-visible { outline: none; color: var(--accent); border-bottom-color: var(--accent); }
+
   .footer { margin-top: 48px; padding-top: 24px; border-top: 1px solid var(--border);
     font-size: 11px; color: var(--muted); text-align: center; }
   .footer a { color: var(--accent); text-decoration: none; }
@@ -127,6 +142,84 @@ function paceColor(pc){return pc.status==='over'?'var(--red)':pc.status==='ahead
 
 function resetIn(ts){if(ts==null)return '';var d=ts-Date.now();if(d<=0)return 'resetting…';var m=Math.ceil(d/60000);if(m<60)return 'in '+m+'m';var h=Math.floor(m/60);if(h<24)return 'in '+h+'h'+(m%60?' '+(m%60)+'m':'');var days=Math.floor(h/24);return 'in '+days+'d'+(h%24?' '+(h%24)+'h':'')}
 
+// Inlined from src/telemetry/profileSpent.ts, unit-tested in
+// profile-spent.test.ts — same arrangement as weeklyPace above.
+var GENERAL_WINDOW_TYPES=${JSON.stringify(GENERAL_WINDOW_TYPES)};
+var FADE_FROM=${FADE_FROM};
+var SPENT_AT=${SPENT_AT};
+function isUnusable(p){if(p.loggedIn===false)return true;return p.error==='no_token'}
+function generalUtilization(windows){
+  var worst=null;
+  for(var i=0;i<(windows||[]).length;i++){
+    var w=windows[i];
+    if(GENERAL_WINDOW_TYPES.indexOf(w.type)<0)continue;
+    if(w.utilization==null||!isFinite(w.utilization))continue;
+    var c=Math.max(0,Math.min(1,w.utilization));
+    if(worst==null||c>worst)worst=c;
+  }
+  return worst;
+}
+function computeProfileSpend(p){
+  if(isUnusable(p))return {fraction:1,state:'spent',fade:0,reason:'unusable'};
+  var f=generalUtilization(p.windows);
+  if(f==null)return {fraction:null,state:'unknown',fade:0,reason:null};
+  if(f>=SPENT_AT)return {fraction:f,state:'spent',fade:1,reason:'usage'};
+  if(f>=FADE_FROM)return {fraction:f,state:'fading',fade:(f-FADE_FROM)/(SPENT_AT-FADE_FROM),reason:null};
+  return {fraction:f,state:'available',fade:0,reason:null};
+}
+
+// Inlined from src/telemetry/profileSort.ts, unit-tested in
+// profile-sort.test.ts.
+var PROFILE_SORT_MODES=${JSON.stringify(PROFILE_SORT_MODES)};
+var viewSort=${JSON.stringify(DEFAULT_PROFILE_SORT)};
+function sortProfilesForView(items,mode,spentOf){
+  var list=items.slice();
+  if(mode==='configured')return list;
+  var direction=mode==='spent-desc'?-1:1;
+  return list
+    .map(function(item,index){return {item:item,index:index,spent:spentOf(item)}})
+    .sort(function(a,b){
+      if(a.spent==null||b.spent==null){
+        if(a.spent==null&&b.spent==null)return a.index-b.index;
+        return a.spent==null?1:-1;
+      }
+      if(a.spent!==b.spent)return (a.spent-b.spent)*direction;
+      return a.index-b.index;
+    })
+    .map(function(entry){return entry.item});
+}
+function sortTabs(count){
+  if(count<2)return '';
+  var out='';
+  for(var i=0;i<PROFILE_SORT_MODES.length;i++){
+    var m=PROFILE_SORT_MODES[i];var on=m.id===viewSort;
+    out+='<button type="button" class="sort-tab'+(on?' active':'')+'" data-sort="'+esc(m.id)+'"'
+      +' title="'+esc(m.title)+'" aria-pressed="'+(on?'true':'false')+'">'+esc(m.label)+'</button>';
+  }
+  return '<div class="sort-tabs" role="group" aria-label="Sort accounts">'+out+'</div>';
+}
+
+// Re-sorting must not wait for the next 10s poll, so the last payload is
+// kept and re-rendered from memory. The choice is a view preference and is
+// never sent to the server — the saved pool order (/settings) is untouched.
+var SORT_STORAGE_KEY='meridian.accountSort';
+var lastData=null;
+function readStoredSort(){
+  try{
+    var stored=localStorage.getItem(SORT_STORAGE_KEY);
+    for(var i=0;i<PROFILE_SORT_MODES.length;i++)if(PROFILE_SORT_MODES[i].id===stored)return stored;
+  }catch(_){/* storage blocked (private mode) — the default is fine */}
+  return null;
+}
+function setViewSort(mode){
+  if(mode===viewSort)return;
+  var refocus=!!(document.activeElement&&document.activeElement.closest&&document.activeElement.closest('.sort-tab'));
+  viewSort=mode;
+  try{localStorage.setItem(SORT_STORAGE_KEY,mode)}catch(_){/* a lost preference is not worth failing over */}
+  if(lastData)render(lastData[0],lastData[1],lastData[2],lastData[3]);
+  if(refocus){var el=document.querySelector('.sort-tab[data-sort="'+mode+'"]');if(el)el.focus()}
+}
+
 function introSection(h){
   var meta=[];
   if(h.auth&&h.auth.loggedIn)meta.push(esc(h.auth.email||'')+(h.auth.subscriptionType?' ('+esc(h.auth.subscriptionType)+')':''));
@@ -142,7 +235,7 @@ function introSection(h){
 function profileSection(q,s,pl,h){
   var byProfile=(s&&s.costEstimate&&s.costEstimate.byProfile)||{};
   var quotaByProfile={};
-  if(q&&Array.isArray(q.profiles))for(var i=0;i<q.profiles.length;i++){var qid=q.profiles[i].id||q.profiles[i].profile||'default';quotaByProfile[qid]=q.profiles[i].windows||[]}
+  if(q&&Array.isArray(q.profiles))for(var i=0;i<q.profiles.length;i++){var qid=q.profiles[i].id||q.profiles[i].profile||'default';quotaByProfile[qid]=q.profiles[i]}
   var profs=[];var seen={};
   var configured=(pl&&Array.isArray(pl.profiles))?pl.profiles:[];
   var multi=configured.length>1;
@@ -150,7 +243,7 @@ function profileSection(q,s,pl,h){
     // Real profiles exist: show exactly those. Traffic that predates
     // per-profile attribution (the synthetic "default" bucket) still
     // counts in the totals strip but doesn't render as a fake account.
-    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,configured:true});seen[p.id]=1}
+    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,loggedIn:p.loggedIn,configured:true});seen[p.id]=1}
   }else{
     // Single-account setup: one card, labeled with the logged-in email.
     var email=(h&&h.auth&&h.auth.loggedIn&&h.auth.email)||'';
@@ -158,10 +251,15 @@ function profileSection(q,s,pl,h){
     for(var k in byProfile){if(!seen[k])profs.push({id:k,label:k==='default'?(email||'account'):k,configured:false});seen[k]=1}
   }
   if(profs.length===0)return '';
+  function spentOf(p){
+    var quota=quotaByProfile[p.id]||{};
+    return computeProfileSpend({windows:quota.windows,error:quota.error,loggedIn:p.loggedIn}).fraction;
+  }
+  profs=sortProfilesForView(profs,viewSort,spentOf);
   var cards='';
   for(var i=0;i<profs.length;i++){
     var p=profs[i];var cost=byProfile[p.id];
-    var wins=(quotaByProfile[p.id]||[]).filter(function(w){return w.utilization!=null});
+    var wins=((quotaByProfile[p.id]||{}).windows||[]).filter(function(w){return w.utilization!=null});
     if(!p.configured&&wins.length===0&&!cost)continue;
     var rows='';
     for(var j=0;j<wins.length;j++){
@@ -202,7 +300,8 @@ function profileSection(q,s,pl,h){
       +rows+'</div>';
   }
   if(!cards)return '';
-  return '<div class="section"><div class="section-title">'+(profs.length===1?'Account':'Accounts')+'</div><div class="profile-grid">'+cards+'</div></div>';
+  return '<div class="section"><div class="section-head"><div class="section-title">'+(profs.length===1?'Account':'Accounts')+'</div>'+sortTabs(profs.length)+'</div>'
+    +'<div class="profile-grid">'+cards+'</div></div>';
 }
 
 function strip(items){
@@ -228,6 +327,7 @@ async function refresh(){
 function tokens(v){if(v==null)return '—';if(v>=1e6)return (v/1e6).toFixed(1)+'M';if(v>=1e3)return (v/1e3).toFixed(1)+'k';return String(v)}
 
 function render(h,s,q,pl){
+  lastData=[h,s,q,pl];
   let o='';
   o+=introSection(h);
 
@@ -261,6 +361,8 @@ function switchProfile(id){
     .catch(function(){});
 }
 document.getElementById('content').addEventListener('click',function(e){
+  var tab=e.target.closest('.sort-tab');
+  if(tab&&tab.dataset.sort){setViewSort(tab.dataset.sort);return}
   var card=e.target.closest('.profile-card.switchable');
   if(card&&card.dataset.profile)switchProfile(card.dataset.profile);
 });
@@ -269,6 +371,7 @@ document.getElementById('content').addEventListener('keydown',function(e){
   var card=e.target.closest('.profile-card.switchable');
   if(card&&card.dataset.profile){e.preventDefault();switchProfile(card.dataset.profile)}
 });
+viewSort=readStoredSort()||viewSort;
 refresh();setInterval(refresh,10000);
 ` + profileBarJs + `
 </script>

--- a/src/telemetry/profileSort.ts
+++ b/src/telemetry/profileSort.ts
@@ -1,0 +1,60 @@
+/**
+ * View-only ordering for the home page's account cards.
+ *
+ * Distinct from the `profileOrder` setting, which is durable and decides
+ * which account Priority routing drains first. This one answers "show me
+ * the ones with capacity" while looking at the page, and is deliberately
+ * not persisted anywhere.
+ *
+ * Mirrored by the inline browser script in landing.ts, the same house
+ * pattern profileUsage.ts uses: the page is one template literal that runs
+ * in the browser and cannot import at runtime, so this TS module is the
+ * tested source of truth (profile-sort.test.ts).
+ */
+
+export type ProfileSortMode = "configured" | "spent-desc" | "spent-asc"
+
+export const DEFAULT_PROFILE_SORT: ProfileSortMode = "configured"
+
+/** Rendered as the control, in this order. `id` is what the comparator takes. */
+export const PROFILE_SORT_MODES: ReadonlyArray<{ id: ProfileSortMode; label: string; title: string }> = [
+  { id: "configured", label: "Order", title: "The order profiles are configured in" },
+  { id: "spent-desc", label: "Most spent", title: "Closest to running out first" },
+  { id: "spent-asc", label: "Least spent", title: "Most capacity left first" },
+]
+
+export function parseProfileSortMode(raw: string | null | undefined): ProfileSortMode {
+  return PROFILE_SORT_MODES.some((m) => m.id === raw) ? (raw as ProfileSortMode) : DEFAULT_PROFILE_SORT
+}
+
+/**
+ * Order `items` for display. `spentOf` returns 0..1 for a profile, or null
+ * when nothing is known about it.
+ *
+ * A profile with no reading sorts last in BOTH directions. Null is absence
+ * of evidence, not a low number — sorting it to the front of "least spent"
+ * would recommend the one account we cannot vouch for.
+ *
+ * Ties and the "configured" mode keep the incoming order, which is the
+ * order the profiles are configured in.
+ */
+export function sortProfilesForView<T>(
+  items: readonly T[],
+  mode: ProfileSortMode,
+  spentOf: (item: T) => number | null,
+): T[] {
+  const list = items.slice()
+  if (mode === "configured") return list
+  const direction = mode === "spent-desc" ? -1 : 1
+  return list
+    .map((item, index) => ({ item, index, spent: spentOf(item) }))
+    .sort((a, b) => {
+      if (a.spent == null || b.spent == null) {
+        if (a.spent == null && b.spent == null) return a.index - b.index
+        return a.spent == null ? 1 : -1
+      }
+      if (a.spent !== b.spent) return (a.spent - b.spent) * direction
+      return a.index - b.index
+    })
+    .map((entry) => entry.item)
+}

--- a/src/telemetry/profileSpent.ts
+++ b/src/telemetry/profileSpent.ts
@@ -1,0 +1,109 @@
+/**
+ * How spent a Claude account is — one definition, so every surface that
+ * asks "can this account still do work?" gets the same answer.
+ *
+ * Mirrored by the inline browser script in landing.ts, the same house
+ * pattern profileUsage.ts uses: the page is one template literal that runs
+ * in the browser and cannot import at runtime, so this TS module is the
+ * tested source of truth (profile-spent.test.ts) and the page carries a
+ * copy of the arithmetic.
+ */
+
+/**
+ * Windows that describe the account as a whole. Anthropic also reports
+ * per-model caps (seven_day_opus, seven_day_sonnet, seven_day_fable, …);
+ * those are deliberately excluded, because hitting one leaves the rest of
+ * the account working. seven_day_fable is the concrete case: a profile on
+ * the author's fleet sat at 94% Fable with its general windows nearly
+ * untouched, and folding that in would have greyed out a usable account.
+ */
+export const GENERAL_WINDOW_TYPES: readonly string[] = ["five_hour", "seven_day"]
+
+/** Where the gradient starts — below this a profile reads as untouched. */
+export const FADE_FROM = 0.85
+/** At or above this a profile is spent, whatever the exact number. */
+export const SPENT_AT = 0.95
+
+export interface SpendWindow {
+  type: string
+  utilization?: number | null
+}
+
+export interface SpendInput {
+  /** `windows` for this profile from /v1/usage/quota/all. */
+  windows?: readonly SpendWindow[] | null
+  /** `error` for this profile from /v1/usage/quota/all. */
+  error?: string | null
+  /** `loggedIn` for this profile from /profiles/list. */
+  loggedIn?: boolean | null
+}
+
+export type SpendState = "unknown" | "available" | "fading" | "spent"
+
+export interface ProfileSpend {
+  /** 0..1 — the worse of the general windows; null when nothing is known. */
+  fraction: number | null
+  state: SpendState
+  /**
+   * 0..1 — how far to grey the account out. Zero for an unusable one even
+   * though it is fully spent: fading is for an account that will come back
+   * on its own, and that is the opposite of what a missing login needs.
+   * Callers give `reason: "unusable"` its own, louder treatment.
+   */
+  fade: number
+  /** Why it is spent. "unusable" needs a human; "usage" only needs time. */
+  reason: "usage" | "unusable" | null
+}
+
+/**
+ * A profile that cannot serve a request at all, measured rather than
+ * assumed: a request carrying `x-meridian-profile` for a profile whose
+ * quota entry reports `no_token` comes back 401.
+ *
+ * `not_oauth` is explicitly NOT this. It is how /v1/usage/quota/all reports
+ * an API-key profile, which has no OAuth quota to report and works fine —
+ * treating that error like the others would grey out a healthy account.
+ */
+export function isUnusable(input: SpendInput): boolean {
+  if (input.loggedIn === false) return true
+  return input.error === "no_token"
+}
+
+/**
+ * The worse of the general windows, or null when none of them carries a
+ * number. Null means "no evidence", which is not the same as zero and must
+ * not render as a pristine account.
+ */
+export function generalUtilization(windows: readonly SpendWindow[] | null | undefined): number | null {
+  let worst: number | null = null
+  for (const w of windows ?? []) {
+    if (!GENERAL_WINDOW_TYPES.includes(w.type)) continue
+    const u = w.utilization
+    if (u == null || !Number.isFinite(u)) continue
+    const clamped = Math.max(0, Math.min(1, u))
+    if (worst == null || clamped > worst) worst = clamped
+  }
+  return worst
+}
+
+export function computeProfileSpend(input: SpendInput): ProfileSpend {
+  if (isUnusable(input)) {
+    return { fraction: 1, state: "spent", fade: 0, reason: "unusable" }
+  }
+  const fraction = generalUtilization(input.windows)
+  if (fraction == null) {
+    return { fraction: null, state: "unknown", fade: 0, reason: null }
+  }
+  if (fraction >= SPENT_AT) {
+    return { fraction, state: "spent", fade: 1, reason: "usage" }
+  }
+  if (fraction >= FADE_FROM) {
+    return {
+      fraction,
+      state: "fading",
+      fade: (fraction - FADE_FROM) / (SPENT_AT - FADE_FROM),
+      reason: null,
+    }
+  }
+  return { fraction, state: "available", fade: 0, reason: null }
+}


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Adds a view-only sort to the home page's account list: configured order, most spent first, least spent first.

## Why

With ten accounts on the page, "which one can still do work?" is answered by reading ten cards and comparing percentages by eye. The configured order is the right *default* — it is the order the user thinks in, and under Priority routing it is the order the pool drains in — but it is the wrong order for that question.

Three tabs beside the Accounts heading. They appear only with more than one account.

## What "spent" means

`max(five_hour, seven_day)`, the worse of the two general windows.

**Per-model caps are excluded deliberately.** `seven_day_fable` caps Fable-model use only, and an account was observed at **94% Fable with its general windows nearly untouched** — folding it in would rank a perfectly usable account as the most spent on the page.

**An account that cannot serve a request at all** (no token, or not logged in) counts as fully spent, because it is. Measured: a request pinned to such a profile returns `401`.

**An account with no reading sorts last in BOTH directions.** Null is absence of evidence, not a low number; at the front of "least spent" it would recommend the one account nothing is known about.

## This never reaches the server

The durable `profileOrder` setting, which decides Priority failover, has exactly one writer and it is not this page. The choice is kept in `localStorage` so it survives a reload, and re-renders from the last payload rather than waiting out the next 10s poll.

## Structure

The comparator and the spent classifier are pure and unit-tested (`profile-sort.test.ts`, `profile-spent.test.ts`), mirrored into the page's inline script the way `profileUsage.ts` already is, with the thresholds and the mode list **interpolated from the TS modules** so the two copies cannot drift apart.

Accessibility: the tabs are real buttons, so they are tab-reachable and activate on Enter/Space with no extra handler, they carry `aria-pressed`, and focus is restored across the re-render they trigger.

## Verification

- `bunx tsc --noEmit` exit 0.
- `bun run test` (the project's own chain) — **2522 pass, 0 fail**, pipeline exit 0.
- Driven in a real browser against a development instance on its own port and config dir.

## Note on overlap

`src/telemetry/profileSpent.ts` is byte-identical to the copy in the companion dim-spent PR. The two are deliberately independent so either can be taken alone; whichever merges second is a trivial identical-content conflict.

This PR is AI generated, but under direct supervision and on request of Nowaker.
