### PR TITLE
feat(profiles): create a profile from the web UI

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,8 @@ adapter lets the subprocess run the built-in WebFetch at all.
 | `POST /profiles/active` | Switch the active profile |
 | `POST /profiles/login/start` | Begin an OAuth login for a profile — returns the authorize URL (see [Re-authenticating from the web UI](profiles.md#from-the-web-ui-re-authenticate-a-profile-without-a-terminal)) |
 | `POST /profiles/login/complete` | Finish that login with the code the user pasted back |
+| `POST /profiles/add/start` | Begin creating a new profile — validates the name and returns the authorize URL (see [Adding from the web UI](profiles.md#from-the-web-ui-add-a-profile)) |
+| `POST /profiles/add/complete` | Finish that creation — writes the profile only once Anthropic returns credentials |
 | `GET /v1/usage/quota` | Usage windows for the active profile (JSON) |
 | `GET /v1/usage/quota/all` | Usage windows for every profile (JSON) |
 | `GET /settings` | SDK feature toggles + model pricing UI |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,6 +100,8 @@ adapter lets the subprocess run the built-in WebFetch at all.
 | `GET /profiles` | Profile management page |
 | `GET /profiles/list` | List profiles with auth status (JSON) |
 | `POST /profiles/active` | Switch the active profile |
+| `POST /profiles/login/start` | Begin an OAuth login for a profile — returns the authorize URL (see [Re-authenticating from the web UI](profiles.md#from-the-web-ui-re-authenticate-a-profile-without-a-terminal)) |
+| `POST /profiles/login/complete` | Finish that login with the code the user pasted back |
 | `GET /v1/usage/quota` | Usage windows for the active profile (JSON) |
 | `GET /v1/usage/quota/all` | Usage windows for every profile (JSON) |
 | `GET /settings` | SDK feature toggles + model pricing UI |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,6 +31,37 @@ Open the printed URL in a browser, sign in to the target Claude account, then pa
 meridian profile login work --headless
 ```
 
+#### From the web UI: re-authenticate a profile without a terminal
+
+A profile whose credentials expired can be logged in again from the Profiles page, with no shell on the Meridian host. Click **Log in from browser** on the profile's card:
+
+1. Meridian creates the PKCE login server-side and opens Claude's sign-in in a new tab.
+2. Sign in to that profile's Claude account. Claude shows you a code.
+3. Paste it into the box on the card. Either form works — the **bare code**, or the **whole callback URL** from the address bar (`https://platform.claude.com/oauth/code/callback?code=…&state=…`), which is usually easier to copy.
+
+The same two steps are available for scripting:
+
+```bash
+# → {"loginId":"…","authorizeUrl":"https://claude.com/cai/oauth/authorize?…","expiresAt":…,"profile":"work"}
+curl -X POST http://127.0.0.1:3456/profiles/login/start \
+  -H 'Content-Type: application/json' -d '{"profile":"work"}'
+
+# `code` accepts the bare code or the full callback URL
+curl -X POST http://127.0.0.1:3456/profiles/login/complete \
+  -H 'Content-Type: application/json' -d '{"loginId":"…","code":"…"}'
+```
+
+**Why you paste a code instead of being redirected back.** Claude's OAuth client registers exactly one redirect URI — `https://platform.claude.com/oauth/code/callback`, a page Anthropic hosts. There is no `http://localhost:<port>/callback` variant registered, and a redirect URI belonging to your Meridian instance cannot be added, so an automatic hand-off back into the UI would be rejected at the authorize step. Accepting the callback page's whole URL is as close as this flow gets.
+
+Details worth knowing:
+
+- The PKCE verifier never leaves the server. The browser only ever holds an opaque login id.
+- A login is **single-use** and expires **10 minutes** after it starts. `state` must match the login it was started with, exactly as the CLI requires.
+- Only **claude-max** profiles have this flow. `api` and `oauth-token` profiles are refused with the reason — replace an OAuth token with `meridian profile remove <name> && meridian profile add <name> --oauth-token`.
+- An unknown profile name is refused, not created. `meridian profile add` remains the only way a profile comes into existence.
+- An instance told not to write credential files (`MERIDIAN_CREDENTIALS_READONLY=1` — set on a second instance that shares another's credentials) refuses **before** opening the sign-in tab, and names where the login can be completed instead. Refusing after sign-in would have burned a one-time code for nothing.
+- These routes sit behind `MERIDIAN_API_KEY` like the rest of `/profiles/*` when that key is configured.
+
 #### Headless / CI: register an OAuth token
 
 When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -15,6 +15,8 @@ meridian profile add personal
 meridian profile add work
 ```
 
+Or add one from the Profiles page without a terminal at all — see [From the web UI: add a profile](#from-the-web-ui-add-a-profile).
+
 > **⚠ Important:** Claude's OAuth reuses your browser session. Before adding a second account, sign out of claude.ai and sign into the other account first.
 
 #### Headless / SSH: complete Claude OAuth with a pasted code
@@ -58,9 +60,42 @@ Details worth knowing:
 - The PKCE verifier never leaves the server. The browser only ever holds an opaque login id.
 - A login is **single-use** and expires **10 minutes** after it starts. `state` must match the login it was started with, exactly as the CLI requires.
 - Only **claude-max** profiles have this flow. `api` and `oauth-token` profiles are refused with the reason — replace an OAuth token with `meridian profile remove <name> && meridian profile add <name> --oauth-token`.
-- An unknown profile name is refused, not created. `meridian profile add` remains the only way a profile comes into existence.
+- An unknown profile name is refused here rather than created — a typo in a re-authentication must not quietly produce a second account slot. Creating one is a separate, explicit act: see [Add a profile from the web UI](#from-the-web-ui-add-a-profile) below.
 - An instance told not to write credential files (`MERIDIAN_CREDENTIALS_READONLY=1` — set on a second instance that shares another's credentials) refuses **before** opening the sign-in tab, and names where the login can be completed instead. Refusing after sign-in would have burned a one-time code for nothing.
 - These routes sit behind `MERIDIAN_API_KEY` like the rest of `/profiles/*` when that key is configured.
+
+#### From the web UI: add a profile
+
+A new Claude account can be added from the Profiles page without a shell on the Meridian host. Under **Add a profile**, type a name and click **Add profile**:
+
+1. Meridian validates the name, refuses it if anything is wrong, then mints the PKCE login and opens Claude's sign-in in a new tab.
+2. Sign in to the Claude account this profile should use. Claude shows you a code.
+3. Paste it back — the **bare code** or the **whole callback URL**, exactly as for a re-login.
+
+The profile appears in the list, with its own config directory under `~/.config/meridian/profiles/<name>/`, ready to use with no restart.
+
+```bash
+# → {"addId":"…","authorizeUrl":"https://claude.com/cai/oauth/authorize?…","expiresAt":…,"profile":"work"}
+curl -X POST http://127.0.0.1:3456/profiles/add/start \
+  -H 'Content-Type: application/json' -d '{"profile":"work"}'
+
+# `code` accepts the bare code or the full callback URL
+curl -X POST http://127.0.0.1:3456/profiles/add/complete \
+  -H 'Content-Type: application/json' -d '{"addId":"…","code":"…"}'
+```
+
+**Nothing is written until the credentials are in hand.** The exchange with Anthropic happens first; the `profiles.json` entry is written only once it succeeds. A sign-in that is abandoned, rejected or never finished therefore leaves no profile behind at all — there is no half-made account slot stuck at "not logged in" to notice and clean up. Just add it again with the same name.
+
+**Who can do this.** These routes inherit `/profiles/*`'s `requireAuth`, so they are behind `MERIDIAN_API_KEY` **when that key is set**. When it is not set — the default — the only thing standing between this page and a new profile is whatever reaches the port: bind Meridian to loopback, or to a private network you trust. Adding a profile is the most privileged thing the Profiles page does, so treat an unauthenticated instance on a shared network accordingly. There is deliberately no delete, rename or edit here; removal stays `meridian profile remove <name>` on the host.
+
+Details worth knowing:
+
+- Names may use only letters, numbers, hyphens and underscores. The name becomes a directory, and the check is the same one `meridian profile add` applies.
+- An existing name is refused and points you at **Log in from browser** on that profile's card — re-authenticating an account is what that button is for.
+- One open sign-in per name at a time, so two people cannot both be part-way through creating the same one. Starting another for the same name **replaces** the first rather than being refused — cancelling the panel, reloading the page and closing the tab all abandon a sign-in without telling the server, and a name you could not retry until the 10-minute expiry would be worse than the race it prevents. Only the most recently started sign-in can be completed.
+- `MERIDIAN_CREDENTIALS_READONLY=1` refuses **before** the sign-in tab opens, and names `meridian profile add <name>` as the alternative.
+- Only **claude-max** profiles are created this way. `api` and `oauth-token` profiles are CLI-only — neither has an OAuth flow to drive from a page.
+- **The `~/.claude` import offer is CLI-only.** `meridian profile add` on a host whose default config dir is already signed in offers to adopt those credentials as the new profile. The UI never does: clicking **Add profile** always signs in fresh. Silently claiming the account you happen to be logged in as on that machine is not something a button press should be able to do.
 
 #### Headless / CI: register an OAuth token
 

--- a/src/__tests__/profile-add-route.test.ts
+++ b/src/__tests__/profile-add-route.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { resetPendingAdds } from "../proxy/profileAdd"
+import type { ProfileConfig } from "../proxy/profiles"
+import { createProxyServer } from "../proxy/server"
+import { stopBackgroundRefresh } from "../proxy/tokenRefresh"
+
+const TOKEN_RESPONSE = {
+  access_token: "add-route-access-token",
+  refresh_token: "add-route-refresh-token",
+  expires_in: 3600,
+}
+
+// Credential writes are Keychain-backed on darwin; the paths that actually
+// persist are Linux/Windows only, as in profile-login-route.test.ts.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profile add routes", () => {
+  let originalFetch: typeof globalThis.fetch
+  let configDir: string
+  let savedConfigDir: string | undefined
+  let app: ReturnType<typeof createProxyServer>["app"]
+
+  function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+    return app.fetch(new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }))
+  }
+
+  async function startAdd(profile: string): Promise<{ addId: string; state: string }> {
+    const res = await post("/profiles/add/start", { profile })
+    if (res.status !== 200) throw new Error(`start failed with ${res.status}`)
+    const body = await res.json() as { addId: string; authorizeUrl: string }
+    const state = new URL(body.authorizeUrl).searchParams.get("state")
+    if (!state) throw new Error("authorize URL carried no state")
+    return { addId: body.addId, state }
+  }
+
+  function profilesJson(): ProfileConfig[] {
+    return JSON.parse(readFileSync(join(configDir, "profiles.json"), "utf-8")) as ProfileConfig[]
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    // Redirected so a route test can never write the real profiles.json.
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    configDir = mkdtempSync(join(tmpdir(), "meridian-add-route-"))
+    process.env.MERIDIAN_CONFIG_DIR = configDir
+    mkdirSync(join(configDir, "profiles", "personal"), { recursive: true })
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+
+    app = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [{ id: "personal", claudeConfigDir: join(configDir, "profiles", "personal") }],
+      defaultProfile: "personal",
+      silent: true,
+    }).app
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    stopBackgroundRefresh()
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
+    rmSync(configDir, { recursive: true, force: true })
+  })
+
+  function stubTokenEndpoint(makeResponse: () => Response) {
+    const requests: Array<Record<string, unknown>> = []
+    globalThis.fetch = Object.assign(
+      async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>)
+        return makeResponse()
+      },
+      { preconnect: originalFetch.preconnect },
+    )
+    return requests
+  }
+
+  function stubOkToken() {
+    return stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+  }
+
+  it("starts a creation and returns an authorize URL without the PKCE verifier", async () => {
+    const res = await post("/profiles/add/start", { profile: "work" })
+    expect(res.status).toBe(200)
+
+    const raw = await res.text()
+    expect(raw).not.toContain("codeVerifier")
+    expect(raw).not.toContain("code_verifier")
+
+    const body = JSON.parse(raw) as { addId: string; authorizeUrl: string; expiresAt: number; profile: string }
+    expect(body.profile).toBe("work")
+    expect(body.addId).toBeTruthy()
+    expect(body.expiresAt).toBeGreaterThan(Date.now())
+    expect(new URL(body.authorizeUrl).searchParams.get("code_challenge")).toBeTruthy()
+
+    // Starting is not creating: nothing exists until a code comes back.
+    expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+  })
+
+  it("refuses to start on an instance that must not write credentials", async () => {
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    const res = await post("/profiles/add/start", { profile: "work" })
+    expect(res.status).toBe(409)
+
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe("credentials_readonly")
+    expect(body.error).toContain("MERIDIAN_CREDENTIALS_READONLY")
+    expect(body.error).toContain("meridian profile add work")
+  })
+
+  it("400s a name that would escape the profiles directory", async () => {
+    const res = await post("/profiles/add/start", { profile: "../../etc" })
+    expect(res.status).toBe(400)
+    expect((await res.json() as { code: string }).code).toBe("invalid_profile_id")
+  })
+
+  it("409s an existing name and sends the user to the login button instead", async () => {
+    const res = await post("/profiles/add/start", { profile: "personal" })
+    expect(res.status).toBe(409)
+
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe("profile_exists")
+    expect(body.error).toContain("Log in from browser")
+  })
+
+  it("400s a missing name, malformed JSON, and a completion with no add id", async () => {
+    expect((await post("/profiles/add/start", {})).status).toBe(400)
+
+    const malformed = await app.fetch(new Request("http://localhost/profiles/add/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    }))
+    expect(malformed.status).toBe(400)
+
+    const noId = await post("/profiles/add/complete", { code: "abc123" })
+    expect(noId.status).toBe(400)
+    expect((await noId.json() as { code: string }).code).toBe("invalid_request")
+  })
+
+  it("410s an add id that was never issued", async () => {
+    const res = await post("/profiles/add/complete", { addId: "made-up", code: "abc123" })
+    expect(res.status).toBe(410)
+    expect((await res.json() as { code: string }).code).toBe("expired_add")
+  })
+
+  it.skipIf(skipOnDarwin)("creates the profile from a bare code", async () => {
+    const { addId } = await startAdd("work")
+    const requests = stubOkToken()
+
+    const res = await post("/profiles/add/complete", { addId, code: "abc123" })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ success: true, profile: "work" })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({ grant_type: "authorization_code", code: "abc123" })
+    expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: join(configDir, "profiles", "work") }])
+    expect(JSON.parse(readFileSync(join(configDir, "profiles", "work", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+      .toBe("add-route-access-token")
+  })
+
+  it.skipIf(skipOnDarwin)("creates the profile from the pasted callback URL", async () => {
+    const { addId, state } = await startAdd("work")
+    stubOkToken()
+
+    const res = await post("/profiles/add/complete", {
+      addId,
+      code: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+    })
+    expect(res.status).toBe(200)
+    expect(profilesJson().map(p => p.id)).toEqual(["work"])
+  })
+
+  it.skipIf(skipOnDarwin)("410s a replayed completion", async () => {
+    const { addId } = await startAdd("work")
+    const requests = stubOkToken()
+
+    expect((await post("/profiles/add/complete", { addId, code: "abc123" })).status).toBe(200)
+    expect((await post("/profiles/add/complete", { addId, code: "abc123" })).status).toBe(410)
+    expect(requests).toHaveLength(1)
+    expect(profilesJson()).toHaveLength(1)
+  })
+
+  it("400s a state that does not match, and never contacts the token endpoint", async () => {
+    const { addId } = await startAdd("work")
+    const requests = stubTokenEndpoint(() => new Response("{}", { status: 200 }))
+
+    const res = await post("/profiles/add/complete", {
+      addId,
+      code: "https://platform.claude.com/oauth/code/callback?code=abc123&state=someone-elses-state",
+    })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ code: "state_mismatch", retryable: true })
+    expect(requests).toHaveLength(0)
+    expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+
+    // Nothing reached Anthropic, so the sign-in is still open for the right paste.
+    const retry = await post("/profiles/add/complete", { addId, code: "abc123" })
+    expect(retry.status).not.toBe(410)
+  })
+
+  it("502s an upstream rejection, leaves no profile, and does not leak the error body", async () => {
+    const { addId } = await startAdd("work")
+    stubTokenEndpoint(() => new Response(
+      JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    ))
+
+    const res = await post("/profiles/add/complete", { addId, code: "stale-code" })
+    expect(res.status).toBe(502)
+    const raw = await res.text()
+    expect(raw).toContain("exchange_failed")
+    expect(raw).not.toContain("retryable")
+    expect(raw).not.toContain("invalid_grant")
+    expect(raw).not.toContain("already redeemed")
+    expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+  })
+
+  // Both routes sit under the /profiles/* prefix, so they inherit requireAuth
+  // rather than needing their own registration — asserted rather than assumed.
+  it("requires the API key on both routes when one is configured", async () => {
+    process.env.MERIDIAN_API_KEY = "secret-key"
+
+    expect((await post("/profiles/add/start", { profile: "work" })).status).toBe(401)
+    expect((await post("/profiles/add/complete", { addId: "x", code: "y" })).status).toBe(401)
+
+    const authorized = await post("/profiles/add/start", { profile: "work" }, { "x-api-key": "secret-key" })
+    expect(authorized.status).toBe(200)
+  })
+
+  it("serves an Add profile affordance on the profiles page", async () => {
+    const res = await app.fetch(new Request("http://localhost/profiles"))
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("Add a profile")
+    expect(html).toContain("/profiles/add/start")
+    expect(html).toContain("/profiles/add/complete")
+  })
+})

--- a/src/__tests__/profile-add-unit.test.ts
+++ b/src/__tests__/profile-add-unit.test.ts
@@ -1,0 +1,401 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  completeProfileAdd,
+  pendingAddCount,
+  resetPendingAdds,
+  startProfileAdd,
+} from "../proxy/profileAdd"
+import { createProfileSlot, isValidProfileId, loadProfileIds } from "../proxy/profileCli"
+import { LOGIN_TTL_MS } from "../proxy/profileLogin"
+import type { ProfileConfig } from "../proxy/profiles"
+
+const TOKEN_RESPONSE = {
+  access_token: "web-add-access-token",
+  refresh_token: "web-add-refresh-token",
+  expires_in: 3600,
+  scope: "user:inference user:profile",
+}
+
+interface TokenRequest {
+  code?: string
+  state?: string
+  code_verifier?: string
+  grant_type?: string
+}
+
+function stubTokenFetch(makeResponse: () => Response) {
+  const requests: TokenRequest[] = []
+  const fetchFn: typeof fetch = Object.assign(
+    async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      requests.push(JSON.parse(String(init?.body ?? "{}")) as TokenRequest)
+      return makeResponse()
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+  return { fetchFn, requests }
+}
+
+function okTokenFetch() {
+  return stubTokenFetch(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }))
+}
+
+// Credential writes go to the Keychain on darwin, so every assertion that reads
+// a .credentials.json file is Linux/Windows only — same reason
+// profile-login-unit.test.ts skips there.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profileAdd", () => {
+  let configDir: string
+  let savedConfigDir: string | undefined
+  let profiles: ProfileConfig[]
+
+  function profilesJson(): ProfileConfig[] {
+    return JSON.parse(readFileSync(join(configDir, "profiles.json"), "utf-8")) as ProfileConfig[]
+  }
+
+  function writeProfilesJson(entries: ProfileConfig[]): void {
+    mkdirSync(join(configDir, "profiles"), { recursive: true })
+    writeFileSync(join(configDir, "profiles.json"), `${JSON.stringify(entries, null, 2)}\n`)
+  }
+
+  /** Start an add and hand back what a completion needs, or fail loudly. */
+  function start(id: string): { addId: string; state: string } {
+    const result = startProfileAdd({ profiles, profileId: id })
+    if (!result.ok) throw new Error(`expected a started add, got ${result.code}`)
+    const state = new URL(result.authorizeUrl).searchParams.get("state")
+    if (!state) throw new Error("authorize URL carried no state")
+    return { addId: result.addId, state }
+  }
+
+  beforeEach(() => {
+    // Redirected so nothing here can reach the real ~/.config/meridian —
+    // profiles.json is the file this feature writes, and a test that writes
+    // the developer's own is a test that creates a real account slot.
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    configDir = mkdtempSync(join(tmpdir(), "meridian-web-add-"))
+    process.env.MERIDIAN_CONFIG_DIR = configDir
+    profiles = [{ id: "personal", claudeConfigDir: join(configDir, "profiles", "personal") }]
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+  })
+
+  afterEach(() => {
+    resetPendingAdds()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
+    rmSync(configDir, { recursive: true, force: true })
+  })
+
+  describe("isValidProfileId", () => {
+    it("accepts the character set a directory name can carry", () => {
+      for (const id of ["work", "work-2", "work_2", "Work2", "a"]) {
+        expect(isValidProfileId(id)).toBe(true)
+      }
+    })
+
+    it("rejects an empty id", () => {
+      expect(isValidProfileId("")).toBe(false)
+    })
+
+    // The reason this function exists: the id becomes a directory name.
+    it("rejects path traversal and separators", () => {
+      for (const id of ["../../etc", "..", ".", "a/b", "a\\b", "~", "/etc/passwd"]) {
+        expect(isValidProfileId(id)).toBe(false)
+      }
+    })
+
+    it("rejects spaces, dots and shell metacharacters", () => {
+      for (const id of ["my profile", "work.2", "a;b", "a$b", "a\u0000b"]) {
+        expect(isValidProfileId(id)).toBe(false)
+      }
+    })
+  })
+
+  describe("createProfileSlot", () => {
+    it("writes the profiles.json entry and the config directory together", () => {
+      const created = createProfileSlot("work")
+      if (!created.ok) throw new Error(`expected success, got ${created.reason}`)
+
+      expect(created.profile.id).toBe("work")
+      expect(created.profile.claudeConfigDir).toBe(join(configDir, "profiles", "work"))
+      expect(existsSync(join(configDir, "profiles", "work"))).toBe(true)
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: join(configDir, "profiles", "work") }])
+    })
+
+    it("appends rather than replacing what is already there", () => {
+      createProfileSlot("work")
+      createProfileSlot("personal")
+      expect(loadProfileIds()).toEqual(["work", "personal"])
+    })
+
+    it("refuses an invalid id without creating anything", () => {
+      const created = createProfileSlot("../escape")
+      expect(created).toMatchObject({ ok: false, reason: "invalid_id" })
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+    })
+
+    it("refuses a collision", () => {
+      writeProfilesJson([{ id: "work", claudeConfigDir: "/somewhere/else" }])
+      const created = createProfileSlot("work")
+      expect(created).toMatchObject({ ok: false, reason: "already_exists" })
+      // The existing entry is untouched — a refusal must not rewrite it.
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: "/somewhere/else" }])
+    })
+
+    it("adopts an explicit config dir — the CLI's ~/.claude import", () => {
+      const existing = join(configDir, "dot-claude")
+      mkdirSync(existing, { recursive: true })
+      const created = createProfileSlot("imported", { claudeConfigDir: existing })
+      if (!created.ok) throw new Error(`expected success, got ${created.reason}`)
+      expect(created.profile.claudeConfigDir).toBe(existing)
+      expect(existsSync(join(configDir, "profiles", "imported"))).toBe(false)
+    })
+  })
+
+  describe("startProfileAdd", () => {
+    it("returns an authorize URL and an opaque id, and never the PKCE verifier", () => {
+      const result = startProfileAdd({ profiles, profileId: "work" })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.profileId).toBe("work")
+      expect(result.addId.length).toBeGreaterThan(16)
+      expect(result.expiresAt).toBeGreaterThan(Date.now())
+
+      const url = new URL(result.authorizeUrl)
+      expect(url.origin + url.pathname).toBe("https://claude.com/cai/oauth/authorize")
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+      expect(url.searchParams.get("code_challenge")).toBeTruthy()
+      expect(url.searchParams.get("redirect_uri")).toBe("https://platform.claude.com/oauth/code/callback")
+
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain("codeVerifier")
+      expect(serialized).not.toContain("code_verifier")
+    })
+
+    // The slot appearing only after a successful exchange is the whole answer
+    // to "what happens if OAuth fails" — so nothing may exist yet at this point.
+    it("writes nothing to disk", () => {
+      startProfileAdd({ profiles, profileId: "work" })
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+      expect(existsSync(join(configDir, "profiles", "work"))).toBe(false)
+      expect(pendingAddCount()).toBe(1)
+    })
+
+    it("refuses an empty name", () => {
+      expect(startProfileAdd({ profiles, profileId: "   " }))
+        .toMatchObject({ ok: false, code: "invalid_request", status: 400 })
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    it("refuses an id that would escape the profiles directory", () => {
+      const result = startProfileAdd({ profiles, profileId: "../../etc" })
+      expect(result).toMatchObject({ ok: false, code: "invalid_profile_id", status: 400 })
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    it("refuses a name the running instance already serves, and points at the login button", () => {
+      const result = startProfileAdd({ profiles, profileId: "personal" })
+      expect(result).toMatchObject({ ok: false, code: "profile_exists", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("Log in from browser")
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    // Disk discovery is off in tests, so an instance configured from
+    // MERIDIAN_PROFILES would not see this one in its effective list — the
+    // profiles.json read is what stops the write landing on top of it.
+    it("refuses a name already written to profiles.json but not served", () => {
+      writeProfilesJson([{ id: "onlyondisk", claudeConfigDir: join(configDir, "profiles", "onlyondisk") }])
+      expect(startProfileAdd({ profiles, profileId: "onlyondisk" }))
+        .toMatchObject({ ok: false, code: "profile_exists", status: 409 })
+    })
+
+    it("refuses on an instance that must not write credential files, before minting anything", () => {
+      process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+      const result = startProfileAdd({ profiles, profileId: "work" })
+      expect(result).toMatchObject({ ok: false, code: "credentials_readonly", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("MERIDIAN_CREDENTIALS_READONLY")
+      expect(result.message).toContain("meridian profile add work")
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    // Found in browser QA: cancelling the panel, reloading the page and closing
+    // the tab all abandon a sign-in without telling the server, so refusing a
+    // second start locked the name out for the whole TTL with nothing the user
+    // could do to release it.
+    it("supersedes an abandoned sign-in for the same name rather than locking the name out", async () => {
+      const first = startProfileAdd({ profiles, profileId: "work" })
+      if (!first.ok) throw new Error("expected success")
+
+      const second = startProfileAdd({ profiles, profileId: "work" })
+      if (!second.ok) throw new Error(`expected the retry to be allowed, got ${second.code}`)
+      expect(second.addId).not.toBe(first.addId)
+      // Still one entry per name — that is what stops two sign-ins for one new
+      // name from both completing.
+      expect(pendingAddCount()).toBe(1)
+
+      // The superseded one is dead, and says so without contacting Anthropic.
+      const stale = await completeProfileAdd({ addId: first.addId, input: "abc123" })
+      expect(stale).toMatchObject({ ok: false, code: "expired_add" })
+    })
+
+    it("allows concurrent sign-ins for different names", () => {
+      start("work")
+      start("side")
+      expect(pendingAddCount()).toBe(2)
+    })
+
+    it("frees the name again once the pending add has expired", () => {
+      const first = startProfileAdd({ profiles, profileId: "work" })
+      if (!first.ok) throw new Error("expected success")
+      const later = startProfileAdd({ profiles, profileId: "work", now: Date.now() + LOGIN_TTL_MS + 1 })
+      expect(later.ok).toBe(true)
+    })
+  })
+
+  describe("completeProfileAdd", () => {
+    it("410s an id that was never issued", async () => {
+      const result = await completeProfileAdd({ addId: "made-up", input: "abc123" })
+      expect(result).toMatchObject({ ok: false, code: "expired_add", status: 410 })
+    })
+
+    it("410s an expired sign-in", async () => {
+      const { addId } = start("work")
+      const result = await completeProfileAdd({ addId, input: "abc123", now: Date.now() + LOGIN_TTL_MS + 1 })
+      expect(result).toMatchObject({ ok: false, code: "expired_add", status: 410 })
+    })
+
+    it("keeps the sign-in open when the paste holds no code", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({ addId, input: "   ", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "no_code", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      expect(pendingAddCount()).toBe(1)
+    })
+
+    it("keeps the sign-in open on a state mismatch, and never contacts Anthropic", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({
+        addId,
+        input: "https://platform.claude.com/oauth/code/callback?code=abc123&state=another-tabs-state",
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "state_mismatch", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      expect(pendingAddCount()).toBe(1)
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+    })
+
+    it.skipIf(skipOnDarwin)("creates the profile from a bare code", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({ addId, input: "abc123", fetchFn })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.profileId).toBe("work")
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({ grant_type: "authorization_code", code: "abc123" })
+
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: join(configDir, "profiles", "work") }])
+      const stored = JSON.parse(readFileSync(join(result.claudeConfigDir, ".credentials.json"), "utf-8"))
+      expect(stored.claudeAiOauth.accessToken).toBe("web-add-access-token")
+      expect(stored.claudeAiOauth.refreshToken).toBe("web-add-refresh-token")
+      expect(pendingAddCount()).toBe(0)
+    })
+
+    it.skipIf(skipOnDarwin)("creates the profile from the whole pasted callback URL", async () => {
+      const { addId, state } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      const result = await completeProfileAdd({
+        addId,
+        input: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+        fetchFn,
+      })
+      expect(result.ok).toBe(true)
+      expect(requests[0]).toMatchObject({ code: "url-code", state })
+      expect(loadProfileIds()).toEqual(["work"])
+    })
+
+    it.skipIf(skipOnDarwin)("is single use", async () => {
+      const { addId } = start("work")
+      const { fetchFn, requests } = okTokenFetch()
+
+      expect((await completeProfileAdd({ addId, input: "abc123", fetchFn })).ok).toBe(true)
+      expect(await completeProfileAdd({ addId, input: "abc123", fetchFn }))
+        .toMatchObject({ ok: false, code: "expired_add", status: 410 })
+      expect(requests).toHaveLength(1)
+    })
+
+    // The judgement call this flow had to make: a failed exchange leaves no
+    // profile at all, rather than a slot that shows as permanently logged out.
+    it("leaves no profile behind when Anthropic rejects the code", async () => {
+      const { addId } = start("work")
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ))
+
+      const result = await completeProfileAdd({ addId, input: "stale-code", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+      if (result.ok) throw new Error("expected refusal")
+
+      // Neither half of a profile exists, and the upstream body is not echoed.
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+      expect(result.message).not.toContain("invalid_grant")
+      expect(result.message).not.toContain("already redeemed")
+      expect(result.retryable).toBeUndefined()
+    })
+
+    it("frees the name for another attempt after a failed exchange", async () => {
+      const { addId } = start("work")
+      const { fetchFn } = stubTokenFetch(() => new Response("nope", { status: 500 }))
+
+      await completeProfileAdd({ addId, input: "stale-code", fetchFn })
+      expect(pendingAddCount()).toBe(0)
+      expect(startProfileAdd({ profiles, profileId: "work" }).ok).toBe(true)
+    })
+
+    it("reports the network reaching Anthropic failing without claiming a profile exists", async () => {
+      const { addId } = start("work")
+      const fetchFn: typeof fetch = Object.assign(
+        async () => { throw new Error("ECONNREFUSED") },
+        { preconnect: globalThis.fetch.preconnect },
+      )
+
+      const result = await completeProfileAdd({ addId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+      expect(existsSync(join(configDir, "profiles.json"))).toBe(false)
+    })
+
+    // Nothing holds the name on disk during the sign-in, so the CLI (or another
+    // instance) can take it in the meantime. Said plainly rather than reported
+    // as success — the credentials just authorized went into that directory.
+    it.skipIf(skipOnDarwin)("refuses when the name was taken during the sign-in", async () => {
+      const { addId } = start("work")
+      const { fetchFn } = okTokenFetch()
+      writeProfilesJson([{ id: "work", claudeConfigDir: "/somebody/elses/dir" }])
+
+      const result = await completeProfileAdd({ addId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "profile_exists", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("created elsewhere")
+      expect(profilesJson()).toEqual([{ id: "work", claudeConfigDir: "/somebody/elses/dir" }])
+    })
+  })
+})

--- a/src/__tests__/profile-login-route.test.ts
+++ b/src/__tests__/profile-login-route.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { resetPendingLogins } from "../proxy/profileLogin"
+import { createProxyServer } from "../proxy/server"
+import { stopBackgroundRefresh } from "../proxy/tokenRefresh"
+
+const TOKEN_RESPONSE = {
+  access_token: "route-access-token",
+  refresh_token: "route-refresh-token",
+  expires_in: 3600,
+}
+
+// Credential writes are Keychain-backed on darwin; the paths that actually
+// persist are Linux/Windows only here, as in profile-token-refresh-route.test.ts.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profile login routes", () => {
+  let originalFetch: typeof globalThis.fetch
+  let tempDir: string
+  let app: ReturnType<typeof createProxyServer>["app"]
+
+  function post(path: string, body: unknown, headers: Record<string, string> = {}) {
+    return app.fetch(new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    }))
+  }
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    tempDir = mkdtempSync(join(tmpdir(), "meridian-login-route-"))
+    mkdirSync(join(tempDir, "personal"), { recursive: true })
+    resetPendingLogins()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+
+    app = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [
+        { id: "personal", claudeConfigDir: join(tempDir, "personal") },
+        { id: "direct", type: "api", apiKey: "sk-ant-api-test" },
+      ],
+      defaultProfile: "personal",
+      silent: true,
+    }).app
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    stopBackgroundRefresh()
+    resetPendingLogins()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.MERIDIAN_API_KEY
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  function stubTokenEndpoint(makeResponse: () => Response) {
+    const requests: Array<Record<string, unknown>> = []
+    globalThis.fetch = Object.assign(
+      async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        requests.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>)
+        return makeResponse()
+      },
+      { preconnect: originalFetch.preconnect },
+    )
+    return requests
+  }
+
+  it("starts a login and returns an authorize URL without the PKCE verifier", async () => {
+    const res = await post("/profiles/login/start", { profile: "personal" })
+    expect(res.status).toBe(200)
+
+    const raw = await res.text()
+    expect(raw).not.toContain("codeVerifier")
+    expect(raw).not.toContain("code_verifier")
+
+    const body = JSON.parse(raw) as { loginId: string; authorizeUrl: string; expiresAt: number; profile: string }
+    expect(body.profile).toBe("personal")
+    expect(body.loginId).toBeTruthy()
+    expect(body.expiresAt).toBeGreaterThan(Date.now())
+    expect(new URL(body.authorizeUrl).searchParams.get("code_challenge")).toBeTruthy()
+  })
+
+  it("refuses to start on an instance that must not write credentials", async () => {
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    const res = await post("/profiles/login/start", { profile: "personal" })
+    expect(res.status).toBe(409)
+
+    const body = await res.json() as { error: string; code: string }
+    expect(body.code).toBe("credentials_readonly")
+    expect(body.error).toContain("MERIDIAN_CREDENTIALS_READONLY")
+    expect(body.error).toContain("meridian profile login personal")
+  })
+
+  it("404s an unknown profile and 400s a profile type with no OAuth flow", async () => {
+    const unknown = await post("/profiles/login/start", { profile: "ghost" })
+    expect(unknown.status).toBe(404)
+    expect((await unknown.json() as { code: string }).code).toBe("unknown_profile")
+
+    const apiProfile = await post("/profiles/login/start", { profile: "direct" })
+    expect(apiProfile.status).toBe(400)
+    expect((await apiProfile.json() as { code: string }).code).toBe("unsupported_profile_type")
+  })
+
+  it("400s a missing profile, malformed JSON, and a completion with no login id", async () => {
+    expect((await post("/profiles/login/start", {})).status).toBe(400)
+
+    const malformed = await app.fetch(new Request("http://localhost/profiles/login/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not json",
+    }))
+    expect(malformed.status).toBe(400)
+
+    const noId = await post("/profiles/login/complete", { code: "abc123" })
+    expect(noId.status).toBe(400)
+    expect((await noId.json() as { code: string }).code).toBe("invalid_request")
+  })
+
+  it("410s a login id that was never issued", async () => {
+    const res = await post("/profiles/login/complete", { loginId: "made-up", code: "abc123" })
+    expect(res.status).toBe(410)
+    expect((await res.json() as { code: string }).code).toBe("expired_login")
+  })
+
+  it.skipIf(skipOnDarwin)("completes a login from a bare code and writes the profile's credentials", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    const requests = stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    const res = await post("/profiles/login/complete", { loginId, code: "abc123" })
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ success: true, profile: "personal" })
+
+    expect(requests).toHaveLength(1)
+    expect(requests[0]).toMatchObject({ grant_type: "authorization_code", code: "abc123" })
+    expect(JSON.parse(readFileSync(join(tempDir, "personal", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+      .toBe("route-access-token")
+  })
+
+  it.skipIf(skipOnDarwin)("completes a login from the pasted callback URL", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId, authorizeUrl } = await started.json() as { loginId: string; authorizeUrl: string }
+    const state = new URL(authorizeUrl).searchParams.get("state")
+
+    stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    const res = await post("/profiles/login/complete", {
+      loginId,
+      code: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+    })
+    expect(res.status).toBe(200)
+    expect(JSON.parse(readFileSync(join(tempDir, "personal", ".credentials.json"), "utf-8")).claudeAiOauth.accessToken)
+      .toBe("route-access-token")
+  })
+
+  it.skipIf(skipOnDarwin)("410s a replayed completion", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    const requests = stubTokenEndpoint(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    expect((await post("/profiles/login/complete", { loginId, code: "abc123" })).status).toBe(200)
+    expect((await post("/profiles/login/complete", { loginId, code: "abc123" })).status).toBe(410)
+    expect(requests).toHaveLength(1)
+  })
+
+  it("400s a state that does not match, and never contacts the token endpoint", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    const requests = stubTokenEndpoint(() => new Response("{}", { status: 200 }))
+
+    const res = await post("/profiles/login/complete", {
+      loginId,
+      code: "https://platform.claude.com/oauth/code/callback?code=abc123&state=someone-elses-state",
+    })
+    expect(res.status).toBe(400)
+    // `retryable` is what tells the page to keep its paste box open rather than
+    // sending the user back through sign-in.
+    expect(await res.json()).toMatchObject({ code: "state_mismatch", retryable: true })
+    expect(requests).toHaveLength(0)
+    expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+
+    // Nothing reached Anthropic, so the login is still open for the right paste.
+    const retry = await post("/profiles/login/complete", { loginId, code: "abc123" })
+    expect(retry.status).not.toBe(410)
+  })
+
+  it("502s an upstream rejection without leaking the token endpoint's body", async () => {
+    const started = await post("/profiles/login/start", { profile: "personal" })
+    const { loginId } = await started.json() as { loginId: string }
+
+    stubTokenEndpoint(() => new Response(
+      JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    ))
+
+    const res = await post("/profiles/login/complete", { loginId, code: "stale-code" })
+    expect(res.status).toBe(502)
+    const raw = await res.text()
+    expect(raw).toContain("exchange_failed")
+    expect(raw).not.toContain("retryable")
+    expect(raw).not.toContain("invalid_grant")
+    expect(raw).not.toContain("already redeemed")
+  })
+
+  // Both routes sit under the /profiles/* prefix, so they inherit requireAuth
+  // rather than needing their own registration — asserted rather than assumed.
+  it("requires the API key on both routes when one is configured", async () => {
+    process.env.MERIDIAN_API_KEY = "secret-key"
+
+    expect((await post("/profiles/login/start", { profile: "personal" })).status).toBe(401)
+    expect((await post("/profiles/login/complete", { loginId: "x", code: "y" })).status).toBe(401)
+
+    const authorized = await post("/profiles/login/start", { profile: "personal" }, { "x-api-key": "secret-key" })
+    expect(authorized.status).toBe(200)
+  })
+})

--- a/src/__tests__/profile-login-unit.test.ts
+++ b/src/__tests__/profile-login-unit.test.ts
@@ -1,0 +1,394 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  LOGIN_TTL_MS,
+  completeProfileLogin,
+  pendingLoginCount,
+  resetPendingLogins,
+  startProfileLogin,
+} from "../proxy/profileLogin"
+import type { ProfileConfig } from "../proxy/profiles"
+
+const TOKEN_RESPONSE = {
+  access_token: "web-login-access-token",
+  refresh_token: "web-login-refresh-token",
+  expires_in: 3600,
+  scope: "user:inference user:profile",
+}
+
+interface TokenRequest {
+  code?: string
+  state?: string
+  code_verifier?: string
+  redirect_uri?: string
+  grant_type?: string
+}
+
+/** Records the token requests it is handed, so tests can assert what was sent
+ *  (and, for the failure paths, that nothing was sent at all). */
+function stubTokenFetch(makeResponse: () => Response) {
+  const requests: TokenRequest[] = []
+  const fetchFn: typeof fetch = Object.assign(
+    async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      requests.push(JSON.parse(String(init?.body ?? "{}")) as TokenRequest)
+      return makeResponse()
+    },
+    { preconnect: globalThis.fetch.preconnect },
+  )
+  return { fetchFn, requests }
+}
+
+function okTokenFetch() {
+  return stubTokenFetch(() => new Response(JSON.stringify(TOKEN_RESPONSE), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }))
+}
+
+function credentialsAt(dir: string): { accessToken: string; refreshToken: string; scopes: string[] } {
+  return JSON.parse(readFileSync(join(dir, ".credentials.json"), "utf-8")).claudeAiOauth
+}
+
+// Credential writes go to the Keychain on darwin, so the assertions that read a
+// .credentials.json file (and any path that writes at all) are Linux/Windows
+// only — same reason profile-token-refresh-route.test.ts skips there.
+const skipOnDarwin = process.platform === "darwin"
+
+describe("profileLogin", () => {
+  let tempDir: string
+  let profiles: ProfileConfig[]
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "meridian-web-login-"))
+    mkdirSync(join(tempDir, "personal"), { recursive: true })
+    mkdirSync(join(tempDir, "work"), { recursive: true })
+    profiles = [
+      { id: "personal", claudeConfigDir: join(tempDir, "personal") },
+      { id: "work", claudeConfigDir: join(tempDir, "work") },
+      { id: "ci", type: "oauth-token", oauthToken: "sk-ant-oat01-test" },
+      { id: "direct", type: "api", apiKey: "sk-ant-api-test" },
+    ]
+    resetPendingLogins()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+  })
+
+  afterEach(() => {
+    resetPendingLogins()
+    delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    delete process.env.CLAUDE_PROXY_CREDENTIALS_READONLY
+    rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe("startProfileLogin", () => {
+    it("returns an authorize URL and an opaque login id, and never the PKCE verifier", () => {
+      const result = startProfileLogin({ profiles, profileId: "personal" })
+      if (!result.ok) throw new Error(`expected success, got ${result.code}`)
+
+      expect(result.profileId).toBe("personal")
+      expect(result.loginId.length).toBeGreaterThan(16)
+      expect(result.expiresAt).toBeGreaterThan(Date.now())
+
+      const url = new URL(result.authorizeUrl)
+      expect(url.origin + url.pathname).toBe("https://claude.com/cai/oauth/authorize")
+      expect(url.searchParams.get("code_challenge_method")).toBe("S256")
+      expect(url.searchParams.get("code_challenge")).toBeTruthy()
+      expect(url.searchParams.get("state")).toBeTruthy()
+      expect(url.searchParams.get("redirect_uri")).toBe("https://platform.claude.com/oauth/code/callback")
+
+      // The whole point of the server-side map: neither half of the PKCE pair
+      // that the browser must not hold may appear in the response.
+      const serialized = JSON.stringify(result)
+      expect(serialized).not.toContain("codeVerifier")
+      expect(serialized).not.toContain("code_verifier")
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it("refuses an unknown profile instead of creating one", () => {
+      const result = startProfileLogin({ profiles, profileId: "nope" })
+      expect(result).toMatchObject({ ok: false, code: "unknown_profile", status: 404 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("personal")
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("refuses when no profiles are configured", () => {
+      const result = startProfileLogin({ profiles: [], profileId: "personal" })
+      expect(result).toMatchObject({ ok: false, code: "no_profiles", status: 400 })
+    })
+
+    it("refuses a blank profile id", () => {
+      const result = startProfileLogin({ profiles, profileId: "  " })
+      expect(result).toMatchObject({ ok: false, code: "invalid_request", status: 400 })
+    })
+
+    it("refuses an oauth-token profile and names the replacement path", () => {
+      const result = startProfileLogin({ profiles, profileId: "ci" })
+      expect(result).toMatchObject({ ok: false, code: "unsupported_profile_type", status: 400 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("oauth-token")
+      expect(result.message).toContain("--oauth-token")
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("refuses an api profile", () => {
+      const result = startProfileLogin({ profiles, profileId: "direct" })
+      expect(result).toMatchObject({ ok: false, code: "unsupported_profile_type", status: 400 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("api")
+    })
+
+    it("refuses on a read-only instance before any login is started", () => {
+      process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+      const result = startProfileLogin({ profiles, profileId: "personal" })
+      expect(result).toMatchObject({ ok: false, code: "credentials_readonly", status: 409 })
+      if (result.ok) throw new Error("expected refusal")
+      expect(result.message).toContain("MERIDIAN_CREDENTIALS_READONLY")
+      expect(result.message).toContain("meridian profile login personal")
+      // Nothing was minted, so no authorization code can be burned against it.
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("honours the legacy CLAUDE_PROXY_ alias for the read-only flag", () => {
+      process.env.CLAUDE_PROXY_CREDENTIALS_READONLY = "1"
+      expect(startProfileLogin({ profiles, profileId: "personal" })).toMatchObject({
+        ok: false,
+        code: "credentials_readonly",
+      })
+    })
+
+    it("keeps two logins for different profiles independent", () => {
+      const first = startProfileLogin({ profiles, profileId: "personal" })
+      const second = startProfileLogin({ profiles, profileId: "work" })
+      if (!first.ok || !second.ok) throw new Error("expected both to start")
+
+      expect(first.loginId).not.toBe(second.loginId)
+      expect(new URL(first.authorizeUrl).searchParams.get("state"))
+        .not.toBe(new URL(second.authorizeUrl).searchParams.get("state"))
+      expect(pendingLoginCount()).toBe(2)
+    })
+  })
+
+  describe("completeProfileLogin", () => {
+    it("rejects an unknown login id", async () => {
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({ loginId: "never-issued", input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(0)
+    })
+
+    it("rejects a login past its TTL", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: "abc123",
+        now: Date.now() + LOGIN_TTL_MS + 1,
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(0)
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("rejects a state that does not match the login, without sending the code", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: "https://platform.claude.com/oauth/code/callback?code=abc123&state=not-my-state",
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: false, code: "state_mismatch", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+      // Nothing was spent, so the login survives — see the next test.
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it.skipIf(skipOnDarwin)("still accepts the right paste after a state mismatch", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const wrongTab = await completeProfileLogin({
+        loginId: started.loginId,
+        input: "https://platform.claude.com/oauth/code/callback?code=other-flow&state=not-my-state",
+        fetchFn,
+      })
+      expect(wrongTab).toMatchObject({ ok: false, code: "state_mismatch" })
+
+      const rightTab = await completeProfileLogin({
+        loginId: started.loginId,
+        input: `https://platform.claude.com/oauth/code/callback?code=real-code&state=${state}`,
+        fetchFn,
+      })
+      expect(rightTab).toMatchObject({ ok: true, profileId: "personal" })
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({ code: "real-code" })
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it("keeps the login open when the paste carries no code", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "   ", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "no_code", status: 400, retryable: true })
+      expect(requests).toHaveLength(0)
+      // A mistyped paste must not cost the user another trip through sign-in.
+      expect(pendingLoginCount()).toBe(1)
+    })
+
+    it("reports an upstream rejection without echoing the token endpoint's body", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ error: "invalid_grant", error_description: "code already redeemed" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      ))
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "expired-code", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+      if (result.ok) throw new Error("expected refusal")
+      // The code reached Anthropic and is spent — never invite a retry with it.
+      expect(result.retryable).toBeUndefined()
+      expect(pendingLoginCount()).toBe(0)
+      expect(result.message).toContain("400")
+      expect(result.message).not.toContain("invalid_grant")
+      expect(result.message).not.toContain("already redeemed")
+    })
+
+    it("reports a transport failure", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const fetchFn: typeof fetch = Object.assign(
+        async () => { throw new Error("getaddrinfo ENOTFOUND platform.claude.com") },
+        { preconnect: globalThis.fetch.preconnect },
+      )
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed", status: 502 })
+    })
+
+    it.skipIf(skipOnDarwin)("accepts a bare code and writes the profile's credentials", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "  abc123  ", fetchFn })
+      expect(result).toMatchObject({ ok: true, profileId: "personal" })
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({
+        grant_type: "authorization_code",
+        code: "abc123",
+        redirect_uri: "https://platform.claude.com/oauth/code/callback",
+      })
+
+      const stored = credentialsAt(join(tempDir, "personal"))
+      expect(stored.accessToken).toBe("web-login-access-token")
+      expect(stored.refreshToken).toBe("web-login-refresh-token")
+      expect(stored.scopes).toEqual(["user:inference", "user:profile"])
+      expect(existsSync(join(tempDir, "work", ".credentials.json"))).toBe(false)
+    })
+
+    it.skipIf(skipOnDarwin)("accepts the whole callback URL, matching its state", async () => {
+      const started = startProfileLogin({ profiles, profileId: "work" })
+      if (!started.ok) throw new Error("expected success")
+      const state = new URL(started.authorizeUrl).searchParams.get("state")
+
+      const { fetchFn, requests } = okTokenFetch()
+      const result = await completeProfileLogin({
+        loginId: started.loginId,
+        input: `https://platform.claude.com/oauth/code/callback?code=url-code&state=${state}`,
+        fetchFn,
+      })
+      expect(result).toMatchObject({ ok: true, profileId: "work" })
+      expect(requests[0]).toMatchObject({ code: "url-code", state })
+      expect(credentialsAt(join(tempDir, "work")).accessToken).toBe("web-login-access-token")
+    })
+
+    it.skipIf(skipOnDarwin)("sends the verifier that matches the challenge the browser was given", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+      const challenge = new URL(started.authorizeUrl).searchParams.get("code_challenge") ?? ""
+
+      const { fetchFn, requests } = okTokenFetch()
+      await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+
+      const sent = requests[0]?.code_verifier
+      expect(sent).toBeTruthy()
+      expect(createHash("sha256").update(String(sent)).digest("base64url")).toBe(challenge)
+    })
+
+    it.skipIf(skipOnDarwin)("is single-use — a replayed login id is gone", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn, requests } = okTokenFetch()
+      expect(await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn }))
+        .toMatchObject({ ok: true })
+      expect(await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn }))
+        .toMatchObject({ ok: false, code: "expired_login", status: 410 })
+      expect(requests).toHaveLength(1)
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it.skipIf(skipOnDarwin)("consumes the login even when the exchange fails, since the code was sent", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn } = stubTokenFetch(() => new Response("{}", { status: 400 }))
+      await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+      expect(pendingLoginCount()).toBe(0)
+    })
+
+    it.skipIf(skipOnDarwin)("refuses a token response that omits the refresh token", async () => {
+      const started = startProfileLogin({ profiles, profileId: "personal" })
+      if (!started.ok) throw new Error("expected success")
+
+      const { fetchFn } = stubTokenFetch(() => new Response(
+        JSON.stringify({ access_token: "only-access", expires_in: 3600 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+      const result = await completeProfileLogin({ loginId: started.loginId, input: "abc123", fetchFn })
+      expect(result).toMatchObject({ ok: false, code: "exchange_failed" })
+      expect(existsSync(join(tempDir, "personal", ".credentials.json"))).toBe(false)
+    })
+
+    it.skipIf(skipOnDarwin)("routes two concurrent logins to their own profiles", async () => {
+      const first = startProfileLogin({ profiles, profileId: "personal" })
+      const second = startProfileLogin({ profiles, profileId: "work" })
+      if (!first.ok || !second.ok) throw new Error("expected both to start")
+
+      const personalFetch = stubTokenFetch(() => new Response(
+        JSON.stringify({ ...TOKEN_RESPONSE, access_token: "personal-token" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+      const workFetch = stubTokenFetch(() => new Response(
+        JSON.stringify({ ...TOKEN_RESPONSE, access_token: "work-token" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ))
+
+      const [personalResult, workResult] = await Promise.all([
+        completeProfileLogin({ loginId: first.loginId, input: "code-a", fetchFn: personalFetch.fetchFn }),
+        completeProfileLogin({ loginId: second.loginId, input: "code-b", fetchFn: workFetch.fetchFn }),
+      ])
+
+      expect(personalResult).toMatchObject({ ok: true, profileId: "personal" })
+      expect(workResult).toMatchObject({ ok: true, profileId: "work" })
+      expect(credentialsAt(join(tempDir, "personal")).accessToken).toBe("personal-token")
+      expect(credentialsAt(join(tempDir, "work")).accessToken).toBe("work-token")
+    })
+  })
+})

--- a/src/__tests__/profiles-unit.test.ts
+++ b/src/__tests__/profiles-unit.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, test, expect, beforeEach } from "bun:test"
 import { join } from "node:path"
-import { homedir } from "node:os"
+import { meridianConfigDir } from "../proxy/settings"
 import {
   resolveProfile,
   listProfiles,
@@ -107,7 +107,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-foo")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
   })
 
@@ -117,7 +117,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-bar")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
   })
 
@@ -129,7 +129,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-baz")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
     expect(result.env.CLAUDE_CONFIG_DIR).not.toBe("/ignored")
   })
@@ -160,7 +160,7 @@ describe("resolveProfile", () => {
     expect(result.type).toBe("oauth-token")
     expect(result.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-qux")
     expect(result.env.CLAUDE_CONFIG_DIR).toBe(
-      join(homedir(), ".config", "meridian", "profiles", "ci"),
+      join(meridianConfigDir(), "profiles", "ci"),
     )
   })
 })

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -670,9 +670,11 @@ export function resetCachedClaudeAuthStatus(): void {
   profileAuthCaches.clear()
 }
 
-/** Expire the auth status cache without clearing lastKnownGoodAuthStatus — for testing only.
- *  This simulates the TTL expiring so the next call re-executes `claude auth status`,
- *  while preserving the "last known good" fallback state. */
+/** Expire the auth status cache without clearing lastKnownGoodAuthStatus.
+ *  The next call re-executes `claude auth status` while the "last known good"
+ *  fallback state survives. Used by tests to simulate the TTL elapsing, and by
+ *  the login route so a just-authenticated profile stops reporting the cached
+ *  "not logged in". */
 export function expireAuthStatusCache(): void {
   cachedAuthStatusAt = 0
   cachedAuthStatusPromise = null

--- a/src/proxy/profileAdd.ts
+++ b/src/proxy/profileAdd.ts
@@ -1,0 +1,329 @@
+/**
+ * Browser-completable creation of a new claude-max profile.
+ *
+ * Backs `POST /profiles/add/start` and `POST /profiles/add/complete`. Adding an
+ * account no longer requires a shell on the box Meridian runs on, which is the
+ * same gap `profileLogin.ts` closed for re-authenticating one.
+ *
+ * Deliberately a SEPARATE route from the login flow rather than a loosened
+ * guard on it. `/profiles/login/start` refuses unknown ids, and that refusal is
+ * what stops "re-authenticate enrique-corp" from silently creating
+ * "enrique-crop" on a typo. Creating an account slot is a different act from
+ * re-authenticating one that exists, so it gets its own button, its own route
+ * and its own refusals.
+ *
+ * The slot is written only after Anthropic has returned credentials — see
+ * `completeProfileAdd`. Everything that can refuse does so at `/start`, before
+ * a sign-in tab opens, because a user who signs in and is only then refused has
+ * burned a one-time authorization code for nothing.
+ *
+ * This is a leaf module — no imports from server.ts or session/.
+ */
+
+import { randomBytes } from "node:crypto"
+import { envBool } from "../env"
+import {
+  createManualOAuthSession,
+  createProfileSlot,
+  exchangeAuthorizationCodeForCredentials,
+  isValidProfileId,
+  parseAuthorizationCodeInput,
+  profileConfigDirFor,
+  loadProfileIds,
+} from "./profileCli"
+import { LOGIN_TTL_MS } from "./profileLogin"
+import { getEffectiveProfiles, type ProfileConfig } from "./profiles"
+
+interface PendingAdd {
+  profileId: string
+  claudeConfigDir: string
+  codeVerifier: string
+  state: string
+  expiresAt: number
+}
+
+/**
+ * Started-but-unfinished creations, keyed by the opaque id handed to the
+ * browser. Server-side for the same reason as pending logins: the PKCE
+ * verifier is half of the proof and must not travel to the browser holding
+ * the other half.
+ *
+ * At most one entry per profile id: starting a second sign-in for the same name
+ * SUPERSEDES the first (see `startProfileAdd`). Nothing is on disk between
+ * `/start` and `/complete`, so this map is the only thing stopping two sign-ins
+ * for one new name from both completing, with the loser having spent a code to
+ * be told the name is taken.
+ */
+const pendingAdds = new Map<string, PendingAdd>()
+
+export type AddErrorCode =
+  | "credentials_readonly"
+  | "invalid_request"
+  | "invalid_profile_id"
+  | "profile_exists"
+  | "expired_add"
+  | "no_code"
+  | "state_mismatch"
+  | "exchange_failed"
+  | "write_failed"
+  | "create_failed"
+
+export interface AddFailure {
+  ok: false
+  code: AddErrorCode
+  status: number
+  message: string
+  /**
+   * The pending creation is still open — paste again, no second sign-in.
+   * Set exactly when the paste was rejected locally, before any code reached
+   * Anthropic. Same contract as `LoginFailure.retryable`, read by the same
+   * page code.
+   */
+  retryable?: boolean
+}
+
+export interface StartAddSuccess {
+  ok: true
+  profileId: string
+  addId: string
+  authorizeUrl: string
+  expiresAt: number
+}
+
+export interface CompleteAddSuccess {
+  ok: true
+  profileId: string
+  claudeConfigDir: string
+}
+
+export interface StartAddParams {
+  profiles: ProfileConfig[] | undefined
+  profileId: string
+  now?: number
+}
+
+export interface CompleteAddParams {
+  addId: string
+  input: string
+  now?: number
+  fetchFn?: typeof fetch
+}
+
+function prune(now: number): void {
+  for (const [id, add] of pendingAdds) {
+    if (add.expiresAt <= now) pendingAdds.delete(id)
+  }
+}
+
+/**
+ * Refuse when this instance must not write credential files.
+ *
+ * Creating a profile writes both credentials and profiles.json, so a readonly
+ * instance can do even less of it than a re-login. Refused at `/start` for the
+ * reason the login flow refuses there: the button is present on an instance
+ * that shares another's credential files, so it is there to be clicked.
+ */
+function readonlyRefusal(profileId: string): AddFailure | null {
+  if (!envBool("CREDENTIALS_READONLY")) return null
+  return {
+    ok: false,
+    code: "credentials_readonly",
+    status: 409,
+    message:
+      "This Meridian instance runs with MERIDIAN_CREDENTIALS_READONLY=1 and must not write credential files, "
+      + "so it cannot create a profile. Use the instance that owns these credentials, "
+      + `or a terminal on the box that holds them: meridian profile add ${profileId}`,
+  }
+}
+
+/**
+ * Every id this instance would consider taken: the profiles it serves plus the
+ * ones already written to profiles.json.
+ *
+ * Both, because they can differ. An instance configured from MERIDIAN_PROFILES
+ * does not read profiles.json at all, so the effective list alone would let a
+ * write land on top of an existing entry; and with disk discovery on, a profile
+ * added seconds ago may not have reached the effective list's cache yet.
+ */
+function takenIds(profiles: ProfileConfig[] | undefined): Set<string> {
+  const taken = new Set<string>()
+  for (const p of getEffectiveProfiles(profiles)) taken.add(p.id)
+  for (const id of loadProfileIds()) taken.add(id)
+  return taken
+}
+
+/**
+ * Create a pending profile: validate the name, refuse everything refusable,
+ * reserve the id, and mint PKCE. Nothing is written to disk here.
+ */
+export function startProfileAdd(params: StartAddParams): StartAddSuccess | AddFailure {
+  const now = params.now ?? Date.now()
+  const profileId = params.profileId.trim()
+  if (!profileId) {
+    return { ok: false, code: "invalid_request", status: 400, message: "Missing 'profile' in request body" }
+  }
+
+  const readonly = readonlyRefusal(profileId)
+  if (readonly) return readonly
+
+  // Before anything else touches it: this name becomes a directory.
+  if (!isValidProfileId(profileId)) {
+    return {
+      ok: false,
+      code: "invalid_profile_id",
+      status: 400,
+      message: "Profile names may use only letters, numbers, hyphens and underscores.",
+    }
+  }
+
+  if (takenIds(params.profiles).has(profileId)) {
+    return {
+      ok: false,
+      code: "profile_exists",
+      status: 409,
+      message: `Profile "${profileId}" already exists. To sign it in again, use "Log in from browser" on its card.`,
+    }
+  }
+
+  prune(now)
+  // A second sign-in for the same name REPLACES the first rather than being
+  // refused. Cancelling the panel, reloading the page or closing the tab all
+  // abandon a sign-in without telling the server, so refusing here would lock
+  // the name out for the full TTL with no way for the user to release it. One
+  // entry per name still holds, which is what stops two sign-ins from both
+  // completing; superseding just decides which one survives.
+  for (const [id, pending] of pendingAdds) {
+    if (pending.profileId === profileId) pendingAdds.delete(id)
+  }
+
+  const session = createManualOAuthSession()
+  const addId = randomBytes(16).toString("base64url")
+  const expiresAt = now + LOGIN_TTL_MS
+  pendingAdds.set(addId, {
+    profileId,
+    claudeConfigDir: profileConfigDirFor(profileId),
+    codeVerifier: session.codeVerifier,
+    state: session.state,
+    expiresAt,
+  })
+
+  return { ok: true, profileId, addId, authorizeUrl: session.authorizeUrl, expiresAt }
+}
+
+/**
+ * Finish a creation from what the user pasted — a bare code, or the whole
+ * callback URL from the browser's address bar.
+ *
+ * Order matters: the credentials are exchanged FIRST and the profiles.json
+ * entry is written only once they are in hand. An OAuth failure therefore
+ * leaves no profile behind at all, rather than a half-made one that shows as
+ * permanently logged out and has to be noticed and cleaned up. The residue of
+ * a failure is at most an empty directory, which the next attempt reuses.
+ */
+export async function completeProfileAdd(params: CompleteAddParams): Promise<CompleteAddSuccess | AddFailure> {
+  const now = params.now ?? Date.now()
+  prune(now)
+
+  const pending = pendingAdds.get(params.addId)
+  if (!pending) {
+    return {
+      ok: false,
+      code: "expired_add",
+      status: 410,
+      message: "This sign-in is no longer open — it expired, or it was already completed. Start it again.",
+    }
+  }
+
+  // Parsed before the pending entry is consumed: a mistyped paste should not
+  // force the user back through Anthropic's sign-in.
+  const parsed = parseAuthorizationCodeInput(params.input)
+  if (!parsed) {
+    return {
+      ok: false,
+      code: "no_code",
+      status: 400,
+      message: "No authorization code found in that paste. Paste the code Claude showed you, or the whole callback URL.",
+      retryable: true,
+    }
+  }
+
+  // Consumed BEFORE the exchange: deleting first is what makes single-use hold
+  // against two completions racing the same id.
+  pendingAdds.delete(params.addId)
+
+  const exchange = await exchangeAuthorizationCodeForCredentials({
+    code: parsed.code,
+    returnedState: parsed.state,
+    sessionState: pending.state,
+    codeVerifier: pending.codeVerifier,
+    claudeConfigDir: pending.claudeConfigDir,
+    fetchFn: params.fetchFn,
+  })
+
+  if (!exchange.ok) {
+    if (exchange.reason === "state_mismatch") {
+      // Rejected locally — nothing was spent, so put the reservation back and
+      // let the user paste from the right tab.
+      pendingAdds.set(params.addId, pending)
+      return {
+        ok: false,
+        code: "state_mismatch",
+        status: 400,
+        message: "OAuth state did not match this sign-in. Paste the code from the tab this sign-in opened.",
+        retryable: true,
+      }
+    }
+    if (exchange.reason === "write_failed") {
+      return {
+        ok: false,
+        code: "write_failed",
+        status: 500,
+        message: `Signed in, but the credentials for "${pending.profileId}" could not be written, so the profile was not created.`,
+      }
+    }
+    // The token endpoint's own error body is deliberately not forwarded — it is
+    // one-time-credential-adjacent and belongs nowhere near a rendered page.
+    return {
+      ok: false,
+      code: "exchange_failed",
+      status: 502,
+      message: exchange.status
+        ? `Anthropic rejected the authorization code (HTTP ${exchange.status}). Codes expire quickly — start again.`
+        : "Could not reach Anthropic to exchange the authorization code. Start again.",
+    }
+  }
+
+  const created = createProfileSlot(pending.profileId)
+  if (!created.ok) {
+    if (created.reason === "already_exists") {
+      // Something created this name during the sign-in — the CLI, or another
+      // instance. Said plainly rather than reported as success: the credentials
+      // just authorized went into that profile's directory.
+      return {
+        ok: false,
+        code: "profile_exists",
+        status: 409,
+        message: `Profile "${pending.profileId}" was created elsewhere while you were signing in. `
+          + "The account you just authorized was written to its config directory; check it before using it.",
+      }
+    }
+    return {
+      ok: false,
+      code: "create_failed",
+      status: 500,
+      message: `Signed in, but "${pending.profileId}" could not be written to profiles.json (${created.message}). `
+        + `The credentials are on disk — \`meridian profile add ${pending.profileId}\` will pick them up.`,
+    }
+  }
+
+  return { ok: true, profileId: created.profile.id, claudeConfigDir: created.profile.claudeConfigDir ?? pending.claudeConfigDir }
+}
+
+export function pendingAddCount(): number {
+  return pendingAdds.size
+}
+
+/** Drop all pending creations — for testing only. */
+export function resetPendingAdds(): void {
+  pendingAdds.clear()
+}

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -16,11 +16,22 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
-import { setSetting } from "./settings"
+import { meridianConfigDir, setSetting } from "./settings"
 import { createPlatformCredentialStore } from "./tokenRefresh"
 
-const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
+/**
+ * Resolved per call, not frozen at import, so these track MERIDIAN_CONFIG_DIR
+ * exactly as `profiles.ts` does when it reads them back. Freezing them here
+ * while the reader resolves dynamically is how a written profile becomes an
+ * invisible one.
+ */
+function profilesDir(): string {
+  return join(meridianConfigDir(), "profiles")
+}
+
+function configFile(): string {
+  return join(meridianConfigDir(), "profiles.json")
+}
 const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -35,7 +46,7 @@ const OAUTH_SCOPES = [
 ]
 
 function ensureProfilesDir(): void {
-  mkdirSync(PROFILES_DIR, { recursive: true })
+  mkdirSync(profilesDir(), { recursive: true })
 }
 
 /**
@@ -45,7 +56,7 @@ function ensureProfilesDir(): void {
  * (profiles.ts already builds it for oauth-token isolation).
  */
 export function profileConfigDirFor(id: string): string {
-  return join(PROFILES_DIR, id)
+  return join(profilesDir(), id)
 }
 
 function getProfileDir(id: string): string {
@@ -126,18 +137,30 @@ export function parseAuthorizationCodeInput(input: string): ParsedAuthorizationC
 }
 
 function loadProfileConfig(): ProfileConfig[] {
-  if (!existsSync(CONFIG_FILE)) return []
+  const file = configFile()
+  if (!existsSync(file)) return []
   try {
-    return JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
+    return JSON.parse(readFileSync(file, "utf-8"))
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     return []
   }
 }
 
+/**
+ * Ids currently written to profiles.json, for collision checks.
+ *
+ * Ids only. The file also holds `apiKey` and `oauthToken` values, and a
+ * collision check has no business handling those — the narrower return type is
+ * what keeps them from reaching a caller that might render or log one.
+ */
+export function loadProfileIds(): string[] {
+  return loadProfileConfig().map(p => p.id)
+}
+
 function saveProfileConfig(profiles: ProfileConfig[]): void {
   ensureProfilesDir()
-  writeFileSync(CONFIG_FILE, `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
+  writeFileSync(configFile(), `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
 }
 
 function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; subscriptionType?: string } {
@@ -313,12 +336,88 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   return false
 }
 
+/**
+ * A profile id becomes a directory name under `profiles/`, so this character
+ * set is what stops `../../etc` from becoming one. Exported so the CLI and the
+ * web add route ask the same question — a second regex elsewhere is a second
+ * answer to "what is a legal id", and the two would drift.
+ */
+export function isValidProfileId(id: string): boolean {
+  return Boolean(id) && !/[^a-zA-Z0-9_-]/.test(id)
+}
+
+export type ProfileSlotFailureReason = "invalid_id" | "already_exists" | "write_failed"
+
+export type CreateProfileSlotResult =
+  | { ok: true; profile: ProfileConfig; profiles: ProfileConfig[] }
+  | { ok: false; reason: ProfileSlotFailureReason; message: string }
+
+/**
+ * Turn a valid, non-colliding id into the two things a browser-login profile
+ * is made of: an entry in profiles.json and a CLAUDE_CONFIG_DIR of its own.
+ *
+ * ONE implementation, two front ends — `meridian profile add` and
+ * `POST /profiles/add/complete` — for the same reason the token exchange has
+ * one: two copies of "what a profile is made of" drift, and the copy that
+ * drifts is the one nobody runs.
+ *
+ * The collision check reads profiles.json at call time rather than trusting a
+ * list the caller loaded earlier, so a slot created between an early check and
+ * this one is still caught.
+ *
+ * `claudeConfigDir` adopts a directory that already holds credentials — the
+ * CLI's `~/.claude` import. Omitted, the profile gets a fresh directory of its
+ * own under `profiles/<id>`.
+ */
+export function createProfileSlot(
+  id: string,
+  options: { claudeConfigDir?: string } = {},
+): CreateProfileSlotResult {
+  if (!isValidProfileId(id)) {
+    return {
+      ok: false,
+      reason: "invalid_id",
+      message: "Invalid profile ID. Use only letters, numbers, hyphens and underscores.",
+    }
+  }
+
+  const profiles = loadProfileConfig()
+  if (profiles.some(p => p.id === id)) {
+    return { ok: false, reason: "already_exists", message: `Profile "${id}" already exists.` }
+  }
+
+  const claudeConfigDir = options.claudeConfigDir ?? profileConfigDirFor(id)
+  const profile: ProfileConfig = { id, claudeConfigDir }
+  try {
+    mkdirSync(claudeConfigDir, { recursive: true })
+    profiles.push(profile)
+    saveProfileConfig(profiles)
+  } catch (err) {
+    return { ok: false, reason: "write_failed", message: err instanceof Error ? err.message : String(err) }
+  }
+
+  return { ok: true, profile, profiles }
+}
+
+/** CLI wrapper: `createProfileSlot` refusals are fatal for `meridian profile add`. */
+function createProfileSlotOrExit(id: string, options: { claudeConfigDir?: string } = {}): ProfileConfig[] {
+  const created = createProfileSlot(id, options)
+  if (!created.ok) {
+    console.error(`\x1b[31m✗ ${created.message}\x1b[0m`)
+    if (created.reason === "already_exists") console.error(`  Run: meridian profile list`)
+    process.exit(1)
+  }
+  return created.profiles
+}
+
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {
-  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+  if (!isValidProfileId(id)) {
     console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
 
+  // Checked here as well as inside createProfileSlot: this one fails before a
+  // browser login the user would otherwise complete for nothing.
   const profiles = loadProfileConfig()
   if (profiles.find(p => p.id === id)) {
     console.error(`\x1b[31m✗ Profile "${id}" already exists.\x1b[0m`)
@@ -336,10 +435,9 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
       console.log(`\x1b[32m✓ Found existing Claude credentials (${defaultAuth.email}, ${defaultAuth.subscriptionType || "unknown"})\x1b[0m`)
       const answer = promptYesNo(`  Import as profile "${id}"?`)
       if (answer) {
-        profiles.push({ id, claudeConfigDir: defaultClaudeDir })
-        saveProfileConfig(profiles)
+        const imported = createProfileSlotOrExit(id, { claudeConfigDir: defaultClaudeDir })
         console.log(`\x1b[32m✓ Profile "${id}" imported — using ${defaultAuth.email}\x1b[0m`)
-        printEnvHint(profiles)
+        printEnvHint(imported)
         return
       }
       console.log()
@@ -349,6 +447,9 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
   }
 
   const configDir = getProfileDir(id)
+  // Created before the login rather than by createProfileSlot afterwards: the
+  // `claude auth login` subprocess writes its credentials into this directory,
+  // so it has to exist first. The profiles.json entry still waits for success.
   mkdirSync(configDir, { recursive: true })
 
   console.log(`\x1b[36mAdding profile: ${id}\x1b[0m`)
@@ -359,9 +460,7 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
   const existingAuth = getAuthStatus(configDir)
   if (existingAuth.loggedIn) {
     console.log(`\x1b[32m✓ Already authenticated as ${existingAuth.email}\x1b[0m`)
-    profiles.push({ id, claudeConfigDir: configDir })
-    saveProfileConfig(profiles)
-    printEnvHint(profiles)
+    printEnvHint(createProfileSlotOrExit(id))
     return
   }
 
@@ -414,13 +513,11 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
   console.log()
   console.log(`\x1b[32m✓ Profile "${id}" created — logged in as ${auth.email} (${auth.subscriptionType || "unknown"})\x1b[0m`)
 
-  profiles.push({ id, claudeConfigDir: configDir })
-  saveProfileConfig(profiles)
-  printEnvHint(profiles)
+  printEnvHint(createProfileSlotOrExit(id))
 }
 
 export async function profileAddOauthToken(id: string, tokenArg: string | undefined): Promise<void> {
-  if (!id || /[^a-zA-Z0-9_-]/.test(id)) {
+  if (!isValidProfileId(id)) {
     console.error("\x1b[31m✗ Invalid profile ID.\x1b[0m Use only letters, numbers, hyphens, underscores.")
     process.exit(1)
   }
@@ -509,7 +606,7 @@ export function profileRemove(id: string): void {
     console.error(`\x1b[31m✗ Profile "${id}" not found.\x1b[0m`)
     process.exit(1)
   }
-  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, PROFILES_DIR)
+  const dirsToRemove = dirsToRemoveOnProfileRemove(removed, profilesDir())
   profiles.splice(idx, 1)
   saveProfileConfig(profiles)
 
@@ -663,7 +760,7 @@ function promptToken(question: string): string {
 }
 
 function printEnvHint(_profiles: ProfileConfig[]): void {
-  console.log(`\x1b[90mConfig: ${CONFIG_FILE}\x1b[0m`)
+  console.log(`\x1b[90mConfig: ${configFile()}\x1b[0m`)
   console.log("\x1b[90mProfiles are picked up automatically — no restart needed.\x1b[0m")
 }
 

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -38,8 +38,18 @@ function ensureProfilesDir(): void {
   mkdirSync(PROFILES_DIR, { recursive: true })
 }
 
-function getProfileDir(id: string): string {
+/**
+ * Config directory a browser-login profile gets when it carries no explicit
+ * `claudeConfigDir`. Exported so the web login route resolves the same
+ * directory this CLI would, instead of rebuilding the path a third time
+ * (profiles.ts already builds it for oauth-token isolation).
+ */
+export function profileConfigDirFor(id: string): string {
   return join(PROFILES_DIR, id)
+}
+
+function getProfileDir(id: string): string {
+  return profileConfigDirFor(id)
 }
 
 interface AuthLoginOptions {
@@ -156,6 +166,105 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
+export type OAuthExchangeFailureReason =
+  | "state_mismatch"
+  | "request_failed"
+  | "http_error"
+  | "invalid_response"
+  | "missing_tokens"
+  | "write_failed"
+
+export type OAuthExchangeResult =
+  | { ok: true }
+  | { ok: false; reason: OAuthExchangeFailureReason; status?: number; detail?: string }
+
+export interface OAuthExchangeParams {
+  /** Authorization code parsed out of the user's paste. */
+  code: string
+  /** `state` the paste carried, when it carried one (a pasted URL does). */
+  returnedState?: string
+  /** `state` this login was started with — what `returnedState` must match. */
+  sessionState: string
+  /** PKCE verifier for this login. */
+  codeVerifier: string
+  /** CLAUDE_CONFIG_DIR whose credential store receives the tokens. */
+  claudeConfigDir: string
+  /** Scopes recorded when the token response omits `scope`. */
+  scopes?: string[]
+  /** Injectable for tests — defaults to global `fetch`. */
+  fetchFn?: typeof fetch
+}
+
+/**
+ * Validate `state`, exchange an authorization code for OAuth credentials, and
+ * write them to a profile's credential store.
+ *
+ * ONE implementation, two front ends: `meridian profile login --headless`
+ * (which prompts for the paste) and `POST /profiles/login/complete` (which
+ * receives it over HTTP). Both parse the paste with
+ * `parseAuthorizationCodeInput` and hand the result here, so state validation,
+ * the token request and what gets persisted cannot drift between them.
+ *
+ * Returns a reason instead of throwing or printing, because the two callers
+ * present failure differently: the CLI renders reasons as red lines, the HTTP
+ * route maps them to status codes. `detail` carries the token endpoint's error
+ * body (truncated) for the CLI's diagnostics; the route drops it rather than
+ * rendering an upstream error body into a page.
+ */
+export async function exchangeAuthorizationCodeForCredentials(params: OAuthExchangeParams): Promise<OAuthExchangeResult> {
+  if (params.returnedState && params.returnedState !== params.sessionState) {
+    return { ok: false, reason: "state_mismatch" }
+  }
+
+  const fetchFn = params.fetchFn ?? fetch
+  let response: Response
+  try {
+    response = await fetchFn(OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: OAUTH_CLIENT_ID,
+        code: params.code,
+        redirect_uri: OAUTH_REDIRECT_URI,
+        code_verifier: params.codeVerifier,
+        state: params.returnedState ?? params.sessionState,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    })
+  } catch (err) {
+    return { ok: false, reason: "request_failed", detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "")
+    return { ok: false, reason: "http_error", status: response.status, detail: body.slice(0, 300) || undefined }
+  }
+
+  let tokenData: OAuthTokenResponse
+  try {
+    tokenData = await response.json() as OAuthTokenResponse
+  } catch (err) {
+    return { ok: false, reason: "invalid_response", detail: err instanceof Error ? err.message : String(err) }
+  }
+
+  if (!tokenData.access_token || !tokenData.refresh_token) {
+    return { ok: false, reason: "missing_tokens" }
+  }
+
+  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+  const store = createPlatformCredentialStore({ claudeConfigDir: params.claudeConfigDir })
+  const written = await store.write({
+    claudeAiOauth: {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt,
+      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? params.scopes ?? OAUTH_SCOPES,
+    },
+  })
+  return written ? { ok: true } : { ok: false, reason: "write_failed" }
+}
+
 async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   const session = createManualOAuthSession()
   console.log("\x1b[33m⚠ Headless OAuth login: open this URL in a browser:\x1b[0m")
@@ -163,67 +272,45 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   console.log(session.authorizeUrl)
   console.log()
   console.log("After sign-in, paste the code shown by Claude below.")
+  console.log("\x1b[90m(the whole callback URL works too)\x1b[0m")
   const input = promptLine("Paste code:")
   const parsed = parseAuthorizationCodeInput(input)
   if (!parsed) {
     console.error("\x1b[31m✗ No authorization code received.\x1b[0m")
     return false
   }
-  if (parsed.state && parsed.state !== session.state) {
-    console.error("\x1b[31m✗ OAuth state mismatch. Please retry the login.\x1b[0m")
-    return false
-  }
 
-  let response: Response
-  try {
-    response = await fetch(OAUTH_TOKEN_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "authorization_code",
-        client_id: OAUTH_CLIENT_ID,
-        code: parsed.code,
-        redirect_uri: OAUTH_REDIRECT_URI,
-        code_verifier: session.codeVerifier,
-        state: parsed.state ?? session.state,
-      }),
-      signal: AbortSignal.timeout(30_000),
-    })
-  } catch (err) {
-    console.error(`\x1b[31m✗ OAuth token exchange failed: ${err instanceof Error ? err.message : err}\x1b[0m`)
-    return false
-  }
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "")
-    console.error(`\x1b[31m✗ OAuth token exchange failed (${response.status}).\x1b[0m`)
-    if (body) console.error(`  ${body.slice(0, 300)}`)
-    return false
-  }
-
-  let tokenData: OAuthTokenResponse
-  try {
-    tokenData = await response.json() as OAuthTokenResponse
-  } catch (err) {
-    console.error(`\x1b[31m✗ OAuth token response was invalid: ${err instanceof Error ? err.message : err}\x1b[0m`)
-    return false
-  }
-
-  if (!tokenData.access_token || !tokenData.refresh_token) {
-    console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
-    return false
-  }
-
-  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
-  const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write({
-    claudeAiOauth: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt,
-      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
-    },
+  const result = await exchangeAuthorizationCodeForCredentials({
+    code: parsed.code,
+    returnedState: parsed.state,
+    sessionState: session.state,
+    codeVerifier: session.codeVerifier,
+    claudeConfigDir: configDir,
   })
+  if (result.ok) return true
+
+  switch (result.reason) {
+    case "state_mismatch":
+      console.error("\x1b[31m✗ OAuth state mismatch. Please retry the login.\x1b[0m")
+      break
+    case "request_failed":
+      console.error(`\x1b[31m✗ OAuth token exchange failed: ${result.detail}\x1b[0m`)
+      break
+    case "http_error":
+      console.error(`\x1b[31m✗ OAuth token exchange failed (${result.status}).\x1b[0m`)
+      if (result.detail) console.error(`  ${result.detail}`)
+      break
+    case "invalid_response":
+      console.error(`\x1b[31m✗ OAuth token response was invalid: ${result.detail}\x1b[0m`)
+      break
+    case "missing_tokens":
+      console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
+      break
+    case "write_failed":
+      console.error("\x1b[31m✗ Could not write credentials for this profile.\x1b[0m")
+      break
+  }
+  return false
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/profileLogin.ts
+++ b/src/proxy/profileLogin.ts
@@ -1,0 +1,292 @@
+/**
+ * Browser-completable OAuth login for claude-max profiles.
+ *
+ * Backs `POST /profiles/login/start` and `POST /profiles/login/complete`, so
+ * re-authenticating an account does not require a terminal on the box Meridian
+ * runs on. The browser gets an opaque login id and the authorize URL; the PKCE
+ * verifier stays here.
+ *
+ * Why the user pastes a code instead of being redirected back: Anthropic's
+ * client id has exactly one registered redirect URI —
+ * `https://platform.claude.com/oauth/code/callback`, a page Anthropic hosts.
+ * There is no `http://localhost:<port>/callback` variant registered, and a
+ * redirect_uri Meridian controls would be rejected at the authorize step. So
+ * the callback page shows the user a code, and they bring it back here.
+ * `parseAuthorizationCodeInput` accepts that page's whole URL as well as a bare
+ * code, which is the closest thing to an automatic hand-off available.
+ *
+ * This is a leaf module — no imports from server.ts or session/.
+ */
+
+import { randomBytes } from "node:crypto"
+import { envBool } from "../env"
+import {
+  createManualOAuthSession,
+  exchangeAuthorizationCodeForCredentials,
+  parseAuthorizationCodeInput,
+  profileConfigDirFor,
+} from "./profileCli"
+import { getEffectiveProfiles, resolveProfile, type ProfileConfig } from "./profiles"
+
+/**
+ * How long a started login stays completable.
+ *
+ * Bounded because an unfinished login holds a PKCE verifier and a `state` this
+ * process would otherwise accept forever. Ten minutes covers a human signing
+ * in — including a password manager and a 2FA prompt — and Anthropic's
+ * authorization code expires well before it anyway.
+ */
+export const LOGIN_TTL_MS = 10 * 60_000
+
+interface PendingLogin {
+  profileId: string
+  claudeConfigDir: string
+  codeVerifier: string
+  state: string
+  expiresAt: number
+}
+
+/**
+ * Started-but-unfinished logins, keyed by the opaque id handed to the browser.
+ *
+ * Server-side because the verifier is half of the PKCE proof: sending it to the
+ * browser would put both halves in one place that is not the one that started
+ * the flow. Two logins for different profiles are two entries and cannot
+ * interfere — each carries its own verifier, state and target directory.
+ */
+const pendingLogins = new Map<string, PendingLogin>()
+
+export type LoginErrorCode =
+  | "credentials_readonly"
+  | "no_profiles"
+  | "unknown_profile"
+  | "unsupported_profile_type"
+  | "invalid_request"
+  | "expired_login"
+  | "no_code"
+  | "state_mismatch"
+  | "exchange_failed"
+  | "write_failed"
+
+export interface LoginFailure {
+  ok: false
+  code: LoginErrorCode
+  status: number
+  message: string
+  /**
+   * The login is still open — paste again, no second sign-in.
+   *
+   * Set exactly when the paste was rejected locally, before any code reached
+   * Anthropic. The client reads this instead of matching on `code`, because
+   * only this module knows whether the session survived the attempt; a client
+   * re-deriving it from the code list would drift the moment a code is added.
+   */
+  retryable?: boolean
+}
+
+export interface StartLoginSuccess {
+  ok: true
+  profileId: string
+  loginId: string
+  authorizeUrl: string
+  expiresAt: number
+}
+
+export interface CompleteLoginSuccess {
+  ok: true
+  profileId: string
+}
+
+export interface StartLoginParams {
+  profiles: ProfileConfig[] | undefined
+  profileId: string
+  now?: number
+}
+
+export interface CompleteLoginParams {
+  loginId: string
+  input: string
+  now?: number
+  fetchFn?: typeof fetch
+}
+
+function prune(now: number): void {
+  for (const [id, login] of pendingLogins) {
+    if (login.expiresAt <= now) pendingLogins.delete(id)
+  }
+}
+
+/**
+ * Refuse when this instance must not write credential files.
+ *
+ * `MERIDIAN_CREDENTIALS_READONLY=1` marks an instance that shares another
+ * instance's credential files — a development build beside a production one.
+ * Such an instance can still serve this page, so the button is there to be
+ * clicked; refusing at the START is the whole point. A user who signs in and is
+ * refused afterwards has burned a one-time authorization code for nothing.
+ */
+function readonlyRefusal(profileId: string): LoginFailure | null {
+  if (!envBool("CREDENTIALS_READONLY")) return null
+  return {
+    ok: false,
+    code: "credentials_readonly",
+    status: 409,
+    message:
+      "This Meridian instance runs with MERIDIAN_CREDENTIALS_READONLY=1 and must not write credential files, "
+      + "so it cannot complete a login. Use the instance that owns these credentials, "
+      + `or a terminal on the box that holds them: meridian profile login ${profileId}`,
+  }
+}
+
+/**
+ * Create a login: resolve the profile, mint PKCE, and return the authorize URL
+ * with an opaque id. Every refusal happens here, before the user is sent to
+ * Anthropic to sign in.
+ */
+export function startProfileLogin(params: StartLoginParams): StartLoginSuccess | LoginFailure {
+  const now = params.now ?? Date.now()
+  const profileId = params.profileId.trim()
+  if (!profileId) {
+    return { ok: false, code: "invalid_request", status: 400, message: "Missing 'profile' in request body" }
+  }
+
+  const readonly = readonlyRefusal(profileId)
+  if (readonly) return readonly
+
+  const effective = getEffectiveProfiles(params.profiles)
+  if (effective.length === 0) {
+    return { ok: false, code: "no_profiles", status: 400, message: "No profiles configured" }
+  }
+
+  // Unknown ids are refused rather than created. `meridian profile add` is the
+  // one place a profile comes into existence, and this surface is reachable by
+  // anyone who can reach the page — creating an account slot from it is a
+  // different decision than re-authenticating one that exists.
+  if (!effective.some(p => p.id === profileId)) {
+    return {
+      ok: false,
+      code: "unknown_profile",
+      status: 404,
+      message: `Unknown profile: ${profileId}. Available: ${effective.map(p => p.id).join(", ")}`,
+    }
+  }
+
+  // Reuse the request-path resolver so the type inference and the config-dir
+  // choice are the ones every request already gets, not a second reading of
+  // the same fields.
+  const resolved = resolveProfile(params.profiles, undefined, profileId)
+  if (resolved.type !== "claude-max") {
+    return {
+      ok: false,
+      code: "unsupported_profile_type",
+      status: 400,
+      message: `Profile "${profileId}" is an ${resolved.type} profile, which has no OAuth login flow. `
+        + (resolved.type === "oauth-token"
+          ? `Replace its token instead: meridian profile remove ${profileId} && meridian profile add ${profileId} --oauth-token`
+          : "Edit its API key in ~/.config/meridian/profiles.json instead."),
+    }
+  }
+
+  const session = createManualOAuthSession()
+  const loginId = randomBytes(16).toString("base64url")
+  const expiresAt = now + LOGIN_TTL_MS
+  prune(now)
+  pendingLogins.set(loginId, {
+    profileId,
+    claudeConfigDir: resolved.env.CLAUDE_CONFIG_DIR ?? profileConfigDirFor(profileId),
+    codeVerifier: session.codeVerifier,
+    state: session.state,
+    expiresAt,
+  })
+
+  return { ok: true, profileId, loginId, authorizeUrl: session.authorizeUrl, expiresAt }
+}
+
+/**
+ * Finish a login from what the user pasted — a bare code, or the whole callback
+ * URL from the browser's address bar.
+ */
+export async function completeProfileLogin(params: CompleteLoginParams): Promise<CompleteLoginSuccess | LoginFailure> {
+  const now = params.now ?? Date.now()
+  prune(now)
+
+  const pending = pendingLogins.get(params.loginId)
+  if (!pending) {
+    return {
+      ok: false,
+      code: "expired_login",
+      status: 410,
+      message: "This login is no longer open — it expired, or it was already completed. Start it again.",
+    }
+  }
+
+  // Parsed before the session is consumed: a mistyped paste should not force
+  // the user back through Anthropic's sign-in. The session is single-use from
+  // the moment a code is actually sent, which is the exchange below.
+  const parsed = parseAuthorizationCodeInput(params.input)
+  if (!parsed) {
+    return {
+      ok: false,
+      code: "no_code",
+      status: 400,
+      message: "No authorization code found in that paste. Paste the code Claude showed you, or the whole callback URL.",
+      retryable: true,
+    }
+  }
+
+  // Consumed BEFORE the exchange, not after: deleting first is what makes
+  // single-use hold against two completions racing the same login id.
+  pendingLogins.delete(params.loginId)
+
+  const result = await exchangeAuthorizationCodeForCredentials({
+    code: parsed.code,
+    returnedState: parsed.state,
+    sessionState: pending.state,
+    codeVerifier: pending.codeVerifier,
+    claudeConfigDir: pending.claudeConfigDir,
+    fetchFn: params.fetchFn,
+  })
+
+  if (result.ok) return { ok: true, profileId: pending.profileId }
+
+  if (result.reason === "state_mismatch") {
+    // Rejected locally — the code never reached Anthropic, so nothing was
+    // spent and this login is still good. Put it back: pasting the wrong
+    // browser tab should cost a second paste, not a second sign-in.
+    pendingLogins.set(params.loginId, pending)
+    return {
+      ok: false,
+      code: "state_mismatch",
+      status: 400,
+      message: "OAuth state did not match this login. Paste the code from the tab this login opened.",
+      retryable: true,
+    }
+  }
+  if (result.reason === "write_failed") {
+    return {
+      ok: false,
+      code: "write_failed",
+      status: 500,
+      message: `Signed in, but the credentials for "${pending.profileId}" could not be written.`,
+    }
+  }
+  // The token endpoint's own error body is deliberately not forwarded — it is
+  // one-time-credential-adjacent and belongs nowhere near a rendered page.
+  return {
+    ok: false,
+    code: "exchange_failed",
+    status: 502,
+    message: result.status
+      ? `Anthropic rejected the authorization code (HTTP ${result.status}). Codes expire quickly — start the login again.`
+      : "Could not reach Anthropic to exchange the authorization code. Start the login again.",
+  }
+}
+
+export function pendingLoginCount(): number {
+  return pendingLogins.size
+}
+
+/** Drop all pending logins — for testing only. */
+export function resetPendingLogins(): void {
+  pendingLogins.clear()
+}

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -16,16 +16,25 @@
 
 import { existsSync, readFileSync } from "node:fs"
 import { join } from "node:path"
-import { homedir } from "node:os"
-import { setSetting, getSetting } from "./settings"
+import { meridianConfigDir, setSetting, getSetting } from "./settings"
 import { pickStickyProfile, type RoutingMode } from "./routing"
 
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
+/**
+ * Where profiles live on disk. Resolved per call so it tracks
+ * MERIDIAN_CONFIG_DIR — the writer (`profileCli.ts`) resolves the same path
+ * the same way, and a reader and writer that disagree produce a profile that
+ * is written and never seen.
+ */
+function profilesFile(): string {
+  return join(meridianConfigDir(), "profiles.json")
+}
 
 /** Disk profile cache with short TTL so new profiles are picked up quickly */
 const DISK_CACHE_TTL_MS = 5_000
 let diskProfilesCache: ProfileConfig[] = []
 let diskProfilesCacheAt = 0
+/** Path the cache was filled from — a changed override must not serve stale entries. */
+let diskProfilesCachePath = ""
 
 /**
  * Load profiles from ~/.config/meridian/profiles.json.
@@ -33,20 +42,23 @@ let diskProfilesCacheAt = 0
  * while avoiding synchronous disk I/O on every request.
  */
 export function loadProfilesFromDisk(): ProfileConfig[] {
-  if (diskProfilesCacheAt > 0 && Date.now() - diskProfilesCacheAt < DISK_CACHE_TTL_MS) {
+  const file = profilesFile()
+  if (diskProfilesCacheAt > 0 && diskProfilesCachePath === file && Date.now() - diskProfilesCacheAt < DISK_CACHE_TTL_MS) {
     return diskProfilesCache
   }
   try {
-    if (!existsSync(CONFIG_FILE)) {
+    if (!existsSync(file)) {
       diskProfilesCache = []
     } else {
-      diskProfilesCache = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
+      diskProfilesCache = JSON.parse(readFileSync(file, "utf-8"))
     }
     diskProfilesCacheAt = Date.now()
+    diskProfilesCachePath = file
     return diskProfilesCache
   } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
     diskProfilesCacheAt = Date.now()
+    diskProfilesCachePath = file
     diskProfilesCache = []
     return []
   }
@@ -221,8 +233,10 @@ function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
       // Isolate from host ~/.claude. Without this, the SDK's 401-recovery
       // silently reads host creds from disk and swaps a refreshed token in
       // for our env value, masking token failures. Path must not collapse
-      // to ~/.claude — see query.ts re: upstream claude-code#20553.
-      env.CLAUDE_CONFIG_DIR = join(homedir(), ".config", "meridian", "profiles", profile.id)
+      // to ~/.claude — see query.ts re: upstream claude-code#20553. Built
+      // from meridianConfigDir() so it stays the directory profileCli.ts
+      // creates and profileRemove deletes.
+      env.CLAUDE_CONFIG_DIR = join(meridianConfigDir(), "profiles", profile.id)
     }
     return { id: profile.id, type: "oauth-token", env }
   }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -78,6 +78,7 @@ import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
 import { startProfileLogin, completeProfileLogin } from "./profileLogin"
+import { startProfileAdd, completeProfileAdd } from "./profileAdd"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -3937,6 +3938,71 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
     })
     plog(`[PROXY] Profile login completed for "${result.profileId}"`)
+    return c.json({ success: true, profile: result.profileId })
+  })
+
+  // --- Profile creation routes (browser-completable OAuth) ---
+  //
+  // Same two-step shape as the login routes above, deliberately NOT the same
+  // routes: /profiles/login/start refuses unknown ids, and that refusal is what
+  // stops a typo in a re-authentication from creating an account slot. Creating
+  // one is its own act, so it is its own explicit route. Decisions live in
+  // profileAdd.ts.
+
+  app.post("/profiles/add/start", async (c) => {
+    let body: { profile?: string }
+    try {
+      body = await c.req.json() as { profile?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    const result = startProfileAdd({ profiles: finalConfig.profiles, profileId: body.profile ?? "" })
+    if (!result.ok) {
+      claudeLog("profile.add_refused", {
+        profile: body.profile?.slice(0, 64) ?? null,
+        reason: result.code,
+        userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+      })
+      return c.json({ error: result.message, code: result.code }, result.status as 400)
+    }
+    plog(`[PROXY] Profile creation started for "${result.profileId}" (expires in ${Math.round((result.expiresAt - Date.now()) / 1000)}s)`)
+    return c.json({
+      addId: result.addId,
+      authorizeUrl: result.authorizeUrl,
+      expiresAt: result.expiresAt,
+      profile: result.profileId,
+    })
+  })
+
+  app.post("/profiles/add/complete", async (c) => {
+    let body: { addId?: string; code?: string }
+    try {
+      body = await c.req.json() as { addId?: string; code?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    if (!body.addId) {
+      return c.json({ error: "Missing 'addId' in request body", code: "invalid_request" }, 400)
+    }
+    const result = await completeProfileAdd({ addId: body.addId, input: body.code ?? "" })
+    if (!result.ok) {
+      // The paste itself is never logged — it is a one-time credential.
+      claudeLog("profile.add_failed", { reason: result.code })
+      return c.json({
+        error: result.message,
+        code: result.code,
+        ...(result.retryable ? { retryable: true } : {}),
+      }, result.status as 400)
+    }
+    // A profile that did not exist a moment ago has no cached auth answer, but
+    // the list-wide cache does — drop it so the new card renders authenticated
+    // on the UI's next poll rather than after the 60s TTL.
+    expireAuthStatusCache()
+    claudeLog("profile.add_completed", {
+      profile: result.profileId,
+      userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+    })
+    plog(`[PROXY] Profile "${result.profileId}" created from the web UI`)
     return c.json({ success: true, profile: result.profileId })
   })
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -62,7 +62,7 @@ import {
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, expireAuthStatusCache, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
@@ -77,6 +77,7 @@ import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { startProfileLogin, completeProfileLogin } from "./profileLogin"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -3874,6 +3875,69 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     })
     plog(`[PROXY] Active profile switched to: ${body.profile} (from ${previousProfile ?? "unset"}, ua: ${(c.req.header("user-agent") || "unknown").slice(0, 60)}) (session + rate-limit caches cleared)`)
     return c.json({ success: true, activeProfile: body.profile })
+  })
+
+  // --- Profile login routes (browser-completable OAuth) ---
+  //
+  // Two steps because Anthropic's client id registers exactly one redirect URI,
+  // a page Anthropic hosts — nothing can redirect back into Meridian. /start
+  // hands the browser an opaque login id and the authorize URL; the user signs
+  // in and brings the code back to /complete. Decisions live in profileLogin.ts.
+
+  app.post("/profiles/login/start", async (c) => {
+    let body: { profile?: string }
+    try {
+      body = await c.req.json() as { profile?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    const result = startProfileLogin({ profiles: finalConfig.profiles, profileId: body.profile ?? "" })
+    if (!result.ok) {
+      claudeLog("profile.login_refused", {
+        profile: body.profile ?? null,
+        reason: result.code,
+        userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+      })
+      return c.json({ error: result.message, code: result.code }, result.status as 400)
+    }
+    plog(`[PROXY] Profile login started for "${result.profileId}" (expires in ${Math.round((result.expiresAt - Date.now()) / 1000)}s)`)
+    return c.json({
+      loginId: result.loginId,
+      authorizeUrl: result.authorizeUrl,
+      expiresAt: result.expiresAt,
+      profile: result.profileId,
+    })
+  })
+
+  app.post("/profiles/login/complete", async (c) => {
+    let body: { loginId?: string; code?: string }
+    try {
+      body = await c.req.json() as { loginId?: string; code?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    if (!body.loginId) {
+      return c.json({ error: "Missing 'loginId' in request body", code: "invalid_request" }, 400)
+    }
+    const result = await completeProfileLogin({ loginId: body.loginId, input: body.code ?? "" })
+    if (!result.ok) {
+      // The paste itself is never logged — it is a one-time credential.
+      claudeLog("profile.login_failed", { reason: result.code })
+      return c.json({
+        error: result.message,
+        code: result.code,
+        ...(result.retryable ? { retryable: true } : {}),
+      }, result.status as 400)
+    }
+    // The auth-status cache holds a 60s "not logged in" answer for this profile;
+    // drop it so /profiles/list reflects the login on the UI's next poll.
+    expireAuthStatusCache()
+    claudeLog("profile.login_completed", {
+      profile: result.profileId,
+      userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+    })
+    plog(`[PROXY] Profile login completed for "${result.profileId}"`)
+    return c.json({ success: true, profile: result.profileId })
   })
 
   // --- Plugin management routes ---

--- a/src/proxy/settings.ts
+++ b/src/proxy/settings.ts
@@ -13,22 +13,28 @@ import { join, dirname } from "node:path"
 import { homedir } from "node:os"
 
 /**
- * Resolve the settings file path.
+ * Resolve Meridian's own config directory — the one holding `settings.json`,
+ * `profiles.json`, and the per-profile `CLAUDE_CONFIG_DIR`s under `profiles/`.
  *
  * Resolved per call rather than frozen at import time so tests can redirect
  * it via MERIDIAN_CONFIG_DIR (see `src/__tests__/preload.ts`). Without the
  * override the path is exactly what it has always been, so existing installs
  * are unaffected.
  *
+ * Shared by settings.ts, profiles.ts and profileCli.ts so the override moves
+ * all of Meridian's state together. A reader and a writer disagreeing about
+ * where profiles.json lives is a profile that gets written and never seen.
+ *
  * NOTE: deliberately does NOT honour XDG_CONFIG_HOME — anyone who has that
  * set would silently relocate to a different settings file and appear to
  * lose their configuration.
  */
+export function meridianConfigDir(): string {
+  return process.env.MERIDIAN_CONFIG_DIR ?? join(homedir(), ".config", "meridian")
+}
+
 function settingsFile(): string {
-  const override = process.env.MERIDIAN_CONFIG_DIR
-  return override
-    ? join(override, "settings.json")
-    : join(homedir(), ".config", "meridian", "settings.json")
+  return join(meridianConfigDir(), "settings.json")
 }
 
 export interface MeridianSettings {

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -76,6 +76,34 @@ export const profilePageHtml = `<!DOCTYPE html>
   }
   .guide .warn strong { color: var(--yellow); }
 
+  /* Browser login — the paste box that replaces a terminal round trip. */
+  .login-btn {
+    padding: 6px 12px; font-size: 12px; font-weight: 500;
+    background: var(--surface2); color: var(--accent); border: 1px solid var(--accent);
+    border-radius: 6px; cursor: pointer; transition: all 0.15s;
+  }
+  .login-btn:hover { background: rgba(88,166,255,0.12); }
+  .login-btn:disabled { opacity: 0.4; cursor: default; }
+  .login-panel {
+    margin-top: 12px; padding: 14px 16px; background: var(--surface2);
+    border: 1px solid var(--border); border-radius: 8px;
+  }
+  .login-panel-title { font-size: 12px; font-weight: 600; margin-bottom: 8px; }
+  .login-steps { font-size: 12px; color: var(--muted); padding-left: 18px; margin-bottom: 10px; }
+  .login-steps li { margin-bottom: 4px; }
+  .login-row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .login-input {
+    flex: 1 1 260px; min-width: 0; padding: 7px 10px; border-radius: 6px;
+    background: var(--bg); border: 1px solid var(--border); color: var(--text);
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px;
+  }
+  .login-input:focus { outline: none; border-color: var(--accent); }
+  .login-msg { margin-top: 10px; font-size: 12px; }
+  .login-msg.err { color: var(--red); }
+  .login-msg.busy { color: var(--muted); }
+  .login-reopen { color: var(--accent); font-size: 11px; text-decoration: none; }
+  .login-reopen:hover { text-decoration: underline; }
+
   .mono { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; }
   .copy-cmd {
     font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px;
@@ -173,10 +201,20 @@ export const profilePageHtml = `<!DOCTYPE html>
       <li><strong>Per-request:</strong> Send <code>x-meridian-profile: &lt;name&gt;</code> header</li>
     </ol>
 
+    <h3 style="margin-top:16px">Re-authenticating a profile</h3>
+    <ol>
+      <li><strong>UI:</strong> Click <strong>Log in from browser</strong> on the profile card, sign in,
+          then paste the code Claude shows you \u2014 the whole callback URL works too</li>
+      <li><strong>CLI:</strong> <code>meridian profile login &lt;name&gt;</code></li>
+    </ol>
+    <p style="font-size:12px;color:var(--muted);margin-top:8px">
+      Claude sends you to a page it hosts rather than back to Meridian, so the code has to
+      make one hop by hand \u2014 Anthropic registers a single redirect URI for this client.
+    </p>
+
     <h3 style="margin-top:16px">Other commands</h3>
     <div style="font-size:13px;margin-top:8px">
       <code>meridian profile list</code> \u2014 show all profiles and auth status<br>
-      <code>meridian profile login &lt;name&gt;</code> \u2014 re-authenticate an expired profile<br>
       <code>meridian profile remove &lt;name&gt;</code> \u2014 remove a profile
     </div>
   </div>
@@ -390,7 +428,14 @@ function render(data, quotaData) {
     html += '<button class="copy-btn" data-cmd="meridian profile login ' + esc(p.id) + '" onclick="copyCmd(this)" title="Copy to clipboard">';
     html += '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25zM5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25z"/></svg>';
     html += '</button>';
+    // Only claude-max profiles have an OAuth flow; api and oauth-token profiles
+    // would only ever get a refusal, so they get no button.
+    if ((p.type || 'claude-max') === 'claude-max') {
+      html += '<button class="login-btn" onclick="startLogin(&quot;'+esc(p.id)+'&quot;)">Log in from browser</button>';
+    }
     html += '</div>';
+
+    html += '<div class="login-slot" id="login-slot-' + esc(p.id) + '"></div>';
 
     html += renderUsageSection(quotaById[p.id]);
 
@@ -438,8 +483,140 @@ async function switchProfile(id) {
   if (data.success) refresh();
 }
 
+// --- Browser login ---
+//
+// The open login is held here rather than in the DOM because render() rebuilds
+// #content wholesale on every poll — a panel written into a card would be
+// destroyed mid-typing. While a login is open the poll is paused, so the panel
+// and whatever is half-pasted into it survive.
+var activeLogin = null;
+
+function loginSlot(id) { return document.getElementById('login-slot-' + id); }
+
+function setLoginMsg(text, kind) {
+  var slot = activeLogin ? loginSlot(activeLogin.profile) : null;
+  if (!slot) return;
+  var msg = slot.querySelector('.login-msg');
+  if (!msg) return;
+  msg.className = 'login-msg' + (kind ? ' ' + kind : '');
+  msg.textContent = text || '';
+}
+
+async function startLogin(id) {
+  if (activeLogin) cancelLogin();
+  var slot = loginSlot(id);
+  if (!slot) return;
+  slot.innerHTML = '<div class="login-panel"><div class="login-msg busy">Starting…</div></div>';
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/login/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: id })
+    });
+    data = await res.json();
+  } catch (err) {
+    slot.innerHTML = '<div class="login-panel"><div class="login-msg err">Could not reach Meridian.</div></div>';
+    return;
+  }
+
+  if (!res.ok) {
+    slot.innerHTML = '<div class="login-panel"><div class="login-msg err">' + esc(data.error || 'Login unavailable.') + '</div></div>';
+    return;
+  }
+
+  activeLogin = { profile: id, loginId: data.loginId };
+  slot.innerHTML = renderLoginPanel(id, data.authorizeUrl);
+  var input = slot.querySelector('.login-input');
+  if (input) {
+    input.addEventListener('keydown', function (e) { if (e.key === 'Enter') submitLogin(); });
+    input.focus();
+  }
+  window.open(data.authorizeUrl, '_blank', 'noopener');
+}
+
+function renderLoginPanel(id, authorizeUrl) {
+  return '<div class="login-panel">'
+    + '<div class="login-panel-title">Sign in as ' + esc(id) + '</div>'
+    + '<ol class="login-steps">'
+    +   '<li>A Claude sign-in tab just opened — '
+    +     '<a class="login-reopen" href="' + esc(authorizeUrl) + '" target="_blank" rel="noopener">open it again</a>'
+    +     ' if it was blocked.</li>'
+    +   '<li>Make sure you are signed into the right Claude account for this profile.</li>'
+    +   '<li>Paste the code Claude shows you below — or the whole callback URL from the address bar.</li>'
+    + '</ol>'
+    + '<div class="login-row">'
+    +   '<input class="login-input" type="text" autocomplete="off" spellcheck="false" placeholder="code, or https://platform.claude.com/oauth/code/callback?code=…">'
+    +   '<button class="login-btn login-submit" onclick="submitLogin()">Complete login</button>'
+    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="cancelLogin()">Cancel</button>'
+    + '</div>'
+    + '<div class="login-msg"></div>'
+    + '</div>';
+}
+
+async function submitLogin() {
+  if (!activeLogin || activeLogin.spent) return;
+  var slot = loginSlot(activeLogin.profile);
+  var input = slot ? slot.querySelector('.login-input') : null;
+  var value = input ? input.value.trim() : '';
+  if (!value) { setLoginMsg('Paste the code first.', 'err'); return; }
+
+  var buttons = slot ? slot.querySelectorAll('button') : [];
+  for (var i = 0; i < buttons.length; i++) buttons[i].disabled = true;
+  setLoginMsg('Exchanging…', 'busy');
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/login/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ loginId: activeLogin.loginId, code: value })
+    });
+    data = await res.json();
+  } catch (err) {
+    setLoginMsg('Could not reach Meridian.', 'err');
+    for (var j = 0; j < buttons.length; j++) buttons[j].disabled = false;
+    return;
+  }
+
+  if (!res.ok) {
+    setLoginMsg(data.error || 'Login failed.', 'err');
+    var cancelBtn = slot ? slot.querySelector('.login-cancel') : null;
+    if (cancelBtn) cancelBtn.disabled = false;
+    // The server says whether the login survived: it does when the paste was
+    // rejected before any code reached Anthropic. Otherwise the code is spent
+    // and this panel cannot retry it.
+    if (data.retryable) {
+      var submitBtn = slot ? slot.querySelector('.login-submit') : null;
+      if (submitBtn) submitBtn.disabled = false;
+      if (input) input.focus();
+    } else {
+      // Keep the panel — and with it the paused poll — so the reason stays
+      // readable. render() rebuilds #content wholesale, so resuming here would
+      // erase the very message telling the user their code was spent. Cancel
+      // is the way out.
+      activeLogin.spent = true;
+    }
+    return;
+  }
+
+  activeLogin = null;
+  if (window.meridianHeaderRefresh) window.meridianHeaderRefresh();
+  refresh();
+}
+
+function cancelLogin() {
+  var previous = activeLogin;
+  activeLogin = null;
+  if (previous) {
+    var slot = loginSlot(previous.profile);
+    if (slot) slot.innerHTML = '';
+  }
+}
+
 refresh();
-setInterval(refresh, 10000);
+setInterval(function () { if (!activeLogin) refresh(); }, 10000);
 ` + profileBarJs + `
 </script>
 </body>

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -103,6 +103,8 @@ export const profilePageHtml = `<!DOCTYPE html>
   .login-msg.busy { color: var(--muted); }
   .login-reopen { color: var(--accent); font-size: 11px; text-decoration: none; }
   .login-reopen:hover { text-decoration: underline; }
+  .add-intro { font-size: 13px; color: var(--muted); margin-bottom: 10px; }
+  .add-note { font-size: 11px; color: var(--muted); margin-top: 8px; }
 
   .mono { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; }
   .copy-cmd {
@@ -170,6 +172,13 @@ export const profilePageHtml = `<!DOCTYPE html>
 
 <div id="content"><div style="color:var(--muted);padding:40px;text-align:center">Loading\u2026</div></div>
 
+<!-- Outside #content on purpose: render() rebuilds that element wholesale on
+     every poll, which would destroy a half-typed name or a pasted code. -->
+<div class="section">
+  <div class="section-title">Add a profile</div>
+  <div class="profile-card"><div id="add-slot"></div></div>
+</div>
+
 <div class="section" style="margin-top:32px">
   <div class="section-title">Setup Guide</div>
   <div class="guide">
@@ -181,17 +190,22 @@ export const profilePageHtml = `<!DOCTYPE html>
 
     <h3 style="margin-top:16px">Adding a new profile</h3>
     <ol>
-      <li>Open a terminal and run: <code>meridian profile add &lt;name&gt;</code></li>
-      <li>This opens your browser for Claude login</li>
-      <li>Done \u2014 the profile is ready to use</li>
+      <li><strong>UI:</strong> Name it under <strong>Add a profile</strong> above, sign in, then paste
+          the code Claude shows you \u2014 the whole callback URL works too</li>
+      <li><strong>CLI:</strong> <code>meridian profile add &lt;name&gt;</code></li>
     </ol>
+    <p style="font-size:12px;color:var(--muted);margin-top:8px">
+      Either way the profile gets its own config directory and is ready to use immediately.
+      Only the CLI offers to adopt existing <code>~/.claude</code> credentials as a profile;
+      the UI always signs in fresh, so clicking Add can never quietly claim the account
+      you are already logged in as on this machine.
+    </p>
 
     <div class="warn">
-      <strong>\u26a0 Important for adding a second account:</strong> Before running
-      <code>meridian profile add</code> for a different account, sign out of claude.ai
-      in your browser first, then sign in with the other account. Claude\u2019s OAuth
-      reuses your browser session \u2014 if you\u2019re already signed in, the login will
-      silently use the same account.
+      <strong>\u26a0 Important for adding a second account:</strong> Before adding a different
+      account, sign out of claude.ai in your browser first, then sign in with the other
+      account. Claude\u2019s OAuth reuses your browser session \u2014 if you\u2019re already signed
+      in, the login will silently use the same account.
     </div>
 
     <h3 style="margin-top:16px">Switching profiles</h3>
@@ -376,7 +390,7 @@ function render(data, quotaData) {
   if (profiles.length === 0) {
     document.getElementById('content').innerHTML = '<div class="empty-state">'
       + '<h2>No profiles configured</h2>'
-      + '<p style="margin-top:8px">Add your first profile from the terminal:</p>'
+      + '<p style="margin-top:8px">Add your first one below, or from a terminal:</p>'
       + '<p style="margin-top:8px"><code class="mono" style="background:var(--bg);padding:8px 16px;border-radius:6px;display:inline-block">meridian profile add personal</code></p>'
       + '</div>';
     return;
@@ -493,13 +507,16 @@ var activeLogin = null;
 
 function loginSlot(id) { return document.getElementById('login-slot-' + id); }
 
-function setLoginMsg(text, kind) {
-  var slot = activeLogin ? loginSlot(activeLogin.profile) : null;
+function setPanelMsg(slot, text, kind) {
   if (!slot) return;
   var msg = slot.querySelector('.login-msg');
   if (!msg) return;
   msg.className = 'login-msg' + (kind ? ' ' + kind : '');
   msg.textContent = text || '';
+}
+
+function setLoginMsg(text, kind) {
+  setPanelMsg(activeLogin ? loginSlot(activeLogin.profile) : null, text, kind);
 }
 
 async function startLogin(id) {
@@ -536,23 +553,37 @@ async function startLogin(id) {
   window.open(data.authorizeUrl, '_blank', 'noopener');
 }
 
-function renderLoginPanel(id, authorizeUrl) {
+// One panel for both flows. Signing a profile in and creating one differ in
+// their wording and their handlers, not in their shape — two copies of this
+// markup would drift the moment either is touched.
+function renderOauthPanel(o) {
   return '<div class="login-panel">'
-    + '<div class="login-panel-title">Sign in as ' + esc(id) + '</div>'
+    + '<div class="login-panel-title">' + o.title + '</div>'
     + '<ol class="login-steps">'
     +   '<li>A Claude sign-in tab just opened — '
-    +     '<a class="login-reopen" href="' + esc(authorizeUrl) + '" target="_blank" rel="noopener">open it again</a>'
+    +     '<a class="login-reopen" href="' + esc(o.authorizeUrl) + '" target="_blank" rel="noopener">open it again</a>'
     +     ' if it was blocked.</li>'
-    +   '<li>Make sure you are signed into the right Claude account for this profile.</li>'
+    +   '<li>' + o.accountStep + '</li>'
     +   '<li>Paste the code Claude shows you below — or the whole callback URL from the address bar.</li>'
     + '</ol>'
     + '<div class="login-row">'
     +   '<input class="login-input" type="text" autocomplete="off" spellcheck="false" placeholder="code, or https://platform.claude.com/oauth/code/callback?code=…">'
-    +   '<button class="login-btn login-submit" onclick="submitLogin()">Complete login</button>'
-    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="cancelLogin()">Cancel</button>'
+    +   '<button class="login-btn login-submit" onclick="' + o.onSubmit + '">' + o.submitLabel + '</button>'
+    +   '<button class="switch-btn current login-cancel" style="margin-top:0" onclick="' + o.onCancel + '">Cancel</button>'
     + '</div>'
     + '<div class="login-msg"></div>'
     + '</div>';
+}
+
+function renderLoginPanel(id, authorizeUrl) {
+  return renderOauthPanel({
+    title: 'Sign in as ' + esc(id),
+    authorizeUrl: authorizeUrl,
+    accountStep: 'Make sure you are signed into the right Claude account for this profile.',
+    submitLabel: 'Complete login',
+    onSubmit: 'submitLogin()',
+    onCancel: 'cancelLogin()',
+  });
 }
 
 async function submitLogin() {
@@ -615,7 +646,140 @@ function cancelLogin() {
   }
 }
 
+// --- Add a profile ---
+//
+// The same two steps against its own routes. Creating an account is a
+// different act from re-authenticating one, and /profiles/login/start refuses
+// an unknown name precisely so a typo there cannot create one.
+//
+// #add-slot sits outside #content, so this panel survives the poll on its own
+// and — unlike the login panels — does not have to pause it.
+var activeAdd = null;
+
+function addSlot() { return document.getElementById('add-slot'); }
+
+function renderAddForm(prefill) {
+  return '<div class="add-intro">Sign in to another Claude account and keep it here alongside the others.</div>'
+    + '<div class="login-row">'
+    +   '<input class="login-input add-input" type="text" autocomplete="off" spellcheck="false"'
+    +     ' placeholder="new profile name" value="' + esc(prefill || '') + '">'
+    +   '<button class="login-btn" onclick="startAdd()">Add profile</button>'
+    + '</div>'
+    + '<div class="add-note">Letters, numbers, hyphens and underscores.</div>'
+    + '<div class="login-msg"></div>';
+}
+
+function resetAddForm(prefill) {
+  activeAdd = null;
+  var slot = addSlot();
+  if (!slot) return;
+  slot.innerHTML = renderAddForm(prefill);
+  var input = slot.querySelector('.add-input');
+  if (input) input.addEventListener('keydown', function (e) { if (e.key === 'Enter') startAdd(); });
+}
+
+function renderAddPanel(id, authorizeUrl) {
+  return renderOauthPanel({
+    title: 'Create ' + esc(id),
+    authorizeUrl: authorizeUrl,
+    accountStep: 'Sign in with the Claude account this profile should use \u2014 if a different account is already '
+      + 'signed in at claude.ai, sign out there first, or Claude will reuse it without asking.',
+    submitLabel: 'Create profile',
+    onSubmit: 'submitAdd()',
+    onCancel: 'cancelAdd()',
+  });
+}
+
+async function startAdd() {
+  var slot = addSlot();
+  if (!slot) return;
+  var nameInput = slot.querySelector('.add-input');
+  var name = nameInput ? nameInput.value.trim() : '';
+  if (!name) { setPanelMsg(slot, 'Name the profile first.', 'err'); return; }
+
+  setPanelMsg(slot, 'Starting\u2026', 'busy');
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/add/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ profile: name })
+    });
+    data = await res.json();
+  } catch (err) {
+    setPanelMsg(slot, 'Could not reach Meridian.', 'err');
+    return;
+  }
+
+  // The form is left standing on a refusal, name and all: every refusal here
+  // is about the name, and retyping it to fix a typo is the wrong ask.
+  if (!res.ok) { setPanelMsg(slot, data.error || 'Could not start.', 'err'); return; }
+
+  activeAdd = { profile: name, addId: data.addId };
+  slot.innerHTML = renderAddPanel(name, data.authorizeUrl);
+  var codeInput = slot.querySelector('.login-input');
+  if (codeInput) {
+    codeInput.addEventListener('keydown', function (e) { if (e.key === 'Enter') submitAdd(); });
+    codeInput.focus();
+  }
+  window.open(data.authorizeUrl, '_blank', 'noopener');
+}
+
+async function submitAdd() {
+  if (!activeAdd || activeAdd.spent) return;
+  var slot = addSlot();
+  var input = slot ? slot.querySelector('.login-input') : null;
+  var value = input ? input.value.trim() : '';
+  if (!value) { setPanelMsg(slot, 'Paste the code first.', 'err'); return; }
+
+  var buttons = slot ? slot.querySelectorAll('button') : [];
+  for (var i = 0; i < buttons.length; i++) buttons[i].disabled = true;
+  setPanelMsg(slot, 'Creating\u2026', 'busy');
+
+  var res, data;
+  try {
+    res = await fetch('/profiles/add/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ addId: activeAdd.addId, code: value })
+    });
+    data = await res.json();
+  } catch (err) {
+    setPanelMsg(slot, 'Could not reach Meridian.', 'err');
+    for (var j = 0; j < buttons.length; j++) buttons[j].disabled = false;
+    return;
+  }
+
+  if (!res.ok) {
+    setPanelMsg(slot, data.error || 'Could not create the profile.', 'err');
+    var cancelBtn = slot ? slot.querySelector('.login-cancel') : null;
+    if (cancelBtn) cancelBtn.disabled = false;
+    if (data.retryable) {
+      var submitBtn = slot ? slot.querySelector('.login-submit') : null;
+      if (submitBtn) submitBtn.disabled = false;
+      if (input) input.focus();
+    } else {
+      // The code is spent. Keep the panel so the reason stays readable —
+      // Cancel is the way back to the form.
+      activeAdd.spent = true;
+    }
+    return;
+  }
+
+  resetAddForm('');
+  if (window.meridianHeaderRefresh) window.meridianHeaderRefresh();
+  refresh();
+}
+
+function cancelAdd() {
+  // Keeps the name. Abandoning a sign-in almost always means the wrong Claude
+  // account was signed in, not that the name was wrong.
+  resetAddForm(activeAdd ? activeAdd.profile : '');
+}
+
 refresh();
+resetAddForm('');
 setInterval(function () { if (!activeLogin) refresh(); }, 10000);
 ` + profileBarJs + `
 </script>


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

**Stacked on #792.** This branch is cut from `feat/profile-login-from-web-ui`, not
from `main`, because it reuses the PKCE login machinery that PR introduces. GitHub
cannot express that across a fork, so the diff below carries **two** commits — take
`be4c279` as the change under review here and #792 as its prerequisite.

Adding an account currently needs a shell on the machine Meridian runs on. This
finishes what #792 started: the Profiles page grows an "Add a profile" box — name
it, sign in to Claude in the tab that opens, paste back what Claude shows (the bare
code or the whole callback URL). The profile appears with its own config directory,
ready to use with no restart.

## It is its own route, not a loosened guard

`/profiles/login/start` refuses unknown ids **deliberately**, and that refusal is
what stops "re-authenticate `enrique-corp`" from silently creating `enrique-crop`
on a typo. Creating an account slot is a different act from re-authenticating one,
so it gets its own button, its own routes and its own refusals.

## One definition of what a profile is made of

`profileAdd` welded id validation, a collision check, `mkdir` and the
`profiles.json` entry into the middle of an interactive CLI flow. The creation half
is now `createProfileSlot`, called by the CLI at each of its three success paths and
by the new route. `isValidProfileId` is lifted out of a regex that had been written
inline twice — the id becomes a directory name, so having one answer to "what is a
legal id" is the whole point.

## Nothing is written until the credentials are in hand

The exchange with Anthropic happens first; the `profiles.json` entry only once it
succeeds. A sign-in that is abandoned, rejected or never finished leaves **no
profile behind at all** — no half-made slot stuck at "not logged in" for someone to
find and clean up. The residue of a failure is at most an empty directory the next
attempt reuses.

Every refusal happens at `/start`, before a sign-in tab opens: an illegal name, a
name that already exists (pointing at "Log in from browser", which is what that
button is for), and `MERIDIAN_CREDENTIALS_READONLY`. Refusing *after* sign-in would
burn a one-time code for nothing.

## Superseding, not refusing, a second sign-in for the same name

Refusing was the first implementation, and driving it in a browser proved it wrong:
cancelling the panel, reloading the page and closing the tab all abandon a sign-in
without telling the server, so the name was locked out for the full ten minutes by a
message telling the user to cancel something they had no way to cancel. One entry per
name still holds — that is what stops two sign-ins for one new name from both
completing; superseding only decides which survives.

## What actually guards this, stated rather than implied

Both routes sit under `/profiles/*` and inherit `requireAuth`, so they are behind
`MERIDIAN_API_KEY` when one is set. **When it is not — the default — the only thing
between the page and a new profile is whatever can reach the port.** Measured on the
author's box: `GET /profiles` answers `200` with no auth header, on loopback and
through a reverse proxy alike. Adding a profile is the most privileged thing that
page does, so it is kept to exactly that: no delete, no rename, no edit. The docs say
this rather than implying the routes are protected on their own.

Nothing from the code or the token response is logged; the refusal log records a
reason code and nothing else. `loadProfileIds` returns ids rather than profiles so a
collision check can never reach an `apiKey`.

## The `~/.claude` import stays CLI-only

`meridian profile add` on a host whose default config dir is already signed in offers
to adopt those credentials. The UI always signs in fresh: silently claiming whichever
account you happen to be logged in as on that machine is not something a button press
should be able to do. The docs say so.

## Tests

43 across two new files — id validation including traversal-shaped names, collisions
against both the effective profile list and `profiles.json`, readonly refusal,
supersede, expiry, single use, both paste forms, API-key enforcement on both routes,
and the slot **not** being written when the exchange fails. Also driven in a real
browser against two throwaway instances, one with `MERIDIAN_CREDENTIALS_READONLY`,
which is where the lockout above was found.

`bun run test` green and `bun run typecheck` clean on the branch.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
