### PR TITLE
chore(opencode): pre-approve Meridian's own directories, refuse its credentials

### DIFF
--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -1,0 +1,73 @@
+# opencode project configuration
+
+[`opencode.json`](./opencode.json) pre-approves the directories Meridian owns,
+so that working on this repository with an agent does not interrupt you to
+confirm access to Meridian's own config directory several times an hour.
+
+It also refuses a handful of files outright. **That half is the point**, and it
+is why this config is not simply `"external_directory": "allow"`.
+
+## What is allowed, and why it needs saying
+
+Meridian reads and writes outside the repository by design, so an agent doing
+almost anything here - running the proxy, reading settings, inspecting
+telemetry - crosses opencode's external-directory boundary immediately:
+
+| path | what lives there |
+|---|---|
+| `~/.config/meridian/**` | `settings.json`, `adapter-instances.json`, `sdk-features.json`, `model-pricing.json`, `plugins.json`, `plugins/`, `telemetry.db` |
+| `~/.cache/meridian/**` | the session store (`MERIDIAN_SESSION_DIR`) |
+| `~/.cache/opencode-claude-max-proxy/**` | the same store under its pre-rename path |
+
+## What is denied, and why it cannot be relaxed
+
+Four files in those same locations hold **live credentials**. Without the
+denies below, pre-approving the directory would hand every agent working on
+this repository the keys to every account configured in it:
+
+| path | what it holds |
+|---|---|
+| `~/.config/meridian/profiles.json` | `apiKey` and `oauthToken` per profile (`ProfileConfig`, `src/proxy/profiles.ts`) |
+| `~/.config/meridian/profiles/<id>/.credentials.json` | the OAuth access and **refresh** tokens for a browser-login profile |
+| `~/.config/meridian/design-token.json` | a refresh token, which rotates on use |
+| `~/.claude/.credentials.json` | Claude Code's own credentials (`src/proxy/tokenRefresh.ts`) |
+
+A refresh token is the serious one: it is long-lived, it rotates on use, and a
+copy that leaks into a transcript cannot be un-leaked. Recovering from that is
+an interactive `claude login` per affected account.
+
+**The two rules are not interchangeable, and each is load-bearing.**
+`external_directory` is a *directory*-level gate - the prompt it raises names
+`~/.config/meridian/*`, not a file - so it cannot tell `profiles.json` from
+`settings.json`, which sit side by side. Only the file-path-matched `read`
+rules can. Deleting the `read` block therefore silently exposes the
+credentials while leaving this file looking careful.
+
+Ordering is also load-bearing: opencode evaluates the **last** matching rule
+(`findLast` in `packages/opencode/src/permission/index.ts`), so the broad
+allows must stay above the narrow denies. Reordering them inverts the meaning.
+
+Nothing here restricts Meridian itself. These rules govern opencode's own
+file tools; the proxy, the CLI and their subprocesses read and write exactly
+as they always have, which is why `meridian profile add` and `meridian profile
+login` still work normally.
+
+## Deliberately not listed
+
+- **`~/.claude/**` as a whole** and **`~/.config/opencode/**`** are not
+  pre-approved *here*. The first is Claude Code's directory rather than
+  Meridian's; the second belongs to another tool and holds its provider API
+  keys, and Meridian only writes it during `meridian setup`. Whether they
+  prompt is left to your own global config, which is the right place to decide
+  about somewhere this project mostly does not go. The `read` deny on
+  `~/.claude/.credentials.json` still applies either way.
+- **Relocated directories.** `MERIDIAN_CONFIG_DIR`, `MERIDIAN_SESSION_DIR`,
+  `MERIDIAN_PLUGIN_DIR`, `MERIDIAN_PRICING_CONFIG`, `MERIDIAN_TELEMETRY_DB` and
+  `MERIDIAN_DESIGN_TOKEN_PATH` can put any of this anywhere, so no static
+  config can enumerate them. If you relocate one, add it yourself - and add the
+  matching `read` deny if the new location holds credentials.
+
+## Applying it
+
+opencode loads config once at startup, so a change here reaches a session only
+after that session's opencode is restarted.

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "external_directory": {
+      "~/.config/meridian/**": "allow",
+      "~/.cache/meridian/**": "allow",
+      "~/.cache/opencode-claude-max-proxy/**": "allow"
+    },
+    "read": {
+      "~/.config/meridian/profiles.json": "deny",
+      "~/.config/meridian/profiles/**": "deny",
+      "~/.config/meridian/design-token.json": "deny",
+      "~/.claude/.credentials.json": "deny"
+    }
+  }
+}


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Adds `.opencode/opencode.json`, a project-scoped permission config for anyone
who works on this repository with [opencode](https://opencode.ai).

## The problem

Meridian reads and writes outside its own checkout by design, so an agent doing
almost anything here - starting the proxy, reading `settings.json`, inspecting
`telemetry.db`, testing profile isolation - crosses opencode's
external-directory boundary immediately. The confirmation prompt for
`~/.config/meridian` fires several times an hour and is approved every time. A
prompt that is always approved has stopped carrying information.

## Why this is not `"external_directory": "allow"`

Four files under those same paths hold **live credentials**:

| path | what it holds |
|---|---|
| `~/.config/meridian/profiles.json` | `apiKey` and `oauthToken` per profile (`ProfileConfig`, `src/proxy/profiles.ts`) |
| `~/.config/meridian/profiles/<id>/.credentials.json` | OAuth access and **refresh** tokens for a browser-login profile |
| `~/.config/meridian/design-token.json` | a refresh token, which rotates on use |
| `~/.claude/.credentials.json` | Claude Code's own credentials (`src/proxy/tokenRefresh.ts`) |

A refresh token is the serious one: long-lived, rotates on use, and a copy that
reaches an agent transcript cannot be un-leaked. Recovery is an interactive
`claude login` per affected account.

So the config does both halves at once - it pre-approves the three directories
Meridian owns, and denies those four files by path:

```json
{
  "permission": {
    "external_directory": {
      "~/.config/meridian/**": "allow",
      "~/.cache/meridian/**": "allow",
      "~/.cache/opencode-claude-max-proxy/**": "allow"
    },
    "read": {
      "~/.config/meridian/profiles.json": "deny",
      "~/.config/meridian/profiles/**": "deny",
      "~/.config/meridian/design-token.json": "deny",
      "~/.claude/.credentials.json": "deny"
    }
  }
}
```

**The two rules are not interchangeable.** `external_directory` is a
*directory*-level gate - the prompt it raises names `~/.config/meridian/*`
rather than a file - so it cannot tell `profiles.json` from `settings.json`,
which sit beside each other. Only `read`, which matches on the file path, can.
Deleting the `read` block would silently expose the credentials while leaving
the config looking careful, which is why `.opencode/README.md` records the
reasoning next to it.

Ordering is load-bearing too: opencode resolves a permission with `findLast`
over the merged ruleset, so the broad allows must stay above the narrow denies.
Reordering them inverts the meaning.

## What it does not do

**Nothing here restricts Meridian.** These rules govern opencode's own file
tools. The proxy, the CLI and their subprocesses read and write exactly as
before, so `meridian profile add` and `meridian profile login` are unaffected.

`~/.claude` as a whole and `~/.config/opencode` are deliberately left out - the
first is Claude Code's directory rather than Meridian's, the second belongs to
another tool and holds its provider API keys, and Meridian only writes it during
`meridian setup`. Both are better decided in a user's global config than
pre-approved by a project.

Directories relocated with `MERIDIAN_CONFIG_DIR`, `MERIDIAN_SESSION_DIR`,
`MERIDIAN_PLUGIN_DIR`, `MERIDIAN_PRICING_CONFIG`, `MERIDIAN_TELEMETRY_DB` or
`MERIDIAN_DESIGN_TOKEN_PATH` cannot be enumerated statically; the README says so
and says what to add.

## Verification

Diffed `opencode debug config` run in a worktree carrying the file against the
same command in one without it:

| | with | without |
|---|---|---|
| Meridian-related rules resolved | **7** | 2 |

All three allows and all four denies appear, and each lands **last** in its own
list - which is what makes the denies win.

## Scope

Inert for anyone not using opencode: it is a config file for one tool, in that
tool's own directory, and nothing in the build, the tests or the runtime reads
it. Happy to drop it if you would rather not carry tool-specific config in the
repository - it works equally well as a local file, and this is offered because
the credential-deny half is worth having by default rather than rediscovered.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
