### PR TITLE
fix(errors): recognize the CLI's other limit wordings

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -496,6 +496,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's 'You've hit your weekly limit' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your weekly limit \u00b7 resets 2pm (Asia/Jerusalem)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps 'usage limit reached' to rate_limit_error", () => {
     const r = classifyError("usage limit reached | resets at 5pm")
     expect(r.type).toBe("rate_limit_error")

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -490,6 +490,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's shorter 'You've hit your limit' wording to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your limit \u00b7 resets 6:40pm (UTC)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps 'usage limit reached' to rate_limit_error", () => {
     const r = classifyError("usage limit reached | resets at 5pm")
     expect(r.type).toBe("rate_limit_error")

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -502,6 +502,25 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
+  // failover, a PR. These pin the shape so the next variant is already covered.
+  it.each([
+    ["daily", "You've hit your daily limit · resets midnight (UTC)"],
+    ["monthly", "You've hit your monthly limit"],
+    ["hyphenated", "You've hit your 5-hour limit · resets 3pm"],
+  ])("maps an unseen '%s' limit qualifier to rate_limit_error", (_label, msg) => {
+    const r = classifyError(`Claude Code returned an error result: ${msg}`)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  // The qualifier is one word, not a wildcard — an unrelated sentence that
+  // merely contains "limit" must not become a 429 that clients back off on.
+  it("does not treat unrelated 'limit' prose as a rate limit", () => {
+    const r = classifyError("Claude Code returned an error result: you have hit your configured tool call depth limit")
+    expect(r.type).not.toBe("rate_limit_error")
+  })
+
   it("maps 'usage limit reached' to rate_limit_error", () => {
     const r = classifyError("usage limit reached | resets at 5pm")
     expect(r.type).toBe("rate_limit_error")

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -13,6 +13,8 @@ import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, m
 
 let capturedEnvs: string[] = []
 let failingDirs = new Set<string>()
+const DEFAULT_FAILURE = "429 rate limit reached for this account"
+let failureMessage = DEFAULT_FAILURE
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
@@ -21,7 +23,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const streaming = params.options?.includePartialMessages === true
     return (async function* () {
       if ([...failingDirs].some((f) => dir.includes(f))) {
-        throw new Error("429 rate limit reached for this account")
+        throw new Error(failureMessage)
       }
       if (streaming) {
         yield messageStart("msg-1")
@@ -96,6 +98,7 @@ const savedEnv: Record<string, string | undefined> = {}
 // (file-level) hooks before inner (describe-level) ones, so those overrides
 // still win for those tests.
 beforeEach(() => {
+  failureMessage = DEFAULT_FAILURE
   __setFetchOAuthUsageOverride(async () => null)
 })
 
@@ -143,6 +146,16 @@ describe("priority routing", () => {
     // work attempted (with its internal retry ladder), then personal
     expect(capturedEnvs.some((e) => e.includes("prof-work"))).toBe(true)
     expect(capturedEnvs[capturedEnvs.length - 1]).toContain("prof-personal")
+  }, 20_000)
+
+  it("fails over on the CLI's shorter 'You've hit your limit' wording", async () => {
+    failureMessage = "Claude Code returned an error result: You've hit your limit · resets 6:40pm (UTC)"
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0].text).toContain("prof-personal")
   }, 20_000)
 
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -110,6 +110,7 @@ describe("priority routing", () => {
   beforeEach(() => {
     capturedEnvs = []
     failingDirs = new Set()
+    failureMessage = DEFAULT_FAILURE
     clearSessionCache()
     // The active profile is process-global module state; other test files
     // (profile-switch integration) set it. This suite's expectations are
@@ -155,7 +156,17 @@ describe("priority routing", () => {
     const res = await post(app)
     expect(res.status).toBe(200)
     const body = await res.json() as { content: Array<{ text: string }> }
-    expect(body.content[0].text).toContain("prof-personal")
+    expect(body.content[0]?.text).toContain("prof-personal")
+  }, 20_000)
+
+  it("fails over on the CLI's 'You've hit your weekly limit' wording", async () => {
+    failureMessage = "Claude Code returned an error result: You've hit your weekly limit \u00b7 resets 2pm (Asia/Jerusalem)"
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
   }, 20_000)
 
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -110,7 +110,9 @@ describe("priority routing", () => {
   beforeEach(() => {
     capturedEnvs = []
     failingDirs = new Set()
-    failureMessage = DEFAULT_FAILURE
+    // failureMessage resets in the file-level beforeEach, which runs first and
+    // covers the later describes too — this one only ever saw the leak because
+    // its own tests happened to run last.
     clearSessionCache()
     // The active profile is process-global module state; other test files
     // (profile-switch integration) set it. This suite's expectations are

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -42,6 +42,11 @@ export function extendedContextHint(model?: string): string {
   return advise("MERIDIAN_1M_CONTEXT_SUPPORT=0")
 }
 
+/** "hit your limit", "hit your session limit", "hit your weekly limit", and any
+ *  future single-word qualifier the CLI adopts. Anchored on both sides so it
+ *  can't drift into unrelated text that happens to contain "limit". */
+const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
+
 /**
  * Detect specific SDK errors and return helpful messages to the client.
  *
@@ -70,16 +75,20 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
-  // Rate limiting. The CLI phrases 5h-window exhaustion as "You've hit your
-  // session limit · resets <time>" or the shorter "You've hit your limit", and
-  // weekly caps as "You've hit your weekly limit" or "usage limit reached". All
-  // are quota exhaustion and must classify as rate_limit_error (429), not
-  // generic api_error: clients back off correctly and priority routing's
-  // failover keys off this class.
+  // Rate limiting. All quota exhaustion must classify as rate_limit_error
+  // (429), not generic api_error: clients back off correctly and priority
+  // routing's failover keys off this class. Misclassifying costs a 500 and a
+  // profile that never fails over.
+  //
+  // The CLI's phrasing is a moving target — "You've hit your session limit ·
+  // resets <time>", the shorter "You've hit your limit", and "You've hit your
+  // weekly limit" have all been observed live, each arriving as its own bug
+  // report after the previous literal stopped matching (#764, #787). Match the
+  // shape instead of enumerating: "hit your <anything> limit" covers the
+  // variants seen so far and the daily/monthly/5-hour ones that would
+  // otherwise be the next report.
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
-    || lower.includes("hit your session limit") || lower.includes("hit your limit")
-    || lower.includes("hit your weekly limit")
-    || lower.includes("usage limit reached")) {
+    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -70,13 +70,15 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
-  // Rate limiting. The CLI phrases 5h-window exhaustion as either "You've hit
-  // your session limit · resets <time>" or the shorter "You've hit your limit".
-  // Weekly caps use "usage limit reached". These ARE quota exhaustion and must
-  // classify as rate_limit_error (429), not generic api_error: clients back off
-  // correctly and priority routing's failover keys off this class.
+  // Rate limiting. The CLI phrases 5h-window exhaustion as "You've hit your
+  // session limit · resets <time>" or the shorter "You've hit your limit", and
+  // weekly caps as "You've hit your weekly limit" or "usage limit reached". All
+  // are quota exhaustion and must classify as rate_limit_error (429), not
+  // generic api_error: clients back off correctly and priority routing's
+  // failover keys off this class.
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
     || lower.includes("hit your session limit") || lower.includes("hit your limit")
+    || lower.includes("hit your weekly limit")
     || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -70,13 +70,14 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
-  // Rate limiting. The CLI phrases 5h-window exhaustion as "You've hit your
-  // session limit · resets <time>" (live-observed) and weekly caps as
-  // "usage limit reached" — both ARE quota exhaustion and must classify as
-  // rate_limit_error (429), not generic api_error: clients back off correctly
-  // and priority routing's failover keys off this class.
+  // Rate limiting. The CLI phrases 5h-window exhaustion as either "You've hit
+  // your session limit · resets <time>" or the shorter "You've hit your limit".
+  // Weekly caps use "usage limit reached". These ARE quota exhaustion and must
+  // classify as rate_limit_error (429), not generic api_error: clients back off
+  // correctly and priority routing's failover keys off this class.
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
-    || lower.includes("hit your session limit") || lower.includes("usage limit reached")) {
+    || lower.includes("hit your session limit") || lower.includes("hit your limit")
+    || lower.includes("usage limit reached")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""


### PR DESCRIPTION
Cherry-picked from #764 (@justprosh) and #787 (@WarGloom), which fix the same
class of bug from opposite ends. `main` requires signed commits, so fork PRs
can't merge directly; both original commits are preserved with their authors,
and the generalization is a separate commit on top.

Closes #764. Closes #787.

## Problem

`classifyError` matched the CLI's quota-exhaustion wording by literal. When the
CLI says anything else, the error falls through to a generic `api_error` — the
client gets a 500 instead of a 429, doesn't back off, and priority routing never
fails the profile over, because `sniffQuotaFailure` keys on `rate_limit_error`.

Two live-observed wordings were unmatched, and neither subsumes the other —
`"hit your limit"` is not a substring of `"hit your weekly limit"`:

- `You've hit your limit · resets 6:40pm (UTC)` — #764
- `You've hit your weekly limit · resets 2pm (Asia/Jerusalem)` — #787

## Change

Both contributors' commits land as-authored, each with its own regression test.

On top, one commit replaces the growing literal list with
`/hit your (?:[\w-]+ )?limit/`. Enumerating variants means the next qualifier is
already a bug nobody has reported yet — two PRs in one window for two variants
is the evidence. The pattern covers session/weekly/plain plus daily, monthly,
and 5-hour.

The qualifier is one word, not a wildcard, so unrelated prose containing "limit"
still classifies normally — pinned by a negative test.

## Test-scope fix

#787 put the `failureMessage` reset in the `priority routing` describe's
`beforeEach`, but the variable is module-level and two later describes never
reset it. It was benign only because that block's tests happen to run last; add
or reorder one test and it leaks into `keyless priority affinity`, whose timing
assumptions depend on the retry ladder. #764 placed it at file scope, which is
correct — that's what this branch keeps.

## Known follow-up (not addressed)

Weekly caps now reach priority failover, but `priorityCooldownUntil`
(`server.ts:503`) and `refinePriorityCooldown` (`server.ts:558`) gate on the
`five_hour` window only. A weekly-exhausted profile is benched for the 10-minute
default and re-probed with a full failing request every 10 minutes, for days.
The OAuth snapshot already exposes `seven_day` windows. Still strictly better
than the current behavior (a 500 and no bench at all).

## Tests

`errors.test.ts` 80 pass. `priority-routing-integration.test.ts` 26 pass / 1
fail — that failure (`does not attempt an OAuth usage fetch for a
non-claude-max profile (#699)`) reproduces identically on a clean `origin/main`
worktree and is an ambient `CLAUDE_CONFIG_DIR` artifact, not from this branch.