### PR TITLE
fix(session): say which message broke the lineage, not just how many matched

### DIFF
--- a/scripts/e2e-lineage-divergence.mjs
+++ b/scripts/e2e-lineage-divergence.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
- * Live check: does `onSession` actually reach a plugin, and does the report
- * distinguish the two cases that matter?
+ * Live check: does a divergence explain itself, and does the append-only path
+ * avoid one in the first place?
  *
  * Three turns against a real model, cheapest tier:
  *
@@ -9,7 +9,7 @@
  *   2. extend the trailing message with a late parallel tool result
  *      → must CONTINUE (this is the #767 shape, fixed in 1.61.0)
  *   3. rewrite an earlier message
- *      → must DIVERGE, and lineage-doctor must name the index
+ *      → must DIVERGE, and the log must name the offending index
  *
  * Requires Claude Max auth. Two turns of Haiku plus one short one.
  */
@@ -24,13 +24,13 @@ const reports = []
 const realError = console.error
 console.error = (...args) => {
   const line = args.map(String).join(" ")
-  if (line.includes("lineage-doctor")) reports.push(line)
+  if (line.includes("first mismatch at index")) reports.push(line)
   realError(...args)
 }
 
-// pluginConfigPath must be passed explicitly: MERIDIAN_PLUGIN_CONFIG is read
-// by the CLI, not by startProxyServer, so a programmatic instance otherwise
-// silently loads whatever the user has in ~/.config/meridian/plugins.json.
+// No plugin config: the diagnosis is core's, so it must appear with nothing
+// installed. Passing an explicit (empty) path also stops a programmatic
+// instance from silently picking up whatever is in ~/.config/meridian.
 const inst = await startProxyServer({
   port: PORT,
   host: "127.0.0.1",
@@ -109,15 +109,15 @@ console.log("  status", await send([
   { role: "user", content: "and now?" },
 ], session))
 
-console.log("\n--- lineage-doctor reports ---")
-if (reports.length === 0) console.log("(none — the hook never reached the plugin)")
+console.log("\n--- divergence reports ---")
+if (reports.length === 0) console.log("(none — the divergence went unexplained)")
 for (const r of reports) console.log(r)
 
 console.log("\n--- verdict ---")
 const named = reports.some(r => r.includes("first mismatch at index"))
 console.log(named
-  ? "OK: the plugin received onSession and named the diverging message"
-  : "FAIL: no mismatch detail reached the plugin")
+  ? "OK: core named the diverging message"
+  : "FAIL: the divergence was logged without saying which message broke")
 
 await inst.close()
 process.exit(named ? 0 : 1)

--- a/scripts/e2e-lineage-doctor.mjs
+++ b/scripts/e2e-lineage-doctor.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+/**
+ * Live check: does `onSession` actually reach a plugin, and does the report
+ * distinguish the two cases that matter?
+ *
+ * Three turns against a real model, cheapest tier:
+ *
+ *   1. establish a session
+ *   2. extend the trailing message with a late parallel tool result
+ *      → must CONTINUE (this is the #767 shape, fixed in 1.61.0)
+ *   3. rewrite an earlier message
+ *      → must DIVERGE, and lineage-doctor must name the index
+ *
+ * Requires Claude Max auth. Two turns of Haiku plus one short one.
+ */
+import { startProxyServer } from "../src/proxy/server.ts"
+
+const PORT = Number(process.env.E2E_PORT ?? 3530)
+const MODEL = process.env.E2E_MODEL ?? "claude-haiku-4-5-20251001"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+
+const reports = []
+const realError = console.error
+console.error = (...args) => {
+  const line = args.map(String).join(" ")
+  if (line.includes("lineage-doctor")) reports.push(line)
+  realError(...args)
+}
+
+// pluginConfigPath must be passed explicitly: MERIDIAN_PLUGIN_CONFIG is read
+// by the CLI, not by startProxyServer, so a programmatic instance otherwise
+// silently loads whatever the user has in ~/.config/meridian/plugins.json.
+const inst = await startProxyServer({
+  port: PORT,
+  host: "127.0.0.1",
+  silent: true,
+  pluginConfigPath: process.env.E2E_PLUGIN_CONFIG,
+})
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file from disk",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string" } },
+    required: ["file_path"],
+  },
+}
+
+async function send(messages, sessionId) {
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": sessionId,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify({ model: MODEL, max_tokens: 512, stream: false, tools: [READ_TOOL], messages }),
+  })
+  return res.status
+}
+
+const session = `lineage-doctor-${Date.now()}`
+const ask = { role: "user", content: "Read /etc/hostname and tell me what it contains." }
+
+console.log("turn 1: establish the session")
+console.log("  status", await send([ask], session))
+
+// Turn 2 — the #767 shape: the trailing user message gains a second tool
+// result while the conversation grows. Must continue, not replay.
+const assistantParallel = {
+  role: "assistant",
+  content: [
+    { type: "tool_use", id: "call-a", name: "read", input: { file_path: "/etc/hostname" } },
+    { type: "tool_use", id: "call-b", name: "read", input: { file_path: "/etc/shells" } },
+  ],
+}
+const firstResultOnly = { role: "user", content: [
+  { type: "tool_result", tool_use_id: "call-a", content: "e2e-test-host\n" },
+] }
+
+console.log("turn 2: seed a trailing tool_result message")
+console.log("  status", await send([ask, assistantParallel, firstResultOnly], session))
+
+console.log("turn 3: late sibling result extends that SAME message (#767 shape)")
+console.log("  status", await send([
+  ask,
+  assistantParallel,
+  { role: "user", content: [
+    { type: "tool_result", tool_use_id: "call-a", content: "e2e-test-host\n" },
+    { type: "tool_result", tool_use_id: "call-b", content: "/bin/zsh\n" },
+  ] },
+], session))
+
+// Turn 4 — the same trailing message, but REWRITTEN rather than extended,
+// while the history grows. That must still diverge (the safety property the
+// append path deliberately does not relax) and is now explained.
+console.log("turn 4: rewrite the trailing message — must diverge and be explained")
+console.log("  status", await send([
+  ask,
+  assistantParallel,
+  { role: "user", content: [
+    { type: "tool_result", tool_use_id: "call-a", content: "REWRITTEN-result\n" },
+    { type: "tool_result", tool_use_id: "call-b", content: "/bin/zsh\n" },
+  ] },
+  { role: "assistant", content: [{ type: "text", text: "ok" }] },
+  { role: "user", content: "and now?" },
+], session))
+
+console.log("\n--- lineage-doctor reports ---")
+if (reports.length === 0) console.log("(none — the hook never reached the plugin)")
+for (const r of reports) console.log(r)
+
+console.log("\n--- verdict ---")
+const named = reports.some(r => r.includes("first mismatch at index"))
+console.log(named
+  ? "OK: the plugin received onSession and named the diverging message"
+  : "FAIL: no mismatch detail reached the plugin")
+
+await inst.close()
+process.exit(named ? 0 : 1)

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it, expect } from "bun:test"
 import {
+  describeLineageMismatch,
   computeLineageHash,
   hashMessage,
   computeMessageHashes,
@@ -243,7 +244,7 @@ describe("verifyLineage", () => {
       msg("user", "i"),           // New
     ]
     const result = verifyLineage(session, extended)
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       type: "diverged",
       reason: "modified-history",
       prefixOverlap: 6,
@@ -271,7 +272,7 @@ describe("verifyLineage", () => {
     const result = verifyLineage(session, incoming)
 
     expect(incoming).toHaveLength(727)
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       type: "diverged",
       reason: "modified-history",
       prefixOverlap: 514,
@@ -539,6 +540,62 @@ describe("verifyLineage stale modified continuation (#689)", () => {
   })
 })
 
+// #767 asked for exactly this: "prefix overlap 50/51" says how many messages
+// matched and never which one stopped. The answer was always in hand at the
+// point of the decision — it just was not reported.
+describe("describeLineageMismatch", () => {
+  function sessionFor(messages: Array<{ role: string; content: any }>): SessionState {
+    return makeSession({
+      lastAccess: 0,
+      lineageHash: computeLineageHash(messages),
+      messageCount: messages.length,
+      messageHashes: computeMessageHashes(messages),
+    })
+  }
+
+  it("names the first index that stopped matching, with both digests", () => {
+    const stored = [
+      { role: "user", content: "one" },
+      { role: "assistant", content: "two" },
+      { role: "user", content: "three" },
+    ]
+    const incoming = [
+      { role: "user", content: "one" },
+      { role: "assistant", content: "two" },
+      { role: "user", content: "three-EDITED" },
+    ]
+
+    const detail = describeLineageMismatch(sessionFor(stored), incoming)
+    expect(detail.index).toBe(2)
+    expect(detail.storedDigest).toBeDefined()
+    expect(detail.incomingDigest).toBeDefined()
+    expect(detail.storedDigest).not.toBe(detail.incomingDigest)
+    // The preceding index matched — that is what makes the named index the seam.
+    expect(detail.previousDigest).toBe(computeMessageHashes(stored)[1])
+    expect(detail.storedCount).toBe(3)
+    expect(detail.incomingCount).toBe(3)
+  })
+
+  it("reports shape without ever carrying content", () => {
+    const secret = "SECRET-do-not-log-this"
+    const stored = [{ role: "user", content: "one" }]
+    const incoming = [{ role: "user", content: [
+      { type: "text", text: secret },
+      { type: "tool_result", tool_use_id: "t1", content: secret },
+    ] }]
+
+    const detail = describeLineageMismatch(sessionFor(stored), incoming)
+    expect(detail.incomingShape).toEqual({ role: "user", blocks: "text,tool_result", bytes: expect.any(Number) })
+    expect(JSON.stringify(detail)).not.toContain(secret)
+  })
+
+  it("reports -1 when the shared prefix matches all the way", () => {
+    const stored = [{ role: "user", content: "one" }]
+    const incoming = [{ role: "user", content: "one" }, { role: "assistant", content: "two" }]
+    expect(describeLineageMismatch(sessionFor(stored), incoming).index).toBe(-1)
+  })
+})
+
 describe("verifyLineage append-only tool-result extension", () => {
   const toolResult = (id: string, content: string) => ({
     type: "tool_result",
@@ -676,7 +733,7 @@ describe("verifyLineage append-only tool-result extension", () => {
       { role: "assistant", content: "next" },
     ]
 
-    expect(verifyLineage(sessionFor(stored), incoming)).toEqual({
+    expect(verifyLineage(sessionFor(stored), incoming)).toMatchObject({
       type: "diverged",
       reason: "modified-history",
       prefixOverlap: 2,

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -586,6 +586,78 @@ describe("verifyLineage append-only tool-result extension", () => {
     })
   })
 
+  // #767: OpenCode + Opus reported `prefix overlap N/N+1` on nearly every turn,
+  // each one forcing a fresh replay (cache 97% -> 32%, ~3.9x cost). The reported
+  // shape is exactly this path: the trailing stored message is the user turn
+  // carrying tool_results, a parallel call lands late and extends it, and the
+  // conversation grows by an assistant+user pair on top. Opus issues parallel
+  // tool calls far more readily than Haiku, which is the model correlation the
+  // report measured (85% clean on Haiku vs 30-40% on Opus).
+  it("continues on the #767 signature: trailing message extended, history grown", () => {
+    // 51 stored messages, the last one a user turn with one result of two.
+    const head: Array<{ role: string; content: any }> = []
+    for (let i = 0; i < 49; i++) {
+      head.push({ role: i % 2 === 0 ? "user" : "assistant", content: [{ type: "text", text: `turn ${i}` }] })
+    }
+    const assistantWithParallelCalls = { role: "assistant", content: [
+      { type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } },
+      { type: "tool_use", id: "call-b", name: "bash", input: { command: "b" } },
+    ] }
+    const stored = [
+      ...head,
+      assistantWithParallelCalls,
+      { role: "user", content: [toolResult("call-a", "a-result")] },
+    ]
+    expect(stored.length).toBe(51)
+
+    const incoming = [
+      ...head,
+      assistantWithParallelCalls,
+      // The late sibling result extends the SAME message rather than adding one.
+      { role: "user", content: [toolResult("call-a", "a-result"), toolResult("call-b", "b-result")] },
+      { role: "assistant", content: [{ type: "text", text: "and the answer" }] },
+      { role: "user", content: [{ type: "text", text: "next question" }] },
+    ]
+    expect(incoming.length).toBe(53)
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(50)
+      expect(result.resumeContentFrom).toBe(1)
+    }
+  })
+
+  // The caveat that decides whether a fix is visible in the field: block hashes
+  // are only recorded from 1.61.0 on, so a session cached by an older build
+  // keeps replaying until it is started fresh.
+  it("a session stored without block hashes still diverges (pre-1.61.0 cache entry)", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "run both" }] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } },
+        { type: "tool_use", id: "call-b", name: "bash", input: { command: "b" } },
+      ] },
+      { role: "user", content: [toolResult("call-a", "a-result")] },
+    ]
+    const legacySession = makeSession({
+      lastAccess: 0,
+      lineageHash: computeLineageHash(stored),
+      messageCount: stored.length,
+      messageHashes: computeMessageHashes(stored),
+      // messageBlockHashes deliberately absent — what a pre-1.61.0 entry holds.
+    })
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [toolResult("call-a", "a-result"), toolResult("call-b", "b-result")] },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
+      { role: "user", content: [{ type: "text", text: "next" }] },
+    ]
+
+    expect(verifyLineage(legacySession, incoming).type).toBe("diverged")
+  })
+
   it("still diverges when an existing tool result changed", () => {
     const stored = [
       { role: "user", content: [{ type: "text", text: "run both" }] },

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect } from "bun:test"
 import {
   describeLineageMismatch,
+  formatLineageMismatch,
   computeLineageHash,
   hashMessage,
   computeMessageHashes,
@@ -593,6 +594,51 @@ describe("describeLineageMismatch", () => {
     const stored = [{ role: "user", content: "one" }]
     const incoming = [{ role: "user", content: "one" }, { role: "assistant", content: "two" }]
     expect(describeLineageMismatch(sessionFor(stored), incoming).index).toBe(-1)
+  })
+})
+
+// The log line this feeds is the whole point: core already knew which message
+// broke, and reported only a count nobody could act on.
+describe("formatLineageMismatch", () => {
+  const base = {
+    index: 50,
+    storedDigest: "19d133336ded0000000000000000aaaa",
+    incomingDigest: "d546681fb008000000000000000bbbbb",
+    previousDigest: "d61d1384ce00000000000000000ccccc",
+    incomingShape: { role: "user", blocks: "tool_result,tool_result", bytes: 812 },
+    storedCount: 51,
+    incomingCount: 53,
+  }
+
+  it("names the index, truncates both digests, and reports the shape", () => {
+    const out = formatLineageMismatch(base)!
+    expect(out).toContain("first mismatch at index 50")
+    expect(out).toContain("stored=19d133336ded")
+    expect(out).toContain("incoming=d546681fb008")
+    expect(out).toContain("user[tool_result,tool_result] 812B")
+  })
+
+  // A trailing-only mismatch is a late tool result; a mid-history one means the
+  // transcript was rewritten. The overlap count cannot tell them apart.
+  it("calls out a trailing-only mismatch", () => {
+    expect(formatLineageMismatch(base)).toContain("trailing message only")
+  })
+
+  it("does not call a mid-history mismatch trailing", () => {
+    expect(formatLineageMismatch({ ...base, index: 2 })).not.toContain("trailing")
+  })
+
+  it("returns nothing when the shared prefix matched all the way", () => {
+    expect(formatLineageMismatch({ ...base, index: -1 })).toBeUndefined()
+  })
+
+  it("never carries content", () => {
+    const secret = "SECRET-do-not-log"
+    const out = formatLineageMismatch({
+      ...base,
+      incomingShape: { role: "user", blocks: "text", bytes: secret.length },
+    })!
+    expect(out).not.toContain(secret)
   })
 })
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1112,6 +1112,34 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (lineageResult.type === "undo" && adapterBase === "opencode" && !agentSessionId) {
           lineageResult = { type: "diverged", reason: "missing-session-header" }
         }
+        // Publish the decision to plugins. Core has always known WHICH message
+        // stopped matching; the log line only ever reported how many matched
+        // ("prefix overlap 50/51"), which is why #767 had to hand-patch a build
+        // to get any further. The detail is computed only on a divergence — the
+        // one case that is both rare and already about to cost a full replay —
+        // and carries digests and shapes, never content.
+        if (pipeline.some(t => t.onSession)) {
+          // verifyLineage attaches the detail on modified-history, where it has
+          // the stored digests in hand; nothing recomputes it here.
+          const mismatch = lineageResult.type === "diverged" ? lineageResult.mismatch : undefined
+          runTransformHook(pipeline, "onSession", {
+            adapter: adapterBase,
+            lineage: lineageResult.type,
+            reason: lineageResult.type === "diverged" ? lineageResult.reason : undefined,
+            sessionKey: profileSessionId,
+            storedCount: mismatch?.storedCount,
+            incomingCount: (body.messages || []).length,
+            prefixOverlap: lineageResult.type === "diverged" ? lineageResult.prefixOverlap : undefined,
+            mismatch: mismatch && mismatch.index >= 0 ? {
+              index: mismatch.index,
+              storedDigest: mismatch.storedDigest,
+              incomingDigest: mismatch.incomingDigest,
+              previousDigest: mismatch.previousDigest,
+              incomingShape: mismatch.incomingShape,
+            } : undefined,
+          }, adapterBase)
+        }
+
         const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -17,6 +17,7 @@ import {
 import { getConversationFingerprint } from "./fingerprint"
 import {
   computeLineageHash,
+  formatLineageMismatch,
   computeMessageBlockHashes,
   computeMessageHashes,
   verifyLineage,
@@ -149,7 +150,11 @@ function classifyLineage(
     console.error(`[PROXY] ${msg}`)
     diagnosticLog.lineage(msg)
   } else if (result.type === "diverged" && result.reason === "modified-history") {
+    // The overlap count alone is not actionable — name the message that broke,
+    // which verifyLineage already worked out to reach this branch.
+    const detail = result.mismatch ? formatLineageMismatch(result.mismatch) : undefined
     const msg = `Stale session detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap || 0}/${state.messageCount}, incoming ${messages.length} msgs. Starting fresh replay.`
+      + (detail ? `\n  ${detail}` : "")
     console.error(`[PROXY] ${msg}`)
     diagnosticLog.lineage(msg)
   }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -70,7 +70,10 @@ export type LineageResult =
   | { type: "continuation"; session: SessionState; resumeFrom: number; resumeContentFrom?: number }
   | { type: "compaction";   session: SessionState; resumeFrom: number; suffixOverlap: number }
   | { type: "undo";         session: SessionState; prefixOverlap: number; rollbackUuid: string | undefined }
-  | { type: "diverged";     reason: LineageDivergenceReason; prefixOverlap?: number }
+  | { type: "diverged";     reason: LineageDivergenceReason; prefixOverlap?: number;
+      /** Which message stopped matching. Present for modified-history, the
+       *  only divergence where the answer is both knowable and useful. */
+      mismatch?: LineageMismatch }
 
 export type LineageDivergenceReason =
   | "unverifiable"
@@ -103,6 +106,86 @@ export function hashMessage(message: { role: string; content: any }): string {
     .update(`${message.role}:${normalizeContent(message.content)}`)
     .digest("hex")
     .slice(0, 32)
+}
+
+/** A message's shape, for diagnostics that must never carry its content. */
+export interface MessageShape {
+  role: string
+  /** "string" for plain content, otherwise the block types in order. */
+  blocks: string
+  /** Bytes of normalized content — size moves when content does. */
+  bytes: number
+}
+
+/** Why two histories stopped matching, in terms safe to log.
+ *
+ * Answers the question `prefix overlap 50/51` raises and never answers: WHICH
+ * message stopped matching, and what changed about its shape. Content never
+ * appears here — only role, block types, byte counts, and digests.
+ */
+export interface LineageMismatch {
+  /** First index whose digest differs, or -1 when the prefix matches entirely. */
+  index: number
+  storedDigest?: string
+  incomingDigest?: string
+  /** Only the incoming side has a shape: the stored side is kept as digests,
+   *  so its structure is not recoverable — by design, nothing to recover. */
+  incomingShape?: MessageShape
+  /** Digest of the preceding index, which by definition matched. */
+  previousDigest?: string
+  storedCount: number
+  incomingCount: number
+}
+
+function describeShape(message: { role: string; content: any }): MessageShape {
+  const normalized = normalizeContent(message.content)
+  return {
+    role: message.role,
+    blocks: Array.isArray(message.content)
+      ? message.content.map((b: any) => String(b?.type ?? "unknown")).join(",")
+      : typeof message.content === "string" ? "string" : "unknown",
+    bytes: Buffer.byteLength(normalized, "utf8"),
+  }
+}
+
+/**
+ * Locate the first message whose hash differs between a stored session and an
+ * incoming request.
+ *
+ * Pure and allocation-light: callers reach for it only on a divergence, which
+ * is rare and already about to cost a full replay.
+ */
+export function describeLineageMismatch(
+  cached: SessionState,
+  messages: Array<{ role: string; content: any }>,
+  /** Reuse the caller's hashes. verifyLineage has already hashed the incoming
+   *  history to measure overlap; hashing it again on a 700-message transcript
+   *  would double the cost of the request that is already paying for a replay. */
+  precomputedIncomingHashes?: string[],
+): LineageMismatch {
+  const storedHashes = cached.messageHashes ?? []
+  const incomingHashes = precomputedIncomingHashes ?? computeMessageHashes(messages)
+  const limit = Math.min(storedHashes.length, incomingHashes.length)
+
+  let index = -1
+  for (let i = 0; i < limit; i++) {
+    if (storedHashes[i] !== incomingHashes[i]) { index = i; break }
+  }
+
+  const base: LineageMismatch = {
+    index,
+    storedCount: cached.messageCount,
+    incomingCount: messages.length,
+  }
+  if (index < 0) return base
+
+  return {
+    ...base,
+    storedDigest: storedHashes[index],
+    incomingDigest: incomingHashes[index],
+    incomingShape: messages[index] ? describeShape(messages[index]!) : undefined,
+    previousDigest: index > 0 ? storedHashes[index - 1] : undefined,
+  }
 }
 
 /**
@@ -399,7 +482,12 @@ export function verifyLineage(
   // holds content the client no longer claims — so the bound is gone and the
   // whole shape diverges.
   if (prefixOverlap > 0 && messages.length > cached.messageCount) {
-    return { type: "diverged", reason: "modified-history", prefixOverlap }
+    return {
+      type: "diverged",
+      reason: "modified-history",
+      prefixOverlap,
+      mismatch: describeLineageMismatch(cached, messages, incomingHashes),
+    }
   }
 
   // No meaningful overlap — completely different conversation.

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -189,6 +189,34 @@ export function describeLineageMismatch(
 }
 
 /**
+ * One-line explanation of a divergence, for the log that reports it.
+ *
+ * `prefix overlap 50/51` says how many messages matched and never which one
+ * stopped, which is the fact needed to act on it — a trailing-only mismatch is
+ * a late tool result or a client re-serialising its last turn, while a mismatch
+ * in the middle means the history was rewritten. Same overlap count, different
+ * bug.
+ *
+ * Digests are truncated and content never appears, so the line is safe to paste
+ * into a public issue.
+ */
+export function formatLineageMismatch(mismatch: LineageMismatch): string | undefined {
+  if (mismatch.index < 0) return undefined
+  const short = (digest: string | undefined) => (digest ? digest.slice(0, 12) : "—")
+  const trailing = mismatch.index === mismatch.storedCount - 1
+    ? " (trailing message only — the rest of the history matched)"
+    : ""
+  const shape = mismatch.incomingShape
+    ? `${mismatch.incomingShape.role}[${mismatch.incomingShape.blocks}] ${mismatch.incomingShape.bytes}B`
+    : "unknown"
+  return (
+    `first mismatch at index ${mismatch.index}${trailing}: ` +
+    `stored=${short(mismatch.storedDigest)} incoming=${short(mismatch.incomingDigest)}, ` +
+    `incoming now ${shape}`
+  )
+}
+
+/**
  * Compute per-message hashes for an entire message array.
  */
 export function computeMessageHashes(messages: Array<{ role: string; content: any }>): string[] {

--- a/src/proxy/transform.ts
+++ b/src/proxy/transform.ts
@@ -110,8 +110,41 @@ export interface TelemetryContext {
   readonly cacheHitRate: number
 }
 
+/**
+ * A lineage decision, after it has been made.
+ *
+ * Observe-only in practice: the pipeline takes the returned context, but
+ * nothing downstream reads it back, so a plugin cannot change how a session
+ * resumes. That is deliberate — resume correctness is core's to own, and the
+ * three stale-lineage defects it has already produced are not a surface to
+ * open to third parties.
+ *
+ * `mismatch` is present only on a divergence, which is the case worth
+ * diagnosing: it names WHICH message stopped matching, where `prefix overlap
+ * 50/51` only ever said how many did. Content never appears — roles, block
+ * types, byte counts, and digests are enough to tell a late tool result from a
+ * rewritten transcript, and they are safe to write to a log.
+ */
+export interface SessionContext {
+  readonly adapter: string
+  readonly lineage: "continuation" | "compaction" | "undo" | "diverged"
+  /** Set when lineage is `diverged`. */
+  readonly reason?: string
+  readonly sessionKey?: string
+  readonly storedCount?: number
+  readonly incomingCount?: number
+  readonly prefixOverlap?: number
+  readonly mismatch?: {
+    readonly index: number
+    readonly storedDigest?: string
+    readonly incomingDigest?: string
+    readonly previousDigest?: string
+    readonly incomingShape?: { readonly role: string; readonly blocks: string; readonly bytes: number }
+  }
+  [key: string]: unknown
+}
+
 // Roadmap context types (reserved, not yet used)
-export interface SessionContext { readonly adapter: string; [key: string]: unknown }
 export interface ToolUseContext { readonly adapter: string; [key: string]: unknown }
 export interface ToolResultContext { readonly adapter: string; [key: string]: unknown }
 export interface ErrorContext { readonly adapter: string; [key: string]: unknown }


### PR DESCRIPTION
Follow-up to #767, which reported that nearly every OpenCode + Opus turn diverged
as `modified-history` with `prefix overlap == messageCount - 1`, forcing a full
replay and dropping cache hit rate from 97% to 32%.

## The diagnosis the log never gave

```
Stale session detected (key=ses_0260…): prefix overlap 50/51, incoming 53 msgs. Starting fresh replay.
```

That reports how many messages matched and never which one stopped. The two cases
it conflates need opposite fixes:

- a **trailing-only** mismatch is a late tool result, or a client re-serialising
  its last turn
- a mismatch **in the middle** means the transcript was rewritten

`verifyLineage` has always known — it holds both digest arrays at the point it
decides. The line now finishes its sentence:

```
Stale session detected (key=ses_0260…): prefix overlap 2/3, incoming 5 msgs. Starting fresh replay.
  first mismatch at index 2 (trailing message only — the rest of the history matched): stored=086224e99523 incoming=c5e1bce812fa, incoming now user[tool_result,tool_result] 65B
```

No content — roles, block types, byte counts and truncated digests only, so it is
safe to paste into a public issue. Pinned by a test that asserts a secret string
cannot appear in the output.

## Why this is in core and not a plugin

It was briefly a plugin. That was wrong. `docs/plugins.md` draws the line at
rewriting client content — which is why the scrubs are plugins — and this
rewrites nothing. Core already owns observability: `diagnosticLog`, the telemetry
store, and this very log line. Shipping it as a plugin would also have meant
every bug report costing a round-trip to install one, which is precisely the
friction the reporter hit: they patched a build by hand and it never loaded,
because OpenCode spawns its own Meridian on a random port.

## `onSession` was a dead hook

Declared in the `Transform` interface and listed in `KNOWN_HOOKS` since the plugin
system shipped, with zero call sites and a placeholder `SessionContext`. A plugin
declaring it validated cleanly and then silently never ran. It now carries a real
typed context and is dispatched — only when a transform actually subscribes.

## On #767 itself

The lineage work already released in 1.61.0 targets exactly the reported
signature: a late parallel tool result extending the trailing user message while
the conversation grows. Opus issues parallel tool calls far more readily than
Haiku, and OpenCode appends each result to the same user message as it completes
— which fits the model correlation the reporter measured (85% clean on Haiku vs
30–40% on Opus) without needing thinking blocks as an explanation.

Two tests pin it: the exact reported shape (51 stored, overlap 50, 53 incoming)
now continues, and — the caveat that decides whether the fix is visible in the
field — a session cached by a pre-1.61.0 build still diverges, because block
hashes are only recorded from 1.61.0 on. Upgrading in place does not fix existing
sessions; they have to be started fresh.

## Verification

`scripts/e2e-lineage-divergence.mjs` drives four turns against a live model with
**no plugin installed**: the append shape continues, and a rewrite of the same
message diverges and names index 2 as trailing-only. Full suite 2600 tests with
only the pre-existing environment failures; typecheck clean.