### PR TITLE
fix(passthrough): stop announcing a truncated turn as a clean finish

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, extendedContextHint, classifyResumeRefusal, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
+import { canRecoverCapturedToolUses, classifyError, extendedContextHint, classifyResumeRefusal, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -176,6 +176,75 @@ describe("classifyError", () => {
       const r = classifyError(msg)
       expect(r.type).not.toBe("billing_error")
       expect(isAccountFailoverError(r.type)).toBe(false)
+    })
+  })
+
+  // #770: guardUpstreamIdle is meridian's own termination, not the SDK's. Its
+  // message matched none of the needles, so it landed on "unknown" — which
+  // excludes it from canRecoverAsToolUse and discards tool calls the hook had
+  // already captured.
+  describe("upstream idle termination", () => {
+    it("recognises the idle guard's own error and reads the idle window", () => {
+      const t = extractSdkTermination("upstream idle for 90001ms (limit 90000ms)")
+      expect(t.reason).toBe("upstream_idle")
+      expect(t.idleMs).toBe(90001)
+    })
+
+    it("recognises it when wrapped by the SDK error text", () => {
+      const t = extractSdkTermination("Error: upstream idle for 90001ms (limit 90000ms)\n    at guard.ts:1")
+      expect(t.reason).toBe("upstream_idle")
+    })
+
+    it("leaves the client-facing classification untouched", () => {
+      // The 504 upstream_timeout the client sees comes from an
+      // `instanceof UpstreamIdleError` branch in server.ts, NOT from
+      // classifyError — which still reads this as a generic api_error. #770 is
+      // about the termination reason only, so this pins that the wire status
+      // did not move with it.
+      const r = classifyError("upstream idle for 90001ms (limit 90000ms)")
+      expect(r.status).toBe(500)
+      expect(r.type).toBe("api_error")
+    })
+
+    it("does not swallow a max_turns error that mentions idling", () => {
+      const t = extractSdkTermination("Reached maximum number of turns (3) while waiting for an idle upstream")
+      expect(t.reason).toBe("max_turns")
+    })
+  })
+
+  describe("canRecoverCapturedToolUses", () => {
+    const base = { passthrough: true, capturedToolUses: 2, abortIsOurs: true } as const
+
+    it("recovers a turn-cap termination", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "max_turns" })).toBe(true)
+    })
+
+    // #770: the stall killed the stream, not the work already captured.
+    it("recovers an idle-guard termination", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "upstream_idle" })).toBe(true)
+    })
+
+    it("recovers our own abort but not a client disconnect", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "aborted", abortIsOurs: true })).toBe(true)
+      expect(canRecoverCapturedToolUses({ ...base, reason: "aborted", abortIsOurs: false })).toBe(false)
+    })
+
+    it("does not recover an unrecognised termination", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "unknown" })).toBe(false)
+    })
+
+    it("does not recover a process crash", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "process_exit" })).toBe(false)
+    })
+
+    // Without captured calls there is nothing to deliver, and outside
+    // passthrough the client does not execute tools at all.
+    it("requires captured tool calls", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "max_turns", capturedToolUses: 0 })).toBe(false)
+    })
+
+    it("requires passthrough", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "max_turns", passthrough: false })).toBe(false)
     })
   })
 

--- a/src/__tests__/proxy-stream-error-recovery.test.ts
+++ b/src/__tests__/proxy-stream-error-recovery.test.ts
@@ -135,6 +135,12 @@ describe("Stream error recovery after message_start", () => {
     // The error should still be present
     const errorEvent = events[errorIdx]
     expect((errorEvent?.data as any).error.type).toBe("rate_limit_error")
+
+    // #770: a turn that streamed text and THEN failed used to close with
+    // "end_turn" — the wire's word for a clean finish. The client commits a
+    // successful message and never retries. Partial output followed by a crash
+    // is a truncation, and nothing here can know the answer was complete.
+    expect((recoveryDelta?.data as any).delta.stop_reason).toBe("max_tokens")
   })
 
   it("should emit error immediately when message_start was NOT sent", async () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -348,11 +348,13 @@ export function isExtraUsageRequiredError(errMsg: string): boolean {
  * collapses into a generic api_error.
  */
 export interface SdkTermination {
-  reason: "max_turns" | "process_exit" | "aborted" | "unknown"
+  reason: "max_turns" | "process_exit" | "aborted" | "upstream_idle" | "unknown"
   /** Turn count when reason=max_turns and parseable. */
   turns?: number
   /** Exit code when reason=process_exit and parseable. */
   exitCode?: number
+  /** Milliseconds the upstream was silent, when reason=upstream_idle. */
+  idleMs?: number
   /** Captured "Subprocess stderr: …" tail (truncated). */
   stderrTail?: string
   /** Truncated raw error message — set only when reason="unknown" so the log
@@ -389,6 +391,44 @@ function makeRawTail(errMsg: string): string | undefined {
  * Returns reason="unknown" when the message doesn't match any recognized
  * pattern; callers can still log it with whatever surrounding context they have.
  */
+/**
+ * Can a failed passthrough turn still be delivered as a tool-use response?
+ *
+ * When the PreToolUse hook already captured tool calls, the client has
+ * everything it needs to run them and drive the next turn — so a terminated
+ * turn can end as a normal `stop_reason: "tool_use"` instead of a 500 with the
+ * calls thrown away.
+ *
+ * `upstream_idle` qualifies for exactly the same reason as `max_turns` (#770):
+ * the stall killed the stream, not the work already captured. Dropping those
+ * calls is what leaves the model resuming against its own unfulfilled promise
+ * and reporting that it "forgot".
+ *
+ * `abortIsOurs` exists because the two call sites disagree, deliberately: the
+ * streaming path accepts an abort only when meridian raised it (a duplicate
+ * tool_use or an early stop), since a client disconnect must never be recorded
+ * as a recovered success. The non-streaming path has no client-disconnect abort
+ * to distinguish and passes true.
+ */
+export function canRecoverCapturedToolUses(input: {
+  reason: SdkTermination["reason"]
+  passthrough: boolean
+  capturedToolUses: number
+  abortIsOurs: boolean
+}): boolean {
+  if (!input.passthrough) return false
+  if (input.capturedToolUses <= 0) return false
+  switch (input.reason) {
+    case "max_turns":
+    case "upstream_idle":
+      return true
+    case "aborted":
+      return input.abortIsOurs
+    default:
+      return false
+  }
+}
+
 export function extractSdkTermination(errMsg: string): SdkTermination {
   const stderrTail = extractStderrTail(errMsg)
 
@@ -396,6 +436,22 @@ export function extractSdkTermination(errMsg: string): SdkTermination {
   // (the SDK sometimes emits the operative phrase only into stderr).
   const haystack = `${errMsg}\n${stderrTail ?? ""}`
   const lower = haystack.toLowerCase()
+
+  // Meridian's own terminations, not the SDK's. guardUpstreamIdle raises this
+  // when the model stream goes quiet past the limit; the message matches none
+  // of the SDK needles below, so it used to land on "unknown" — which excludes
+  // it from canRecoverAsToolUse and silently DISCARDS any tool_use blocks the
+  // PreToolUse hook had already captured (#770). The client then never sees the
+  // calls, and the next turn resumes against a history where the model promised
+  // work it never appears to have requested.
+  if (lower.includes("upstream idle for")) {
+    const m = haystack.match(/upstream idle for (\d+)ms/i)
+    return {
+      reason: "upstream_idle",
+      ...(m ? { idleMs: Number(m[1]) } : {}),
+      ...(stderrTail ? { stderrTail } : {}),
+    }
+  }
 
   if (lower.includes("reached maximum number of turns")) {
     const m = haystack.match(/Reached maximum number of turns \((\d+)\)/i)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -51,7 +51,7 @@ import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
+import { canRecoverCapturedToolUses, classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
@@ -2208,10 +2208,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // that never triggered the loop-break (e.g. wide parallel exceeding
             // the turn budget) land here.
             const sdkTerm = extractSdkTermination(error instanceof Error ? error.message : String(error))
-            const canRecoverAsToolUse =
-              passthrough &&
-              capturedToolUses.length > 0 &&
-              (sdkTerm.reason === "max_turns" || sdkTerm.reason === "aborted")
+            const canRecoverAsToolUse = canRecoverCapturedToolUses({
+              reason: sdkTerm.reason,
+              passthrough,
+              capturedToolUses: capturedToolUses.length,
+              // No client-disconnect abort reaches this path.
+              abortIsOurs: true,
+            })
             if (canRecoverAsToolUse) {
               diagnosticLog.session(
                 `${requestMeta.requestId} sdk_termination_recovered ${formatSdkTermination(sdkTerm, {
@@ -3803,12 +3806,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // single-step duplicate abort (sawDuplicateToolUse) or the
               // early stop (earlyStopFired) — a client-disconnect abort must
               // not be recorded as a recovered success.
-              const canRecoverAsToolUse =
-                (sdkTerm.reason === "max_turns" ||
-                  (sdkTerm.reason === "aborted" && (sawDuplicateToolUse || earlyStopFired))) &&
-                passthrough &&
-                capturedToolUses.length > 0 &&
-                messageStartEmitted
+              // "upstream_idle" joins them for the same reason (#770): the guard
+              // killed a stalled stream, but the tool calls were already
+              // captured and are exactly what the client needs to make progress.
+              // Discarding them turns a recoverable stall into a turn the model
+              // later reports having "forgotten", because the next resume shows
+              // its promise to act with no matching call.
+              const canRecoverAsToolUse = canRecoverCapturedToolUses({
+                reason: sdkTerm.reason,
+                passthrough,
+                capturedToolUses: capturedToolUses.length,
+                abortIsOurs: sawDuplicateToolUse || earlyStopFired,
+              }) && messageStartEmitted
 
               if (canRecoverAsToolUse) {
                 // Log the recovery at session level (not error) — it's a
@@ -3968,11 +3977,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               //
               // A turn cut off mid-generation is exactly what "max_tokens"
               // describes on the wire — truncated, not finished — and every
-              // Anthropic-compatible client already handles it. Reserve
-              // "end_turn" for the case where the model really did produce a
-              // complete answer before the failure.
+              // Anthropic-compatible client already handles it.
+              //
+              // Unconditional, including when text was already forwarded (#770).
+              // The earlier carve-out reserved "end_turn" for "the model really
+              // did produce a complete answer before the failure", but nothing
+              // here can know that: reaching this branch means the turn raised
+              // instead of completing, and a partial answer followed by a crash
+              // is still a truncation. Emitting "end_turn" there was the one
+              // value that actively lies, and it lies in the direction that
+              // makes an autonomous loop stop.
               if (messageStartEmitted) {
-                const errorStopReason = textEventsForwarded > 0 ? "end_turn" : "max_tokens"
+                const errorStopReason = "max_tokens"
                 claudeLog("response.error_envelope", {
                   mode: "stream",
                   stopReason: errorStopReason,


### PR DESCRIPTION
Closes #770, reported by @justprosh.

Of the three directions the issue lists, **one is already done**: emitting the
`error` event before `message_delta`/`message_stop` landed in #793, from
@justprosh's own #768 commits. This PR does the other two.

## 1. A truncated turn no longer claims `end_turn`

`stop_reason` was `textEventsForwarded > 0 ? "end_turn" : "max_tokens"`, so a
turn that streamed some text and *then* failed closed with the wire's word for
"the model finished and had nothing more to say". The client commits a
successful message and never retries; an autonomous loop reads a crashed turn as
a completed one.

Reaching that branch means the turn raised instead of completing, and nothing
there can know whether the answer was complete. It is `max_tokens`
unconditionally now — the honest description of a truncation, and already what
this same path sent when no text had been forwarded, so clients are not seeing a
new value from Meridian.

## 2. An idle-guard kill no longer discards captured tool calls

`guardUpstreamIdle` is Meridian's own termination, not the SDK's, and
`upstream idle for 90001ms (limit 90000ms)` matches none of
`extractSdkTermination`'s needles — so it fell through to `"unknown"`, which is
excluded from the tool-use recovery. Any `tool_use` blocks the PreToolUse hook
had already captured were **thrown away**.

That is the production case in the issue: the client never sees the calls, and
the next resume shows the model its own promise to act with no corresponding
call — which is why it then reports having "forgotten". As @justprosh notes, it
reports that whatever the real cause, so the self-diagnosis is actively
misleading.

It now classifies as `upstream_idle` and recovers exactly as `max_turns` does:
the stall killed the stream, not the work already captured.

## Extraction

The recovery gate moved to `canRecoverCapturedToolUses` in `errors.ts` so both
call sites share one definition and it can be tested directly.

They had drifted: the streaming path accepts an abort only when Meridian raised
it (duplicate tool_use or early stop), because a client disconnect must never be
recorded as a recovered success; the non-streaming path has no
client-disconnect abort to distinguish. That difference is **preserved**, now
expressed as an `abortIsOurs` argument instead of living implicitly in two
copies.

## On regressions

- Nothing in the suite pinned `end_turn` for the text-then-error case; the
  existing test asserts ordering and usage only. It now also asserts
  `max_tokens`.
- The client-facing `504 upstream_timeout` comes from an
  `instanceof UpstreamIdleError` branch in `server.ts`, not from
  `classifyError` — a test pins that this change did not move it.
- Every new assertion was confirmed to fail against the unfixed code, including
  reverting *only* the `upstream_idle` case to check that specific test.
- Full suite 2635 tests with only the pre-existing environment failures;
  typecheck clean; live stream E2E re-run clean (recovery, ordering, and
  post-recovery resume all intact, no envelope problems).