### PR TITLE
feat(settings): put Routing at the top of the page

### DIFF
--- a/src/telemetry/settingsPage.ts
+++ b/src/telemetry/settingsPage.ts
@@ -117,19 +117,7 @@ export const settingsPageHtml = `<!DOCTYPE html>
 <body>
 ${profileBarHtml}
 <div class="content">
-  <h1>SDK Features <span style="font-size:11px;padding:2px 8px;border-radius:10px;background:rgba(210,153,34,0.15);color:var(--yellow);vertical-align:middle;margin-left:8px">Experimental</span></h1>
-  <p class="subtitle" style="max-width:720px;line-height:1.6">
-    Unlock Claude Code features for any connected agent. Capabilities like auto-memory, dreaming, and CLAUDE.md — normally
-    exclusive to Claude Code — become available to OpenCode, Crush, Droid, and any other harness routed through Meridian.
-    Each agent keeps its own toolchain while gaining access to these additional features.<br><br>
-    <strong style="color:var(--text)">System prompts:</strong> For these features to work correctly, both the Claude Code prompt and your client prompt
-    should be enabled. When both are active, they are appended together — Claude Code's base instructions come first,
-    followed by your agent's specific instructions.
-  </p>
-
-  <div id="adapters"></div>
-
-  <h1 style="margin-top:40px">Routing</h1>
+  <h1>Routing</h1>
   <p class="subtitle" style="max-width:720px;line-height:1.6">
     How unpinned requests choose an account. <strong style="color:var(--text)">Active</strong> uses the manually
     selected profile. <strong style="color:var(--text)">Sticky</strong> distributes sessions across profiles evenly
@@ -141,6 +129,18 @@ ${profileBarHtml}
   <div class="adapter-card" id="routing-card">
     <div id="routing-body">Loading…</div>
   </div>
+
+  <h1 style="margin-top:40px">SDK Features <span style="font-size:11px;padding:2px 8px;border-radius:10px;background:rgba(210,153,34,0.15);color:var(--yellow);vertical-align:middle;margin-left:8px">Experimental</span></h1>
+  <p class="subtitle" style="max-width:720px;line-height:1.6">
+    Unlock Claude Code features for any connected agent. Capabilities like auto-memory, dreaming, and CLAUDE.md — normally
+    exclusive to Claude Code — become available to OpenCode, Crush, Droid, and any other harness routed through Meridian.
+    Each agent keeps its own toolchain while gaining access to these additional features.<br><br>
+    <strong style="color:var(--text)">System prompts:</strong> For these features to work correctly, both the Claude Code prompt and your client prompt
+    should be enabled. When both are active, they are appended together — Claude Code's base instructions come first,
+    followed by your agent's specific instructions.
+  </p>
+
+  <div id="adapters"></div>
 
   <h1 style="margin-top:40px">Model Pricing</h1>
   <p class="subtitle" style="max-width:720px;line-height:1.6">


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Nowaker is still iterating on this. Filed early so the change is visible and
reviewable when it is ready; please hold off until the DRAFT marker is gone.

---

## What

Moves the **Routing** section to the top of `/settings`. Pure reordering: same
markup, same `PUT /settings/api/routing` wiring, same `loadRouting()`.

## Why this is a discoverability bug, not a preference

Routing decides which account an unpinned request drains - `active` uses the
manually selected profile, `sticky` distributes sessions cache-affine, and
`priority` drains the pool in order and **fails over per request when an account
runs out**. On a multi-account fleet it is the most consequential control on the
page.

It sat below the per-adapter SDK Features list, which is long enough that the
page reads as being only that list. The concrete case that prompted this: the
owner of a **ten-account fleet** did not know the routing modes existed. Nothing
invisible was ever chosen.

## The one non-mechanical detail

The `margin-top:40px` on Routing's `<h1>` existed to separate it from the
section above it. At the top of the page it would read as a stray gap, so it
moves to the SDK Features heading - which is now the one that needs it.

## Verification

- `bunx tsc --noEmit` exit 0, 0 errors
- `bun run test` (the project's own chain, which deliberately runs several files
  in separate processes) - **2493 pass, 0 fail**, pipeline exit 0
- Rendered in a browser against a development instance on its own port and
  config dir: Routing renders first and still saves

## Scope

Presentation only. `resolveProfile`, `resolvePriorityOrder`, `dispatchPriority`
and the settings API are untouched.

Cut from `main`, one commit, independent of the sibling PR that turns the SDK
Features list into tabs - either can be taken alone.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
