### PR TITLE
feat(profiles): complete a profile login from the web UI

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,10 @@ adapter lets the subprocess run the built-in WebFetch at all.
 | `GET /profiles` | Profile management page |
 | `GET /profiles/list` | List profiles with auth status (JSON) |
 | `POST /profiles/active` | Switch the active profile |
+| `POST /profiles/login/start` | Begin an OAuth login for a profile — returns the authorize URL (see [Re-authenticating from the web UI](profiles.md#from-the-web-ui-re-authenticate-a-profile-without-a-terminal)) |
+| `GET /profiles/login/status` | Poll a started login: `waiting`, `completed` or `failed` |
+| `POST /profiles/login/complete` | Finish that login with the code the user pasted back |
+| `GET /callback` | Anthropic's OAuth redirect target. **Not** behind `MERIDIAN_API_KEY` — the redirect carries no key; acts only on a single-use `state` minted by `/profiles/login/start` |
 | `GET /v1/usage/quota` | Usage windows for the active profile (JSON) |
 | `GET /v1/usage/quota/all` | Usage windows for every profile (JSON) |
 | `GET /settings` | SDK feature toggles + model pricing UI |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,8 @@ adapter lets the subprocess run the built-in WebFetch at all.
 | `GET /profiles/login/status` | Poll a started login: `waiting`, `completed` or `failed` |
 | `POST /profiles/login/complete` | Finish that login with the code the user pasted back |
 | `GET /callback` | Anthropic's OAuth redirect target. **Not** behind `MERIDIAN_API_KEY` — the redirect carries no key; acts only on a single-use `state` minted by `/profiles/login/start` |
+| `POST /profiles/add/start` | Begin creating a new profile — validates the name and returns the authorize URL (see [Adding from the web UI](profiles.md#from-the-web-ui-add-a-profile)) |
+| `POST /profiles/add/complete` | Finish that creation — writes the profile only once Anthropic returns credentials |
 | `GET /v1/usage/quota` | Usage windows for the active profile (JSON) |
 | `GET /v1/usage/quota/all` | Usage windows for every profile (JSON) |
 | `GET /settings` | SDK feature toggles + model pricing UI |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,6 +15,8 @@ meridian profile add personal
 meridian profile add work
 ```
 
+Or add one from the Profiles page without a terminal at all — see [From the web UI: add a profile](#from-the-web-ui-add-a-profile).
+
 > **⚠ Important:** Claude's OAuth reuses your browser session. Before adding a second account, sign out of claude.ai and sign into the other account first.
 
 #### Headless / SSH: complete Claude OAuth with a pasted code
@@ -75,8 +77,41 @@ Details worth knowing:
 - A login is **single-use** and expires **10 minutes** after it starts. `state` must match the login it was started with, exactly as the CLI requires; on the redirect path that `state` is what identifies the login at all.
 - `GET /callback` is deliberately **not** behind `MERIDIAN_API_KEY` — Anthropic's redirect carries no key. It acts only on an unguessable, single-use `state` minted by `/profiles/login/start`, which *is* gated, and answers 410 to anything else.
 - Only **claude-max** profiles have this flow. `api` and `oauth-token` profiles are refused with the reason — replace an OAuth token with `meridian profile remove <name> && meridian profile add <name> --oauth-token`.
-- An unknown profile name is refused, not created. `meridian profile add` remains the only way a profile comes into existence.
+- An unknown profile name is refused here rather than created — a typo in a re-authentication must not quietly produce a second account slot. Creating one is a separate, explicit act: see [Add a profile from the web UI](#from-the-web-ui-add-a-profile) below.
 - An instance told not to write credential files (`MERIDIAN_CREDENTIALS_READONLY=1` — set on a second instance that shares another's credentials) refuses **before** opening the sign-in tab, and names where the login can be completed instead. Refusing after sign-in would have burned a one-time code for nothing.
+
+#### From the web UI: add a profile
+
+A new Claude account can be added from the Profiles page without a shell on the Meridian host. Under **Add a profile**, type a name and click **Add profile**:
+
+1. Meridian validates the name, refuses it if anything is wrong, then mints the PKCE login and opens Claude's sign-in in a new tab.
+2. Sign in to the Claude account this profile should use. Claude shows you a code.
+3. Paste it back — the **bare code** or the **whole callback URL**, exactly as for a re-login.
+
+The profile appears in the list, with its own config directory under `~/.config/meridian/profiles/<name>/`, ready to use with no restart.
+
+```bash
+# → {"addId":"…","authorizeUrl":"https://claude.com/cai/oauth/authorize?…","expiresAt":…,"profile":"work"}
+curl -X POST http://127.0.0.1:3456/profiles/add/start \
+  -H 'Content-Type: application/json' -d '{"profile":"work"}'
+
+# `code` accepts the bare code or the full callback URL
+curl -X POST http://127.0.0.1:3456/profiles/add/complete \
+  -H 'Content-Type: application/json' -d '{"addId":"…","code":"…"}'
+```
+
+**Nothing is written until the credentials are in hand.** The exchange with Anthropic happens first; the `profiles.json` entry is written only once it succeeds. A sign-in that is abandoned, rejected or never finished therefore leaves no profile behind at all — there is no half-made account slot stuck at "not logged in" to notice and clean up. Just add it again with the same name.
+
+**Who can do this.** These routes inherit `/profiles/*`'s `requireAuth`, so they are behind `MERIDIAN_API_KEY` **when that key is set**. When it is not set — the default — the only thing standing between this page and a new profile is whatever reaches the port: bind Meridian to loopback, or to a private network you trust. Adding a profile is the most privileged thing the Profiles page does, so treat an unauthenticated instance on a shared network accordingly. There is deliberately no delete, rename or edit here; removal stays `meridian profile remove <name>` on the host.
+
+Details worth knowing:
+
+- Names may use only letters, numbers, hyphens and underscores. The name becomes a directory, and the check is the same one `meridian profile add` applies.
+- An existing name is refused and points you at **Log in from browser** on that profile's card — re-authenticating an account is what that button is for.
+- One open sign-in per name at a time, so two people cannot both be part-way through creating the same one. Starting another for the same name **replaces** the first rather than being refused — cancelling the panel, reloading the page and closing the tab all abandon a sign-in without telling the server, and a name you could not retry until the 10-minute expiry would be worse than the race it prevents. Only the most recently started sign-in can be completed.
+- `MERIDIAN_CREDENTIALS_READONLY=1` refuses **before** the sign-in tab opens, and names `meridian profile add <name>` as the alternative.
+- Only **claude-max** profiles are created this way. `api` and `oauth-token` profiles are CLI-only — neither has an OAuth flow to drive from a page.
+- **The `~/.claude` import offer is CLI-only.** `meridian profile add` on a host whose default config dir is already signed in offers to adopt those credentials as the new profile. The UI never does: clicking **Add profile** always signs in fresh. Silently claiming the account you happen to be logged in as on that machine is not something a button press should be able to do.
 
 #### Headless / CI: register an OAuth token
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,6 +31,53 @@ Open the printed URL in a browser, sign in to the target Claude account, then pa
 meridian profile login work --headless
 ```
 
+#### From the web UI: re-authenticate a profile without a terminal
+
+A profile whose credentials expired can be logged in again from the Profiles page, with no shell on the Meridian host. Click **Log in from browser** on the profile's card, sign in to that profile's Claude account, and you are done — Claude sends you back to Meridian, which finishes the login and updates the card. There is nothing to copy and paste.
+
+**It is an ordinary link, and that is deliberate.** If you are signed into several Claude accounts, the session your main browser offers is often the wrong one for the profile you are re-authenticating. Because the control is a real `<a href>` carrying the authorize URL, the browser's own context menu applies: **Open Link in Incognito Window**, **Open Link in New Private Window**, or **Copy Link Address** to paste into a different browser or browser profile. The login still lands on the profile it was started for — the PKCE verifier and `state` live on the server, keyed by `state`, so the browser that finishes the sign-in does not have to be the one that started it, and the page you started from notices and updates itself. Nothing secret is in the link: the authorize URL is public by design, and the verifier never leaves the server.
+
+That works whenever the **browser** is on the machine Meridian runs on — including through an SSH port-forward, and including when you reached the UI by some other name such as a LAN or tailnet hostname. What matters is the browser's position, not the URL in its address bar, so the page settles it by measurement: before opening the sign-in tab it asks the browser to reach Meridian on loopback, and takes the redirect flow only if that answers.
+
+A browser on a *different* machine cannot reach it, the check fails in under two seconds, and the panel asks for the code instead. Either form is accepted: the **bare code** Claude shows you, or the **whole callback URL** from the address bar (`https://platform.claude.com/oauth/code/callback?code=…&state=…`), which is usually easier to copy. The redirect flow also offers **Paste a code instead** as a manual fallback, which does not restart anything — both sign-in URLs belong to the same login.
+
+**Why the browser sometimes has to be on the same host.** Anthropic publishes the Claude Code client's registration at [`https://claude.ai/oauth/claude-code-client-metadata`](https://claude.ai/oauth/claude-code-client-metadata), and it declares exactly three ways back:
+
+```json
+"redirect_uris": ["http://localhost/callback", "http://127.0.0.1/callback"]
+```
+
+plus the hosted code-display page, `https://platform.claude.com/oauth/code/callback`. The loopback pair is the [RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3) convention, where the port is not part of the match — which is why Meridian can use whichever port you reached it on. A redirect URI belonging to *your* hostname cannot be added to Anthropic's registration, so it would be rejected at the authorize step; the paste flow is what remains for that case.
+
+For scripting, the same login is three routes:
+
+```bash
+# mode is "redirect" when the Host you call with is a loopback address, else "paste".
+# In "paste" mode the reply also carries loopbackAuthorizeUrl + loopbackProbeUrl:
+# fetch the probe, and if it answers {"status":"waiting"} you can use the
+# loopback URL after all — that is exactly what the web UI does.
+# → {"loginId":"…","mode":"redirect","authorizeUrl":"…","pasteAuthorizeUrl":"…","expiresAt":…,"profile":"work"}
+curl -X POST http://127.0.0.1:3456/profiles/login/start \
+  -H 'Content-Type: application/json' -d '{"profile":"work"}'
+
+# → {"status":"waiting"|"completed"|"failed", "profileId":"work", …}
+curl 'http://127.0.0.1:3456/profiles/login/status?loginId=…'
+
+# only needed for the paste path; `code` accepts the bare code or the full callback URL
+curl -X POST http://127.0.0.1:3456/profiles/login/complete \
+  -H 'Content-Type: application/json' -d '{"loginId":"…","code":"…"}'
+```
+
+Details worth knowing:
+
+- The PKCE verifier never leaves the server. The browser only ever holds an opaque login id.
+- The loopback check the page runs is that login's own `/profiles/login/status` URL, so a reply proves both that the browser can reach loopback *and* that what answered is the instance holding this login. Anything else listening on the port answers 410 and the paste flow stands.
+- A login is **single-use** and expires **10 minutes** after it starts. `state` must match the login it was started with, exactly as the CLI requires; on the redirect path that `state` is what identifies the login at all.
+- `GET /callback` is deliberately **not** behind `MERIDIAN_API_KEY` — Anthropic's redirect carries no key. It acts only on an unguessable, single-use `state` minted by `/profiles/login/start`, which *is* gated, and answers 410 to anything else.
+- Only **claude-max** profiles have this flow. `api` and `oauth-token` profiles are refused with the reason — replace an OAuth token with `meridian profile remove <name> && meridian profile add <name> --oauth-token`.
+- An unknown profile name is refused, not created. `meridian profile add` remains the only way a profile comes into existence.
+- An instance told not to write credential files (`MERIDIAN_CREDENTIALS_READONLY=1` — set on a second instance that shares another's credentials) refuses **before** opening the sign-in tab, and names where the login can be completed instead. Refusing after sign-in would have burned a one-time code for nothing.
+
 #### Headless / CI: register an OAuth token
 
 When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:

--- a/src/__tests__/profile-add-route.test.ts
+++ b/src/__tests__/profile-add-route.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { resetPendingAdds } from "../proxy/profileAdd"
+import type { ProfileConfig } from "../proxy/profiles"
+import { createProxyServer } from "../proxy/server"
+import { stopBackgroundRefresh } from "../proxy/tokenRefresh"
+
+const TOKEN_RESPONSE = {
+  access_token: "add-route-access-token",
+  refresh_token: "add-route-refresh-token",
+  expires_in: 3600,
+}
+
+// Credential writes are Keychain-backed on darwin; the paths that actually
+// persist are Linux/Windows only, as in profile-login-route.test.ts.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profile add routes", () => {
+  let originalFetch: typeof globalThis.fetch
+  let configDir: string
+  let savedConfigDir: string | undefined
+  let app: ReturnType<typeof createProxyServer>["app"]
+
+  function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+    return app.fetch(new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }))
+  }
+
+  async function startAdd(profile: string): Promise<{ addId: string; state: string }> {
+    const res = await post("/profiles/add/start", { profile })
+    if (res.status !== 200) throw new Error(`start failed with ${res.status}`)
+    const body = await res.json() as { addId: string; authorizeUrl: string }
+    const state = new URL(body.authorizeUrl).searchParams.get("state")
+    if (!state) throw new Error("authorize URL carried no state")
+    return { addId: body.addId, state }
+  }
+
+  function profilesJson(): ProfileConfig[] {
+    return JSON.parse(readFileSync(join(configDir, "profiles.json"), "utf-8")) as ProfileConfig[]
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    // Redirected so a route test can never write the real profiles.json.
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    configDir = mkdtempSync(join(tmpdir(), "meridian-add-route-"))
+    process.env.MERIDIAN_CONFIG_DIR = configDir
+    mkdirSync(join(configDir, "profiles", "personal"), { recursive: true })
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+
+    app = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [{ id: "personal", claudeConfigDir: join(configDir, "profiles", "personal") }],
+      defaultProfile: "personal",
+      silent: true,
+    }).app
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    stopBackgroundRefresh()
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
+    rmSync(configDir, { recursive: true, force: true })
+  })
+
+  function stubTokenEndpoint(makeResponse: () => Response) {
+    const requests: Array<Record<string, unknown>> = []
+    globalThis.fetch = Object.assign(
+      async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>)
+        return makeResponse()
+      },
+      { preconnect: originalFetch.preconnect },
+    )
+    return requests
+  }
+
+  function stubOkToken() {
+    return stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+  }
+
+  it("starts a creation and returns an authorize URL without the PKCE verifier", async () => {
+    const res = await post("/profiles/add/start", { profile: "work" })
+    expect(res.status).toBe(200)
+
+    const raw = await res.text()
+    expect(raw).not.toContain("codeVerifier")
+    expect(raw).not.toContain("code_verifier")
+
+    const body = JSON.parse(raw) as { addId: string; authorizeUrl: string; expiresAt: number; profile: string }
+    expect(body.profile).toBe("work")
+    expect(body.addId).toBeTruthy()
+    expect(body.expiresAt).toBeGreaterThan(Date.now())
+    expect(new URL(body.authorizeUrl).searchParams.get("code_challenge")).toBeTruthy()
+
+    // Starting is not creating: nothing exists until a code comes back.
+    expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+  })
+
+  it("refuses to start on an instance that must not write credentials", async () => {
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    const res = await post("/profiles/add/start", { profile: "work" })
+    expect(res.status).toBe(409)
+
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe("credentials_readonly")
+    expect(body.error).toContain("MERIDIAN_CREDENTIALS_READONLY")
+    expect(body.error).toContain("meridian profile add work")
+  })
+
+  it("400s a name that would escape the profiles directory", async () => {
+    const res = await post("/profiles/add/start", { profile: "../../etc" })
+    expect(res.status).toBe(400)
+    expect((await res.json() as { code: string }).code).toBe("invalid_profile_id")
+  })
+
+  it("409s an existing name and sends the user to the login button instead", async () => {
+    const res = await post("/profiles/add/start", { profile: "personal" })
+    expect(res.status).toBe(409)
+
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe("profile_exists")
+    expect(body.error).toContain("Log in from browser")
+  })
+
+  it("400s a missing name, malformed JSON, and a completion with no add id", async () => {
+    expect((await post("/profiles/add/start", {})).status).toBe(400)
+
+    const malformed = await app.fetch(new Request("http://localhost/profiles/add/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    }))
+    expect(malformed.status).toBe(400)
+
+    const noId = await post("/profiles/add/complete", { code: "abc123" })
+    expect(noId.status).toBe(400)
+    expect((await noId.json() as { code: string }).code).toBe("invalid_request")
+  })
+
+  it("410s an add id that was never issued", async () => {
+    const res = await post("/profiles/add/complete", { addId: "made-up", code: "abc123" })
+    expect(res.status).toBe(410)
+    expect((await res.json() as { code: string }).code).toBe("expired_add")
+  })
+
+  it.skipIf(skipOnDarwin)("creates the profile from a bare code", async () => {
+    const { addId } = await startAdd("work")
+    const requests = stubOkToken()
+
+    const res = await post("/profiles/add/complete", { addId, code: "abc123" })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ success: true, profile: "work" })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({ grant_type: "authorization_code", code: "abc123" })
+    expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: join(configDir, "profiles", "work") }])
+    expect(JSON.parse(readFileSync(join(configDir, "profiles", "work", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+      .toBe("add-route-access-token")
+  })
+
+  it.skipIf(skipOnDarwin)("creates the profile from the pasted callback URL", async () => {
+    const { addId, state } = await startAdd("work")
+    stubOkToken()
+
+    const res = await post("/profiles/add/complete", {
+      addId,
+      code: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+    })
+    expect(res.status).toBe(200)
+    expect(profilesJson().map(p => p.id)).toEqual(["work"])
+  })
+
+  it.skipIf(skipOnDarwin)("410s a replayed completion", async () => {
+    const { addId } = await startAdd("work")
+    const requests = stubOkToken()
+
+    expect((await post("/profiles/add/complete", { addId, code: "abc123" })).status).toBe(200)
+    expect((await post("/profiles/add/complete", { addId, code: "abc123" })).status).toBe(410)
+    expect(requests).toHaveLength(1)
+    expect(profilesJson()).toHaveLength(1)
+  })
+
+  it("400s a state that does not match, and never contacts the token endpoint", async () => {
+    const { addId } = await startAdd("work")
+    const requests = stubTokenEndpoint(() => new Response("{}", { status: 200 }))
+
+    const res = await post("/profiles/add/complete", {
+      addId,
+      code: "https://platform.claude.com/oauth/code/callback?code=abc123&state=someone-elses-state",
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ code: "state_mismatch", retryable: true })
+    expect(requests).toHaveLength(0)
+    expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+
+    // Nothing reached Anthropic, so the sign-in is still open for the right paste.
+    const retry = await post("/profiles/add/complete", { addId, code: "abc123" })
+    expect(retry.status).not.toBe(410)
+  })
+
+  it("502s an upstream rejection, leaves no profile, and does not leak the error body", async () => {
+    const { addId } = await startAdd("work")
+    stubTokenEndpoint(() => new Response(
+      JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    ))
+
+    const res = await post("/profiles/add/complete", { addId, code: "stale-code" })
+    expect(res.status).toBe(502)
+    const raw = await res.text()
+    expect(raw).toContain("exchange_failed")
+    expect(raw).not.toContain("retryable")
+    expect(raw).not.toContain("invalid_grant")
+    expect(raw).not.toContain("already redeemed")
+    expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+  })
+
+  // Both routes sit under the /profiles/* prefix, so they inherit requireAuth
+  // rather than needing their own registration — asserted rather than assumed.
+  it("requires the API key on both routes when one is configured", async () => {
+    process.env.MERIDIAN_API_KEY = "secret-key"
+
+    expect((await post("/profiles/add/start", { profile: "work" })).status).toBe(401)
+    expect((await post("/profiles/add/complete", { addId: "x", code: "y" })).status).toBe(401)
+
+    const authorized = await post("/profiles/add/start", { profile: "work" }, { "x-api-key": "secret-key" })
+    expect(authorized.status).toBe(200)
+  })
+
+  it("serves an Add profile affordance on the profiles page", async () => {
+    const res = await app.fetch(new Request("http://localhost/profiles"))
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("Add a profile")
+    expect(html).toContain("/profiles/add/start")
+    expect(html).toContain("/profiles/add/complete")
+  })
+})

--- a/src/__tests__/profile-add-unit.test.ts
+++ b/src/__tests__/profile-add-unit.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  completeProfileAdd,
+  pendingAddCount,
+  resetPendingAdds,
+  startProfileAdd,
+} from "../proxy/profileAdd"
+import { createProfileSlot, isValidProfileId, loadProfileIds } from "../proxy/profileCli"
+import { LOGIN_TTL_MS } from "../proxy/profileLogin"
+import type { ProfileConfig } from "../proxy/profiles"
+
+const TOKEN_RESPONSE = {
+  access_token: "web-add-access-token",
+  refresh_token: "web-add-refresh-token",
+  expires_in: 3600,
+  scope: "user:inference user:profile",
+}
+
+interface TokenRequest {
+  code?: string
+  state?: string
+  code_verifier?: string
+  grant_type?: string
+}
+
+function stubTokenFetch(makeResponse: () => Response) {
+  const requests: TokenRequest[] = []
+  const fetchFn: typeof fetch = Object.assign(
+    async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      requests.push(JSON.parse(String(init?.body ?? "{}")) as TokenRequest)
+      return makeResponse()
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+  return { fetchFn, requests }
+}
+
+function okTokenFetch() {
+  return stubTokenFetch(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }))
+}
+
+// Credential writes go to the Keychain on darwin, so every assertion that reads
+// a .credentials.json file is Linux/Windows only — same reason
+// profile-login-unit.test.ts skips there.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profileAdd", () => {
+  let configDir: string
+  let savedConfigDir: string | undefined
+  let profiles: ProfileConfig[]
+
+  function profilesJson(): ProfileConfig[] {
+    return JSON.parse(readFileSync(join(configDir, "profiles.json"), "utf-8")) as ProfileConfig[]
+  }
+
+  function writeProfilesJson(entries: ProfileConfig[]): void {
+    mkdirSync(join(configDir, "profiles"), { recursive: true })
+    writeFileSync(join(configDir, "profiles.json"), `${JSON.stringify(entries, null, 2)}\n`)
+  }
+
+  /** Start an add and hand back what a completion needs, or fail loudly. */
+  function start(id: string): { addId: string; state: string } {
+    const result = startProfileAdd({ profiles, profileId: id })
+    if (!result.ok) throw new Error(`expected a started add, got ${result.code}`)
+    const state = new URL(result.authorizeUrl).searchParams.get("state")
+    if (!state) throw new Error("authorize URL carried no state")
+    return { addId: result.addId, state }
+  }
+
+  beforeEach(() => {
+    // Redirected so nothing here can reach the real ~/.config/meridian —
+    // profiles.json is the file this feature writes, and a test that writes
+    // the developer's own is a test that creates a real account slot.
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    configDir = mkdtempSync(join(tmpdir(), "meridian-web-add-"))
+    process.env.MERIDIAN_CONFIG_DIR = configDir
+    profiles = [{ id: "personal", claudeConfigDir: join(configDir, "profiles", "personal") }]
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+  })
+
+  afterEach(() => {
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
+    rmSync(configDir, { recursive: true, force: true })
+  })
+
+  describe("isValidProfileId", () => {
+    it("accepts the character set a directory name can carry", () => {
+      for (const id of ["work", "work-2", "work_2", "Work2", "a"]) {
+        expect(isValidProfileId(id)).toBe(true)
+      }
+    })
+
+    it("rejects an empty id", () => {
+      expect(isValidProfileId("")).toBe(false)
+    })
+
+    // The reason this function exists: the id becomes a directory name.
+    it("rejects path traversal and separators", () => {
+      for (const id of ["../../etc", "..", ".", "a/b", "a\\b", "~", "/etc/passwd"]) {
+        expect(isValidProfileId(id)).toBe(false)
+      }
+    })
+
+    it("rejects spaces, dots and shell metacharacters", () => {
+      for (const id of ["my profile", "work.2", "a;b", "a$b", "a\u0000b"]) {
+        expect(isValidProfileId(id)).toBe(false)
+      }
+    })
+  })
+
+  describe("createProfileSlot", () => {
+    it("writes the profiles.json entry and the config directory together", () => {
+      const created = createProfileSlot("work")
+      if (!created.ok) throw new Error(`expected success, got ${created.reason}`)
+
+      expect(created.profile.id).toBe("work")
+      expect(created.profile.claudeConfigDir).toBe(join(configDir, "profiles", "work"))
+      expect(existsSync(join(configDir, "profiles", "work"))).toBe(true)
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: join(configDir, "profiles", "work") }])
+    })
+
+    it("appends rather than replacing what is already there", () => {
+      createProfileSlot("work")
+      createProfileSlot("personal")
+      expect(loadProfileIds()).toEqual(["work", "personal"])
+    })
+
+    it("refuses an invalid id without creating anything", () => {
+      const created = createProfileSlot("../escape")
+      expect(created).toMatchObject({ ok: false, reason: "invalid_id" })
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+    })
+
+    it("refuses a collision", () => {
+      writeProfilesJson([{ id: "work", claudeConfigDir: "/somewhere/else" }])
+      const created = createProfileSlot("work")
+      expect(created).toMatchObject({ ok: false, reason: "already_exists" })
+      // The existing entry is untouched — a refusal must not rewrite it.
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: "/somewhere/else" }])
+    })
+
+    it("adopts an explicit config dir — the CLI's ~/.claude import", () => {
+      const existing = join(configDir, "dot-claude")
+      mkdirSync(existing, { recursive: true })
+      const created = createProfileSlot("imported", { claudeConfigDir: existing })
+      if (!created.ok) throw new Error(`expected success, got ${created.reason}`)
+      expect(created.profile.claudeConfigDir).toBe(existing)
+      expect(existsSync(join(configDir, "profiles", "imported"))).toBe(false)
+    })
+  })
+
+  describe("startProfileAdd", () => {
+    it("returns an authorize URL and an opaque id, and never the PKCE verifier", () => {
+      const result = startProfileAdd({ profiles, profileId: "work" })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.profileId).toBe("work")
+      expect(result.addId.length).toBeGreaterThan(16)
+      expect(result.expiresAt).toBeGreaterThan(Date.now())
+
+      const url = new URL(result.authorizeUrl)
+      expect(url.origin + url.pathname).toBe("https://claude.com/cai/oauth/authorize")
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+      expect(url.searchParams.get("code_challenge")).toBeTruthy()
+      expect(url.searchParams.get("redirect_uri")).toBe("https://platform.claude.com/oauth/code/callback")
+
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain("codeVerifier")
+      expect(serialized).not.toContain("code_verifier")
+    })
+
+    // The slot appearing only after a successful exchange is the whole answer
+    // to "what happens if OAuth fails" — so nothing may exist yet at this point.
+    it("writes nothing to disk", () => {
+      startProfileAdd({ profiles, profileId: "work" })
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+      expect(existsSync(join(configDir, "profiles", "work"))).toBe(false)
+      expect(pendingAddCount()).toBe(1)
+    })
+
+    it("refuses an empty name", () => {
+      expect(startProfileAdd({ profiles, profileId: "   " }))
+        .toMatchObject({ ok: false, code: "invalid_request", status: 400 })
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    it("refuses an id that would escape the profiles directory", () => {
+      const result = startProfileAdd({ profiles, profileId: "../../etc" })
+      expect(result).toMatchObject({ ok: false, code: "invalid_profile_id", status: 400 })
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    it("refuses a name the running instance already serves, and points at the login button", () => {
+      const result = startProfileAdd({ profiles, profileId: "personal" })
+      expect(result).toMatchObject({ ok: false, code: "profile_exists", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("Log in from browser")
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    // Disk discovery is off in tests, so an instance configured from
+    // MERIDIAN_PROFILES would not see this one in its effective list — the
+    // profiles.json read is what stops the write landing on top of it.
+    it("refuses a name already written to profiles.json but not served", () => {
+      writeProfilesJson([{ id: "onlyondisk", claudeConfigDir: join(configDir, "profiles", "onlyondisk") }])
+      expect(startProfileAdd({ profiles, profileId: "onlyondisk" }))
+        .toMatchObject({ ok: false, code: "profile_exists", status: 409 })
+    })
+
+    it("refuses on an instance that must not write credential files, before minting anything", () => {
+      process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+      const result = startProfileAdd({ profiles, profileId: "work" })
+      expect(result).toMatchObject({ ok: false, code: "credentials_readonly", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("MERIDIAN_CREDENTIALS_READONLY")
+      expect(result.message).toContain("meridian profile add work")
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    // Found in browser QA: cancelling the panel, reloading the page and closing
+    // the tab all abandon a sign-in without telling the server, so refusing a
+    // second start locked the name out for the whole TTL with nothing the user
+    // could do to release it.
+    it("supersedes an abandoned sign-in for the same name rather than locking the name out", async () => {
+      const first = startProfileAdd({ profiles, profileId: "work" })
+      if (!first.ok) throw new Error("expected success")
+
+      const second = startProfileAdd({ profiles, profileId: "work" })
+      if (!second.ok) throw new Error(`expected the retry to be allowed, got ${second.code}`)
+      expect(second.addId).not.toBe(first.addId)
+      // Still one entry per name — that is what stops two sign-ins for one new
+      // name from both completing.
+      expect(pendingAddCount()).toBe(1)
+
+      // The superseded one is dead, and says so without contacting Anthropic.
+      const stale = await completeProfileAdd({ addId: first.addId, input: "abc123" })
+      expect(stale).toMatchObject({ ok: false, code: "expired_add" })
+    })
+
+    it("allows concurrent sign-ins for different names", () => {
+      start("work")
+      start("side")
+      expect(pendingAddCount()).toBe(2)
+    })
+
+    it("frees the name again once the pending add has expired", () => {
+      const first = startProfileAdd({ profiles, profileId: "work" })
+      if (!first.ok) throw new Error("expected success")
+      const later = startProfileAdd({ profiles, profileId: "work", now: Date.now() + LOGIN_TTL_MS + 1 })
+      expect(later.ok).toBe(true)
+    })
+  })
+
+  describe("completeProfileAdd", () => {
+    it("410s an id that was never issued", async () => {
+      const result = await completeProfileAdd({ addId: "made-up", input: "abc123" })
+      expect(result).toMatchObject({ ok: false, code: "expired_add", status: 410 })
+    })
+
+    it("410s an expired sign-in", async () => {
+      const { addId } = start("work")
+      const result = await completeProfileAdd({ addId, input: "abc123", now: Date.now() + LOGIN_TTL_MS + 1 })
+      expect(result).toMatchObject({ ok: false, code: "expired_add", status: 410 })
+    })
+
+    it("keeps the sign-in open when the paste holds no code", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({ addId, input: "   ", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "no_code", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      expect(pendingAddCount()).toBe(1)
+    })
+
+    it("keeps the sign-in open on a state mismatch, and never contacts Anthropic", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({
+        addId,
+        input: "https://platform.claude.com/oauth/code/callback?code=abc123&state=another-tabs-state",
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "state_mismatch", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      expect(pendingAddCount()).toBe(1)
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+    })
+
+    it.skipIf(skipOnDarwin)("creates the profile from a bare code", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({ addId, input: "abc123", fetchFn })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.profileId).toBe("work")
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({ grant_type: "authorization_code", code: "abc123" })
+
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: join(configDir, "profiles", "work") }])
+      const stored = JSON.parse(readFileSync(join(result.claudeConfigDir, ".credentials.json"), "utf-8"))
+      expect(stored.claudeAiOauth.accessToken).toBe("web-add-access-token")
+      expect(stored.claudeAiOauth.refreshToken).toBe("web-add-refresh-token")
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    it.skipIf(skipOnDarwin)("creates the profile from the whole pasted callback URL", async () => {
+      const { addId, state } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({
+        addId,
+        input: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+        fetchFn,
+      })
+      expect(result.ok).toBe(true)
+      expect(requests[0]).toMatchObject({ code: "url-code", state })
+      expect(loadProfileIds()).toEqual(["work"])
+    })
+
+    it.skipIf(skipOnDarwin)("is single use", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      expect((await completeProfileAdd({ addId, input: "abc123", fetchFn })).ok).toBe(true)
+      expect(await completeProfileAdd({ addId, input: "abc123", fetchFn }))
+        .toMatchObject({ ok: false, code: "expired_add", status: 410 })
+      expect(requests).toHaveLength(1)
+    })
+
+    // The judgement call this flow had to make: a failed exchange leaves no
+    // profile at all, rather than a slot that shows as permanently logged out.
+    it("leaves no profile behind when Anthropic rejects the code", async () => {
+      const { addId } = start("work")
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ))
+
+      const result = await completeProfileAdd({ addId, input: "stale-code", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+      if (result.ok) throw new Error("expected refusal")
+
+      // Neither half of a profile exists, and the upstream body is not echoed.
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+      expect(result.message).not.toContain("invalid_grant")
+      expect(result.message).not.toContain("already redeemed")
+      expect(result.retryable).toBeUndefined()
+    })
+
+    it("frees the name for another attempt after a failed exchange", async () => {
+      const { addId } = start("work")
+      const { fetchFn } = stubTokenFetch(() => new Response("nope", { status: 500 }))
+
+      await completeProfileAdd({ addId, input: "stale-code", fetchFn })
+      expect(pendingAddCount()).toBe(0)
+      expect(startProfileAdd({ profiles, profileId: "work" }).ok).toBe(true)
+    })
+
+    it("reports the network reaching Anthropic failing without claiming a profile exists", async () => {
+      const { addId } = start("work")
+      const fetchFn: typeof fetch = Object.assign(
+        async () => { throw new Error("ECONNREFUSED") },
+        { preconnect: globalThis.fetch.preconnect },
+      )
+
+      const result = await completeProfileAdd({ addId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+    })
+
+    // Nothing holds the name on disk during the sign-in, so the CLI (or another
+    // instance) can take it in the meantime. Said plainly rather than reported
+    // as success — the credentials just authorized went into that directory.
+    it.skipIf(skipOnDarwin)("refuses when the name was taken during the sign-in", async () => {
+      const { addId } = start("work")
+      const { fetchFn } = okTokenFetch()
+      writeProfilesJson([{ id: "work", claudeConfigDir: "/somebody/elses/dir" }])
+
+      const result = await completeProfileAdd({ addId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "profile_exists", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("created elsewhere")
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: "/somebody/elses/dir" }])
+    })
+  })
+})

--- a/src/__tests__/profile-login-route.test.ts
+++ b/src/__tests__/profile-login-route.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { resetPendingLogins } from "../proxy/profileLogin"
+import { resetDiskProfileDiscovery } from "../proxy/profiles"
+import { createProxyServer } from "../proxy/server"
+import { stopBackgroundRefresh } from "../proxy/tokenRefresh"
+
+const TOKEN_RESPONSE = {
+  access_token: "route-access-token",
+  refresh_token: "route-refresh-token",
+  expires_in: 3600,
+}
+
+// Credential writes are Keychain-backed on darwin; the paths that actually
+// persist are Linux/Windows only here, as in profile-token-refresh-route.test.ts.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profile login routes", () => {
+  let originalFetch: typeof globalThis.fetch
+  let tempDir: string
+  let app: ReturnType<typeof createProxyServer>["app"]
+
+  function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+    return app.fetch(new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }))
+  }
+
+  function get(path: string, headers: Record<string, string> = {}) {
+    return app.fetch(new Request(`http://localhost${path}`, { headers }))
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    tempDir = mkdtempSync(join(tmpdir(), "meridian-login-route-"))
+    mkdirSync(join(tempDir, "personal"), { recursive: true })
+    resetPendingLogins()
+    // The server is built with an explicit profile list; keep disk discovery
+    // out of it so an earlier file in the same process cannot merge the host's
+    // real profiles.json into these assertions.
+    resetDiskProfileDiscovery()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+
+    app = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [
+        { id: "personal", claudeConfigDir: join(tempDir, "personal") },
+        { id: "direct", type: "api", apiKey: "sk-ant-api-test" },
+      ],
+      defaultProfile: "personal",
+      silent: true,
+    }).app
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    stopBackgroundRefresh()
+    resetPendingLogins()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function stubTokenEndpoint(makeResponse: () => Response) {
+    const requests: Array<Record<string, unknown>> = []
+    globalThis.fetch = Object.assign(
+      async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>)
+        return makeResponse()
+      },
+      { preconnect: originalFetch.preconnect },
+    )
+    return requests
+  }
+
+  it("starts a login and returns an authorize URL without the PKCE verifier", async () => {
+    const res = await post("/profiles/login/start", { profile: "personal" })
+    expect(res.status).toBe(200)
+
+    const raw = await res.text()
+    expect(raw).not.toContain("codeVerifier")
+    expect(raw).not.toContain("code_verifier")
+
+    const body = JSON.parse(raw) as { loginId: string; authorizeUrl: string; expiresAt: number; profile: string }
+    expect(body.profile).toBe("personal")
+    expect(body.loginId).toBeTruthy()
+    expect(body.expiresAt).toBeGreaterThan(Date.now())
+    expect(new URL(body.authorizeUrl).searchParams.get("code_challenge")).toBeTruthy()
+  })
+
+  it("refuses to start on an instance that must not write credentials", async () => {
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    const res = await post("/profiles/login/start", { profile: "personal" })
+    expect(res.status).toBe(409)
+
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe("credentials_readonly")
+    expect(body.error).toContain("MERIDIAN_CREDENTIALS_READONLY")
+    expect(body.error).toContain("meridian profile login personal")
+  })
+
+  it("404s an unknown profile and 400s a profile type with no OAuth flow", async () => {
+    const unknown = await post("/profiles/login/start", { profile: "ghost" })
+    expect(unknown.status).toBe(404)
+    expect((await unknown.json() as { code: string }).code).toBe("unknown_profile")
+
+    const apiProfile = await post("/profiles/login/start", { profile: "direct" })
+    expect(apiProfile.status).toBe(400)
+    expect((await apiProfile.json() as { code: string }).code).toBe("unsupported_profile_type")
+  })
+
+  it("400s a missing profile, malformed JSON, and a completion with no login id", async () => {
+    expect((await post("/profiles/login/start", {})).status).toBe(400)
+
+    const malformed = await app.fetch(new Request("http://localhost/profiles/login/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    }))
+    expect(malformed.status).toBe(400)
+
+    const noId = await post("/profiles/login/complete", { code: "abc123" })
+    expect(noId.status).toBe(400)
+    expect((await noId.json() as { code: string }).code).toBe("invalid_request")
+  })
+
+  it("410s a login id that was never issued", async () => {
+    const res = await post("/profiles/login/complete", { loginId: "made-up", code: "abc123" })
+    expect(res.status).toBe(410)
+    expect((await res.json() as { code: string }).code).toBe("expired_login")
+  })
+
+  it.skipIf(skipOnDarwin)("completes a login from a bare code and writes the profile's credentials", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    const requests = stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    const res = await post("/profiles/login/complete", { loginId, code: "abc123" })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ success: true, profile: "personal" })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({ grant_type: "authorization_code", code: "abc123" })
+    expect(JSON.parse(readFileSync(join(tempDir, "personal", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+      .toBe("route-access-token")
+  })
+
+  it.skipIf(skipOnDarwin)("completes a login from the pasted callback URL", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId, authorizeUrl } = await started.json() as { loginId: string; authorizeUrl: string }
+    const state = new URL(authorizeUrl).searchParams.get("state")
+
+    stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    const res = await post("/profiles/login/complete", {
+      loginId,
+      code: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+    })
+    expect(res.status).toBe(200)
+    expect(JSON.parse(readFileSync(join(tempDir, "personal", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+      .toBe("route-access-token")
+  })
+
+  it.skipIf(skipOnDarwin)("410s a replayed completion", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    const requests = stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    expect((await post("/profiles/login/complete", { loginId, code: "abc123" })).status).toBe(200)
+    expect((await post("/profiles/login/complete", { loginId, code: "abc123" })).status).toBe(410)
+    expect(requests).toHaveLength(1)
+  })
+
+  it("400s a state that does not match, and never contacts the token endpoint", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    const requests = stubTokenEndpoint(() => new Response("{}", { status: 200 }))
+
+    const res = await post("/profiles/login/complete", {
+      loginId,
+      code: "https://platform.claude.com/oauth/code/callback?code=abc123&state=someone-elses-state",
+    })
+    expect(res.status).toBe(400)
+    // `retryable` is what tells the page to keep its paste box open rather than
+    // sending the user back through sign-in.
+    expect(await res.json()).toMatchObject({ code: "state_mismatch", retryable: true })
+    expect(requests).toHaveLength(0)
+    expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+
+    // Nothing reached Anthropic, so the login is still open for the right paste.
+    const retry = await post("/profiles/login/complete", { loginId, code: "abc123" })
+    expect(retry.status).not.toBe(410)
+  })
+
+  it("502s an upstream rejection without leaking the token endpoint's body", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    stubTokenEndpoint(() => new Response(
+      JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    ))
+
+    const res = await post("/profiles/login/complete", { loginId, code: "stale-code" })
+    expect(res.status).toBe(502)
+    const raw = await res.text()
+    expect(raw).toContain("exchange_failed")
+    expect(raw).not.toContain("retryable")
+    expect(raw).not.toContain("invalid_grant")
+    expect(raw).not.toContain("already redeemed")
+  })
+
+  // The three /profiles/* routes inherit requireAuth from the prefix rather
+  // than registering it themselves — asserted rather than assumed. /callback
+  // deliberately does not; see the next test.
+  it("requires the API key on the profile-scoped routes when one is configured", async () => {
+    process.env.MERIDIAN_API_KEY = "secret-key"
+
+    expect((await post("/profiles/login/start", { profile: "personal" })).status).toBe(401)
+    expect((await post("/profiles/login/complete", { loginId: "x", code: "y" })).status).toBe(401)
+    expect((await get("/profiles/login/status?loginId=x")).status).toBe(401)
+
+    const authorized = await post("/profiles/login/start", { profile: "personal" }, { "x-api-key": "secret-key" })
+    expect(authorized.status).toBe(200)
+  })
+
+  it("leaves /callback reachable without the API key, because Anthropic's redirect carries none", async () => {
+    process.env.MERIDIAN_API_KEY = "secret-key"
+
+    const res = await get("/callback?state=nothing-is-waiting&code=x")
+    // Refused on its merits (no such login), NOT on auth.
+    expect(res.status).toBe(410)
+    expect(res.headers.get("content-type")).toContain("text/html")
+  })
+
+  describe("browser redirect flow", () => {
+    it("offers a loopback redirect to a browser on this host, and a paste to any other", async () => {
+      const local = await post("/profiles/login/start", { profile: "personal" }, { host: "127.0.0.1:3457" })
+      const localBody = await local.json() as { mode: string; authorizeUrl: string; pasteAuthorizeUrl: string }
+      expect(localBody.mode).toBe("redirect")
+      expect(new URL(localBody.authorizeUrl).searchParams.get("redirect_uri")).toBe("http://127.0.0.1:3457/callback")
+      expect(new URL(localBody.pasteAuthorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("https://platform.claude.com/oauth/code/callback")
+
+      const remote = await post("/profiles/login/start", { profile: "personal" }, { host: "meridian.example.com" })
+      const remoteBody = await remote.json() as { mode: string; authorizeUrl: string; pasteAuthorizeUrl: string }
+      expect(remoteBody.mode).toBe("paste")
+      expect(remoteBody.authorizeUrl).toBe(remoteBody.pasteAuthorizeUrl)
+    })
+
+    it.skipIf(skipOnDarwin)("completes a login presented by a client that never initiated it", async () => {
+      // The point of putting a real URL in an href: the sign-in can be finished
+      // in an incognito window, or another browser entirely, which shares no
+      // cookies, no storage and no script with the page that started it. That
+      // works only because the verifier and `state` are held server-side and
+      // keyed by `state` alone — so this pins it.
+      const started = await post("/profiles/login/start", { profile: "personal" }, {
+        host: "127.0.0.1:3457",
+        cookie: "meridian-ui=originating-browser",
+        "user-agent": "OriginatingBrowser/1.0",
+      })
+      const { loginId, loopbackAuthorizeUrl } = await started.json() as {
+        loginId: string
+        loopbackAuthorizeUrl: string
+      }
+      const state = new URL(loopbackAuthorizeUrl).searchParams.get("state") ?? ""
+
+      const requests = stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }))
+
+      const res = await app.fetch(new Request(`http://localhost/callback?state=${state}&code=from-another-browser`, {
+        headers: { "user-agent": "PrivateWindow/2.0", host: "127.0.0.1:3457" },
+      }))
+      expect(res.status).toBe(200)
+      expect(requests).toHaveLength(1)
+      expect(JSON.parse(readFileSync(join(tempDir, "personal", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+        .toBe(TOKEN_RESPONSE.access_token)
+
+      // …and the page that started it learns the outcome, having done nothing.
+      const status = await get(`/profiles/login/status?loginId=${loginId}`)
+      expect(await status.json()).toMatchObject({ status: "completed", profileId: "personal" })
+    })
+
+    it("hands a browser under another name the loopback candidate and a probe for it", async () => {
+      // A configured port is what makes the candidate expressible; the other
+      // tests run on port 0, where there is no address to offer.
+      const ported = createProxyServer({
+        port: 3999,
+        host: "127.0.0.1",
+        profiles: [{ id: "personal", claudeConfigDir: join(tempDir, "personal") }],
+        defaultProfile: "personal",
+        silent: true,
+      }).app
+
+      const res = await ported.fetch(new Request("http://localhost/profiles/login/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", host: "meridian-dev.desktop.ts.nowaker.net" },
+        body: JSON.stringify({ profile: "personal" }),
+      }))
+      const body = await res.json() as {
+        mode: string
+        loginId: string
+        authorizeUrl: string
+        pasteAuthorizeUrl: string
+        loopbackAuthorizeUrl?: string
+        loopbackProbeUrl?: string
+      }
+
+      expect(body.mode).toBe("paste")
+      expect(body.authorizeUrl).toBe(body.pasteAuthorizeUrl)
+      expect(new URL(body.loopbackAuthorizeUrl ?? "").searchParams.get("redirect_uri"))
+        .toBe("http://127.0.0.1:3999/callback")
+      // The probe is this login's own status URL on the loopback origin, so a
+      // 200 from it proves the responder is this very instance.
+      expect(body.loopbackProbeUrl)
+        .toBe(`http://127.0.0.1:3999/profiles/login/status?loginId=${encodeURIComponent(body.loginId)}`)
+    })
+
+    it.skipIf(skipOnDarwin)("completes the login when Claude redirects back, and says so on the page", async () => {
+      const started = await post("/profiles/login/start", { profile: "personal" }, { host: "127.0.0.1:3457" })
+      const { loginId, authorizeUrl } = await started.json() as { loginId: string; authorizeUrl: string }
+      const state = new URL(authorizeUrl).searchParams.get("state") ?? ""
+
+      const requests = stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }))
+
+      const res = await get(`/callback?code=redirect-code&state=${encodeURIComponent(state)}`)
+      expect(res.status).toBe(200)
+      const html = await res.text()
+      expect(html).toContain("Signed in")
+      expect(html).toContain("personal")
+      // The one-time code must not survive into the rendered page.
+      expect(html).not.toContain("redirect-code")
+
+      expect(requests[0]).toMatchObject({ redirect_uri: "http://127.0.0.1:3457/callback" })
+      expect(JSON.parse(readFileSync(join(tempDir, "personal", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+        .toBe("route-access-token")
+
+      const status = await get(`/profiles/login/status?loginId=${encodeURIComponent(loginId)}`)
+      expect(status.status).toBe(200)
+      expect(await status.json()).toEqual({ status: "completed", profileId: "personal" })
+    })
+
+    it("renders an error page, not a success one, when the redirect brings a refusal", async () => {
+      const started = await post("/profiles/login/start", { profile: "personal" }, { host: "127.0.0.1:3457" })
+      const { loginId, authorizeUrl } = await started.json() as { loginId: string; authorizeUrl: string }
+      const state = new URL(authorizeUrl).searchParams.get("state") ?? ""
+
+      const requests = stubTokenEndpoint(() => new Response("{}", { status: 200 }))
+      const res = await get(`/callback?error=access_denied&state=${encodeURIComponent(state)}`)
+
+      expect(res.status).toBe(400)
+      expect(await res.text()).toContain("Login failed")
+      expect(requests).toHaveLength(0)
+
+      const status = await get(`/profiles/login/status?loginId=${encodeURIComponent(loginId)}`)
+      expect(await status.json()).toMatchObject({ status: "failed", code: "login_denied" })
+    })
+
+    it("reports a login still waiting, and 410s a status nobody is holding", async () => {
+      const started = await post("/profiles/login/start", { profile: "personal" }, { host: "127.0.0.1:3457" })
+      const { loginId } = await started.json() as { loginId: string }
+
+      const waiting = await get(`/profiles/login/status?loginId=${encodeURIComponent(loginId)}`)
+      expect(await waiting.json()).toEqual({ status: "waiting", profileId: "personal" })
+
+      const unknown = await get("/profiles/login/status?loginId=made-up")
+      expect(unknown.status).toBe(410)
+      expect((await unknown.json() as { code: string }).code).toBe("expired_login")
+
+      const missingParam = await get("/profiles/login/status")
+      expect(missingParam.status).toBe(400)
+      expect((await missingParam.json() as { code: string }).code).toBe("invalid_request")
+    })
+  })
+})

--- a/src/__tests__/profile-login-unit.test.ts
+++ b/src/__tests__/profile-login-unit.test.ts
@@ -1,0 +1,720 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  LOGIN_RESULT_TTL_MS,
+  LOGIN_TTL_MS,
+  completeProfileLogin,
+  completeProfileLoginFromCallback,
+  getProfileLoginStatus,
+  pendingLoginCount,
+  resetPendingLogins,
+  loopbackRedirectUriForPort,
+  resolveLoopbackRedirectUri,
+  startProfileLogin,
+} from "../proxy/profileLogin"
+import { resetDiskProfileDiscovery, type ProfileConfig } from "../proxy/profiles"
+
+const TOKEN_RESPONSE = {
+  access_token: "web-login-access-token",
+  refresh_token: "web-login-refresh-token",
+  expires_in: 3600,
+  scope: "user:inference user:profile",
+}
+
+interface TokenRequest {
+  code?: string
+  state?: string
+  code_verifier?: string
+  redirect_uri?: string
+  grant_type?: string
+}
+
+/** Records the token requests it is handed, so tests can assert what was sent
+ *  (and, for the failure paths, that nothing was sent at all). */
+function stubTokenFetch(makeResponse: () => Response) {
+  const requests: TokenRequest[] = []
+  const fetchFn: typeof fetch = Object.assign(
+    async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      requests.push(JSON.parse(String(init?.body ?? "{}")) as TokenRequest)
+      return makeResponse()
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+  return { fetchFn, requests }
+}
+
+function okTokenFetch() {
+  return stubTokenFetch(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }))
+}
+
+function credentialsAt(dir: string): { accessToken: string; refreshToken: string; scopes: string[] } {
+  return JSON.parse(readFileSync(join(dir, ".credentials.json"), "utf-8")).claudeAiOauth
+}
+
+// Credential writes go to the Keychain on darwin, so the assertions that read a
+// .credentials.json file (and any path that writes at all) are Linux/Windows
+// only — same reason profile-token-refresh-route.test.ts skips there.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profileLogin", () => {
+  let tempDir: string
+  let profiles: ProfileConfig[]
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "meridian-web-login-"))
+    mkdirSync(join(tempDir, "personal"), { recursive: true })
+    mkdirSync(join(tempDir, "work"), { recursive: true })
+    profiles = [
+      { id: "personal", claudeConfigDir: join(tempDir, "personal") },
+      { id: "work", claudeConfigDir: join(tempDir, "work") },
+      { id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-test" },
+      { id: "direct", type: "api", apiKey: "sk-ant-api-test" },
+    ]
+    resetPendingLogins()
+    // These cases pass an explicit profile list, so disk discovery must be off
+    // — otherwise a file that ran earlier in the same process (proxy-async-ops
+    // imports bin/cli.ts) has turned it on, and the host's real profiles.json
+    // merges into every assertion.
+    resetDiskProfileDiscovery()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+  })
+
+  afterEach(() => {
+    resetPendingLogins()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe("startProfileLogin", () => {
+    it("returns an authorize URL and an opaque login id, and never the PKCE verifier", () => {
+      const result = startProfileLogin({ profiles, profileId: "personal" })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.profileId).toBe("personal")
+      expect(result.loginId.length).toBeGreaterThan(16)
+      expect(result.expiresAt).toBeGreaterThan(Date.now())
+
+      const url = new URL(result.authorizeUrl)
+      expect(url.origin + url.pathname).toBe("https://claude.com/cai/oauth/authorize")
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+      expect(url.searchParams.get("code_challenge")).toBeTruthy()
+      expect(url.searchParams.get("state")).toBeTruthy()
+      expect(url.searchParams.get("redirect_uri")).toBe("https://platform.claude.com/oauth/code/callback")
+
+      // The whole point of the server-side map: neither half of the PKCE pair
+      // that the browser must not hold may appear in the response.
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain("codeVerifier")
+      expect(serialized).not.toContain("code_verifier")
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it("refuses an unknown profile instead of creating one", () => {
+      const result = startProfileLogin({ profiles, profileId: "nope" })
+      expect(result).toMatchObject({ ok: false, code: "unknown_profile", status: 404 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("personal")
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("refuses when no profiles are configured", () => {
+      const result = startProfileLogin({ profiles: [], profileId: "personal" })
+      expect(result).toMatchObject({ ok: false, code: "no_profiles", status: 400 })
+    })
+
+    it("refuses a blank profile id", () => {
+      const result = startProfileLogin({ profiles, profileId: "  " })
+      expect(result).toMatchObject({ ok: false, code: "invalid_request", status: 400 })
+    })
+
+    it("refuses an oauth-token profile and names the replacement path", () => {
+      const result = startProfileLogin({ profiles, profileId: "ci" })
+      expect(result).toMatchObject({ ok: false, code: "unsupported_profile_type", status: 400 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("oauth-token")
+      expect(result.message).toContain("--oauth-token")
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("refuses an api profile", () => {
+      const result = startProfileLogin({ profiles, profileId: "direct" })
+      expect(result).toMatchObject({ ok: false, code: "unsupported_profile_type", status: 400 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("api")
+    })
+
+    it("refuses on a read-only instance before any login is started", () => {
+      process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+      const result = startProfileLogin({ profiles, profileId: "personal" })
+      expect(result).toMatchObject({ ok: false, code: "credentials_readonly", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("MERIDIAN_CREDENTIALS_READONLY")
+      expect(result.message).toContain("meridian profile login personal")
+      // Nothing was minted, so no authorization code can be burned against it.
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("honours the legacy CLAUDE_PROXY_ alias for the read-only flag", () => {
+      process.env.CLAUDE_PROXY_CREDENTIALS_READONLY = "1"
+      expect(startProfileLogin({ profiles, profileId: "personal" })).toMatchObject({
+        ok: false,
+        code: "credentials_readonly",
+      })
+    })
+
+    it("keeps two logins for different profiles independent", () => {
+      const first = startProfileLogin({ profiles, profileId: "personal" })
+      const second = startProfileLogin({ profiles, profileId: "work" })
+      if (!first.ok || !second.ok) throw new Error("expected both to start")
+
+      expect(first.loginId).not.toBe(second.loginId)
+      expect(new URL(first.authorizeUrl).searchParams.get("state"))
+        .not.toBe(new URL(second.authorizeUrl).searchParams.get("state"))
+      expect(pendingLoginCount()).toBe(2)
+    })
+  })
+
+  describe("completeProfileLogin", () => {
+    it("rejects an unknown login id", async () => {
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({ loginId: "never-issued", input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(0)
+    })
+
+    it("rejects a login past its TTL", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: "abc123",
+        now: Date.now() + LOGIN_TTL_MS + 1,
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(0)
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("rejects a state that does not match the login, without sending the code", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: "https://platform.claude.com/oauth/code/callback?code=abc123&state=not-my-state",
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "state_mismatch", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+      // Nothing was spent, so the login survives — see the next test.
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it.skipIf(skipOnDarwin)("still accepts the right paste after a state mismatch", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const wrongTab = await completeProfileLogin({
+        loginId: started.loginId,
+        input: "https://platform.claude.com/oauth/code/callback?code=other-flow&state=not-my-state",
+        fetchFn,
+      })
+      expect(wrongTab).toMatchObject({ ok: false, code: "state_mismatch" })
+
+      const rightTab = await completeProfileLogin({
+        loginId: started.loginId,
+        input: `https://platform.claude.com/oauth/code/callback?code=real-code&state=${state}`,
+        fetchFn,
+      })
+      expect(rightTab).toMatchObject({ ok: true, profileId: "personal" })
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({ code: "real-code" })
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("keeps the login open when the paste carries no code", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "   ", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "no_code", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      // A mistyped paste must not cost the user another trip through sign-in.
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it("reports an upstream rejection without echoing the token endpoint's body", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ))
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "expired-code", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+      if (result.ok) throw new Error("expected refusal")
+      // The code reached Anthropic and is spent — never invite a retry with it.
+      expect(result.retryable).toBeUndefined()
+      expect(pendingLoginCount()).toBe(0)
+      expect(result.message).toContain("400")
+      expect(result.message).not.toContain("invalid_grant")
+      expect(result.message).not.toContain("already redeemed")
+    })
+
+    it("reports a transport failure", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const fetchFn: typeof fetch = Object.assign(
+        async () => { throw new Error("getaddrinfo ENOTFOUND platform.claude.com") },
+        { preconnect: globalThis.fetch.preconnect },
+      )
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+    })
+
+    it.skipIf(skipOnDarwin)("accepts a bare code and writes the profile's credentials", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "  abc123  ", fetchFn })
+      expect(result).toMatchObject({ ok: true, profileId: "personal" })
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({
+        grant_type: "authorization_code",
+        code: "abc123",
+        redirect_uri: "https://platform.claude.com/oauth/code/callback",
+      })
+
+      const stored = credentialsAt(join(tempDir, "personal"))
+      expect(stored.accessToken).toBe("web-login-access-token")
+      expect(stored.refreshToken).toBe("web-login-refresh-token")
+      expect(stored.scopes).toEqual(["user:inference", "user:profile"])
+      expect(existsSync(join(tempDir, "work", ".credentials.json"))).toBe(false)
+    })
+
+    it.skipIf(skipOnDarwin)("accepts the whole callback URL, matching its state", async () => {
+      const started = startProfileLogin({ profiles, profileId: "work" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: true, profileId: "work" })
+      expect(requests[0]).toMatchObject({ code: "url-code", state })
+      expect(credentialsAt(join(tempDir, "work")).accessToken).toBe("web-login-access-token")
+    })
+
+    it.skipIf(skipOnDarwin)("sends the verifier that matches the challenge the browser was given", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+      const challenge = new URL(started.authorizeUrl).searchParams.get("code_challenge") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+
+      const sent = requests[0]?.code_verifier
+      expect(sent).toBeTruthy()
+      expect(createHash("sha256").update(String(sent)).digest("base64url")).toBe(challenge)
+    })
+
+    it.skipIf(skipOnDarwin)("is single-use — a replayed login id is gone", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      expect(await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn }))
+        .toMatchObject({ ok: true })
+      expect(await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn }))
+        .toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(1)
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it.skipIf(skipOnDarwin)("consumes the login even when the exchange fails, since the code was sent", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn } = stubTokenFetch(() => new Response("{}", { status: 400 }))
+      await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it.skipIf(skipOnDarwin)("refuses a token response that omits the refresh token", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ access_token: "only-access", expires_in: 3600 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed" })
+      expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+    })
+
+    it.skipIf(skipOnDarwin)("routes two concurrent logins to their own profiles", async () => {
+      const first = startProfileLogin({ profiles, profileId: "personal" })
+      const second = startProfileLogin({ profiles, profileId: "work" })
+      if (!first.ok || !second.ok) throw new Error("expected both to start")
+
+      const personalFetch = stubTokenFetch(() => new Response(
+        JSON.stringify({ ...TOKEN_RESPONSE, access_token: "personal-token" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+      const workFetch = stubTokenFetch(() => new Response(
+        JSON.stringify({ ...TOKEN_RESPONSE, access_token: "work-token" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+
+      const [personalResult, workResult] = await Promise.all([
+        completeProfileLogin({ loginId: first.loginId, input: "code-a", fetchFn: personalFetch.fetchFn }),
+        completeProfileLogin({ loginId: second.loginId, input: "code-b", fetchFn: workFetch.fetchFn }),
+      ])
+
+      expect(personalResult).toMatchObject({ ok: true, profileId: "personal" })
+      expect(workResult).toMatchObject({ ok: true, profileId: "work" })
+      expect(credentialsAt(join(tempDir, "personal")).accessToken).toBe("personal-token")
+      expect(credentialsAt(join(tempDir, "work")).accessToken).toBe("work-token")
+    })
+  })
+
+  describe("resolveLoopbackRedirectUri", () => {
+    it("builds a callback URL for the two hosts Anthropic registered", () => {
+      expect(resolveLoopbackRedirectUri("localhost:3457")).toBe("http://localhost:3457/callback")
+      expect(resolveLoopbackRedirectUri("127.0.0.1:3457")).toBe("http://127.0.0.1:3457/callback")
+      // Port 80 — the registered URI verbatim.
+      expect(resolveLoopbackRedirectUri("localhost")).toBe("http://localhost/callback")
+    })
+
+    it("declines every origin a redirect could not come back from", () => {
+      expect(resolveLoopbackRedirectUri("meridian.example.com")).toBeUndefined()
+      expect(resolveLoopbackRedirectUri("meridian-dev.desktop.ts.nowaker.net")).toBeUndefined()
+      expect(resolveLoopbackRedirectUri("192.168.1.5:3457")).toBeUndefined()
+      expect(resolveLoopbackRedirectUri(undefined)).toBeUndefined()
+      expect(resolveLoopbackRedirectUri("")).toBeUndefined()
+      expect(resolveLoopbackRedirectUri("not a host")).toBeUndefined()
+      expect(resolveLoopbackRedirectUri("localhost:999999")).toBeUndefined()
+    })
+
+    it("declines IPv6 loopback, which is not among the registered URIs", () => {
+      expect(resolveLoopbackRedirectUri("[::1]:3457")).toBeUndefined()
+    })
+
+    it("rebuilds the URL instead of echoing the header", () => {
+      // Host is client-supplied; anything past the authority is discarded
+      // rather than trusted into the redirect target.
+      expect(resolveLoopbackRedirectUri("localhost:3457/evil?x=1")).toBe("http://localhost:3457/callback")
+      expect(resolveLoopbackRedirectUri("LOCALHOST:3457")).toBe("http://localhost:3457/callback")
+    })
+  })
+
+  describe("loopbackRedirectUriForPort", () => {
+    it("builds the candidate on the registered loopback host", () => {
+      expect(loopbackRedirectUriForPort(3457)).toBe("http://127.0.0.1:3457/callback")
+      expect(loopbackRedirectUriForPort(1)).toBe("http://127.0.0.1:1/callback")
+      expect(loopbackRedirectUriForPort(65535)).toBe("http://127.0.0.1:65535/callback")
+    })
+
+    it("has nothing to offer without a real port", () => {
+      expect(loopbackRedirectUriForPort(undefined)).toBeUndefined()
+      expect(loopbackRedirectUriForPort(0)).toBeUndefined()
+      expect(loopbackRedirectUriForPort(-1)).toBeUndefined()
+      expect(loopbackRedirectUriForPort(65536)).toBeUndefined()
+      expect(loopbackRedirectUriForPort(3457.5)).toBeUndefined()
+      expect(loopbackRedirectUriForPort(Number.NaN)).toBeUndefined()
+    })
+  })
+
+  describe("startProfileLogin — redirect vs paste", () => {
+    it("offers a loopback redirect when the browser is on this host", () => {
+      const result = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.mode).toBe("redirect")
+      expect(new URL(result.authorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("http://127.0.0.1:3457/callback")
+      expect(new URL(result.pasteAuthorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("https://platform.claude.com/oauth/code/callback")
+    })
+
+    it("mints both authorize URLs from ONE challenge, so either may be completed", () => {
+      const result = startProfileLogin({ profiles, profileId: "personal", hostHeader: "localhost:3457" })
+      if (!result.ok) throw new Error("expected success")
+
+      const redirect = new URL(result.authorizeUrl).searchParams
+      const paste = new URL(result.pasteAuthorizeUrl).searchParams
+      expect(redirect.get("state")).toBe(paste.get("state"))
+      expect(redirect.get("code_challenge")).toBe(paste.get("code_challenge"))
+      // One login, not two.
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it("falls back to paste for a browser that cannot be redirected back", () => {
+      const result = startProfileLogin({ profiles, profileId: "personal", hostHeader: "meridian.example.com" })
+      if (!result.ok) throw new Error("expected success")
+
+      expect(result.mode).toBe("paste")
+      expect(result.authorizeUrl).toBe(result.pasteAuthorizeUrl)
+      expect(new URL(result.authorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("https://platform.claude.com/oauth/code/callback")
+    })
+
+    it("offers a loopback CANDIDATE to a browser that reached us under another name", () => {
+      const result = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "meridian-dev.desktop.ts.nowaker.net",
+        serverPort: 3457,
+      })
+      if (!result.ok) throw new Error("expected success")
+
+      // Still paste by default — being on the Meridian host is not proven yet.
+      expect(result.mode).toBe("paste")
+      expect(result.authorizeUrl).toBe(result.pasteAuthorizeUrl)
+
+      // …but the upgrade is offered, for the page to probe.
+      expect(new URL(result.loopbackAuthorizeUrl ?? "").searchParams.get("redirect_uri"))
+        .toBe("http://127.0.0.1:3457/callback")
+      expect(result.loopbackProbeUrl)
+        .toBe(`http://127.0.0.1:3457/profiles/login/status?loginId=${encodeURIComponent(result.loginId)}`)
+    })
+
+    it("offers no candidate when it cannot name a port", () => {
+      const result = startProfileLogin({ profiles, profileId: "personal", hostHeader: "meridian.example.com" })
+      if (!result.ok) throw new Error("expected success")
+      expect(result.loopbackAuthorizeUrl).toBeUndefined()
+      expect(result.loopbackProbeUrl).toBeUndefined()
+    })
+
+    it("does not need the probe when Host already proved loopback", () => {
+      const result = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "localhost:3457",
+        serverPort: 3457,
+      })
+      if (!result.ok) throw new Error("expected success")
+      expect(result.mode).toBe("redirect")
+      // Host wins over the port-derived guess: it is the address the browser
+      // actually used, so it is the one that will come back.
+      expect(result.authorizeUrl).toBe(result.loopbackAuthorizeUrl ?? "")
+      expect(new URL(result.authorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("http://localhost:3457/callback")
+    })
+
+    it.skipIf(skipOnDarwin)("exchanges an UPGRADED login against the loopback redirect_uri", async () => {
+      // The page probed loopback, took the upgrade and signed in there, so the
+      // grant must name the loopback URI even though `mode` said paste.
+      const started = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "meridian-dev.desktop.ts.nowaker.net",
+        serverPort: 3457,
+      })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.loopbackAuthorizeUrl ?? "").searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      expect(await completeProfileLoginFromCallback({ state, code: "redirected-code", fetchFn }))
+        .toMatchObject({ ok: true, profileId: "personal" })
+      expect(requests[0]?.redirect_uri).toBe("http://127.0.0.1:3457/callback")
+    })
+
+    it.skipIf(skipOnDarwin)("still exchanges a PASTED code against the code-display redirect_uri", async () => {
+      // Started in redirect mode, finished by paste: the code came from the
+      // other URL, so the grant must name that one or Anthropic rejects it.
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      expect(await completeProfileLogin({ loginId: started.loginId, input: "pasted-code", fetchFn }))
+        .toMatchObject({ ok: true })
+      expect(requests[0]?.redirect_uri).toBe("https://platform.claude.com/oauth/code/callback")
+    })
+  })
+
+  describe("completeProfileLoginFromCallback", () => {
+    it.skipIf(skipOnDarwin)("exchanges against the loopback redirect_uri and writes the credentials", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLoginFromCallback({ state, code: "redirect-code", fetchFn })
+
+      expect(result).toMatchObject({ ok: true, profileId: "personal" })
+      expect(requests[0]).toMatchObject({
+        code: "redirect-code",
+        redirect_uri: "http://127.0.0.1:3457/callback",
+        grant_type: "authorization_code",
+      })
+      expect(credentialsAt(join(tempDir, "personal")).accessToken).toBe("web-login-access-token")
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("refuses a state no login is waiting for, without sending anything", async () => {
+      startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLoginFromCallback({ state: "not-a-real-state", code: "x", fetchFn })
+
+      expect(result).toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(0)
+      // The open login is untouched — a wrong state reaches nothing.
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it("reports a refusal from Claude without exchanging anything", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLoginFromCallback({
+        state,
+        error: "access_denied",
+        errorDescription: "user refused",
+        fetchFn,
+      })
+
+      expect(result).toMatchObject({ ok: false, code: "login_denied", status: 400 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("access_denied")
+      expect(requests).toHaveLength(0)
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("refuses a callback for a login that never issued a loopback URL", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "meridian.example.com" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLoginFromCallback({ state, code: "abc", fetchFn })
+
+      expect(result).toMatchObject({ ok: false, code: "no_code" })
+      expect(requests).toHaveLength(0)
+    })
+
+    it.skipIf(skipOnDarwin)("is single-use — the same redirect replayed finds nothing", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      expect(await completeProfileLoginFromCallback({ state, code: "abc", fetchFn })).toMatchObject({ ok: true })
+      expect(await completeProfileLoginFromCallback({ state, code: "abc", fetchFn }))
+        .toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(1)
+    })
+
+    it("refuses a callback for an expired login", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLoginFromCallback({
+        state,
+        code: "abc",
+        now: Date.now() + LOGIN_TTL_MS + 1,
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(0)
+    })
+
+    it.skipIf(skipOnDarwin)("keeps two concurrent logins apart by state", async () => {
+      const first = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      const second = startProfileLogin({ profiles, profileId: "work", hostHeader: "127.0.0.1:3457" })
+      if (!first.ok || !second.ok) throw new Error("expected both to start")
+      const secondState = new URL(second.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ ...TOKEN_RESPONSE, access_token: "work-token" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+      expect(await completeProfileLoginFromCallback({ state: secondState, code: "abc", fetchFn }))
+        .toMatchObject({ ok: true, profileId: "work" })
+
+      expect(credentialsAt(join(tempDir, "work")).accessToken).toBe("work-token")
+      expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+      expect(pendingLoginCount()).toBe(1)
+    })
+  })
+
+  describe("getProfileLoginStatus", () => {
+    it("reports waiting while the user is still signing in", () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      expect(getProfileLoginStatus(started.loginId)).toEqual({ status: "waiting", profileId: "personal" })
+    })
+
+    it.skipIf(skipOnDarwin)("reports completed once the redirect finished the login", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn } = okTokenFetch()
+      await completeProfileLoginFromCallback({ state, code: "abc", fetchFn })
+      expect(getProfileLoginStatus(started.loginId)).toEqual({ status: "completed", profileId: "personal" })
+    })
+
+    it("reports the reason a login failed, so the page can show it", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ error: "invalid_grant" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ))
+      await completeProfileLoginFromCallback({ state, code: "stale", fetchFn })
+
+      const status = getProfileLoginStatus(started.loginId)
+      expect(status).toMatchObject({ status: "failed", profileId: "personal", code: "exchange_failed" })
+      expect(status?.error).toContain("400")
+      // The token endpoint's body never reaches a surface the user can read.
+      expect(status?.error).not.toContain("invalid_grant")
+    })
+
+    it("knows nothing about an id it never issued", () => {
+      expect(getProfileLoginStatus("never-issued")).toBeNull()
+    })
+
+    it.skipIf(skipOnDarwin)("forgets an outcome once its retention window passes", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state") ?? ""
+
+      const { fetchFn } = okTokenFetch()
+      await completeProfileLoginFromCallback({ state, code: "abc", fetchFn })
+      expect(getProfileLoginStatus(started.loginId)).toMatchObject({ status: "completed" })
+      expect(getProfileLoginStatus(started.loginId, Date.now() + LOGIN_RESULT_TTL_MS + 1)).toBeNull()
+    })
+  })
+})

--- a/src/__tests__/profile-login-unit.test.ts
+++ b/src/__tests__/profile-login-unit.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test"
 import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { networkInterfaces, tmpdir } from "node:os"
 import { join } from "node:path"
 import {
   LOGIN_RESULT_TTL_MS,
   LOGIN_TTL_MS,
+  clientIsOnThisHost,
   completeProfileLogin,
   completeProfileLoginFromCallback,
   getProfileLoginStatus,
+  isLoopbackCallbackInput,
+  normalizeClientAddress,
   pendingLoginCount,
   resetPendingLogins,
   loopbackRedirectUriForPort,
@@ -61,6 +64,15 @@ function credentialsAt(dir: string): { accessToken: string; refreshToken: string
 // .credentials.json file (and any path that writes at all) are Linux/Windows
 // only — same reason profile-token-refresh-route.test.ts skips there.
 const skipOnDarwin = process.platform === "darwin"
+
+// A real address of the machine running the test, so "is this one of ours?" is
+// asserted against what the host actually reports rather than a literal that
+// would only be right on one box. A container with nothing but loopback has
+// none, and those cases skip.
+const ownExternalAddress = Object.values(networkInterfaces())
+  .flatMap(addresses => addresses ?? [])
+  .find(address => !address.internal && address.family === "IPv4")
+  ?.address
 
 describe("profileLogin", () => {
   let tempDir: string
@@ -449,6 +461,70 @@ describe("profileLogin", () => {
     })
   })
 
+  describe("normalizeClientAddress", () => {
+    it("strips what a proxy adds around an address", () => {
+      expect(normalizeClientAddress("10.0.0.4:51234")).toBe("10.0.0.4")
+      expect(normalizeClientAddress("[fd7a:115c:a1e0::1]:51234")).toBe("fd7a:115c:a1e0::1")
+      expect(normalizeClientAddress("fe80::1%eth0")).toBe("fe80::1")
+      expect(normalizeClientAddress("::ffff:127.0.0.1")).toBe("127.0.0.1")
+      expect(normalizeClientAddress("  100.105.229.19  ")).toBe("100.105.229.19")
+      expect(normalizeClientAddress("")).toBe("")
+    })
+
+    it("does not mistake an IPv6 address's last group for a port", () => {
+      expect(normalizeClientAddress("fd7a:115c:a1e0::9538:e513")).toBe("fd7a:115c:a1e0::9538:e513")
+      expect(normalizeClientAddress("::1")).toBe("::1")
+    })
+  })
+
+  describe("clientIsOnThisHost", () => {
+    it("says nothing when no proxy recorded an address", () => {
+      expect(clientIsOnThisHost(undefined)).toBe(false)
+      expect(clientIsOnThisHost("")).toBe(false)
+      expect(clientIsOnThisHost("   ")).toBe(false)
+    })
+
+    it("recognizes loopback however it is spelled", () => {
+      expect(clientIsOnThisHost("127.0.0.1")).toBe(true)
+      expect(clientIsOnThisHost("::1")).toBe(true)
+      expect(clientIsOnThisHost("::ffff:127.0.0.1")).toBe(true)
+    })
+
+    it("does not claim a browser on another machine", () => {
+      expect(clientIsOnThisHost("203.0.113.7")).toBe(false)
+      expect(clientIsOnThisHost("2001:db8::1")).toBe(false)
+    })
+
+    it("reads the CLIENT, not the proxy that carried it", () => {
+      // Left to right: the first entry is the browser. A local proxy appearing
+      // later must not make a remote browser look local — that would hand the
+      // redirect flow to a machine it cannot come back to.
+      expect(clientIsOnThisHost("127.0.0.1, 10.0.0.1")).toBe(true)
+      expect(clientIsOnThisHost("203.0.113.7, 127.0.0.1")).toBe(false)
+    })
+
+    it.skipIf(!ownExternalAddress)("recognizes an address this machine answers on", () => {
+      expect(clientIsOnThisHost(ownExternalAddress)).toBe(true)
+      expect(clientIsOnThisHost(`${ownExternalAddress}:51234`)).toBe(true)
+    })
+  })
+
+  describe("isLoopbackCallbackInput", () => {
+    it("recognizes the address bar of a loopback callback", () => {
+      expect(isLoopbackCallbackInput("http://127.0.0.1:3457/callback?code=x&state=y")).toBe(true)
+      expect(isLoopbackCallbackInput("http://localhost:3457/callback?code=x")).toBe(true)
+      expect(isLoopbackCallbackInput("  http://127.0.0.1:3457/callback?code=x  ")).toBe(true)
+    })
+
+    it("does not mistake a code, or the code-display page, for one", () => {
+      expect(isLoopbackCallbackInput("bare-authorization-code")).toBe(false)
+      expect(isLoopbackCallbackInput("https://platform.claude.com/oauth/code/callback?code=x")).toBe(false)
+      expect(isLoopbackCallbackInput("http://127.0.0.1:3457/profiles")).toBe(false)
+      expect(isLoopbackCallbackInput("https://127.0.0.1:3457/callback?code=x")).toBe(false)
+      expect(isLoopbackCallbackInput("http://meridian.example.com/callback?code=x")).toBe(false)
+    })
+  })
+
   describe("startProfileLogin — redirect vs paste", () => {
     it("offers a loopback redirect when the browser is on this host", () => {
       const result = startProfileLogin({ profiles, profileId: "personal", hostHeader: "127.0.0.1:3457" })
@@ -503,6 +579,70 @@ describe("profileLogin", () => {
         .toBe(`http://127.0.0.1:3457/profiles/login/status?loginId=${encodeURIComponent(result.loginId)}`)
     })
 
+    it("redirects a browser a proxy placed on this host, without any probe", () => {
+      // Nowaker's topology: the browser is on the Meridian box but reaches it
+      // through Caddy under a tailnet name, so `Host` cannot tell and the page
+      // was left to probe loopback from JavaScript. The proxy already knew.
+      const result = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "meridian-dev.desktop.ts.nowaker.net",
+        forwardedFor: "127.0.0.1",
+        serverPort: 3457,
+      })
+      if (!result.ok) throw new Error("expected success")
+
+      expect(result.mode).toBe("redirect")
+      expect(result.authorizeUrl).toBe(result.loopbackAuthorizeUrl ?? "")
+      expect(new URL(result.authorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("http://127.0.0.1:3457/callback")
+    })
+
+    it.skipIf(!ownExternalAddress)("redirects when the proxy recorded one of this host's own addresses", () => {
+      const result = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "meridian-dev.desktop.ts.nowaker.net",
+        forwardedFor: ownExternalAddress,
+        serverPort: 3457,
+      })
+      if (!result.ok) throw new Error("expected success")
+      expect(result.mode).toBe("redirect")
+    })
+
+    it("still pastes for a browser the proxy placed on another machine", () => {
+      const result = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "meridian-dev.desktop.ts.nowaker.net",
+        forwardedFor: "203.0.113.7",
+        serverPort: 3457,
+      })
+      if (!result.ok) throw new Error("expected success")
+
+      expect(result.mode).toBe("paste")
+      expect(result.authorizeUrl).toBe(result.pasteAuthorizeUrl)
+      // The candidate and its probe stand: a phone on the tailnet cannot reach
+      // this host's loopback, but an SSH port-forward on another box can.
+      expect(result.loopbackAuthorizeUrl).toBeDefined()
+      expect(result.loopbackProbeUrl).toBeDefined()
+    })
+
+    it("prefers the address the browser actually used over the one a proxy reported", () => {
+      const result = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "localhost:9999",
+        forwardedFor: "203.0.113.7",
+        serverPort: 3457,
+      })
+      if (!result.ok) throw new Error("expected success")
+
+      expect(result.mode).toBe("redirect")
+      expect(new URL(result.authorizeUrl).searchParams.get("redirect_uri"))
+        .toBe("http://localhost:9999/callback")
+    })
+
     it("offers no candidate when it cannot name a port", () => {
       const result = startProfileLogin({ profiles, profileId: "personal", hostHeader: "meridian.example.com" })
       if (!result.ok) throw new Error("expected success")
@@ -554,6 +694,35 @@ describe("profileLogin", () => {
       expect(await completeProfileLogin({ loginId: started.loginId, input: "pasted-code", fetchFn }))
         .toMatchObject({ ok: true })
       expect(requests[0]?.redirect_uri).toBe("https://platform.claude.com/oauth/code/callback")
+    })
+
+    it.skipIf(skipOnDarwin)("completes from a PASTED loopback callback URL", async () => {
+      // The redirect could not land — a browser on another machine, or a tab
+      // that failed to load — so the user copied the address bar instead. That
+      // code is bound to the loopback redirect_uri, and naming the code-display
+      // one would have Anthropic reject a sign-in the user already completed.
+      const started = startProfileLogin({
+        profiles,
+        profileId: "personal",
+        hostHeader: "meridian-dev.desktop.ts.nowaker.net",
+        serverPort: 3457,
+      })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.loopbackAuthorizeUrl ?? "").searchParams.get("state") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: `http://127.0.0.1:3457/callback?code=address-bar-code&state=${encodeURIComponent(state)}`,
+        fetchFn,
+      })
+
+      expect(result).toMatchObject({ ok: true, profileId: "personal" })
+      expect(requests[0]).toMatchObject({
+        code: "address-bar-code",
+        redirect_uri: "http://127.0.0.1:3457/callback",
+      })
+      expect(credentialsAt(join(tempDir, "personal")).accessToken).toBe("web-login-access-token")
     })
   })
 

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, test, expect, beforeEach } from "bun:test"
 import { join } from "node:path"
-import { homedir } from "node:os"
+import { meridianConfigDir } from "../proxy/settings"
 import {
   resolveProfile,
   listProfiles,
@@ -107,7 +107,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-foo")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
   })
 
@@ -117,7 +117,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-bar")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
   })
 
@@ -129,7 +129,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-baz")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
     expect(result.env.CLAUDE_CONFIG_DIR).not.toBe("/ignored")
   })
@@ -160,7 +160,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-qux")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
   })
 })

--- a/src/__tests__/proxy-settings-auth.test.ts
+++ b/src/__tests__/proxy-settings-auth.test.ts
@@ -91,10 +91,31 @@ describe("MERIDIAN_API_KEY — /settings/api/* (regression for #477)", () => {
 // Audit: any sensitive route added in the future must go through requireAuth.
 // ---------------------------------------------------------------------------
 describe("auth audit: every registered prefix is protected when MERIDIAN_API_KEY is set", () => {
-  // Routes that are *intentionally* public. Both serve read-only,
-  // non-sensitive content (landing page; auth status). If you're adding to
-  // this list, that's a security review. When in doubt, gate it.
-  const PUBLIC_PREFIXES = new Set(["/", "/health"])
+  // Routes that are *intentionally* public. If you're adding to this list,
+  // that's a security review — write it here. When in doubt, gate it.
+  //
+  //   /         landing page — read-only, non-sensitive
+  //   /health   auth status — read-only, non-sensitive
+  //
+  //   /callback OAuth redirect target for profile login.
+  //
+  //     Cannot be gated: Anthropic redirects the user's BROWSER here after
+  //     sign-in, and that redirect carries no API key. Gating it would make
+  //     the browser login flow fail on exactly the instances that took the
+  //     trouble to set MERIDIAN_API_KEY.
+  //
+  //     Safe to leave open because reaching it proves nothing and grants
+  //     nothing. It acts only on a `state` that (a) was minted by
+  //     /profiles/login/start, which IS gated, (b) is 256 bits of CSPRNG
+  //     output that never leaves this process except into the authorize URL,
+  //     and (c) is single-use and expires in 10 minutes. Without a matching
+  //     open login it returns 410 and does nothing at all. It cannot start a
+  //     login, cannot name a profile, cannot enumerate anything: the response
+  //     is the same page whether the `state` was wrong or merely expired.
+  //     An attacker who could guess a live `state` would still be handing
+  //     Anthropic's own authorization code to the user's own profile — the
+  //     PKCE verifier it would be exchanged against is held here, not by them.
+  const PUBLIC_PREFIXES = new Set(["/", "/health", "/callback"])
 
   it("rejects unauthenticated requests to every non-public route prefix", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })

--- a/src/__tests__/site-header.test.ts
+++ b/src/__tests__/site-header.test.ts
@@ -14,6 +14,7 @@ import { settingsPageHtml } from "../telemetry/settingsPage"
 import { profilePageHtml } from "../telemetry/profilePage"
 import { pluginPageHtml } from "../proxy/plugins/pluginPage"
 import { profileBarHtml, profileBarJs } from "../telemetry/profileBar"
+import { renderLoginCallbackPage } from "../telemetry/loginCallbackPage"
 
 const allPages: Array<[string, string]> = [
   ["landing", landingHtml],
@@ -53,6 +54,16 @@ describe("shared site header", () => {
       const count = html.split("meridian-header").length - 1
       expect(count, `${name} page should embed the header once`).toBeGreaterThanOrEqual(1)
     }
+  })
+
+  test("the OAuth callback page is the deliberate exception", () => {
+    // /callback is reachable WITHOUT the API key — Anthropic's redirect carries
+    // none — while the header polls /health and /profiles/list, which are gated.
+    // Embedding it would render broken "offline" chrome on the one page a user
+    // sees mid-login. This pins that exception so it is not "fixed" by hand.
+    const html = renderLoginCallbackPage({ ok: true, profileId: "personal" })
+    expect(html).not.toContain("meridian-header")
+    expect(html).toContain("href=\"/profiles\"")
   })
 })
 
@@ -101,6 +112,7 @@ describe("design-system conformance (DESIGN.md)", () => {
     "src/telemetry/dashboard.ts",
     "src/telemetry/settingsPage.ts",
     "src/telemetry/profilePage.ts",
+    "src/telemetry/loginCallbackPage.ts",
     "src/proxy/plugins/pluginPage.ts",
   ]
 
@@ -118,6 +130,47 @@ describe("design-system conformance (DESIGN.md)", () => {
       const bodyRule = src.match(/body \{[^}]*\}/)?.[0] ?? ""
       expect(bodyRule.includes("background"), `${path} body rule must not set background`).toBe(false)
     }
+  })
+})
+
+describe("profiles page — the sign-in control is a real link", () => {
+  // Someone signed into several Claude accounts needs the browser's own
+  // context menu — "Open Link in Incognito Window", "Copy Link Address" — to
+  // choose which session answers the sign-in. Chrome and Firefox offer that
+  // for an anchor with an href and for nothing else, so these assertions are
+  // the feature, not decoration.
+  test("renders an anchor with an href, not a button", () => {
+    expect(profilePageHtml).toContain('<a class="login-btn login-link"')
+    expect(profilePageHtml).toContain("loginHrefFor(p.id)")
+    expect(profilePageHtml).toContain('rel="noopener noreferrer"')
+    expect(profilePageHtml).not.toContain('<button class="login-btn" onclick="startLogin')
+  })
+
+  test("nothing in the login flow opens a window from script", () => {
+    // A scripted window.open is exactly what denies the context menu, and it
+    // also ignores ctrl-click and middle-click. Scoped to the login section so
+    // this says something precise about THIS flow rather than policing every
+    // other feature on the page.
+    const start = profilePageHtml.indexOf("// --- Browser login ---")
+    expect(start).toBeGreaterThan(-1)
+    const next = profilePageHtml.indexOf("// --- ", start + 24)
+    const loginSection = next === -1 ? profilePageHtml.slice(start) : profilePageHtml.slice(start, next)
+    expect(loginSection).not.toContain("window.open(")
+  })
+
+  test("the fallback to pasting a code is also a real link", () => {
+    expect(profilePageHtml).toContain('onclick="switchToPaste();return true;"')
+    expect(profilePageHtml).not.toContain('href="#" onclick="switchToPaste()')
+  })
+
+  test("hrefs survive a re-render and are refreshed before they expire", () => {
+    expect(profilePageHtml).toContain("applyLoginHrefs()")
+    expect(profilePageHtml).toContain("ensureLoginLinks(profiles)")
+  })
+
+  test("no PKCE material is ever put in a link", () => {
+    expect(profilePageHtml).not.toContain("codeVerifier")
+    expect(profilePageHtml).not.toContain("code_verifier")
   })
 })
 

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -700,9 +700,11 @@ export function resetCachedClaudeAuthStatus(): void {
   profileAuthCaches.clear()
 }
 
-/** Expire the auth status cache without clearing lastKnownGoodAuthStatus — for testing only.
- *  This simulates the TTL expiring so the next call re-executes `claude auth status`,
- *  while preserving the "last known good" fallback state. */
+/** Expire the auth status cache without clearing lastKnownGoodAuthStatus.
+ *  The next call re-executes `claude auth status` while the "last known good"
+ *  fallback state survives. Used by tests to simulate the TTL elapsing, and by
+ *  the login route so a just-authenticated profile stops reporting the cached
+ *  "not logged in". */
 export function expireAuthStatusCache(): void {
   cachedAuthStatusAt = 0
   cachedAuthStatusPromise = null

--- a/src/proxy/profileAdd.ts
+++ b/src/proxy/profileAdd.ts
@@ -1,0 +1,329 @@
+/**
+ * Browser-completable creation of a new claude-max profile.
+ *
+ * Backs `POST /profiles/add/start` and `POST /profiles/add/complete`. Adding an
+ * account no longer requires a shell on the box Meridian runs on, which is the
+ * same gap `profileLogin.ts` closed for re-authenticating one.
+ *
+ * Deliberately a SEPARATE route from the login flow rather than a loosened
+ * guard on it. `/profiles/login/start` refuses unknown ids, and that refusal is
+ * what stops "re-authenticate enrique-corp" from silently creating
+ * "enrique-crop" on a typo. Creating an account slot is a different act from
+ * re-authenticating one that exists, so it gets its own button, its own route
+ * and its own refusals.
+ *
+ * The slot is written only after Anthropic has returned credentials — see
+ * `completeProfileAdd`. Everything that can refuse does so at `/start`, before
+ * a sign-in tab opens, because a user who signs in and is only then refused has
+ * burned a one-time authorization code for nothing.
+ *
+ * This is a leaf module — no imports from server.ts or session/.
+ */
+
+import { randomBytes } from "node:crypto"
+import { envBool } from "../env"
+import {
+  createManualOAuthSession,
+  createProfileSlot,
+  exchangeAuthorizationCodeForCredentials,
+  isValidProfileId,
+  parseAuthorizationCodeInput,
+  profileConfigDirFor,
+  loadProfileIds,
+} from "./profileCli"
+import { LOGIN_TTL_MS } from "./profileLogin"
+import { getEffectiveProfiles, type ProfileConfig } from "./profiles"
+
+interface PendingAdd {
+  profileId: string
+  claudeConfigDir: string
+  codeVerifier: string
+  state: string
+  expiresAt: number
+}
+
+/**
+ * Started-but-unfinished creations, keyed by the opaque id handed to the
+ * browser. Server-side for the same reason as pending logins: the PKCE
+ * verifier is half of the proof and must not travel to the browser holding
+ * the other half.
+ *
+ * At most one entry per profile id: starting a second sign-in for the same name
+ * SUPERSEDES the first (see `startProfileAdd`). Nothing is on disk between
+ * `/start` and `/complete`, so this map is the only thing stopping two sign-ins
+ * for one new name from both completing, with the loser having spent a code to
+ * be told the name is taken.
+ */
+const pendingAdds = new Map<string, PendingAdd>()
+
+export type AddErrorCode =
+  | "credentials_readonly"
+  | "invalid_request"
+  | "invalid_profile_id"
+  | "profile_exists"
+  | "expired_add"
+  | "no_code"
+  | "state_mismatch"
+  | "exchange_failed"
+  | "write_failed"
+  | "create_failed"
+
+export interface AddFailure {
+  ok: false
+  code: AddErrorCode
+  status: number
+  message: string
+  /**
+   * The pending creation is still open — paste again, no second sign-in.
+   * Set exactly when the paste was rejected locally, before any code reached
+   * Anthropic. Same contract as `LoginFailure.retryable`, read by the same
+   * page code.
+   */
+  retryable?: boolean
+}
+
+export interface StartAddSuccess {
+  ok: true
+  profileId: string
+  addId: string
+  authorizeUrl: string
+  expiresAt: number
+}
+
+export interface CompleteAddSuccess {
+  ok: true
+  profileId: string
+  claudeConfigDir: string
+}
+
+export interface StartAddParams {
+  profiles: ProfileConfig[] | undefined
+  profileId: string
+  now?: number
+}
+
+export interface CompleteAddParams {
+  addId: string
+  input: string
+  now?: number
+  fetchFn?: typeof fetch
+}
+
+function prune(now: number): void {
+  for (const [id, add] of pendingAdds) {
+    if (add.expiresAt <= now) pendingAdds.delete(id)
+  }
+}
+
+/**
+ * Refuse when this instance must not write credential files.
+ *
+ * Creating a profile writes both credentials and profiles.json, so a readonly
+ * instance can do even less of it than a re-login. Refused at `/start` for the
+ * reason the login flow refuses there: the button is present on an instance
+ * that shares another's credential files, so it is there to be clicked.
+ */
+function readonlyRefusal(profileId: string): AddFailure | null {
+  if (!envBool("CREDENTIALS_READONLY")) return null
+  return {
+    ok: false,
+    code: "credentials_readonly",
+    status: 409,
+    message:
+      "This Meridian instance runs with MERIDIAN_CREDENTIALS_READONLY=1 and must not write credential files, "
+      + "so it cannot create a profile. Use the instance that owns these credentials, "
+      + `or a terminal on the box that holds them: meridian profile add ${profileId}`,
+  }
+}
+
+/**
+ * Every id this instance would consider taken: the profiles it serves plus the
+ * ones already written to profiles.json.
+ *
+ * Both, because they can differ. An instance configured from MERIDIAN_PROFILES
+ * does not read profiles.json at all, so the effective list alone would let a
+ * write land on top of an existing entry; and with disk discovery on, a profile
+ * added seconds ago may not have reached the effective list's cache yet.
+ */
+function takenIds(profiles: ProfileConfig[] | undefined): Set<string> {
+  const taken = new Set<string>()
+  for (const p of getEffectiveProfiles(profiles)) taken.add(p.id)
+  for (const id of loadProfileIds()) taken.add(id)
+  return taken
+}
+
+/**
+ * Create a pending profile: validate the name, refuse everything refusable,
+ * reserve the id, and mint PKCE. Nothing is written to disk here.
+ */
+export function startProfileAdd(params: StartAddParams): StartAddSuccess | AddFailure {
+  const now = params.now ?? Date.now()
+  const profileId = params.profileId.trim()
+  if (!profileId) {
+    return { ok: false, code: "invalid_request", status: 400, message: "Missing 'profile' in request body" }
+  }
+
+  const readonly = readonlyRefusal(profileId)
+  if (readonly) return readonly
+
+  // Before anything else touches it: this name becomes a directory.
+  if (!isValidProfileId(profileId)) {
+    return {
+      ok: false,
+      code: "invalid_profile_id",
+      status: 400,
+      message: "Profile names may use only letters, numbers, hyphens and underscores.",
+    }
+  }
+
+  if (takenIds(params.profiles).has(profileId)) {
+    return {
+      ok: false,
+      code: "profile_exists",
+      status: 409,
+      message: `Profile "${profileId}" already exists. To sign it in again, use "Log in from browser" on its card.`,
+    }
+  }
+
+  prune(now)
+  // A second sign-in for the same name REPLACES the first rather than being
+  // refused. Cancelling the panel, reloading the page or closing the tab all
+  // abandon a sign-in without telling the server, so refusing here would lock
+  // the name out for the full TTL with no way for the user to release it. One
+  // entry per name still holds, which is what stops two sign-ins from both
+  // completing; superseding just decides which one survives.
+  for (const [id, pending] of pendingAdds) {
+    if (pending.profileId === profileId) pendingAdds.delete(id)
+  }
+
+  const session = createManualOAuthSession()
+  const addId = randomBytes(16).toString("base64url")
+  const expiresAt = now + LOGIN_TTL_MS
+  pendingAdds.set(addId, {
+    profileId,
+    claudeConfigDir: profileConfigDirFor(profileId),
+    codeVerifier: session.codeVerifier,
+    state: session.state,
+    expiresAt,
+  })
+
+  return { ok: true, profileId, addId, authorizeUrl: session.authorizeUrl, expiresAt }
+}
+
+/**
+ * Finish a creation from what the user pasted — a bare code, or the whole
+ * callback URL from the browser's address bar.
+ *
+ * Order matters: the credentials are exchanged FIRST and the profiles.json
+ * entry is written only once they are in hand. An OAuth failure therefore
+ * leaves no profile behind at all, rather than a half-made one that shows as
+ * permanently logged out and has to be noticed and cleaned up. The residue of
+ * a failure is at most an empty directory, which the next attempt reuses.
+ */
+export async function completeProfileAdd(params: CompleteAddParams): Promise<CompleteAddSuccess | AddFailure> {
+  const now = params.now ?? Date.now()
+  prune(now)
+
+  const pending = pendingAdds.get(params.addId)
+  if (!pending) {
+    return {
+      ok: false,
+      code: "expired_add",
+      status: 410,
+      message: "This sign-in is no longer open — it expired, or it was already completed. Start it again.",
+    }
+  }
+
+  // Parsed before the pending entry is consumed: a mistyped paste should not
+  // force the user back through Anthropic's sign-in.
+  const parsed = parseAuthorizationCodeInput(params.input)
+  if (!parsed) {
+    return {
+      ok: false,
+      code: "no_code",
+      status: 400,
+      message: "No authorization code found in that paste. Paste the code Claude showed you, or the whole callback URL.",
+      retryable: true,
+    }
+  }
+
+  // Consumed BEFORE the exchange: deleting first is what makes single-use hold
+  // against two completions racing the same id.
+  pendingAdds.delete(params.addId)
+
+  const exchange = await exchangeAuthorizationCodeForCredentials({
+    code: parsed.code,
+    returnedState: parsed.state,
+    sessionState: pending.state,
+    codeVerifier: pending.codeVerifier,
+    claudeConfigDir: pending.claudeConfigDir,
+    fetchFn: params.fetchFn,
+  })
+
+  if (!exchange.ok) {
+    if (exchange.reason === "state_mismatch") {
+      // Rejected locally — nothing was spent, so put the reservation back and
+      // let the user paste from the right tab.
+      pendingAdds.set(params.addId, pending)
+      return {
+        ok: false,
+        code: "state_mismatch",
+        status: 400,
+        message: "OAuth state did not match this sign-in. Paste the code from the tab this sign-in opened.",
+        retryable: true,
+      }
+    }
+    if (exchange.reason === "write_failed") {
+      return {
+        ok: false,
+        code: "write_failed",
+        status: 500,
+        message: `Signed in, but the credentials for "${pending.profileId}" could not be written, so the profile was not created.`,
+      }
+    }
+    // The token endpoint's own error body is deliberately not forwarded — it is
+    // one-time-credential-adjacent and belongs nowhere near a rendered page.
+    return {
+      ok: false,
+      code: "exchange_failed",
+      status: 502,
+      message: exchange.status
+        ? `Anthropic rejected the authorization code (HTTP ${exchange.status}). Codes expire quickly — start again.`
+        : "Could not reach Anthropic to exchange the authorization code. Start again.",
+    }
+  }
+
+  const created = createProfileSlot(pending.profileId)
+  if (!created.ok) {
+    if (created.reason === "already_exists") {
+      // Something created this name during the sign-in — the CLI, or another
+      // instance. Said plainly rather than reported as success: the credentials
+      // just authorized went into that profile's directory.
+      return {
+        ok: false,
+        code: "profile_exists",
+        status: 409,
+        message: `Profile "${pending.profileId}" was created elsewhere while you were signing in. `
+          + "The account you just authorized was written to its config directory; check it before using it.",
+      }
+    }
+    return {
+      ok: false,
+      code: "create_failed",
+      status: 500,
+      message: `Signed in, but "${pending.profileId}" could not be written to profiles.json (${created.message}). `
+        + `The credentials are on disk — \`meridian profile add ${pending.profileId}\` will pick them up.`,
+    }
+  }
+
+  return { ok: true, profileId: created.profile.id, claudeConfigDir: created.profile.claudeConfigDir ?? pending.claudeConfigDir }
+}
+
+export function pendingAddCount(): number {
+  return pendingAdds.size
+}
+
+/** Drop all pending creations — for testing only. */
+export function resetPendingAdds(): void {
+  pendingAdds.clear()
+}

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -25,6 +25,18 @@ const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+
+/**
+ * Path Anthropic has registered for this client's loopback redirect.
+ *
+ * `https://claude.ai/oauth/claude-code-client-metadata` declares
+ * `redirect_uris: ["http://localhost/callback", "http://127.0.0.1/callback"]`
+ * — the RFC 8252 §7.3 loopback convention, where the port is not part of the
+ * match but the host and path are. So a redirect back into Meridian has to be
+ * served from `/callback` at the root, on `localhost` or `127.0.0.1`; no other
+ * path will be accepted, which is why the route is not under `/profiles/`.
+ */
+export const OAUTH_LOOPBACK_CALLBACK_PATH = "/callback"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -38,8 +50,18 @@ function ensureProfilesDir(): void {
   mkdirSync(PROFILES_DIR, { recursive: true })
 }
 
-function getProfileDir(id: string): string {
+/**
+ * Config directory a browser-login profile gets when it carries no explicit
+ * `claudeConfigDir`. Exported so the web login route resolves the same
+ * directory this CLI would, instead of rebuilding the path a third time
+ * (profiles.ts already builds it for oauth-token isolation).
+ */
+export function profileConfigDirFor(id: string): string {
   return join(PROFILES_DIR, id)
+}
+
+function getProfileDir(id: string): string {
+  return profileConfigDirFor(id)
 }
 
 interface AuthLoginOptions {
@@ -79,21 +101,66 @@ function base64Url(bytes: Buffer): string {
   return bytes.toString("base64url")
 }
 
-export function createManualOAuthSession(scopes?: string[]): ManualOAuthSession {
-  const scopeList = scopes ?? OAUTH_SCOPES
+export interface OAuthPkce {
+  codeVerifier: string
+  codeChallenge: string
+  state: string
+}
+
+export function createOAuthPkce(): OAuthPkce {
   const codeVerifier = base64Url(randomBytes(32))
-  const state = base64Url(randomBytes(32))
-  const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url")
+  return {
+    codeVerifier,
+    codeChallenge: createHash("sha256").update(codeVerifier).digest("base64url"),
+    state: base64Url(randomBytes(32)),
+  }
+}
+
+/**
+ * Build an authorize URL for one PKCE challenge and one redirect_uri.
+ *
+ * Separate from `createOAuthPkce` because a single login needs TWO of these:
+ * one redirecting to a loopback listener, one to Anthropic's code-display
+ * page. Claude Code builds the same pair from one challenge
+ * (`buildAuthUrl({...opts, isManual: true})` and `isManual: false`), opens the
+ * loopback one and prints the manual one, then picks the matching redirect_uri
+ * again at exchange time. Whichever the user completes, the other is simply
+ * never used — so the paste fallback costs nothing and needs no second login.
+ *
+ * `code=true` is set for both. It is NOT what makes Anthropic display the code
+ * rather than redirect: Claude Code appends it unconditionally in both modes,
+ * and the redirect_uri alone decides.
+ */
+export function buildAuthorizeUrl(params: {
+  codeChallenge: string
+  state: string
+  redirectUri: string
+  scopes?: string[]
+}): string {
   const url = new URL(OAUTH_AUTHORIZE_URL)
   url.searchParams.set("code", "true")
   url.searchParams.set("client_id", OAUTH_CLIENT_ID)
   url.searchParams.set("response_type", "code")
-  url.searchParams.set("redirect_uri", OAUTH_REDIRECT_URI)
-  url.searchParams.set("scope", scopeList.join(" "))
-  url.searchParams.set("code_challenge", codeChallenge)
+  url.searchParams.set("redirect_uri", params.redirectUri)
+  url.searchParams.set("scope", (params.scopes ?? OAUTH_SCOPES).join(" "))
+  url.searchParams.set("code_challenge", params.codeChallenge)
   url.searchParams.set("code_challenge_method", "S256")
-  url.searchParams.set("state", state)
-  return { authorizeUrl: url.toString(), codeVerifier, state }
+  url.searchParams.set("state", params.state)
+  return url.toString()
+}
+
+export function createManualOAuthSession(scopes?: string[]): ManualOAuthSession {
+  const pkce = createOAuthPkce()
+  return {
+    authorizeUrl: buildAuthorizeUrl({
+      codeChallenge: pkce.codeChallenge,
+      state: pkce.state,
+      redirectUri: OAUTH_REDIRECT_URI,
+      scopes,
+    }),
+    codeVerifier: pkce.codeVerifier,
+    state: pkce.state,
+  }
 }
 
 export function parseAuthorizationCodeInput(input: string): ParsedAuthorizationCode | null {
@@ -156,6 +223,111 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
+export type OAuthExchangeFailureReason =
+  | "state_mismatch"
+  | "request_failed"
+  | "http_error"
+  | "invalid_response"
+  | "missing_tokens"
+  | "write_failed"
+
+export type OAuthExchangeResult =
+  | { ok: true }
+  | { ok: false; reason: OAuthExchangeFailureReason; status?: number; detail?: string }
+
+export interface OAuthExchangeParams {
+  /** Authorization code parsed out of the user's paste. */
+  code: string
+  /** `state` the paste carried, when it carried one (a pasted URL does). */
+  returnedState?: string
+  /** `state` this login was started with — what `returnedState` must match. */
+  sessionState: string
+  /** PKCE verifier for this login. */
+  codeVerifier: string
+  /** CLAUDE_CONFIG_DIR whose credential store receives the tokens. */
+  claudeConfigDir: string
+  /**
+   * redirect_uri to send with the grant. MUST be the one the authorize step
+   * used — the code is bound to it, and a mismatch is rejected. Defaults to
+   * the code-display page, which is what a pasted code always comes from.
+   */
+  redirectUri?: string
+  /** Scopes recorded when the token response omits `scope`. */
+  scopes?: string[]
+  /** Injectable for tests — defaults to global `fetch`. */
+  fetchFn?: typeof fetch
+}
+
+/**
+ * Validate `state`, exchange an authorization code for OAuth credentials, and
+ * write them to a profile's credential store.
+ *
+ * ONE implementation, two front ends: `meridian profile login --headless`
+ * (which prompts for the paste) and `POST /profiles/login/complete` (which
+ * receives it over HTTP). Both parse the paste with
+ * `parseAuthorizationCodeInput` and hand the result here, so state validation,
+ * the token request and what gets persisted cannot drift between them.
+ *
+ * Returns a reason instead of throwing or printing, because the two callers
+ * present failure differently: the CLI renders reasons as red lines, the HTTP
+ * route maps them to status codes. `detail` carries the token endpoint's error
+ * body (truncated) for the CLI's diagnostics; the route drops it rather than
+ * rendering an upstream error body into a page.
+ */
+export async function exchangeAuthorizationCodeForCredentials(params: OAuthExchangeParams): Promise<OAuthExchangeResult> {
+  if (params.returnedState && params.returnedState !== params.sessionState) {
+    return { ok: false, reason: "state_mismatch" }
+  }
+
+  const fetchFn = params.fetchFn ?? fetch
+  let response: Response
+  try {
+    response = await fetchFn(OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: OAUTH_CLIENT_ID,
+        code: params.code,
+        redirect_uri: params.redirectUri ?? OAUTH_REDIRECT_URI,
+        code_verifier: params.codeVerifier,
+        state: params.returnedState ?? params.sessionState,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+  } catch (err) {
+    return { ok: false, reason: "request_failed", detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    return { ok: false, reason: "http_error", status: response.status, detail: body.slice(0, 300) || undefined }
+  }
+
+  let tokenData: OAuthTokenResponse
+  try {
+    tokenData = await response.json() as OAuthTokenResponse
+  } catch (err) {
+    return { ok: false, reason: "invalid_response", detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  if (!tokenData.access_token || !tokenData.refresh_token) {
+    return { ok: false, reason: "missing_tokens" }
+  }
+
+  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+  const store = createPlatformCredentialStore({ claudeConfigDir: params.claudeConfigDir })
+  const written = await store.write({
+    claudeAiOauth: {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt,
+      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? params.scopes ?? OAUTH_SCOPES,
+    },
+  })
+  return written ? { ok: true } : { ok: false, reason: "write_failed" }
+}
+
 async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   const session = createManualOAuthSession()
   console.log("\x1b[33m⚠ Headless OAuth login: open this URL in a browser:\x1b[0m")
@@ -163,67 +335,45 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   console.log(session.authorizeUrl)
   console.log()
   console.log("After sign-in, paste the code shown by Claude below.")
+  console.log("\x1b[90m(the whole callback URL works too)\x1b[0m")
   const input = promptLine("Paste code:")
   const parsed = parseAuthorizationCodeInput(input)
   if (!parsed) {
     console.error("\x1b[31m✗ No authorization code received.\x1b[0m")
     return false
   }
-  if (parsed.state && parsed.state !== session.state) {
-    console.error("\x1b[31m✗ OAuth state mismatch. Please retry the login.\x1b[0m")
-    return false
-  }
 
-  let response: Response
-  try {
-    response = await fetch(OAUTH_TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "authorization_code",
-        client_id: OAUTH_CLIENT_ID,
-        code: parsed.code,
-        redirect_uri: OAUTH_REDIRECT_URI,
-        code_verifier: session.codeVerifier,
-        state: parsed.state ?? session.state,
-      }),
-      signal: AbortSignal.timeout(30_000),
-    })
-  } catch (err) {
-    console.error(`\x1b[31m✗ OAuth token exchange failed: ${err instanceof Error ? err.message : err}\x1b[0m`)
-    return false
-  }
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "")
-    console.error(`\x1b[31m✗ OAuth token exchange failed (${response.status}).\x1b[0m`)
-    if (body) console.error(`  ${body.slice(0, 300)}`)
-    return false
-  }
-
-  let tokenData: OAuthTokenResponse
-  try {
-    tokenData = await response.json() as OAuthTokenResponse
-  } catch (err) {
-    console.error(`\x1b[31m✗ OAuth token response was invalid: ${err instanceof Error ? err.message : err}\x1b[0m`)
-    return false
-  }
-
-  if (!tokenData.access_token || !tokenData.refresh_token) {
-    console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
-    return false
-  }
-
-  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
-  const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write({
-    claudeAiOauth: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt,
-      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
-    },
+  const result = await exchangeAuthorizationCodeForCredentials({
+    code: parsed.code,
+    returnedState: parsed.state,
+    sessionState: session.state,
+    codeVerifier: session.codeVerifier,
+    claudeConfigDir: configDir,
   })
+  if (result.ok) return true
+
+  switch (result.reason) {
+    case "state_mismatch":
+      console.error("\x1b[31m✗ OAuth state mismatch. Please retry the login.\x1b[0m")
+      break
+    case "request_failed":
+      console.error(`\x1b[31m✗ OAuth token exchange failed: ${result.detail}\x1b[0m`)
+      break
+    case "http_error":
+      console.error(`\x1b[31m✗ OAuth token exchange failed (${result.status}).\x1b[0m`)
+      if (result.detail) console.error(`  ${result.detail}`)
+      break
+    case "invalid_response":
+      console.error(`\x1b[31m✗ OAuth token response was invalid: ${result.detail}\x1b[0m`)
+      break
+    case "missing_tokens":
+      console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
+      break
+    case "write_failed":
+      console.error("\x1b[31m✗ Could not write credentials for this profile.\x1b[0m")
+      break
+  }
+  return false
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -16,11 +16,22 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
-import { setSetting } from "./settings"
+import { meridianConfigDir, setSetting } from "./settings"
 import { createPlatformCredentialStore } from "./tokenRefresh"
 
-const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
+/**
+ * Resolved per call, not frozen at import, so these track MERIDIAN_CONFIG_DIR
+ * exactly as `profiles.ts` does when it reads them back. Freezing them here
+ * while the reader resolves dynamically is how a written profile becomes an
+ * invisible one.
+ */
+function profilesDir(): string {
+  return join(meridianConfigDir(), "profiles")
+}
+
+function configFile(): string {
+  return join(meridianConfigDir(), "profiles.json")
+}
 const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -47,7 +58,7 @@ const OAUTH_SCOPES = [
 ]
 
 function ensureProfilesDir(): void {
-  mkdirSync(PROFILES_DIR, { recursive: true })
+  mkdirSync(profilesDir(), { recursive: true })
 }
 
 /**
@@ -57,7 +68,7 @@ function ensureProfilesDir(): void {
  * (profiles.ts already builds it for oauth-token isolation).
  */
 export function profileConfigDirFor(id: string): string {
-  return join(PROFILES_DIR, id)
+  return join(profilesDir(), id)
 }
 
 function getProfileDir(id: string): string {
@@ -183,18 +194,30 @@ export function parseAuthorizationCodeInput(input: string): ParsedAuthorizationC
 }
 
 function loadProfileConfig(): ProfileConfig[] {
-  if (!existsSync(CONFIG_FILE)) return []
+  const file = configFile()
+  if (!existsSync(file)) return []
   try {
-    return JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
+    return JSON.parse(readFileSync(file, "utf-8"))
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     return []
   }
 }
 
+/**
+ * Ids currently written to profiles.json, for collision checks.
+ *
+ * Ids only. The file also holds `apiKey` and `oauthToken` values, and a
+ * collision check has no business handling those — the narrower return type is
+ * what keeps them from reaching a caller that might render or log one.
+ */
+export function loadProfileIds(): string[] {
+  return loadProfileConfig().map(p => p.id)
+}
+
 function saveProfileConfig(profiles: ProfileConfig[]): void {
   ensureProfilesDir()
-  writeFileSync(CONFIG_FILE, `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
+  writeFileSync(configFile(), `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
 }
 
 function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; subscriptionType?: string } {
@@ -376,12 +399,88 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   return false
 }
 
+/**
+ * A profile id becomes a directory name under `profiles/`, so this character
+ * set is what stops `../../etc` from becoming one. Exported so the CLI and the
+ * web add route ask the same question — a second regex elsewhere is a second
+ * answer to "what is a legal id", and the two would drift.
+ */
+export function isValidProfileId(id: string): boolean {
+  return Boolean(id) && !/[^a-zA-Z0-9_-]/.test(id)
+}
+
+export type ProfileSlotFailureReason = "invalid_id" | "already_exists" | "write_failed"
+
+export type CreateProfileSlotResult =
+  | { ok: true; profile: ProfileConfig; profiles: ProfileConfig[] }
+  | { ok: false; reason: ProfileSlotFailureReason; message: string }
+
+/**
+ * Turn a valid, non-colliding id into the two things a browser-login profile
+ * is made of: an entry in profiles.json and a CLAUDE_CONFIG_DIR of its own.
+ *
+ * ONE implementation, two front ends — `meridian profile add` and
+ * `POST /profiles/add/complete` — for the same reason the token exchange has
+ * one: two copies of "what a profile is made of" drift, and the copy that
+ * drifts is the one nobody runs.
+ *
+ * The collision check reads profiles.json at call time rather than trusting a
+ * list the caller loaded earlier, so a slot created between an early check and
+ * this one is still caught.
+ *
+ * `claudeConfigDir` adopts a directory that already holds credentials — the
+ * CLI's `~/.claude` import. Omitted, the profile gets a fresh directory of its
+ * own under `profiles/<id>`.
+ */
+export function createProfileSlot(
+  id: string,
+  options: { claudeConfigDir?: string } = {},
+): CreateProfileSlotResult {
+  if (!isValidProfileId(id)) {
+    return {
+      ok: false,
+      reason: "invalid_id",
+      message: "Invalid profile ID. Use only letters, numbers, hyphens and underscores.",
+    }
+  }
+
+  const profiles = loadProfileConfig()
+  if (profiles.some(p => p.id === id)) {
+    return { ok: false, reason: "already_exists", message: `Profile "${id}" already exists.` }
+  }
+
+  const claudeConfigDir = options.claudeConfigDir ?? profileConfigDirFor(id)
+  const profile: ProfileConfig = { id, claudeConfigDir }
+  try {
+    mkdirSync(claudeConfigDir, { recursive: true })
+    profiles.push(profile)
+    saveProfileConfig(profiles)
+  } catch (err) {
+    return { ok: false, reason: "write_failed", message: err instanceof Error ? err.message : String(err) }
+  }
+
+  return { ok: true, profile, profiles }
+}
+
+/** CLI wrapper: `createProfileSlot` refusals are fatal for `meridian profile add`. */
+function createProfileSlotOrExit(id: string, options: { claudeConfigDir?: string } = {}): ProfileConfig[] {
+  const created = createProfileSlot(id, options)
+  if (!created.ok) {
+    console.error(`\x1b[31m✗ ${created.message}\x1b[0m`)
+    if (created.reason === "already_exists") console.error(`  Run: meridian profile list`)
+    process.exit(1)
+  }
+  return created.profiles
+}
+
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {
-  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+  if (!isValidProfileId(id)) {
     console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
 
+  // Checked here as well as inside createProfileSlot: this one fails before a
+  // browser login the user would otherwise complete for nothing.
   const profiles = loadProfileConfig()
   if (profiles.find(p => p.id === id)) {
     console.error(`\x1b[31m✗ Profile "${id}" already exists.\x1b[0m`)
@@ -399,10 +498,9 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
       console.log(`\x1b[32m✓ Found existing Claude credentials (${defaultAuth.email}, ${defaultAuth.subscriptionType || "unknown"})\x1b[0m`)
       const answer = promptYesNo(`  Import as profile "${id}"?`)
       if (answer) {
-        profiles.push({ id, claudeConfigDir: defaultClaudeDir })
-        saveProfileConfig(profiles)
+        const imported = createProfileSlotOrExit(id, { claudeConfigDir: defaultClaudeDir })
         console.log(`\x1b[32m✓ Profile "${id}" imported — using ${defaultAuth.email}\x1b[0m`)
-        printEnvHint(profiles)
+        printEnvHint(imported)
         return
       }
       console.log()
@@ -412,6 +510,9 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
   }
 
   const configDir = getProfileDir(id)
+  // Created before the login rather than by createProfileSlot afterwards: the
+  // `claude auth login` subprocess writes its credentials into this directory,
+  // so it has to exist first. The profiles.json entry still waits for success.
   mkdirSync(configDir, { recursive: true })
 
   console.log(`\x1b[36mAdding profile: ${id}\x1b[0m`)
@@ -422,9 +523,7 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
   const existingAuth = getAuthStatus(configDir)
   if (existingAuth.loggedIn) {
     console.log(`\x1b[32m✓ Already authenticated as ${existingAuth.email}\x1b[0m`)
-    profiles.push({ id, claudeConfigDir: configDir })
-    saveProfileConfig(profiles)
-    printEnvHint(profiles)
+    printEnvHint(createProfileSlotOrExit(id))
     return
   }
 
@@ -477,13 +576,11 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
   console.log()
   console.log(`\x1b[32m✓ Profile "${id}" created — logged in as ${auth.email} (${auth.subscriptionType || "unknown"})\x1b[0m`)
 
-  profiles.push({ id, claudeConfigDir: configDir })
-  saveProfileConfig(profiles)
-  printEnvHint(profiles)
+  printEnvHint(createProfileSlotOrExit(id))
 }
 
 export async function profileAddOauthToken(id: string, tokenArg: string | undefined): Promise<void> {
-  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+  if (!isValidProfileId(id)) {
     console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
@@ -572,7 +669,7 @@ export function profileRemove(id: string): void {
     console.error(`\x1b[31m✗ Profile "${id}" not found.\x1b[0m`)
     process.exit(1)
   }
-  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, PROFILES_DIR)
+  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, profilesDir())
   profiles.splice(idx, 1)
   saveProfileConfig(profiles)
 
@@ -726,7 +823,7 @@ function promptToken(question: string): string {
 }
 
 function printEnvHint(_profiles: ProfileConfig[]): void {
-  console.log(`\x1b[90mConfig: ${CONFIG_FILE}\x1b[0m`)
+  console.log(`\x1b[90mConfig: ${configFile()}\x1b[0m`)
   console.log("\x1b[90mProfiles are picked up automatically — no restart needed.\x1b[0m")
 }
 

--- a/src/proxy/profileLogin.ts
+++ b/src/proxy/profileLogin.ts
@@ -1,0 +1,631 @@
+/**
+ * Browser-completable OAuth login for claude-max profiles.
+ *
+ * Backs `POST /profiles/login/start`, `GET /callback`,
+ * `GET /profiles/login/status` and `POST /profiles/login/complete`, so
+ * re-authenticating an account does not require a terminal on the box Meridian
+ * runs on. The browser only ever holds an opaque login id; the PKCE verifier
+ * stays here.
+ *
+ * A login started from a browser ON THE MERIDIAN HOST finishes by itself:
+ * Anthropic redirects to `http://127.0.0.1:<port>/callback`, this module
+ * exchanges the code, and the page notices via `GET /profiles/login/status`.
+ * Anthropic's published client metadata for the Claude Code client
+ * (`https://claude.ai/oauth/claude-code-client-metadata`) registers
+ * `http://localhost/callback` and `http://127.0.0.1/callback`, so a loopback
+ * redirect is the one alternative to the code-display page that will be
+ * accepted — an origin like `meridian.example.com` cannot be registered.
+ *
+ * That is also the flow's limit: a redirect to loopback only comes back to
+ * Meridian when the browser is on the same host (directly, or through an SSH
+ * port-forward, since the forward makes the same loopback address reach it).
+ * A browser on another machine keeps the paste flow, which is why both
+ * authorize URLs are minted from ONE PKCE challenge and either may be
+ * completed — the same thing Claude Code does with its manual/automatic pair.
+ *
+ * This is a leaf module — no imports from server.ts or session/.
+ */
+
+import { randomBytes } from "node:crypto"
+import { envBool } from "../env"
+import {
+  buildAuthorizeUrl,
+  createOAuthPkce,
+  exchangeAuthorizationCodeForCredentials,
+  parseAuthorizationCodeInput,
+  profileConfigDirFor,
+  OAUTH_LOOPBACK_CALLBACK_PATH,
+  OAUTH_REDIRECT_URI,
+} from "./profileCli"
+import { getEffectiveProfiles, resolveProfile, type ProfileConfig } from "./profiles"
+
+/**
+ * How long a started login stays completable.
+ *
+ * Bounded because an unfinished login holds a PKCE verifier and a `state` this
+ * process would otherwise accept forever. Ten minutes covers a human signing
+ * in — including a password manager and a 2FA prompt — and Anthropic's
+ * authorization code expires well before it anyway.
+ */
+export const LOGIN_TTL_MS = 10 * 60_000
+
+/**
+ * How long a finished login's OUTCOME remains readable by the status route.
+ *
+ * The page polls every second or two, so this is only for a user who switched
+ * tabs. Kept in a separate record that holds no verifier and no code.
+ */
+export const LOGIN_RESULT_TTL_MS = 5 * 60_000
+
+/**
+ * Hosts a loopback redirect may be built for.
+ *
+ * Exactly the two Anthropic registered. Anything else — a LAN address, a
+ * tailnet name, a reverse-proxy hostname — is refused at the authorize step,
+ * so offering it would produce a broken login rather than a fallback.
+ */
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1"])
+
+interface PendingLogin {
+  profileId: string
+  claudeConfigDir: string
+  codeVerifier: string
+  state: string
+  expiresAt: number
+  /** Present only when this login was started with a usable loopback origin. */
+  loopbackRedirectUri?: string
+}
+
+interface FinishedLogin {
+  profileId: string
+  status: "completed" | "failed"
+  expiresAt: number
+  failure?: { code: LoginErrorCode; message: string }
+}
+
+/**
+ * Started-but-unfinished logins, keyed by the opaque id handed to the browser.
+ *
+ * Server-side because the verifier is half of the PKCE proof: sending it to the
+ * browser would put both halves in one place that is not the one that started
+ * the flow. Two logins for different profiles are two entries and cannot
+ * interfere — each carries its own verifier, state and target directory.
+ */
+const pendingLogins = new Map<string, PendingLogin>()
+
+/**
+ * `state` → login id.
+ *
+ * The redirect from Anthropic carries `state` and nothing else that identifies
+ * the login, so this index IS the state check on that path: an id is only
+ * reached by presenting the unguessable 256-bit `state` that login was started
+ * with. There is no lookup that skips it.
+ */
+const loginIdByState = new Map<string, string>()
+
+/** Outcomes of finished logins, so the page can read what happened. */
+const finishedLogins = new Map<string, FinishedLogin>()
+
+export type LoginErrorCode =
+  | "credentials_readonly"
+  | "no_profiles"
+  | "unknown_profile"
+  | "unsupported_profile_type"
+  | "invalid_request"
+  | "expired_login"
+  | "no_code"
+  | "state_mismatch"
+  | "login_denied"
+  | "exchange_failed"
+  | "write_failed"
+
+export interface LoginFailure {
+  ok: false
+  code: LoginErrorCode
+  status: number
+  message: string
+  /**
+   * The login is still open — paste again, no second sign-in.
+   *
+   * Set exactly when the paste was rejected locally, before any code reached
+   * Anthropic. The client reads this instead of matching on `code`, because
+   * only this module knows whether the session survived the attempt; a client
+   * re-deriving it from the code list would drift the moment a code is added.
+   */
+  retryable?: true
+}
+
+/** How the browser is expected to finish this login. */
+export type LoginMode = "redirect" | "paste"
+
+export interface StartLoginSuccess {
+  ok: true
+  profileId: string
+  loginId: string
+  mode: LoginMode
+  /** The URL to open. Redirects back here in `redirect` mode. */
+  authorizeUrl: string
+  /**
+   * Authorize URL whose sign-in ends on Anthropic's code-display page.
+   *
+   * Always present, even in `redirect` mode, so the page can offer "paste it
+   * instead" without starting a second login: both URLs carry the same
+   * challenge and `state`, and whichever is completed first wins.
+   */
+  pasteAuthorizeUrl: string
+  /**
+   * Authorize URL that redirects to this instance on loopback, when one can be
+   * built at all. In `redirect` mode this is `authorizeUrl`; in `paste` mode it
+   * is the upgrade the page may take if `loopbackProbeUrl` answers.
+   */
+  loopbackAuthorizeUrl?: string
+  /**
+   * Status URL for THIS login on the loopback origin, for the page to probe.
+   *
+   * Deliberately the status route rather than something like `/health`: a 200
+   * from it proves the browser can reach loopback AND that what answers there
+   * is the same instance holding this login. Anything else on that port
+   * answers 410 and the page keeps the paste flow.
+   */
+  loopbackProbeUrl?: string
+  expiresAt: number
+}
+
+export interface CompleteLoginSuccess {
+  ok: true
+  profileId: string
+}
+
+export interface StartLoginParams {
+  profiles: ProfileConfig[] | undefined
+  profileId: string
+  /**
+   * The request's own `Host` header — the origin the user is actually on,
+   * which decides whether a loopback redirect can reach this instance.
+   */
+  hostHeader?: string
+  /** Port this instance listens on, used to offer a loopback candidate when
+   *  `hostHeader` is some other name. */
+  serverPort?: number
+  now?: number
+}
+
+export interface CompleteLoginParams {
+  loginId: string
+  input: string
+  now?: number
+  fetchFn?: typeof fetch
+}
+
+export interface CallbackParams {
+  state?: string
+  code?: string
+  /** `error` / `error_description` as Anthropic sends them on a refusal. */
+  error?: string
+  errorDescription?: string
+  now?: number
+  fetchFn?: typeof fetch
+}
+
+export interface LoginStatusReport {
+  status: "waiting" | "completed" | "failed"
+  profileId: string
+  error?: string
+  code?: LoginErrorCode
+}
+
+function prune(now: number): void {
+  for (const [id, login] of pendingLogins) {
+    if (login.expiresAt <= now) {
+      pendingLogins.delete(id)
+      loginIdByState.delete(login.state)
+    }
+  }
+  for (const [id, finished] of finishedLogins) {
+    if (finished.expiresAt <= now) finishedLogins.delete(id)
+  }
+}
+
+/** Take a login out of play. Returns it, or undefined if it was not open. */
+function consume(loginId: string): PendingLogin | undefined {
+  const pending = pendingLogins.get(loginId)
+  if (!pending) return undefined
+  pendingLogins.delete(loginId)
+  loginIdByState.delete(pending.state)
+  return pending
+}
+
+function restore(loginId: string, pending: PendingLogin): void {
+  pendingLogins.set(loginId, pending)
+  loginIdByState.set(pending.state, loginId)
+}
+
+function finish(loginId: string, profileId: string, now: number, failure?: LoginFailure): void {
+  finishedLogins.set(loginId, {
+    profileId,
+    status: failure ? "failed" : "completed",
+    expiresAt: now + LOGIN_RESULT_TTL_MS,
+    ...(failure ? { failure: { code: failure.code, message: failure.message } } : {}),
+  })
+}
+
+/**
+ * The loopback URL Anthropic should redirect to, or undefined when this
+ * browser cannot be redirected back.
+ *
+ * Derived from the request's own `Host` header rather than from configuration
+ * because that header IS the address the user reached this instance on — which
+ * is the address a redirect has to come back to. It also makes an SSH
+ * port-forward work unchanged: the browser is on `localhost:<forwarded port>`,
+ * so that is what gets built, and the forward carries it back.
+ *
+ * SECURITY. `Host` is client-supplied, so this deliberately does not echo it:
+ * the value is parsed, the hostname must be one of the two Anthropic
+ * registered, and the URL is REBUILT from the parsed host with a fixed path.
+ * The only reachable abuse is aiming the redirect at a different port on the
+ * user's own loopback, which needs a forged `Host` (browsers set it from the
+ * address bar) and still yields nothing: the code is bound by PKCE to a
+ * verifier held only here, and the `state` needed to redeem it never left this
+ * process.
+ */
+export function resolveLoopbackRedirectUri(hostHeader: string | undefined): string | undefined {
+  if (!hostHeader) return undefined
+  let parsed: URL
+  try {
+    parsed = new URL(`http://${hostHeader}`)
+  } catch {
+    return undefined
+  }
+  if (!LOOPBACK_HOSTNAMES.has(parsed.hostname)) return undefined
+  return `http://${parsed.host}${OAUTH_LOOPBACK_CALLBACK_PATH}`
+}
+
+/**
+ * A loopback redirect this instance MIGHT be reachable at, for a browser that
+ * reached it under some other name.
+ *
+ * `Host` proves a loopback redirect will work; its absence proves nothing. A
+ * user browsing `https://meridian.example.net` from the very machine Meridian
+ * runs on can still be redirected to `http://127.0.0.1:<port>/callback` — the
+ * browser is on that host, it simply did not say so. Measured in Chromium: a
+ * page on an HTTPS origin may both `fetch` and be navigated to loopback, since
+ * `127.0.0.1` is a potentially-trustworthy origin and so is exempt from
+ * mixed-content blocking.
+ *
+ * So this returns a CANDIDATE, offered alongside the paste URL rather than
+ * used in its place. The page probes it (see `loopbackProbeUrl`) and upgrades
+ * only when the probe answers; a browser on another machine never reaches it,
+ * the probe fails, and the paste flow stands.
+ */
+export function loopbackRedirectUriForPort(port: number | undefined): string | undefined {
+  if (!port || !Number.isInteger(port) || port <= 0 || port > 65535) return undefined
+  return `http://127.0.0.1:${port}${OAUTH_LOOPBACK_CALLBACK_PATH}`
+}
+
+/**
+ * Refuse when this instance must not write credential files.
+ *
+ * `MERIDIAN_CREDENTIALS_READONLY=1` marks an instance that shares another
+ * instance's credential files — a standby beside the one that owns them. Such
+ * an instance can still serve this page, so the button is there to be clicked;
+ * refusing at the START is the whole point. A user who signs in and is refused
+ * afterwards has burned a one-time authorization code for nothing.
+ */
+function readonlyRefusal(profileId: string): LoginFailure | null {
+  if (!envBool("CREDENTIALS_READONLY")) return null
+  return {
+    ok: false,
+    code: "credentials_readonly",
+    status: 409,
+    message:
+      "This Meridian instance runs with MERIDIAN_CREDENTIALS_READONLY=1 and must not write credential files, "
+      + "so it cannot complete a login. Use the instance that owns these credentials, "
+      + `or a terminal on the box that holds them: meridian profile login ${profileId}`,
+  }
+}
+
+/**
+ * Create a login: resolve the profile, mint one PKCE challenge, and return the
+ * authorize URL for whichever completion this browser can manage. Every
+ * refusal happens here, before the user is sent to Anthropic to sign in.
+ */
+export function startProfileLogin(params: StartLoginParams): StartLoginSuccess | LoginFailure {
+  const now = params.now ?? Date.now()
+  const profileId = params.profileId.trim()
+  if (!profileId) {
+    return { ok: false, code: "invalid_request", status: 400, message: "Missing 'profile' in request body" }
+  }
+
+  const readonly = readonlyRefusal(profileId)
+  if (readonly) return readonly
+
+  const effective = getEffectiveProfiles(params.profiles)
+  if (effective.length === 0) {
+    return { ok: false, code: "no_profiles", status: 400, message: "No profiles configured" }
+  }
+
+  // Unknown ids are refused rather than created. `meridian profile add` is the
+  // one place a profile comes into existence, and this surface is reachable by
+  // anyone who can reach the page — creating an account slot from it is a
+  // different decision than re-authenticating one that exists.
+  if (!effective.some(p => p.id === profileId)) {
+    return {
+      ok: false,
+      code: "unknown_profile",
+      status: 404,
+      message: `Unknown profile: ${profileId}. Available: ${effective.map(p => p.id).join(", ")}`,
+    }
+  }
+
+  // Reuse the request-path resolver so the type inference and the config-dir
+  // choice are the ones every request already gets, not a second reading of
+  // the same fields.
+  const resolved = resolveProfile(params.profiles, undefined, profileId)
+  if (resolved.type !== "claude-max") {
+    return {
+      ok: false,
+      code: "unsupported_profile_type",
+      status: 400,
+      message: `Profile "${profileId}" is an ${resolved.type} profile, which has no OAuth login flow. `
+        + (resolved.type === "oauth-token"
+          ? `Replace its token instead: meridian profile remove ${profileId} && meridian profile add ${profileId} --oauth-token`
+          : "Edit its API key in ~/.config/meridian/profiles.json instead."),
+    }
+  }
+
+  const pkce = createOAuthPkce()
+  // Two questions, not one: whether a loopback redirect is CERTAIN (the browser
+  // said it reached us on loopback) and whether one is POSSIBLE (it may be on
+  // this host under another name). The first picks the mode; the second is
+  // offered for the page to probe.
+  const certainLoopbackUri = resolveLoopbackRedirectUri(params.hostHeader)
+  const loopbackRedirectUri = certainLoopbackUri ?? loopbackRedirectUriForPort(params.serverPort)
+  const pasteAuthorizeUrl = buildAuthorizeUrl({
+    codeChallenge: pkce.codeChallenge,
+    state: pkce.state,
+    redirectUri: OAUTH_REDIRECT_URI,
+  })
+  const loopbackAuthorizeUrl = loopbackRedirectUri
+    ? buildAuthorizeUrl({
+        codeChallenge: pkce.codeChallenge,
+        state: pkce.state,
+        redirectUri: loopbackRedirectUri,
+      })
+    : undefined
+  const authorizeUrl = certainLoopbackUri ? loopbackAuthorizeUrl! : pasteAuthorizeUrl
+
+  const loginId = randomBytes(16).toString("base64url")
+  const expiresAt = now + LOGIN_TTL_MS
+  prune(now)
+  restore(loginId, {
+    profileId,
+    claudeConfigDir: resolved.env.CLAUDE_CONFIG_DIR ?? profileConfigDirFor(profileId),
+    codeVerifier: pkce.codeVerifier,
+    state: pkce.state,
+    expiresAt,
+    loopbackRedirectUri,
+  })
+
+  return {
+    ok: true,
+    profileId,
+    loginId,
+    mode: certainLoopbackUri ? "redirect" : "paste",
+    authorizeUrl,
+    pasteAuthorizeUrl,
+    ...(loopbackAuthorizeUrl ? { loopbackAuthorizeUrl } : {}),
+    ...(loopbackRedirectUri
+      ? { loopbackProbeUrl: `${new URL(loopbackRedirectUri).origin}/profiles/login/status?loginId=${encodeURIComponent(loginId)}` }
+      : {}),
+    expiresAt,
+  }
+}
+
+/**
+ * Finish a login from what the user pasted — a bare code, or the whole callback
+ * URL from the browser's address bar.
+ */
+export async function completeProfileLogin(params: CompleteLoginParams): Promise<CompleteLoginSuccess | LoginFailure> {
+  const now = params.now ?? Date.now()
+  prune(now)
+
+  const pending = pendingLogins.get(params.loginId)
+  if (!pending) {
+    return {
+      ok: false,
+      code: "expired_login",
+      status: 410,
+      message: "This login is no longer open — it expired, or it was already completed. Start it again.",
+    }
+  }
+
+  // Parsed before the session is consumed: a mistyped paste should not force
+  // the user back through Anthropic's sign-in. The session is single-use from
+  // the moment a code is actually sent, which is the exchange below.
+  const parsed = parseAuthorizationCodeInput(params.input)
+  if (!parsed) {
+    return {
+      ok: false,
+      code: "no_code",
+      status: 400,
+      retryable: true,
+      message: "No authorization code found in that paste. Paste the code Claude showed you, or the whole callback URL.",
+    }
+  }
+
+  // Consumed BEFORE the exchange, not after: taking it out of both indexes
+  // first is what makes single-use hold against two completions racing the
+  // same login id.
+  consume(params.loginId)
+
+  // A pasted code always comes from the code-display page, so it is bound to
+  // THAT redirect_uri — even when this login also issued a loopback URL the
+  // user chose not to use.
+  const result = await exchangeAuthorizationCodeForCredentials({
+    code: parsed.code,
+    returnedState: parsed.state,
+    sessionState: pending.state,
+    codeVerifier: pending.codeVerifier,
+    claudeConfigDir: pending.claudeConfigDir,
+    redirectUri: OAUTH_REDIRECT_URI,
+    fetchFn: params.fetchFn,
+  })
+
+  if (result.ok) {
+    finish(params.loginId, pending.profileId, now)
+    return { ok: true, profileId: pending.profileId }
+  }
+
+  if (result.reason === "state_mismatch") {
+    // Rejected locally — the code never reached Anthropic, so nothing was
+    // spent and this login is still good. Put it back: pasting the wrong
+    // browser tab should cost a second paste, not a second sign-in.
+    restore(params.loginId, pending)
+    return {
+      ok: false,
+      code: "state_mismatch",
+      status: 400,
+      retryable: true,
+      message: "OAuth state did not match this login. Paste the code from the tab this login opened.",
+    }
+  }
+
+  const failure = exchangeFailure(result, pending.profileId)
+  finish(params.loginId, pending.profileId, now, failure)
+  return failure
+}
+
+/**
+ * Finish a login from Anthropic's redirect back to `/callback`.
+ *
+ * Addressed by `state` alone, because that is all the redirect carries that
+ * identifies the login — and being unguessable is exactly what makes it
+ * sufficient. A `state` with no open login is indistinguishable from an
+ * expired one and gets the same answer.
+ */
+export async function completeProfileLoginFromCallback(
+  params: CallbackParams,
+): Promise<CompleteLoginSuccess | LoginFailure> {
+  const now = params.now ?? Date.now()
+  prune(now)
+
+  const loginId = params.state ? loginIdByState.get(params.state) : undefined
+  const pending = loginId ? pendingLogins.get(loginId) : undefined
+  if (!loginId || !pending) {
+    return {
+      ok: false,
+      code: "expired_login",
+      status: 410,
+      message: "No login is waiting for this sign-in — it expired, or it was already completed. Start it again from the Profiles page.",
+    }
+  }
+
+  if (params.error) {
+    const failure: LoginFailure = {
+      ok: false,
+      code: "login_denied",
+      status: 400,
+      message: `Claude did not authorize this login (${params.error}${params.errorDescription ? `: ${params.errorDescription}` : ""}).`,
+    }
+    consume(loginId)
+    finish(loginId, pending.profileId, now, failure)
+    return failure
+  }
+
+  // Only a login that issued a loopback URL can be finished by a redirect;
+  // anything else means a `state` arriving on a path it was never minted for.
+  if (!params.code || !pending.loopbackRedirectUri) {
+    const failure: LoginFailure = {
+      ok: false,
+      code: "no_code",
+      status: 400,
+      message: "That sign-in came back without an authorization code. Start the login again.",
+    }
+    consume(loginId)
+    finish(loginId, pending.profileId, now, failure)
+    return failure
+  }
+
+  consume(loginId)
+
+  const result = await exchangeAuthorizationCodeForCredentials({
+    code: params.code,
+    returnedState: params.state,
+    sessionState: pending.state,
+    codeVerifier: pending.codeVerifier,
+    claudeConfigDir: pending.claudeConfigDir,
+    redirectUri: pending.loopbackRedirectUri,
+    fetchFn: params.fetchFn,
+  })
+
+  if (result.ok) {
+    finish(loginId, pending.profileId, now)
+    return { ok: true, profileId: pending.profileId }
+  }
+
+  const failure = exchangeFailure(result, pending.profileId)
+  finish(loginId, pending.profileId, now, failure)
+  return failure
+}
+
+function exchangeFailure(
+  result: Extract<Awaited<ReturnType<typeof exchangeAuthorizationCodeForCredentials>>, { ok: false }>,
+  profileId: string,
+): LoginFailure {
+  if (result.reason === "state_mismatch") {
+    return {
+      ok: false,
+      code: "state_mismatch",
+      status: 400,
+      message: "OAuth state did not match this login. Start the login again.",
+    }
+  }
+  if (result.reason === "write_failed") {
+    return {
+      ok: false,
+      code: "write_failed",
+      status: 500,
+      message: `Signed in, but the credentials for "${profileId}" could not be written.`,
+    }
+  }
+  // The token endpoint's own error body is deliberately not forwarded — it is
+  // one-time-credential-adjacent and belongs nowhere near a rendered page.
+  return {
+    ok: false,
+    code: "exchange_failed",
+    status: 502,
+    message: result.status
+      ? `Anthropic rejected the authorization code (HTTP ${result.status}). Codes expire quickly — start the login again.`
+      : "Could not reach Anthropic to exchange the authorization code. Start the login again.",
+  }
+}
+
+/**
+ * What became of a login. `null` once nothing is known about the id — either it
+ * was never issued, or both its TTLs have passed.
+ */
+export function getProfileLoginStatus(loginId: string, now: number = Date.now()): LoginStatusReport | null {
+  prune(now)
+  const pending = pendingLogins.get(loginId)
+  if (pending) return { status: "waiting", profileId: pending.profileId }
+  const finished = finishedLogins.get(loginId)
+  if (!finished) return null
+  if (finished.status === "completed") return { status: "completed", profileId: finished.profileId }
+  return {
+    status: "failed",
+    profileId: finished.profileId,
+    error: finished.failure?.message,
+    code: finished.failure?.code,
+  }
+}
+
+export function pendingLoginCount(): number {
+  return pendingLogins.size
+}
+
+/** Drop all pending logins — for testing only. */
+export function resetPendingLogins(): void {
+  pendingLogins.clear()
+  loginIdByState.clear()
+  finishedLogins.clear()
+}

--- a/src/proxy/profileLogin.ts
+++ b/src/proxy/profileLogin.ts
@@ -27,6 +27,7 @@
  */
 
 import { randomBytes } from "node:crypto"
+import { networkInterfaces } from "node:os"
 import { envBool } from "../env"
 import {
   buildAuthorizeUrl,
@@ -184,6 +185,13 @@ export interface StartLoginParams {
    * which decides whether a loopback redirect can reach this instance.
    */
   hostHeader?: string
+  /**
+   * The request's `X-Forwarded-For`, which a reverse proxy in front of this
+   * instance fills with the browser's own address. It answers the question
+   * `hostHeader` cannot: whether a browser that reached us under some other
+   * name is nonetheless on this host.
+   */
+  forwardedFor?: string
   /** Port this instance listens on, used to offer a loopback candidate when
    *  `hostHeader` is some other name. */
   serverPort?: number
@@ -303,6 +311,99 @@ export function loopbackRedirectUriForPort(port: number | undefined): string | u
 }
 
 /**
+ * One address, spelled the one way, so the three spellings of it compare equal.
+ *
+ * A proxy may write a port (`10.0.0.4:51234`, `[fd7a::1]:51234`), a zone id
+ * (`fe80::1%eth0`), or an IPv4-mapped IPv6 address (`::ffff:127.0.0.1`) — all
+ * of which name a host that `networkInterfaces()` reports plainly.
+ *
+ * The port is only stripped from a bracketed address or a dotted quad: a bare
+ * IPv6 address is nothing but colons, so treating its last group as a port
+ * would truncate the address itself.
+ */
+export function normalizeClientAddress(raw: string): string {
+  let addr = raw.trim().toLowerCase()
+  if (!addr) return ""
+
+  if (addr.startsWith("[")) {
+    const close = addr.indexOf("]")
+    if (close === -1) return ""
+    addr = addr.slice(1, close)
+  } else if (addr.includes(".") && addr.split(":").length === 2) {
+    addr = addr.slice(0, addr.indexOf(":"))
+  }
+
+  const zone = addr.indexOf("%")
+  if (zone !== -1) addr = addr.slice(0, zone)
+
+  if (addr.startsWith("::ffff:") && addr.includes(".")) addr = addr.slice("::ffff:".length)
+  return addr
+}
+
+/** Every address this machine answers on, as `networkInterfaces()` spells it. */
+function ownHostAddresses(): Set<string> {
+  const own = new Set<string>()
+  for (const addresses of Object.values(networkInterfaces())) {
+    for (const address of addresses ?? []) own.add(normalizeClientAddress(address.address))
+  }
+  return own
+}
+
+/**
+ * Whether the browser that made this request is on the Meridian host itself,
+ * according to the address a reverse proxy recorded for it.
+ *
+ * This is the case `Host` cannot answer. A user browsing
+ * `https://meridian.example.net` from the very machine Meridian runs on sends
+ * a `Host` of `meridian.example.net`, so `resolveLoopbackRedirectUri` refuses —
+ * yet a loopback redirect would reach this instance perfectly. The proxy in
+ * front knows what `Host` lost: it saw the browser's own address and wrote it
+ * into `X-Forwarded-For`. When that address is one this machine answers on,
+ * the browser is provably here.
+ *
+ * Only the FIRST entry is read. `X-Forwarded-For` accumulates left to right,
+ * so the first is the original client and every later one is a proxy.
+ *
+ * SECURITY. The header is client-settable, so a request may claim to be local
+ * and be believed. That grants nothing: the only effect is that this login's
+ * `authorizeUrl` becomes the loopback one — which the response already returns
+ * unconditionally as `loopbackAuthorizeUrl` for the page to upgrade to. A
+ * forger gains a URL they were handed anyway, pointed at loopback on THEIR
+ * machine, and the code it carries is still redeemable only against a verifier
+ * that never left this process.
+ */
+export function clientIsOnThisHost(forwardedFor: string | undefined): boolean {
+  const first = forwardedFor?.split(",")[0]
+  if (!first) return false
+  const addr = normalizeClientAddress(first)
+  if (!addr) return false
+  if (addr === "::1" || addr.startsWith("127.")) return true
+  return ownHostAddresses().has(addr)
+}
+
+/**
+ * Whether a paste is the address bar of a loopback callback rather than a code
+ * from Anthropic's code-display page.
+ *
+ * Which one it is decides the `redirect_uri` the grant must name, because
+ * Anthropic binds a code to the URI its authorize request carried. A user who
+ * took the loopback link and could not be redirected back — a browser on
+ * another machine, a tab that failed to load — still has the code in that
+ * tab's address bar, and the panel invites them to paste it.
+ */
+export function isLoopbackCallbackInput(input: string): boolean {
+  let url: URL
+  try {
+    url = new URL(input.trim())
+  } catch {
+    return false
+  }
+  return url.protocol === "http:"
+    && LOOPBACK_HOSTNAMES.has(url.hostname)
+    && url.pathname === OAUTH_LOOPBACK_CALLBACK_PATH
+}
+
+/**
  * Refuse when this instance must not write credential files.
  *
  * `MERIDIAN_CREDENTIALS_READONLY=1` marks an instance that shares another
@@ -374,11 +475,14 @@ export function startProfileLogin(params: StartLoginParams): StartLoginSuccess |
   }
 
   const pkce = createOAuthPkce()
-  // Two questions, not one: whether a loopback redirect is CERTAIN (the browser
-  // said it reached us on loopback) and whether one is POSSIBLE (it may be on
-  // this host under another name). The first picks the mode; the second is
-  // offered for the page to probe.
+  // Two questions, not one: whether a loopback redirect is CERTAIN and whether
+  // one is merely POSSIBLE. Certain has two proofs — the browser reached us ON
+  // loopback (`Host`), or a proxy in front recorded it at an address this host
+  // answers on (`X-Forwarded-For`). Possible is everything else with a port to
+  // guess at. The first picks the mode; the second is offered for the page to
+  // probe.
   const certainLoopbackUri = resolveLoopbackRedirectUri(params.hostHeader)
+    ?? (clientIsOnThisHost(params.forwardedFor) ? loopbackRedirectUriForPort(params.serverPort) : undefined)
   const loopbackRedirectUri = certainLoopbackUri ?? loopbackRedirectUriForPort(params.serverPort)
   const pasteAuthorizeUrl = buildAuthorizeUrl({
     codeChallenge: pkce.codeChallenge,
@@ -458,16 +562,24 @@ export async function completeProfileLogin(params: CompleteLoginParams): Promise
   // same login id.
   consume(params.loginId)
 
-  // A pasted code always comes from the code-display page, so it is bound to
-  // THAT redirect_uri — even when this login also issued a loopback URL the
-  // user chose not to use.
+  // Which sign-in this code came from decides the redirect_uri the grant must
+  // name. A paste is USUALLY the code-display page, but not always: a user sent
+  // to the loopback URL whose browser could not be redirected back still has
+  // the code in the failed tab's address bar, and the panel asks for exactly
+  // that. Reading the shape of the paste is what tells the two apart. The URI
+  // itself comes from the login, never from the paste, so a pasted address is
+  // evidence and not input.
+  const redirectUri = pending.loopbackRedirectUri && isLoopbackCallbackInput(params.input)
+    ? pending.loopbackRedirectUri
+    : OAUTH_REDIRECT_URI
+
   const result = await exchangeAuthorizationCodeForCredentials({
     code: parsed.code,
     returnedState: parsed.state,
     sessionState: pending.state,
     codeVerifier: pending.codeVerifier,
     claudeConfigDir: pending.claudeConfigDir,
-    redirectUri: OAUTH_REDIRECT_URI,
+    redirectUri,
     fetchFn: params.fetchFn,
   })
 

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -142,6 +142,17 @@ export function enableDiskProfileDiscovery(): void {
   diskDiscoveryEnabled = true
 }
 
+/** Disable disk auto-discovery — for testing only.
+ *
+ *  The flag is process-global and one-way, so a test file that imports
+ *  `bin/cli.ts` turns it on for every file that runs after it in the same
+ *  `bun test` process. Any test asserting behaviour for an EMPTY profile list
+ *  then reads the host's real `~/.config/meridian/profiles.json` instead, and
+ *  passes or fails depending on file order. This is the way back. */
+export function resetDiskProfileDiscovery(): void {
+  diskDiscoveryEnabled = false
+}
+
 export function getEffectiveProfiles(configProfiles: ProfileConfig[] | undefined): ProfileConfig[] {
   const fromConfig = configProfiles ?? []
   if (!diskDiscoveryEnabled) return fromConfig

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -16,16 +16,25 @@
 
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
-import { homedir } from "node:os"
-import { setSetting, getSetting } from "./settings"
+import { meridianConfigDir, setSetting, getSetting } from "./settings"
 import { pickStickyProfile, type RoutingMode } from "./routing"
 
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
+/**
+ * Where profiles live on disk. Resolved per call so it tracks
+ * MERIDIAN_CONFIG_DIR — the writer (`profileCli.ts`) resolves the same path
+ * the same way, and a reader and writer that disagree produce a profile that
+ * is written and never seen.
+ */
+function profilesFile(): string {
+  return join(meridianConfigDir(), "profiles.json")
+}
 
 /** Disk profile cache with short TTL so new profiles are picked up quickly */
 const DISK_CACHE_TTL_MS = 5_000
 let diskProfilesCache: ProfileConfig[] = []
 let diskProfilesCacheAt = 0
+/** Path the cache was filled from — a changed override must not serve stale entries. */
+let diskProfilesCachePath = ""
 
 /**
  * Load profiles from ~/.config/meridian/profiles.json.
@@ -33,20 +42,23 @@ let diskProfilesCacheAt = 0
  * while avoiding synchronous disk I/O on every request.
  */
 export function loadProfilesFromDisk(): ProfileConfig[] {
-  if (diskProfilesCacheAt > 0 && Date.now() - diskProfilesCacheAt < DISK_CACHE_TTL_MS) {
+  const file = profilesFile()
+  if (diskProfilesCacheAt > 0 && diskProfilesCachePath === file && Date.now() - diskProfilesCacheAt < DISK_CACHE_TTL_MS) {
     return diskProfilesCache
   }
   try {
-    if (!existsSync(CONFIG_FILE)) {
+    if (!existsSync(file)) {
       diskProfilesCache = []
     } else {
-      diskProfilesCache = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
+      diskProfilesCache = JSON.parse(readFileSync(file, "utf-8"))
     }
     diskProfilesCacheAt = Date.now()
+    diskProfilesCachePath = file
     return diskProfilesCache
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     diskProfilesCacheAt = Date.now()
+    diskProfilesCachePath = file
     diskProfilesCache = []
     return []
   }
@@ -232,8 +244,10 @@ function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
       // Isolate from host ~/.claude. Without this, the SDK's 401-recovery
       // silently reads host creds from disk and swaps a refreshed token in
       // for our env value, masking token failures. Path must not collapse
-      // to ~/.claude — see query.ts re: upstream claude-code#20553.
-      env.CLAUDE_CONFIG_DIR = join(homedir(), ".config", "meridian", "profiles", profile.id)
+      // to ~/.claude — see query.ts re: upstream claude-code#20553. Built
+      // from meridianConfigDir() so it stays the directory profileCli.ts
+      // creates and profileRemove deletes.
+      env.CLAUDE_CONFIG_DIR = join(meridianConfigDir(), "profiles", profile.id)
     }
     return { id: profile.id, type: "oauth-token", env }
   }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4859,6 +4859,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       profiles: finalConfig.profiles,
       profileId: body.profile ?? "",
       hostHeader: c.req.header("host"),
+      forwardedFor: c.req.header("x-forwarded-for"),
       serverPort: finalConfig.port,
     })
     if (!result.ok) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -82,6 +82,7 @@ import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
 import { startProfileLogin, completeProfileLogin, completeProfileLoginFromCallback, getProfileLoginStatus } from "./profileLogin"
+import { startProfileAdd, completeProfileAdd } from "./profileAdd"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -4953,6 +4954,71 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     claudeLog("profile.login_completed", { profile: result.profileId, via: "callback" })
     plog(`[PROXY] Profile login completed for "${result.profileId}" (browser redirect)`)
     return c.html(renderLoginCallbackPage({ ok: true, profileId: result.profileId }))
+  })
+
+  // --- Profile creation routes (browser-completable OAuth) ---
+  //
+  // Same two-step shape as the login routes above, deliberately NOT the same
+  // routes: /profiles/login/start refuses unknown ids, and that refusal is what
+  // stops a typo in a re-authentication from creating an account slot. Creating
+  // one is its own act, so it is its own explicit route. Decisions live in
+  // profileAdd.ts.
+
+  app.post("/profiles/add/start", async (c) => {
+    let body: { profile?: string }
+    try {
+      body = await c.req.json() as { profile?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    const result = startProfileAdd({ profiles: finalConfig.profiles, profileId: body.profile ?? "" })
+    if (!result.ok) {
+      claudeLog("profile.add_refused", {
+        profile: body.profile?.slice(0, 64) ?? null,
+        reason: result.code,
+        userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+      })
+      return c.json({ error: result.message, code: result.code }, result.status as 400)
+    }
+    plog(`[PROXY] Profile creation started for "${result.profileId}" (expires in ${Math.round((result.expiresAt - Date.now()) / 1000)}s)`)
+    return c.json({
+      addId: result.addId,
+      authorizeUrl: result.authorizeUrl,
+      expiresAt: result.expiresAt,
+      profile: result.profileId,
+    })
+  })
+
+  app.post("/profiles/add/complete", async (c) => {
+    let body: { addId?: string; code?: string }
+    try {
+      body = await c.req.json() as { addId?: string; code?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    if (!body.addId) {
+      return c.json({ error: "Missing 'addId' in request body", code: "invalid_request" }, 400)
+    }
+    const result = await completeProfileAdd({ addId: body.addId, input: body.code ?? "" })
+    if (!result.ok) {
+      // The paste itself is never logged — it is a one-time credential.
+      claudeLog("profile.add_failed", { reason: result.code })
+      return c.json({
+        error: result.message,
+        code: result.code,
+        ...(result.retryable ? { retryable: true } : {}),
+      }, result.status as 400)
+    }
+    // A profile that did not exist a moment ago has no cached auth answer, but
+    // the list-wide cache does — drop it so the new card renders authenticated
+    // on the UI's next poll rather than after the 60s TTL.
+    expireAuthStatusCache()
+    claudeLog("profile.add_completed", {
+      profile: result.profileId,
+      userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+    })
+    plog(`[PROXY] Profile "${result.profileId}" created from the web UI`)
+    return c.json({ success: true, profile: result.profileId })
   })
 
   // --- Plugin management routes ---

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -65,7 +65,7 @@ import {
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, expireAuthStatusCache, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
@@ -81,6 +81,7 @@ import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { startProfileLogin, completeProfileLogin, completeProfileLoginFromCallback, getProfileLoginStatus } from "./profileLogin"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -4835,6 +4836,123 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     })
     plog(`[PROXY] Active profile switched to: ${body.profile} (from ${previousProfile ?? "unset"}, ua: ${(c.req.header("user-agent") || "unknown").slice(0, 60)}) (session + rate-limit caches cleared)`)
     return c.json({ success: true, activeProfile: body.profile })
+  })
+
+  // --- Profile login routes (browser-completable OAuth) ---
+  //
+  // /start mints one PKCE challenge and hands the browser an opaque login id
+  // plus an authorize URL. A browser on this host gets one that redirects to
+  // GET /callback below, and the login finishes on its own; a browser anywhere
+  // else gets the code-display page and finishes via /complete with a paste.
+  // /status is how the page learns which happened. Decisions live in
+  // profileLogin.ts.
+
+  app.post("/profiles/login/start", async (c) => {
+    let body: { profile?: string }
+    try {
+      body = await c.req.json() as { profile?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    const result = startProfileLogin({
+      profiles: finalConfig.profiles,
+      profileId: body.profile ?? "",
+      hostHeader: c.req.header("host"),
+      serverPort: finalConfig.port,
+    })
+    if (!result.ok) {
+      claudeLog("profile.login_refused", {
+        profile: body.profile ?? null,
+        reason: result.code,
+        userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+      })
+      return c.json({ error: result.message, code: result.code }, result.status as 400)
+    }
+    plog(`[PROXY] Profile login started for "${result.profileId}" (mode=${result.mode}, expires in ${Math.round((result.expiresAt - Date.now()) / 1000)}s)`)
+    return c.json({
+      loginId: result.loginId,
+      mode: result.mode,
+      authorizeUrl: result.authorizeUrl,
+      pasteAuthorizeUrl: result.pasteAuthorizeUrl,
+      ...(result.loopbackAuthorizeUrl ? { loopbackAuthorizeUrl: result.loopbackAuthorizeUrl } : {}),
+      ...(result.loopbackProbeUrl ? { loopbackProbeUrl: result.loopbackProbeUrl } : {}),
+      expiresAt: result.expiresAt,
+      profile: result.profileId,
+    })
+  })
+
+  app.get("/profiles/login/status", (c) => {
+    const loginId = c.req.query("loginId")
+    if (!loginId) {
+      return c.json({ error: "Missing 'loginId' query parameter", code: "invalid_request" }, 400)
+    }
+    const status = getProfileLoginStatus(loginId)
+    if (!status) {
+      return c.json({
+        error: "This login is no longer open — it expired, or it was already completed. Start it again.",
+        code: "expired_login",
+      }, 410)
+    }
+    return c.json(status)
+  })
+
+  app.post("/profiles/login/complete", async (c) => {
+    let body: { loginId?: string; code?: string }
+    try {
+      body = await c.req.json() as { loginId?: string; code?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    if (!body.loginId) {
+      return c.json({ error: "Missing 'loginId' in request body", code: "invalid_request" }, 400)
+    }
+    const result = await completeProfileLogin({ loginId: body.loginId, input: body.code ?? "" })
+    if (!result.ok) {
+      // The paste itself is never logged — it is a one-time credential.
+      claudeLog("profile.login_failed", { reason: result.code })
+      return c.json({
+        error: result.message,
+        code: result.code,
+        ...(result.retryable ? { retryable: true } : {}),
+      }, result.status as 400)
+    }
+    // The auth-status cache holds a 60s "not logged in" answer for this profile;
+    // drop it so /profiles/list reflects the login on the UI's next poll.
+    expireAuthStatusCache()
+    claudeLog("profile.login_completed", {
+      profile: result.profileId,
+      userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+    })
+    plog(`[PROXY] Profile login completed for "${result.profileId}"`)
+    return c.json({ success: true, profile: result.profileId })
+  })
+
+  // PUBLIC — no requireAuth. Anthropic redirects the user's browser here and
+  // that redirect carries no API key, so gating it would break the flow for
+  // every instance running with MERIDIAN_API_KEY set. The path and root
+  // placement are Anthropic's, not ours: the client's registered loopback
+  // redirect URIs are `http://localhost/callback` and
+  // `http://127.0.0.1/callback`. Its security review is in
+  // proxy-settings-auth.test.ts beside the allowlist entry.
+  app.get("/callback", async (c) => {
+    const { renderLoginCallbackPage } = await import("../telemetry/loginCallbackPage")
+    const result = await completeProfileLoginFromCallback({
+      state: c.req.query("state"),
+      code: c.req.query("code"),
+      error: c.req.query("error"),
+      errorDescription: c.req.query("error_description"),
+    })
+    if (!result.ok) {
+      // Neither the code nor the state is logged — both are one-time
+      // credentials for this login.
+      claudeLog("profile.login_failed", { reason: result.code, via: "callback" })
+      plog(`[PROXY] Profile login callback failed: ${result.code}`)
+      return c.html(renderLoginCallbackPage({ ok: false, message: result.message }), result.status as 400)
+    }
+    expireAuthStatusCache()
+    claudeLog("profile.login_completed", { profile: result.profileId, via: "callback" })
+    plog(`[PROXY] Profile login completed for "${result.profileId}" (browser redirect)`)
+    return c.html(renderLoginCallbackPage({ ok: true, profileId: result.profileId }))
   })
 
   // --- Plugin management routes ---

--- a/src/proxy/settings.ts
+++ b/src/proxy/settings.ts
@@ -13,22 +13,28 @@ import { join, dirname } from "node:path"
 import { homedir } from "node:os"
 
 /**
- * Resolve the settings file path.
+ * Resolve Meridian's own config directory — the one holding `settings.json`,
+ * `profiles.json`, and the per-profile `CLAUDE_CONFIG_DIR`s under `profiles/`.
  *
  * Resolved per call rather than frozen at import time so tests can redirect
  * it via MERIDIAN_CONFIG_DIR (see `src/__tests__/preload.ts`). Without the
  * override the path is exactly what it has always been, so existing installs
  * are unaffected.
  *
+ * Shared by settings.ts, profiles.ts and profileCli.ts so the override moves
+ * all of Meridian's state together. A reader and a writer disagreeing about
+ * where profiles.json lives is a profile that gets written and never seen.
+ *
  * NOTE: deliberately does NOT honour XDG_CONFIG_HOME — anyone who has that
  * set would silently relocate to a different settings file and appear to
  * lose their configuration.
  */
+export function meridianConfigDir(): string {
+  return process.env.MERIDIAN_CONFIG_DIR ?? join(homedir(), ".config", "meridian")
+}
+
 function settingsFile(): string {
-  const override = process.env.MERIDIAN_CONFIG_DIR
-  return override
-    ? join(override, "settings.json")
-    : join(homedir(), ".config", "meridian", "settings.json")
+  return join(meridianConfigDir(), "settings.json")
 }
 
 export interface MeridianSettings {

--- a/src/telemetry/loginCallbackPage.ts
+++ b/src/telemetry/loginCallbackPage.ts
@@ -1,0 +1,74 @@
+/**
+ * Landing page for Anthropic's OAuth redirect (`GET /callback`).
+ *
+ * Deliberately the one page without the shared site header. `/callback` is
+ * reachable without the API key — it has to be, since Anthropic's redirect
+ * carries no credentials — and the header polls `/health` and `/profiles/list`,
+ * which are gated. Embedding it would render a broken "offline" chrome on the
+ * one page a user sees mid-login. Everything else follows DESIGN.md: theme
+ * tokens only, no page-level body background.
+ *
+ * The tab is not closed for the user. It was opened with `noopener`, so
+ * `window.close()` would be refused after the sign-in navigation anyway, and
+ * the page the user came from already knows the outcome — it polls for it.
+ */
+
+import { themeCss } from "./profileBar"
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+export interface LoginCallbackPageParams {
+  ok: boolean
+  profileId?: string
+  message?: string
+}
+
+export function renderLoginCallbackPage(params: LoginCallbackPageParams): string {
+  const title = params.ok ? "Signed in" : "Login failed"
+  const detail = params.ok
+    ? `Profile <strong>${escapeHtml(params.profileId ?? "")}</strong> is authenticated. You can close this tab — the Profiles page has already updated.`
+    : escapeHtml(params.message ?? "The login could not be completed.")
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Meridian — ${escapeHtml(title)}</title>
+<style>
+  ${themeCss}
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+         color: var(--text); line-height: 1.5; min-height: 100vh;
+         display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .card {
+    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
+    padding: 28px 32px; max-width: 520px; text-align: center;
+  }
+  .mark { font-size: 28px; line-height: 1; margin-bottom: 12px; }
+  .mark.ok { color: var(--green); }
+  .mark.err { color: var(--red); }
+  h1 { font-size: 18px; font-weight: 600; margin-bottom: 8px; }
+  p { font-size: 13px; color: var(--muted); }
+  a { color: var(--accent); text-decoration: none; font-size: 13px; }
+  a:hover { text-decoration: underline; }
+  .back { margin-top: 18px; display: inline-block; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="mark ${params.ok ? "ok" : "err"}">${params.ok ? "\u2713" : "\u2717"}</div>
+  <h1>${escapeHtml(title)}</h1>
+  <p>${detail}</p>
+  <a class="back" href="/profiles">Back to Profiles</a>
+</div>
+</body>
+</html>`
+}

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -76,6 +76,41 @@ export const profilePageHtml = `<!DOCTYPE html>
   }
   .guide .warn strong { color: var(--yellow); }
 
+  /* Browser login — the paste box that replaces a terminal round trip. */
+  .login-btn {
+    padding: 6px 12px; font-size: 12px; font-weight: 500;
+    background: var(--surface2); color: var(--accent); border: 1px solid var(--accent);
+    border-radius: 6px; cursor: pointer; transition: all 0.15s;
+  }
+  .login-btn:hover { background: rgba(88,166,255,0.12); }
+  .login-btn:disabled { opacity: 0.4; cursor: default; }
+  /* The sign-in control is an <a>, so it needs a button's box back. */
+  a.login-btn { display: inline-block; text-decoration: none; line-height: normal; }
+  a.login-btn[aria-disabled="true"] { opacity: 0.5; cursor: default; }
+  .login-panel {
+    margin-top: 12px; padding: 14px 16px; background: var(--surface2);
+    border: 1px solid var(--border); border-radius: 8px;
+  }
+  .login-panel-title { font-size: 12px; font-weight: 600; margin-bottom: 8px; }
+  .login-note {
+    font-size: 12px; color: var(--muted); margin-bottom: 8px; padding: 8px 10px;
+    background: rgba(210,153,34,0.1); border: 1px solid rgba(210,153,34,0.3); border-radius: 6px;
+  }
+  .login-steps { font-size: 12px; color: var(--muted); padding-left: 18px; margin-bottom: 10px; }
+  .login-steps li { margin-bottom: 4px; }
+  .login-row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .login-input {
+    flex: 1 1 260px; min-width: 0; padding: 7px 10px; border-radius: 6px;
+    background: var(--bg); border: 1px solid var(--border); color: var(--text);
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px;
+  }
+  .login-input:focus { outline: none; border-color: var(--accent); }
+  .login-msg { margin-top: 10px; font-size: 12px; }
+  .login-msg.err { color: var(--red); }
+  .login-msg.busy { color: var(--muted); }
+  .login-reopen { color: var(--accent); font-size: 11px; text-decoration: none; }
+  .login-reopen:hover { text-decoration: underline; }
+
   .mono { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; }
   .copy-cmd {
     font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px;
@@ -173,10 +208,23 @@ export const profilePageHtml = `<!DOCTYPE html>
       <li><strong>Per-request:</strong> Send <code>x-meridian-profile: &lt;name&gt;</code> header</li>
     </ol>
 
+    <h3 style="margin-top:16px">Re-authenticating a profile</h3>
+    <ol>
+      <li><strong>UI:</strong> Click <strong>Log in from browser</strong> on the profile card and sign in.
+          Claude sends you back here and the login finishes itself. It is an ordinary link, so
+          right-click it to open the sign-in in a private window or copy it into another browser
+          \u2014 useful when this browser is already signed into a different Claude account.</li>
+      <li><strong>CLI:</strong> <code>meridian profile login &lt;name&gt;</code></li>
+    </ol>
+    <p style="font-size:12px;color:var(--muted);margin-top:8px">
+      Claude will only redirect back to <code>localhost</code> or <code>127.0.0.1</code> \u2014 those are the
+      addresses registered for this client. Browsing Meridian on any other hostname, the panel
+      asks for the code instead; the bare code or the whole callback URL both work.
+    </p>
+
     <h3 style="margin-top:16px">Other commands</h3>
     <div style="font-size:13px;margin-top:8px">
       <code>meridian profile list</code> \u2014 show all profiles and auth status<br>
-      <code>meridian profile login &lt;name&gt;</code> \u2014 re-authenticate an expired profile<br>
       <code>meridian profile remove &lt;name&gt;</code> \u2014 remove a profile
     </div>
   </div>
@@ -399,7 +447,24 @@ function render(data, quotaData) {
     html += '<button class="copy-btn" data-cmd="meridian profile login ' + esc(p.id) + '" onclick="copyCmd(this)" title="Copy to clipboard">';
     html += '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>';
     html += '</button>';
+    // Only claude-max profiles have an OAuth flow; api and oauth-token profiles
+    // would only ever get a refusal, so they get no button.
+    if ((p.type || 'claude-max') === 'claude-max') {
+      // A real anchor with a real href, not a button. That is the only way the
+      // browser offers "Open Link in Incognito Window" and "Copy Link Address"
+      // — and someone signed into several Claude accounts needs those, because
+      // the ambient session in their main browser is usually the wrong account
+      // for the profile being re-authenticated. A button, or an anchor that
+      // navigates from a click handler, gets no such menu.
+      html += '<a class="login-btn login-link" data-profile="' + esc(p.id) + '"'
+        + ' href="' + esc(loginHrefFor(p.id) || '#') + '"'
+        + (loginHrefFor(p.id) ? '' : ' aria-disabled="true"')
+        + ' target="_blank" rel="noopener noreferrer"'
+        + ' onclick="return onLoginLinkClick(event, &quot;' + esc(p.id) + '&quot;)">Log in from browser</a>';
+    }
     html += '</div>';
+
+    html += '<div class="login-slot" id="login-slot-' + esc(p.id) + '"></div>';
 
     html += renderUsageSection(quotaById[p.id]);
 
@@ -414,6 +479,11 @@ function render(data, quotaData) {
 
   html += '</div>';
   document.getElementById('content').innerHTML = html;
+  // render() replaces #content wholesale, so the anchors are new elements with
+  // whatever href the markup carried. Restore them from the cache, then top up
+  // anything missing or near expiry in the background.
+  applyLoginHrefs();
+  ensureLoginLinks(profiles);
 }
 
 function timeAgo(ts) {
@@ -447,8 +517,345 @@ async function switchProfile(id) {
   if (data.success) refresh();
 }
 
+// --- Browser login ---
+//
+// The open login is held here rather than in the DOM because render() rebuilds
+// #content wholesale on every poll — a panel written into a card would be
+// destroyed mid-typing. While a login is open the card poll is paused, so the
+// panel and whatever is half-pasted into it survive.
+var activeLogin = null;
+var loginPollTimer = null;
+
+function loginSlot(id) { return document.getElementById('login-slot-' + id); }
+
+function setLoginMsg(text, kind) {
+  var slot = activeLogin ? loginSlot(activeLogin.profile) : null;
+  if (!slot) return;
+  var msg = slot.querySelector('.login-msg');
+  if (!msg) return;
+  msg.className = 'login-msg' + (kind ? ' ' + kind : '');
+  msg.textContent = text || '';
+}
+
+// Sign-in links, minted server-side and held per profile so the anchor has a
+// real href before anyone clicks it. Nothing secret lives here: the authorize
+// URL is public by design, and the PKCE verifier never leaves the server.
+var loginLinks = {};
+// Whether this browser can reach Meridian on loopback. A fact about the
+// BROWSER, not about any one profile, so it is answered once for the page.
+var loopbackOk = null;
+// Set when the refusal is about the instance rather than a profile.
+var loginBlocked = null;
+
+function loginHrefFor(id) {
+  var link = loginLinks[id];
+  if (!link) return '';
+  return (loopbackOk && link.loopback) ? link.loopback : link.hosted;
+}
+
+function applyLoginHrefs() {
+  var els = document.querySelectorAll('.login-link');
+  for (var i = 0; i < els.length; i++) {
+    var el = els[i];
+    var href = loginHrefFor(el.getAttribute('data-profile'));
+    if (href) {
+      el.setAttribute('href', href);
+      el.removeAttribute('aria-disabled');
+    } else {
+      el.setAttribute('href', '#');
+      el.setAttribute('aria-disabled', 'true');
+    }
+    if (loginBlocked) el.setAttribute('title', loginBlocked);
+  }
+}
+
+async function mintLoginLink(id) {
+  var res, data;
+  try {
+    res = await fetch('/profiles/login/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: id })
+    });
+    data = await res.json();
+  } catch (err) {
+    return 'error';
+  }
+  if (!res.ok) {
+    if (data.code === 'credentials_readonly' || data.code === 'no_profiles') {
+      loginBlocked = data.error || 'Login unavailable on this instance.';
+      return 'blocked';
+    }
+    return 'error';
+  }
+  if (data.mode === 'redirect') loopbackOk = true;
+  loginLinks[id] = {
+    loginId: data.loginId,
+    hosted: data.pasteAuthorizeUrl,
+    loopback: data.loopbackAuthorizeUrl || null,
+    probeUrl: data.loopbackProbeUrl || null,
+    expiresAt: data.expiresAt
+  };
+  return 'ok';
+}
+
+// Keep every claude-max card's href live. Re-minted before the pending login
+// expires, so a link that has sat on screen for a while still works when it is
+// finally clicked — or when it is opened in another browser minutes later.
+async function ensureLoginLinks(profiles) {
+  if (loginBlocked) return;
+  var due = [];
+  for (var i = 0; i < profiles.length; i++) {
+    var p = profiles[i];
+    if ((p.type || 'claude-max') !== 'claude-max') continue;
+    var link = loginLinks[p.id];
+    if (!link || link.expiresAt - Date.now() < 120000) due.push(p.id);
+  }
+  if (due.length === 0) return;
+
+  // The first alone: a refusal about the INSTANCE (a read-only standby, no
+  // profiles at all) would otherwise repeat once per card, and each one is a
+  // logged refusal on the server.
+  if (await mintLoginLink(due[0]) === 'blocked') { applyLoginHrefs(); return; }
+  await Promise.all(due.slice(1).map(mintLoginLink));
+
+  if (loopbackOk === null) {
+    var probe = null;
+    for (var id in loginLinks) {
+      if (loginLinks[id].probeUrl) { probe = loginLinks[id].probeUrl; break; }
+    }
+    loopbackOk = probe ? await loopbackReachable(probe) : false;
+  }
+  applyLoginHrefs();
+}
+
+function showLoginMessage(id, text, kind) {
+  var slot = loginSlot(id);
+  if (!slot) return;
+  slot.innerHTML = '<div class="login-panel"><div class="login-msg ' + esc(kind) + '"></div></div>';
+  var msg = slot.querySelector('.login-msg');
+  if (msg) msg.textContent = text;
+}
+
+function onLoginLinkClick(ev, id) {
+  if (loginBlocked) {
+    ev.preventDefault();
+    showLoginMessage(id, loginBlocked, 'err');
+    return false;
+  }
+  var link = loginLinks[id];
+  if (!link) {
+    ev.preventDefault();
+    showLoginMessage(id, 'Preparing the sign-in link\\u2026', 'busy');
+    return false;
+  }
+  openLoginPanel(id, link);
+  // Returning true lets the BROWSER follow the href. Nothing here opens a
+  // window, so ctrl-click, middle-click and "open in incognito" all behave as
+  // the user asked instead of being second-guessed by script.
+  return true;
+}
+
+function openLoginPanel(id, link) {
+  if (activeLogin && activeLogin.profile !== id) cancelLogin();
+  var slot = loginSlot(id);
+  if (!slot) return;
+  activeLogin = { profile: id, loginId: link.loginId, pasteUrl: link.hosted };
+  if (loopbackOk && link.loopback) {
+    slot.innerHTML = renderWaitingPanel(id, link.loopback, link.hosted);
+  } else {
+    slot.innerHTML = renderPastePanel(id, link.hosted,
+      'This browser cannot be redirected back to Meridian, so paste the code instead.');
+    bindPasteInput(slot);
+  }
+  // Poll either way: the login can also be finished in another browser, and
+  // then this panel should get out of the way.
+  scheduleLoginPoll();
+}
+
+// Can this browser reach the instance that served this page on loopback?
+//
+// The probe is that login's own status route, so a 200 proves both that
+// loopback is reachable AND that what answered holds this login — something
+// else listening on the port answers 410. Any failure keeps the paste flow,
+// so a wrong guess costs nothing.
+async function loopbackReachable(probeUrl) {
+  var ctrl = new AbortController();
+  var timer = setTimeout(function () { ctrl.abort(); }, 2000);
+  try {
+    var res = await fetch(probeUrl, { signal: ctrl.signal, cache: 'no-store' });
+    if (!res.ok) return false;
+    var body = await res.json();
+    return body.status === 'waiting';
+  } catch (err) {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function renderWaitingPanel(id, authorizeUrl, pasteUrl) {
+  return '<div class="login-panel">'
+    + '<div class="login-panel-title">Sign in as ' + esc(id) + '</div>'
+    + '<ol class="login-steps">'
+    +   '<li>A Claude sign-in tab just opened — '
+    +     '<a class="login-reopen" href="' + esc(authorizeUrl) + '" target="_blank" rel="noopener noreferrer">open it again</a>'
+    +     ' if it was blocked. Right-click either link to sign in from a private window or another browser.</li>'
+    +   '<li>Make sure you are signed into the right Claude account for this profile.</li>'
+    +   '<li>That is all — Claude sends you back here and this page finishes the login itself.</li>'
+    + '</ol>'
+    + '<div class="login-row">'
+    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="cancelLogin()">Cancel</button>'
+    // Also a real link, and pointed at the hosted code page on purpose: it is
+    // the one that still works from a browser on ANOTHER machine, where a
+    // loopback redirect has nowhere to come back to.
+    +   '<a class="login-reopen" href="' + esc(pasteUrl || authorizeUrl) + '" target="_blank" rel="noopener noreferrer" onclick="switchToPaste();return true;">Paste a code instead</a>'
+    + '</div>'
+    + '<div class="login-msg busy">Waiting for you to finish signing in\\u2026</div>'
+    + '</div>';
+}
+
+function renderPastePanel(id, authorizeUrl, note) {
+  return '<div class="login-panel">'
+    + '<div class="login-panel-title">Sign in as ' + esc(id) + '</div>'
+    + (note ? '<div class="login-note">' + esc(note) + '</div>' : '')
+    + '<ol class="login-steps">'
+    +   '<li>A Claude sign-in tab just opened — '
+    +     '<a class="login-reopen" href="' + esc(authorizeUrl) + '" target="_blank" rel="noopener">open it again</a>'
+    +     ' if it was blocked.</li>'
+    +   '<li>Make sure you are signed into the right Claude account for this profile.</li>'
+    +   '<li>Paste the code Claude shows you below — or the whole callback URL from the address bar.</li>'
+    + '</ol>'
+    + '<div class="login-row">'
+    +   '<input class="login-input" type="text" autocomplete="off" spellcheck="false" placeholder="code, or https://platform.claude.com/oauth/code/callback?code=…">'
+    +   '<button class="login-btn login-submit" onclick="submitLogin()">Complete login</button>'
+    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="cancelLogin()">Cancel</button>'
+    + '</div>'
+    + '<div class="login-msg"></div>'
+    + '</div>';
+}
+
+function bindPasteInput(slot) {
+  var input = slot.querySelector('.login-input');
+  if (!input) return;
+  input.addEventListener('keydown', function (e) { if (e.key === 'Enter') submitLogin(); });
+  input.focus();
+}
+
+// Falls back WITHOUT restarting the login: both authorize URLs were minted from
+// the same challenge, so the one that shows a code completes the login already
+// in progress.
+function switchToPaste() {
+  if (!activeLogin) return;
+  var slot = loginSlot(activeLogin.profile);
+  if (!slot || !activeLogin.pasteUrl) return;
+  slot.innerHTML = renderPastePanel(activeLogin.profile, activeLogin.pasteUrl,
+    'Opened a second sign-in that ends on a page showing the code.');
+  bindPasteInput(slot);
+}
+
+function scheduleLoginPoll() {
+  stopLoginPoll();
+  loginPollTimer = setTimeout(checkLoginStatus, 1500);
+}
+
+function stopLoginPoll() {
+  if (loginPollTimer) clearTimeout(loginPollTimer);
+  loginPollTimer = null;
+}
+
+async function checkLoginStatus() {
+  if (!activeLogin || activeLogin.spent) return;
+  var loginId = activeLogin.loginId;
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/login/status?loginId=' + encodeURIComponent(loginId));
+    data = await res.json();
+  } catch (err) {
+    scheduleLoginPoll();
+    return;
+  }
+
+  // The login may have been cancelled or replaced while this was in flight.
+  if (!activeLogin || activeLogin.loginId !== loginId) return;
+
+  if (res.ok && data.status === 'waiting') { scheduleLoginPoll(); return; }
+  if (res.ok && data.status === 'completed') { finishLogin(); return; }
+
+  setLoginMsg(data.error || 'Login failed.', 'err');
+  activeLogin.spent = true;
+  stopLoginPoll();
+}
+
+function finishLogin() {
+  stopLoginPoll();
+  activeLogin = null;
+  if (window.meridianHeaderRefresh) window.meridianHeaderRefresh();
+  refresh();
+}
+
+async function submitLogin() {
+  if (!activeLogin || activeLogin.spent) return;
+  var slot = loginSlot(activeLogin.profile);
+  var input = slot ? slot.querySelector('.login-input') : null;
+  var value = input ? input.value.trim() : '';
+  if (!value) { setLoginMsg('Paste the code first.', 'err'); return; }
+
+  var buttons = slot ? slot.querySelectorAll('button') : [];
+  for (var i = 0; i < buttons.length; i++) buttons[i].disabled = true;
+  setLoginMsg('Exchanging…', 'busy');
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/login/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ loginId: activeLogin.loginId, code: value })
+    });
+    data = await res.json();
+  } catch (err) {
+    setLoginMsg('Could not reach Meridian.', 'err');
+    for (var j = 0; j < buttons.length; j++) buttons[j].disabled = false;
+    return;
+  }
+
+  if (!res.ok) {
+    setLoginMsg(data.error || 'Login failed.', 'err');
+    var cancelBtn = slot ? slot.querySelector('.login-cancel') : null;
+    if (cancelBtn) cancelBtn.disabled = false;
+    // The server says whether the login survived: it does when the paste was
+    // rejected before any code reached Anthropic. Otherwise the code is spent
+    // and this panel cannot retry it.
+    if (data.retryable) {
+      var submitBtn = slot ? slot.querySelector('.login-submit') : null;
+      if (submitBtn) submitBtn.disabled = false;
+      if (input) input.focus();
+    } else {
+      // Keep the panel — and with it the paused poll — so the reason stays
+      // readable. render() rebuilds #content wholesale, so resuming here would
+      // erase the very message telling the user their code was spent. Cancel
+      // is the way out.
+      activeLogin.spent = true;
+    }
+    return;
+  }
+
+  finishLogin();
+}
+
+function cancelLogin() {
+  var previous = activeLogin;
+  stopLoginPoll();
+  activeLogin = null;
+  if (previous) {
+    var slot = loginSlot(previous.profile);
+    if (slot) slot.innerHTML = '';
+  }
+}
+
 refresh();
-setInterval(refresh, 10000);
+setInterval(function () { if (!activeLogin) refresh(); }, 10000);
 ` + profileBarJs + `
 </script>
 </body>

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -110,6 +110,8 @@ export const profilePageHtml = `<!DOCTYPE html>
   .login-msg.busy { color: var(--muted); }
   .login-reopen { color: var(--accent); font-size: 11px; text-decoration: none; }
   .login-reopen:hover { text-decoration: underline; }
+  .add-intro { font-size: 13px; color: var(--muted); margin-bottom: 10px; }
+  .add-note { font-size: 11px; color: var(--muted); margin-top: 8px; }
 
   .mono { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; }
   .copy-cmd {
@@ -177,6 +179,13 @@ export const profilePageHtml = `<!DOCTYPE html>
 
 <div id="content"><div style="color:var(--muted);padding:40px;text-align:center">Loading\u2026</div></div>
 
+<!-- Outside #content on purpose: render() rebuilds that element wholesale on
+     every poll, which would destroy a half-typed name or a pasted code. -->
+<div class="section">
+  <div class="section-title">Add a profile</div>
+  <div class="profile-card"><div id="add-slot"></div></div>
+</div>
+
 <div class="section" style="margin-top:32px">
   <div class="section-title">Setup Guide</div>
   <div class="guide">
@@ -188,17 +197,22 @@ export const profilePageHtml = `<!DOCTYPE html>
 
     <h3 style="margin-top:16px">Adding a new profile</h3>
     <ol>
-      <li>Open a terminal and run: <code>meridian profile add &lt;name&gt;</code></li>
-      <li>This opens your browser for Claude login</li>
-      <li>Done \u2014 the profile is ready to use</li>
+      <li><strong>UI:</strong> Name it under <strong>Add a profile</strong> above, sign in, then paste
+          the code Claude shows you \u2014 the whole callback URL works too</li>
+      <li><strong>CLI:</strong> <code>meridian profile add &lt;name&gt;</code></li>
     </ol>
+    <p style="font-size:12px;color:var(--muted);margin-top:8px">
+      Either way the profile gets its own config directory and is ready to use immediately.
+      Only the CLI offers to adopt existing <code>~/.claude</code> credentials as a profile;
+      the UI always signs in fresh, so clicking Add can never quietly claim the account
+      you are already logged in as on this machine.
+    </p>
 
     <div class="warn">
-      <strong>\u26a0 Important for adding a second account:</strong> Before running
-      <code>meridian profile add</code> for a different account, sign out of claude.ai
-      in your browser first, then sign in with the other account. Claude\u2019s OAuth
-      reuses your browser session \u2014 if you\u2019re already signed in, the login will
-      silently use the same account.
+      <strong>\u26a0 Important for adding a second account:</strong> Before adding a different
+      account, sign out of claude.ai in your browser first, then sign in with the other
+      account. Claude\u2019s OAuth reuses your browser session \u2014 if you\u2019re already signed
+      in, the login will silently use the same account.
     </div>
 
     <h3 style="margin-top:16px">Switching profiles</h3>
@@ -395,7 +409,7 @@ function render(data, quotaData) {
   if (profiles.length === 0) {
     document.getElementById('content').innerHTML = '<div class="empty-state">'
       + '<h2>No profiles configured</h2>'
-      + '<p style="margin-top:8px">Add your first profile from the terminal:</p>'
+      + '<p style="margin-top:8px">Add your first one below, or from a terminal:</p>'
       + '<p style="margin-top:8px"><code class="mono" style="background:var(--bg);padding:8px 16px;border-radius:6px;display:inline-block">meridian profile add personal</code></p>'
       + '</div>';
     return;
@@ -528,13 +542,16 @@ var loginPollTimer = null;
 
 function loginSlot(id) { return document.getElementById('login-slot-' + id); }
 
-function setLoginMsg(text, kind) {
-  var slot = activeLogin ? loginSlot(activeLogin.profile) : null;
+function setPanelMsg(slot, text, kind) {
   if (!slot) return;
   var msg = slot.querySelector('.login-msg');
   if (!msg) return;
   msg.className = 'login-msg' + (kind ? ' ' + kind : '');
   msg.textContent = text || '';
+}
+
+function setLoginMsg(text, kind) {
+  setPanelMsg(activeLogin ? loginSlot(activeLogin.profile) : null, text, kind);
 }
 
 // Sign-in links, minted server-side and held per profile so the anchor has a
@@ -694,6 +711,8 @@ async function loopbackReachable(probeUrl) {
   }
 }
 
+// The redirect flow's panel. It has no paste box on purpose — Claude comes
+// back to Meridian by itself — so it does not share renderOauthPanel's shape.
 function renderWaitingPanel(id, authorizeUrl, pasteUrl) {
   return '<div class="login-panel">'
     + '<div class="login-panel-title">Sign in as ' + esc(id) + '</div>'
@@ -715,24 +734,39 @@ function renderWaitingPanel(id, authorizeUrl, pasteUrl) {
     + '</div>';
 }
 
-function renderPastePanel(id, authorizeUrl, note) {
+// One panel for both paste flows. Signing a profile in and creating one differ
+// in their wording and their handlers, not in their shape — two copies of this
+// markup would drift the moment either is touched.
+function renderOauthPanel(o) {
   return '<div class="login-panel">'
-    + '<div class="login-panel-title">Sign in as ' + esc(id) + '</div>'
-    + (note ? '<div class="login-note">' + esc(note) + '</div>' : '')
+    + '<div class="login-panel-title">' + o.title + '</div>'
+    + (o.note ? '<div class="login-note">' + esc(o.note) + '</div>' : '')
     + '<ol class="login-steps">'
     +   '<li>A Claude sign-in tab just opened — '
-    +     '<a class="login-reopen" href="' + esc(authorizeUrl) + '" target="_blank" rel="noopener">open it again</a>'
+    +     '<a class="login-reopen" href="' + esc(o.authorizeUrl) + '" target="_blank" rel="noopener noreferrer">open it again</a>'
     +     ' if it was blocked.</li>'
-    +   '<li>Make sure you are signed into the right Claude account for this profile.</li>'
+    +   '<li>' + o.accountStep + '</li>'
     +   '<li>Paste the code Claude shows you below — or the whole callback URL from the address bar.</li>'
     + '</ol>'
     + '<div class="login-row">'
     +   '<input class="login-input" type="text" autocomplete="off" spellcheck="false" placeholder="code, or https://platform.claude.com/oauth/code/callback?code=…">'
-    +   '<button class="login-btn login-submit" onclick="submitLogin()">Complete login</button>'
-    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="cancelLogin()">Cancel</button>'
+    +   '<button class="login-btn login-submit" onclick="' + o.onSubmit + '">' + o.submitLabel + '</button>'
+    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="' + o.onCancel + '">Cancel</button>'
     + '</div>'
     + '<div class="login-msg"></div>'
     + '</div>';
+}
+
+function renderPastePanel(id, authorizeUrl, note) {
+  return renderOauthPanel({
+    title: 'Sign in as ' + esc(id),
+    authorizeUrl: authorizeUrl,
+    note: note,
+    accountStep: 'Make sure you are signed into the right Claude account for this profile.',
+    submitLabel: 'Complete login',
+    onSubmit: 'submitLogin()',
+    onCancel: 'cancelLogin()',
+  });
 }
 
 function bindPasteInput(slot) {
@@ -854,7 +888,140 @@ function cancelLogin() {
   }
 }
 
+// --- Add a profile ---
+//
+// The same two steps against its own routes. Creating an account is a
+// different act from re-authenticating one, and /profiles/login/start refuses
+// an unknown name precisely so a typo there cannot create one.
+//
+// #add-slot sits outside #content, so this panel survives the poll on its own
+// and — unlike the login panels — does not have to pause it.
+var activeAdd = null;
+
+function addSlot() { return document.getElementById('add-slot'); }
+
+function renderAddForm(prefill) {
+  return '<div class="add-intro">Sign in to another Claude account and keep it here alongside the others.</div>'
+    + '<div class="login-row">'
+    +   '<input class="login-input add-input" type="text" autocomplete="off" spellcheck="false"'
+    +     ' placeholder="new profile name" value="' + esc(prefill || '') + '">'
+    +   '<button class="login-btn" onclick="startAdd()">Add profile</button>'
+    + '</div>'
+    + '<div class="add-note">Letters, numbers, hyphens and underscores.</div>'
+    + '<div class="login-msg"></div>';
+}
+
+function resetAddForm(prefill) {
+  activeAdd = null;
+  var slot = addSlot();
+  if (!slot) return;
+  slot.innerHTML = renderAddForm(prefill);
+  var input = slot.querySelector('.add-input');
+  if (input) input.addEventListener('keydown', function (e) { if (e.key === 'Enter') startAdd(); });
+}
+
+function renderAddPanel(id, authorizeUrl) {
+  return renderOauthPanel({
+    title: 'Create ' + esc(id),
+    authorizeUrl: authorizeUrl,
+    accountStep: 'Sign in with the Claude account this profile should use \u2014 if a different account is already '
+      + 'signed in at claude.ai, sign out there first, or Claude will reuse it without asking.',
+    submitLabel: 'Create profile',
+    onSubmit: 'submitAdd()',
+    onCancel: 'cancelAdd()',
+  });
+}
+
+async function startAdd() {
+  var slot = addSlot();
+  if (!slot) return;
+  var nameInput = slot.querySelector('.add-input');
+  var name = nameInput ? nameInput.value.trim() : '';
+  if (!name) { setPanelMsg(slot, 'Name the profile first.', 'err'); return; }
+
+  setPanelMsg(slot, 'Starting\u2026', 'busy');
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/add/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: name })
+    });
+    data = await res.json();
+  } catch (err) {
+    setPanelMsg(slot, 'Could not reach Meridian.', 'err');
+    return;
+  }
+
+  // The form is left standing on a refusal, name and all: every refusal here
+  // is about the name, and retyping it to fix a typo is the wrong ask.
+  if (!res.ok) { setPanelMsg(slot, data.error || 'Could not start.', 'err'); return; }
+
+  activeAdd = { profile: name, addId: data.addId };
+  slot.innerHTML = renderAddPanel(name, data.authorizeUrl);
+  var codeInput = slot.querySelector('.login-input');
+  if (codeInput) {
+    codeInput.addEventListener('keydown', function (e) { if (e.key === 'Enter') submitAdd(); });
+    codeInput.focus();
+  }
+  window.open(data.authorizeUrl, '_blank', 'noopener');
+}
+
+async function submitAdd() {
+  if (!activeAdd || activeAdd.spent) return;
+  var slot = addSlot();
+  var input = slot ? slot.querySelector('.login-input') : null;
+  var value = input ? input.value.trim() : '';
+  if (!value) { setPanelMsg(slot, 'Paste the code first.', 'err'); return; }
+
+  var buttons = slot ? slot.querySelectorAll('button') : [];
+  for (var i = 0; i < buttons.length; i++) buttons[i].disabled = true;
+  setPanelMsg(slot, 'Creating\u2026', 'busy');
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/add/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ addId: activeAdd.addId, code: value })
+    });
+    data = await res.json();
+  } catch (err) {
+    setPanelMsg(slot, 'Could not reach Meridian.', 'err');
+    for (var j = 0; j < buttons.length; j++) buttons[j].disabled = false;
+    return;
+  }
+
+  if (!res.ok) {
+    setPanelMsg(slot, data.error || 'Could not create the profile.', 'err');
+    var cancelBtn = slot ? slot.querySelector('.login-cancel') : null;
+    if (cancelBtn) cancelBtn.disabled = false;
+    if (data.retryable) {
+      var submitBtn = slot ? slot.querySelector('.login-submit') : null;
+      if (submitBtn) submitBtn.disabled = false;
+      if (input) input.focus();
+    } else {
+      // The code is spent. Keep the panel so the reason stays readable —
+      // Cancel is the way back to the form.
+      activeAdd.spent = true;
+    }
+    return;
+  }
+
+  resetAddForm('');
+  if (window.meridianHeaderRefresh) window.meridianHeaderRefresh();
+  refresh();
+}
+
+function cancelAdd() {
+  // Keeps the name. Abandoning a sign-in almost always means the wrong Claude
+  // account was signed in, not that the name was wrong.
+  resetAddForm(activeAdd ? activeAdd.profile : '');
+}
+
 refresh();
+resetAddForm('');
 setInterval(function () { if (!activeLogin) refresh(); }, 10000);
 ` + profileBarJs + `
 </script>


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Adding a Claude account to Meridian, and re-authenticating one whose token has
expired, both currently need a terminal on the machine Meridian runs on. They
are the same journey — the page that adds an account is the page that
re-authenticates one — so this does both from `/profiles`:

- **Add a profile** — name it, sign in, and the profile is written only once
  Anthropic hands back credentials. No `meridian profile add` on the host.
- **Log in from browser** — a link on each `claude-max` card that
  re-authenticates that account.

When the browser is on the Meridian host, **the login completes by itself**:
Claude redirects back to Meridian, the server exchanges the code, and the card
flips to Authenticated. Nothing to copy. That holds whatever URL was used to
get there — a bare `127.0.0.1`, a tailnet name, a reverse proxy — because the
server reads *where the browser is* rather than *what it typed*. A browser on a
different machine falls back to pasting the code, and which case it is is
established by measurement rather than by guessing.

> Combines #794, which built the add-a-profile half against a stale copy of this
> login work. This branch carries the current login flow, so consolidating the
> other way would have regressed it; #794 is closed in favour of this PR.

## The redirect is available, and here is the measurement

Anthropic publishes this client's registered redirect URIs, and they include
loopback:

```console
$ curl -s https://claude.ai/oauth/claude-code-client-metadata
{"client_id":"https://claude.ai/oauth/claude-code-client-metadata",
 "client_name":"Claude Code",
 "redirect_uris":["http://localhost/callback","http://127.0.0.1/callback"],
 "grant_types":["authorization_code","refresh_token"],
 "response_types":["code"],"token_endpoint_auth_method":"none"}
```

That is the [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3)
loopback convention: **the port is not part of the match, the host and path
are.** Hence `GET /callback` at the root rather than under `/profiles/` — no
other path would be accepted.

Claude Code itself uses exactly this. The bundled `@anthropic-ai/claude-code`
2.1.198 binary builds the URI at run time, which is why grepping it for a
literal loopback URL finds nothing:

```js
redirect_uri: o ? js().MANUAL_REDIRECT_URL : `http://localhost:${r}/callback`
```

…and it picks a **random ephemeral port per login** (49152–65535, falling back
to 3118), which only works if the server accepts any port on loopback. Same
client id (`9d1c250a-…`) for both modes. It also builds *both* URLs from one
PKCE challenge and chooses the `redirect_uri` at exchange time based on which
one fired — the shape this PR copies.

**What could not be measured:** whether the authorize endpoint accepts a given
`redirect_uri` cannot be probed unauthenticated. `claude.ai/oauth/authorize`
bounces an unauthenticated request to `/login?returnTo=…` *before* validating,
and a deliberately bogus control (`https://evil.example.com/callback`) reached
the same login page as the good one — so the probe cannot discriminate.
Cloudflare's interstitial blocks curl outright. The evidence above is
Anthropic's own published registration plus its own client's behaviour, not a
successful end-to-end authorize by me.

## Where the browser is, versus what URL it used

Meridian is often reached on something other than `127.0.0.1` — a tailnet
hostname, a reverse proxy. It is tempting to conclude that such a browser
cannot use the redirect, but that conflates two different questions. A user
browsing `https://meridian.example.net` is very often sitting at the machine
Meridian runs on; they just did not say so.

So the server answers what it can, from two headers rather than one, and the
page settles only what neither header can:

- A **loopback `Host`** proves the browser is on this host. `mode: "redirect"`,
  built from `Host` itself — which is also what makes an SSH port-forward work
  unchanged, since the forwarded address is the one that must come back.
- **Another `Host`, but an `X-Forwarded-For` this machine answers on** proves
  the same thing by the other route. A reverse proxy in front records the
  browser's own address, which is exactly what `Host` lost; when that address
  is one of this machine's own interface addresses (or loopback), the browser
  is provably here. `mode: "redirect"`, built from the listening port. **This
  is the case that used to end in a paste** — reaching Meridian at
  `https://meridian.example.net` from the very box it runs on.
- **Neither** proves anything. `mode: "paste"`, but the reply also carries
  `loopbackAuthorizeUrl` and `loopbackProbeUrl`. Before opening any sign-in
  tab, the page fetches the probe and upgrades to the redirect only if it
  answers.

**The probe is that login's own `/profiles/login/status` URL on the loopback
origin**, so one 200 proves two things: the browser can reach loopback, *and*
what answered is the instance holding this login. Anything else listening on
that port answers 410. Unreachable, blocked or slow all fall back inside two
seconds, so a wrong guess costs nothing. It remains the answer for the case no
header can settle: a browser reaching Meridian directly, with no proxy to write
`X-Forwarded-For` at all, or through one that strips it.

That this is possible at all was measured in Chromium rather than assumed: from
a page on an HTTPS origin, `fetch("http://127.0.0.1:<port>/health")` returns
200 and the tab can be navigated to `http://127.0.0.1:<port>/callback` —
loopback is a potentially-trustworthy origin, so it is exempt from
mixed-content blocking, and Private Network Access did not intervene.

`Host` is client-supplied, so it is parsed rather than echoed: the hostname
must be one of the two Anthropic registered, and the URI is **rebuilt** from
the parsed host with a fixed path.

`X-Forwarded-For` is client-settable too, and deliberately trusted anyway,
because believing a lie about it grants nothing. Only the **first** entry is
read — the header accumulates left to right, so a proxy appended later must
never make a remote browser look local. A request that forges it gains exactly
one thing: its `authorizeUrl` becomes the loopback one, which the same response
already returns unconditionally as `loopbackAuthorizeUrl` for the page to
upgrade to. The forger is handed a URL pointed at loopback on **their own**
machine, and the code it carries is still redeemable only against a PKCE
verifier that never left this process. Addresses are compared after
normalisation, so `[fd7a::1]:51234`, `fe80::1%eth0` and `::ffff:127.0.0.1` are
matched as the addresses they name rather than as strings.

**The paste is kept, and is no longer shown to everyone up front.** It appears
only when the redirect is genuinely unavailable, or when the user asks for it
via *Paste a code instead*. Both authorize URLs are built from **one** PKCE
challenge and one `state`, so falling back costs a paste rather than a second
sign-in, and whichever completes first wins.

## It is a real link, and that is the point

The control is an `<a href="…">` carrying the Claude authorize URL — not a
button, and not an anchor that navigates from a click handler. Both of those
would look identical and lose the thing that matters: **the browser's own
context menu**.

> "since i have many logins to claude.ai my main browser is not good to click
> login button in for some account relogins"

With several Claude accounts signed in, the ambient session in the main browser
is usually the *wrong* one for the profile being re-authenticated, and only the
browser can offer another: **Open Link in Incognito Window**, **Open Link in New
Private Window**, **Copy Link Address** to paste into a different browser or
browser profile. Chrome and Firefox offer those for an anchor with an `href` and
for nothing else. Ctrl-click, middle-click and "open in new tab" come back at
the same time, and the click handler now returns `true` so the browser does the
navigating — there is no `window.open` left in the page.

**Consequence: the login is minted when the card renders, not when it is
clicked**, because an `href` has to be real before a context menu can open.
`/profiles` holds one link per `claude-max` profile and re-mints it a couple of
minutes before the pending login expires, so a link that has sat on screen still
works when it is finally used — or opened in another browser minutes later.

**This is safe only because the browser never held anything worth protecting.**
The PKCE verifier and `state` live in the server-side map keyed by `state`, so a
sign-in may be finished by a client that shares no cookie, no storage and no
script with the page that started it, and the originating page still learns the
outcome from `/profiles/login/status`. The authorize URL is public by design;
nothing else is in the link, and a test asserts no PKCE material ever reaches
the markup.

The **Paste a code instead** fallback is a real link too, pointed at the hosted
code-display page on purpose: that is the one that still works from a browser on
*another machine*, where a loopback redirect has nowhere to come back to.

## Adding an account is the same journey, and deliberately not the same route

`POST /profiles/add/start` and `POST /profiles/add/complete` mirror the login
pair exactly: one PKCE challenge minted server-side, an opaque id handed to the
browser, `state` validated, single-use, the same
`exchangeAuthorizationCodeForCredentials` doing the exchange and the write.

They are **separate routes on purpose.** `/profiles/login/start` refuses an
unknown profile id, and that refusal is what stops a typo in a
re-authentication from quietly creating an account slot. Creating one is its
own act, so it is its own explicit route, with its own name validation and its
own refusal for a name that already exists.

**The profile is written only once Anthropic returns credentials.** A creation
that is started and abandoned, or that fails at the exchange, leaves nothing
behind in `profiles.json` — there is no half-made profile to clean up, and no
empty card on the page.

The add panel is still opened by script rather than by an anchor, and that is
not an oversight: its authorize URL cannot exist until the user has typed a
name, so there is no href to put on a link at render time. The
right-click-into-incognito affordance below therefore applies to
re-authentication, where the URL is known in advance, and not yet to creation.

## What the flow guarantees

- **The PKCE verifier never leaves the server.** `/start` hands the browser an
  opaque login id and keeps the verifier, the `state` and the target config dir
  server-side. Two logins for different profiles cannot interfere.
- **`state` is validated exactly as the CLI validates it**, single-use, 10 minute
  TTL. The exchange sends back the same `redirect_uri` the authorize used —
  Anthropic requires the pair to match, so it is carried on the login rather
  than hardcoded. A login that started in `paste` mode and was upgraded by the
  probe therefore exchanges against the loopback URI, not the hosted one. So
  does a login whose user was sent to the loopback URL, could not be redirected
  back, and pasted the address bar of the failed tab instead: **which URI to
  name is read from the shape of the paste**, since a code is bound to the URI
  its own authorize request carried. The URI itself always comes from the
  login's server-side record — a pasted address is evidence of which sign-in
  ran, never an input to where the grant is sent.
- **A login is consumed by the exchange, not by the attempt.** A paste rejected
  locally — no code in it, or `state` from a different tab — never reached
  Anthropic, so nothing was spent and the login stays open. Only once a code has
  actually been sent is the id burned. The refusal carries `retryable` so the
  page knows which happened without re-deriving it from an error-code list.
- **One implementation of the exchange, not two.** The exchange-and-write half of
  `completeManualOAuthLogin` is now `exchangeAuthorizationCodeForCredentials`,
  called by the CLI (which keeps its prompt) and by both web completions.
- **`MERIDIAN_CREDENTIALS_READONLY` refuses at `/start`**, before the sign-in tab
  opens, naming where the login can be completed instead. A user refused only
  *after* signing in has burned a one-time code for nothing.
- **The login routes still refuse an unknown profile id rather than creating
  one.** Creation has its own route, above; keeping the login route strict is
  what stops a mistyped id from becoming an account slot. `api` and
  `oauth-token` profiles are refused with the reason and get no link.
- **Nothing from the code or the token response is logged**, and the token
  endpoint's error body is not forwarded to the page.

### `GET /callback` is public, deliberately

It is the one route that cannot be gated: Anthropic redirects the user's
*browser* there, and that redirect carries no API key. Gating it would break the
flow on exactly the instances careful enough to set `MERIDIAN_API_KEY`.

It is safe open because reaching it proves nothing and grants nothing. It acts
only on a `state` that was minted by `/profiles/login/start` (which **is**
gated), is 256 bits of CSPRNG output that never leaves the process except into
the authorize URL, is single-use, and expires in ten minutes. Without a matching
open login it returns the same page whether the `state` was wrong or merely
expired, so it enumerates nothing — it cannot start a login or name a profile.
An attacker who could guess a live `state` would still be handing Anthropic's
authorization code to the *user's own* profile, since the PKCE verifier it is
exchanged against is held here.

This repo's auth-audit test walks every registered route and fails CI unless a
new one is gated or on an explicit allowlist; `/callback` is on that allowlist
with the review above written beside it. The other three routes sit under
`/profiles/*` and inherit `requireAuth`, which a test pins rather than assuming.

`meridian profile login <name> --headless` is **unchanged** — a paste is the
right shape for an SSH session.

## Verification

`tsc --noEmit` exit 0.

The project's own `npm test` — the split runner CI uses, which puts several
files in their own processes because `mock.module` and other module-global
state are process-wide — is **green: exit 0, 2903 passing, 0 failures**, on the
current tip rebased onto upstream `950a8e8` (v1.62.5). Measured immediately
before this branch's last commit against a clean tree, and again after: **2889
→ 2903**, a delta of exactly the 14 tests added here.

Plain `bun test` runs everything in one process, which that script deliberately
avoids, so it carries a large pre-existing failure set and the gate there is
**set comparison**, not a count. That comparison was run against the branch's
**previous** merge base and has **not** been re-measured since the rebase, so
the table below is history rather than a current reading — the exit-0 split
run above is the live number:

| | tests | files | pass | fail |
|---|---|---|---|---|
| then-merge-base `8b789e4` | 2493 | 152 | 2391 | 102 |
| this branch, at that time | 2609 | 156 | 2527 | 82 |

`comm` in both directions over the sorted `(fail)` lines, both runs measured
back to back on the same machine:

- **failures introduced by this branch: 0**
- present on the base and not here: **20**

Twelve of those twenty are one mechanism, and this branch closes it. Disk
profile discovery is a process-global one-way flag; a test file that imports
`bin/cli.ts` turns it on for every file that runs after it, and assertions
written against an explicit profile list then silently merge in the host's real
`~/.config/meridian/profiles.json`. So `getEffectiveProfiles`, `listProfiles`,
`resolveProfile`, the sticky-routing pair and `Profile switch API` all pass or
fail depending on file order. This adds `resetDiskProfileDiscovery()` — a
test-only seam beside the existing `resetActiveProfile()` — which the new tests
call, and which restores the documented default for the files that follow them.
Verified directly: sticky passes alone and fails when run after
`proxy-async-ops`.

The other eight (`Busy-session resume retry`, `Stale UUID retry`,
`fresh-session replay envelope`, `priority routing`) are the timing-sensitive
retry tests, which vary between runs under load on this machine. This branch
touches none of that code and claims no credit for them — they are listed only
because the comparison is a set, not a count.

The new tests cover loopback URI resolution (including rejection of a
non-loopback `Host`), the port-derived candidate and its probe URL, the callback
with a matching and a mismatched `state`, status polling, single-use and expiry,
the readonly refusal, wrong profile type, unknown id, and that a paste fallback
exchanges against the *hosted* `redirect_uri` while an upgraded login exchanges
against the loopback one.

For the `X-Forwarded-For` path specifically, against a **real** address of the
machine running the test rather than a fixture, so the interface lookup is
exercised and not stubbed: that a non-loopback `Host` plus a forwarded address
this host answers on yields `mode: "redirect"` with the loopback `redirect_uri`
and needs no probe at all; that the same `Host` with a **remote** forwarded
address still yields `mode: "paste"` — while keeping the candidate and its probe
URL, which is what an SSH port-forward from another box relies on; that only the
first entry counts, so `127.0.0.1, 10.0.0.1` is local and
`203.0.113.7, 127.0.0.1` is not; that `Host` wins when both agree; and that a
port, a bracketed IPv6 address, a zone id and an IPv4-mapped address all
normalise to the address they name — with a bare IPv6 address left intact rather
than truncated at its last colon. Plus that a pasted **loopback callback URL**
exchanges against the loopback `redirect_uri` while a pasted bare code still
exchanges against the hosted one.

For the link specifically: that the rendered control is an anchor with an
`href` and `rel="noopener noreferrer"` rather than a button, that no
`window.open` survives anywhere in the page, that the paste fallback is also a
real link, that hrefs are restored after every re-render and refreshed before
expiry, that no PKCE material appears in the markup — and, at the route level,
that a login **completes when the callback is presented by a client that never
initiated it** (different cookie, different user-agent), with the originating
page then reading `completed` from the status route.

Driven in a real headless Chromium against a throwaway instance — **27/27
checks across four rounds**, including the page served under a **non-loopback
hostname** so the probe path is the one exercised. Checked as the browser sees
it, via the DOM-resolved `element.href` rather than the attribute string: the
control is an `A`, its href is a genuine `claude.com` authorize URL carrying
`code_challenge` and `state` and no verifier, one per `claude-max` profile and
none for an `api` profile, and its `redirect_uri` points back at Meridian even
when the page was served under another hostname. A left-click opens exactly one
tab, at that same URL, and shows the waiting panel. The sign-in was then
finished from a **separate browser context** — its own cookie jar and storage,
which is what an incognito window is — and the originating page picked the
outcome up on its own.

That is also where the defects were found rather than reasoned about: the probe
upgrade called a helper that does not exist on this branch (the panel hung at
"Starting…"), and, in an earlier round, a `state` mismatch used to consume the
login. The fallback was verified by blocking the probe, and the callback wiring
end-to-end by driving a real redirect with a bogus code — Anthropic's token
endpoint rejected it with HTTP 400 and the waiting page picked that up by
polling.

Also verified **live on the deployed instance**, which is the page the report
came from. `meridian-dev` (:3457) restarted onto this code; `/readyz`, `/livez`
and `/health` all 200, and `https://meridian-dev.desktop.ts.nowaker.net/profiles`
renders. A real browser on that published URL finds 12 sign-in links, each an
`<a target="_blank" rel="noopener noreferrer">` whose href is a genuine
`claude.com/cai/oauth/authorize` URL carrying `code_challenge` and
**`redirect_uri=http://127.0.0.1:3457/callback`** — the redirect flow reached
from a tailnet hostname, with no verifier anywhere in the link.

**That live run predates the `X-Forwarded-For` commit** and exercised the
probe-upgrade path, not the header path; the instance has not been restarted
onto the newer code, so nothing here claims the header path was measured in
production. What the live run did settle is why the header path is worth
having. Re-inspected from a real Chrome on that same published URL, the probe
**succeeds**: `loopbackOk === true` and the anchor already carries the loopback
`redirect_uri`. So the paste panel is not reached by every browser on that
host — it is reached by every browser that will not, or cannot, `fetch`
loopback from an HTTPS origin, which is a browser-side capability this flow
should not have to depend on. Cross-origin loopback from a secure context is
exactly the ground Private Network Access is tightening, engine by engine, and
a blocker extension refuses it today. The `X-Forwarded-For` test settles the
question server-side, before any URL is minted: no 2-second probe race ahead of
opening the tab, no dependence on a fetch a browser is entitled to refuse, and
the same answer in every engine. The probe stays as the fallback for the case
no header can settle.

**No real account was re-authenticated during automated QA** — every path that
does not require a genuine sign-in was exercised for real, and the rest was
stubbed.

**Carried over from #794 untouched:** `src/proxy/profileAdd.ts`,
`src/proxy/settings.ts` and the two add-profile test files arrived byte-identical
to that branch's commit. The three conflicts were `docs/configuration.md`,
`src/proxy/server.ts` and `src/telemetry/profilePage.ts`, all resolved as unions
— the two features edit the same regions of the same page and the same route
file, and neither replaces the other. The shared `renderOauthPanel` from #794 now
backs both paste panels; the redirect flow keeps its own panel, which has no
paste box by design.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.




