### PR TITLE
fix(quota): distinguish a rate-limited usage fetch from a missing token

### DIFF
--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test, beforeEach } from "bun:test"
-import { fetchOAuthUsage, resetOAuthUsageCache } from "../proxy/oauthUsage"
+import { fetchOAuthUsage, resetOAuthUsageCache, explainMissingOAuthUsage } from "../proxy/oauthUsage"
 import type { CredentialStore } from "../proxy/tokenRefresh"
 
 const SAMPLE_RESPONSE = {
@@ -243,6 +243,49 @@ describe("oauthUsage", () => {
     await new Promise(resolve => setTimeout(resolve, 30))
     expect(await fetchOAuthUsage(opts)).not.toBeNull()
     expect(getCalls()).toBe(2)
+  })
+
+  // A null return is overloaded — "no credentials" vs "throttled with nothing
+  // left to serve". Consumers rendered the first reading unconditionally and
+  // told users to run `claude login` when their credentials were fine.
+  test("attributes a null return to the rate limit, not a missing token", async () => {
+    const { fetchImpl } = countingFetch(() =>
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "120" } }))
+    const store = makeStore("t")
+
+    expect(explainMissingOAuthUsage("attributed")).toBe("no_token")
+    expect(await fetchOAuthUsage({ force: true, store, profileId: "attributed", fetchImpl })).toBeNull()
+    expect(explainMissingOAuthUsage("attributed")).toBe("rate_limited")
+    // Per-profile: a healthy profile is unaffected by another's cooldown.
+    expect(explainMissingOAuthUsage("untouched")).toBe("no_token")
+  })
+
+  test("stops attributing to the rate limit once the cooldown lapses", async () => {
+    const { fetchImpl } = countingFetch(() =>
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "0" } }))
+    const opts = {
+      force: true,
+      store: makeStore("t"),
+      profileId: "lapsed",
+      fetchImpl,
+      rateLimitBackoffMs: 10,
+      staleMaxMs: 10,
+    }
+
+    expect(await fetchOAuthUsage(opts)).toBeNull()
+    expect(explainMissingOAuthUsage("lapsed")).toBe("rate_limited")
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(explainMissingOAuthUsage("lapsed")).toBe("no_token")
+  })
+
+  test("reports a genuinely missing token as no_token", async () => {
+    const { fetchImpl } = countingFetch(() =>
+      new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+
+    expect(await fetchOAuthUsage({
+      force: true, store: makeStore(null), profileId: "tokenless", fetchImpl,
+    })).toBeNull()
+    expect(explainMissingOAuthUsage("tokenless")).toBe("no_token")
   })
 
   // The cap must not disarm the throttle: a staleMaxMs below the backoff floor

--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -29,7 +29,7 @@ mock.module("../mcpTools", () => ({
 // oauth-usage.test.ts, where 10 tests would flake with `result === null`).
 // The override is bypassed when the caller passes `store` or `fetchImpl`,
 // keeping oauth-usage unit tests isolated.
-const { __setFetchOAuthUsageOverride } = await import("../proxy/oauthUsage")
+const { __setFetchOAuthUsageOverride, fetchOAuthUsage, resetOAuthUsageCache } = await import("../proxy/oauthUsage")
 const { createProxyServer } = await import("../proxy/server")
 const { rateLimitStore } = await import("../proxy/rateLimitStore")
 const { resetActiveProfile } = await import("../proxy/profiles")
@@ -293,3 +293,72 @@ describe("GET /v1/usage/quota", () => {
     expect(fiveHour.map(b => b.utilization)).toEqual([0.10])
   })
 })
+
+// #781 follow-up: a null usage snapshot meant `error: "no_token"` regardless of
+// cause, so an upstream 429 told users their credentials were missing. The 429
+// backoff made that stick for the whole cooldown instead of one poll interval.
+describe("GET /v1/usage/quota/all — null attribution", () => {
+  beforeEach(() => {
+    rateLimitStore.clear()
+    resetActiveProfile()
+    resetOAuthUsageCache()
+    __setFetchOAuthUsageOverride(async () => null)
+  })
+
+  afterEach(() => {
+    __setFetchOAuthUsageOverride(null)
+    resetOAuthUsageCache()
+  })
+
+  async function fetchAll(profiles?: Array<{ id: string; claudeConfigDir: string }>) {
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      ...(profiles ? { profiles, defaultProfile: profiles[0]!.id } : {}),
+    })
+    const res = await app.fetch(new Request("http://localhost/v1/usage/quota/all"))
+    expect(res.status).toBe(200)
+    return await res.json() as { profiles: Array<{ id: string; error: string | null }> }
+  }
+
+  it("reports no_token when there is no cooldown", async () => {
+    const body = await fetchAll()
+    expect(body.profiles.map(p => p.error)).toEqual(["no_token"])
+  })
+
+  it("reports rate_limited once a 429 cooldown is active", async () => {
+    // Passing store+fetchImpl bypasses the override and runs the real impl, so
+    // the 429 registers a genuine cooldown for the default key.
+    await primeRateLimit(undefined)
+
+    const body = await fetchAll()
+    expect(body.profiles.map(p => p.error)).toEqual(["rate_limited"])
+  })
+
+  it("attributes the cooldown per profile", async () => {
+    await primeRateLimit("work")
+
+    const body = await fetchAll([
+      { id: "work", claudeConfigDir: "/tmp/meridian-quota-work" },
+      { id: "personal", claudeConfigDir: "/tmp/meridian-quota-personal" },
+    ])
+    expect(body.profiles.find(p => p.id === "work")?.error).toBe("rate_limited")
+    expect(body.profiles.find(p => p.id === "personal")?.error).toBe("no_token")
+  })
+})
+
+async function primeRateLimit(profileId: string | undefined): Promise<void> {
+  const store = {
+    async read() {
+      return { claudeAiOauth: { accessToken: "t", refreshToken: "rt", expiresAt: Date.now() + 60_000 } } as any
+    },
+    async write() { return true },
+  }
+  const result = await fetchOAuthUsage({
+    force: true,
+    profileId,
+    store: store as any,
+    fetchImpl: async () => new Response("rate limited", { status: 429, headers: { "Retry-After": "120" } }),
+  })
+  expect(result).toBeNull()
+}

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -376,6 +376,20 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   return promise
 }
 
+/** Why {@link fetchOAuthUsage} returned null for a profile.
+ *
+ * `null` is overloaded: it means "no credentials" *and* "upstream is throttling
+ * us and there's no snapshot left to serve". Consumers rendered the first
+ * reading unconditionally, telling users to run `claude login` when their
+ * credentials were fine. Ask here instead of assuming.
+ *
+ * Only meaningful right after a null return — the cooldown is time-bounded.
+ */
+export function explainMissingOAuthUsage(profileId?: string | null): "rate_limited" | "no_token" {
+  const until = rateLimitedUntilByProfile.get(profileId ?? DEFAULT_KEY)
+  return until !== undefined && Date.now() < until ? "rate_limited" : "no_token"
+}
+
 /** Test-only / shutdown helper — clears all cached snapshots and pending fetches. */
 export function resetOAuthUsageCache(): void {
   cacheByProfile.clear()

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -9,7 +9,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { linkRequestAbort } from "./requestAbort"
-import { fetchOAuthUsage } from "./oauthUsage"
+import { fetchOAuthUsage, explainMissingOAuthUsage } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
@@ -4357,8 +4357,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // (which returns only the active profile's data).
   //
   // Each profile entry includes the same shape as `/v1/usage/quota`'s top
-  // level (windows + extraUsage), or `error: "no_token" | "upstream_error"`
-  // when the fetch failed for that profile.
+  // level (windows + extraUsage), or an `error` when the fetch failed for that
+  // profile: `"no_token" | "upstream_error" | "not_oauth" | "rate_limited"`.
+  //
+  // `rate_limited` means Anthropic 429'd the usage endpoint and the backoff has
+  // no last-good snapshot left to serve — the credentials are fine. Consumers
+  // added after #781 should treat it as transient and keep the previous render
+  // rather than prompting for login. Older consumers that only switch on
+  // `no_token` fall through to their default branch, which is why this is a new
+  // value rather than a reuse.
   app.get("/v1/usage/quota/all", async (c) => {
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
     const activeId = getActiveProfileId() || finalConfig.defaultProfile || profilesList[0]?.id || null
@@ -4373,7 +4380,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           windows: oauth?.windows ?? [],
           extraUsage: oauth?.extraUsage ?? null,
           fetchedAt: oauth?.fetchedAt ?? null,
-          error: oauth ? null : "no_token",
+          error: oauth ? null : explainMissingOAuthUsage(),
         }],
         activeProfile: "default",
         asOf: Date.now(),
@@ -4405,7 +4412,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         windows: oauth?.windows ?? [],
         extraUsage: oauth?.extraUsage ?? null,
         fetchedAt: oauth?.fetchedAt ?? null,
-        error: oauth ? null : "no_token",
+        error: oauth ? null : explainMissingOAuthUsage(p.id),
       }
     }))
 

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -277,6 +277,15 @@ function renderUsageSection(profileQuota) {
         + '<div class="usage-empty">Run <code style="background:var(--bg);padding:1px 5px;border-radius:3px">claude login</code> to see usage.</div>'
         + '</div>';
     }
+    // Credentials are fine here — Anthropic is throttling the usage endpoint
+    // and the backoff has no snapshot left to serve. Saying "run claude login"
+    // would send the user chasing a problem they don't have.
+    if (profileQuota.error === 'rate_limited') {
+      return '<div class="usage-section">'
+        + '<div class="usage-section-title">Usage</div>'
+        + '<div class="usage-empty">Usage data is rate limited upstream — retrying shortly.</div>'
+        + '</div>';
+    }
     return ''; // nothing fetched yet
   }
 


### PR DESCRIPTION
Follow-up to #785, which flagged this as a known limitation.

## Problem

`fetchOAuthUsage` returns `null` for two unrelated reasons — no credentials, and
an upstream 429 with no last-good snapshot left to serve — and
`/v1/usage/quota/all` reported both as `error: "no_token"`. The profile page
renders that as "Run `claude login` to see usage", sending users to
re-authenticate credentials that were never the problem.

The mislabel predates #785, but the 429 backoff made it matter: what used to
blink past in a single poll interval now persists for the whole cooldown.

## Change

- `explainMissingOAuthUsage(profileId)` in `oauthUsage.ts` — the leaf module
  that already owns the cooldown state, so `server.ts` keeps orchestrating
  rather than growing the logic.
- Both `/v1/usage/quota/all` call sites emit the new `error: "rate_limited"`
  when a cooldown is active for that profile.
- The profile page renders it as transient ("rate limited upstream — retrying
  shortly") instead of prompting for login.

## Why a new error value, not a reuse

Consumers that only switch on `no_token` fall through to their existing default
branch. For the profile page that means rendering nothing — already better than
a wrong instruction. `/v1/usage/quota/all` is not in `CLAUDE.md`'s stable API
table, but Pylon and the settings UI consume it, so the additive shape matters.
The endpoint's contract comment now documents all four values.

## Tests

Three unit tests on the attribution (set on 429, per-profile, lapses with the
cooldown, and a genuinely absent token still reads `no_token`) and three
integration tests through the HTTP layer covering the single-account and
per-profile paths. Both integration tests were confirmed to fail against the
unmodified server rather than passing vacuously.