### PR TITLE
fix(profiles): persist the account plan at headless OAuth login

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,6 +31,10 @@ Open the printed URL in a browser, sign in to the target Claude account, then pa
 meridian profile login work --headless
 ```
 
+The same login also records the account's plan (`subscriptionType`, `rateLimitTier`), read from Anthropic's OAuth profile endpoint — the token exchange itself returns no plan information. That is what lets `meridian profile list`, `/profiles/list`, `/health` and the dashboard tell a Max account from a Team one, and what makes `/v1/models` advertise the larger context window Max accounts actually have. If the lookup fails the login still succeeds and the plan simply stays unknown.
+
+> **⚠ A profile created by an older Meridian has no plan recorded, and a token refresh cannot backfill it** — the value is only ever written at login, and Anthropic's usage endpoint does not carry it. Re-run `meridian profile login <name> --headless` to repair such a profile.
+
 #### Headless / CI: register an OAuth token
 
 When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:

--- a/src/__tests__/profile-login-plan-fields.test.ts
+++ b/src/__tests__/profile-login-plan-fields.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for the plan fields a headless OAuth login persists.
+ *
+ * Anthropic's token endpoint returns no plan information, so the headless login
+ * reads it from `/api/oauth/profile` and writes `subscriptionType` /
+ * `rateLimitTier` alongside the tokens. Network is swapped via
+ * `globalThis.fetch`; the credential-building step is pure and asserted directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import {
+  buildLoginCredentials,
+  extractPlanFields,
+  fetchOAuthPlanFields,
+  subscriptionTypeFromOrganizationType,
+} from "../proxy/profileCli"
+import type { CredentialStore } from "../proxy/tokenRefresh"
+
+/** Assign a mock to globalThis.fetch without TS complaining about `preconnect`. */
+function mockFetch(fn: (...args: unknown[]) => Promise<Response | never>): void {
+  globalThis.fetch = fn as typeof fetch
+}
+
+function makeSuccessResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const TOKEN_DATA = {
+  access_token: "the-access-token",
+  refresh_token: "the-refresh-token",
+  expires_in: 3600,
+  scope: "user:profile user:inference",
+}
+
+const MAX_PROFILE = {
+  organization: {
+    organization_type: "claude_max",
+    rate_limit_tier: "default_claude_max_20x",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// organization_type → subscriptionType
+// ---------------------------------------------------------------------------
+
+describe("subscriptionTypeFromOrganizationType", () => {
+  it("strips the claude_ prefix the CLI also strips", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_max")).toBe("max")
+    expect(subscriptionTypeFromOrganizationType("claude_pro")).toBe("pro")
+    expect(subscriptionTypeFromOrganizationType("claude_team")).toBe("team")
+    expect(subscriptionTypeFromOrganizationType("claude_enterprise")).toBe("enterprise")
+  })
+
+  it("returns undefined rather than guessing at an unknown plan", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_something_new")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("max")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(null)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(undefined)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("")).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Profile body → plan fields (snake_case on the wire, camelCase on disk)
+// ---------------------------------------------------------------------------
+
+describe("extractPlanFields", () => {
+  it("translates the snake_case wire names to the camelCase on-disk names", () => {
+    expect(extractPlanFields(MAX_PROFILE)).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("distinguishes a team account from a max one", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_team" } }))
+      .toEqual({ subscriptionType: "team" })
+  })
+
+  it("keeps the tier when only the plan is unrecognized", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_future", rate_limit_tier: "some_tier" } }))
+      .toEqual({ rateLimitTier: "some_tier" })
+  })
+
+  it("returns an empty object for an absent or empty organization", () => {
+    expect(extractPlanFields(null)).toEqual({})
+    expect(extractPlanFields(undefined)).toEqual({})
+    expect(extractPlanFields({})).toEqual({})
+    expect(extractPlanFields({ organization: null })).toEqual({})
+    expect(extractPlanFields({ organization: {} })).toEqual({})
+  })
+
+  it("omits keys rather than setting them to undefined", () => {
+    const fields = extractPlanFields({ organization: { organization_type: null, rate_limit_tier: null } })
+    expect(Object.keys(fields)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The profile fetch — best-effort, never fatal
+// ---------------------------------------------------------------------------
+
+describe("fetchOAuthPlanFields", () => {
+  let originalFetch: typeof globalThis.fetch
+  let originalWarn: typeof console.warn
+  let warnings: unknown[][]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    originalWarn = console.warn
+    warnings = []
+    console.warn = (...args: unknown[]) => { warnings.push(args) }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    console.warn = originalWarn
+  })
+
+  it("returns the plan for a healthy response", async () => {
+    mockFetch(async () => makeSuccessResponse(MAX_PROFILE))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("presents the access token as a bearer credential to the profile endpoint", async () => {
+    let seenUrl: unknown
+    let seenInit: RequestInit | undefined
+    mockFetch(async (url: unknown, init: unknown) => {
+      seenUrl = url
+      seenInit = init as RequestInit
+      return makeSuccessResponse(MAX_PROFILE)
+    })
+
+    await fetchOAuthPlanFields("the-access-token")
+
+    expect(seenUrl).toBe("https://api.anthropic.com/api/oauth/profile")
+    const headers = seenInit?.headers as Record<string, string>
+    expect(headers.Authorization).toBe("Bearer the-access-token")
+  })
+
+  it("returns an empty object on a non-ok response", async () => {
+    mockFetch(async () => new Response("Unauthorized", { status: 401 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the request throws", async () => {
+    mockFetch(async () => { throw new Error("network down") })
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the body is not JSON", async () => {
+    mockFetch(async () => new Response("not-json", { status: 200 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// What actually lands on disk — the regression this change closes
+// ---------------------------------------------------------------------------
+
+describe("buildLoginCredentials", () => {
+  it("persists the plan alongside the tokens when it is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("max")
+    expect(creds.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("omits the keys entirely when the plan is unknown", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {})
+
+    // `subscriptionType: undefined` would write a null-ish key into a file the
+    // real CLI also parses — absence must mean absent, not present-and-empty.
+    expect("subscriptionType" in creds.claudeAiOauth).toBe(false)
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+    expect(JSON.stringify(creds)).not.toContain("subscriptionType")
+  })
+
+  it("writes only the field that is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, { subscriptionType: "team" })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("team")
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+  })
+
+  it("still carries the tokens, scopes and expiry", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {}, 1_000_000)
+
+    expect(creds.claudeAiOauth.accessToken).toBe("the-access-token")
+    expect(creds.claudeAiOauth.refreshToken).toBe("the-refresh-token")
+    expect(creds.claudeAiOauth.expiresAt).toBe(1_000_000 + 3600 * 1000)
+    expect(creds.claudeAiOauth.scopes).toEqual(["user:profile", "user:inference"])
+  })
+
+  it("prefers an absolute expires_at over expires_in", () => {
+    const creds = buildLoginCredentials({ ...TOKEN_DATA, expires_at: 42 }, {}, 1_000_000)
+    expect(creds.claudeAiOauth.expiresAt).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Once written, the value must survive every subsequent refresh.
+//
+// doRefresh rebuilds claudeAiOauth with a spread, so anything already on disk
+// is carried forward. Turning that spread into an explicit field list would
+// silently re-open the same hole one refresh cycle after each login.
+// ---------------------------------------------------------------------------
+
+describe("a refresh preserves an already-persisted plan", () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  it("keeps subscriptionType and rateLimitTier across a token refresh", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({
+      access_token: "rotated-access-token",
+      refresh_token: "rotated-refresh-token",
+      expires_in: 3600,
+    }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(stored.claudeAiOauth.accessToken).toBe("rotated-access-token")
+    expect(stored.claudeAiOauth.subscriptionType).toBe("max")
+    expect(stored.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("does not invent a plan for a credential written before this change", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {})
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({ access_token: "rotated", expires_in: 3600 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    // A refresh cannot repair an already-blind profile: only a re-login can.
+    expect("subscriptionType" in stored.claudeAiOauth).toBe(false)
+  })
+})

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -17,7 +17,7 @@ import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
-import { createPlatformCredentialStore } from "./tokenRefresh"
+import { createPlatformCredentialStore, type CredentialsFile } from "./tokenRefresh"
 
 const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
@@ -25,6 +25,18 @@ const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+/**
+ * Where the account's plan comes from — not the token endpoint.
+ *
+ * Everything Claude Code reads off a token response is `access_token`,
+ * `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and
+ * `organization.uuid`. It derives `subscriptionType` / `rateLimitTier` from a
+ * separate authenticated GET here, then writes them into the same
+ * `.credentials.json` Meridian shares with it — so a headless login has to ask
+ * for them too. Note the host differs from OAUTH_TOKEN_URL; reached with the
+ * `user:profile` scope, already in OAUTH_SCOPES.
+ */
+const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -156,6 +168,115 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
+interface OAuthProfileResponse {
+  organization?: {
+    organization_type?: string | null
+    rate_limit_tier?: string | null
+  } | null
+}
+
+export interface OAuthPlanFields {
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+type CompleteOAuthTokenResponse = OAuthTokenResponse & { refresh_token: string }
+
+function hasRequiredTokens(tokenData: OAuthTokenResponse): tokenData is CompleteOAuthTokenResponse {
+  return Boolean(tokenData.access_token && tokenData.refresh_token)
+}
+
+/**
+ * Translate Anthropic's wire `organization_type` into the vocabulary the Claude
+ * CLI writes on disk — the wire value is prefixed (`claude_max`), the stored one
+ * is not (`max`). Mirroring the CLI's own mapping is what keeps a credential
+ * file Meridian writes indistinguishable from one `claude login` wrote, which
+ * matters because `claude auth status` reads it back and is what ultimately
+ * feeds `/profiles/list`, `/health` and the `max`-only branch of `/v1/models`.
+ *
+ * An unrecognized or absent type yields undefined so the caller omits the key,
+ * rather than inventing a plan for an account it could not identify.
+ */
+export function subscriptionTypeFromOrganizationType(
+  organizationType: string | null | undefined,
+): string | undefined {
+  switch (organizationType) {
+    case "claude_max": return "max"
+    case "claude_pro": return "pro"
+    case "claude_team": return "team"
+    case "claude_enterprise": return "enterprise"
+    default: return undefined
+  }
+}
+
+export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
+  const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
+  const rateLimitTier = profile?.organization?.rate_limit_tier
+  return {
+    ...(subscriptionType ? { subscriptionType } : {}),
+    ...(rateLimitTier ? { rateLimitTier } : {}),
+  }
+}
+
+/**
+ * Best-effort plan lookup for a freshly minted access token. Never throws and
+ * never fails the login: a profile whose plan is unknown is strictly better
+ * than no profile at all, and every consumer already treats it as optional.
+ */
+export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPlanFields> {
+  let response: Response
+  try {
+    response = await fetch(OAUTH_PROFILE_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch (err) {
+    console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+
+  if (!response.ok) {
+    console.warn(`[meridian] Could not read the account plan (${response.status}).`)
+    return {}
+  }
+
+  try {
+    return extractPlanFields(await response.json() as OAuthProfileResponse)
+  } catch (err) {
+    console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+}
+
+/**
+ * Build the record a login writes to disk.
+ *
+ * Split out so the on-disk shape is directly assertable: the defect this closes
+ * was a field missing from this object literal, which no test of the
+ * surrounding prompt/fetch I/O would have caught. Plan fields spread in only
+ * when known — `subscriptionType: undefined` would write a null-ish key into a
+ * file the real CLI also parses.
+ */
+export function buildLoginCredentials(
+  tokenData: CompleteOAuthTokenResponse,
+  plan: OAuthPlanFields,
+  now: number = Date.now(),
+): CredentialsFile {
+  return {
+    claudeAiOauth: {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt: tokenData.expires_at ?? now + (tokenData.expires_in ?? 8 * 60 * 60) * 1000,
+      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
+      ...plan,
+    },
+  }
+}
+
 async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   const session = createManualOAuthSession()
   console.log("\x1b[33m⚠ Headless OAuth login: open this URL in a browser:\x1b[0m")
@@ -209,21 +330,14 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
     return false
   }
 
-  if (!tokenData.access_token || !tokenData.refresh_token) {
+  if (!hasRequiredTokens(tokenData)) {
     console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
     return false
   }
 
-  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+  const plan = await fetchOAuthPlanFields(tokenData.access_token)
   const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write({
-    claudeAiOauth: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt,
-      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
-    },
-  })
+  return store.write(buildLoginCredentials(tokenData, plan))
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -51,7 +51,7 @@ export function configDirToCredentialsFile(claudeConfigDir: string): string {
   return join(resolve(claudeConfigDir), ".credentials.json")
 }
 
-interface OAuthCredentials {
+export interface OAuthCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
@@ -70,7 +70,7 @@ interface OAuthCredentials {
   rateLimitTier?: string
 }
 
-interface CredentialsFile {
+export interface CredentialsFile {
   claudeAiOauth: OAuthCredentials
   [key: string]: unknown
 }


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

`meridian profile add --headless` writes four fields into `.credentials.json` — `accessToken`, `refreshToken`, `expiresAt`, `scopes` — and drops the account's plan, even though `OAuthCredentials` has declared `subscriptionType` and `rateLimitTier` all along.

Measured on a ten-account host: a credential file written by `claude login` is **471 B** and carries `subscriptionType`; one written by Meridian's own headless login is **405 B** and does not. Eight of the ten profiles on that host were created by Meridian and are therefore plan-blind.

## Why that matters downstream

Everything reads the plan back out of that file via `claude auth status`, so a headless-created profile stays plan-unknown **forever**:

- `meridian profile list` and `/profiles/list` report no subscription type
- `/health` omits it
- the `max`-only branch in `/v1/models` — the one advertising the larger context window — silently never fires

## The plan is not on the token response

This is the part worth knowing, because the obvious fix does not work. Claude Code reads only `access_token`, `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and `organization.uuid` off a token response. It derives `subscriptionType` / `rateLimitTier` from a **separate** authenticated `GET https://api.anthropic.com/api/oauth/profile`, mapping the wire `organization_type` (`claude_max`) onto the stored value (`max`).

The headless login now makes the same call, using the `user:profile` scope it already requests. The mapping was verified against the shipped `claude` binary rather than inferred: `api/oauth/profile`, `organization_type`, `rate_limit_tier` and all four wire values (`claude_max` ×17, `claude_pro`, `claude_team`, `claude_enterprise`) are present in it.

## Properties

- **Best-effort; never fails the login.** Three separate catch paths and a 10s timeout. On any error the plan stays unknown and the profile is still created — a profile whose plan is unknown is strictly better than no profile, and every consumer already treats the field as optional.
- **Fields are spread in only when known.** `subscriptionType: undefined` would write a null-ish key into a file the real CLI also parses.
- **Nothing credential-shaped is logged.** The three warnings carry an error message or an HTTP status, never a token or a response body.
- **`buildLoginCredentials` is split out and pure**, so the on-disk shape is directly assertable. The defect being closed was a field missing from an object literal, which no test of the surrounding prompt/fetch I/O would have caught.
- **`doRefresh`'s spread over the existing credential is what keeps the value alive** across each ~8h refresh. A test pins that, so it is not later rewritten as an explicit field list — which would re-open the same hole one refresh after every login.

## Forward-looking only

A profile created by an earlier version **cannot be repaired by a token refresh**: the value is written at login and nowhere else, and Anthropic's usage endpoint does not carry it. Operators must re-run `meridian profile login <name> --headless` on affected profiles. `docs/profiles.md` says so.

## Tests

19 new assertions in `src/__tests__/profile-login-plan-fields.test.ts`: the wire→stored mapping including unrecognized and absent types, field omission when unknown, every failure path of the lookup returning `{}` rather than throwing, the credential record's exact on-disk shape, and the refresh spread preserving an existing plan.

`bun run test` green, `tsc --noEmit` exit 0.

---

This PR is AI generated, but under direct supervision and on request of Nowaker.
