### PR TITLE
fix: keep Jcode chat sessions cache-affine

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-Meridian bridges the Claude Agent SDK (formerly the Claude Code SDK) to the standard Anthropic API. No OAuth interception. No binary patches. No hacks. Just pure, documented SDK calls. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, ForgeCode, Crush, Cline, Aider, Pi, Droid, Open WebUI, Claude Code — connects to Meridian and gets Claude, with session management, streaming, and prompt caching handled natively by the SDK.
+Meridian bridges the Claude Agent SDK (formerly the Claude Code SDK) to the standard Anthropic API. No OAuth interception. No binary patches. No hacks. Just pure, documented SDK calls. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, ForgeCode, Crush, Cline, Aider, Pi, Droid, Jcode, Open WebUI, Claude Code — connects to Meridian and gets Claude, with session management, streaming, and prompt caching handled natively by the SDK.
 
 > [!NOTE]
 > ### How Meridian works with Anthropic
@@ -106,6 +106,7 @@ The Claude Agent SDK provides programmatic access to Claude. But your favorite c
 | [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see [Agent Setup](docs/agents.md)) — full tool support via passthrough; detected via `x-meridian-agent: pi` header |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Verified | `ANTHROPIC_BASE_URL` — remote clients share a Max subscription over the network; client CWD preserved in system prompt |
 | [Cherry Studio](https://github.com/CherryHQ/cherry-studio) | ✅ Verified | `cherry` adapter (see [Agent Setup](docs/agents.md)) — chat client with Claude's built-in web search via internal mode |
+| Jcode | ✅ Verified | `/v1/chat/completions` + `x-jcode-session` header — dedicated `jcode` adapter keeps append-only history intact, so retained sessions resume on one SDK session (90.9% cache hit on turn 2 of a two-turn Opus session) |
 | [Codex CLI](https://github.com/openai/codex) | ✅ Verified | `/v1/responses` (see [Agent Setup](docs/agents.md)) — Responses-API provider, passthrough tool execution; verified on 0.144 (plain + tool-driving turns) |
 | [Continue](https://github.com/continuedev/continue) | 🔲 Untested | OpenAI-compatible endpoints should work — set `apiBase` to `http://127.0.0.1:3456` |
 

--- a/docs/superpowers/plans/2026-08-10-jcode-adapter-cache-affinity.md
+++ b/docs/superpowers/plans/2026-08-10-jcode-adapter-cache-affinity.md
@@ -1,0 +1,581 @@
+# Jcode Adapter Cache Affinity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make retained Jcode sessions resume one Meridian SDK session so tool-heavy Opus turns reuse prompt cache instead of rewriting the full conversation on every request.
+
+**Architecture:** Jcode will send its durable local session ID as `x-jcode-session` on direct OpenAI-compatible chat-completions requests. Meridian will recognize that header only with Jcode's verified `jcode/` User-Agent, route through a dedicated `jcode` adapter, preserve Jcode's append-only message history, and use the header as the existing lineage/session key. Generic OpenAI-compatible behavior remains unchanged.
+
+**Tech Stack:** Rust, async-trait, reqwest, Tokio, Cargo tests, TypeScript, Bun tests, Hono, Claude Agent SDK session cache.
+
+## Global Constraints
+
+- Never use a provider-global or prompt-derived session key.
+- Jcode session affinity must be the durable local Jcode session ID used by `--resume`.
+- Generic OpenAI-compatible clients must keep current history-packing behavior byte-for-byte.
+- Jcode requests missing a valid session header must fall back to generic OpenAI behavior.
+- A non-Jcode User-Agent must not activate Jcode behavior even if it sends `x-jcode-session`.
+- Session header values must match `^[A-Za-z0-9._:-]{1,256}$`.
+- Changed history under a valid key must continue to use Meridian's existing fail-closed lineage verification.
+- Implement every behavior test-first and commit each independently reviewable task.
+- Do not stop the currently running Meridian process until isolated verification passes.
+
+---
+
+## File Structure
+
+### Jcode
+
+- Modify `crates/jcode-app-core/src/agent/provider.rs`: select the durable local session ID for direct OpenAI-compatible requests while preserving native provider session IDs for every other provider.
+- Modify `crates/jcode-app-core/src/agent/turn_loops.rs`: use the selected request session ID in the blocking turn loop.
+- Modify `crates/jcode-app-core/src/agent/turn_streaming_mpsc.rs`: use the same selected ID in the streaming MPSC loop.
+- Modify `crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs`: carry the request session ID into the HTTP transport.
+- Modify `crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs`: attach `x-jcode-session` to each direct-compatible request and every retry.
+- Modify `crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs`: prove the header is sent and omitted correctly.
+
+### Meridian
+
+- Create `src/proxy/adapters/jcode.ts`: dedicated Jcode adapter and pure session-header validation.
+- Create `src/__tests__/jcode-adapter.test.ts`: adapter validation and session extraction tests.
+- Modify `src/proxy/adapters/detect.ts`: register and detect Jcode explicitly.
+- Modify `src/proxy/sdkFeatures.ts`: give Jcode the generic OpenAI preset-off default.
+- Modify `src/proxy/transforms/opencode.ts`: include Jcode in the shared OpenCode-core transform allow-list.
+- Modify `src/proxy/plugins/validation.ts`: accept `jcode` as a known adapter.
+- Modify `src/__tests__/adapter-detection.test.ts`: Jcode detection and precedence tests.
+- Modify `src/proxy/openai.ts`: add a translation option that preserves full history only for Jcode.
+- Modify `src/__tests__/openai.test.ts`: keyed Jcode history-preservation tests and generic regression tests.
+- Modify `src/proxy/server.ts`: validate outer Jcode identity, choose the adapter/translation mode, and forward the session/profile headers.
+- Modify `src/__tests__/proxy-openai-compat.test.ts`: two-turn session continuity and isolation tests through the HTTP layer.
+
+---
+
+### Task 1: Jcode selects a durable request affinity ID
+
+**Files:**
+- Modify: `crates/jcode-app-core/src/agent/provider.rs`
+- Modify: `crates/jcode-app-core/src/agent/turn_loops.rs:149-155`
+- Modify: `crates/jcode-app-core/src/agent/turn_streaming_mpsc.rs:230-250`
+
+**Interfaces:**
+- Produces: `select_provider_request_session_id<'a>(native_provider_session_id: Option<&'a str>, local_session_id: &'a str, direct_openai_compatible: bool) -> Option<&'a str>`
+- Produces: `Agent::provider_request_session_id(&self) -> Option<&str>`
+- Consumes: `Provider::direct_openai_compatible_route_parts()` and `self.session.id`
+
+- [ ] **Step 1: Write failing selector tests**
+
+Add focused unit tests beside the pure selector in `agent/provider.rs`:
+
+```rust
+#[cfg(test)]
+mod request_session_id_tests {
+    use super::select_provider_request_session_id;
+
+    #[test]
+    fn direct_compatible_uses_durable_local_session_id() {
+        assert_eq!(
+            select_provider_request_session_id(Some("native-id"), "session_local_123", true),
+            Some("session_local_123"),
+        );
+    }
+
+    #[test]
+    fn native_provider_keeps_native_resume_id() {
+        assert_eq!(
+            select_provider_request_session_id(Some("native-id"), "session_local_123", false),
+            Some("native-id"),
+        );
+    }
+
+    #[test]
+    fn native_provider_without_resume_id_stays_unkeyed() {
+        assert_eq!(
+            select_provider_request_session_id(None, "session_local_123", false),
+            None,
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cargo test -p jcode-app-core request_session_id_tests -- --nocapture
+```
+
+Expected: compile failure because `select_provider_request_session_id` does not exist.
+
+- [ ] **Step 3: Implement the selector and Agent helper**
+
+Add:
+
+```rust
+fn select_provider_request_session_id<'a>(
+    native_provider_session_id: Option<&'a str>,
+    local_session_id: &'a str,
+    direct_openai_compatible: bool,
+) -> Option<&'a str> {
+    if direct_openai_compatible {
+        Some(local_session_id)
+    } else {
+        native_provider_session_id
+    }
+}
+
+impl Agent {
+    pub(super) fn provider_request_session_id(&self) -> Option<&str> {
+        select_provider_request_session_id(
+            self.provider_session_id.as_deref(),
+            self.session.id.as_str(),
+            self.provider.direct_openai_compatible_route_parts().is_some(),
+        )
+    }
+}
+```
+
+Use `self.provider_request_session_id()` in `turn_loops.rs`. In `turn_streaming_mpsc.rs`, clone it before creating the pinned future:
+
+```rust
+let resume_session_id = self.provider_request_session_id().map(str::to_owned);
+```
+
+Do not change the `Provider` trait signature.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p jcode-app-core request_session_id_tests -- --nocapture
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 5: Run the two affected agent test targets**
+
+Run:
+
+```bash
+cargo test -p jcode-app-core agent:: -- --nocapture
+```
+
+Expected: existing agent tests pass with no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/jcode-app-core/src/agent/provider.rs \
+  crates/jcode-app-core/src/agent/turn_loops.rs \
+  crates/jcode-app-core/src/agent/turn_streaming_mpsc.rs
+git commit -m "fix: preserve session identity for compatible providers"
+```
+
+---
+
+### Task 2: Jcode sends `x-jcode-session` on direct-compatible requests
+
+**Files:**
+- Modify: `crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs:34-350`
+- Modify: `crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs:30-180`
+- Modify: `crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs`
+
+**Interfaces:**
+- Consumes: the `resume_session_id` selected in Task 1
+- Produces: `run_stream_with_retries(..., jcode_session_id: Option<String>, ...)`
+- Produces: `stream_response(..., jcode_session_id: Option<String>, ...)`
+- Wire contract: `x-jcode-session: <durable local Jcode session id>`
+
+- [ ] **Step 1: Write the failing HTTP capture test**
+
+Using the existing `spawn_single_response_chat_server()` helper, add:
+
+```rust
+#[test]
+fn direct_openai_compatible_request_sends_jcode_session_header() {
+    let (api_base, request_rx) = spawn_single_response_chat_server();
+    let provider = OpenRouterProvider {
+        api_base,
+        supports_provider_features: false,
+        supports_model_catalog: false,
+        send_openrouter_headers: false,
+        ..make_custom_compatible_provider()
+    };
+    let messages = vec![Message::user("hello")];
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    rt.block_on(async {
+        let mut stream = provider
+            .complete(&messages, &[], "", Some("session_local_123"))
+            .await
+            .expect("request should start");
+        while let Some(event) = stream.next().await {
+            event.expect("stream event should parse");
+        }
+    });
+    let request = request_rx.recv_timeout(Duration::from_secs(2)).expect("captured request");
+    assert!(
+        request.to_ascii_lowercase().contains("x-jcode-session: session_local_123"),
+        "missing Jcode session header: {request}",
+    );
+}
+```
+
+Add a second test invoking `complete(..., None)` and asserting the raw request does not contain `x-jcode-session:`.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p jcode-provider-openrouter-runtime direct_openai_compatible_request_sends_jcode_session_header -- --nocapture
+```
+
+Expected: assertion failure because the header is absent.
+
+- [ ] **Step 3: Thread the ID through retries and attach the header**
+
+Rename `_resume_session_id` to `resume_session_id` in the OpenRouter `Provider` implementation. Convert it to an owned string before `tokio::spawn`, pass it through `run_stream_with_retries` and `stream_response`, and apply it after authentication headers:
+
+```rust
+if let Some(session_id) = jcode_session_id.as_deref() {
+    req = req.header("x-jcode-session", session_id);
+}
+```
+
+Pass the same owned value to every retry so reconnects do not lose affinity. Do not put the session ID in the JSON body or logs.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cargo test -p jcode-provider-openrouter-runtime direct_openai_compatible_request_ -- --nocapture
+```
+
+Expected: both header-present and header-absent tests pass.
+
+- [ ] **Step 5: Run the OpenRouter runtime test target**
+
+Run:
+
+```bash
+cargo test -p jcode-provider-openrouter-runtime --lib -- --nocapture
+```
+
+Expected: all library tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/jcode-provider-openrouter-runtime/src/openrouter_provider_impl.rs \
+  crates/jcode-provider-openrouter-runtime/src/openrouter_sse_stream.rs \
+  crates/jcode-provider-openrouter-runtime/src/openrouter_tests.rs
+git commit -m "fix: send Jcode session affinity to compatible gateways"
+```
+
+---
+
+### Task 3: Add Meridian's dedicated Jcode adapter
+
+**Files:**
+- Create: `src/proxy/adapters/jcode.ts`
+- Create: `src/__tests__/jcode-adapter.test.ts`
+- Modify: `src/proxy/adapters/detect.ts`
+- Modify: `src/proxy/sdkFeatures.ts`
+- Modify: `src/proxy/transforms/opencode.ts`
+- Modify: `src/proxy/plugins/validation.ts`
+- Modify: `src/__tests__/adapter-detection.test.ts`
+
+**Interfaces:**
+- Produces: `normalizeJcodeSessionId(value: string | undefined): string | undefined`
+- Produces: `extractJcodeWorkingDirectory(body: unknown): string | undefined`
+- Produces: `jcodeAdapter: AgentAdapter`
+- Wire input: `x-jcode-session`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Create tests that require:
+
+```ts
+expect(normalizeJcodeSessionId("session_local_123")).toBe("session_local_123")
+expect(normalizeJcodeSessionId(" ")).toBeUndefined()
+expect(normalizeJcodeSessionId("bad session")).toBeUndefined()
+expect(normalizeJcodeSessionId("a".repeat(257))).toBeUndefined()
+expect(extractJcodeWorkingDirectory({ system: "Host: macOS\nWorking directory: /repo/project\nGit branch: main" }))
+  .toBe("/repo/project")
+expect(extractJcodeWorkingDirectory({ system: "no directory marker" })).toBeUndefined()
+expect(jcodeAdapter.getSessionId(makeContext({ "x-jcode-session": "session_local_123" })))
+  .toBe("session_local_123")
+```
+
+Add detection tests for explicit `x-meridian-agent: jcode`, `jcode/0.1.0` User-Agent plus a valid session header, and precedence showing a non-Jcode User-Agent with only `x-jcode-session` remains on its normal adapter.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+bun test src/__tests__/jcode-adapter.test.ts src/__tests__/adapter-detection.test.ts
+```
+
+Expected: missing module/export failures for the new adapter.
+
+- [ ] **Step 3: Implement the adapter and registries**
+
+Create `jcode.ts` as a thin specialization of `openAiAdapter`:
+
+```ts
+const JCODE_SESSION_ID = /^[A-Za-z0-9._:-]{1,256}$/
+
+export function normalizeJcodeSessionId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed && JCODE_SESSION_ID.test(trimmed) ? trimmed : undefined
+}
+
+export function extractJcodeWorkingDirectory(body: unknown): string | undefined {
+  if (body === null || typeof body !== "object") return undefined
+  const system = (body as { system?: unknown }).system
+  const text = typeof system === "string"
+    ? system
+    : Array.isArray(system)
+      ? system
+          .filter((part): part is { type: "text"; text: string } =>
+            part?.type === "text" && typeof part.text === "string")
+          .map(part => part.text)
+          .join("\n")
+      : ""
+  return text.match(/(?:^|\n)Working directory:\s*([^\n]+)/)?.[1]?.trim() || undefined
+}
+
+export const jcodeAdapter: AgentAdapter = {
+  ...openAiAdapter,
+  name: "jcode",
+  getSessionId(c) {
+    return normalizeJcodeSessionId(c.req.header("x-jcode-session"))
+  },
+  extractWorkingDirectory(body) {
+    return extractJcodeWorkingDirectory(body)
+  },
+}
+```
+
+Register `jcode` in `ADAPTER_MAP`, detect `jcode/` only when the validated session header exists, add the OpenAI preset-off defaults, include `jcode` in the shared transform allow-list, and add it to plugin validation.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+bun test src/__tests__/jcode-adapter.test.ts src/__tests__/adapter-detection.test.ts src/__tests__/transform-parity.test.ts src/__tests__/plugin-validation.test.ts
+```
+
+Expected: all focused adapter tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/proxy/adapters/jcode.ts src/__tests__/jcode-adapter.test.ts \
+  src/proxy/adapters/detect.ts src/proxy/sdkFeatures.ts \
+  src/proxy/transforms/opencode.ts src/proxy/plugins/validation.ts \
+  src/__tests__/adapter-detection.test.ts
+git commit -m "feat: add dedicated Jcode adapter"
+```
+
+---
+
+### Task 4: Preserve Jcode history and route its session key
+
+**Files:**
+- Modify: `src/proxy/openai.ts:70-84,421-570`
+- Modify: `src/proxy/server.ts:3962-4025`
+- Modify: `src/__tests__/openai.test.ts`
+- Modify: `src/__tests__/proxy-openai-compat.test.ts`
+
+**Interfaces:**
+- Produces: `OpenAiTranslationOptions { preserveConversationHistory?: boolean }`
+- Updates: `translateOpenAiToAnthropic(body, options?)`
+- Consumes: `normalizeJcodeSessionId` and `jcodeAdapter`
+
+- [ ] **Step 1: Write failing pure translation tests**
+
+Add one test with `system, user, assistant, user` input and `{ preserveConversationHistory: true }`. Assert:
+
+```ts
+expect(result?.system).toBe("stable system")
+expect(result?.messages.map(message => message.role)).toEqual(["user", "assistant", "user"])
+expect(result?.system).not.toContain("<conversation_history>")
+```
+
+Retain or add a generic test calling without options and asserting only the latest turn is sent and `<conversation_history>` remains in `system`.
+
+- [ ] **Step 2: Run the pure tests and verify RED**
+
+Run:
+
+```bash
+bun test src/__tests__/openai.test.ts
+```
+
+Expected: TypeScript/test failure because the translation options parameter does not exist.
+
+- [ ] **Step 3: Implement the narrow translation option**
+
+Add the options interface and change only the existing packing condition:
+
+```ts
+if (turns.length > 1 && !options.preserveConversationHistory) {
+  // existing history-packing block unchanged
+}
+```
+
+Default `options` to `{}` so every existing caller remains byte-compatible.
+
+- [ ] **Step 4: Run pure tests and verify GREEN**
+
+Run:
+
+```bash
+bun test src/__tests__/openai.test.ts
+```
+
+Expected: all OpenAI translation tests pass.
+
+- [ ] **Step 5: Write failing HTTP continuity tests**
+
+Extend the HTTP helper so tests can pass request headers. Add tests proving:
+
+1. `User-Agent: jcode/0.1.0` plus `x-jcode-session: session-a` forwards full history and resumes the same mocked SDK session on turn two.
+2. `session-a` and `session-b` create distinct SDK sessions.
+3. Jcode User-Agent without the session header keeps generic history packing and does not resume.
+4. A non-Jcode User-Agent with `x-jcode-session` does not activate Jcode behavior.
+
+Use these exact continuity assertions, matching the existing Responses endpoint contract:
+
+```ts
+expect(capturedOptions).toHaveLength(2)
+expect(capturedOptions[0].resume).toBeUndefined()
+expect(capturedOptions[1].resume).toBe("sdk-1")
+```
+
+For different keys and both fallback cases, assert `capturedOptions[1].resume` is `undefined`.
+
+- [ ] **Step 6: Run HTTP tests and verify RED**
+
+Run:
+
+```bash
+bun test src/__tests__/proxy-openai-compat.test.ts
+```
+
+Expected: `capturedOptions[1].resume` is `undefined` and the captured system prompt contains `<conversation_history>`, proving the new Jcode path is not implemented yet.
+
+- [ ] **Step 7: Implement route selection and forwarding**
+
+In `/v1/chat/completions`:
+
+```ts
+const userAgent = c.req.header("user-agent") ?? ""
+const jcodeSessionId = userAgent.startsWith("jcode/")
+  ? normalizeJcodeSessionId(c.req.header("x-jcode-session"))
+  : undefined
+const isJcode = jcodeSessionId !== undefined
+const anthropicBody = translateOpenAiToAnthropic(rawBody, {
+  preserveConversationHistory: isJcode,
+})
+```
+
+Set `x-meridian-agent` to `jcode` only when `isJcode`, forward `x-jcode-session`, and also forward `x-meridian-profile` consistently with `/v1/responses`. Resolve SDK features using the selected adapter name rather than hard-coding `openai`.
+
+- [ ] **Step 8: Run HTTP tests and verify GREEN**
+
+Run:
+
+```bash
+bun test src/__tests__/proxy-openai-compat.test.ts src/__tests__/openai.test.ts
+```
+
+Expected: all focused OpenAI and Jcode continuity tests pass.
+
+- [ ] **Step 9: Run targeted build/type verification**
+
+Run:
+
+```bash
+bun test src/__tests__/jcode-adapter.test.ts \
+  src/__tests__/adapter-detection.test.ts \
+  src/__tests__/openai.test.ts \
+  src/__tests__/proxy-openai-compat.test.ts \
+  src/__tests__/transform-parity.test.ts \
+  src/__tests__/plugin-validation.test.ts
+npm test
+npm run build
+```
+
+Expected: the full Meridian test suite passes and the build completes without TypeScript errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/proxy/openai.ts src/proxy/server.ts \
+  src/__tests__/openai.test.ts src/__tests__/proxy-openai-compat.test.ts
+git commit -m "fix: resume keyed Jcode chat sessions"
+```
+
+---
+
+### Task 5: Prove the complete cache-affinity workflow
+
+**Files:**
+- No production files unless verification exposes a specific failing test first.
+- Record results in: `docs/superpowers/specs/2026-08-10-jcode-adapter-cache-affinity-design.md` under a new `## Verification results` section.
+
+**Interfaces:**
+- Consumes: Jcode canary binary with `x-jcode-session`
+- Consumes: isolated patched Meridian instance
+- Produces: telemetry evidence of `new` then `continuation` on one SDK session
+
+- [ ] **Step 1: Build and use the Jcode canary through self-dev mode**
+
+Run the repository's focused build/test workflow from the self-dev checkout. Do not replace the stable installed binary yet.
+
+- [ ] **Step 2: Verify the header without model usage**
+
+Point the canary Jcode build at a local fake OpenAI-compatible endpoint and run two retained turns. Assert both requests contain the same `x-jcode-session`, and a new Jcode session contains a different value.
+
+- [ ] **Step 3: Start isolated patched Meridian**
+
+Use an unused loopback port and a disposable config/state path. Track the exact spawned PID. Do not stop or reuse the current port 3458 process.
+
+- [ ] **Step 4: Run a minimal live retained session**
+
+Use one tiny Jcode session with the minimal tool profile needed to force at least two provider rounds. Stop after two or three rounds.
+
+- [ ] **Step 5: Inspect telemetry acceptance criteria**
+
+Require all of:
+
+- `adapter=jcode`
+- first request `lineage=new`
+- later request `lineage=continuation`
+- later request uses the same `sdkSessionId`
+- no session recovery/divergence warning
+- second/third request cache creation is materially lower than the current fresh-replay baseline
+- cache reads materially exceed the static-prefix-only floor
+
+If any criterion fails, write a failing automated test for the observed behavior before editing production code.
+
+- [ ] **Step 6: Record results and commit**
+
+Append exact commands and summarized telemetry counters without prompts, credentials, or full session IDs, then commit:
+
+```bash
+git add docs/superpowers/specs/2026-08-10-jcode-adapter-cache-affinity-design.md
+git commit -m "docs: verify Jcode cache affinity"
+```
+
+- [ ] **Step 7: Switch the implementation workflow only after proof**
+
+Restart the Meridian instance used by the Pylon implementation only after isolated verification passes. Stop only the PID captured for that instance, never a process found by name matching.

--- a/docs/superpowers/specs/2026-08-10-jcode-adapter-cache-affinity-design.md
+++ b/docs/superpowers/specs/2026-08-10-jcode-adapter-cache-affinity-design.md
@@ -1,0 +1,80 @@
+# Jcode adapter and cache affinity design
+
+## Goal
+
+Give Jcode retained sessions native Meridian session continuity and high prompt-cache reuse without changing generic OpenAI-compatible client behavior or risking cross-conversation state reuse.
+
+## Verified wire behavior
+
+A local fake OpenAI-compatible endpoint captured two retained Jcode 0.74.0 turns without contacting a model:
+
+- endpoint: `POST /v1/chat/completions`
+- User-Agent: `jcode/0.1.0`
+- no `prompt_cache_key` or session header
+- first request roles: `system, user, user`
+- second request roles: `system, user, user, assistant, user`
+- the earlier message hashes were unchanged on the second request
+- the working directory was present in the request context
+
+Jcode therefore sends safe append-only history, but Meridian currently destroys that structure by packing prior turns into one changing `<conversation_history>` system string. The internal request then has one message, no stable session identity, and every tool round starts a new SDK session. This explains the low cache-hit floor observed in live telemetry.
+
+## Architecture
+
+### Jcode
+
+Jcode's OpenAI-compatible transport will attach an opaque `x-jcode-session` header to every chat-completions request. The value is the durable Jcode session identifier already used by `--resume`. It must be dynamic per retained session, never provider-global, and must remain unchanged across tool-loop requests and resumed CLI invocations.
+
+The header carries no prompt content and is used only as an affinity key. Other provider transports remain unchanged.
+
+### Meridian
+
+Meridian will add a dedicated `jcode` adapter rather than extending generic OpenAI behavior.
+
+The outer `/v1/chat/completions` route will identify Jcode by its `jcode/` User-Agent and require a non-empty `x-jcode-session` before enabling Jcode session continuity. It will forward the value to the internal `/v1/messages` hop, tag that hop as `x-meridian-agent: jcode`, and preserve existing authentication and profile headers.
+
+The Jcode adapter will:
+
+- inherit the generic OpenAI adapter's preset-off and tool behavior
+- return `x-jcode-session` from `getSessionId`
+- extract the client working directory from Jcode's request context
+- keep Jcode-specific behavior inside the adapter boundary
+
+For Jcode requests, OpenAI-to-Anthropic translation will preserve the full converted conversation turn list and keep the original system prompt stable. Meridian's existing lineage verifier can then classify the second request as an append-only continuation and send only the delta to the resumed SDK session.
+
+Generic OpenAI clients, including keyed or headerless clients that are not identified as Jcode, retain the existing history-packing behavior byte-for-byte.
+
+## Safety and fallback behavior
+
+- Jcode User-Agent without `x-jcode-session`: use generic OpenAI behavior and a fresh SDK session.
+- `x-jcode-session` from a non-Jcode User-Agent: do not activate the Jcode adapter.
+- Empty or malformed session header: ignore it.
+- Changed history under the same key: Meridian's existing lineage verification rejects resume and fresh-replays safely.
+- Different Jcode session keys: never share a Meridian session.
+- No static global affinity header or prompt-derived identity is permitted.
+
+## Tests
+
+### Jcode
+
+- each OpenAI-compatible request carries the current durable Jcode session ID
+- retained tool-loop requests keep the same header
+- a different Jcode session gets a different header
+- non-OpenAI-compatible providers are unchanged
+
+### Meridian
+
+- adapter detection selects `jcode` only for the verified Jcode identity
+- the route forwards a valid `x-jcode-session` and tags the internal request as Jcode
+- Jcode translation preserves full append-only history and stable system context
+- same key resumes the prior mocked SDK session on turn two
+- different keys remain isolated
+- missing/empty key and generic OpenAI requests preserve current behavior
+
+## Verification
+
+1. Run focused Jcode transport tests and Meridian adapter/OpenAI endpoint tests.
+2. Run targeted builds/typechecks in both repositories.
+3. Start a separate patched Meridian instance on an unused loopback port.
+4. Run one minimal retained Jcode session for two or three turns.
+5. Confirm telemetry shows `adapter=jcode`, first lineage `new`, later lineage `continuation`, the same SDK session, sharply reduced cache creation, and materially increased cache reads.
+6. Only after that proof, replace the current Meridian process used for Pylon implementation.

--- a/docs/superpowers/specs/2026-08-10-jcode-adapter-cache-affinity-design.md
+++ b/docs/superpowers/specs/2026-08-10-jcode-adapter-cache-affinity-design.md
@@ -78,3 +78,23 @@ Generic OpenAI clients, including keyed or headerless clients that are not ident
 4. Run one minimal retained Jcode session for two or three turns.
 5. Confirm telemetry shows `adapter=jcode`, first lineage `new`, later lineage `continuation`, the same SDK session, sharply reduced cache creation, and materially increased cache reads.
 6. Only after that proof, replace the current Meridian process used for Pylon implementation.
+
+## Implementation verification (2026-08-10)
+
+The implementation passed the planned verification in both repositories:
+
+- Jcode focused selector and transport tests passed, including durable session selection and `x-jcode-session` propagation through retries.
+- Jcode's OpenRouter-compatible runtime suite passed with 120 tests and one ignored test; focused agent tests passed with 67 tests.
+- Meridian's focused adapter, translation, endpoint, and session-continuity set passed with 264 tests.
+- Meridian's full test suite, production build, typecheck, and `git diff --check` passed.
+
+A zero-cost fake endpoint then captured two requests from the patched Jcode selfdev binary. Both requests used `User-Agent: jcode/0.1.0`, carried the same durable `x-jcode-session` value as the retained local session, preserved an identical system-prompt hash, and grew append-only from three to five messages.
+
+Finally, a separate patched Meridian instance ran on `127.0.0.1:3462` with disposable config and session state while the existing service on port 3458 stayed online. A minimal two-turn retained Opus session produced:
+
+| Turn | Adapter | Lineage | SDK session | Input | Cache read | Cache creation | Cache hit rate |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: |
+| 1 | `jcode` | `new` | newly created | 2,586 | 0 | 26,042 | 0% |
+| 2 | `jcode` | `continuation` | same session | 2 | 26,042 | 2,622 | 90.85% |
+
+The second turn therefore reused the same SDK session, reduced uncached input from 2,586 tokens to 2 tokens, and read the full 26,042-token cached prefix instead of recreating it. The isolated process was stopped after capture, and the original port-3458 process remained untouched during verification. After the proof passed, port 3458 was restarted from this verified branch; `/health` returned 200 and an unauthenticated empty Jcode chat request reached route validation with the expected 400 response rather than an auth failure.

--- a/src/__tests__/adapter-detection.test.ts
+++ b/src/__tests__/adapter-detection.test.ts
@@ -14,6 +14,7 @@ import { piAdapter } from "../proxy/adapters/pi"
 import { passthroughAdapter } from "../proxy/adapters/passthrough"
 import { forgeCodeAdapter } from "../proxy/adapters/forgecode"
 import { claudeCodeAdapter } from "../proxy/adapters/claudecode"
+import { jcodeAdapter } from "../proxy/adapters/jcode"
 
 function makeContext(userAgent: string, extraHeaders?: Record<string, string>): any {
   const allHeaders: Record<string, string> = {}
@@ -150,6 +151,31 @@ describe("detectAdapter — claude-cli + MERIDIAN_DEFAULT_AGENT tiebreaker", () 
     process.env.MERIDIAN_DEFAULT_AGENT = "pi"
     const adapter = detectAdapter(makeContext("claude-cli/2.0.0", { "x-meridian-agent": "claude-code" }))
     expect(adapter).toBe(claudeCodeAdapter)
+  })
+})
+
+describe("detectAdapter — Jcode detection", () => {
+  it("accepts an explicit Jcode adapter override", () => {
+    expect(detectAdapter(makeContext("", { "x-meridian-agent": "jcode" }))).toBe(jcodeAdapter)
+  })
+
+  it("detects Jcode only when its User-Agent has a valid session header", () => {
+    expect(detectAdapter(makeContext("jcode/0.1.0", {
+      "x-jcode-session": "session_local_123",
+    }))).toBe(jcodeAdapter)
+  })
+
+  it("does not activate Jcode behavior without a valid session header", () => {
+    expect(detectAdapter(makeContext("jcode/0.1.0"))).toBe(openCodeAdapter)
+    expect(detectAdapter(makeContext("jcode/0.1.0", {
+      "x-jcode-session": "bad session",
+    }))).toBe(openCodeAdapter)
+  })
+
+  it("does not let the session header override another identified client", () => {
+    expect(detectAdapter(makeContext("factory-cli/1.0.0", {
+      "x-jcode-session": "session_local_123",
+    }))).toBe(droidAdapter)
   })
 })
 

--- a/src/__tests__/jcode-adapter.test.ts
+++ b/src/__tests__/jcode-adapter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test"
+import type { Context } from "hono"
+import {
+  extractJcodeWorkingDirectory,
+  jcodeAdapter,
+  normalizeJcodeSessionId,
+} from "../proxy/adapters/jcode"
+
+function makeContext(headers: Record<string, string>): Context {
+  const normalized = Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]),
+  )
+  return {
+    req: {
+      header: (name?: string) => name
+        ? normalized[name.toLowerCase()]
+        : { ...normalized },
+    },
+  } as unknown as Context
+}
+
+describe("Jcode adapter", () => {
+  it("accepts only bounded wire-safe session IDs", () => {
+    expect(normalizeJcodeSessionId("session_local_123")).toBe("session_local_123")
+    expect(normalizeJcodeSessionId(" session:local-123 ")).toBe("session:local-123")
+    expect(normalizeJcodeSessionId(" ")).toBeUndefined()
+    expect(normalizeJcodeSessionId("bad session")).toBeUndefined()
+    expect(normalizeJcodeSessionId("a".repeat(257))).toBeUndefined()
+    expect(normalizeJcodeSessionId(undefined)).toBeUndefined()
+  })
+
+  it("extracts Jcode's plain working-directory system line", () => {
+    expect(extractJcodeWorkingDirectory({
+      system: "Host: macOS\nWorking directory: /repo/project\nGit branch: main",
+    })).toBe("/repo/project")
+    expect(extractJcodeWorkingDirectory({ system: "no directory marker" })).toBeUndefined()
+  })
+
+  it("extracts the working directory from text system blocks", () => {
+    expect(extractJcodeWorkingDirectory({
+      system: [
+        { type: "text", text: "Host: macOS" },
+        { type: "text", text: "Working directory: /repo/blocks" },
+      ],
+    })).toBe("/repo/blocks")
+  })
+
+  it("uses the validated Jcode session header as adapter identity", () => {
+    expect(jcodeAdapter.getSessionId(makeContext({
+      "x-jcode-session": "session_local_123",
+    }))).toBe("session_local_123")
+    expect(jcodeAdapter.getSessionId(makeContext({
+      "x-jcode-session": "bad session",
+    }))).toBeUndefined()
+  })
+})

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -7,6 +7,7 @@ import {
   computeLineageHash,
   hashMessage,
   computeMessageHashes,
+  computeMessageBlockHashes,
   measurePrefixOverlap,
   measureSuffixOverlap,
   verifyLineage,
@@ -535,6 +536,109 @@ describe("verifyLineage stale modified continuation (#689)", () => {
     const incoming = [...churn(stored, 1), msg("user", "one more")]
     const result = verifyLineage(session, incoming)
     expect(result.type).toBe("diverged")
+  })
+})
+
+describe("verifyLineage append-only tool-result extension", () => {
+  const toolResult = (id: string, content: string) => ({
+    type: "tool_result",
+    tool_use_id: id,
+    content,
+  })
+
+  function sessionFor(messages: Array<{ role: string; content: any }>): SessionState {
+    return makeSession({
+      lastAccess: 0,
+      lineageHash: computeLineageHash(messages),
+      messageCount: messages.length,
+      messageHashes: computeMessageHashes(messages),
+      messageBlockHashes: computeMessageBlockHashes(messages),
+    })
+  }
+
+  it("resumes from only the newly appended parallel tool result", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "run both" }] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } },
+        { type: "tool_use", id: "call-b", name: "bash", input: { command: "b" } },
+      ] },
+      { role: "user", content: [toolResult("call-a", "a-result")] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("call-a", "a-result"),
+        toolResult("call-b", "b-result"),
+      ] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-c", name: "bash", input: { command: "c" } },
+      ] },
+      { role: "user", content: [toolResult("call-c", "c-result")] },
+    ]
+
+    expect(verifyLineage(sessionFor(stored), incoming)).toEqual({
+      type: "continuation",
+      session: sessionFor(stored),
+      resumeFrom: 2,
+      resumeContentFrom: 1,
+    })
+  })
+
+  it("still diverges when an existing tool result changed", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "run both" }] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } },
+      ] },
+      { role: "user", content: [toolResult("call-a", "old-result")] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("call-a", "changed-result"),
+        toolResult("call-b", "new-result"),
+      ] },
+      { role: "assistant", content: "next" },
+    ]
+
+    expect(verifyLineage(sessionFor(stored), incoming)).toEqual({
+      type: "diverged",
+      reason: "modified-history",
+      prefixOverlap: 2,
+    })
+  })
+
+  it("still diverges when arbitrary user text is appended to the changed slot", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "first" }] },
+    ]
+    const incoming = [
+      { role: "user", content: [
+        { type: "text", text: "first" },
+        { type: "text", text: "edited continuation" },
+      ] },
+      { role: "assistant", content: "next" },
+    ]
+
+    expect(verifyLineage(sessionFor(stored), incoming).type).toBe("diverged")
+  })
+
+  it("still diverges when a prior tool result is appended again", () => {
+    const stored = [
+      { role: "user", content: [toolResult("call-a", "a-result")] },
+    ]
+    const incoming = [
+      { role: "user", content: [
+        toolResult("call-a", "a-result"),
+        toolResult("call-a", "a-result"),
+      ] },
+      { role: "assistant", content: "next" },
+    ]
+
+    expect(verifyLineage(sessionFor(stored), incoming).type).toBe("diverged")
   })
 })
 

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -101,6 +101,21 @@ describe("translateOpenAiToAnthropic", () => {
     expect(result!.system).toContain("assistant: 4")
   })
 
+  it("preserves append-only history for keyed Jcode sessions", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [
+        { role: "system", content: "stable system" },
+        { role: "user", content: "Turn 1" },
+        { role: "assistant", content: "Answer 1" },
+        { role: "user", content: "Turn 2" },
+      ],
+    }, { preserveConversationHistory: true })
+
+    expect(result?.system).toBe("stable system")
+    expect(result?.messages.map(message => message.role)).toEqual(["user", "assistant", "user"])
+    expect(result?.system).not.toContain("<conversation_history>")
+  })
+
   it("prepends system message before conversation history", () => {
     const result = translateOpenAiToAnthropic({
       messages: [

--- a/src/__tests__/plugin-validation.test.ts
+++ b/src/__tests__/plugin-validation.test.ts
@@ -75,4 +75,14 @@ describe("validateTransform", () => {
     expect(result.valid).toBe(true)
     expect(result.warnings ?? []).not.toContain("openai")
   })
+
+  it("accepts 'jcode' as a known adapter without warning", () => {
+    const result = validateTransform({
+      name: "scoped",
+      adapters: ["jcode"],
+      onRequest: () => {},
+    })
+    expect(result.valid).toBe(true)
+    expect(result.warnings ?? []).not.toContain("jcode")
+  })
 })

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -26,12 +26,15 @@ import {
 } from "./helpers"
 
 let mockMessages: unknown[] = []
+let mockSdkSessionId: string | undefined
 let capturedPromptMessages: unknown[] = []
 let capturedOptions: Record<string, unknown> | null = null
+let capturedOptionHistory: Array<Record<string, unknown>> = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: ({ prompt, options }: { prompt: string | AsyncIterable<unknown>; options?: Record<string, unknown> }) => {
     capturedOptions = options ?? null
+    capturedOptionHistory.push(options ?? {})
     return (async function* () {
       capturedPromptMessages = []
       if (typeof prompt === "string") {
@@ -41,7 +44,13 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           capturedPromptMessages.push(msg)
         }
       }
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        if (mockSdkSessionId && msg !== null && typeof msg === "object") {
+          yield { ...msg, session_id: mockSdkSessionId }
+        } else {
+          yield msg
+        }
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
@@ -64,10 +73,14 @@ function createTestApp() {
   return app
 }
 
-async function postChatCompletion(app: ReturnType<typeof createTestApp>, body: Record<string, unknown>) {
+async function postChatCompletion(
+  app: ReturnType<typeof createTestApp>,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
   return app.fetch(new Request("http://localhost/v1/chat/completions", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify(body),
   }))
 }
@@ -238,6 +251,93 @@ describe("POST /v1/chat/completions — non-streaming", () => {
       },
       parent_tool_use_id: null,
     }])
+  })
+})
+
+describe("POST /v1/chat/completions — Jcode session continuity", () => {
+  const firstTurn = {
+    stream: false,
+    messages: [
+      { role: "system", content: "stable system" },
+      { role: "user", content: "Turn 1" },
+    ],
+  }
+  const secondTurn = {
+    stream: false,
+    messages: [
+      { role: "system", content: "stable system" },
+      { role: "user", content: "Turn 1" },
+      { role: "assistant", content: "Answer 1" },
+      { role: "user", content: "Turn 2" },
+    ],
+  }
+
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    mockSdkSessionId = "sdk-1"
+    capturedPromptMessages = []
+    capturedOptions = null
+    capturedOptionHistory = []
+    clearSessionCache()
+  })
+
+  it("resumes the same SDK session for two turns with one verified Jcode key", async () => {
+    const app = createTestApp()
+    const headers = {
+      "User-Agent": "jcode/0.1.0",
+      "x-jcode-session": "session-a",
+    }
+
+    expect((await postChatCompletion(app, firstTurn, headers)).status).toBe(200)
+    expect((await postChatCompletion(app, secondTurn, headers)).status).toBe(200)
+
+    expect(capturedOptionHistory).toHaveLength(2)
+    expect(capturedOptionHistory[0]?.resume).toBeUndefined()
+    expect(capturedOptionHistory[1]?.resume).toBe("sdk-1")
+    expect(capturedOptionHistory[1]?.systemPrompt).toBe("stable system")
+  })
+
+  it("keeps distinct Jcode session keys isolated", async () => {
+    const app = createTestApp()
+
+    await postChatCompletion(app, firstTurn, {
+      "User-Agent": "jcode/0.1.0",
+      "x-jcode-session": "session-a",
+    })
+    await postChatCompletion(app, secondTurn, {
+      "User-Agent": "jcode/0.1.0",
+      "x-jcode-session": "session-b",
+    })
+
+    expect(capturedOptionHistory).toHaveLength(2)
+    expect(capturedOptionHistory[1]?.resume).toBeUndefined()
+  })
+
+  it("falls back to generic history packing when Jcode omits its session header", async () => {
+    const app = createTestApp()
+    const headers = { "User-Agent": "jcode/0.1.0" }
+
+    await postChatCompletion(app, firstTurn, headers)
+    await postChatCompletion(app, secondTurn, headers)
+
+    expect(capturedOptionHistory).toHaveLength(2)
+    expect(capturedOptionHistory[1]?.resume).toBeUndefined()
+    expect(capturedOptionHistory[1]?.systemPrompt).toContain("<conversation_history>")
+  })
+
+  it("ignores x-jcode-session from a non-Jcode client", async () => {
+    const app = createTestApp()
+    const headers = {
+      "User-Agent": "curl/8.0.0",
+      "x-jcode-session": "session-a",
+    }
+
+    await postChatCompletion(app, firstTurn, headers)
+    await postChatCompletion(app, secondTurn, headers)
+
+    expect(capturedOptionHistory).toHaveLength(2)
+    expect(capturedOptionHistory[1]?.resume).toBeUndefined()
+    expect(capturedOptionHistory[1]?.systemPrompt).toContain("<conversation_history>")
   })
 })
 

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -92,14 +92,17 @@ describe("Shared session store", () => {
       undefined,
       undefined,
       undefined,
-      { input_tokens: 9, output_tokens: 4 }
+      { input_tokens: 9, output_tokens: 4 },
+      [["block-hash-a", "block-hash-b"]]
     )
 
     const byKey = lookupSharedSession("session-usage")
     expect(byKey?.contextUsage).toEqual({ input_tokens: 9, output_tokens: 4 })
+    expect(byKey?.messageBlockHashes).toEqual([["block-hash-a", "block-hash-b"]])
 
     const byClaudeId = lookupSharedSessionByClaudeId("claude-sess-usage")
     expect(byClaudeId?.contextUsage).toEqual({ input_tokens: 9, output_tokens: 4 })
+    expect(byClaudeId?.messageBlockHashes).toEqual([["block-hash-a", "block-hash-b"]])
   })
 
   it("should return the freshest match when multiple keys share a Claude session ID", () => {

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -78,7 +78,7 @@ function createTestApp() {
 async function post(
   app: TestApp,
   session: string,
-  messages: Array<{ role: string; content: string }>,
+  messages: Array<{ role: string; content: any }>,
   sessionId: string
 ) {
   queuedSessionIds.push(sessionId)
@@ -224,6 +224,44 @@ describe("Session lineage: normal continuation", () => {
     ], "sdk-1")
 
     expect(getCaptured()?.options?.resume).toBe("sdk-1")
+  })
+
+  it("resumes with only a late parallel tool result plus later user output", async () => {
+    const app = createTestApp()
+    const toolResult = (id: string, content: string) => ({
+      type: "tool_result",
+      tool_use_id: id,
+      content,
+    })
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "run both" }] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } },
+        { type: "tool_use", id: "call-b", name: "bash", input: { command: "b" } },
+      ] },
+      { role: "user", content: [toolResult("call-a", "seen-a-result")] },
+    ]
+
+    await post(app, "sess-parallel", stored, "sdk-parallel")
+    await post(app, "sess-parallel", [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("call-a", "seen-a-result"),
+        toolResult("call-b", "late-b-result"),
+      ] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-c", name: "bash", input: { command: "c" } },
+      ] },
+      { role: "user", content: [toolResult("call-c", "new-c-result")] },
+    ], "sdk-parallel")
+
+    expect(getCaptured()?.options?.resume).toBe("sdk-parallel")
+    const prompt = getCaptured()?.prompt
+    expect(typeof prompt).toBe("string")
+    expect(prompt as string).toContain("late-b-result")
+    expect(prompt as string).toContain("new-c-result")
+    expect(prompt as string).not.toContain("seen-a-result")
   })
 })
 

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -109,8 +109,12 @@ describe("OpenAI-compatible adapters reuse the OpenCode pipeline (#546)", () => 
     expect([...ctx.allowedMcpTools]).toEqual([...openCodeAdapter.getAllowedMcpTools()])
   })
 
+  it("registers the jcode adapter against the OpenCode pipeline", () => {
+    expect(getAdapterTransforms("jcode")).toBe(openCodeTransforms)
+  })
+
   it("applies the same core transforms to Jcode", () => {
-    const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("jcode"), "jcode")
+    const ctx = runTransformHook(getAdapterTransforms("jcode"), "onRequest", makeCtx("jcode"), "jcode")
     expect([...ctx.blockedTools]).toEqual([...openCodeAdapter.getBlockedBuiltinTools()])
     expect([...ctx.allowedMcpTools]).toEqual([...openCodeAdapter.getAllowedMcpTools()])
   })

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -96,7 +96,7 @@ describe("OpenCode transform parity", () => {
 // "openai" is listed there the opencode-core transform is silently skipped —
 // leaving built-in tools UNBLOCKED and passthrough OFF for OpenAI clients (a
 // full Claude Code agent under bypassPermissions, the opposite of intent).
-describe("OpenAI adapter reuses the OpenCode pipeline (#546)", () => {
+describe("OpenAI-compatible adapters reuse the OpenCode pipeline (#546)", () => {
   it("blocks built-in tools for adapterName 'openai' (same as opencode)", () => {
     const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("openai"), "openai")
     expect([...ctx.blockedTools]).toEqual([...openCodeAdapter.getBlockedBuiltinTools()])
@@ -106,6 +106,12 @@ describe("OpenAI adapter reuses the OpenCode pipeline (#546)", () => {
   it("applies the same incompatibleTools and allowedMcpTools as opencode", () => {
     const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("openai"), "openai")
     expect([...ctx.incompatibleTools]).toEqual([...openCodeAdapter.getAgentIncompatibleTools()])
+    expect([...ctx.allowedMcpTools]).toEqual([...openCodeAdapter.getAllowedMcpTools()])
+  })
+
+  it("applies the same core transforms to Jcode", () => {
+    const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("jcode"), "jcode")
+    expect([...ctx.blockedTools]).toEqual([...openCodeAdapter.getBlockedBuiltinTools()])
     expect([...ctx.allowedMcpTools]).toEqual([...openCodeAdapter.getAllowedMcpTools()])
   })
 })

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -15,6 +15,7 @@ import { piAdapter } from "./pi"
 import { forgeCodeAdapter } from "./forgecode"
 import { claudeCodeAdapter } from "./claudecode"
 import { openAiAdapter } from "./openai"
+import { jcodeAdapter, normalizeJcodeSessionId } from "./jcode"
 import { codexAdapter } from "./codex"
 import { cherryAdapter } from "./cherry"
 import { loadAdapterInstances, matchesInstance, type AdapterInstanceDef } from "../adapterInstances"
@@ -34,6 +35,8 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   // Generic OpenAI-compatible endpoint (/v1/chat/completions). Selected via
   // the x-meridian-agent: openai tag the handler sets on the internal hop.
   openai: openAiAdapter,
+  // Jcode uses the OpenAI-compatible endpoint with a durable local session ID.
+  jcode: jcodeAdapter,
   // Codex CLI endpoint (/v1/responses). Forces passthrough — Codex executes
   // its own tools. Selected via the x-meridian-agent: codex internal tag.
   codex: codexAdapter,
@@ -150,6 +153,15 @@ export function detectAdapter(c: Context): AgentAdapter {
   }
 
   const userAgent = c.req.header("user-agent") || ""
+
+  // NOTE: Jcode-specific. The User-Agent alone is insufficient because generic
+  // OpenAI clients must retain their existing history-packing behavior.
+  if (
+    userAgent.startsWith("jcode/")
+    && normalizeJcodeSessionId(c.req.header("x-jcode-session"))
+  ) {
+    return jcodeAdapter
+  }
 
   // OpenCode User-Agent: opencode/<version>
   if (userAgent.startsWith("opencode/")) {

--- a/src/proxy/adapters/jcode.ts
+++ b/src/proxy/adapters/jcode.ts
@@ -31,7 +31,9 @@ export function extractJcodeWorkingDirectory(body: unknown): string | undefined 
     : Array.isArray(system)
       ? system.filter(isTextSystemBlock).map(part => part.text).join("\n")
       : ""
-  return text.match(/(?:^|\n)Working directory:\s*([^\n]+)/)?.[1]?.trim() || undefined
+  // [^\S\n] not \s — \s spans newlines, so an empty marker would swallow the
+  // next line ("Git branch: main") and pass it off as the working directory.
+  return text.match(/(?:^|\n)Working directory:[^\S\n]*([^\n]+)/)?.[1]?.trim() || undefined
 }
 
 export const jcodeAdapter: AgentAdapter = {

--- a/src/proxy/adapters/jcode.ts
+++ b/src/proxy/adapters/jcode.ts
@@ -1,0 +1,48 @@
+/**
+ * Jcode agent adapter.
+ *
+ * Jcode uses the generic OpenAI-compatible transport, but supplies a durable
+ * local session ID and a plain-text working-directory marker.
+ *
+ * NOTE: Jcode-specific. Keep this as a thin specialization of openAiAdapter.
+ */
+
+import type { AgentAdapter } from "../adapter"
+import { openAiAdapter } from "./openai"
+
+const JCODE_SESSION_ID = /^[A-Za-z0-9._:-]{1,256}$/
+
+export function normalizeJcodeSessionId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed && JCODE_SESSION_ID.test(trimmed) ? trimmed : undefined
+}
+
+function isTextSystemBlock(value: unknown): value is { type: "text"; text: string } {
+  if (value === null || typeof value !== "object") return false
+  const part = value as Record<string, unknown>
+  return part.type === "text" && typeof part.text === "string"
+}
+
+export function extractJcodeWorkingDirectory(body: unknown): string | undefined {
+  if (body === null || typeof body !== "object") return undefined
+  const system = (body as { system?: unknown }).system
+  const text = typeof system === "string"
+    ? system
+    : Array.isArray(system)
+      ? system.filter(isTextSystemBlock).map(part => part.text).join("\n")
+      : ""
+  return text.match(/(?:^|\n)Working directory:\s*([^\n]+)/)?.[1]?.trim() || undefined
+}
+
+export const jcodeAdapter: AgentAdapter = {
+  ...openAiAdapter,
+  name: "jcode",
+
+  getSessionId(c): string | undefined {
+    return normalizeJcodeSessionId(c.req.header("x-jcode-session"))
+  },
+
+  extractWorkingDirectory(body): string | undefined {
+    return extractJcodeWorkingDirectory(body)
+  },
+}

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -83,6 +83,11 @@ export interface OpenAiChatRequest {
   stream_options?: { include_usage?: boolean }
 }
 
+export interface OpenAiTranslationOptions {
+  /** Keep append-only turns intact so Meridian can verify and resume lineage. */
+  preserveConversationHistory?: boolean
+}
+
 export interface AnthropicTextBlock {
   type: "text"
   text: string
@@ -418,7 +423,10 @@ function summarizeAnthropicContent(content: string | AnthropicContentBlock[]): s
  *
  * Returns null if the request has no messages (caller should return 400).
  */
-export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRequestBody | null {
+export function translateOpenAiToAnthropic(
+  body: OpenAiChatRequest,
+  options: OpenAiTranslationOptions = {},
+): AnthropicRequestBody | null {
   const messages = body.messages ?? []
   if (messages.length === 0) return null
 
@@ -535,7 +543,7 @@ export function translateOpenAiToAnthropic(body: OpenAiChatRequest): AnthropicRe
   let systemPrompt = systemParts.join("\n")
   let messagesToSend: AnthropicMessage[] = turns
 
-  if (turns.length > 1) {
+  if (turns.length > 1 && !options.preserveConversationHistory) {
     const history = turns.slice(0, -1)
       .map(m => `${m.role}: ${summarizeAnthropicContent(m.content)}`)
       .join("\n")

--- a/src/proxy/plugins/validation.ts
+++ b/src/proxy/plugins/validation.ts
@@ -1,4 +1,4 @@
-const KNOWN_ADAPTERS = ["opencode", "openai", "crush", "droid", "pi", "forgecode", "passthrough"]
+const KNOWN_ADAPTERS = ["opencode", "openai", "jcode", "crush", "droid", "pi", "forgecode", "passthrough"]
 const KNOWN_HOOKS = ["onRequest", "onResponse", "onTelemetry", "onSession", "onToolUse", "onToolResult", "onError"]
 
 export interface ValidationResult {

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -96,6 +96,11 @@ const ADAPTER_DEFAULTS: Record<string, Partial<AdapterFeatures>> = {
   openai: {
     codeSystemPrompt: false,
   },
+  // Jcode supplies its own coding-agent instructions over the generic
+  // OpenAI-compatible endpoint, so the Claude Code preset stays off.
+  jcode: {
+    codeSystemPrompt: false,
+  },
   // Cherry Studio is a chat client that brings its own system prompt. Default
   // the ~28KB Claude Code preset OFF (same rationale as openai/passthrough) so
   // its prompt isn't overridden. WebSearch still works without the preset

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -65,6 +65,7 @@ import { checkPluginConfigured } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
+import { normalizeJcodeSessionId } from "./adapters/jcode"
 import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
@@ -3966,7 +3967,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // See src/proxy/openai.ts for the translation logic and design rationale.
   app.post("/v1/chat/completions", async (c) => {
     const rawBody = await c.req.json() as Record<string, unknown>
-    const anthropicBody = translateOpenAiToAnthropic(rawBody)
+    const userAgent = c.req.header("user-agent") ?? ""
+    const jcodeSessionId = userAgent.startsWith("jcode/")
+      ? normalizeJcodeSessionId(c.req.header("x-jcode-session"))
+      : undefined
+    const isJcode = jcodeSessionId !== undefined
+    const adapterName = isJcode ? "jcode" : "openai"
+    const anthropicBody = translateOpenAiToAnthropic(rawBody, {
+      preserveConversationHistory: isJcode,
+    })
 
     if (!anthropicBody) {
       return c.json(
@@ -3979,15 +3988,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     // Hono resolves the path in-process; the URL scheme/host are ignored.
     // Forward the caller's auth headers so requireAuth on /v1/messages accepts
     // the inner hop when MERIDIAN_API_KEY is set (issue #415).
-    // Tag the inner hop as the generic OpenAI endpoint. Without this the
-    // header-less internal request falls through detectAdapter to the default
-    // `opencode` adapter, whose claude_code preset defaults ON — hijacking the
-    // client's own system prompt with the Claude Code persona (#526). The
-    // `openai` adapter mirrors opencode but defaults the preset OFF.
+    // Tag the inner hop as generic OpenAI unless a verified Jcode request
+    // supplied its durable local session ID. Both adapters keep the Claude Code
+    // preset off, while Jcode additionally preserves append-only history.
     const internalHeaders: Record<string, string> = {
       "Content-Type": "application/json",
-      "x-meridian-agent": "openai",
+      "x-meridian-agent": adapterName,
     }
+    if (jcodeSessionId) internalHeaders["x-jcode-session"] = jcodeSessionId
+    const requestedProfile = c.req.header("x-meridian-profile")
+    if (requestedProfile) internalHeaders["x-meridian-profile"] = requestedProfile
     const xApiKey = c.req.header("x-api-key")
     if (xApiKey) internalHeaders["x-api-key"] = xApiKey
     const authz = c.req.header("authorization")
@@ -4011,12 +4021,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const created = Math.floor(Date.now() / 1000)
     const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : CANONICAL_SONNET_MODEL
 
-    // Resolve SDK features for this request (thinking passthrough setting).
-    // The OpenAI endpoint is unambiguously the `openai` adapter — matching the
-    // x-meridian-agent tag set on the internal hop above — so resolve directly
-    // rather than re-detecting from the (generic) client User-Agent.
+    // Resolve SDK features for the same adapter selected on the internal hop.
     const { getFeaturesForAdapter } = require("./sdkFeatures") as typeof import("./sdkFeatures")
-    const sdkFeatures = getFeaturesForAdapter("openai")
+    const sdkFeatures = getFeaturesForAdapter(adapterName)
 
     if (!anthropicBody.stream) {
       const anthropicRes = await internalRes.json() as Record<string, unknown>

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1104,6 +1104,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const resumeFrom = lineageResult.type === "continuation" || lineageResult.type === "compaction"
           ? lineageResult.resumeFrom
           : undefined
+        const resumeContentFrom = lineageResult.type === "continuation"
+          ? lineageResult.resumeContentFrom
+          : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
 
@@ -1172,7 +1175,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // so we only need to send the new user message.
           messagesToConvert = getLastUserMessage(allMessages)
         } else if (isResume) {
-          if (resumeFrom !== undefined && resumeFrom < allMessages.length) {
+          if (
+            resumeFrom !== undefined &&
+            resumeContentFrom !== undefined &&
+            resumeFrom < allMessages.length &&
+            Array.isArray(allMessages[resumeFrom]?.content)
+          ) {
+            const boundaryMessage = allMessages[resumeFrom]!
+            messagesToConvert = [
+              {
+                ...boundaryMessage,
+                content: boundaryMessage.content.slice(resumeContentFrom),
+              },
+              ...allMessages.slice(resumeFrom + 1),
+            ]
+          } else if (resumeFrom !== undefined && resumeFrom < allMessages.length) {
             messagesToConvert = allMessages.slice(resumeFrom)
           } else {
             messagesToConvert = getLastUserMessage(allMessages)

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -17,6 +17,7 @@ import {
 import { getConversationFingerprint } from "./fingerprint"
 import {
   computeLineageHash,
+  computeMessageBlockHashes,
   computeMessageHashes,
   verifyLineage,
   type SessionState,
@@ -135,7 +136,11 @@ function classifyLineage(
 ): LineageResult {
   const result = verifyLineage(state, messages)
 
-  if (result.type === "compaction") {
+  if (result.type === "continuation" && result.resumeContentFrom !== undefined) {
+    const msg = `Parallel tool-result continuation (key=${cacheKey.slice(0, 8)}…): resume from message ${result.resumeFrom}, content block ${result.resumeContentFrom}.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
+  } else if (result.type === "compaction") {
     const msg = `Compaction detected (key=${cacheKey.slice(0, 8)}…): suffix overlap ${result.suffixOverlap}/${state.messageCount}, resume from incoming message ${result.resumeFrom}.`
     console.error(`[PROXY] ${msg}`)
     diagnosticLog.lineage(msg)
@@ -175,6 +180,7 @@ export function lookupSession(
         messageCount: shared.messageCount || 0,
         lineageHash: shared.lineageHash || "",
         messageHashes: shared.messageHashes,
+        messageBlockHashes: shared.messageBlockHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
         contextUsage: shared.contextUsage,
       }
@@ -203,6 +209,7 @@ export function lookupSession(
         messageCount: shared.messageCount || 0,
         lineageHash: shared.lineageHash || "",
         messageHashes: shared.messageHashes,
+        messageBlockHashes: shared.messageBlockHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
         contextUsage: shared.contextUsage,
       }
@@ -240,6 +247,7 @@ export function getSessionByClaudeId(claudeSessionId: string): SessionState | un
       messageCount: shared.messageCount || 0,
       lineageHash: shared.lineageHash || "",
       messageHashes: shared.messageHashes,
+      messageBlockHashes: shared.messageBlockHashes,
       sdkMessageUuids: shared.sdkMessageUuids,
       contextUsage: shared.contextUsage,
     })
@@ -263,12 +271,14 @@ export function storeSession(
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
   const messageHashes = computeMessageHashes(messages)
+  const messageBlockHashes = computeMessageBlockHashes(messages)
   const state: SessionState = {
     claudeSessionId,
     lastAccess: Date.now(),
     messageCount: messages?.length || 0,
     lineageHash,
     messageHashes,
+    messageBlockHashes,
     sdkMessageUuids,
     ...(contextUsage ? { contextUsage } : {}),
   }
@@ -291,7 +301,8 @@ export function storeSession(
       lineageHash,
       messageHashes,
       sdkMessageUuids,
-      contextUsage
+      contextUsage,
+      messageBlockHashes
     )
   }
 }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -6,7 +6,7 @@
  */
 
 import { createHash } from "crypto"
-import { normalizeContent } from "../messages"
+import { HASH_IGNORED_BLOCK_TYPES, normalizeContent } from "../messages"
 
 // --- Types ---
 
@@ -48,6 +48,10 @@ export interface SessionState {
    *  Used for precise diff-based mutation classification when the aggregate
    *  lineageHash mismatches. */
   messageHashes?: string[]
+  /** Per-message hashes of individual content blocks.
+   *  Lets clients append a late parallel tool_result to the final user turn
+   *  without forcing a full-history replay. */
+  messageBlockHashes?: string[][]
   /** SDK assistant message UUIDs indexed by message position.
    *  Only assistant messages have UUIDs (user messages are null).
    *  Used to find the rollback point for undo. */
@@ -61,7 +65,7 @@ export interface SessionState {
  * the information needed to take the correct SDK action.
  */
 export type LineageResult =
-  | { type: "continuation"; session: SessionState; resumeFrom: number }
+  | { type: "continuation"; session: SessionState; resumeFrom: number; resumeContentFrom?: number }
   | { type: "compaction";   session: SessionState; resumeFrom: number; suffixOverlap: number }
   | { type: "undo";         session: SessionState; prefixOverlap: number; rollbackUuid: string | undefined }
   | { type: "diverged";     reason: LineageDivergenceReason; prefixOverlap?: number }
@@ -105,6 +109,26 @@ export function hashMessage(message: { role: string; content: any }): string {
 export function computeMessageHashes(messages: Array<{ role: string; content: any }>): string[] {
   if (!messages || messages.length === 0) return []
   return messages.map(hashMessage)
+}
+
+function hashNormalizedContent(content: any): string {
+  return createHash("sha256")
+    .update(normalizeContent(content))
+    .digest("hex")
+    .slice(0, 32)
+}
+
+function hashableContentBlocks(content: any): any[] {
+  if (!Array.isArray(content)) return [content]
+  return content.filter((block: any) => !HASH_IGNORED_BLOCK_TYPES.has(block?.type))
+}
+
+/** Compute semantic hashes for each content block in every message. */
+export function computeMessageBlockHashes(messages: Array<{ role: string; content: any }>): string[][] {
+  if (!messages || messages.length === 0) return []
+  return messages.map((message) =>
+    hashableContentBlocks(message.content).map((block) =>
+      hashNormalizedContent(Array.isArray(message.content) ? [block] : block)))
 }
 
 // --- Overlap measurement ---
@@ -290,6 +314,55 @@ export function verifyLineage(
       session: cached,
       resumeFrom: compactionResumeFrom,
       suffixOverlap,
+    }
+  }
+
+  // Append-only parallel tool results: Responses clients can send one result
+  // while another tool from the same assistant turn is still running. The
+  // Responses adapter coalesces consecutive function_call_output items into a
+  // single Anthropic user message, so the later result extends the final cached
+  // slot instead of appending a new message. The SDK session already contains
+  // the old blocks; resume with only the newly appended tool_result blocks.
+  //
+  // This is deliberately narrow. Arbitrary text edits and changed existing
+  // blocks still diverge, preserving the stale-lineage safety fixes in #689 and
+  // #692. Legacy sessions without block hashes also keep replaying safely.
+  const boundary = cached.messageCount - 1
+  if (
+    boundary >= 0 &&
+    prefixOverlap === boundary &&
+    messages.length >= cached.messageCount &&
+    cached.messageBlockHashes?.length === cached.messageCount
+  ) {
+    const incomingBoundary = messages[boundary]
+    const storedBlocks = cached.messageBlockHashes[boundary]
+    if (incomingBoundary?.role === "user" && storedBlocks && Array.isArray(incomingBoundary.content)) {
+      const incomingBlocks = hashableContentBlocks(incomingBoundary.content)
+      const incomingBlockHashes = incomingBlocks.map((block) => hashNormalizedContent([block]))
+      const preservesStoredBlocks =
+        incomingBlocks.length === incomingBoundary.content.length &&
+        incomingBlockHashes.length > storedBlocks.length &&
+        storedBlocks.every((hash, index) => incomingBlockHashes[index] === hash)
+      const appendedBlocks = incomingBlocks.slice(storedBlocks.length)
+      const seenToolResultIds = new Set(
+        incomingBlocks.slice(0, storedBlocks.length)
+          .filter((block) => block?.type === "tool_result" && typeof block.tool_use_id === "string")
+          .map((block) => block.tool_use_id as string),
+      )
+      const hasOnlyNewToolResults = appendedBlocks.every((block) => {
+        if (block?.type !== "tool_result" || typeof block.tool_use_id !== "string") return false
+        if (seenToolResultIds.has(block.tool_use_id)) return false
+        seenToolResultIds.add(block.tool_use_id)
+        return true
+      })
+      if (preservesStoredBlocks && hasOnlyNewToolResults) {
+        return {
+          type: "continuation",
+          session: cached,
+          resumeFrom: boundary,
+          resumeContentFrom: storedBlocks.length,
+        }
+      }
     }
   }
 

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -34,6 +34,8 @@ export interface StoredSession {
   lineageHash?: string
   /** Per-message content hashes for precise diff-based compaction detection */
   messageHashes?: string[]
+  /** Per-message hashes of individual content blocks for append-only tool results */
+  messageBlockHashes?: string[][]
   /** Per-message SDK assistant UUIDs for undo rollback (null for user messages) */
   sdkMessageUuids?: Array<string | null>
   /** Last observed token usage for this Claude session */
@@ -202,7 +204,8 @@ export function storeSharedSession(
   lineageHash?: string,
   messageHashes?: string[],
   sdkMessageUuids?: Array<string | null>,
-  contextUsage?: TokenUsage
+  contextUsage?: TokenUsage,
+  messageBlockHashes?: string[][]
 ): void {
   const path = getStorePath()
   const lockPath = `${path}.lock`
@@ -227,6 +230,7 @@ export function storeSharedSession(
       messageCount: messageCount ?? existing?.messageCount ?? 0,
       lineageHash: lineageHash ?? existing?.lineageHash,
       messageHashes: messageHashes ?? existing?.messageHashes,
+      messageBlockHashes: messageBlockHashes ?? existing?.messageBlockHashes,
       sdkMessageUuids: sdkMessageUuids ?? existing?.sdkMessageUuids,
       contextUsage: contextUsage ?? existing?.contextUsage,
       ...(previousClaudeSessionId ? { previousClaudeSessionId } : {}),

--- a/src/proxy/transforms/opencode.ts
+++ b/src/proxy/transforms/opencode.ts
@@ -13,7 +13,7 @@ export const openCodeTransforms: Transform[] = [
     // transform is skipped and clients get built-in tools unblocked +
     // passthrough off (#546). Codex additionally FORCES passthrough on via a
     // follow-on transform (#475).
-    adapters: ["opencode", "openai", "codex"],
+    adapters: ["opencode", "openai", "jcode", "codex"],
 
     onRequest(ctx: RequestContext): RequestContext {
       const body = ctx.body

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -25,6 +25,10 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   // tool/passthrough behaviour is identical; only the preset default differs
   // (see sdkFeatures.ADAPTER_DEFAULTS.openai).
   openai: openCodeTransforms,
+  // Jcode rides the same OpenAI-compatible endpoint, so it needs the identical
+  // tool config. Without this entry it falls through to the empty default —
+  // built-ins unblocked under bypassPermissions, passthrough off.
+  jcode: openCodeTransforms,
   // Codex (/v1/responses): OpenCode's tool config + a follow-on transform
   // that forces passthrough (Codex executes its own tools). See #475.
   codex: [...openCodeTransforms, ...codexTransforms],


### PR DESCRIPTION
## Problem

Jcode talks to Meridian over the OpenAI-compatible `/v1/chat/completions`
endpoint. That path collapses every prior turn into a summarized history blob
and tags the internal hop as the generic `openai` adapter, so each Jcode
request looked like a brand-new single-turn conversation. Lineage never
verified, sessions never resumed, and prompt cache affinity was lost on every
turn.

## Change

- **New `jcode` adapter** (`src/proxy/adapters/jcode.ts`) — a thin
  specialization of `openAiAdapter` that reads the durable `x-jcode-session`
  header and extracts the plain-text `Working directory:` marker from the
  system prompt.
- **Detection** — `detectAdapter` selects it only when the User-Agent starts
  with `jcode/` *and* a well-formed session ID is present, so generic OpenAI
  clients keep their existing behavior.
- **History preservation** — `translateOpenAiToAnthropic` gains a
  `preserveConversationHistory` option; the chat-completions handler sets it
  for verified Jcode requests so append-only turns survive intact for lineage
  verification and resume.
- **Internal hop** — tagged `x-meridian-agent: jcode`, forwards
  `x-jcode-session` and `x-meridian-profile`, and resolves SDK features for the
  same adapter it tagged.
- Claude Code system-prompt preset stays OFF for `jcode` (same rationale as
  `openai`); the OpenCode tool-config transform now applies to `jcode`.

## Tests

New unit tests for the adapter and detection, plus chat-completions
integration coverage for session resume and history preservation.