### PR TITLE
feat(dev): MERIDIAN_FOLLOW_ACTIVE, take the active profile from another instance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_DEFAULT_AGENT` | — | `opencode` | Default adapter for unrecognized agents: `opencode`, `forgecode`, `pi`, `crush`, `droid`, `cherry`, `claudecode`, `passthrough`. Requires restart. |
 | `MERIDIAN_ROUTING` | — | `active` | Session-to-profile routing: `active` (all traffic to the active profile), `sticky` ([sticky session routing](profiles.md#sticky-session-routing)), or `priority` ([priority failover](profiles.md#priority-failover-routing)) |
 | `MERIDIAN_PROFILE_ORDER` | — | *(config order)* | Priority-mode pool order, comma-separated, highest priority first (e.g. `work,personal`). Also editable at `/settings`. |
+| `MERIDIAN_FOLLOW_ACTIVE` | `CLAUDE_PROXY_FOLLOW_ACTIVE` | unset | Base URL of another Meridian instance to take the active profile from, e.g. `http://127.0.0.1:3456`. For a development instance running beside a primary one — see [Following another instance's active profile](#following-another-instances-active-profile). |
 | `MERIDIAN_PASSTHROUGH_EARLY_STOP` | — | `1` | Set to `0` to disable [digest-turn elimination](#how-tool-calling-works-in-passthrough) and restore the old end-of-turn behavior |
 | `MERIDIAN_SILENT_TURN_RECOVERY` | `CLAUDE_PROXY_SILENT_TURN_RECOVERY` | `1` | Set to `0` to stop spending a recovery turn on a [silent turn](#silent-turns). Detection and telemetry stay on either way |
 | `MERIDIAN_UPSTREAM_IDLE_MS` | `CLAUDE_PROXY_UPSTREAM_IDLE_MS` | `90000` | Milliseconds the upstream stream may go quiet before the turn is treated as stalled. Raise it for long-thinking turns that were being killed mid-flight; `0` disables the guard entirely. Applies to the recovery turn too. |
@@ -50,6 +51,59 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_PLUGIN_CONFIG` | — | `~/.config/meridian/plugins.json` | Plugin manifest path |
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost. Fable 1M is also included at no Extra Usage cost, verified live on both Max and Team.
+
+### Following another instance's active profile
+
+`MERIDIAN_FOLLOW_ACTIVE=http://127.0.0.1:3456` makes an instance take its
+active profile from the instance at that URL instead of from its own
+`settings.json`.
+
+This exists for running a development build beside a primary instance and
+comparing them. `MERIDIAN_CONFIG_DIR` relocates `settings.json` and nothing
+else, so a second instance keeps its **own** `activeProfile` — whatever moves
+the primary's active profile (a click in the UI, `meridian profile use`, an
+external scheduler) leaves the second instance serving from a different
+account, and the comparison is no longer like-for-like.
+
+The value is a Meridian base URL. A bare `host:port` is accepted and assumed
+to be `http`. The followed instance is polled every 10s on `GET /profiles/list`
+and the value is cached, so the request path never waits on the network.
+
+What it does and does not change:
+
+- **Replaces exactly one input** to profile resolution — the active profile.
+  An explicit `x-meridian-profile` header still wins, per request.
+- **Refuses to follow a profile this instance does not have.** The local active
+  profile is used instead and the reason is reported; routing to a name that is
+  not configured here would silently resolve to an unrelated account.
+- **Never fails closed.** If the followed instance is down, slow, or answers
+  something unusable, the last known value keeps being served. If a good value
+  has never been read, the local active profile is used. A poll failure is
+  logged once per outage, not once per poll.
+- **A value that has not been confirmed for two minutes is still served**, and
+  is flagged `stale` on `/profiles/list` and in the header chip. Falling back
+  to the local value on a timeout would split the comparison exactly when you
+  are least likely to notice.
+- **`POST /profiles/active` is refused with `409`**, naming the followed URL.
+  A local write would be shadowed on the next resolution and erased by the next
+  poll — a picker that appears to work and silently doesn't. The web UI's
+  account cards stop being clickable and `meridian profile use` prints the
+  refusal.
+- **No effect under `MERIDIAN_ROUTING=priority`** for unpinned requests, which
+  are dispatched across the pool without consulting the active profile. Startup
+  says so if both are set.
+- **Following your own address is refused** at startup: the followed value
+  could never change and local switching would be refused, freezing the active
+  profile permanently.
+
+The mode is announced at startup and surfaced on `/profiles/list` as a `follow`
+object (`url`, `activeProfile`, `followedValue`, `reason`, `stale`,
+`lastSyncedAt`, `lastError`), which the shared header chip renders on every
+page.
+
+Limitation: the poll sends no credentials, so a followed instance behind
+`MERIDIAN_API_KEY` will always fail the poll and the follower will fall back to
+its local active profile.
 
 ### Subprocess traffic
 

--- a/src/__tests__/follow-active-integration.test.ts
+++ b/src/__tests__/follow-active-integration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * HTTP surface of follow mode: what `/profiles/list` reports, and what
+ * `POST /profiles/active` does when this instance does not own its active
+ * profile.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mock } from "bun:test"
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => (async function* () {
+    yield {
+      type: "assistant",
+      message: { type: "assistant", content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: `session-${Date.now()}`,
+    }
+  })(),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+// Pass through the real resolveSdkModelDefaults — mock.module is process-global
+// in Bun, and stubbing it as () => ({}) leaks to proxy-env-stripping.test.ts.
+import { resolveSdkModelDefaults } from "../proxy/models"
+
+mock.module("../proxy/models", () => ({
+  mapModelToClaudeModel: () => "sonnet",
+  resolveClaudeExecutableAsync: async () => "claude",
+  resolveSdkModelDefaults,
+  getClaudeAuthStatusAsync: async () => ({ loggedIn: true, email: "test@test.com", subscriptionType: "max" }),
+  getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
+  hasExtendedContext: () => false,
+  stripExtendedContext: (m: string) => m,
+  isClosedControllerError: (e: unknown) => e instanceof Error && e.message.includes("controller is closed"),
+  recordExtendedContextUnavailable: () => {},
+  isExtendedContextKnownUnavailable: () => false,
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { resetActiveProfile, setActiveProfile } = await import("../proxy/profiles")
+const { resetFollowActive, setFollowStateForTesting } = await import("../proxy/followActive")
+const { clearSessionCache } = await import("../proxy/session/cache")
+
+const FOLLOWED = "http://127.0.0.1:3456"
+const profiles = [
+  { id: "personal", claudeConfigDir: "/home/.claude" },
+  { id: "work", claudeConfigDir: "/home/.claude-work" },
+]
+
+beforeEach(() => {
+  resetActiveProfile()
+  resetFollowActive()
+  clearSessionCache()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+})
+
+afterEach(() => {
+  resetFollowActive()
+  resetActiveProfile()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+})
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles })
+  return app
+}
+
+function req(url: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${url}`, init)
+}
+
+function following(profileId: string, at = Date.now()): void {
+  process.env.MERIDIAN_FOLLOW_ACTIVE = FOLLOWED
+  setFollowStateForTesting({ lastGood: { profileId, at } })
+}
+
+describe("GET /profiles/list under follow mode", () => {
+  test("no follow block when the mode is off", async () => {
+    const res = await createTestApp().fetch(req("/profiles/list"))
+    const body = await res.json() as Record<string, unknown>
+    expect(body.follow).toBeUndefined()
+  })
+
+  test("activeProfile and isActive report the followed value", async () => {
+    setActiveProfile("personal")
+    following("work")
+
+    const res = await createTestApp().fetch(req("/profiles/list"))
+    const body = await res.json() as {
+      activeProfile: string
+      profiles: Array<{ id: string; isActive: boolean }>
+      follow: { url: string; activeProfile: string | null; reason: string | null; stale: boolean }
+    }
+
+    expect(body.activeProfile).toBe("work")
+    expect(body.profiles.find(p => p.id === "work")?.isActive).toBe(true)
+    expect(body.profiles.find(p => p.id === "personal")?.isActive).toBe(false)
+    expect(body.follow).toMatchObject({ url: FOLLOWED, activeProfile: "work", reason: null, stale: false })
+  })
+
+  test("a followed profile this instance lacks is reported, not routed to", async () => {
+    setActiveProfile("personal")
+    following("randall-personal")
+
+    const res = await createTestApp().fetch(req("/profiles/list"))
+    const body = await res.json() as {
+      activeProfile: string
+      follow: { activeProfile: string | null; followedValue: string | null; reason: string | null }
+    }
+
+    expect(body.activeProfile).toBe("personal")
+    expect(body.follow).toMatchObject({
+      activeProfile: null,
+      followedValue: "randall-personal",
+      reason: "unknown-profile",
+    })
+  })
+})
+
+describe("POST /profiles/active under follow mode", () => {
+  test("refuses with 409 and names what is in charge", async () => {
+    setActiveProfile("personal")
+    following("work")
+
+    const res = await createTestApp().fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "personal" }),
+    }))
+
+    expect(res.status).toBe(409)
+    const body = await res.json() as { error: string; following: { url: string; activeProfile: string | null } }
+    expect(body.error).toContain(FOLLOWED)
+    expect(body.error).toContain("MERIDIAN_FOLLOW_ACTIVE")
+    expect(body.error).toContain("x-meridian-profile")
+    expect(body.following).toMatchObject({ url: FOLLOWED, activeProfile: "work" })
+  })
+
+  test("the refusal does not change what is served", async () => {
+    setActiveProfile("personal")
+    following("work")
+    const app = createTestApp()
+
+    await app.fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "personal" }),
+    }))
+
+    const body = await (await app.fetch(req("/profiles/list"))).json() as { activeProfile: string }
+    expect(body.activeProfile).toBe("work")
+  })
+
+  test("refuses even before a followed value has arrived", async () => {
+    process.env.MERIDIAN_FOLLOW_ACTIVE = FOLLOWED
+
+    const res = await createTestApp().fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "work" }),
+    }))
+
+    expect(res.status).toBe(409)
+  })
+
+  test("switching still works when the mode is off", async () => {
+    const res = await createTestApp().fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "work" }),
+    }))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, activeProfile: "work" })
+  })
+})

--- a/src/__tests__/follow-active.test.ts
+++ b/src/__tests__/follow-active.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Follow-the-active-profile mode — MERIDIAN_FOLLOW_ACTIVE.
+ *
+ * The decision logic is pure so every branch is provable without a second
+ * Meridian instance running: followed value present, absent, unknown here,
+ * stale, and the followed instance being down mid-flight.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+
+import {
+  parseFollowTarget,
+  isSelfTarget,
+  readActiveProfile,
+  decideFollowedProfile,
+  followedActiveProfile,
+  followStatus,
+  followTarget,
+  isFollowEnabled,
+  pollFollowedActiveProfile,
+  resetFollowActive,
+  setFollowStateForTesting,
+  FOLLOW_STALE_AFTER_MS,
+} from "../proxy/followActive"
+import { resolveProfile, resolveActiveProfileId, setActiveProfile, resetActiveProfile } from "../proxy/profiles"
+
+const FOLLOWED = "http://127.0.0.1:3456"
+const realFetch = globalThis.fetch
+
+function follow(url = FOLLOWED): void {
+  process.env.MERIDIAN_FOLLOW_ACTIVE = url
+}
+
+// Bun's `fetch` type carries a `preconnect` member, so a bare function is not
+// assignable — keep the real one rather than reaching for a cast.
+function stubFetch(impl: () => Promise<Response>): void {
+  globalThis.fetch = Object.assign(() => impl(), { preconnect: realFetch.preconnect })
+}
+
+beforeEach(() => {
+  resetFollowActive()
+  resetActiveProfile()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+})
+
+afterEach(() => {
+  resetFollowActive()
+  resetActiveProfile()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+  globalThis.fetch = realFetch
+})
+
+describe("parseFollowTarget", () => {
+  test("unset or blank is off", () => {
+    expect(parseFollowTarget(undefined).kind).toBe("off")
+    expect(parseFollowTarget("").kind).toBe("off")
+    expect(parseFollowTarget("   ").kind).toBe("off")
+  })
+
+  test("normalizes a full URL and strips the trailing slash", () => {
+    expect(parseFollowTarget("http://127.0.0.1:3456")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+    expect(parseFollowTarget("http://127.0.0.1:3456/")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+    expect(parseFollowTarget("http://127.0.0.1:3456/profiles/list")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+  })
+
+  test("assumes http for a bare host:port", () => {
+    expect(parseFollowTarget("127.0.0.1:3456")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+    expect(parseFollowTarget("meridian.internal:8080")).toEqual({ kind: "on", url: "http://meridian.internal:8080" })
+  })
+
+  test("accepts https", () => {
+    expect(parseFollowTarget("https://meridian.example.com")).toEqual({ kind: "on", url: "https://meridian.example.com" })
+  })
+
+  test("rejects a non-http scheme without throwing", () => {
+    const parsed = parseFollowTarget("ftp://host:21")
+    expect(parsed.kind).toBe("invalid")
+  })
+
+  test("rejects a value with no host without throwing", () => {
+    expect(parseFollowTarget("http://").kind).toBe("invalid")
+  })
+})
+
+describe("isSelfTarget", () => {
+  test("same port and same host is self", () => {
+    expect(isSelfTarget("http://127.0.0.1:3456", "127.0.0.1", 3456)).toBe(true)
+  })
+
+  test("loopback spellings are the same machine", () => {
+    expect(isSelfTarget("http://localhost:3456", "127.0.0.1", 3456)).toBe(true)
+    expect(isSelfTarget("http://127.0.0.1:3456", "localhost", 3456)).toBe(true)
+    expect(isSelfTarget("http://[::1]:3456", "127.0.0.1", 3456)).toBe(true)
+  })
+
+  test("a different port is a different instance", () => {
+    expect(isSelfTarget("http://127.0.0.1:3456", "127.0.0.1", 3458)).toBe(false)
+  })
+
+  test("a non-loopback host is a different instance", () => {
+    expect(isSelfTarget("http://10.0.0.5:3456", "127.0.0.1", 3456)).toBe(false)
+  })
+
+  test("implicit scheme ports are compared", () => {
+    expect(isSelfTarget("https://localhost", "127.0.0.1", 443)).toBe(true)
+    expect(isSelfTarget("http://localhost", "127.0.0.1", 80)).toBe(true)
+  })
+})
+
+describe("readActiveProfile", () => {
+  test("reads and trims a string value", () => {
+    expect(readActiveProfile({ activeProfile: "work" })).toBe("work")
+    expect(readActiveProfile({ activeProfile: "  work  " })).toBe("work")
+  })
+
+  test("rejects rubbish bodies", () => {
+    expect(readActiveProfile(null)).toBeUndefined()
+    expect(readActiveProfile("<html>502 Bad Gateway</html>")).toBeUndefined()
+    expect(readActiveProfile({})).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: 42 })).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: null })).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: "" })).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: "x".repeat(500) })).toBeUndefined()
+  })
+})
+
+describe("decideFollowedProfile", () => {
+  const now = 1_000_000
+
+  test("follows a known value", () => {
+    const outcome = decideFollowedProfile({ lastGood: { profileId: "work", at: now } }, ["personal", "work"], now)
+    expect(outcome).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("falls back to local when no value has ever been read", () => {
+    expect(decideFollowedProfile({}, ["personal", "work"], now)).toEqual({ follow: false, reason: "no-value" })
+  })
+
+  test("refuses to follow a profile this instance does not have", () => {
+    const outcome = decideFollowedProfile({ lastGood: { profileId: "randall-personal", at: now } }, ["personal", "work"], now)
+    expect(outcome).toEqual({ follow: false, reason: "unknown-profile", followedValue: "randall-personal" })
+  })
+
+  test("an empty profile list can follow nothing", () => {
+    const outcome = decideFollowedProfile({ lastGood: { profileId: "work", at: now } }, [], now)
+    expect(outcome).toEqual({ follow: false, reason: "unknown-profile", followedValue: "work" })
+  })
+
+  test("an unconfirmed value is still followed, flagged stale", () => {
+    const state = { lastGood: { profileId: "work", at: now - FOLLOW_STALE_AFTER_MS - 1 } }
+    expect(decideFollowedProfile(state, ["work"], now)).toEqual({ follow: true, profileId: "work", stale: true })
+  })
+
+  test("the followed instance being down keeps the last known value", () => {
+    const state = {
+      lastGood: { profileId: "work", at: now - 30_000 },
+      lastPollAt: now,
+      lastError: { message: "fetch failed", at: now },
+    }
+    expect(decideFollowedProfile(state, ["personal", "work"], now)).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("unknown-profile beats stale — a fallback is not a resolution", () => {
+    const state = { lastGood: { profileId: "gone", at: now - FOLLOW_STALE_AFTER_MS - 1 } }
+    expect(decideFollowedProfile(state, ["work"], now)).toEqual({ follow: false, reason: "unknown-profile", followedValue: "gone" })
+  })
+})
+
+describe("configuration", () => {
+  test("off by default", () => {
+    expect(isFollowEnabled()).toBe(false)
+    expect(followTarget()).toBeUndefined()
+    expect(followedActiveProfile(["work"])).toBeUndefined()
+    expect(followStatus(["work"])).toBeUndefined()
+  })
+
+  test("an unusable value leaves follow mode off rather than failing", () => {
+    follow("ftp://nope")
+    expect(isFollowEnabled()).toBe(false)
+    expect(followedActiveProfile(["work"])).toBeUndefined()
+  })
+
+  test("the CLAUDE_PROXY_ alias works", () => {
+    process.env.CLAUDE_PROXY_FOLLOW_ACTIVE = FOLLOWED
+    try {
+      expect(followTarget()).toEqual({ url: FOLLOWED })
+    } finally {
+      delete process.env.CLAUDE_PROXY_FOLLOW_ACTIVE
+    }
+  })
+})
+
+describe("polling the followed instance", () => {
+  function respond(body: unknown, status = 200): void {
+    stubFetch(async () =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } }))
+  }
+
+  function refuseConnection(): void {
+    stubFetch(async () => { throw new Error("connect ECONNREFUSED") })
+  }
+
+  test("a good response becomes the followed value", async () => {
+    follow()
+    respond({ activeProfile: "work", profiles: [] })
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["personal", "work"])).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("does nothing when follow mode is off", async () => {
+    let called = false
+    stubFetch(async () => { called = true; return new Response("{}") })
+    await pollFollowedActiveProfile()
+    expect(called).toBe(false)
+  })
+
+  test("a network failure keeps the last known value", async () => {
+    follow()
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+
+    refuseConnection()
+    await pollFollowedActiveProfile()
+
+    expect(followedActiveProfile(["work"])).toEqual({ follow: true, profileId: "work", stale: false })
+    expect(followStatus(["work"])?.lastError).toContain("ECONNREFUSED")
+  })
+
+  test("a non-200 keeps the last known value", async () => {
+    follow()
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+
+    respond({ error: "unauthorized" }, 401)
+    await pollFollowedActiveProfile()
+
+    expect(followedActiveProfile(["work"])).toEqual({ follow: true, profileId: "work", stale: false })
+    expect(followStatus(["work"])?.lastError).toBe("HTTP 401")
+  })
+
+  test("a rubbish body keeps the last known value", async () => {
+    follow()
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+
+    respond({ something: "else" })
+    await pollFollowedActiveProfile()
+
+    expect(followedActiveProfile(["work"])).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("an unreachable instance that has never answered yields no value", async () => {
+    follow()
+    refuseConnection()
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["work"])).toEqual({ follow: false, reason: "no-value" })
+  })
+
+  test("picks up a change on the followed instance", async () => {
+    follow()
+    respond({ activeProfile: "personal" })
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["personal", "work"])).toMatchObject({ profileId: "personal" })
+
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["personal", "work"])).toMatchObject({ profileId: "work" })
+  })
+})
+
+describe("followStatus", () => {
+  test("reports the value in effect", () => {
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(followStatus(["personal", "work"])).toMatchObject({
+      url: FOLLOWED,
+      activeProfile: "work",
+      followedValue: "work",
+      reason: null,
+      stale: false,
+    })
+  })
+
+  test("reports the fallback and why, keeping the raw followed value visible", () => {
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "randall-personal", at: Date.now() } })
+    expect(followStatus(["personal", "work"])).toMatchObject({
+      activeProfile: null,
+      followedValue: "randall-personal",
+      reason: "unknown-profile",
+    })
+  })
+})
+
+describe("resolveProfile under follow mode", () => {
+  const profiles = [
+    { id: "personal", claudeConfigDir: "/home/.claude" },
+    { id: "work", claudeConfigDir: "/home/.claude-work" },
+  ]
+
+  test("the followed value replaces the local active profile", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined).id).toBe("work")
+    expect(resolveActiveProfileId(["personal", "work"])).toBe("work")
+  })
+
+  test("an explicit header still wins over the followed value", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined, "personal").id).toBe("personal")
+  })
+
+  test("a followed profile this instance lacks falls back to the local one", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "randall-personal", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+  })
+
+  test("no followed value yet falls back to the local one", () => {
+    setActiveProfile("personal")
+    follow()
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+  })
+
+  test("follow mode off leaves resolution exactly as it was", () => {
+    setActiveProfile("personal")
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+  })
+
+  test("a stale followed value is still served", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() - FOLLOW_STALE_AFTER_MS - 1 } })
+    expect(resolveProfile(profiles, undefined).id).toBe("work")
+    expect(followStatus(["personal", "work"])?.stale).toBe(true)
+  })
+})

--- a/src/__tests__/preload.ts
+++ b/src/__tests__/preload.ts
@@ -10,6 +10,12 @@ import { join } from "node:path"
 // Auth middleware reads this at request time; clear it so tests don't need API keys
 delete process.env.MERIDIAN_API_KEY
 
+// Follow mode replaces the active profile for EVERY profile resolution, so a
+// developer with this exported in their shell would silently change what the
+// profile/routing suites resolve to.
+delete process.env.MERIDIAN_FOLLOW_ACTIVE
+delete process.env.CLAUDE_PROXY_FOLLOW_ACTIVE
+
 // Point settings.ts at a throwaway directory so the suite never reads the
 // developer's real ~/.config/meridian/settings.json. A live
 // `routing: "priority"` setting made the sticky- and priority-routing

--- a/src/proxy/followActive.ts
+++ b/src/proxy/followActive.ts
@@ -1,0 +1,391 @@
+/**
+ * Follow-the-active-profile mode — `MERIDIAN_FOLLOW_ACTIVE`.
+ *
+ * Makes a development instance take its active profile from ANOTHER Meridian
+ * instance instead of from its own `settings.json`, so the two serve from the
+ * same account and a side-by-side comparison is like-for-like.
+ *
+ * The problem it solves: `MERIDIAN_CONFIG_DIR` relocates `settings.json` and
+ * nothing else, so a second instance keeps its own `activeProfile`. Whatever
+ * moves the primary's active profile — a UI click, the CLI, an external fleet
+ * scheduler — has no effect on the second instance, which quietly serves from
+ * a different account. Measured on one box: the primary was on one profile
+ * while the dev instance served the same instant from another.
+ *
+ * What this changes: exactly ONE input to `resolveProfile` — the active
+ * profile. The precedence chain around it is untouched, so an explicit
+ * `x-meridian-profile` header still wins, and sticky/priority routing behave
+ * as they always did (priority mode does not consult the active profile at
+ * all for unpinned requests, so follow mode is a no-op there).
+ *
+ * Degradation is the design constraint, not an afterthought. The followed
+ * instance is polled in the background and the last good value is cached; the
+ * request path never waits on the network. If the followed instance is down,
+ * slow, or answers rubbish, the last known value keeps being served — and if
+ * there has never been a good value, the local active profile is used. A dev
+ * convenience must not be able to take an instance offline.
+ *
+ * Leaf module — no imports from server.ts, session/ or profiles.ts.
+ */
+
+import { env } from "../env"
+
+/**
+ * Poll cadence. The followed value changes on the order of minutes (a human
+ * clicking, or a scheduler rotating accounts), so a fetch per request would be
+ * absurd; 10s bounds the divergence window without making the followed
+ * instance do meaningful work — `/profiles/list` serves its auth status from a
+ * 60s cache that the instance's own 45s keepalive already keeps warm.
+ */
+export const FOLLOW_POLL_INTERVAL_MS = 10_000
+
+/** Per-poll timeout. Short: a slow followed instance must not accumulate polls. */
+export const FOLLOW_FETCH_TIMEOUT_MS = 2_000
+
+/**
+ * How long a value may go unconfirmed before it is REPORTED stale.
+ *
+ * Staleness deliberately does not change routing. Falling back to the local
+ * value after a timeout would silently split the comparison exactly when you
+ * are least likely to notice, and the local value is not more correct — it is
+ * just different. A stale-but-known followed value remains the best available
+ * answer to "what is the primary on?"; the dev instance's own `activeProfile`
+ * is arbitrary. So a stale value is still followed, and is flagged as stale
+ * everywhere the mode is surfaced.
+ */
+export const FOLLOW_STALE_AFTER_MS = 120_000
+
+/** Longest plausible profile id — a defence against a garbage response body. */
+const MAX_PROFILE_ID_LENGTH = 128
+
+// --- Pure: configuration parsing ------------------------------------------
+
+export type FollowTarget =
+  | { kind: "off" }
+  | { kind: "on"; url: string }
+  | { kind: "invalid"; raw: string; message: string }
+
+/**
+ * Parse the env var value into a normalized base URL.
+ *
+ * A bare `host:port` is accepted and assumed to be http, because that is what
+ * anyone types first and `new URL()` would otherwise read `127.0.0.1` as a
+ * scheme. Trailing slashes are stripped so callers can concatenate paths.
+ *
+ * A malformed value yields "invalid" rather than throwing: the caller warns
+ * and runs without follow mode. Refusing to start on a typo would take an
+ * instance offline, which is the one outcome this feature must never cause.
+ */
+export function parseFollowTarget(raw: string | undefined): FollowTarget {
+  const trimmed = raw?.trim()
+  if (!trimmed) return { kind: "off" }
+  const withScheme = trimmed.includes("://") ? trimmed : `http://${trimmed}`
+  let parsed: URL
+  try {
+    parsed = new URL(withScheme)
+  } catch {
+    return { kind: "invalid", raw: trimmed, message: "not a URL" }
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { kind: "invalid", raw: trimmed, message: `unsupported scheme "${parsed.protocol}"` }
+  }
+  if (!parsed.hostname) {
+    return { kind: "invalid", raw: trimmed, message: "no host" }
+  }
+  return { kind: "on", url: `${parsed.protocol}//${parsed.host}` }
+}
+
+/** Loopback spellings that all mean "this machine". */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0", "::", "[::]"])
+
+/**
+ * Whether a follow target addresses the instance doing the following.
+ *
+ * Self-follow is a deadlock, not a harmless no-op: the instance would follow
+ * its own active profile (so the value never changes) while refusing local
+ * writes (so nothing can change it), leaving the profile frozen forever. It is
+ * also the realistic typo — copying the wrong port out of a unit file.
+ */
+export function isSelfTarget(url: string, selfHost: string, selfPort: number): boolean {
+  const target = parseFollowTarget(url)
+  if (target.kind !== "on") return false
+  const parsed = new URL(target.url)
+  const targetPort = parsed.port ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80
+  if (targetPort !== selfPort) return false
+  const targetHost = parsed.hostname.toLowerCase()
+  const ownHost = selfHost.toLowerCase()
+  if (targetHost === ownHost) return true
+  return LOOPBACK_HOSTS.has(targetHost) && LOOPBACK_HOSTS.has(ownHost)
+}
+
+// --- Pure: response reading -----------------------------------------------
+
+/**
+ * Extract `activeProfile` from a `/profiles/list` body.
+ *
+ * Deliberately paranoid about the shape. The followed instance may be a
+ * different version, a different program listening on a recycled port, or an
+ * error page — "answers rubbish" is one of the failure modes this must
+ * survive, and a non-string or absurdly long value must be treated as no
+ * value at all rather than routed to.
+ */
+export function readActiveProfile(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined
+  const value = (body as { activeProfile?: unknown }).activeProfile
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > MAX_PROFILE_ID_LENGTH) return undefined
+  return trimmed
+}
+
+// --- Pure: the decision ---------------------------------------------------
+
+export interface FollowState {
+  /** Last value successfully read, and when it was last CONFIRMED by a poll. */
+  lastGood?: { profileId: string; at: number }
+  /** When the most recent poll completed, successful or not. */
+  lastPollAt?: number
+  /** Most recent poll failure. Cleared on the next success. */
+  lastError?: { message: string; at: number }
+}
+
+export type FollowOutcome =
+  | { follow: true; profileId: string; stale: boolean }
+  | { follow: false; reason: "no-value" | "unknown-profile"; followedValue?: string }
+
+/**
+ * Decide whether the followed value should be used, given what this instance
+ * actually has. Pure — the whole point is that every branch is testable
+ * without a second instance running.
+ *
+ * `unknown-profile` is a fallback, not a resolution: routing to a profile this
+ * instance does not have would resolve to "first configured profile" deeper in
+ * `resolveProfile` and silently serve from an unrelated account. Using the
+ * local choice and saying so is the smaller surprise.
+ */
+export function decideFollowedProfile(
+  state: FollowState,
+  availableIds: readonly string[],
+  now: number,
+  staleAfterMs: number = FOLLOW_STALE_AFTER_MS,
+): FollowOutcome {
+  const good = state.lastGood
+  // No good value yet — the followed instance has been unreachable (or has
+  // answered rubbish) for this instance's entire lifetime.
+  if (!good) return { follow: false, reason: "no-value" }
+  if (!availableIds.includes(good.profileId)) {
+    return { follow: false, reason: "unknown-profile", followedValue: good.profileId }
+  }
+  return { follow: true, profileId: good.profileId, stale: now - good.at >= staleAfterMs }
+}
+
+// --- Stateful: configuration, cache, polling ------------------------------
+
+let cachedRaw: string | undefined
+let cachedTarget: FollowTarget = { kind: "off" }
+let warnedInvalid: string | undefined
+let disabledReason: string | undefined
+let state: FollowState = {}
+let pollTimer: ReturnType<typeof setInterval> | undefined
+let bannerLogged = false
+let errorLogged = false
+
+/**
+ * The followed instance's base URL, or undefined when not following.
+ *
+ * Resolved per call rather than frozen at import time, matching `settings.ts`'s
+ * treatment of MERIDIAN_CONFIG_DIR — a value captured at import would be fixed
+ * before any test (or embedding host) could set it. Parsing is memoized on the
+ * raw string so the request path does not build a URL object per call.
+ */
+export function followTarget(): { url: string } | undefined {
+  if (disabledReason) return undefined
+  const raw = env("FOLLOW_ACTIVE")
+  if (raw !== cachedRaw) {
+    cachedRaw = raw
+    cachedTarget = parseFollowTarget(raw)
+  }
+  if (cachedTarget.kind === "invalid") {
+    if (warnedInvalid !== cachedTarget.raw) {
+      warnedInvalid = cachedTarget.raw
+      console.warn(
+        `[PROXY] MERIDIAN_FOLLOW_ACTIVE="${cachedTarget.raw}" is not usable (${cachedTarget.message}). ` +
+        `Expected a Meridian base URL, e.g. http://127.0.0.1:3456. Follow mode is OFF; ` +
+        `this instance uses its own active profile.`
+      )
+    }
+    return undefined
+  }
+  return cachedTarget.kind === "on" ? { url: cachedTarget.url } : undefined
+}
+
+/** Whether this instance takes its active profile from another one. */
+export function isFollowEnabled(): boolean {
+  return followTarget() !== undefined
+}
+
+/**
+ * The follow decision for a given profile list, or undefined when not
+ * following. Called on the request path — synchronous, cache-only, no I/O.
+ */
+export function followedActiveProfile(availableIds: readonly string[]): FollowOutcome | undefined {
+  if (!isFollowEnabled()) return undefined
+  return decideFollowedProfile(state, availableIds, Date.now())
+}
+
+/** Follow state as surfaced by `/profiles/list`. Undefined when not following. */
+export interface FollowStatus {
+  /** Base URL of the followed instance. */
+  url: string
+  /** Value actually in effect, or null when falling back to the local one. */
+  activeProfile: string | null
+  /** Last value read from the followed instance, even if unusable here. */
+  followedValue: string | null
+  /** Why the followed value is not in effect, when it isn't. */
+  reason: "no-value" | "unknown-profile" | null
+  /** Followed value has not been confirmed recently — still in effect. */
+  stale: boolean
+  /** When the followed value was last confirmed. */
+  lastSyncedAt: number | null
+  /** Most recent poll failure, if the last poll failed. */
+  lastError: string | null
+}
+
+export function followStatus(availableIds: readonly string[]): FollowStatus | undefined {
+  const target = followTarget()
+  if (!target) return undefined
+  const outcome = decideFollowedProfile(state, availableIds, Date.now())
+  return {
+    url: target.url,
+    activeProfile: outcome.follow ? outcome.profileId : null,
+    followedValue: state.lastGood?.profileId ?? null,
+    reason: outcome.follow ? null : outcome.reason,
+    stale: outcome.follow ? outcome.stale : false,
+    lastSyncedAt: state.lastGood?.at ?? null,
+    lastError: state.lastError?.message ?? null,
+  }
+}
+
+/**
+ * Read the followed instance's active profile once and update the cache.
+ *
+ * Never throws and never clears a good value on failure: a failed poll leaves
+ * the last known value in place, which is what "degrade, never fail" means
+ * here. Exported so tests can drive it without a timer.
+ */
+export async function pollFollowedActiveProfile(): Promise<void> {
+  const target = followTarget()
+  if (!target) return
+  const now = Date.now()
+  try {
+    const res = await fetch(`${target.url}/profiles/list`, {
+      signal: AbortSignal.timeout(FOLLOW_FETCH_TIMEOUT_MS),
+      headers: { accept: "application/json" },
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const value = readActiveProfile(await res.json())
+    if (!value) throw new Error("response carried no usable activeProfile")
+    const previous = state.lastGood?.profileId
+    state = { lastGood: { profileId: value, at: now }, lastPollAt: now }
+    // Log transitions only. A line per poll would be 8,640 lines a day; the
+    // interesting events are "we picked up a change" and "we recovered".
+    if (previous !== value) {
+      console.warn(
+        `[PROXY] Active profile now following "${value}" from ${target.url}` +
+        (previous ? ` (was "${previous}")` : "")
+      )
+    } else if (errorLogged) {
+      console.warn(`[PROXY] Recovered contact with ${target.url}; still following "${value}".`)
+    }
+    errorLogged = false
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    state = { ...state, lastPollAt: now, lastError: { message, at: now } }
+    if (!errorLogged) {
+      errorLogged = true
+      console.warn(
+        `[PROXY] Could not read the active profile from ${target.url} (${message}). ` +
+        (state.lastGood
+          ? `Continuing on the last known value "${state.lastGood.profileId}".`
+          : `No value has ever been read; using this instance's own active profile.`)
+      )
+    }
+  }
+}
+
+/**
+ * Arm the background poll. Idempotent.
+ *
+ * `self` is the address this instance actually bound (the configured port may
+ * be 0), used only for the self-follow guard.
+ */
+export function startFollowPolling(self?: { host: string; port: number }): void {
+  if (pollTimer) return
+  const target = followTarget()
+  if (!target) return
+  if (self && isSelfTarget(target.url, self.host, self.port)) {
+    disabledReason =
+      `MERIDIAN_FOLLOW_ACTIVE (${target.url}) points at this instance's own address. ` +
+      `Following yourself would freeze the active profile permanently — the followed value ` +
+      `could never change and local switching would be refused. Follow mode is OFF.`
+    console.warn(`[PROXY] ${disabledReason}`)
+    return
+  }
+  void pollFollowedActiveProfile()
+  pollTimer = setInterval(() => { void pollFollowedActiveProfile() }, FOLLOW_POLL_INTERVAL_MS)
+  if (pollTimer.unref) pollTimer.unref()
+}
+
+/** Stop the background poll. Idempotent. */
+export function stopFollowPolling(): void {
+  if (!pollTimer) return
+  clearInterval(pollTimer)
+  pollTimer = undefined
+}
+
+/**
+ * Announce the mode once at startup.
+ *
+ * Not gated on `silent`, matching the treatment of other non-default operating
+ * modes: MERIDIAN_SILENT suppresses routine chatter, and this is not routine —
+ * it changes where a core piece of this instance's state comes from. An
+ * instance silently following another is exactly the hour-long confusion this
+ * line exists to prevent.
+ *
+ * @param routingMode current routing mode, so the one combination where follow
+ *   mode does nothing useful says so instead of being discovered the hard way.
+ */
+export function logFollowBanner(routingMode?: string): void {
+  if (bannerLogged) return
+  const target = followTarget()
+  if (!target) return
+  bannerLogged = true
+  console.warn(
+    `[PROXY] FOLLOWING ACTIVE PROFILE (MERIDIAN_FOLLOW_ACTIVE=${target.url}): ` +
+    `this instance takes its active profile from ${target.url}, not from its own settings. ` +
+    `Local switching is refused; the x-meridian-profile header still overrides per request.`
+  )
+  if (routingMode === "priority") {
+    console.warn(
+      `[PROXY] Routing is "priority", which dispatches unpinned requests across the pool ` +
+      `without consulting the active profile — follow mode will have no visible effect on them.`
+    )
+  }
+}
+
+/** Reset all module state — for testing only. */
+export function resetFollowActive(): void {
+  stopFollowPolling()
+  cachedRaw = undefined
+  cachedTarget = { kind: "off" }
+  warnedInvalid = undefined
+  disabledReason = undefined
+  state = {}
+  bannerLogged = false
+  errorLogged = false
+}
+
+/** Seed the cache directly — for testing only. */
+export function setFollowStateForTesting(next: FollowState): void {
+  state = next
+}

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -8,7 +8,8 @@
  *
  * Profile selection priority:
  *   1. x-meridian-profile request header (per-request override)
- *   2. Active profile (set via POST /profiles/active or UI)
+ *   2. Active profile (set via POST /profiles/active or UI, or taken from
+ *      another instance under MERIDIAN_FOLLOW_ACTIVE — see followActive.ts)
  *   3. First configured profile (or implicit "default" if none configured)
  *
  * This is a leaf module — no imports from server.ts or session/.
@@ -19,6 +20,7 @@ import { join } from "node:path"
 import { homedir } from "node:os"
 import { setSetting, getSetting } from "./settings"
 import { pickStickyProfile, type RoutingMode } from "./routing"
+import { followedActiveProfile } from "./followActive"
 
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 
@@ -96,15 +98,55 @@ export function setActiveProfile(profileId: string): void {
 }
 
 /**
- * Get the current active profile ID.
+ * Get the LOCAL active profile ID — this instance's own choice, ignoring
+ * follow mode. Callers that want the profile actually in effect want
+ * `resolveActiveProfileId` instead.
  */
 export function getActiveProfileId(): string | undefined {
   return activeProfileId
 }
 
+/** Last followed value warned about, so the warning is once per value. */
+let warnedUnknownFollowed: string | undefined
+
+/**
+ * The active profile actually in effect: the followed instance's choice under
+ * MERIDIAN_FOLLOW_ACTIVE, otherwise this instance's own.
+ *
+ * This is the ONE input follow mode replaces. Everything around it — the
+ * header override, sticky assignment, the config default, the first-profile
+ * fallback — is unchanged.
+ *
+ * @param availableIds profile IDs this instance actually has, so a followed
+ *   value it cannot serve is rejected here rather than resolving to an
+ *   unrelated account further down `resolveProfile`.
+ */
+export function resolveActiveProfileId(availableIds: readonly string[]): string | undefined {
+  const outcome = followedActiveProfile(availableIds)
+  if (!outcome) return activeProfileId
+  if (outcome.follow) {
+    warnedUnknownFollowed = undefined
+    return outcome.profileId
+  }
+  if (outcome.reason === "unknown-profile" && outcome.followedValue !== warnedUnknownFollowed) {
+    warnedUnknownFollowed = outcome.followedValue
+    console.warn(
+      `[meridian] Followed instance is on profile "${outcome.followedValue}", which is not configured here. ` +
+      `Using this instance's own active profile instead.`
+    )
+  }
+  return activeProfileId
+}
+
+/** The active profile in effect, resolved against the effective profile list. */
+export function getEffectiveActiveProfileId(configProfiles: ProfileConfig[] | undefined): string | undefined {
+  return resolveActiveProfileId(getEffectiveProfiles(configProfiles).map(p => p.id))
+}
+
 /** Reset active profile — for testing only. */
 export function resetActiveProfile(): void {
   activeProfileId = undefined
+  warnedUnknownFollowed = undefined
 }
 
 /**
@@ -199,7 +241,8 @@ export function resolveProfile(
       : undefined
 
   // Priority: header > sticky > active > config default > first profile
-  const resolvedId = requestedId || stickyId || activeProfileId || defaultProfile || effective[0]!.id
+  const activeId = resolveActiveProfileId(effective.map(p => p.id))
+  const resolvedId = requestedId || stickyId || activeId || defaultProfile || effective[0]!.id
   const profile = effective.find(p => p.id === resolvedId)
 
   if (!profile) {
@@ -252,7 +295,7 @@ export function listProfiles(
   const effective = getEffectiveProfiles(profiles)
   if (effective.length === 0) return []
 
-  const currentActive = activeProfileId || defaultProfile || effective[0]!.id
+  const currentActive = resolveActiveProfileId(effective.map(p => p.id)) || defaultProfile || effective[0]!.id
   return effective.map(p => ({
     id: p.id,
     type: p.type ?? "claude-max",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -80,7 +80,8 @@ import { runTransformHook, buildPipeline, createRequestContext } from "./transfo
 import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
-import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, resolveActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { followStatus, startFollowPolling, stopFollowPolling, logFollowBanner, FOLLOW_POLL_INTERVAL_MS } from "./followActive"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -4784,12 +4785,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           exhausted: priorityExhaustion.snapshot(),
         }
       : {}
+    // Additive: follow state, so UIs can say where the active profile comes
+    // from and why switching is refused. Absent unless MERIDIAN_FOLLOW_ACTIVE.
+    const follow = followStatus(profiles.map(p => p.id))
     return c.json({
       profiles: enriched,
-      activeProfile: getActiveProfileId() || finalConfig.defaultProfile || profiles[0]?.id || "default",
+      activeProfile: resolveActiveProfileId(profiles.map(p => p.id)) || finalConfig.defaultProfile || profiles[0]?.id || "default",
       // Additive (#383): current routing mode so UIs can surface it.
       routing: routingModeNow,
       ...priorityInfo,
+      ...(follow ? { follow } : {}),
     })
   })
 
@@ -4799,6 +4804,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   })
 
   app.post("/profiles/active", async (c) => {
+    // Refuse rather than accept-and-lose. Under follow mode the write would
+    // persist locally, be shadowed by the followed value on the very next
+    // resolve, and be erased by the next poll — a picker that appears to work
+    // and silently doesn't. 409 because the request is well-formed and
+    // conflicts with the instance's operating mode, not with its input.
+    const following = followStatus(getEffectiveProfiles(finalConfig.profiles).map(p => p.id))
+    if (following) {
+      return c.json({
+        error: `This instance follows ${following.url} for its active profile (MERIDIAN_FOLLOW_ACTIVE). ` +
+          `Switch there instead — a local change would be overwritten within ` +
+          `${Math.round(FOLLOW_POLL_INTERVAL_MS / 1000)}s. ` +
+          `For a single request, send the x-meridian-profile header.`,
+        following,
+      }, 409)
+    }
     let body: { profile?: string }
     try {
       body = await c.req.json() as { profile?: string }
@@ -5209,7 +5229,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const requestedProfile = c.req.query("profile")
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
     const targetProfileId = requestedProfile
-      || getActiveProfileId()
+      || resolveActiveProfileId(profilesList.map(p => p.id))
       || finalConfig.defaultProfile
       || profilesList[0]?.id
       || null
@@ -5321,7 +5341,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // values rather than reuses.
   app.get("/v1/usage/quota/all", async (c) => {
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
-    const activeId = getActiveProfileId() || finalConfig.defaultProfile || profilesList[0]?.id || null
+    const activeId = resolveActiveProfileId(profilesList.map(p => p.id)) || finalConfig.defaultProfile || profilesList[0]?.id || null
 
     if (profilesList.length === 0) {
       // Single-account mode — just return the default OAuth account's data.
@@ -5589,6 +5609,10 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     hostname: finalConfig.host,
     overrideGlobalObjects: false,
   }, (info) => {
+    // Armed here, not before serve(), because the self-follow guard needs the
+    // port actually bound — the configured one may be 0.
+    startFollowPolling({ host: finalConfig.host, port: info.port })
+    logFollowBanner(getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing")))
     if (!finalConfig.silent) {
       console.log(`Meridian running at http://${finalConfig.host}:${info.port}`)
       console.log(`Telemetry dashboard: http://${finalConfig.host}:${info.port}/telemetry`)
@@ -5670,6 +5694,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       closePromise ??= (async () => {
         clearInterval(profileTokenRefreshInterval)
         if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+        stopFollowPolling()
         stopBackgroundRefresh()
 
         // Stop admitting new requests, then give whatever is already in flight

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -187,8 +187,10 @@ function profileSection(q,s,pl,h){
     }
     if(!rows)rows='<div class="no-usage">no usage data yet</div>';
     var isPriority=pl&&pl.routing==='priority';
-    var switchable=multi&&p.configured&&!p.isActive&&!isPriority;
+    var follow=pl&&pl.follow;
+    var switchable=multi&&p.configured&&!p.isActive&&!isPriority&&!follow;
     var badge=isPriority?'':p.isActive?'<span class="active-pill">Active</span>':switchable?'<span class="switch-hint">Click to activate</span>':'';
+    if(follow&&p.isActive)badge+=' <span class="pool-chip">'+(follow.activeProfile?'following '+esc(follow.url):'local — '+esc(follow.url)+' unreachable')+(follow.stale?' · stale':'')+'</span>';
     if(isPriority){
       var orderIdx=(pl.profileOrder||[]).indexOf(p.id);
       if(orderIdx>=0)badge+='<span class="pool-chip">#'+(orderIdx+1)+' in pool</span>';
@@ -264,7 +266,7 @@ function render(h,s,q,pl){
 function switchProfile(id){
   fetch('/profiles/active',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({profile:id})})
     .then(function(r){return r.json()})
-    .then(function(data){if(data.success){refresh();if(window.meridianHeaderRefresh)window.meridianHeaderRefresh()}})
+    .then(function(data){if(data.success){refresh();if(window.meridianHeaderRefresh)window.meridianHeaderRefresh()}else if(data.error)alert(data.error)})
     .catch(function(){});
 }
 document.getElementById('content').addEventListener('click',function(e){

--- a/src/telemetry/profileBar.ts
+++ b/src/telemetry/profileBar.ts
@@ -123,6 +123,10 @@ export const profileBarCss = `
   .meridian-header .mh-profile .mh-profile-type {
     color: var(--muted, #8b949e); font-size: 10px;
   }
+  .meridian-header .mh-profile.following { border-color: var(--accent2, #bc8cff); }
+  .meridian-header .mh-profile .mh-profile-follow {
+    color: var(--accent2, #bc8cff); font-size: 10px;
+  }
   .meridian-header .mh-status {
     display: inline-flex; align-items: center; gap: 6px;
     font-size: 11px; color: var(--muted, #8b949e); white-space: nowrap;
@@ -191,7 +195,20 @@ export const profileBarJs = `
     fetch('/profiles/list').then(function(r) { return r.json(); }).then(function(data) {
       var current = (data.profiles || []).find(function(p) { return p.isActive; });
       if (!current) { profileChip.classList.remove('visible'); return; }
-      profileChip.innerHTML = esc(current.id) + ' <span class="mh-profile-type">' + esc(current.type || '') + '</span>';
+      // Follow mode: say so on every page. An instance quietly taking its
+      // active profile from another one, with a picker that won't stick, is
+      // otherwise an hour of confusion.
+      var follow = data.follow;
+      var followLabel = follow ? (follow.activeProfile ? 'following' : 'follow: local') : '';
+      if (follow && follow.stale) followLabel += ' (stale)';
+      profileChip.innerHTML = esc(current.id) + ' <span class="mh-profile-type">' + esc(current.type || '') + '</span>'
+        + (follow ? ' <span class="mh-profile-follow">' + esc(followLabel) + '</span>' : '');
+      profileChip.classList.toggle('following', !!follow);
+      profileChip.title = follow
+        ? 'Active profile follows ' + follow.url + ' (MERIDIAN_FOLLOW_ACTIVE)'
+          + (follow.activeProfile ? '' : ' — no usable value from it, using the local profile')
+          + '. Switching here is refused; switch on the followed instance.'
+        : 'Active profile — switch from the home page';
       profileChip.classList.add('visible');
     }).catch(function() {});
   }

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -445,6 +445,7 @@ async function switchProfile(id) {
   });
   const data = await res.json();
   if (data.success) refresh();
+  else if (data.error) alert(data.error);
 }
 
 refresh();


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Adds `MERIDIAN_FOLLOW_ACTIVE`, which makes an instance take its active profile
from another instance instead of from its own `settings.json`.

## Why

`MERIDIAN_CONFIG_DIR` relocates `settings.json` and nothing else, so a second
instance keeps its **own** `activeProfile`. Whatever moves the primary's active
profile - a click in the UI, `meridian profile use`, an external scheduler -
leaves the second instance serving from a different account.

Observed on one box while comparing a development build against a packaged one:
the primary served from `enrique-personal` while the dev instance served the
same instant from `personal`. The comparison was silently not like-for-like,
and switching logic aimed at the primary did nothing to the instance actually
taking the traffic.

```bash
MERIDIAN_PORT=3457 \
MERIDIAN_CONFIG_DIR=~/.config/meridian-dev \
MERIDIAN_FOLLOW_ACTIVE=http://127.0.0.1:3456 \
meridian
```

A bare `host:port` is accepted and assumed `http`. The followed instance is
polled every 10s on `GET /profiles/list` and cached, so the request path never
waits on the network - the followed value changes on the order of minutes, and
a fetch per request would be absurd.

## What it does and does not change

It replaces **exactly one input** to `resolveProfile`. The precedence chain
around it is untouched: an explicit `x-meridian-profile` header still wins per
request, sticky assignment is unaffected, and `MERIDIAN_ROUTING=priority` - which
does not consult the active profile for unpinned requests - is a no-op, which
startup says out loud when both are set.

**Degradation is the design constraint.** A poll failure never clears a good
value: if the followed instance is down, slow, or answers something unusable,
the last known value keeps being served, and if one has never been read the
local active profile is used. A value unconfirmed for two minutes is still
served and flagged `stale` rather than abandoned - falling back on a timeout
would split the comparison exactly when you are least likely to notice, and the
local value is not more correct, only different. Failures log once per outage,
not once per poll. A development convenience must not be able to take an
instance offline.

**A followed profile this instance does not have is refused** rather than routed
to. The two instances can hold different profile lists, and an unknown id would
resolve to "first configured profile" deeper in `resolveProfile` and quietly
serve from an unrelated account.

**`POST /profiles/active` is refused with `409`**, naming the followed URL. The
alternative - accepting a write the next poll erases - is a picker that appears
to work and silently doesn't. `409` rather than `400` because the request is
well-formed and conflicts with the instance's operating mode, not its input. The
UI's account cards stop being clickable, mirroring how priority mode already
treats them, and `meridian profile use` prints the refusal it already surfaced.

**Following your own address is refused at startup**: the followed value could
never change while local switching stayed refused, freezing the active profile
permanently. The guard runs against the port actually bound, not the configured
one, which may be `0`.

The mode is announced at startup - not gated on `MERIDIAN_SILENT`, since it
changes where a core piece of state comes from - and surfaced on
`/profiles/list` as an additive `follow` object that the shared header chip
renders on every page.

## Verification

The decision logic is pure and unit-tested across every branch - value present,
absent, unknown here, stale, and the followed instance down mid-flight - so none
of it needs a second instance to prove.

It was nevertheless run against two real instances before this PR was opened:

| check | result |
|---|---|
| startup announces the mode | `FOLLOWING ACTIVE PROFILE (MERIDIAN_FOLLOW_ACTIVE=http://127.0.0.1:3456)` |
| follower mirrors the followed instance | both `enrique-personal`, while a third instance not following sat on `personal` |
| `/profiles/list` surfaces the state | `follow: {url, activeProfile, followedValue, reason, stale: false, lastSyncedAt, lastError}` |
| it tracks a change | followed instance switched to `corp3`; follower reported `corp3` at the next poll |
| local switch refused | `POST /profiles/active` -> `409`, naming the followed URL |

`bun run test` (the repository's own chain, which runs several files in separate
processes): **2538 pass, 0 fail**. `tsc --noEmit`: exit 0.

## Limitation

The poll sends no credentials, so a followed instance behind `MERIDIAN_API_KEY`
will always fail the poll and the follower falls back to its local active
profile. Documented in `docs/configuration.md` rather than left to be
discovered.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
