### PR TITLE
fix: recognize weekly Claude limit wording

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -490,6 +490,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's 'You've hit your weekly limit' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your weekly limit \u00b7 resets 2pm (Asia/Jerusalem)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps 'usage limit reached' to rate_limit_error", () => {
     const r = classifyError("usage limit reached | resets at 5pm")
     expect(r.type).toBe("rate_limit_error")

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -13,6 +13,8 @@ import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, m
 
 let capturedEnvs: string[] = []
 let failingDirs = new Set<string>()
+const DEFAULT_FAILURE = "429 rate limit reached for this account"
+let failureMessage = DEFAULT_FAILURE
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
@@ -21,7 +23,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const streaming = params.options?.includePartialMessages === true
     return (async function* () {
       if ([...failingDirs].some((f) => dir.includes(f))) {
-        throw new Error("429 rate limit reached for this account")
+        throw new Error(failureMessage)
       }
       if (streaming) {
         yield messageStart("msg-1")
@@ -107,6 +109,7 @@ describe("priority routing", () => {
   beforeEach(() => {
     capturedEnvs = []
     failingDirs = new Set()
+    failureMessage = DEFAULT_FAILURE
     clearSessionCache()
     // The active profile is process-global module state; other test files
     // (profile-switch integration) set it. This suite's expectations are
@@ -143,6 +146,16 @@ describe("priority routing", () => {
     // work attempted (with its internal retry ladder), then personal
     expect(capturedEnvs.some((e) => e.includes("prof-work"))).toBe(true)
     expect(capturedEnvs[capturedEnvs.length - 1]).toContain("prof-personal")
+  }, 20_000)
+
+  it("fails over on the CLI's 'You've hit your weekly limit' wording", async () => {
+    failureMessage = "Claude Code returned an error result: You've hit your weekly limit \u00b7 resets 2pm (Asia/Jerusalem)"
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
   }, 20_000)
 
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -71,12 +71,14 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   }
 
   // Rate limiting. The CLI phrases 5h-window exhaustion as "You've hit your
-  // session limit · resets <time>" (live-observed) and weekly caps as
-  // "usage limit reached" — both ARE quota exhaustion and must classify as
+  // session limit · resets <time>" (live-observed) and weekly caps as either
+  // "You've hit your weekly limit" or "usage limit reached". All are quota
+  // exhaustion and must classify as
   // rate_limit_error (429), not generic api_error: clients back off correctly
   // and priority routing's failover keys off this class.
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
-    || lower.includes("hit your session limit") || lower.includes("usage limit reached")) {
+    || lower.includes("hit your session limit") || lower.includes("hit your weekly limit")
+    || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""


### PR DESCRIPTION
## Summary

- classify the live Claude Code wording `You've hit your weekly limit` as `429 rate_limit_error`
- let priority routing retry the next configured profile instead of returning a generic 500
- add classifier and HTTP-level priority failover regression coverage

This complements #764, whose shorter `You've hit your limit` pattern does not match the observed weekly wording.

## Verification

- red phase: both new regressions failed as `api_error` / HTTP 500
- `bun test src/__tests__/errors.test.ts src/__tests__/priority-routing-integration.test.ts` - 101 passed
- `npm run build` - passed, including declaration generation
- full suite comparison: the patch run and untouched `origin/main` reproduce the same five unrelated SDK-feature/system-prompt failures; no changed-path test fails

Observed production error:

```text
Claude Code returned an error result: You've hit your weekly limit · resets 2pm (Asia/Jerusalem)
```