### PR TITLE
fix(routing): fail over when an account's subscription is refused

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -75,7 +75,7 @@ Request logs show the assignment (`profile=work(sticky)`), and `GET /profiles/li
 
 ### Priority failover routing
 
-**Opt-in.** With multiple profiles, `routing = "priority"` drains an ordered account pool: unpinned requests prefer the highest-priority account, and when it runs out (rate-limit/quota errors), the request **fails over automatically** to the next account in the order — usually before the client sees any error:
+**Opt-in.** With multiple profiles, `routing = "priority"` drains an ordered account pool: unpinned requests prefer the highest-priority account, and when it can no longer serve (a spent quota window, or a subscription the account can't bill), the request **fails over automatically** to the next account in the order — usually before the client sees any error:
 
 ```bash
 MERIDIAN_ROUTING=priority MERIDIAN_PROFILE_ORDER=work,personal meridian
@@ -85,8 +85,8 @@ MERIDIAN_ROUTING=priority MERIDIAN_PROFILE_ORDER=work,personal meridian
 
 - **Conversations keep their account** while it's healthy — a session never flips accounts just because the pool preference changed (protects per-account prompt caches). A session on an exhausted account fails over and then stays on its new account. A conversation is identified by its session header when the client sends one, and otherwise by a fingerprint of its opening message and project directory — so keyless clients get the same affinity.
 - **Drain-back is new-sessions-only**: when the preferred account's window resets, new sessions prefer it again immediately; existing conversations finish where they are.
-- **Exhaustion is tracked in-memory** using that account's own reported reset time (conservative 10-minute default when unknown), refined shortly after by an authoritative check against the usage API that can extend — never shorten — the cooldown once that account's five-hour window is confirmed exhausted. The home page shows `#n in pool` and `exhausted · resets in …` badges per account.
-- When **every** account is exhausted, the last-tried account's error is surfaced unchanged.
+- **Exhaustion is tracked in-memory.** A quota refusal uses that account's own reported reset time (conservative 10-minute default when unknown), refined shortly after by an authoritative check against the usage API that can extend — never shorten — the cooldown once that account's five-hour window is confirmed exhausted. A billing refusal has no reset to wait for, so it takes the conservative default unrefined — the account is simply re-probed later, since only a human can fix a subscription. The home page shows `#n in pool` and `exhausted · resets in …` badges per account.
+- When **every** account is exhausted, the last-tried account's error is surfaced unchanged, with its own status — a pool that ran out of billing is not reported as a rate limit.
 - An explicit `x-meridian-profile` header always bypasses the pool (per-session pinning keeps working).
 - Failovers are logged (`profile.failover` in the diagnostic stream; `profile=<id>(priority)` in request lines).
 

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, extendedContextHint, isStaleSessionError, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination } from "../proxy/errors"
+import { classifyError, extendedContextHint, isStaleSessionError, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -525,5 +525,51 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     const r = classifyError("usage limit reached | resets at 5pm")
     expect(r.type).toBe("rate_limit_error")
     expect(r.status).toBe(429)
+  })
+})
+
+describe("isAccountFailoverError", () => {
+  it("accepts the types that exhaust one account and leave the pool viable", () => {
+    expect(isAccountFailoverError("rate_limit_error")).toBe(true)
+    expect(isAccountFailoverError("billing_error")).toBe(true)
+  })
+
+  it("rejects failures that say nothing about the account", () => {
+    // Failing over on these would spend every account on one upstream hiccup
+    // and mark them all exhausted for something none of them did.
+    expect(isAccountFailoverError("api_error")).toBe(false)
+    expect(isAccountFailoverError("overloaded_error")).toBe(false)
+    expect(isAccountFailoverError("timeout_error")).toBe(false)
+    expect(isAccountFailoverError("upstream_timeout")).toBe(false)
+  })
+
+  it("rejects authentication_error, which the token refresh recovers in place", () => {
+    expect(isAccountFailoverError("authentication_error")).toBe(false)
+  })
+
+  it("rejects a missing or malformed type rather than guessing", () => {
+    expect(isAccountFailoverError(undefined)).toBe(false)
+    expect(isAccountFailoverError(null)).toBe(false)
+    expect(isAccountFailoverError("")).toBe(false)
+  })
+
+  it("agrees with classifyError on a subscription refusal", () => {
+    const classified = classifyError("Your Claude Max subscription is inactive - update your payment method")
+    expect(classified.type).toBe("billing_error")
+    expect(classified.status).toBe(402)
+    expect(isAccountFailoverError(classified.type)).toBe(true)
+  })
+})
+
+describe("isQuotaRefusal", () => {
+  it("separates the refusal that names its own reset from the one that does not", () => {
+    expect(isQuotaRefusal("rate_limit_error")).toBe(true)
+    expect(isQuotaRefusal("billing_error")).toBe(false)
+    expect(isQuotaRefusal(undefined)).toBe(false)
+  })
+
+  it("is a strict subset of the failover set", () => {
+    expect(isAccountFailoverError("rate_limit_error") && isQuotaRefusal("rate_limit_error")).toBe(true)
+    expect(isAccountFailoverError("billing_error") && !isQuotaRefusal("billing_error")).toBe(true)
   })
 })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -150,6 +150,33 @@ describe("classifyError", () => {
       const result = classifyError("subscription expired")
       expect(result.status).toBe(402)
     })
+
+    it("detects a lapsed subscription with a payment-method prompt", () => {
+      const r = classifyError("Claude Code returned an error result: Your Claude Max subscription is inactive — update your payment method to continue.")
+      expect(r.status).toBe(402)
+      expect(r.type).toBe("billing_error")
+    })
+
+    it("detects an exhausted extra-usage refusal", () => {
+      const r = classifyError("API Error: 400 You're out of extra usage. Add more at claude.ai/settings/usage")
+      expect(r.type).toBe("billing_error")
+    })
+
+    // These used to classify as billing because the branch matched bare
+    // substrings anywhere in the text, and it runs before the crash/max-turns
+    // branches so it won. Harmless as a wrong status code; not harmless once
+    // isAccountFailoverError keys on the type (#796), where an incidental
+    // filename could mark every profile in the pool exhausted.
+    it.each([
+      ["a filename", "Claude Code returned an error result: Reached maximum number of turns (3) while editing subscription.ts"],
+      ["a path", "Error: ENOENT: no such file or directory, open '/repo/src/billing/index.ts'"],
+      ["a URL", "fetch failed: https://api.example.com/payment/status returned 500"],
+      ["a stack frame line number", "TypeError: undefined is not a function\n    at handler.js:402:15"],
+    ])("does not read %s as a billing error", (_label, msg) => {
+      const r = classifyError(msg)
+      expect(r.type).not.toBe("billing_error")
+      expect(isAccountFailoverError(r.type)).toBe(false)
+    })
   })
 
   describe("process crashes", () => {

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -24,6 +24,11 @@ const SUBSCRIPTION_REFUSAL = "Claude Code returned an error result: Your Claude 
 // Classifies as overloaded_error (503): says nothing about the account, so it
 // must NOT spend the pool.
 const UPSTREAM_HICCUP = "Claude Code returned an error result: upstream is overloaded"
+// A perfectly ordinary failure that happens to name a file called
+// subscription.ts. Before the classifier was tightened this read as
+// billing_error and, with billing in the failover set, burned the whole pool.
+const INCIDENTAL_BILLING_WORD =
+  "Claude Code returned an error result: Reached maximum number of turns (3) while editing subscription.ts"
 let failureMessage = DEFAULT_FAILURE
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
@@ -277,6 +282,36 @@ describe("priority routing", () => {
     expect(marks.map(m => m.id)).toEqual(["work"])
     expect(marks[0]?.reason).toBe("billing_error")
   }, 20_000)
+
+  // The blast radius of putting billing_error in the failover set: any error
+  // text containing "subscription", "billing" or "payment" — a filename, a
+  // path, an MCP server's stderr — used to mark EVERY profile exhausted, and a
+  // fully exhausted pool collapses the candidate list, so the next genuine
+  // quota failure never reaches the healthy account.
+  it("does not spend the pool on an error that merely names a billing word", async () => {
+    failureMessage = INCIDENTAL_BILLING_WORD
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).not.toContain("personal")
+    expect(marks.map(m => m.id)).not.toContain("work")
+  }, 20_000)
+
+  it("still fails over to a healthy account after one of those errors", async () => {
+    failureMessage = INCIDENTAL_BILLING_WORD
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+
+    // The pool must be intact: a real quota refusal now still reaches personal.
+    failureMessage = DEFAULT_FAILURE
+    const res = await post(app, {}, "second request after an incidental billing word")
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
+  }, 30_000)
 
   it("streams fail over on a refused subscription too", async () => {
     failureMessage = SUBSCRIPTION_REFUSAL

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -13,7 +13,17 @@ import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, m
 
 let capturedEnvs: string[] = []
 let failingDirs = new Set<string>()
+// Accounts that fail only AFTER streaming some content — the error frame then
+// lands behind message_start, where the sniffer must not touch it.
+let failAfterContentDirs = new Set<string>()
 const DEFAULT_FAILURE = "429 rate limit reached for this account"
+// Classifies as billing_error (402): an account whose subscription lapsed or
+// whose card was declined. Per-account like a quota refusal, but with no reset
+// to wait for.
+const SUBSCRIPTION_REFUSAL = "Claude Code returned an error result: Your Claude Max subscription is inactive — update your payment method to continue."
+// Classifies as overloaded_error (503): says nothing about the account, so it
+// must NOT spend the pool.
+const UPSTREAM_HICCUP = "Claude Code returned an error result: upstream is overloaded"
 let failureMessage = DEFAULT_FAILURE
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
@@ -23,6 +33,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const streaming = params.options?.includePartialMessages === true
     return (async function* () {
       if ([...failingDirs].some((f) => dir.includes(f))) {
+        throw new Error(failureMessage)
+      }
+      if ([...failAfterContentDirs].some((f) => dir.includes(f))) {
+        if (streaming) {
+          yield messageStart("msg-1")
+          yield textBlockStart(0)
+          yield textDelta(0, "partial from " + dir)
+        }
         throw new Error(failureMessage)
       }
       if (streaming) {
@@ -99,6 +117,7 @@ const savedEnv: Record<string, string | undefined> = {}
 // still win for those tests.
 beforeEach(() => {
   failureMessage = DEFAULT_FAILURE
+  failAfterContentDirs = new Set()
   __setFetchOAuthUsageOverride(async () => null)
 })
 
@@ -239,6 +258,146 @@ describe("priority routing", () => {
     expect(text.split("event: message_start").length - 1).toBe(1)
   }, 20_000)
 
+  it("fails over when the preferred account's subscription is refused", async () => {
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
+  }, 20_000)
+
+  it("marks the refused account with its own reason, not the quota one", async () => {
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    await post(app)
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).toEqual(["work"])
+    expect(marks[0]?.reason).toBe("billing_error")
+  }, 20_000)
+
+  it("streams fail over on a refused subscription too", async () => {
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("prof-personal")
+    expect(text.split("event: message_start").length - 1).toBe(1)
+  }, 20_000)
+
+  it("surfaces the refusal's own status when every account is refused", async () => {
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    failingDirs.add("prof-personal")
+    const app = createTestApp()
+    const res = await post(app)
+    // Not a 429: a client told to back off would retry a pool that cannot
+    // recover on its own.
+    expect(res.status).toBe(402)
+    const body = await res.json() as { error: { type: string } }
+    expect(body.error.type).toBe("billing_error")
+  }, 30_000)
+
+  it("does NOT spend the pool on a failure that says nothing about the account", async () => {
+    failureMessage = UPSTREAM_HICCUP
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(503)
+    // personal was never tried, and work carries no exhaustion mark
+    expect(capturedEnvs.length).toBeGreaterThan(0)
+    expect(capturedEnvs.every((e) => e.includes("prof-work"))).toBe(true)
+    expect(await exhaustedMarks(app)).toEqual([])
+  }, 20_000)
+
+  it("moves an assigned conversation off an account once its subscription is refused", async () => {
+    const app = createTestApp()
+    // s1 lands on work, and assignment affinity pins it there
+    const first = await post(app, { "x-opencode-session": "s1" })
+    expect(first.status).toBe(200)
+    const firstBody = await first.json() as { content: Array<{ text: string }> }
+    expect(firstBody.content[0]?.text).toContain("prof-work")
+
+    // work's subscription lapses. Affinity outranks the pool order, so nothing
+    // but an exhaustion mark can move this conversation — which is exactly
+    // what a refusal that fails to mark leaves stuck.
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    const second = await post(app, { "x-opencode-session": "s1" })
+    expect(second.status).toBe(200)
+    const secondBody = await second.json() as { content: Array<{ text: string }> }
+    expect(secondBody.content[0]?.text).toContain("prof-personal")
+
+    // and it does not drift back: the mark makes the next request skip work
+    capturedEnvs = []
+    const third = await post(app, { "x-opencode-session": "s1" })
+    expect(third.status).toBe(200)
+    expect(capturedEnvs).toHaveLength(1)
+    expect(capturedEnvs[0]).toContain("prof-personal")
+  }, 30_000)
+
+  it("streams the refusal's own payload when every account is refused", async () => {
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    failingDirs.add("prof-personal")
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    // SSE carries its failure in the frame, not in the status
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("event: error")
+    expect(text).toContain("billing_error")
+    expect(text).not.toContain("message_start")
+  }, 30_000)
+
+  it("leaves a refusal that arrives AFTER content alone", async () => {
+    // The deliberate limit of this whole mechanism: once the client is
+    // consuming a stream it is never yanked, whatever the error says. The
+    // account keeps its place — the failure is not attributed to it here.
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failAfterContentDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: true,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("partial from")
+    expect(text).toContain("billing_error")
+    expect(capturedEnvs).toHaveLength(1)
+    expect(capturedEnvs[0]).toContain("prof-work")
+    expect(await exhaustedMarks(app)).toEqual([])
+  }, 20_000)
+
   it("mode OFF is byte-identical: no failover, error surfaces from the default profile", async () => {
     delete process.env.MERIDIAN_ROUTING
     failingDirs.add("prof-work")
@@ -297,6 +456,32 @@ describe("priority cooldown resolution", () => {
     const marks = await exhaustedMarks(app)
     expect(marks.map(m => m.id)).toEqual(["work"])
     expect(marks.map(m => m.until)).toEqual([WORK_RESET])
+  }, 20_000)
+
+  it("ignores the five_hour reset when the refusal is about the subscription, not the quota", async () => {
+    // work has a rejected five_hour window on record, resetting 4h out. A
+    // billing refusal must not borrow that number: entitlement does not come
+    // back when a quota window rolls over, so adopting it would hide the
+    // account for four hours instead of re-probing it on the conservative
+    // default.
+    rateLimitStore.record("work", {
+      status: "rejected",
+      rateLimitType: "five_hour",
+      utilization: 1,
+      resetsAt: WORK_RESET,
+    })
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const before = Date.now()
+    await post(app)
+
+    const marks = await exhaustedMarks(app)
+    expect(marks.map(m => m.id)).toEqual(["work"])
+    expect(marks[0]?.reason).toBe("billing_error")
+    expect(marks[0]?.until).toBeLessThan(WORK_RESET)
+    expect(marks[0]?.until).toBeGreaterThanOrEqual(before + 10 * 60_000)
+    expect(marks[0]?.until).toBeLessThanOrEqual(Date.now() + 10 * 60_000)
   }, 20_000)
 
   it("adopts a SECONDS-valued reset from the SDK, which tier 1 could never match before (#708)", async () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -244,6 +244,47 @@ export function isRateLimitError(errMsg: string): boolean {
 }
 
 /**
+ * Error types that exhaust the CURRENT account while leaving the rest of the
+ * pool viable — priority routing's cue to try the next candidate instead of
+ * handing the failure to the client.
+ *
+ * `rate_limit_error` is a spent quota window; `billing_error` is a lapsed
+ * subscription or a declined payment method. Both are properties of the one
+ * account that raised them and neither can succeed on a retry there, which is
+ * exactly what makes another account worth trying.
+ *
+ * Deliberately absent: `authentication_error`, which the token refresh already
+ * recovers in place, and the account-blind failures (`api_error`,
+ * `overloaded_error`, `timeout_error`) — those say nothing about entitlement,
+ * and failing over on them would spend the whole pool on one upstream hiccup
+ * and leave every account marked exhausted for something none of them did.
+ */
+const ACCOUNT_FAILOVER_ERROR_TYPES: ReadonlySet<string> = new Set([
+  "rate_limit_error",
+  "billing_error",
+])
+
+/**
+ * Whether a classified error type means "this account cannot serve the
+ * request, another one might". Used by priority routing to decide failover.
+ */
+export function isAccountFailoverError(errorType: string | null | undefined): errorType is string {
+  return typeof errorType === "string" && ACCOUNT_FAILOVER_ERROR_TYPES.has(errorType)
+}
+
+/**
+ * Whether the refusal is the quota kind, which names its own reset — the two
+ * cooldown tiers read the account's five-hour window, and only this kind has
+ * anything to look up there. Lives beside the set so the type name stays
+ * owned by one module: a rename that missed a caller in the orchestrator would
+ * not break failover loudly, it would silently downgrade every quota cooldown
+ * to the conservative default.
+ */
+export function isQuotaRefusal(errorType: string | null | undefined): boolean {
+  return errorType === "rate_limit_error"
+}
+
+/**
  * Detect errors caused by the 1M context window requiring Extra Usage.
  * Max subscribers without Extra Usage enabled get this error when using
  * sonnet[1m] or opus[1m]. The fix is to fall back to the base model.

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -42,6 +42,21 @@ export function extendedContextHint(model?: string): string {
   return advise("MERIDIAN_1M_CONTEXT_SUPPORT=0")
 }
 
+/** Phrases that actually indicate a billing or subscription refusal.
+ *
+ *  `\b402\b` excludes a `:digits` suffix so a stack frame like
+ *  `handler.js:402:15` cannot be read as a payment-required status. */
+const BILLING_SIGNALS: readonly RegExp[] = [
+  /\b402\b(?!:\d)/,
+  /billing[_ ](?:error|issue|problem|failure)/,
+  /subscription (?:is |has )?(?:inactive|expired|lapsed|cancell?ed|ended|invalid|not active)/,
+  /(?:expired|inactive|lapsed|invalid|no active|cancell?ed) subscription/,
+  /payment (?:method|required|failed|declined|details|info)/,
+  /update your payment/,
+  /(?:out of|draw from|draws from) extra usage/,
+  /insufficient (?:credit|funds|balance)/,
+]
+
 /** "hit your limit", "hit your session limit", "hit your weekly limit", and any
  *  future single-word qualifier the CLI adopts. Anchored on both sides so it
  *  can't drift into unrelated text that happens to contain "limit". */
@@ -99,8 +114,14 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
-  // Billing / subscription
-  if (lower.includes("402") || lower.includes("billing") || lower.includes("subscription") || lower.includes("payment")) {
+  // Billing / subscription. Matched on phrases rather than bare tokens: an
+  // error mentioning `subscription.ts`, a path under `src/billing/`, or a URL
+  // containing `/payment/` is not a billing problem, and this branch runs
+  // BEFORE the process-crash and max-turns branches, so it wins on any message
+  // that merely contains the word. That was a wrong status code until
+  // isAccountFailoverError started keying on it (#796) — at which point an
+  // MCP server's stderr could mark every profile in the pool exhausted.
+  if (BILLING_SIGNALS.some(rx => rx.test(lower))) {
     return {
       status: 402,
       type: "billing_error",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -50,7 +50,7 @@ import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError } from "./errors"
+import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
@@ -583,25 +583,37 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       })
   }
 
-  /** Inspect an inner response for a quota failure without destroying it.
-   *  Non-stream: a 429 body. Stream: an `event: error` frame with
-   *  rate_limit_error BEFORE any content frame (mid-content errors pass
-   *  through — never yank a stream a client is already consuming). */
-  async function sniffQuotaFailure(res: Response): Promise<{ failed: boolean; errorPayload: unknown; response: Response }> {
+  /** Inspect an inner response for an account-level failure without destroying
+   *  it. Non-stream: an error body on a non-OK status. Stream: an
+   *  `event: error` frame BEFORE any content frame (mid-content errors pass
+   *  through — never yank a stream a client is already consuming).
+   *
+   *  `isAccountFailoverError` decides which classified types are worth another
+   *  account; anything else is this account's honest answer and belongs to the
+   *  client untouched. The non-stream status gate is `!res.ok` rather than a
+   *  literal 429 because the qualifying types do not share one status — a
+   *  spent quota window is 429, a refused subscription 402. */
+  async function sniffAccountFailure(res: Response): Promise<
+    | { failed: true; errorPayload: unknown; errorType: string; response: Response }
+    | { failed: false; errorPayload: null; errorType: null; response: Response }
+  > {
     const contentType = res.headers.get("content-type") ?? ""
     if (!contentType.includes("text/event-stream")) {
-      if (res.status === 429) {
+      if (!res.ok) {
         const body = await res.clone().json().catch(() => null) as { error?: { type?: string } } | null
-        if (body?.error?.type === "rate_limit_error") return { failed: true, errorPayload: body, response: res }
+        const errorType = body?.error?.type
+        if (isAccountFailoverError(errorType)) {
+          return { failed: true, errorPayload: body, errorType, response: res }
+        }
       }
-      return { failed: false, errorPayload: null, response: res }
+      return { failed: false, errorPayload: null, errorType: null, response: res }
     }
     const reader = res.body?.getReader()
-    if (!reader) return { failed: false, errorPayload: null, response: res }
+    if (!reader) return { failed: false, errorPayload: null, errorType: null, response: res }
     const decoder = new TextDecoder()
     const consumed: Uint8Array[] = []
     let text = ""
-    let failedPayload: unknown = null
+    let failure: { payload: unknown; type: string } | null = null
     while (true) {
       const { done, value } = await reader.read()
       if (done) break
@@ -614,16 +626,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const dataLine = frame.split("\n").find(l => l.startsWith("data: "))
         try {
           const parsed = dataLine ? JSON.parse(dataLine.slice(6)) as { error?: { type?: string } } : null
-          if (parsed?.error?.type === "rate_limit_error") {
-            failedPayload = parsed
+          const parsedType = parsed?.error?.type
+          if (isAccountFailoverError(parsedType)) {
+            failure = { payload: parsed, type: parsedType }
           }
-        } catch { /* not a quota frame — pass through below */ }
+        } catch { /* not an account-failure frame — pass through below */ }
       }
       break // first complete frame decides
     }
-    if (failedPayload) {
+    if (failure) {
       await reader.cancel().catch(() => {})
-      return { failed: true, errorPayload: failedPayload, response: res }
+      return { failed: true, errorPayload: failure.payload, errorType: failure.type, response: res }
     }
     const rest = new ReadableStream<Uint8Array>({
       start(ctrl) { for (const chunk of consumed) ctrl.enqueue(chunk) },
@@ -634,44 +647,61 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       },
       cancel(reason) { void reader.cancel(reason).catch(() => {}) },
     })
-    return { failed: false, errorPayload: null, response: new Response(rest, { status: res.status, headers: res.headers }) }
+    return { failed: false, errorPayload: null, errorType: null, response: new Response(rest, { status: res.status, headers: res.headers }) }
   }
 
   async function dispatchPriority(c: Context, orderedCandidateIds: string[], sessionKey: string | null, wantsStream: boolean): Promise<Response> {
     const bodyBuf = await c.req.arrayBuffer()
     let lastError: unknown = null
+    let lastStatus = 429
     let previous: string | null = null
+    let previousReason = "rate_limit_error"
     for (const candidate of orderedCandidateIds) {
       const headers = new Headers(c.req.raw.headers)
       headers.set("x-meridian-profile", candidate)
       headers.set("x-meridian-priority-dispatch", "1")
       const inner = await app.fetch(new Request(c.req.url, { method: "POST", headers, body: bodyBuf }))
-      const { failed, errorPayload, response } = await sniffQuotaFailure(inner)
-      if (!failed) {
+      const sniffed = await sniffAccountFailure(inner)
+      if (!sniffed.failed) {
         if (sessionKey) priorityAssignments.set(sessionKey, candidate)
         if (previous) {
-          claudeLog("profile.failover", { from: previous, to: candidate, reason: "rate_limit_error", sessionKey })
-          plog(`[PROXY] PRIORITY failover ${previous} -> ${candidate}`)
+          claudeLog("profile.failover", { from: previous, to: candidate, reason: previousReason, sessionKey })
+          plog(`[PROXY] PRIORITY failover ${previous} -> ${candidate} (${previousReason})`)
         }
-        return response
+        return sniffed.response
       }
-      const cooldownUntil = priorityCooldownUntil(candidate, Date.now())
-      priorityExhaustion.mark(candidate, cooldownUntil, "rate_limit_error")
-      claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil })
-      refinePriorityCooldown(candidate)
-      lastError = errorPayload
+      const reason = sniffed.errorType
+      // Only a quota refusal has a reset to look up. Both cooldown tiers read
+      // the account's five-hour window, which says nothing about entitlement:
+      // a refused subscription would be suppressed until an unrelated quota
+      // boundary, and `refinePriorityCooldown` could only push that further
+      // out (`mark` lets a later refinement extend a cooldown, never shorten
+      // it). The conservative default stands instead, so the account is
+      // re-probed once the subscription may plausibly have been fixed.
+      const quotaRefusal = isQuotaRefusal(reason)
+      const cooldownUntil = quotaRefusal
+        ? priorityCooldownUntil(candidate, Date.now())
+        : Date.now() + PRIORITY_DEFAULT_COOLDOWN_MS
+      priorityExhaustion.mark(candidate, cooldownUntil, reason)
+      claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil, reason })
+      if (quotaRefusal) refinePriorityCooldown(candidate)
+      lastError = sniffed.errorPayload
+      lastStatus = inner.status
       previous = candidate
+      previousReason = reason
     }
     // Every candidate failed: surface the LAST tried profile's error (owner
     // decision). Stream sniff consumed the inner body, so reconstruct the
-    // exact frame for SSE requests; non-stream errors pass through as JSON.
+    // exact frame for SSE requests; non-stream errors pass through as JSON,
+    // carrying the status that came with them — a pool refused for billing
+    // must not reach the client as a 429 it would dutifully back off from.
     if (wantsStream) {
       return new Response(`event: error\ndata: ${JSON.stringify(lastError)}\n\n`, {
         status: 200,
         headers: { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache" },
       })
     }
-    return new Response(JSON.stringify(lastError), { status: 429, headers: { "content-type": "application/json" } })
+    return new Response(JSON.stringify(lastError), { status: lastStatus, headers: { "content-type": "application/json" } })
   }
   app.use("/auth/*", requireAuth)
 

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -193,7 +193,14 @@ function profileSection(q,s,pl,h){
       var orderIdx=(pl.profileOrder||[]).indexOf(p.id);
       if(orderIdx>=0)badge+='<span class="pool-chip">#'+(orderIdx+1)+' in pool</span>';
       var exh=(pl.exhausted||[]).filter(function(e){return e.id===p.id})[0];
-      if(exh)badge+=' <span class="pool-chip exhausted">exhausted · resets '+resetIn(exh.until)+'</span>';
+      if(exh){
+        // A billing refusal has no reset to wait for — the pool re-probes on the
+        // same timer, but nothing changes until a human fixes the account.
+        // Showing it as 'resets in 9m' promises a recovery that never comes.
+        badge+=exh.reason==='billing_error'
+          ?' <span class="pool-chip exhausted" title="Subscription or payment refused — this does not clear on its own">subscription refused</span>'
+          :' <span class="pool-chip exhausted">exhausted · resets '+resetIn(exh.until)+'</span>';
+      }
     }
     cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+'"'+(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
       +'<div class="profile-head"><span class="profile-name"><span class="prof-dot"></span>'+esc(p.label||p.id)+' '+badge+'</span>'


### PR DESCRIPTION
Cherry-picked from #796 by @justprosh, whose commit is preserved with their
authorship — `main` requires signed commits, so fork PRs cannot merge directly.
One fix on top.

Closes #796.

## The change

Priority routing failed over on quota exhaustion but not on an account-level
refusal, so a lapsed subscription (or a Team seat refusing third-party traffic)
was returned to the client while a healthy account sat unused. `billing_error`
now joins the failover set, with its own exhaustion reason so the two are
distinguishable, and the cooldown splits: a quota refusal names its own reset,
a billing one has nothing to look up.

The `!res.ok` widening, the `lastStatus` passthrough, and the mid-content stream
carve-out all check out.

## The fix on top

`classifyError` matched `billing`, `subscription` and `payment` as **bare
substrings anywhere in the text**, and that branch runs *before* the
process-crash and max-turns branches, so it won on any message containing one.
Until now that was a wrong status code and nothing more.

Putting `billing_error` in the failover set changes the stakes. Verified on the
branch — all of these classified as `billing_error` and triggered account
failover:

| Error text | Reality |
|---|---|
| max-turns while editing `subscription.ts` | a filename |
| `ENOENT ... /repo/src/billing/index.ts` | a path |
| fetch failure to a URL containing `/payment/` | a URL |
| `at handler.js:402:15` | a stack frame line number |

Each one marks **every** profile exhausted for ten minutes. A fully exhausted
pool makes `choosePriorityProfile` report `allExhausted`, which collapses the
candidate list to the first profile — so the *next* request, a genuine quota
refusal on the preferred account, is returned to the client with the healthy one
never tried. Failover breaks precisely when it is needed. Any MCP server's
stderr mentioning a payment API is enough.

Billing is now matched by phrase: a `402` not followed by `:digits` (so a stack
frame cannot pose as a status), `billing_error|issue|problem`, `subscription
inactive|expired|lapsed|cancelled`, `payment method|required|failed`, and the
extra-usage refusals. Nine cases pinned — four incidental mentions that must not
fail over, five real refusals that must.

This is the same weakness the rate-limit matcher had in #788, fixed the same
way: match the shape, not the token.

## Also

`GET /profiles/list` carried the new `reason`, but `landing.ts` never read it —
a billing refusal rendered as `exhausted · resets in 9m` and re-probed forever,
looking identical to the case that clears itself. It now reads
`subscription refused`, with a tooltip saying it will not clear on its own.

## Tests

Six new tests, all confirmed to fail against the unfixed classifier: four
incidental-mention cases, plus two integration tests proving the pool is not
spent and that a healthy account is still reachable afterwards. Full suite 2624
tests with only the pre-existing environment failures; typecheck clean.