### PR TITLE
feat(profiles): say what plan an account is on, and how much usage it buys

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,6 +31,10 @@ Open the printed URL in a browser, sign in to the target Claude account, then pa
 meridian profile login work --headless
 ```
 
+The same login also records the account's plan (`subscriptionType`, `rateLimitTier`), read from Anthropic's OAuth profile endpoint — the token exchange itself returns no plan information. That is what lets `meridian profile list`, `/profiles/list`, `/health` and the dashboard tell a Max account from a Team one, and what makes `/v1/models` advertise the larger context window Max accounts actually have. If the lookup fails the login still succeeds and the plan simply stays unknown.
+
+> **⚠ A profile created by an older Meridian has no plan recorded, and a token refresh cannot backfill it** — the value is only ever written at login, and Anthropic's usage endpoint does not carry it. Re-run `meridian profile login <name> --headless` to repair such a profile.
+
 #### Headless / CI: register an OAuth token
 
 When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:

--- a/src/__tests__/plan-allowance.test.ts
+++ b/src/__tests__/plan-allowance.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the plan → allotment multiplier derivation.
+ *
+ * The module is pure, so these are direct assertions with no mocks. The cases
+ * that matter are the ones where a wrong answer is worse than no answer: a
+ * `max` that could be 5x or 20x, and a tier string Anthropic has not shipped
+ * yet.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { normalizeRateLimitTier, planAllowance } from "../proxy/planAllowance"
+
+describe("normalizeRateLimitTier", () => {
+  it("strips the wire prefix and the underscores", () => {
+    expect(normalizeRateLimitTier("default_claude_max_20x")).toBe("max 20x")
+    expect(normalizeRateLimitTier("default_team_tier_1")).toBe("team tier 1")
+  })
+
+  it("accepts the bare spelling of the same tier", () => {
+    expect(normalizeRateLimitTier("max_5x")).toBe("max 5x")
+    expect(normalizeRateLimitTier("MAX_5X")).toBe("max 5x")
+  })
+
+  it("treats absent and blank as unknown rather than as a tier", () => {
+    expect(normalizeRateLimitTier(null)).toBeNull()
+    expect(normalizeRateLimitTier(undefined)).toBeNull()
+    expect(normalizeRateLimitTier("   ")).toBeNull()
+  })
+})
+
+describe("planAllowance", () => {
+  it("derives every published Claude Code allotment", () => {
+    expect(planAllowance({ rateLimitTier: "default_claude_max_20x" }))
+      .toEqual({ multiplier: "20x", weight: 20, label: "Personal Max" })
+    expect(planAllowance({ rateLimitTier: "default_claude_max_5x" }))
+      .toEqual({ multiplier: "5x", weight: 5, label: "Personal Max" })
+    expect(planAllowance({ rateLimitTier: "default_claude_pro" }))
+      .toEqual({ multiplier: "1x", weight: 1, label: "Personal Pro" })
+    expect(planAllowance({ rateLimitTier: "team_tier_1" }))
+      .toEqual({ multiplier: "6.25x", weight: 6.25, label: "Team Premium" })
+    expect(planAllowance({ rateLimitTier: "team_premium" }))
+      .toEqual({ multiplier: "6.25x", weight: 6.25, label: "Team Premium" })
+    expect(planAllowance({ rateLimitTier: "team_standard" }))
+      .toEqual({ multiplier: "1x", weight: 1, label: "Team Standard" })
+  })
+
+  it("prefers the tier over the subscription type when both are present", () => {
+    // `subscriptionType: "max"` alone cannot distinguish 5x from 20x, so the
+    // tier has to win — this is the case the whole module exists for.
+    expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "max" }).multiplier)
+      .toBe("5x")
+  })
+
+  it("never calls a Team seat Personal, however its tier is spelled", () => {
+    // Measured on a ten-account host: two Team profiles report
+    // `subscriptionType: "team"` with `rateLimitTier: "default_claude_max_5x"`.
+    // The size is genuinely 5x; the name "Personal Max" is not, and a reader
+    // deciding whose allotment to spend acts on the name.
+    expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "team" }))
+      .toEqual({ multiplier: "5x", weight: 5, label: "Team" })
+    expect(planAllowance({ rateLimitTier: "default_claude_max_20x", subscriptionType: "team" }))
+      .toEqual({ multiplier: "20x", weight: 20, label: "Team" })
+    expect(planAllowance({ rateLimitTier: "team_standard", subscriptionType: "max" }))
+      .toEqual({ multiplier: "1x", weight: 1, label: "Personal" })
+    expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "enterprise" }))
+      .toEqual({ multiplier: "5x", weight: 5, label: "Enterprise" })
+  })
+
+  it("keeps the tier's own label when the two agree", () => {
+    expect(planAllowance({ rateLimitTier: "default_claude_max_20x", subscriptionType: "max" }).label)
+      .toBe("Personal Max")
+    expect(planAllowance({ rateLimitTier: "team_tier_1", subscriptionType: "team" }).label)
+      .toBe("Team Premium")
+    expect(planAllowance({ rateLimitTier: "default_claude_pro", subscriptionType: "pro" }).label)
+      .toBe("Personal Pro")
+  })
+
+  it("keeps the tier's label when the subscription type says nothing usable", () => {
+    expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "something_new" }).label)
+      .toBe("Personal Max")
+    expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "  " }).label)
+      .toBe("Personal Max")
+  })
+
+  it("reports max and team as unknown when only the subscription type is known", () => {
+    expect(planAllowance({ subscriptionType: "max" })).toEqual({ multiplier: null, weight: null, label: null })
+    expect(planAllowance({ subscriptionType: "team" })).toEqual({ multiplier: null, weight: null, label: null })
+    expect(planAllowance({ subscriptionType: "enterprise" })).toEqual({ multiplier: null, weight: null, label: null })
+  })
+
+  it("falls back to the subscription type for the one tier it pins", () => {
+    expect(planAllowance({ subscriptionType: "pro" }))
+      .toEqual({ multiplier: "1x", weight: 1, label: "Personal Pro" })
+  })
+
+  it("returns nothing rather than a default for a tier it does not know", () => {
+    expect(planAllowance({ rateLimitTier: "default_claude_max_50x" }))
+      .toEqual({ multiplier: null, weight: null, label: null })
+    expect(planAllowance({})).toEqual({ multiplier: null, weight: null, label: null })
+    expect(planAllowance(null)).toEqual({ multiplier: null, weight: null, label: null })
+    expect(planAllowance(undefined)).toEqual({ multiplier: null, weight: null, label: null })
+  })
+
+  it("hands back a fresh object so a caller cannot corrupt the table", () => {
+    const first = planAllowance({ rateLimitTier: "default_claude_max_20x" })
+    first.multiplier = "1x"
+    expect(planAllowance({ rateLimitTier: "default_claude_max_20x" }).multiplier).toBe("20x")
+  })
+})

--- a/src/__tests__/plan-allowance.test.ts
+++ b/src/__tests__/plan-allowance.test.ts
@@ -31,17 +31,75 @@ describe("normalizeRateLimitTier", () => {
 describe("planAllowance", () => {
   it("derives every published Claude Code allotment", () => {
     expect(planAllowance({ rateLimitTier: "default_claude_max_20x" }))
-      .toEqual({ multiplier: "20x", weight: 20, label: "Personal Max" })
+      .toEqual({ multiplier: "20x", weight: 20, label: "Personal Max", accountType: "Personal", planName: "Max 20x" })
     expect(planAllowance({ rateLimitTier: "default_claude_max_5x" }))
-      .toEqual({ multiplier: "5x", weight: 5, label: "Personal Max" })
+      .toEqual({ multiplier: "5x", weight: 5, label: "Personal Max", accountType: "Personal", planName: "Max 5x" })
     expect(planAllowance({ rateLimitTier: "default_claude_pro" }))
-      .toEqual({ multiplier: "1x", weight: 1, label: "Personal Pro" })
+      .toEqual({ multiplier: "1x", weight: 1, label: "Personal Pro", accountType: "Personal", planName: "Pro" })
     expect(planAllowance({ rateLimitTier: "team_tier_1" }))
-      .toEqual({ multiplier: "6.25x", weight: 6.25, label: "Team Premium" })
+      .toEqual({ multiplier: "6.25x", weight: 6.25, label: "Team Premium", accountType: "Team", planName: "Premium seat" })
     expect(planAllowance({ rateLimitTier: "team_premium" }))
-      .toEqual({ multiplier: "6.25x", weight: 6.25, label: "Team Premium" })
+      .toEqual({ multiplier: "6.25x", weight: 6.25, label: "Team Premium", accountType: "Team", planName: "Premium seat" })
     expect(planAllowance({ rateLimitTier: "team_standard" }))
-      .toEqual({ multiplier: "1x", weight: 1, label: "Team Standard" })
+      .toEqual({ multiplier: "1x", weight: 1, label: "Team Standard", accountType: "Team", planName: "Standard seat" })
+  })
+
+  it("sizes a Team seat from seatTier, which rateLimitTier cannot do", () => {
+    // Measured across eleven live accounts: every Team seat reports
+    // `rate_limit_tier: "default_claude_max_5x"` — byte-identical to a personal
+    // Max 5x — while `seat_tier` carries `team_tier_1`. Sizing a Premium seat
+    // off the rate-limit tier understates it by 25% and names it Personal.
+    expect(planAllowance({
+      rateLimitTier: "default_claude_max_5x",
+      seatTier: "team_tier_1",
+      subscriptionType: "team",
+    })).toEqual({
+      multiplier: "6.25x", weight: 6.25, label: "Team Premium",
+      accountType: "Team", planName: "Premium seat",
+    })
+  })
+
+  // The falsification test, and it is the whole reason to trust `seatTier`: a
+  // real Team STANDARD seat was measured beside the four Premium ones, and it
+  // differs in `seat_tier` alone. Its `rate_limit_tier` is `default_raven`, an
+  // Anthropic codename naming no published allotment - so the rate-limit tier
+  // cannot size EITHER kind of Team seat, one because it lies and one because
+  // it says nothing.
+  it("sizes a Team Standard seat whose rateLimitTier names no known tier", () => {
+    expect(planAllowance({
+      rateLimitTier: "default_raven",
+      seatTier: "team_standard",
+      subscriptionType: "team",
+    })).toEqual({
+      multiplier: "1x", weight: 1, label: "Team Standard",
+      accountType: "Team", planName: "Standard seat",
+    })
+  })
+
+  // Both spellings reach the same seat, since `seat_tier` is already scoped to
+  // a team - a bare `standard` there means what `team_standard` means.
+  it("accepts a seat tier spelled with or without its team prefix", () => {
+    expect(planAllowance({ seatTier: "standard" }).planName).toBe("Standard seat")
+    expect(planAllowance({ seatTier: "team_standard" }).planName).toBe("Standard seat")
+    expect(planAllowance({ seatTier: "premium" }).planName).toBe("Premium seat")
+  })
+
+  it("ignores a seat tier on an account that has none, rather than guessing", () => {
+    expect(planAllowance({ rateLimitTier: "default_claude_max_20x", seatTier: null }))
+      .toEqual({
+        multiplier: "20x", weight: 20, label: "Personal Max",
+        accountType: "Personal", planName: "Max 20x",
+      })
+  })
+
+  it("reads a bare seat tier as the team tier of that name", () => {
+    expect(planAllowance({ seatTier: "standard", subscriptionType: "team" }).planName).toBe("Standard seat")
+    expect(planAllowance({ seatTier: "premium", subscriptionType: "team" }).multiplier).toBe("6.25x")
+  })
+
+  it("leaves a personal account to its rate limit tier, since its seat tier is null", () => {
+    expect(planAllowance({ rateLimitTier: "default_claude_max_20x", seatTier: null, subscriptionType: "max" }))
+      .toEqual({ multiplier: "20x", weight: 20, label: "Personal Max", accountType: "Personal", planName: "Max 20x" })
   })
 
   it("prefers the tier over the subscription type when both are present", () => {
@@ -57,13 +115,13 @@ describe("planAllowance", () => {
     // The size is genuinely 5x; the name "Personal Max" is not, and a reader
     // deciding whose allotment to spend acts on the name.
     expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "team" }))
-      .toEqual({ multiplier: "5x", weight: 5, label: "Team" })
+      .toEqual({ multiplier: "5x", weight: 5, label: "Team", accountType: "Team", planName: null })
     expect(planAllowance({ rateLimitTier: "default_claude_max_20x", subscriptionType: "team" }))
-      .toEqual({ multiplier: "20x", weight: 20, label: "Team" })
+      .toEqual({ multiplier: "20x", weight: 20, label: "Team", accountType: "Team", planName: null })
     expect(planAllowance({ rateLimitTier: "team_standard", subscriptionType: "max" }))
-      .toEqual({ multiplier: "1x", weight: 1, label: "Personal" })
+      .toEqual({ multiplier: "1x", weight: 1, label: "Personal", accountType: "Personal", planName: null })
     expect(planAllowance({ rateLimitTier: "default_claude_max_5x", subscriptionType: "enterprise" }))
-      .toEqual({ multiplier: "5x", weight: 5, label: "Enterprise" })
+      .toEqual({ multiplier: "5x", weight: 5, label: "Enterprise", accountType: "Enterprise", planName: null })
   })
 
   it("keeps the tier's own label when the two agree", () => {
@@ -82,23 +140,26 @@ describe("planAllowance", () => {
       .toBe("Personal Max")
   })
 
-  it("reports max and team as unknown when only the subscription type is known", () => {
-    expect(planAllowance({ subscriptionType: "max" })).toEqual({ multiplier: null, weight: null, label: null })
-    expect(planAllowance({ subscriptionType: "team" })).toEqual({ multiplier: null, weight: null, label: null })
-    expect(planAllowance({ subscriptionType: "enterprise" })).toEqual({ multiplier: null, weight: null, label: null })
+  it("still names the family when the size is unknowable from the subscription type alone", () => {
+    expect(planAllowance({ subscriptionType: "max" }))
+      .toEqual({ multiplier: null, weight: null, label: null, accountType: "Personal", planName: null })
+    expect(planAllowance({ subscriptionType: "team" }))
+      .toEqual({ multiplier: null, weight: null, label: null, accountType: "Team", planName: null })
+    expect(planAllowance({ subscriptionType: "enterprise" }))
+      .toEqual({ multiplier: null, weight: null, label: null, accountType: "Enterprise", planName: null })
   })
 
   it("falls back to the subscription type for the one tier it pins", () => {
     expect(planAllowance({ subscriptionType: "pro" }))
-      .toEqual({ multiplier: "1x", weight: 1, label: "Personal Pro" })
+      .toEqual({ multiplier: "1x", weight: 1, label: "Personal Pro", accountType: "Personal", planName: "Pro" })
   })
 
   it("returns nothing rather than a default for a tier it does not know", () => {
     expect(planAllowance({ rateLimitTier: "default_claude_max_50x" }))
-      .toEqual({ multiplier: null, weight: null, label: null })
-    expect(planAllowance({})).toEqual({ multiplier: null, weight: null, label: null })
-    expect(planAllowance(null)).toEqual({ multiplier: null, weight: null, label: null })
-    expect(planAllowance(undefined)).toEqual({ multiplier: null, weight: null, label: null })
+      .toEqual({ multiplier: null, weight: null, label: null, accountType: null, planName: null })
+    expect(planAllowance({})).toEqual({ multiplier: null, weight: null, label: null, accountType: null, planName: null })
+    expect(planAllowance(null)).toEqual({ multiplier: null, weight: null, label: null, accountType: null, planName: null })
+    expect(planAllowance(undefined)).toEqual({ multiplier: null, weight: null, label: null, accountType: null, planName: null })
   })
 
   it("hands back a fresh object so a caller cannot corrupt the table", () => {

--- a/src/__tests__/profile-login-plan-fields.test.ts
+++ b/src/__tests__/profile-login-plan-fields.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for the plan fields a headless OAuth login persists.
+ *
+ * Anthropic's token endpoint returns no plan information, so the headless login
+ * reads it from `/api/oauth/profile` and writes `subscriptionType` /
+ * `rateLimitTier` alongside the tokens. Network is swapped via
+ * `globalThis.fetch`; the credential-building step is pure and asserted directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import {
+  buildLoginCredentials,
+  extractPlanFields,
+  fetchOAuthPlanFields,
+  subscriptionTypeFromOrganizationType,
+} from "../proxy/profileCli"
+import type { CredentialStore } from "../proxy/tokenRefresh"
+
+/** Assign a mock to globalThis.fetch without TS complaining about `preconnect`. */
+function mockFetch(fn: (...args: unknown[]) => Promise<Response | never>): void {
+  globalThis.fetch = fn as typeof fetch
+}
+
+function makeSuccessResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const TOKEN_DATA = {
+  access_token: "the-access-token",
+  refresh_token: "the-refresh-token",
+  expires_in: 3600,
+  scope: "user:profile user:inference",
+}
+
+const MAX_PROFILE = {
+  organization: {
+    organization_type: "claude_max",
+    rate_limit_tier: "default_claude_max_20x",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// organization_type → subscriptionType
+// ---------------------------------------------------------------------------
+
+describe("subscriptionTypeFromOrganizationType", () => {
+  it("strips the claude_ prefix the CLI also strips", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_max")).toBe("max")
+    expect(subscriptionTypeFromOrganizationType("claude_pro")).toBe("pro")
+    expect(subscriptionTypeFromOrganizationType("claude_team")).toBe("team")
+    expect(subscriptionTypeFromOrganizationType("claude_enterprise")).toBe("enterprise")
+  })
+
+  it("returns undefined rather than guessing at an unknown plan", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_something_new")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("max")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(null)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(undefined)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("")).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Profile body → plan fields (snake_case on the wire, camelCase on disk)
+// ---------------------------------------------------------------------------
+
+describe("extractPlanFields", () => {
+  it("translates the snake_case wire names to the camelCase on-disk names", () => {
+    expect(extractPlanFields(MAX_PROFILE)).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("distinguishes a team account from a max one", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_team" } }))
+      .toEqual({ subscriptionType: "team" })
+  })
+
+  it("keeps the tier when only the plan is unrecognized", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_future", rate_limit_tier: "some_tier" } }))
+      .toEqual({ rateLimitTier: "some_tier" })
+  })
+
+  it("returns an empty object for an absent or empty organization", () => {
+    expect(extractPlanFields(null)).toEqual({})
+    expect(extractPlanFields(undefined)).toEqual({})
+    expect(extractPlanFields({})).toEqual({})
+    expect(extractPlanFields({ organization: null })).toEqual({})
+    expect(extractPlanFields({ organization: {} })).toEqual({})
+  })
+
+  it("omits keys rather than setting them to undefined", () => {
+    const fields = extractPlanFields({ organization: { organization_type: null, rate_limit_tier: null } })
+    expect(Object.keys(fields)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The profile fetch — best-effort, never fatal
+// ---------------------------------------------------------------------------
+
+describe("fetchOAuthPlanFields", () => {
+  let originalFetch: typeof globalThis.fetch
+  let originalWarn: typeof console.warn
+  let warnings: unknown[][]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    originalWarn = console.warn
+    warnings = []
+    console.warn = (...args: unknown[]) => { warnings.push(args) }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    console.warn = originalWarn
+  })
+
+  it("returns the plan for a healthy response", async () => {
+    mockFetch(async () => makeSuccessResponse(MAX_PROFILE))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("presents the access token as a bearer credential to the profile endpoint", async () => {
+    let seenUrl: unknown
+    let seenInit: RequestInit | undefined
+    mockFetch(async (url: unknown, init: unknown) => {
+      seenUrl = url
+      seenInit = init as RequestInit
+      return makeSuccessResponse(MAX_PROFILE)
+    })
+
+    await fetchOAuthPlanFields("the-access-token")
+
+    expect(seenUrl).toBe("https://api.anthropic.com/api/oauth/profile")
+    const headers = seenInit?.headers as Record<string, string>
+    expect(headers.Authorization).toBe("Bearer the-access-token")
+  })
+
+  it("returns an empty object on a non-ok response", async () => {
+    mockFetch(async () => new Response("Unauthorized", { status: 401 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the request throws", async () => {
+    mockFetch(async () => { throw new Error("network down") })
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the body is not JSON", async () => {
+    mockFetch(async () => new Response("not-json", { status: 200 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// What actually lands on disk — the regression this change closes
+// ---------------------------------------------------------------------------
+
+describe("buildLoginCredentials", () => {
+  it("persists the plan alongside the tokens when it is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("max")
+    expect(creds.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("omits the keys entirely when the plan is unknown", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {})
+
+    // `subscriptionType: undefined` would write a null-ish key into a file the
+    // real CLI also parses — absence must mean absent, not present-and-empty.
+    expect("subscriptionType" in creds.claudeAiOauth).toBe(false)
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+    expect(JSON.stringify(creds)).not.toContain("subscriptionType")
+  })
+
+  it("writes only the field that is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, { subscriptionType: "team" })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("team")
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+  })
+
+  it("still carries the tokens, scopes and expiry", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {}, 1_000_000)
+
+    expect(creds.claudeAiOauth.accessToken).toBe("the-access-token")
+    expect(creds.claudeAiOauth.refreshToken).toBe("the-refresh-token")
+    expect(creds.claudeAiOauth.expiresAt).toBe(1_000_000 + 3600 * 1000)
+    expect(creds.claudeAiOauth.scopes).toEqual(["user:profile", "user:inference"])
+  })
+
+  it("prefers an absolute expires_at over expires_in", () => {
+    const creds = buildLoginCredentials({ ...TOKEN_DATA, expires_at: 42 }, {}, 1_000_000)
+    expect(creds.claudeAiOauth.expiresAt).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Once written, the value must survive every subsequent refresh.
+//
+// doRefresh rebuilds claudeAiOauth with a spread, so anything already on disk
+// is carried forward. Turning that spread into an explicit field list would
+// silently re-open the same hole one refresh cycle after each login.
+// ---------------------------------------------------------------------------
+
+describe("a refresh preserves an already-persisted plan", () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  it("keeps subscriptionType and rateLimitTier across a token refresh", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({
+      access_token: "rotated-access-token",
+      refresh_token: "rotated-refresh-token",
+      expires_in: 3600,
+    }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(stored.claudeAiOauth.accessToken).toBe("rotated-access-token")
+    expect(stored.claudeAiOauth.subscriptionType).toBe("max")
+    expect(stored.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("does not invent a plan for a credential written before this change", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {})
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({ access_token: "rotated", expires_in: 3600 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    // A refresh cannot repair an already-blind profile: only a re-login can.
+    expect("subscriptionType" in stored.claudeAiOauth).toBe(false)
+  })
+})

--- a/src/__tests__/profile-login-plan-fields.test.ts
+++ b/src/__tests__/profile-login-plan-fields.test.ts
@@ -80,6 +80,41 @@ describe("extractPlanFields", () => {
       .toEqual({ subscriptionType: "team" })
   })
 
+  // Both Team seats this fleet holds, measured through the live endpoint. They
+  // are `claude_team` with a differing `seat_tier`, and their `rate_limit_tier`
+  // can size neither: the Premium seat's is what a personal Max 5x reports, and
+  // the Standard seat's is an Anthropic codename naming no published allotment.
+  it("keeps the seat tier, the only field that sizes a Team seat", () => {
+    expect(extractPlanFields({
+      organization: {
+        organization_type: "claude_team",
+        rate_limit_tier: "default_claude_max_5x",
+        seat_tier: "team_tier_1",
+      },
+    })).toEqual({
+      subscriptionType: "team",
+      rateLimitTier: "default_claude_max_5x",
+      seatTier: "team_tier_1",
+    })
+    expect(extractPlanFields({
+      organization: {
+        organization_type: "claude_team",
+        rate_limit_tier: "default_raven",
+        seat_tier: "team_standard",
+      },
+    })).toEqual({
+      subscriptionType: "team",
+      rateLimitTier: "default_raven",
+      seatTier: "team_standard",
+    })
+  })
+
+  it("omits the seat tier a personal account does not have", () => {
+    expect(extractPlanFields(MAX_PROFILE)).not.toHaveProperty("seatTier")
+    expect(extractPlanFields({ organization: { organization_type: "claude_max", seat_tier: null } }))
+      .toEqual({ subscriptionType: "max" })
+  })
+
   it("keeps the tier when only the plan is unrecognized", () => {
     expect(extractPlanFields({ organization: { organization_type: "claude_future", rate_limit_tier: "some_tier" } }))
       .toEqual({ rateLimitTier: "some_tier" })

--- a/src/proxy/planAllowance.ts
+++ b/src/proxy/planAllowance.ts
@@ -1,0 +1,158 @@
+/**
+ * Plan → coding-allotment multiplier.
+ *
+ * Anthropic sizes a plan's Claude Code allotment as a multiple of the Pro
+ * baseline — 5x, 20x, 6.25x — and that number, not the plan name, is what says
+ * how much work an account can actually do. Two accounts both reporting
+ * `Plan: max` can differ by 4x in capacity, so a page that shows only the plan
+ * cannot tell the user which account has room left.
+ *
+ * The multiplier is derived from `rateLimitTier` — the raw string the profile
+ * endpoint returns, e.g. `default_claude_max_20x` — rather than from
+ * `subscriptionType`, because that field is too coarse: it collapses Max 5x
+ * and Max 20x into the single word `max`, and Team Standard and Team Premium
+ * into `team`. `subscriptionType` is used only as a fallback for the tiers it
+ * does identify unambiguously.
+ *
+ * An unrecognized tier yields null rather than a default, which is the whole
+ * point of the field: rendering `1x` for an account that is really 20x is
+ * worse than rendering nothing, because a reader acts on it.
+ *
+ * This is a leaf module — pure, no I/O, no imports.
+ */
+
+export interface PlanAllowance {
+  /** Multiplier as displayed, e.g. `"20x"`. Null when the tier is unknown. */
+  multiplier: string | null
+  /**
+   * The same value as a number, so callers can weight or rank accounts without
+   * re-parsing the label. Null whenever `multiplier` is.
+   */
+  weight: number | null
+  /** Tier label, e.g. `"Personal Max"`. Null when the tier is unknown. */
+  label: string | null
+}
+
+const UNKNOWN: PlanAllowance = { multiplier: null, weight: null, label: null }
+
+/**
+ * Which side of Anthropic's pricing an account sits on. Tracked separately
+ * from the multiplier because the two fields can disagree: measured on a
+ * ten-account host, a Team seat reports `subscriptionType: "team"` with
+ * `rateLimitTier: "default_claude_max_5x"`, so the tier names the SIZE of the
+ * allotment and `subscriptionType` names WHOSE it is.
+ */
+type PlanFamily = "personal" | "team" | "enterprise"
+
+interface TierProfile {
+  label: string
+  family: PlanFamily
+  multiplier: string
+  weight: number
+}
+
+/**
+ * Reduce a raw tier string to the form the table below is keyed by.
+ *
+ * Anthropic prefixes the wire value (`default_claude_max_20x`) and separates
+ * words with underscores; the same tier also appears bare (`max_20x`) in
+ * places, and `team_tier_1` is the wire spelling of what the pricing page
+ * calls Team Premium. Normalizing first means one entry per tier instead of
+ * one per spelling.
+ */
+export function normalizeRateLimitTier(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  return trimmed
+    .replace(/^default_claude_/, "")
+    .replace(/^default_/, "")
+    .replace(/_/g, " ")
+    .toLowerCase()
+}
+
+/**
+ * Multipliers are Anthropic's published Claude Code allotments relative to
+ * Pro. Team Premium is listed as 6.25x — the ratio of its $125 seat to the $20
+ * Pro plan — and is the reason this table stores a fractional weight rather
+ * than an integer.
+ *
+ * Bare `max` and bare `team` deliberately have no entry: both name a family
+ * with two differently-sized members, so resolving them would mean picking one
+ * at random.
+ */
+const TIERS: Record<string, TierProfile> = {
+  "max 20x": { label: "Personal Max", family: "personal", multiplier: "20x", weight: 20 },
+  "max 5x": { label: "Personal Max", family: "personal", multiplier: "5x", weight: 5 },
+  "pro": { label: "Personal Pro", family: "personal", multiplier: "1x", weight: 1 },
+  "team premium": { label: "Team Premium", family: "team", multiplier: "6.25x", weight: 6.25 },
+  "team tier 1": { label: "Team Premium", family: "team", multiplier: "6.25x", weight: 6.25 },
+  "team standard": { label: "Team Standard", family: "team", multiplier: "1x", weight: 1 },
+}
+
+/** Which family each `subscriptionType` names, for the reconciliation below. */
+const SUBSCRIPTION_FAMILY: Record<string, PlanFamily> = {
+  max: "personal",
+  pro: "personal",
+  team: "team",
+  enterprise: "enterprise",
+}
+
+/**
+ * What to call an account whose declared family contradicts its tier's. Only
+ * the family is left, so the label drops to it rather than asserting a product
+ * name nobody can confirm.
+ */
+const FAMILY_LABEL: Record<PlanFamily, string> = {
+  personal: "Personal",
+  team: "Team",
+  enterprise: "Enterprise",
+}
+
+/**
+ * `subscriptionType` values that pin a single tier on their own. `max` and
+ * `team` are absent for the reason given above, and `enterprise` because its
+ * allotment is negotiated per contract rather than published.
+ */
+const SUBSCRIPTION_FALLBACK: Record<string, string> = {
+  pro: "pro",
+}
+
+/**
+ * Derive the allowance from whatever plan fields a credential file carries.
+ *
+ * Both arguments are optional because both are optional on disk: a profile
+ * written before the plan was persisted has neither, and one written by an
+ * older Meridian has only `subscriptionType`. Every unknown case returns the
+ * same all-null shape, so callers can render conditionally on one field.
+ */
+export function planAllowance(fields: {
+  rateLimitTier?: string | null
+  subscriptionType?: string | null
+} | null | undefined): PlanAllowance {
+  const subscription = fields?.subscriptionType?.trim().toLowerCase()
+  const declaredFamily = subscription ? SUBSCRIPTION_FAMILY[subscription] : undefined
+
+  const fromTier = TIERS[normalizeRateLimitTier(fields?.rateLimitTier) ?? ""]
+  if (fromTier) return reconcile(fromTier, declaredFamily)
+
+  const key = subscription ? SUBSCRIPTION_FALLBACK[subscription] : undefined
+  const fromSubscription = key ? TIERS[key] : undefined
+  return fromSubscription ? reconcile(fromSubscription, declaredFamily) : { ...UNKNOWN }
+}
+
+/**
+ * Size from the tier, name from `subscriptionType` — and where the two
+ * disagree, the name degrades to the family rather than keeping the tier's.
+ *
+ * A Team seat sized like Personal Max 5x is a real account on this host, and
+ * calling it "Personal Max" is wrong in the direction that matters: the reader
+ * is deciding whose allotment they are about to spend. The multiplier is still
+ * the tier's, because the tier is what Anthropic sizes the allotment by.
+ */
+function reconcile(tier: TierProfile, declaredFamily: PlanFamily | undefined): PlanAllowance {
+  const label = declaredFamily && declaredFamily !== tier.family
+    ? FAMILY_LABEL[declaredFamily]
+    : tier.label
+  return { multiplier: tier.multiplier, weight: tier.weight, label }
+}

--- a/src/proxy/planAllowance.ts
+++ b/src/proxy/planAllowance.ts
@@ -7,12 +7,12 @@
  * `Plan: max` can differ by 4x in capacity, so a page that shows only the plan
  * cannot tell the user which account has room left.
  *
- * The multiplier is derived from `rateLimitTier` — the raw string the profile
- * endpoint returns, e.g. `default_claude_max_20x` — rather than from
- * `subscriptionType`, because that field is too coarse: it collapses Max 5x
- * and Max 20x into the single word `max`, and Team Standard and Team Premium
- * into `team`. `subscriptionType` is used only as a fallback for the tiers it
- * does identify unambiguously.
+ * The multiplier is derived from the raw strings the profile endpoint returns
+ * — `seatTier` for a Team account, `rateLimitTier` otherwise — rather than
+ * from `subscriptionType`, because that field is too coarse: it collapses Max
+ * 5x and Max 20x into the single word `max`, and Team Standard and Team
+ * Premium into `team`. `subscriptionType` names the family and is used for the
+ * size only as a fallback for the one tier it pins unambiguously.
  *
  * An unrecognized tier yields null rather than a default, which is the whole
  * point of the field: rendering `1x` for an account that is really 20x is
@@ -31,9 +31,33 @@ export interface PlanAllowance {
   weight: number | null
   /** Tier label, e.g. `"Personal Max"`. Null when the tier is unknown. */
   label: string | null
+  /**
+   * Which side of Anthropic's pricing the account sits on — `"Personal"`,
+   * `"Team"` or `"Enterprise"`. Separate from `planName` because the two are
+   * answered by different fields and either can be known without the other: an
+   * account whose family is declared but whose tier is unrecognized still has
+   * a trustworthy family.
+   */
+  accountType: string | null
+  /**
+   * The plan WITHIN that family, in the vocabulary of Anthropic's own pricing
+   * page: `"Max 20x"`, `"Max 5x"`, `"Pro"`, `"Free"` for personal accounts and
+   * `"Premium seat"` / `"Standard seat"` for Team ones.
+   *
+   * Null when the family is known but the plan is not — which is the common
+   * case for a Team seat with no `seat_tier`, since its `rate_limit_tier`
+   * reports the underlying bucket rather than the seat.
+   */
+  planName: string | null
 }
 
-const UNKNOWN: PlanAllowance = { multiplier: null, weight: null, label: null }
+const UNKNOWN: PlanAllowance = {
+  multiplier: null,
+  weight: null,
+  label: null,
+  accountType: null,
+  planName: null,
+}
 
 /**
  * Which side of Anthropic's pricing an account sits on. Tracked separately
@@ -47,6 +71,8 @@ type PlanFamily = "personal" | "team" | "enterprise"
 interface TierProfile {
   label: string
   family: PlanFamily
+  /** The plan's own name within its family, as Anthropic's pricing page words it. */
+  planName: string
   multiplier: string
   weight: number
 }
@@ -82,12 +108,35 @@ export function normalizeRateLimitTier(raw: string | null | undefined): string |
  * at random.
  */
 const TIERS: Record<string, TierProfile> = {
-  "max 20x": { label: "Personal Max", family: "personal", multiplier: "20x", weight: 20 },
-  "max 5x": { label: "Personal Max", family: "personal", multiplier: "5x", weight: 5 },
-  "pro": { label: "Personal Pro", family: "personal", multiplier: "1x", weight: 1 },
-  "team premium": { label: "Team Premium", family: "team", multiplier: "6.25x", weight: 6.25 },
-  "team tier 1": { label: "Team Premium", family: "team", multiplier: "6.25x", weight: 6.25 },
-  "team standard": { label: "Team Standard", family: "team", multiplier: "1x", weight: 1 },
+  "max 20x": { label: "Personal Max", family: "personal", planName: "Max 20x", multiplier: "20x", weight: 20 },
+  "max 5x": { label: "Personal Max", family: "personal", planName: "Max 5x", multiplier: "5x", weight: 5 },
+  "pro": { label: "Personal Pro", family: "personal", planName: "Pro", multiplier: "1x", weight: 1 },
+  "team premium": { label: "Team Premium", family: "team", planName: "Premium seat", multiplier: "6.25x", weight: 6.25 },
+  "team tier 1": { label: "Team Premium", family: "team", planName: "Premium seat", multiplier: "6.25x", weight: 6.25 },
+  "team standard": { label: "Team Standard", family: "team", planName: "Standard seat", multiplier: "1x", weight: 1 },
+}
+
+/**
+ * A Team seat's size comes from `seat_tier`, NOT from `rate_limit_tier`.
+ *
+ * Measured across eleven live accounts: every Team seat reports
+ * `rate_limit_tier: "default_claude_max_5x"` — byte-identical to what a
+ * personal Max 5x reports — while `seat_tier` carries `"team_tier_1"`, which
+ * DreamHost's usage tracker canonicalizes to Team Premium at 6.25x. Sizing a
+ * Team seat off the rate-limit tier therefore understates it by 25% and names
+ * it after the wrong product.
+ *
+ * The field is null on every personal account, so its mere presence is also
+ * evidence of the family.
+ *
+ * The bare spellings are tried with a `team ` prefix because `seat_tier` is
+ * already scoped to a team — a value of `standard` there means the same thing
+ * `team_standard` means in `rate_limit_tier`.
+ */
+function tierFromSeat(seatTier: string | null | undefined): TierProfile | undefined {
+  const normalized = normalizeRateLimitTier(seatTier)
+  if (!normalized) return undefined
+  return TIERS[normalized] ?? TIERS[`team ${normalized}`]
 }
 
 /** Which family each `subscriptionType` names, for the reconciliation below. */
@@ -128,17 +177,26 @@ const SUBSCRIPTION_FALLBACK: Record<string, string> = {
  */
 export function planAllowance(fields: {
   rateLimitTier?: string | null
+  seatTier?: string | null
   subscriptionType?: string | null
 } | null | undefined): PlanAllowance {
   const subscription = fields?.subscriptionType?.trim().toLowerCase()
   const declaredFamily = subscription ? SUBSCRIPTION_FAMILY[subscription] : undefined
+
+  const fromSeat = tierFromSeat(fields?.seatTier)
+  if (fromSeat) return reconcile(fromSeat, declaredFamily)
 
   const fromTier = TIERS[normalizeRateLimitTier(fields?.rateLimitTier) ?? ""]
   if (fromTier) return reconcile(fromTier, declaredFamily)
 
   const key = subscription ? SUBSCRIPTION_FALLBACK[subscription] : undefined
   const fromSubscription = key ? TIERS[key] : undefined
-  return fromSubscription ? reconcile(fromSubscription, declaredFamily) : { ...UNKNOWN }
+  if (fromSubscription) return reconcile(fromSubscription, declaredFamily)
+
+  return {
+    ...UNKNOWN,
+    accountType: declaredFamily ? FAMILY_LABEL[declaredFamily] : null,
+  }
 }
 
 /**
@@ -151,8 +209,12 @@ export function planAllowance(fields: {
  * the tier's, because the tier is what Anthropic sizes the allotment by.
  */
 function reconcile(tier: TierProfile, declaredFamily: PlanFamily | undefined): PlanAllowance {
-  const label = declaredFamily && declaredFamily !== tier.family
-    ? FAMILY_LABEL[declaredFamily]
-    : tier.label
-  return { multiplier: tier.multiplier, weight: tier.weight, label }
+  const contradicted = Boolean(declaredFamily && declaredFamily !== tier.family)
+  return {
+    multiplier: tier.multiplier,
+    weight: tier.weight,
+    label: contradicted ? FAMILY_LABEL[declaredFamily!] : tier.label,
+    accountType: FAMILY_LABEL[declaredFamily ?? tier.family],
+    planName: contradicted ? null : tier.planName,
+  }
 }

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -17,7 +17,7 @@ import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
-import { createPlatformCredentialStore } from "./tokenRefresh"
+import { createPlatformCredentialStore, type CredentialsFile } from "./tokenRefresh"
 
 const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
@@ -25,6 +25,18 @@ const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+/**
+ * Where the account's plan comes from — not the token endpoint.
+ *
+ * Everything Claude Code reads off a token response is `access_token`,
+ * `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and
+ * `organization.uuid`. It derives `subscriptionType` / `rateLimitTier` from a
+ * separate authenticated GET here, then writes them into the same
+ * `.credentials.json` Meridian shares with it — so a headless login has to ask
+ * for them too. Note the host differs from OAUTH_TOKEN_URL; reached with the
+ * `user:profile` scope, already in OAUTH_SCOPES.
+ */
+const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -156,6 +168,115 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
+interface OAuthProfileResponse {
+  organization?: {
+    organization_type?: string | null
+    rate_limit_tier?: string | null
+  } | null
+}
+
+export interface OAuthPlanFields {
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+type CompleteOAuthTokenResponse = OAuthTokenResponse & { refresh_token: string }
+
+function hasRequiredTokens(tokenData: OAuthTokenResponse): tokenData is CompleteOAuthTokenResponse {
+  return Boolean(tokenData.access_token && tokenData.refresh_token)
+}
+
+/**
+ * Translate Anthropic's wire `organization_type` into the vocabulary the Claude
+ * CLI writes on disk — the wire value is prefixed (`claude_max`), the stored one
+ * is not (`max`). Mirroring the CLI's own mapping is what keeps a credential
+ * file Meridian writes indistinguishable from one `claude login` wrote, which
+ * matters because `claude auth status` reads it back and is what ultimately
+ * feeds `/profiles/list`, `/health` and the `max`-only branch of `/v1/models`.
+ *
+ * An unrecognized or absent type yields undefined so the caller omits the key,
+ * rather than inventing a plan for an account it could not identify.
+ */
+export function subscriptionTypeFromOrganizationType(
+  organizationType: string | null | undefined,
+): string | undefined {
+  switch (organizationType) {
+    case "claude_max": return "max"
+    case "claude_pro": return "pro"
+    case "claude_team": return "team"
+    case "claude_enterprise": return "enterprise"
+    default: return undefined
+  }
+}
+
+export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
+  const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
+  const rateLimitTier = profile?.organization?.rate_limit_tier
+  return {
+    ...(subscriptionType ? { subscriptionType } : {}),
+    ...(rateLimitTier ? { rateLimitTier } : {}),
+  }
+}
+
+/**
+ * Best-effort plan lookup for a freshly minted access token. Never throws and
+ * never fails the login: a profile whose plan is unknown is strictly better
+ * than no profile at all, and every consumer already treats it as optional.
+ */
+export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPlanFields> {
+  let response: Response
+  try {
+    response = await fetch(OAUTH_PROFILE_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch (err) {
+    console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+
+  if (!response.ok) {
+    console.warn(`[meridian] Could not read the account plan (${response.status}).`)
+    return {}
+  }
+
+  try {
+    return extractPlanFields(await response.json() as OAuthProfileResponse)
+  } catch (err) {
+    console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+}
+
+/**
+ * Build the record a login writes to disk.
+ *
+ * Split out so the on-disk shape is directly assertable: the defect this closes
+ * was a field missing from this object literal, which no test of the
+ * surrounding prompt/fetch I/O would have caught. Plan fields spread in only
+ * when known — `subscriptionType: undefined` would write a null-ish key into a
+ * file the real CLI also parses.
+ */
+export function buildLoginCredentials(
+  tokenData: CompleteOAuthTokenResponse,
+  plan: OAuthPlanFields,
+  now: number = Date.now(),
+): CredentialsFile {
+  return {
+    claudeAiOauth: {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt: tokenData.expires_at ?? now + (tokenData.expires_in ?? 8 * 60 * 60) * 1000,
+      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
+      ...plan,
+    },
+  }
+}
+
 async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   const session = createManualOAuthSession()
   console.log("\x1b[33m⚠ Headless OAuth login: open this URL in a browser:\x1b[0m")
@@ -209,21 +330,14 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
     return false
   }
 
-  if (!tokenData.access_token || !tokenData.refresh_token) {
+  if (!hasRequiredTokens(tokenData)) {
     console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
     return false
   }
 
-  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+  const plan = await fetchOAuthPlanFields(tokenData.access_token)
   const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write({
-    claudeAiOauth: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt,
-      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
-    },
-  })
+  return store.write(buildLoginCredentials(tokenData, plan))
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -172,12 +172,23 @@ interface OAuthProfileResponse {
   organization?: {
     organization_type?: string | null
     rate_limit_tier?: string | null
+    seat_tier?: string | null
   } | null
 }
 
 export interface OAuthPlanFields {
   subscriptionType?: string
   rateLimitTier?: string
+  /**
+   * Which seat a Team member holds, and the ONLY field that separates a
+   * Premium seat from a Standard one. Measured across twelve live accounts:
+   * every Premium seat reports `rate_limit_tier: "default_claude_max_5x"` —
+   * byte-identical to what a personal Max 5x reports — and a Standard seat
+   * reports `default_raven`, a codename naming no published allotment. So the
+   * rate-limit tier can size neither kind of Team seat: one because it lies
+   * and one because it says nothing. Null on every personal account.
+   */
+  seatTier?: string
 }
 
 type CompleteOAuthTokenResponse = OAuthTokenResponse & { refresh_token: string }
@@ -212,9 +223,11 @@ export function subscriptionTypeFromOrganizationType(
 export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
   const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
   const rateLimitTier = profile?.organization?.rate_limit_tier
+  const seatTier = profile?.organization?.seat_tier
   return {
     ...(subscriptionType ? { subscriptionType } : {}),
     ...(rateLimitTier ? { rateLimitTier } : {}),
+    ...(seatTier ? { seatTier } : {}),
   }
 }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -53,7 +53,8 @@ import { LRUMap } from "../utils/lruMap"
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
 import { canRecoverCapturedToolUses, classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
-import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
+import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, getStoredPlanFields, resolveRenewalWarnDays, type CredentialStore, type StoredPlanFields } from "./tokenRefresh"
+import { planAllowance } from "./planAllowance"
 import {
   createFileDesignTokenStore,
   createDesignLogin,
@@ -4725,10 +4726,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // are separate auth contexts keyed by CLAUDE_CONFIG_DIR, so the default
       // store would report an unrelated account's expiry.
       const renewalConfigDir = profileEnvOverrides?.CLAUDE_CONFIG_DIR
-      const renewal = await getAuthRenewalStatus(
-        renewalConfigDir ? createPlatformCredentialStore({ claudeConfigDir: renewalConfigDir }) : undefined,
-        warnDays,
-      ).catch(() => ({ renewalRequiredSoon: false }))
+      const healthStore = renewalConfigDir
+        ? createPlatformCredentialStore({ claudeConfigDir: renewalConfigDir })
+        : undefined
+      const renewal = await getAuthRenewalStatus(healthStore, warnDays)
+        .catch(() => ({ renewalRequiredSoon: false }))
+      // `claude auth status` reports the plan family (`max`) but not the tier
+      // that sizes it, so the 5x-vs-20x distinction can only come off disk.
+      // Same store, same cached read as the renewal window above.
+      const plan = await getStoredPlanFields(healthStore).catch((): StoredPlanFields => ({}))
+      const allowance = planAllowance({ ...plan, subscriptionType: auth.subscriptionType })
 
       return c.json({
         status: "healthy",
@@ -4737,6 +4744,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           loggedIn: true,
           email: auth.email,
           subscriptionType: auth.subscriptionType,
+          rateLimitTier: plan.rateLimitTier ?? null,
+          allowance: allowance.multiplier,
+          allowanceWeight: allowance.weight,
+          planLabel: allowance.label,
           ...renewal,
         },
         mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
@@ -4766,10 +4777,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         envOverrides
       )
       const cacheInfo = getAuthCacheInfo(p.id !== "default" ? p.id : undefined)
+      // The tier that sizes the plan is never in `claude auth status` — only
+      // the family (`max`), which covers both 5x and 20x. It is on disk, in
+      // the profile's own credential file.
+      const plan = await getStoredPlanFields(credentialStoreForProfile(resolved)).catch((): StoredPlanFields => ({}))
+      const allowance = planAllowance({ ...plan, subscriptionType: auth?.subscriptionType })
       return {
         ...p,
         email: auth?.email || null,
         subscriptionType: auth?.subscriptionType || null,
+        rateLimitTier: plan.rateLimitTier ?? null,
+        allowance: allowance.multiplier,
+        allowanceWeight: allowance.weight,
+        planLabel: allowance.label,
         loggedIn: auth?.loggedIn ?? false,
         lastCheckedAt: cacheInfo.lastCheckedAt || null,
         lastSuccessAt: cacheInfo.lastSuccessAt || null,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4735,7 +4735,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // that sizes it, so the 5x-vs-20x distinction can only come off disk.
       // Same store, same cached read as the renewal window above.
       const plan = await getStoredPlanFields(healthStore).catch((): StoredPlanFields => ({}))
-      const allowance = planAllowance({ ...plan, subscriptionType: auth.subscriptionType })
+      // Spread the live status only WHEN IT HAS ONE. `subscriptionType:
+      // undefined` overwrites the value read off disk, so an account whose
+      // `claude auth status` omits the field lost its stored plan entirely -
+      // which is why a personal Max rendered no Plan row at all.
+      const allowance = planAllowance({
+        ...plan,
+        ...(auth.subscriptionType ? { subscriptionType: auth.subscriptionType } : {}),
+      })
 
       return c.json({
         status: "healthy",
@@ -4745,9 +4752,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           email: auth.email,
           subscriptionType: auth.subscriptionType,
           rateLimitTier: plan.rateLimitTier ?? null,
+          seatTier: plan.seatTier ?? null,
           allowance: allowance.multiplier,
           allowanceWeight: allowance.weight,
           planLabel: allowance.label,
+          accountType: allowance.accountType,
+          planName: allowance.planName,
           ...renewal,
         },
         mode: envBool("PASSTHROUGH") ? "passthrough" : "internal",
@@ -4781,15 +4791,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // the family (`max`), which covers both 5x and 20x. It is on disk, in
       // the profile's own credential file.
       const plan = await getStoredPlanFields(credentialStoreForProfile(resolved)).catch((): StoredPlanFields => ({}))
-      const allowance = planAllowance({ ...plan, subscriptionType: auth?.subscriptionType })
+      const allowance = planAllowance({
+        ...plan,
+        ...(auth?.subscriptionType ? { subscriptionType: auth.subscriptionType } : {}),
+      })
       return {
         ...p,
         email: auth?.email || null,
         subscriptionType: auth?.subscriptionType || null,
         rateLimitTier: plan.rateLimitTier ?? null,
+        seatTier: plan.seatTier ?? null,
         allowance: allowance.multiplier,
         allowanceWeight: allowance.weight,
         planLabel: allowance.label,
+        accountType: allowance.accountType,
+        planName: allowance.planName,
         loggedIn: auth?.loggedIn ?? false,
         lastCheckedAt: cacheInfo.lastCheckedAt || null,
         lastSuccessAt: cacheInfo.lastSuccessAt || null,

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -51,7 +51,7 @@ export function configDirToCredentialsFile(claudeConfigDir: string): string {
   return join(resolve(claudeConfigDir), ".credentials.json")
 }
 
-interface OAuthCredentials {
+export interface OAuthCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
@@ -70,7 +70,7 @@ interface OAuthCredentials {
   rateLimitTier?: string
 }
 
-interface CredentialsFile {
+export interface CredentialsFile {
   claudeAiOauth: OAuthCredentials
   [key: string]: unknown
 }

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -436,28 +436,41 @@ export interface AuthRenewalStatus {
  * on every deployment that predates the CLI writing it.
  */
 /**
- * How long a read of the refresh-token expiry stays fresh.
+ * How long a read of the stored credential facts stays fresh.
  *
  * `/health` is hot: the dashboard polls it every 10s per open page, plugin
  * health checks hit it, and external monitors poll it too. On macOS a
  * credential-store read spawns `/usr/bin/security find-generic-password`, so
- * reading per request means a subprocess per poll — for a value that moves on
- * a ~30-day cadence. Five minutes is far shorter than any meaningful change to
- * the login window and still collapses ~97% of the reads.
+ * reading per request means a subprocess per poll — for values that move on a
+ * ~30-day cadence at best, and only at login for the plan. Five minutes is far
+ * shorter than any meaningful change to either and still collapses ~97% of the
+ * reads.
  */
-const RENEWAL_EXPIRY_TTL_MS = 5 * 60_000
+const CREDENTIAL_FACTS_TTL_MS = 5 * 60_000
 
-const renewalExpiryCache = new Map<string, { value: number | undefined; at: number }>()
-const renewalExpiryInflight = new Map<string, Promise<number | undefined>>()
+/**
+ * The fields read off a credential file that describe the *account* rather
+ * than the current access token. One read serves all of them because they
+ * arrive in one file and are wanted by the same request: `/health` reports the
+ * login window and the plan together.
+ */
+interface StoredCredentialFacts {
+  refreshTokenExpiresAt?: number
+  subscriptionType?: string
+  rateLimitTier?: string
+}
 
-/** Drop cached refresh-token expiries — for tests, and after a re-login. */
+const credentialFactsCache = new Map<string, { value: StoredCredentialFacts; at: number }>()
+const credentialFactsInflight = new Map<string, Promise<StoredCredentialFacts>>()
+
+/** Drop cached credential facts — for tests, and after a re-login. */
 export function resetAuthRenewalCache(): void {
-  renewalExpiryCache.clear()
-  renewalExpiryInflight.clear()
+  credentialFactsCache.clear()
+  credentialFactsInflight.clear()
 }
 
 /**
- * Read the refresh-token expiry, cached per credential store.
+ * Read the account-describing credential fields, cached per credential store.
  *
  * Keyed on `refreshKey`, which both real stores set (`keychain:` / `file:`).
  * A store WITHOUT one is not cached at all: its identity is unknown, so
@@ -467,33 +480,63 @@ export function resetAuthRenewalCache(): void {
  * A failed read is never cached. A keychain blip should retry on the next
  * poll, not suppress the renewal warning for the whole TTL.
  */
-async function readRefreshTokenExpiry(s: CredentialStore): Promise<number | undefined> {
+async function readCredentialFacts(s: CredentialStore): Promise<StoredCredentialFacts> {
   const key = s.refreshKey
   if (key) {
-    const cached = renewalExpiryCache.get(key)
-    if (cached && Date.now() - cached.at < RENEWAL_EXPIRY_TTL_MS) return cached.value
-    const inflight = renewalExpiryInflight.get(key)
+    const cached = credentialFactsCache.get(key)
+    if (cached && Date.now() - cached.at < CREDENTIAL_FACTS_TTL_MS) return cached.value
+    const inflight = credentialFactsInflight.get(key)
     if (inflight) return inflight
   }
 
-  const read = (async (): Promise<number | undefined> => {
+  const read = (async (): Promise<StoredCredentialFacts> => {
     let credentials: CredentialsFile | null = null
     try {
       credentials = await s.read()
     } catch {
-      return undefined
+      return {}
     }
-    const value = credentials?.claudeAiOauth?.refreshTokenExpiresAt
-    if (key) renewalExpiryCache.set(key, { value, at: Date.now() })
+    const oauth = credentials?.claudeAiOauth
+    const value: StoredCredentialFacts = {
+      refreshTokenExpiresAt: oauth?.refreshTokenExpiresAt,
+      subscriptionType: oauth?.subscriptionType,
+      rateLimitTier: oauth?.rateLimitTier,
+    }
+    if (key) credentialFactsCache.set(key, { value, at: Date.now() })
     return value
   })()
 
   if (!key) return read
-  renewalExpiryInflight.set(key, read)
+  credentialFactsInflight.set(key, read)
   try {
     return await read
   } finally {
-    renewalExpiryInflight.delete(key)
+    credentialFactsInflight.delete(key)
+  }
+}
+
+/**
+ * The plan fields a login persisted, as stored.
+ *
+ * `claude auth status` reports `subscriptionType` and nothing else, so the
+ * tier that separates Max 5x from Max 20x is only ever available here. Both
+ * fields are optional on disk — a credential file written before Meridian
+ * persisted them has neither — and absent keys are omitted rather than nulled
+ * so a caller can spread the result over a live status without erasing it.
+ */
+export interface StoredPlanFields {
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+export async function getStoredPlanFields(
+  store?: CredentialStore,
+): Promise<StoredPlanFields> {
+  const s = store ?? createPlatformCredentialStore()
+  const { subscriptionType, rateLimitTier } = await readCredentialFacts(s)
+  return {
+    ...(subscriptionType ? { subscriptionType } : {}),
+    ...(rateLimitTier ? { rateLimitTier } : {}),
   }
 }
 
@@ -504,7 +547,7 @@ export async function getAuthRenewalStatus(
   const s = store ?? createPlatformCredentialStore()
   // Only the READ is cached. The day count and the flag are recomputed every
   // call so elapsed time and a changed warnDays are always reflected.
-  const refreshTokenExpiresAt = await readRefreshTokenExpiry(s)
+  const { refreshTokenExpiresAt } = await readCredentialFacts(s)
   if (!refreshTokenExpiresAt) return { renewalRequiredSoon: false }
 
   const msRemaining = refreshTokenExpiresAt - Date.now()

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -68,6 +68,14 @@ export interface OAuthCredentials {
   scopes?: string[]
   subscriptionType?: string
   rateLimitTier?: string
+  /**
+   * Which seat a Team member holds. The only field that separates a Premium
+   * seat from a Standard one: measured across twelve live accounts, every
+   * Premium seat reports `rate_limit_tier: "default_claude_max_5x"` — what a
+   * personal Max 5x reports — and a Standard seat reports `default_raven`,
+   * which names no published allotment at all.
+   */
+  seatTier?: string
 }
 
 export interface CredentialsFile {
@@ -458,6 +466,7 @@ interface StoredCredentialFacts {
   refreshTokenExpiresAt?: number
   subscriptionType?: string
   rateLimitTier?: string
+  seatTier?: string
 }
 
 const credentialFactsCache = new Map<string, { value: StoredCredentialFacts; at: number }>()
@@ -501,6 +510,7 @@ async function readCredentialFacts(s: CredentialStore): Promise<StoredCredential
       refreshTokenExpiresAt: oauth?.refreshTokenExpiresAt,
       subscriptionType: oauth?.subscriptionType,
       rateLimitTier: oauth?.rateLimitTier,
+      seatTier: oauth?.seatTier,
     }
     if (key) credentialFactsCache.set(key, { value, at: Date.now() })
     return value
@@ -527,16 +537,18 @@ async function readCredentialFacts(s: CredentialStore): Promise<StoredCredential
 export interface StoredPlanFields {
   subscriptionType?: string
   rateLimitTier?: string
+  seatTier?: string
 }
 
 export async function getStoredPlanFields(
   store?: CredentialStore,
 ): Promise<StoredPlanFields> {
   const s = store ?? createPlatformCredentialStore()
-  const { subscriptionType, rateLimitTier } = await readCredentialFacts(s)
+  const { subscriptionType, rateLimitTier, seatTier } = await readCredentialFacts(s)
   return {
     ...(subscriptionType ? { subscriptionType } : {}),
     ...(rateLimitTier ? { rateLimitTier } : {}),
+    ...(seatTier ? { seatTier } : {}),
   }
 }
 

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -63,6 +63,8 @@ export const landingHtml = `<!DOCTYPE html>
   .pace-row .w-pct { font-weight: 600; }
   .pool-chip { font-size: 10px; padding: 2px 8px; border-radius: 10px; background: var(--surface2); color: var(--muted); margin-left: 6px; vertical-align: middle; }
   .pool-chip.exhausted { color: var(--red); background: rgba(248,81,73,0.12); }
+  .plan-chip { font-size: 10px; padding: 2px 8px; border-radius: 10px; background: var(--surface2);
+    color: var(--accent2); margin-left: 6px; vertical-align: middle; font-variant-numeric: tabular-nums; }
   .usage-row .w-pct { width: 38px; text-align: right; font-variant-numeric: tabular-nums; font-weight: 600; }
   .usage-row .w-reset { color: var(--muted); font-size: 11px; width: 76px; text-align: right; }
   .no-usage { font-size: 12px; color: var(--muted); padding: 4px 0; }
@@ -150,7 +152,7 @@ function profileSection(q,s,pl,h){
     // Real profiles exist: show exactly those. Traffic that predates
     // per-profile attribution (the synthetic "default" bucket) still
     // counts in the totals strip but doesn't render as a fake account.
-    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,configured:true});seen[p.id]=1}
+    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,configured:true,allowance:p.allowance,planLabel:p.planLabel,rateLimitTier:p.rateLimitTier});seen[p.id]=1}
   }else{
     // Single-account setup: one card, labeled with the logged-in email.
     var email=(h&&h.auth&&h.auth.loggedIn&&h.auth.email)||'';
@@ -189,6 +191,9 @@ function profileSection(q,s,pl,h){
     var isPriority=pl&&pl.routing==='priority';
     var switchable=multi&&p.configured&&!p.isActive&&!isPriority;
     var badge=isPriority?'':p.isActive?'<span class="active-pill">Active</span>':switchable?'<span class="switch-hint">Click to activate</span>':'';
+    // Sits beside the name because it qualifies the percentages below it: 70%
+    // of a 20x account is several times the work left in 70% of a 5x one.
+    if(p.allowance)badge+='<span class="plan-chip" title="'+esc((p.planLabel||'')+(p.rateLimitTier?' · '+p.rateLimitTier:''))+'">'+esc(p.allowance)+'</span>';
     if(isPriority){
       var orderIdx=(pl.profileOrder||[]).indexOf(p.id);
       if(orderIdx>=0)badge+='<span class="pool-chip">#'+(orderIdx+1)+' in pool</span>';

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -373,9 +373,18 @@ function render(data, quotaData) {
       html += '<span class="detail-label">Email</span>';
       html += '<span class="detail-value">' + esc(p.email) + '</span>';
     }
-    if (p.subscriptionType) {
+    // Two rows, because two different fields answer two different questions
+    // and either can be known without the other: a Team seat whose seat_tier
+    // is missing has a trustworthy family and an unknowable plan.
+    if (p.accountType) {
+      html += '<span class="detail-label">Account</span>';
+      html += '<span class="detail-value">' + esc(p.accountType) + '</span>';
+    }
+    var planName = p.planName || p.planLabel || p.subscriptionType;
+    if (planName) {
       html += '<span class="detail-label">Plan</span>';
-      html += '<span class="detail-value">' + esc(p.planLabel || p.subscriptionType) + '</span>';
+      html += '<span class="detail-value" title="' + esc(p.seatTier || p.rateLimitTier || '') + '">'
+        + esc(planName) + '</span>';
     }
     if (p.allowance) {
       // The number that says how much work the account can do. The plan alone

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -375,7 +375,14 @@ function render(data, quotaData) {
     }
     if (p.subscriptionType) {
       html += '<span class="detail-label">Plan</span>';
-      html += '<span class="detail-value">' + esc(p.subscriptionType) + '</span>';
+      html += '<span class="detail-value">' + esc(p.planLabel || p.subscriptionType) + '</span>';
+    }
+    if (p.allowance) {
+      // The number that says how much work the account can do. The plan alone
+      // does not: Max 5x and Max 20x both report "max" and differ 4x.
+      html += '<span class="detail-label">Allowance</span>';
+      html += '<span class="detail-value" title="' + esc(p.rateLimitTier || '') + '">' + esc(p.allowance)
+        + ' <span style="color:var(--muted);font-weight:400">of a Pro plan\u2019s Claude Code usage</span></span>';
     }
     if (p.lastSuccessAt) {
       html += '<span class="detail-label">Last Verified</span>';


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

> Stacks on #795. The first commit here is that PR's; the two after it are this one. Read/merge #795 first.

`Plan: max` does not say how much work an account can do.

Personal Max **5x** and Personal Max **20x** both report `max` through `claude auth status` and differ by **4x** in Claude Code allotment. So a Profiles page showing only the plan cannot tell the reader which of two accounts has room left — and on the landing page it leaves every usage bar unqualified, because 70% of a 20x account is several times the work left in 70% of a 5x one.

## Where the distinguishing field lives

`rateLimitTier` (`default_claude_max_20x`) is the field that separates them, and it is **never** in `claude auth status` — that reports `subscriptionType` and nothing else. It exists only in the profile's own `.credentials.json`, written at login. So the derivation reads the credential store rather than the live auth status.

`readRefreshTokenExpiry` already read that file on the `/health` path and cached it per `refreshKey` for 5 minutes, because on macOS each read spawns `security find-generic-password`. Rather than add a second read with its own cache, that one is generalized to `readCredentialFacts` and now carries the plan fields alongside the refresh-token expiry — they arrive in one file and are wanted by the same request. `/health` and `/profiles/list` therefore gain the allowance at **no extra store hit**.

## A Team seat is sized by its seat, not by its rate-limit tier

`rate_limit_tier` cannot size a Team account, and the two ways it fails are opposite. Measured across twelve live accounts through `/api/oauth/profile`:

| seat | `organization.rate_limit_tier` | `organization.seat_tier` |
|---|---|---|
| Team Premium (x4) | `default_claude_max_5x` | `team_tier_1` |
| Team Standard | `default_raven` | `team_standard` |
| personal Max | `default_claude_max_5x` / `default_claude_max_20x` | `null` |

A Premium seat's tier is **byte-identical** to what a personal Max 5x reports, so reading it understates a 6.25x seat as 5x and names it after somebody else's product. A Standard seat's is a codename naming no published allotment, so reading it yields nothing at all.

`seat_tier` separates them, is absent on every personal account, and is therefore consulted **first**; `rate_limit_tier` still sizes personal plans, which is the only thing it is reliable for.

On the page this was two visible defects. A Team Premium seat rendered `Plan: Team` with `Allowance: 5x of a Pro plan's Claude Code usage`, understating it by 25%. A Team Standard seat rendered a bare lowercase `Plan: team` with **no Allowance row at all**, because `default_raven` matches no tier.

## The mapping

`planAllowance()` (`src/proxy/planAllowance.ts`) is a pure leaf module — no I/O, no imports — mapping a normalized tier to a multiplier, matching Anthropic's published allotments:

| tier | plan | allowance |
|---|---|---|
| `max_20x` | Max 20x | 20x |
| `max_5x` | Max 5x | 5x |
| `pro` | Pro | 1x |
| `team_tier_1` / `team_premium` | Premium seat | 6.25x |
| `team_standard` | Standard seat | 1x |

Normalization strips the `default_claude_` / `default_` prefix and underscores first, so one entry covers every spelling of a tier rather than one entry per spelling. `seat_tier` is looked up in the same table and also with a `team ` prefix, since that field is already scoped to a team — a bare `standard` there means what `team_standard` means in `rate_limit_tier`.

Bare `max` and bare `team` deliberately resolve to **nothing**. Each names a family with two differently-sized members, so answering would mean picking one at random — and rendering `1x` for an account that is really 20x is worse than rendering nothing, because a reader acts on it.

## Plan and account are separate answers

Two fields answer two questions and either can be known without the other: an account whose family is declared but whose seat is missing still has a trustworthy family. So `accountType` (Personal / Team / Enterprise) and `planName` (the name on Anthropic's own pricing page) are derived and rendered separately, and `planName` degrades to null — rather than asserting a product name nobody can confirm — when the declared family contradicts the tier's.

## A live status must not erase what was read off disk

`/health` and `/profiles/list` both spread the live `claude auth status` over the stored plan fields. `subscriptionType: undefined` **overwrites** rather than defers, so an account whose status omits the field lost its stored plan entirely — which is why a personal Max rendered no Plan row at all. The live value is now spread only when there is one.

## What clients see

Both routes emit `rateLimitTier`, `seatTier`, `allowance`, `allowanceWeight`, `planLabel`, `accountType` and `planName`. Every field is additive and nullable, so a client that predates them is unaffected. `allowanceWeight` is the same value as a number, so a caller can weight or rank accounts without re-parsing the label.

- `/profiles` renders `Account` and `Plan` rows beside `Allowance: 20x of a Pro plan's Claude Code usage`, with the raw seat or tier in the `title`.
- `/` renders a `20x` chip beside the profile name, where it qualifies the usage bars below it.

`seat_tier` is carried through `extractPlanFields`, the credential file, the facts cache and `getStoredPlanFields`, so it survives a token refresh the way the other two plan fields already did.

## Verification

`npm run typecheck` clean. The derivation's own unit tests are green — **39 pass, 0 fail** across `plan-allowance.test.ts` and `profile-login-plan-fields.test.ts`, covering every tier, both spellings of Team Premium, the prefix stripping, the deliberate refusal on bare `max`/`team`, the `subscriptionType`-only fallback, and the two measured Team seats above as real wire payloads.

The full suite's failure set is **identical with and without this change**, verified as a control rather than by comparing two runs: the change was stashed in the same worktree and the suite re-run at the same moment, giving the same failures. (Several integration tests in this repo read the developer's real `~/.config/meridian`, so their outcome moves with the live account list and two runs taken minutes apart are not comparable.)

This PR is AI generated, but under direct supervision and on request of Nowaker.
