### PR TITLE
fix(usage): report why a usage fetch failed instead of calling every failure no_token

### DIFF
--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test, beforeEach } from "bun:test"
-import { fetchOAuthUsage, resetOAuthUsageCache, explainMissingOAuthUsage } from "../proxy/oauthUsage"
+import { fetchOAuthUsage, fetchOAuthUsageResult, resetOAuthUsageCache } from "../proxy/oauthUsage"
 import type { CredentialStore } from "../proxy/tokenRefresh"
 
 const SAMPLE_RESPONSE = {
@@ -248,21 +248,39 @@ describe("oauthUsage", () => {
   // A null return is overloaded — "no credentials" vs "throttled with nothing
   // left to serve". Consumers rendered the first reading unconditionally and
   // told users to run `claude login` when their credentials were fine.
-  test("attributes a null return to the rate limit, not a missing token", async () => {
+  test("attributes a throttled fetch to the rate limit, not a missing token", async () => {
     const { fetchImpl } = countingFetch(() =>
       new Response("rate limited", { status: 429, headers: { "Retry-After": "120" } }))
     const store = makeStore("t")
 
-    expect(explainMissingOAuthUsage("attributed")).toBe("no_token")
-    expect(await fetchOAuthUsage({ force: true, store, profileId: "attributed", fetchImpl })).toBeNull()
-    expect(explainMissingOAuthUsage("attributed")).toBe("rate_limited")
-    // Per-profile: a healthy profile is unaffected by another's cooldown.
-    expect(explainMissingOAuthUsage("untouched")).toBe("no_token")
+    const limited = await fetchOAuthUsageResult({ force: true, store, profileId: "attributed", fetchImpl })
+    expect(limited.snapshot).toBeNull()
+    expect(limited.error).toBe("rate_limited")
+
+    // The cooldown is per-profile, so an untouched profile reports its own
+    // (absent) credentials rather than inheriting the throttle.
+    const other = await fetchOAuthUsageResult({
+      force: true, store: makeStore(null), profileId: "untouched", fetchImpl,
+    })
+    expect(other.error).toBe("no_token")
   })
 
-  test("stops attributing to the rate limit once the cooldown lapses", async () => {
-    const { fetchImpl } = countingFetch(() =>
-      new Response("rate limited", { status: 429, headers: { "Retry-After": "0" } }))
+  test("keeps reporting rate_limited while the cooldown suppresses the fetch", async () => {
+    const { fetchImpl, getCalls } = countingFetch(() =>
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "120" } }))
+    const opts = { force: true, store: makeStore("t"), profileId: "suppressed", fetchImpl }
+
+    expect((await fetchOAuthUsageResult(opts)).error).toBe("rate_limited")
+    // Second call never reaches the network — the reason has to survive the
+    // early return, not just the branch that set the cooldown.
+    expect((await fetchOAuthUsageResult(opts)).error).toBe("rate_limited")
+    expect(getCalls()).toBe(1)
+  })
+
+  test("stops reporting rate_limited once the cooldown lapses", async () => {
+    const { fetchImpl } = countingFetch(calls => calls === 1
+      ? new Response("rate limited", { status: 429, headers: { "Retry-After": "0" } })
+      : new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
     const opts = {
       force: true,
       store: makeStore("t"),
@@ -272,20 +290,22 @@ describe("oauthUsage", () => {
       staleMaxMs: 10,
     }
 
-    expect(await fetchOAuthUsage(opts)).toBeNull()
-    expect(explainMissingOAuthUsage("lapsed")).toBe("rate_limited")
+    expect((await fetchOAuthUsageResult(opts)).error).toBe("rate_limited")
     await new Promise(resolve => setTimeout(resolve, 20))
-    expect(explainMissingOAuthUsage("lapsed")).toBe("no_token")
+    const recovered = await fetchOAuthUsageResult(opts)
+    expect(recovered.error).toBeNull()
+    expect(recovered.snapshot).not.toBeNull()
   })
 
   test("reports a genuinely missing token as no_token", async () => {
     const { fetchImpl } = countingFetch(() =>
       new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
 
-    expect(await fetchOAuthUsage({
+    const result = await fetchOAuthUsageResult({
       force: true, store: makeStore(null), profileId: "tokenless", fetchImpl,
-    })).toBeNull()
-    expect(explainMissingOAuthUsage("tokenless")).toBe("no_token")
+    })
+    expect(result.snapshot).toBeNull()
+    expect(result.error).toBe("no_token")
   })
 
   // The cap must not disarm the throttle: a staleMaxMs below the backoff floor
@@ -415,5 +435,72 @@ describe("oauthUsage", () => {
     const w = result!.windows[0]
     expect(w).toBeDefined()
     expect(w!.resetsAt).toBe(Date.parse(iso))
+  })
+})
+
+/**
+ * The failure REASON, which is what a per-profile status display shows a
+ * human. Every failure used to reach callers as a bare null, so the quota
+ * routes labelled all of them "no_token" and a rate-limited read rendered as
+ * an account that had lost its credentials.
+ */
+describe("fetchOAuthUsageResult", () => {
+  beforeEach(() => {
+    resetOAuthUsageCache()
+  })
+
+  test("reports no_token only when the store holds no token", async () => {
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const { snapshot, error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore(null), profileId: "reason-empty", fetchImpl,
+    })
+    expect(snapshot).toBeNull()
+    expect(error).toBe("no_token")
+  })
+
+  // Narrowed from the original `upstream_error`: a 429 is the one failure the
+  // backoff can keep returning for minutes, so it gets its own value rather
+  // than hiding among generic upstream faults. Still never `no_token`, which
+  // was the bug.
+  test("reports rate_limited for a 429 rather than no_token", async () => {
+    const fetchImpl = fixedFetch(() => new Response("rate limited", { status: 429 }))
+    const { snapshot, error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-429", fetchImpl,
+    })
+    expect(snapshot).toBeNull()
+    expect(error).toBe("rate_limited")
+  })
+
+  test("reports upstream_error for a 500", async () => {
+    const fetchImpl = fixedFetch(() => new Response("boom", { status: 500 }))
+    const { error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-500", fetchImpl,
+    })
+    expect(error).toBe("upstream_error")
+  })
+
+  test("reports no error on success", async () => {
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const { snapshot, error } = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-ok", fetchImpl,
+    })
+    expect(snapshot).not.toBeNull()
+    expect(error).toBeNull()
+  })
+
+  test("a snapshot served stale after a failure is not an error", async () => {
+    const { fetchImpl } = countingFetch(calls => calls === 1
+      ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+      : new Response("rate limited", { status: 429 }))
+    const first = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-stale", fetchImpl,
+    })
+    expect(first.error).toBeNull()
+
+    const second = await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "reason-stale", fetchImpl,
+    })
+    expect(second.snapshot?.stale).toBe(true)
+    expect(second.error).toBeNull()
   })
 })

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -89,6 +89,30 @@ export interface OAuthUsageSnapshot {
   stale?: boolean
 }
 
+/**
+ * Why a usage fetch produced no snapshot.
+ *
+ * Distinct values because they call for different things from a human: a
+ * missing token needs `claude login`, and the rest need waiting. Keeping them
+ * apart is the whole point of this type — every failure used to reach callers
+ * as a bare `null`, so the quota routes labelled all of them `no_token`, and a
+ * rate-limited read rendered as an account that had lost its credentials. A 429
+ * and an empty credential file are not the same news, and only one of them is
+ * the user's problem to fix.
+ *
+ * `rate_limited` is split out from `upstream_error` because it's the one the
+ * backoff can keep returning for minutes at a stretch, so it's worth saying
+ * plainly rather than as a generic upstream failure.
+ */
+export type OAuthUsageError = "no_token" | "rate_limited" | "upstream_error"
+
+/** A usage fetch outcome: the snapshot, or why there isn't one. */
+export interface OAuthUsageResult {
+  snapshot: OAuthUsageSnapshot | null
+  /** Set only when `snapshot` is null. */
+  error: OAuthUsageError | null
+}
+
 const CACHE_TTL_MS_DEFAULT = 30_000
 // A transiently failing fetch serves the last-good snapshot instead of
 // blanking the consumer ("no usage data yet" flapping) — but only within
@@ -98,7 +122,7 @@ const RATE_LIMIT_BACKOFF_MS_DEFAULT = 60_000
 
 /** Per-profile cache. Key = profileId (or DEFAULT_KEY for the unscoped default). */
 const cacheByProfile = new Map<string, OAuthUsageSnapshot>()
-const inflightByProfile = new Map<string, Promise<OAuthUsageSnapshot | null>>()
+const inflightByProfile = new Map<string, Promise<OAuthUsageResult>>()
 const rateLimitedUntilByProfile = new Map<string, number>()
 const DEFAULT_KEY = "__default__"
 
@@ -272,15 +296,37 @@ export function __setFetchOAuthUsageOverride(
  *                        Defaults to globalThis.fetch.
  */
 export async function fetchOAuthUsage(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageSnapshot | null> {
+  return (await fetchOAuthUsageResult(opts)).snapshot
+}
+
+/** Why a profile has no snapshot, judged from cooldown state alone. Used where
+ *  the fetch itself didn't report a reason. */
+function missingReason(cacheKey: string): OAuthUsageError {
+  const until = rateLimitedUntilByProfile.get(cacheKey)
+  return until !== undefined && Date.now() < until ? "rate_limited" : "no_token"
+}
+
+/**
+ * As `fetchOAuthUsage`, but says why there is no snapshot. Callers that
+ * report a per-profile status to a human want this one; `fetchOAuthUsage`
+ * remains for callers that only act on the numbers.
+ */
+export async function fetchOAuthUsageResult(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageResult> {
   // If the caller injected real test deps, run the real impl. This keeps
   // oauth-usage unit tests isolated from any test-set _testOverride.
   if (_testOverride && !opts?.fetchImpl && !opts?.store) {
-    return _testOverride(opts)
+    const snapshot = await _testOverride(opts)
+    // The override returns a bare snapshot-or-null, so the reason has to come
+    // from the one piece of real state that outlives it: the 429 cooldown.
+    // Defaulting to "no_token" here would make the override contradict the
+    // cooldown the same process just recorded.
+    const error = snapshot ? null : missingReason(opts?.profileId ?? DEFAULT_KEY)
+    return { snapshot, error }
   }
   return fetchOAuthUsageImpl(opts)
 }
 
-async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageSnapshot | null> {
+async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageResult> {
   const ttl = opts?.ttlMs ?? CACHE_TTL_MS_DEFAULT
   const cacheKey = opts?.profileId ?? DEFAULT_KEY
   const fetchImpl = opts?.fetchImpl ?? globalThis.fetch
@@ -289,18 +335,18 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   // On transient failure, serve the last-good snapshot (bounded) instead of
   // null — a credential-read blip or upstream 5xx should not blank the
   // consumer's usage display until the next successful fetch.
-  const staleOr = (reason: string): OAuthUsageSnapshot | null => {
+  const staleOr = (reason: string, error: OAuthUsageError): OAuthUsageResult => {
     const last = cacheByProfile.get(cacheKey)
     if (last && Date.now() - last.fetchedAt < staleMaxMs) {
       claudeLog("oauth_usage.serving_stale", { profile: cacheKey, reason, ageMs: Date.now() - last.fetchedAt })
-      return { ...last, stale: true }
+      return { snapshot: { ...last, stale: true }, error: null }
     }
-    return null
+    return { snapshot: null, error }
   }
 
   if (!opts?.force) {
     const cached = cacheByProfile.get(cacheKey)
-    if (cached && Date.now() - cached.fetchedAt < ttl) return cached
+    if (cached && Date.now() - cached.fetchedAt < ttl) return { snapshot: cached, error: null }
   }
   const existing = inflightByProfile.get(cacheKey)
   if (existing) return existing
@@ -310,7 +356,7 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   // private usage endpoint permanently rate-limited.
   const rateLimitedUntil = rateLimitedUntilByProfile.get(cacheKey)
   if (rateLimitedUntil !== undefined) {
-    if (Date.now() < rateLimitedUntil) return staleOr("rate_limited")
+    if (Date.now() < rateLimitedUntil) return staleOr("rate_limited", "rate_limited")
     rateLimitedUntilByProfile.delete(cacheKey)
   }
 
@@ -325,7 +371,7 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
         // token-refresh rewrite) was previously silent — log it so flapping
         // usage displays are diagnosable.
         claudeLog("oauth_usage.no_token", { profile: cacheKey })
-        return staleOr("no_token")
+        return staleOr("no_token", "no_token")
       }
 
       let result = await callAnthropic(token, fetchImpl)
@@ -334,10 +380,15 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
         const refreshed = await refreshOAuthToken(store)
         if (!refreshed) {
           claudeLog("oauth_usage.refresh_failed", { profile: cacheKey })
-          return staleOr("refresh_failed")
+          // Not `no_token`: the token is present, and a read-only instance
+          // declines to refresh it BY DESIGN (credentialsMode.ts). Reporting
+          // a missing login here would tell the operator to re-authenticate
+          // every account on the box, on the one instance that is forbidden
+          // from touching credentials.
+          return staleOr("refresh_failed", "upstream_error")
         }
         const newToken = await readAccessToken(store)
-        if (!newToken) return staleOr("no_token_after_refresh")
+        if (!newToken) return staleOr("no_token_after_refresh", "no_token")
         result = await callAnthropic(newToken, fetchImpl)
       }
       if ("__status" in result) {
@@ -357,16 +408,19 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
           rateLimitedUntilByProfile.set(cacheKey, Date.now() + retryAfterMs)
         }
         claudeLog("oauth_usage.upstream_error", { profile: cacheKey, status: result.__status })
-        return staleOr(`upstream_${result.__status}`)
+        return staleOr(
+          `upstream_${result.__status}`,
+          result.__status === 429 ? "rate_limited" : "upstream_error",
+        )
       }
 
       rateLimitedUntilByProfile.delete(cacheKey)
       const snapshot = buildSnapshot(result)
       cacheByProfile.set(cacheKey, snapshot)
-      return snapshot
+      return { snapshot, error: null }
     } catch (err) {
       claudeLog("oauth_usage.fetch_failed", { profile: cacheKey, error: err instanceof Error ? err.message : String(err) })
-      return staleOr("exception")
+      return staleOr("exception", "upstream_error")
     } finally {
       inflightByProfile.delete(cacheKey)
     }
@@ -374,20 +428,6 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
 
   inflightByProfile.set(cacheKey, promise)
   return promise
-}
-
-/** Why {@link fetchOAuthUsage} returned null for a profile.
- *
- * `null` is overloaded: it means "no credentials" *and* "upstream is throttling
- * us and there's no snapshot left to serve". Consumers rendered the first
- * reading unconditionally, telling users to run `claude login` when their
- * credentials were fine. Ask here instead of assuming.
- *
- * Only meaningful right after a null return — the cooldown is time-bounded.
- */
-export function explainMissingOAuthUsage(profileId?: string | null): "rate_limited" | "no_token" {
-  const until = rateLimitedUntilByProfile.get(profileId ?? DEFAULT_KEY)
-  return until !== undefined && Date.now() < until ? "rate_limited" : "no_token"
 }
 
 /** Test-only / shutdown helper — clears all cached snapshots and pending fetches. */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -9,7 +9,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { linkRequestAbort } from "./requestAbort"
-import { fetchOAuthUsage, explainMissingOAuthUsage } from "./oauthUsage"
+import { fetchOAuthUsage, fetchOAuthUsageResult } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
@@ -4360,19 +4360,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // level (windows + extraUsage), or an `error` when the fetch failed for that
   // profile: `"no_token" | "upstream_error" | "not_oauth" | "rate_limited"`.
   //
-  // `rate_limited` means Anthropic 429'd the usage endpoint and the backoff has
-  // no last-good snapshot left to serve — the credentials are fine. Consumers
-  // added after #781 should treat it as transient and keep the previous render
-  // rather than prompting for login. Older consumers that only switch on
-  // `no_token` fall through to their default branch, which is why this is a new
-  // value rather than a reuse.
+  // Only `no_token` asks anything of the operator (`claude login`). The other
+  // two are transient and want waiting, not action: `rate_limited` is a 429
+  // with no last-good snapshot left to serve, and `upstream_error` covers 5xx
+  // and a refusal to refresh (which a read-only instance does BY DESIGN, so
+  // reporting it as a missing login would be actively wrong).
+  //
+  // The reason is threaded out of the fetch rather than inferred here — a null
+  // snapshot alone can't tell these apart, which is exactly how every failure
+  // came to be labelled `no_token`. Older consumers that only switch on
+  // `no_token` fall through to their default branch, which is why these are new
+  // values rather than reuses.
   app.get("/v1/usage/quota/all", async (c) => {
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
     const activeId = getActiveProfileId() || finalConfig.defaultProfile || profilesList[0]?.id || null
 
     if (profilesList.length === 0) {
       // Single-account mode — just return the default OAuth account's data.
-      const oauth = await fetchOAuthUsage({})
+      const { snapshot: oauth, error } = await fetchOAuthUsageResult({})
       return c.json({
         profiles: [{
           id: "default",
@@ -4380,7 +4385,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           windows: oauth?.windows ?? [],
           extraUsage: oauth?.extraUsage ?? null,
           fetchedAt: oauth?.fetchedAt ?? null,
-          error: oauth ? null : explainMissingOAuthUsage(),
+          error,
         }],
         activeProfile: "default",
         asOf: Date.now(),
@@ -4401,7 +4406,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           error: "not_oauth" as const,
         }
       }
-      const oauth = await fetchOAuthUsage({
+      const { snapshot: oauth, error } = await fetchOAuthUsageResult({
         profileId: p.id,
         claudeConfigDir: p.claudeConfigDir,
       })
@@ -4412,7 +4417,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         windows: oauth?.windows ?? [],
         extraUsage: oauth?.extraUsage ?? null,
         fetchedAt: oauth?.fetchedAt ?? null,
-        error: oauth ? null : explainMissingOAuthUsage(p.id),
+        error,
       }
     }))
 


### PR DESCRIPTION
Cherry-picked from #783 by @Nowaker. `main` requires signed commits, so fork PRs
can't merge directly; the commit is preserved with Nowaker as author.

Closes #783.

## Why this supersedes what's already on main

#786 (mine) addressed the same bug and merged first, which is what put #783 into
conflict. #783's design is better and this replaces mine:

| | #786 (on main) | #783 (this) |
|---|---|---|
| Where the reason comes from | module-state lookup *after* a null return | threaded out of the fetch |
| 500 with empty cache | mislabelled `no_token` | `upstream_error` |
| Refusal to refresh | mislabelled `no_token` | `upstream_error` |
| 429 with empty cache | `rate_limited` | `rate_limited` |

`explainMissingOAuthUsage` is removed. A null snapshot can't tell these apart —
which is exactly how every failure came to be labelled `no_token` — so asking
after the fact was never going to cover the 5xx and refresh-refusal cases.

The refresh-refusal case is the sharpest one: a read-only instance declines to
refresh credentials *by design*, and reporting that as a missing login would
tell an operator to re-authenticate every account on the box, on the one
instance forbidden from touching credentials.

## Changes I made on top of Nowaker's commit

These are inside the cherry-picked commit as conflict resolution against a
codebase that moved under it (#785, #786), so calling them out explicitly:

- **Split `rate_limited` out of `upstream_error`.** Nowaker's union was
  `no_token | upstream_error`; a 429 returned `upstream_error`. Since #785's
  backoff can keep returning that state for minutes at a stretch, it earns its
  own value. Their test asserting `upstream_error` for a 429 now asserts
  `rate_limited` — narrowed, still never `no_token`, which was the bug.
- **The test override now consults the cooldown.** The shim returned
  `no_token` for any null, which would have made it contradict a cooldown the
  same process had just recorded, and broke #786's integration tests.
- Rewrote #786's unit tests against the threaded API and updated the endpoint's
  contract comment to describe all four values.

## Tests

42 pass across `oauth-usage.test.ts` and `proxy-usage-quota-route.test.ts`,
including a new case pinning that the reason survives the cooldown's early
return — not just the branch that sets it. Full suite matches the pre-existing
baseline.