### PR TITLE
fix(replay): restore tool-call attribution for pi, bash, and code tools

### DIFF
--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -311,6 +311,65 @@ describe("buildToolUseIndex / tool-result attribution (#552)", () => {
     expect(describeToolCall({ name: "custom", target: undefined, contentSummary: undefined })).toBe("[your custom]")
   })
 
+  // A code-execution tool's whole payload is the `code` field. Without it in
+  // TOOL_TARGET_KEYS every call replayed as the same bare `[your ipython]`:
+  // the model could not tell which cell produced which result, nor that it had
+  // already run one, and re-ran the first cell indefinitely.
+  it("attributes code-execution tools by the code they ran", () => {
+    const idx = buildToolUseIndex([
+      { role: "assistant", content: [{ type: "tool_use", id: "c1", name: "ipython", input: { code: "2+2" } }] },
+      { role: "assistant", content: [{ type: "tool_use", id: "c2", name: "ipython", input: { code: "3+3" } }] },
+    ])
+    expect(idx.get("c1")).toEqual({ name: "ipython", target: "2+2", contentSummary: undefined })
+    expect(idx.get("c2")).toEqual({ name: "ipython", target: "3+3", contentSummary: undefined })
+
+    const labels = [...idx.values()].map(describeToolCall)
+    expect(new Set(labels).size).toBe(2)
+    expect(labels).toEqual(["[your ipython 2+2]", "[your ipython 3+3]"])
+  })
+
+  // The label is rendered inline in a single-line bracket. A multi-line value
+  // used to embed raw newlines into the replayed prompt, breaking the compact
+  // shape #111/#386 rely on. Affects `command` for every bash-using adapter,
+  // not just code tools.
+  it("keeps multi-line targets on one line", () => {
+    const idx = buildToolUseIndex([
+      { role: "assistant", content: [
+        { type: "tool_use", id: "b1", name: "bash", input: { command: "echo one\necho two\necho three" } },
+        { type: "tool_use", id: "b2", name: "ipython", input: { code: "import os\nprint(os.getcwd())" } },
+      ] },
+    ])
+    for (const id of ["b1", "b2"]) {
+      const label = describeToolCall(idx.get(id)!)
+      expect(label).not.toContain("\n")
+      expect(label.startsWith("[")).toBe(true)
+      expect(label.endsWith("]")).toBe(true)
+    }
+    expect(idx.get("b1")!.target).toBe("echo one echo two echo three")
+    expect(idx.get("b2")!.target).toBe("import os print(os.getcwd())")
+  })
+
+  it("still truncates long targets to the 80-char budget after collapsing", () => {
+    const idx = buildToolUseIndex([
+      { role: "assistant", content: [
+        { type: "tool_use", id: "t1", name: "ipython", input: { code: "x = 1\n".repeat(100) } },
+      ] },
+    ])
+    const target = idx.get("t1")!.target!
+    expect(target.length).toBeLessThanOrEqual(80)
+    expect(target.endsWith("...")).toBe(true)
+    expect(target).not.toContain("\n")
+  })
+
+  it("ignores a whitespace-only target and falls through to the next key", () => {
+    const idx = buildToolUseIndex([
+      { role: "assistant", content: [
+        { type: "tool_use", id: "t1", name: "runner", input: { command: "   \n  ", code: "print(1)" } },
+      ] },
+    ])
+    expect(idx.get("t1")!.target).toBe("print(1)")
+  })
+
   it("returns an empty index for non-array and toolless content", () => {
     expect(buildToolUseIndex([{ role: "user", content: "hi" }]).size).toBe(0)
     expect(buildToolUseIndex([]).size).toBe(0)

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -361,6 +361,37 @@ describe("buildToolUseIndex / tool-result attribution (#552)", () => {
     expect(target).not.toContain("\n")
   })
 
+  // Pi's edit tool sends oldText/newText — confirmed from a real ~/.pi session
+  // transcript. It matched neither newString nor new_string, so every Pi edit
+  // replayed with no content summary: the #496 failure where the model knows it
+  // edited a file but not what it wrote, and re-derives near-duplicate edits.
+  it("summarises an edit under every spelling of the replacement field", () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["new_string", { path: "a.ts", old_string: "x", new_string: "const a = 2" }],
+      ["newString", { path: "a.ts", oldString: "x", newString: "const a = 2" }],
+      ["new_text", { path: "a.ts", old_text: "x", new_text: "const a = 2" }],
+      ["newText", { path: "a.ts", oldText: "x", newText: "const a = 2" }],
+    ]
+    for (const [label, input] of cases) {
+      const idx = buildToolUseIndex([
+        { role: "assistant", content: [{ type: "tool_use", id: "e", name: "edit", input }] },
+      ])
+      expect(idx.get("e")).toEqual({ name: "edit", target: "a.ts", contentSummary: "const a = 2" })
+      expect(describeToolCall(idx.get("e")!)).toBe(`[your edit a.ts → "const a = 2"]`)
+      if (label === "newText") expect(idx.get("e")!.contentSummary).toBeDefined()
+    }
+  })
+
+  it("summarises multiedit under the same spellings", () => {
+    const idx = buildToolUseIndex([
+      { role: "assistant", content: [{
+        type: "tool_use", id: "m", name: "multiedit",
+        input: { path: "a.ts", edits: [{ oldText: "x", newText: "first change" }, { oldText: "y", newText: "second" }] },
+      }] },
+    ])
+    expect(idx.get("m")!.contentSummary).toBe("2 edits; first: first change")
+  })
+
   it("ignores a whitespace-only target and falls through to the next key", () => {
     const idx = buildToolUseIndex([
       { role: "assistant", content: [

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -327,11 +327,44 @@ export interface ToolCallInfo {
   contentSummary: string | undefined
 }
 
-/** Input keys that identify what a tool call operated on, in priority order. */
-const TOOL_TARGET_KEYS = ["filePath", "file_path", "path", "command", "pattern", "query", "url"] as const
+/**
+ * Input keys that identify what a tool call operated on, in priority order.
+ *
+ * `code` covers tools whose whole payload is a program rather than a path or a
+ * shell line — Prime Agent's `ipython`, and notebook/REPL tools generally. Its
+ * omission was not cosmetic: with no matching key the target is undefined and
+ * `extractContentSummary` has no case either, so EVERY call from such a tool
+ * replayed as the same bare `[your ipython]`. The model could not tell which
+ * cell produced which result, nor that it had already run one, and re-ran the
+ * first cell indefinitely (observed: `2+2` seven times in one turn).
+ */
+const TOOL_TARGET_KEYS = ["filePath", "file_path", "path", "command", "code", "pattern", "query", "url"] as const
+
+/** Max length of a replayed target label, including the "..." marker. */
+const TOOL_TARGET_MAX = 80
 
 /** Max length of a replayed content summary (before the "..." marker). */
 const CONTENT_SUMMARY_MAX = 120
+
+/**
+ * Normalize a tool-call target for the single-line `[your bash …]` label.
+ *
+ * Collapsing whitespace is what keeps the attribution on one line. A
+ * multi-line value — a heredoc, a `&&` chain split across lines, an `ipython`
+ * cell — previously embedded raw newlines straight into the replayed prompt,
+ * breaking the compact bracketed shape that #111/#386 depend on for the model
+ * to read it as context rather than as tool syntax to imitate.
+ *
+ * Truncation math is unchanged from the original inline slice (77 + "..." =
+ * 80), so labels that were already single-line render byte-identically.
+ */
+function normalizeTarget(value: string): string | undefined {
+  const collapsed = value.replace(/\s+/g, " ").trim()
+  if (!collapsed) return undefined
+  return collapsed.length > TOOL_TARGET_MAX
+    ? collapsed.slice(0, TOOL_TARGET_MAX - 3) + "..."
+    : collapsed
+}
 
 /** Collapse whitespace runs to single spaces and truncate. */
 function summarizeContent(value: unknown): string | undefined {
@@ -390,8 +423,8 @@ export function buildToolUseIndex(
         for (const key of TOOL_TARGET_KEYS) {
           const v = (input as Record<string, unknown>)[key]
           if (typeof v === "string" && v) {
-            target = v.length > 80 ? v.slice(0, 77) + "..." : v
-            break
+            target = normalizeTarget(v)
+            if (target) break
           }
         }
       }

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -375,6 +375,24 @@ function summarizeContent(value: unknown): string | undefined {
 }
 
 /**
+ * The replacement text of an edit, under any of the spellings harnesses use.
+ *
+ * Harnesses disagree on this field name and the disagreement is silent: a
+ * miss yields no summary at all, and the replay then tells the model THAT it
+ * edited a file but not WHAT it wrote — the #496 failure where it re-derives
+ * near-duplicate edits and confabulates a parallel editor.
+ *
+ * `new_string` is Claude Code's; `newText` is Pi's — confirmed from a real
+ * `~/.pi` session transcript (`edit: path, oldText, newText`), which matched
+ * neither existing key, so every Pi edit replayed summary-less. Both casings of
+ * both nouns are accepted rather than adding them one incident at a time.
+ */
+function editReplacementText(rec: Record<string, unknown> | null | undefined): unknown {
+  if (!rec) return undefined
+  return rec.new_string ?? rec.newString ?? rec.new_text ?? rec.newText
+}
+
+/**
  * Extract a content summary for mutating tools. Non-mutating tools (read,
  * bash, grep, ...) return undefined — their target alone identifies the call.
  */
@@ -383,14 +401,14 @@ function extractContentSummary(name: string, input: unknown): string | undefined
   const rec = input as Record<string, unknown>
   switch (name.toLowerCase()) {
     case "edit":
-      return summarizeContent(rec.newString ?? rec.new_string)
+      return summarizeContent(editReplacementText(rec))
     case "write":
       return summarizeContent(rec.content)
     case "multiedit": {
       const edits = rec.edits
       if (!Array.isArray(edits) || edits.length === 0) return undefined
       const first = edits[0] as Record<string, unknown> | null | undefined
-      const firstSummary = summarizeContent(first?.newString ?? first?.new_string)
+      const firstSummary = summarizeContent(editReplacementText(first))
       if (!firstSummary) return undefined
       return edits.length > 1 ? `${edits.length} edits; first: ${firstSummary}` : firstSummary
     }


### PR DESCRIPTION
## What

Three gaps in the replayed tool-result attribution from #590/#496. Each one silently drops information the model needs to recognise its own prior tool calls when a conversation is replayed into a fresh session — and since the replay deliberately strips the assistant's `tool_use` blocks (#111/#386), that attribution is the *only* record the model gets.

### 1. Pi's edits replayed with no content summary

`extractContentSummary` read only `newString ?? new_string`. Pi's `edit` sends `oldText` / `newText` — confirmed from a real `~/.pi` session transcript:

```
edit           path, oldText, newText
```

Neither key matched, so every Pi edit lost its summary:

```
[your edit src/app.ts]                    <- pi edit: no content
[your write src/new.ts → "export const…"] <- pi write: fine (uses `content`)
```

This is precisely the #496 failure the surrounding comment warns about: the model is told *that* it edited a file but not *what* it wrote, so it re-derives near-duplicate edits and confabulates a parallel editor when it doesn't recognise its own wording.

Now accepts all four spellings (`new_string`, `newString`, `new_text`, `newText`) rather than adding them one incident at a time, and applies the same to `multiedit`'s inner edits.

### 2. Code-execution tools got no attribution at all

`TOOL_TARGET_KEYS` had no `code` entry, and `extractContentSummary` has no case for such tools, so every call rendered identically:

```
t1  ->  [your ipython]
t2  ->  [your ipython]
t3  ->  [your ipython]
```

**Observed live** against Prime Agent (whose only tool is `ipython`): asked to run three distinct cells, the model ran `2+2`, received `4`, and ran `2+2` again — seven times in one turn, because nothing in the replay told it what it had already run.

After: `[your ipython 2+2]`, `[your ipython 3+3]`, `[your ipython print(open('a.txt','w').write('hi'))]`.

### 3. Multi-line targets injected raw newlines into the prompt

`target` was a raw `slice(0, 77)` with no whitespace collapsing, unlike `summarizeContent` which does collapse:

```
"[your bash echo one\necho two\necho three]"
```

That breaks the compact single-line bracket the label depends on to read as context rather than as tool syntax to imitate. **Affects `command` on every bash-using adapter** — OpenCode, Crush, Droid, ForgeCode.

## Compatibility

Target truncation math is unchanged (77 + `...` = 80), so any label that was already single-line renders byte-identically. Only other behaviour change: a whitespace-only target value now falls through to the next key instead of becoming a whitespace label.

## Not verified

OpenCode's and Crush's edit/write key names could not be confirmed — their on-disk transcripts don't retain tool inputs in a readable form. They may or may not already match; this PR neither fixes nor breaks them.

## Testing

Seven new tests in `messages.test.ts`, each mutation-checked against the unfixed code:

- reverting the edit-field aliases fails 2
- removing `code` from `TOOL_TARGET_KEYS` fails 4
- removing the whitespace collapse fails 2

`messages.test.ts` 66/66. Full suite 2488 pass / 1 fail — that failure is `priority cooldown resolution > does not attempt an OAuth usage fetch for a non-claude-max profile (#699)`, which reproduces identically on untouched `origin/main` (verified in a clean worktree) and is unrelated.