### PR TITLE
fix(usage): report why a usage fetch failed instead of calling every failure no_token

### DIFF
--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test, beforeEach } from "bun:test"
-import { fetchOAuthUsage, resetOAuthUsageCache } from "../proxy/oauthUsage"
+import { fetchOAuthUsage, fetchOAuthUsageResult, resetOAuthUsageCache } from "../proxy/oauthUsage"
 import type { CredentialStore } from "../proxy/tokenRefresh"
 
 const SAMPLE_RESPONSE = {
@@ -279,5 +279,68 @@ describe("oauthUsage", () => {
     const w = result!.windows[0]
     expect(w).toBeDefined()
     expect(w!.resetsAt).toBe(Date.parse(iso))
+  })
+})
+
+/**
+ * The failure REASON, which is what a per-profile status display shows a
+ * human. Every failure used to reach callers as a bare null, so the quota
+ * routes labelled all of them "no_token" and a rate-limited read rendered as
+ * an account that had lost its credentials.
+ */
+describe("fetchOAuthUsageResult", () => {
+  beforeEach(() => {
+    resetOAuthUsageCache()
+  })
+
+  test("reports no_token only when the store holds no token", async () => {
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const { snapshot, error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore(null), profileId: "reason-empty", fetchImpl,
+    })
+    expect(snapshot).toBeNull()
+    expect(error).toBe("no_token")
+  })
+
+  test("reports upstream_error for a 429 rather than no_token", async () => {
+    const fetchImpl = fixedFetch(() => new Response("rate limited", { status: 429 }))
+    const { snapshot, error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-429", fetchImpl,
+    })
+    expect(snapshot).toBeNull()
+    expect(error).toBe("upstream_error")
+  })
+
+  test("reports upstream_error for a 500", async () => {
+    const fetchImpl = fixedFetch(() => new Response("boom", { status: 500 }))
+    const { error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-500", fetchImpl,
+    })
+    expect(error).toBe("upstream_error")
+  })
+
+  test("reports no error on success", async () => {
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const { snapshot, error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-ok", fetchImpl,
+    })
+    expect(snapshot).not.toBeNull()
+    expect(error).toBeNull()
+  })
+
+  test("a snapshot served stale after a failure is not an error", async () => {
+    const { fetchImpl } = countingFetch(calls => calls === 1
+      ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+      : new Response("rate limited", { status: 429 }))
+    const first = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-stale", fetchImpl,
+    })
+    expect(first.error).toBeNull()
+
+    const second = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-stale", fetchImpl,
+    })
+    expect(second.snapshot?.stale).toBe(true)
+    expect(second.error).toBeNull()
   })
 })

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -89,6 +89,26 @@ export interface OAuthUsageSnapshot {
   stale?: boolean
 }
 
+/**
+ * Why a usage fetch produced no snapshot.
+ *
+ * Two values, because there are exactly two things to do about it: a missing
+ * token needs a human to run `claude login`, and everything else needs
+ * waiting. Keeping them apart is the whole point of this type — every failure
+ * used to reach callers as a bare `null`, so the quota routes labelled all of
+ * them `no_token`, and a rate-limited read rendered as an account that had
+ * lost its credentials. A 429 and an empty credential file are not the same
+ * news, and only one of them is the user's problem to fix.
+ */
+export type OAuthUsageError = "no_token" | "upstream_error"
+
+/** A usage fetch outcome: the snapshot, or why there isn't one. */
+export interface OAuthUsageResult {
+  snapshot: OAuthUsageSnapshot | null
+  /** Set only when `snapshot` is null. */
+  error: OAuthUsageError | null
+}
+
 const CACHE_TTL_MS_DEFAULT = 30_000
 // A transiently failing fetch serves the last-good snapshot instead of
 // blanking the consumer ("no usage data yet" flapping) — but only within
@@ -97,7 +117,7 @@ const STALE_MAX_MS_DEFAULT = 15 * 60_000
 
 /** Per-profile cache. Key = profileId (or DEFAULT_KEY for the unscoped default). */
 const cacheByProfile = new Map<string, OAuthUsageSnapshot>()
-const inflightByProfile = new Map<string, Promise<OAuthUsageSnapshot | null>>()
+const inflightByProfile = new Map<string, Promise<OAuthUsageResult>>()
 const DEFAULT_KEY = "__default__"
 
 const WINDOW_TYPES: Array<keyof RawOAuthUsageResponse> = [
@@ -252,22 +272,35 @@ export function __setFetchOAuthUsageOverride(
  *                        Defaults to globalThis.fetch.
  */
 export async function fetchOAuthUsage(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageSnapshot | null> {
+  return (await fetchOAuthUsageResult(opts)).snapshot
+}
+
+/**
+ * As `fetchOAuthUsage`, but says why there is no snapshot. Callers that
+ * report a per-profile status to a human want this one; `fetchOAuthUsage`
+ * remains for callers that only act on the numbers.
+ */
+export async function fetchOAuthUsageResult(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageResult> {
   // If the caller injected real test deps, run the real impl. This keeps
   // oauth-usage unit tests isolated from any test-set _testOverride.
   if (_testOverride && !opts?.fetchImpl && !opts?.store) {
-    return _testOverride(opts)
+    const snapshot = await _testOverride(opts)
+    // The override predates the reason and returns a bare snapshot-or-null,
+    // so there is nothing truer to report than the label those callers have
+    // always seen.
+    return { snapshot, error: snapshot ? null : "no_token" }
   }
   return fetchOAuthUsageImpl(opts)
 }
 
-async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageSnapshot | null> {
+async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageResult> {
   const ttl = opts?.ttlMs ?? CACHE_TTL_MS_DEFAULT
   const cacheKey = opts?.profileId ?? DEFAULT_KEY
   const fetchImpl = opts?.fetchImpl ?? globalThis.fetch
 
   if (!opts?.force) {
     const cached = cacheByProfile.get(cacheKey)
-    if (cached && Date.now() - cached.fetchedAt < ttl) return cached
+    if (cached && Date.now() - cached.fetchedAt < ttl) return { snapshot: cached, error: null }
   }
   const existing = inflightByProfile.get(cacheKey)
   if (existing) return existing
@@ -278,13 +311,13 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   // On transient failure, serve the last-good snapshot (bounded) instead of
   // null — a credential-read blip or upstream 5xx should not blank the
   // consumer's usage display until the next successful fetch.
-  const staleOr = (reason: string): OAuthUsageSnapshot | null => {
+  const staleOr = (reason: string, error: OAuthUsageError): OAuthUsageResult => {
     const last = cacheByProfile.get(cacheKey)
     if (last && Date.now() - last.fetchedAt < staleMaxMs) {
       claudeLog("oauth_usage.serving_stale", { profile: cacheKey, reason, ageMs: Date.now() - last.fetchedAt })
-      return { ...last, stale: true }
+      return { snapshot: { ...last, stale: true }, error: null }
     }
-    return null
+    return { snapshot: null, error }
   }
 
   const promise = (async () => {
@@ -295,7 +328,7 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
         // token-refresh rewrite) was previously silent — log it so flapping
         // usage displays are diagnosable.
         claudeLog("oauth_usage.no_token", { profile: cacheKey })
-        return staleOr("no_token")
+        return staleOr("no_token", "no_token")
       }
 
       let result = await callAnthropic(token, fetchImpl)
@@ -304,23 +337,28 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
         const refreshed = await refreshOAuthToken(store)
         if (!refreshed) {
           claudeLog("oauth_usage.refresh_failed", { profile: cacheKey })
-          return staleOr("refresh_failed")
+          // Not `no_token`: the token is present, and a read-only instance
+          // declines to refresh it BY DESIGN (credentialsMode.ts). Reporting
+          // a missing login here would tell the operator to re-authenticate
+          // every account on the box, on the one instance that is forbidden
+          // from touching credentials.
+          return staleOr("refresh_failed", "upstream_error")
         }
         const newToken = await readAccessToken(store)
-        if (!newToken) return staleOr("no_token_after_refresh")
+        if (!newToken) return staleOr("no_token_after_refresh", "no_token")
         result = await callAnthropic(newToken, fetchImpl)
       }
       if ("__status" in result) {
         claudeLog("oauth_usage.upstream_error", { profile: cacheKey, status: result.__status })
-        return staleOr(`upstream_${result.__status}`)
+        return staleOr(`upstream_${result.__status}`, "upstream_error")
       }
 
       const snapshot = buildSnapshot(result)
       cacheByProfile.set(cacheKey, snapshot)
-      return snapshot
+      return { snapshot, error: null }
     } catch (err) {
       claudeLog("oauth_usage.fetch_failed", { profile: cacheKey, error: err instanceof Error ? err.message : String(err) })
-      return staleOr("exception")
+      return staleOr("exception", "upstream_error")
     } finally {
       inflightByProfile.delete(cacheKey)
     }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -9,7 +9,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { linkRequestAbort } from "./requestAbort"
-import { fetchOAuthUsage } from "./oauthUsage"
+import { fetchOAuthUsage, fetchOAuthUsageResult } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
@@ -4338,7 +4338,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
     if (profilesList.length === 0) {
       // Single-account mode — just return the default OAuth account's data.
-      const oauth = await fetchOAuthUsage({})
+      const { snapshot: oauth, error } = await fetchOAuthUsageResult({})
       return c.json({
         profiles: [{
           id: "default",
@@ -4346,7 +4346,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           windows: oauth?.windows ?? [],
           extraUsage: oauth?.extraUsage ?? null,
           fetchedAt: oauth?.fetchedAt ?? null,
-          error: oauth ? null : "no_token",
+          error,
         }],
         activeProfile: "default",
         asOf: Date.now(),
@@ -4367,7 +4367,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           error: "not_oauth" as const,
         }
       }
-      const oauth = await fetchOAuthUsage({
+      const { snapshot: oauth, error } = await fetchOAuthUsageResult({
         profileId: p.id,
         claudeConfigDir: p.claudeConfigDir,
       })
@@ -4378,7 +4378,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         windows: oauth?.windows ?? [],
         extraUsage: oauth?.extraUsage ?? null,
         fetchedAt: oauth?.fetchedAt ?? null,
-        error: oauth ? null : "no_token",
+        error,
       }
     }))
 


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

`/v1/usage/quota/all` documents `error: "no_token" | "upstream_error"` and only
ever emits the first, because `fetchOAuthUsage` collapses every failure into
`null` and the route has nothing else to go on. A rate-limited read therefore
reaches the UI as an account that has lost its credentials.

## How it was found

Measured on a ten-account box running two Meridian instances against the same
credential files. Anthropic's usage endpoint answered **429 for all ten
accounts** — one per-account budget, two readers — and the dashboard put a
**"needs login" pill on every one of them, including the account it was
serving from at that moment**.

That is the part worth stating plainly: `claude login` was the advertised
remedy for a problem that was neither the account's nor the operator's, and
following the advice would have re-authenticated ten healthy accounts. Two of
them are borrowed, so it would also have meant asking their owners.

The accounts recovered on their own once the rate limit passed. Nothing was
ever wrong with any token.

## The change

`fetchOAuthUsageResult` returns the reason beside the snapshot, and the two
values are exactly the two available responses:

| reason | means |
|---|---|
| `no_token` | needs a human |
| `upstream_error` | needs waiting |

**A 401 that could not be refreshed is `upstream_error`, not `no_token`.** The
token is present, and an instance may decline to refresh it deliberately —
`MERIDIAN_CREDENTIALS_READONLY` is exactly that case — so a missing login is
the one thing it is not.

A snapshot served stale after a transient failure still reports no error,
because the caller did get numbers.

`fetchOAuthUsage` stays as the snapshot-only form for callers that act on the
figures rather than reporting a status, so the exhaustion refinement and the
single-profile route are unchanged.

## Scope

Three files, +120/-19, cut clean off `main`. The new behaviour is covered in
`src/__tests__/oauth-usage.test.ts`; `bun run test` is green (2692 pass, 0
fail) and `tsc --noEmit` exits 0 on the integration branch carrying it.

This PR is AI generated, but under direct supervision and on request of Nowaker.
