### PR TITLE
fix(quota): back off OAuth usage rate limits

### DIFF
--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -171,6 +171,57 @@ describe("oauthUsage", () => {
     expect(result).toBeNull()
   })
 
+  test("backs off repeated 429 responses per profile even when forced", async () => {
+    const { fetchImpl, getCalls } = countingFetch(() =>
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "120" } }))
+    const store = makeStore("t")
+
+    const first = await fetchOAuthUsage({ force: true, store, profileId: "limited", fetchImpl })
+    const second = await fetchOAuthUsage({ force: true, store, profileId: "limited", fetchImpl })
+    const otherProfile = await fetchOAuthUsage({ force: true, store, profileId: "other", fetchImpl })
+
+    expect(first).toBeNull()
+    expect(second).toBeNull()
+    expect(otherProfile).toBeNull()
+    expect(getCalls()).toBe(2)
+  })
+
+  test("serves stale usage while 429 backoff suppresses forced retries", async () => {
+    const { fetchImpl, getCalls } = countingFetch((calls) =>
+      calls === 1
+        ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+        : new Response("rate limited", { status: 429, headers: { "Retry-After": "0" } }))
+    const store = makeStore("t")
+
+    const fresh = await fetchOAuthUsage({ force: true, store, profileId: "stale-limited", fetchImpl })
+    const limited = await fetchOAuthUsage({ force: true, store, profileId: "stale-limited", fetchImpl })
+    const backedOff = await fetchOAuthUsage({ force: true, store, profileId: "stale-limited", fetchImpl })
+
+    expect(fresh?.stale).toBeUndefined()
+    expect(limited?.stale).toBe(true)
+    expect(backedOff?.stale).toBe(true)
+    expect(backedOff?.windows).toEqual(fresh?.windows)
+    expect(getCalls()).toBe(2)
+  })
+
+  test("retries after the configured 429 backoff expires", async () => {
+    const { fetchImpl, getCalls } = countingFetch((calls) =>
+      calls === 1
+        ? new Response("rate limited", { status: 429, headers: { "Retry-After": "0" } })
+        : new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const opts = {
+      force: true,
+      store: makeStore("t"),
+      profileId: "retry",
+      fetchImpl,
+      rateLimitBackoffMs: 0,
+    }
+
+    expect(await fetchOAuthUsage(opts)).toBeNull()
+    expect(await fetchOAuthUsage(opts)).not.toBeNull()
+    expect(getCalls()).toBe(2)
+  })
+
   test("caches result within TTL", async () => {
     const { fetchImpl, getCalls } = countingFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
     const store = makeStore("t")

--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -222,6 +222,48 @@ describe("oauthUsage", () => {
     expect(getCalls()).toBe(2)
   })
 
+  // A cooldown longer than the stale window is self-defeating: it suppresses
+  // every fetch, so the last-good snapshot ages out with nothing able to
+  // refresh it and the display blanks until the cooldown lapses. Cap it.
+  test("caps a long Retry-After at the stale window so the snapshot can refresh", async () => {
+    const { fetchImpl, getCalls } = countingFetch((calls) =>
+      calls === 1
+        ? new Response("rate limited", { status: 429, headers: { "Retry-After": "3600" } })
+        : new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const opts = {
+      force: true,
+      store: makeStore("t"),
+      profileId: "capped",
+      fetchImpl,
+      rateLimitBackoffMs: 0,
+      staleMaxMs: 20,
+    }
+
+    expect(await fetchOAuthUsage(opts)).toBeNull()
+    await new Promise(resolve => setTimeout(resolve, 30))
+    expect(await fetchOAuthUsage(opts)).not.toBeNull()
+    expect(getCalls()).toBe(2)
+  })
+
+  // The cap must not disarm the throttle: a staleMaxMs below the backoff floor
+  // still gets the full floor, not the (smaller) stale window.
+  test("never caps the cooldown below the backoff floor", async () => {
+    const { fetchImpl, getCalls } = countingFetch(() =>
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "1" } }))
+    const opts = {
+      force: true,
+      store: makeStore("t"),
+      profileId: "floor",
+      fetchImpl,
+      rateLimitBackoffMs: 60_000,
+      staleMaxMs: 0,
+    }
+
+    expect(await fetchOAuthUsage(opts)).toBeNull()
+    expect(await fetchOAuthUsage(opts)).toBeNull()
+    expect(getCalls()).toBe(1)
+  })
+
   test("caches result within TTL", async () => {
     const { fetchImpl, getCalls } = countingFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
     const store = makeStore("t")

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -94,10 +94,12 @@ const CACHE_TTL_MS_DEFAULT = 30_000
 // blanking the consumer ("no usage data yet" flapping) — but only within
 // this bound, so genuinely dead credentials still surface as missing data.
 const STALE_MAX_MS_DEFAULT = 15 * 60_000
+const RATE_LIMIT_BACKOFF_MS_DEFAULT = 60_000
 
 /** Per-profile cache. Key = profileId (or DEFAULT_KEY for the unscoped default). */
 const cacheByProfile = new Map<string, OAuthUsageSnapshot>()
 const inflightByProfile = new Map<string, Promise<OAuthUsageSnapshot | null>>()
+const rateLimitedUntilByProfile = new Map<string, number>()
 const DEFAULT_KEY = "__default__"
 
 const WINDOW_TYPES: Array<keyof RawOAuthUsageResponse> = [
@@ -120,6 +122,14 @@ function normalizeUtilization(raw: number | null | undefined): number | null {
   if (typeof raw !== "number" || !Number.isFinite(raw)) return null
   // OAuth returns 0..100. Normalize to 0..1 to match SDK rate_limit_event.
   return Math.max(0, raw / 100)
+}
+
+function parseRetryAfterMs(raw: string | null): number | null {
+  if (!raw) return null
+  const seconds = Number(raw)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+  const retryAt = Date.parse(raw)
+  return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : null
 }
 
 function modelScopedWindowType(limit: RawOAuthLimit): string | null {
@@ -188,7 +198,7 @@ async function callAnthropic(
   token: string,
   fetchImpl: FetchLike,
   signal?: AbortSignal,
-): Promise<RawOAuthUsageResponse | { __status: number }> {
+): Promise<RawOAuthUsageResponse | { __status: number; retryAfterMs: number | null }> {
   const res = await fetchImpl(OAUTH_USAGE_URL, {
     headers: {
       Authorization: `Bearer ${token}`,
@@ -197,7 +207,12 @@ async function callAnthropic(
     },
     signal: signal ?? AbortSignal.timeout(10_000),
   })
-  if (!res.ok) return { __status: res.status }
+  if (!res.ok) {
+    return {
+      __status: res.status,
+      retryAfterMs: parseRetryAfterMs(res.headers.get("retry-after")),
+    }
+  }
   return (await res.json()) as RawOAuthUsageResponse
 }
 
@@ -205,6 +220,8 @@ export interface FetchOAuthUsageOpts {
   ttlMs?: number
   /** Max age of a last-good snapshot served on fetch failure (default 15 min). */
   staleMaxMs?: number
+  /** Minimum per-profile cooldown after HTTP 429 (default 60s). */
+  rateLimitBackoffMs?: number
   force?: boolean
   store?: CredentialStore
   profileId?: string | null
@@ -264,17 +281,8 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   const ttl = opts?.ttlMs ?? CACHE_TTL_MS_DEFAULT
   const cacheKey = opts?.profileId ?? DEFAULT_KEY
   const fetchImpl = opts?.fetchImpl ?? globalThis.fetch
-
-  if (!opts?.force) {
-    const cached = cacheByProfile.get(cacheKey)
-    if (cached && Date.now() - cached.fetchedAt < ttl) return cached
-  }
-  const existing = inflightByProfile.get(cacheKey)
-  if (existing) return existing
-
-  const store = opts?.store ?? createPlatformCredentialStore({ claudeConfigDir: opts?.claudeConfigDir })
-
   const staleMaxMs = opts?.staleMaxMs ?? STALE_MAX_MS_DEFAULT
+
   // On transient failure, serve the last-good snapshot (bounded) instead of
   // null — a credential-read blip or upstream 5xx should not blank the
   // consumer's usage display until the next successful fetch.
@@ -286,6 +294,25 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
     }
     return null
   }
+
+  if (!opts?.force) {
+    const cached = cacheByProfile.get(cacheKey)
+    if (cached && Date.now() - cached.fetchedAt < ttl) return cached
+  }
+  const existing = inflightByProfile.get(cacheKey)
+  if (existing) return existing
+
+  // A 429 must throttle forced and normal callers alike. Without a negative
+  // cache, every quota poll retries immediately and can keep Anthropic's
+  // private usage endpoint permanently rate-limited.
+  const rateLimitedUntil = rateLimitedUntilByProfile.get(cacheKey)
+  if (rateLimitedUntil !== undefined) {
+    if (Date.now() < rateLimitedUntil) return staleOr("rate_limited")
+    rateLimitedUntilByProfile.delete(cacheKey)
+  }
+
+  const store = opts?.store ?? createPlatformCredentialStore({ claudeConfigDir: opts?.claudeConfigDir })
+  const rateLimitBackoffMs = opts?.rateLimitBackoffMs ?? RATE_LIMIT_BACKOFF_MS_DEFAULT
 
   const promise = (async () => {
     try {
@@ -311,10 +338,15 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
         result = await callAnthropic(newToken, fetchImpl)
       }
       if ("__status" in result) {
+        if (result.__status === 429) {
+          const retryAfterMs = Math.max(rateLimitBackoffMs, result.retryAfterMs ?? 0)
+          rateLimitedUntilByProfile.set(cacheKey, Date.now() + retryAfterMs)
+        }
         claudeLog("oauth_usage.upstream_error", { profile: cacheKey, status: result.__status })
         return staleOr(`upstream_${result.__status}`)
       }
 
+      rateLimitedUntilByProfile.delete(cacheKey)
       const snapshot = buildSnapshot(result)
       cacheByProfile.set(cacheKey, snapshot)
       return snapshot
@@ -334,4 +366,5 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
 export function resetOAuthUsageCache(): void {
   cacheByProfile.clear()
   inflightByProfile.clear()
+  rateLimitedUntilByProfile.clear()
 }

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -258,7 +258,10 @@ export function __setFetchOAuthUsageOverride(
  * callers for the same profile share a single in-flight request.
  *
  * @param ttlMs           Override the cache TTL (default 30s).
- * @param force           Bypass the cache and fetch fresh.
+ * @param force           Bypass the TTL cache and fetch fresh. Does NOT bypass
+ *                        the in-flight de-dupe or the 429 cooldown — both still
+ *                        apply, so a forced caller can still get a stale (or
+ *                        null) snapshot rather than a fresh upstream call.
  * @param store           Override the credential store (for testing).
  * @param profileId       Logical profile identifier used as the cache key.
  *                        Pass null/undefined for the default OAuth account.
@@ -339,7 +342,18 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
       }
       if ("__status" in result) {
         if (result.__status === 429) {
-          const retryAfterMs = Math.max(rateLimitBackoffMs, result.retryAfterMs ?? 0)
+          // Floor at the backoff, but cap at staleMaxMs: the cooldown suppresses
+          // every fetch, so one longer than the stale window would age the
+          // last-good snapshot out with nothing able to refresh it — staleOr
+          // starts returning null and the display blanks for the remainder.
+          // Capping means at most one retry per stale window, still far below
+          // the every-poll retries this backoff exists to stop.
+          // The cap never drops below the backoff floor, so a small staleMaxMs
+          // can't disarm the throttle this whole change exists to provide.
+          const retryAfterMs = Math.min(
+            Math.max(rateLimitBackoffMs, result.retryAfterMs ?? 0),
+            Math.max(staleMaxMs, rateLimitBackoffMs),
+          )
           rateLimitedUntilByProfile.set(cacheKey, Date.now() + retryAfterMs)
         }
         claudeLog("oauth_usage.upstream_error", { profile: cacheKey, status: result.__status })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -532,7 +532,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
    *  right when it's needed. `force` only skips the cache read — the
    *  in-flight-request de-dupe still applies after it, so concurrent
    *  exhaustions of the same profile still share one upstream call rather
-   *  than stampeding it. A `stale: true` snapshot (served when a fresh fetch
+   *  than stampeding it. The per-profile 429 cooldown suppresses forced
+   *  callers too, so an upstream rate limit leaves this refinement on the
+   *  conservative default instead of stampeding a limited endpoint. A
+   *  `stale: true` snapshot (served when a fresh fetch
    *  failed transiently) is not authoritative about the current window, so
    *  it's skipped too — the conservative default is the safer thing to
    *  leave standing. */


### PR DESCRIPTION
Cherry-picked from #781 by @CrazyCoder to satisfy `main`'s signed-commit
requirement, which blocks fork PRs from merging directly. Serge Baranov is
preserved as the author of the original commit; the follow-up fix is a separate
commit on top.

Closes #781.

## Problem

A 429 from Anthropic's private OAuth usage endpoint triggered an immediate
retry on the next quota poll. With several pollers that can keep the endpoint
permanently rate-limited.

## Change (from #781)

- Per-profile negative cache honoring `Retry-After` (numeric seconds or
  HTTP-date), with a 60s floor, checked after the in-flight de-dupe and cleared
  on success and by `resetOAuthUsageCache`.
- Credential-store construction moved below the early return, so a cooldown no
  longer pays for a Keychain subprocess on every poll.

## Follow-up fix

The cooldown had a floor but no ceiling, and could outlive the 15-minute
`STALE_MAX_MS_DEFAULT` window that `staleOr` enforces. With `Retry-After: 3600`
the snapshot aged out at 15 minutes while the cooldown kept suppressing every
fetch — 45 minutes of `null` usage with zero retries, defeating the change's own
goal of serving the last-good snapshot through the cooldown.

The cooldown is now capped at `staleMaxMs`, floored so a small `staleMaxMs`
can't disarm the throttle. Two regression tests cover both directions; the
ceiling test fails against the un-capped code.

Also documented the 429 cooldown as a second suppressor of `force` — the
comment at `server.ts:527` claimed `force` was only limited by the in-flight
de-dupe, and `refinePriorityCooldown`'s correctness reasoning leans on it.

## Known limitation (not addressed)

Entering the cooldown with an empty cache returns `null`, which `server.ts`
maps to `error: "no_token"` and the profile page renders as "Run `claude login`
to see usage". The mislabel predates this PR; the cooldown makes it stick for
60s+ instead of one poll interval. Fixing it means a new error value on
`/v1/usage/quota/all`, which Pylon and the settings UI consume — worth its own
change, tracked separately.
