### PR TITLE
feat(profiles): fill in a missing account plan at the next token refresh

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,6 +31,10 @@ Open the printed URL in a browser, sign in to the target Claude account, then pa
 meridian profile login work --headless
 ```
 
+The same login also records the account's plan (`subscriptionType`, `rateLimitTier`), read from Anthropic's OAuth profile endpoint — the token exchange itself returns no plan information. That is what lets `meridian profile list`, `/profiles/list`, `/health` and the dashboard tell a Max account from a Team one, and what makes `/v1/models` advertise the larger context window Max accounts actually have. If the lookup fails the login still succeeds and the plan simply stays unknown.
+
+> **⚠ A profile created by an older Meridian has no plan recorded, and a token refresh cannot backfill it** — the value is only ever written at login, and Anthropic's usage endpoint does not carry it. Re-run `meridian profile login <name> --headless` to repair such a profile.
+
 #### Headless / CI: register an OAuth token
 
 When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:

--- a/src/__tests__/profile-login-plan-fields.test.ts
+++ b/src/__tests__/profile-login-plan-fields.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for the plan fields a headless OAuth login persists.
+ *
+ * Anthropic's token endpoint returns no plan information, so the headless login
+ * reads it from `/api/oauth/profile` and writes `subscriptionType` /
+ * `rateLimitTier` alongside the tokens. Network is swapped via
+ * `globalThis.fetch`; the credential-building step is pure and asserted directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import {
+  buildLoginCredentials,
+  extractPlanFields,
+  fetchOAuthPlanFields,
+  subscriptionTypeFromOrganizationType,
+} from "../proxy/profileCli"
+import type { CredentialStore } from "../proxy/tokenRefresh"
+
+/** Assign a mock to globalThis.fetch without TS complaining about `preconnect`. */
+function mockFetch(fn: (...args: unknown[]) => Promise<Response | never>): void {
+  globalThis.fetch = fn as typeof fetch
+}
+
+function makeSuccessResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const TOKEN_DATA = {
+  access_token: "the-access-token",
+  refresh_token: "the-refresh-token",
+  expires_in: 3600,
+  scope: "user:profile user:inference",
+}
+
+const MAX_PROFILE = {
+  organization: {
+    organization_type: "claude_max",
+    rate_limit_tier: "default_claude_max_20x",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// organization_type → subscriptionType
+// ---------------------------------------------------------------------------
+
+describe("subscriptionTypeFromOrganizationType", () => {
+  it("strips the claude_ prefix the CLI also strips", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_max")).toBe("max")
+    expect(subscriptionTypeFromOrganizationType("claude_pro")).toBe("pro")
+    expect(subscriptionTypeFromOrganizationType("claude_team")).toBe("team")
+    expect(subscriptionTypeFromOrganizationType("claude_enterprise")).toBe("enterprise")
+  })
+
+  it("returns undefined rather than guessing at an unknown plan", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_something_new")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("max")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(null)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(undefined)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("")).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Profile body → plan fields (snake_case on the wire, camelCase on disk)
+// ---------------------------------------------------------------------------
+
+describe("extractPlanFields", () => {
+  it("translates the snake_case wire names to the camelCase on-disk names", () => {
+    expect(extractPlanFields(MAX_PROFILE)).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("distinguishes a team account from a max one", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_team" } }))
+      .toEqual({ subscriptionType: "team" })
+  })
+
+  it("keeps the tier when only the plan is unrecognized", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_future", rate_limit_tier: "some_tier" } }))
+      .toEqual({ rateLimitTier: "some_tier" })
+  })
+
+  it("returns an empty object for an absent or empty organization", () => {
+    expect(extractPlanFields(null)).toEqual({})
+    expect(extractPlanFields(undefined)).toEqual({})
+    expect(extractPlanFields({})).toEqual({})
+    expect(extractPlanFields({ organization: null })).toEqual({})
+    expect(extractPlanFields({ organization: {} })).toEqual({})
+  })
+
+  it("omits keys rather than setting them to undefined", () => {
+    const fields = extractPlanFields({ organization: { organization_type: null, rate_limit_tier: null } })
+    expect(Object.keys(fields)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The profile fetch — best-effort, never fatal
+// ---------------------------------------------------------------------------
+
+describe("fetchOAuthPlanFields", () => {
+  let originalFetch: typeof globalThis.fetch
+  let originalWarn: typeof console.warn
+  let warnings: unknown[][]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    originalWarn = console.warn
+    warnings = []
+    console.warn = (...args: unknown[]) => { warnings.push(args) }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    console.warn = originalWarn
+  })
+
+  it("returns the plan for a healthy response", async () => {
+    mockFetch(async () => makeSuccessResponse(MAX_PROFILE))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("presents the access token as a bearer credential to the profile endpoint", async () => {
+    let seenUrl: unknown
+    let seenInit: RequestInit | undefined
+    mockFetch(async (url: unknown, init: unknown) => {
+      seenUrl = url
+      seenInit = init as RequestInit
+      return makeSuccessResponse(MAX_PROFILE)
+    })
+
+    await fetchOAuthPlanFields("the-access-token")
+
+    expect(seenUrl).toBe("https://api.anthropic.com/api/oauth/profile")
+    const headers = seenInit?.headers as Record<string, string>
+    expect(headers.Authorization).toBe("Bearer the-access-token")
+  })
+
+  it("returns an empty object on a non-ok response", async () => {
+    mockFetch(async () => new Response("Unauthorized", { status: 401 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the request throws", async () => {
+    mockFetch(async () => { throw new Error("network down") })
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the body is not JSON", async () => {
+    mockFetch(async () => new Response("not-json", { status: 200 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// What actually lands on disk — the regression this change closes
+// ---------------------------------------------------------------------------
+
+describe("buildLoginCredentials", () => {
+  it("persists the plan alongside the tokens when it is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("max")
+    expect(creds.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("omits the keys entirely when the plan is unknown", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {})
+
+    // `subscriptionType: undefined` would write a null-ish key into a file the
+    // real CLI also parses — absence must mean absent, not present-and-empty.
+    expect("subscriptionType" in creds.claudeAiOauth).toBe(false)
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+    expect(JSON.stringify(creds)).not.toContain("subscriptionType")
+  })
+
+  it("writes only the field that is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, { subscriptionType: "team" })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("team")
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+  })
+
+  it("still carries the tokens, scopes and expiry", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {}, 1_000_000)
+
+    expect(creds.claudeAiOauth.accessToken).toBe("the-access-token")
+    expect(creds.claudeAiOauth.refreshToken).toBe("the-refresh-token")
+    expect(creds.claudeAiOauth.expiresAt).toBe(1_000_000 + 3600 * 1000)
+    expect(creds.claudeAiOauth.scopes).toEqual(["user:profile", "user:inference"])
+  })
+
+  it("prefers an absolute expires_at over expires_in", () => {
+    const creds = buildLoginCredentials({ ...TOKEN_DATA, expires_at: 42 }, {}, 1_000_000)
+    expect(creds.claudeAiOauth.expiresAt).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Once written, the value must survive every subsequent refresh.
+//
+// doRefresh rebuilds claudeAiOauth with a spread, so anything already on disk
+// is carried forward. Turning that spread into an explicit field list would
+// silently re-open the same hole one refresh cycle after each login.
+// ---------------------------------------------------------------------------
+
+describe("a refresh preserves an already-persisted plan", () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  it("keeps subscriptionType and rateLimitTier across a token refresh", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({
+      access_token: "rotated-access-token",
+      refresh_token: "rotated-refresh-token",
+      expires_in: 3600,
+    }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(stored.claudeAiOauth.accessToken).toBe("rotated-access-token")
+    expect(stored.claudeAiOauth.subscriptionType).toBe("max")
+    expect(stored.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("does not invent a plan for a credential written before this change", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {})
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({ access_token: "rotated", expires_in: 3600 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    // A refresh cannot repair an already-blind profile: only a re-login can.
+    expect("subscriptionType" in stored.claudeAiOauth).toBe(false)
+  })
+})

--- a/src/__tests__/profile-login-plan-fields.test.ts
+++ b/src/__tests__/profile-login-plan-fields.test.ts
@@ -8,12 +8,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { buildLoginCredentials } from "../proxy/profileCli"
 import {
-  buildLoginCredentials,
   extractPlanFields,
   fetchOAuthPlanFields,
   subscriptionTypeFromOrganizationType,
-} from "../proxy/profileCli"
+} from "../proxy/oauthPlan"
 import type { CredentialStore } from "../proxy/tokenRefresh"
 
 /** Assign a mock to globalThis.fetch without TS complaining about `preconnect`. */

--- a/src/__tests__/token-refresh-plan-backfill.test.ts
+++ b/src/__tests__/token-refresh-plan-backfill.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for the plan backfill a token refresh performs.
+ *
+ * The plan is written at login and never again, so a credential file created
+ * before Meridian persisted it stays plan-blind for the life of the login. A
+ * refresh is the only other moment holding a valid access token, so it is the
+ * only place the gap can be closed without an interactive re-login.
+ *
+ * Both endpoints are reached through `globalThis.fetch`, so the mock dispatches
+ * on URL: the token endpoint returns rotated tokens, the profile endpoint
+ * returns the plan. Profile-endpoint calls are counted, because "does not ask
+ * when it already knows" is the assertion that keeps this one GET per profile
+ * rather than one per refresh.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import type { CredentialStore } from "../proxy/tokenRefresh"
+import { planFieldsMissing } from "../proxy/oauthPlan"
+
+const TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
+const PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
+
+function jsonResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const ROTATED_TOKENS = {
+  access_token: "rotated-access-token",
+  refresh_token: "rotated-refresh-token",
+  expires_in: 3600,
+}
+
+const MAX_20X_PROFILE = {
+  organization: {
+    organization_type: "claude_max",
+    rate_limit_tier: "default_claude_max_20x",
+  },
+}
+
+/**
+ * Route the two endpoints and count profile hits.
+ *
+ * `profileResponse` returning null stands for a profile lookup that fails —
+ * the case that must leave the refresh itself successful.
+ */
+function stubEndpoints(profileResponse: () => Response | null) {
+  let profileCalls = 0
+  let profileAuthorization: string | undefined
+  globalThis.fetch = (async (url: unknown, init?: RequestInit) => {
+    const href = String(url)
+    if (href === TOKEN_URL) return jsonResponse(ROTATED_TOKENS)
+    if (href === PROFILE_URL) {
+      profileCalls++
+      profileAuthorization = (init?.headers as Record<string, string> | undefined)?.Authorization
+      const res = profileResponse()
+      if (!res) throw new Error("profile endpoint unreachable")
+      return res
+    }
+    throw new Error(`unexpected fetch: ${href}`)
+  }) as typeof fetch
+
+  return {
+    profileCalls: () => profileCalls,
+    profileAuthorization: () => profileAuthorization,
+  }
+}
+
+/** A store seeded with tokens plus whatever plan fields the case is about. */
+function makeStore(plan: { subscriptionType?: string; rateLimitTier?: string }) {
+  let stored: Record<string, unknown> = {
+    claudeAiOauth: {
+      accessToken: "old-access-token",
+      refreshToken: "the-refresh-token",
+      expiresAt: Date.now() - 1000,
+      scopes: ["user:profile", "user:inference"],
+      ...plan,
+    },
+  }
+  const store: CredentialStore = {
+    async read() { return JSON.parse(JSON.stringify(stored)) as never },
+    async write(credentials) { stored = credentials as never; return true },
+  }
+  return {
+    store,
+    oauth: () => (stored.claudeAiOauth as Record<string, unknown>),
+  }
+}
+
+describe("planFieldsMissing", () => {
+  it("is true while either field is absent", () => {
+    expect(planFieldsMissing({})).toBe(true)
+    expect(planFieldsMissing({ subscriptionType: "max" })).toBe(true)
+    expect(planFieldsMissing({ rateLimitTier: "default_claude_max_20x" })).toBe(true)
+    expect(planFieldsMissing(null)).toBe(true)
+    expect(planFieldsMissing(undefined)).toBe(true)
+  })
+
+  it("is false only once both are present", () => {
+    expect(planFieldsMissing({ subscriptionType: "max", rateLimitTier: "default_claude_max_20x" })).toBe(false)
+  })
+})
+
+describe("a token refresh backfills a plan-blind credential", () => {
+  let originalFetch: typeof globalThis.fetch
+  let originalWarn: typeof console.warn
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    originalWarn = console.warn
+    console.warn = () => {}
+  })
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    console.warn = originalWarn
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  it("writes both fields when the credential has neither", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, oauth } = makeStore({})
+    const stub = stubEndpoints(() => jsonResponse(MAX_20X_PROFILE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(oauth().subscriptionType).toBe("max")
+    expect(oauth().rateLimitTier).toBe("default_claude_max_20x")
+    expect(stub.profileCalls()).toBe(1)
+  })
+
+  it("completes a credential the CLI filled only halfway", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    // `claude login` records subscriptionType without always recording the
+    // tier, and the tier is the half that separates Max 5x from Max 20x.
+    const { store, oauth } = makeStore({ subscriptionType: "max" })
+    stubEndpoints(() => jsonResponse(MAX_20X_PROFILE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(oauth().rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("presents the freshly rotated access token to the profile endpoint", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store } = makeStore({})
+    const stub = stubEndpoints(() => jsonResponse(MAX_20X_PROFILE))
+
+    await refreshOAuthToken(store)
+
+    // The old token may already be rejected — that is why the refresh ran.
+    expect(stub.profileAuthorization()).toBe("Bearer rotated-access-token")
+  })
+
+  it("does not ask again once both fields are known", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store } = makeStore({ subscriptionType: "max", rateLimitTier: "default_claude_max_20x" })
+    const stub = stubEndpoints(() => jsonResponse(MAX_20X_PROFILE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(stub.profileCalls()).toBe(0)
+  })
+
+  it("keeps the stored value when the endpoint reports a different one", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    // Only the missing half is being filled in; a plan already on disk was
+    // written by a login and is not up for revision by a backfill.
+    const { store, oauth } = makeStore({ subscriptionType: "team" })
+    stubEndpoints(() => jsonResponse(MAX_20X_PROFILE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(oauth().subscriptionType).toBe("team")
+    expect(oauth().rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("still refreshes the token when the plan lookup fails", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, oauth } = makeStore({})
+    stubEndpoints(() => null)
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(oauth().accessToken).toBe("rotated-access-token")
+    expect("subscriptionType" in oauth()).toBe(false)
+  })
+
+  it("writes no plan key at all for an account it could not identify", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    const { store, oauth } = makeStore({})
+    stubEndpoints(() => jsonResponse({ organization: { organization_type: "claude_something_new" } }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(JSON.stringify(oauth())).not.toContain("subscriptionType")
+    expect(JSON.stringify(oauth())).not.toContain("rateLimitTier")
+  })
+
+  it("leaves the refresh a single credential-store write", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+    let writes = 0
+    let stored: Record<string, unknown> = {
+      claudeAiOauth: {
+        accessToken: "old-access-token",
+        refreshToken: "the-refresh-token",
+        expiresAt: Date.now() - 1000,
+      },
+    }
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) as never },
+      async write(credentials) { writes++; stored = credentials as never; return true },
+    }
+    stubEndpoints(() => jsonResponse(MAX_20X_PROFILE))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(writes).toBe(1)
+    expect((stored.claudeAiOauth as Record<string, unknown>).rateLimitTier).toBe("default_claude_max_20x")
+  })
+})

--- a/src/proxy/oauthPlan.ts
+++ b/src/proxy/oauthPlan.ts
@@ -1,0 +1,115 @@
+/**
+ * The account's plan, as Anthropic reports it for a given access token.
+ *
+ * Shared by the two moments a plan can be learned: an interactive login, which
+ * has just minted a token, and a token refresh, which has just minted another.
+ * It lives in its own module rather than in profileCli.ts because profileCli
+ * already imports tokenRefresh for the credential store, so the refresh path
+ * importing back would close a cycle.
+ *
+ * This is a leaf module — one authenticated GET, no imports.
+ */
+
+/**
+ * Where the account's plan comes from — not the token endpoint.
+ *
+ * Everything Claude Code reads off a token response is `access_token`,
+ * `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and
+ * `organization.uuid`. It derives `subscriptionType` / `rateLimitTier` from a
+ * separate authenticated GET here, then writes them into the same
+ * `.credentials.json` Meridian shares with it — so a headless login has to ask
+ * for them too. Note the host differs from the token endpoint; reached with
+ * the `user:profile` scope, which every login already requests.
+ */
+const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
+
+interface OAuthProfileResponse {
+  organization?: {
+    organization_type?: string | null
+    rate_limit_tier?: string | null
+  } | null
+}
+
+export interface OAuthPlanFields {
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+/**
+ * Translate Anthropic's wire `organization_type` into the vocabulary the Claude
+ * CLI writes on disk — the wire value is prefixed (`claude_max`), the stored one
+ * is not (`max`). Mirroring the CLI's own mapping is what keeps a credential
+ * file Meridian writes indistinguishable from one `claude login` wrote, which
+ * matters because `claude auth status` reads it back and is what ultimately
+ * feeds `/profiles/list`, `/health` and the `max`-only branch of `/v1/models`.
+ *
+ * An unrecognized or absent type yields undefined so the caller omits the key,
+ * rather than inventing a plan for an account it could not identify.
+ */
+export function subscriptionTypeFromOrganizationType(
+  organizationType: string | null | undefined,
+): string | undefined {
+  switch (organizationType) {
+    case "claude_max": return "max"
+    case "claude_pro": return "pro"
+    case "claude_team": return "team"
+    case "claude_enterprise": return "enterprise"
+    default: return undefined
+  }
+}
+
+export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
+  const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
+  const rateLimitTier = profile?.organization?.rate_limit_tier
+  return {
+    ...(subscriptionType ? { subscriptionType } : {}),
+    ...(rateLimitTier ? { rateLimitTier } : {}),
+  }
+}
+
+/**
+ * Whether a stored credential is still missing plan information.
+ *
+ * Either field being absent counts, because they answer different questions
+ * and arrive from different writers: `claude login` records `subscriptionType`
+ * but not always `rateLimitTier`, and only `rateLimitTier` distinguishes Max 5x
+ * from Max 20x. Requiring both means a file half-filled by the CLI still gets
+ * completed.
+ */
+export function planFieldsMissing(fields: OAuthPlanFields | null | undefined): boolean {
+  return !fields?.subscriptionType || !fields?.rateLimitTier
+}
+
+/**
+ * Best-effort plan lookup for a valid access token. Never throws and never
+ * fails its caller: a profile whose plan is unknown is strictly better than no
+ * profile at all, and every consumer already treats it as optional.
+ */
+export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPlanFields> {
+  let response: Response
+  try {
+    response = await fetch(OAUTH_PROFILE_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch (err) {
+    console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+
+  if (!response.ok) {
+    console.warn(`[meridian] Could not read the account plan (${response.status}).`)
+    return {}
+  }
+
+  try {
+    return extractPlanFields(await response.json() as OAuthProfileResponse)
+  } catch (err) {
+    console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+}

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -17,7 +17,7 @@ import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
-import { createPlatformCredentialStore } from "./tokenRefresh"
+import { createPlatformCredentialStore, type CredentialsFile } from "./tokenRefresh"
 
 const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
@@ -25,6 +25,18 @@ const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+/**
+ * Where the account's plan comes from — not the token endpoint.
+ *
+ * Everything Claude Code reads off a token response is `access_token`,
+ * `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and
+ * `organization.uuid`. It derives `subscriptionType` / `rateLimitTier` from a
+ * separate authenticated GET here, then writes them into the same
+ * `.credentials.json` Meridian shares with it — so a headless login has to ask
+ * for them too. Note the host differs from OAUTH_TOKEN_URL; reached with the
+ * `user:profile` scope, already in OAUTH_SCOPES.
+ */
+const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -156,6 +168,115 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
+interface OAuthProfileResponse {
+  organization?: {
+    organization_type?: string | null
+    rate_limit_tier?: string | null
+  } | null
+}
+
+export interface OAuthPlanFields {
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+type CompleteOAuthTokenResponse = OAuthTokenResponse & { refresh_token: string }
+
+function hasRequiredTokens(tokenData: OAuthTokenResponse): tokenData is CompleteOAuthTokenResponse {
+  return Boolean(tokenData.access_token && tokenData.refresh_token)
+}
+
+/**
+ * Translate Anthropic's wire `organization_type` into the vocabulary the Claude
+ * CLI writes on disk — the wire value is prefixed (`claude_max`), the stored one
+ * is not (`max`). Mirroring the CLI's own mapping is what keeps a credential
+ * file Meridian writes indistinguishable from one `claude login` wrote, which
+ * matters because `claude auth status` reads it back and is what ultimately
+ * feeds `/profiles/list`, `/health` and the `max`-only branch of `/v1/models`.
+ *
+ * An unrecognized or absent type yields undefined so the caller omits the key,
+ * rather than inventing a plan for an account it could not identify.
+ */
+export function subscriptionTypeFromOrganizationType(
+  organizationType: string | null | undefined,
+): string | undefined {
+  switch (organizationType) {
+    case "claude_max": return "max"
+    case "claude_pro": return "pro"
+    case "claude_team": return "team"
+    case "claude_enterprise": return "enterprise"
+    default: return undefined
+  }
+}
+
+export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
+  const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
+  const rateLimitTier = profile?.organization?.rate_limit_tier
+  return {
+    ...(subscriptionType ? { subscriptionType } : {}),
+    ...(rateLimitTier ? { rateLimitTier } : {}),
+  }
+}
+
+/**
+ * Best-effort plan lookup for a freshly minted access token. Never throws and
+ * never fails the login: a profile whose plan is unknown is strictly better
+ * than no profile at all, and every consumer already treats it as optional.
+ */
+export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPlanFields> {
+  let response: Response
+  try {
+    response = await fetch(OAUTH_PROFILE_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch (err) {
+    console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+
+  if (!response.ok) {
+    console.warn(`[meridian] Could not read the account plan (${response.status}).`)
+    return {}
+  }
+
+  try {
+    return extractPlanFields(await response.json() as OAuthProfileResponse)
+  } catch (err) {
+    console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+}
+
+/**
+ * Build the record a login writes to disk.
+ *
+ * Split out so the on-disk shape is directly assertable: the defect this closes
+ * was a field missing from this object literal, which no test of the
+ * surrounding prompt/fetch I/O would have caught. Plan fields spread in only
+ * when known — `subscriptionType: undefined` would write a null-ish key into a
+ * file the real CLI also parses.
+ */
+export function buildLoginCredentials(
+  tokenData: CompleteOAuthTokenResponse,
+  plan: OAuthPlanFields,
+  now: number = Date.now(),
+): CredentialsFile {
+  return {
+    claudeAiOauth: {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt: tokenData.expires_at ?? now + (tokenData.expires_in ?? 8 * 60 * 60) * 1000,
+      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
+      ...plan,
+    },
+  }
+}
+
 async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   const session = createManualOAuthSession()
   console.log("\x1b[33m⚠ Headless OAuth login: open this URL in a browser:\x1b[0m")
@@ -209,21 +330,14 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
     return false
   }
 
-  if (!tokenData.access_token || !tokenData.refresh_token) {
+  if (!hasRequiredTokens(tokenData)) {
     console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
     return false
   }
 
-  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+  const plan = await fetchOAuthPlanFields(tokenData.access_token)
   const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write({
-    claudeAiOauth: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt,
-      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
-    },
-  })
+  return store.write(buildLoginCredentials(tokenData, plan))
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -15,6 +15,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node
 import { homedir } from "node:os"
 import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
+import { fetchOAuthPlanFields, type OAuthPlanFields } from "./oauthPlan"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
 import { createPlatformCredentialStore, type CredentialsFile } from "./tokenRefresh"
@@ -25,18 +26,6 @@ const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
-/**
- * Where the account's plan comes from — not the token endpoint.
- *
- * Everything Claude Code reads off a token response is `access_token`,
- * `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and
- * `organization.uuid`. It derives `subscriptionType` / `rateLimitTier` from a
- * separate authenticated GET here, then writes them into the same
- * `.credentials.json` Meridian shares with it — so a headless login has to ask
- * for them too. Note the host differs from OAUTH_TOKEN_URL; reached with the
- * `user:profile` scope, already in OAUTH_SCOPES.
- */
-const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -168,88 +157,10 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
-interface OAuthProfileResponse {
-  organization?: {
-    organization_type?: string | null
-    rate_limit_tier?: string | null
-  } | null
-}
-
-export interface OAuthPlanFields {
-  subscriptionType?: string
-  rateLimitTier?: string
-}
-
 type CompleteOAuthTokenResponse = OAuthTokenResponse & { refresh_token: string }
 
 function hasRequiredTokens(tokenData: OAuthTokenResponse): tokenData is CompleteOAuthTokenResponse {
   return Boolean(tokenData.access_token && tokenData.refresh_token)
-}
-
-/**
- * Translate Anthropic's wire `organization_type` into the vocabulary the Claude
- * CLI writes on disk — the wire value is prefixed (`claude_max`), the stored one
- * is not (`max`). Mirroring the CLI's own mapping is what keeps a credential
- * file Meridian writes indistinguishable from one `claude login` wrote, which
- * matters because `claude auth status` reads it back and is what ultimately
- * feeds `/profiles/list`, `/health` and the `max`-only branch of `/v1/models`.
- *
- * An unrecognized or absent type yields undefined so the caller omits the key,
- * rather than inventing a plan for an account it could not identify.
- */
-export function subscriptionTypeFromOrganizationType(
-  organizationType: string | null | undefined,
-): string | undefined {
-  switch (organizationType) {
-    case "claude_max": return "max"
-    case "claude_pro": return "pro"
-    case "claude_team": return "team"
-    case "claude_enterprise": return "enterprise"
-    default: return undefined
-  }
-}
-
-export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
-  const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
-  const rateLimitTier = profile?.organization?.rate_limit_tier
-  return {
-    ...(subscriptionType ? { subscriptionType } : {}),
-    ...(rateLimitTier ? { rateLimitTier } : {}),
-  }
-}
-
-/**
- * Best-effort plan lookup for a freshly minted access token. Never throws and
- * never fails the login: a profile whose plan is unknown is strictly better
- * than no profile at all, and every consumer already treats it as optional.
- */
-export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPlanFields> {
-  let response: Response
-  try {
-    response = await fetch(OAUTH_PROFILE_URL, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-Type": "application/json",
-        "Cache-Control": "no-cache",
-      },
-      signal: AbortSignal.timeout(10_000),
-    })
-  } catch (err) {
-    console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
-    return {}
-  }
-
-  if (!response.ok) {
-    console.warn(`[meridian] Could not read the account plan (${response.status}).`)
-    return {}
-  }
-
-  try {
-    return extractPlanFields(await response.json() as OAuthProfileResponse)
-  } catch (err) {
-    console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
-    return {}
-  }
 }
 
 /**

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -51,7 +51,7 @@ export function configDirToCredentialsFile(claudeConfigDir: string): string {
   return join(resolve(claudeConfigDir), ".credentials.json")
 }
 
-interface OAuthCredentials {
+export interface OAuthCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
@@ -70,7 +70,7 @@ interface OAuthCredentials {
   rateLimitTier?: string
 }
 
-interface CredentialsFile {
+export interface CredentialsFile {
   claudeAiOauth: OAuthCredentials
   [key: string]: unknown
 }

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -21,6 +21,7 @@ import { homedir, platform, userInfo } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 import { claudeLog } from "../logger"
+import { fetchOAuthPlanFields, planFieldsMissing } from "./oauthPlan"
 
 const execFile = promisify(execFileCb)
 
@@ -353,13 +354,35 @@ async function doRefresh(store: CredentialStore): Promise<boolean> {
     ...(refreshTokenExpiresAt ? { refreshTokenExpiresAt } : {}),
   }
 
+  // The plan is only ever written at login, so a credential file created before
+  // Meridian persisted it stays plan-blind forever — nothing else in the
+  // lifecycle ever asks. A refresh is the one other moment that holds a valid
+  // access token, which is what the profile endpoint requires, so it is the
+  // only place a backfill can happen without forcing an interactive re-login.
+  //
+  // Gated on the fields being absent, so this costs one extra GET once per
+  // profile rather than on every ~8h refresh: the next refresh reads the value
+  // this one wrote and skips. Merged before the write so the whole thing is
+  // still a single store write, and spread UNDER the existing fields so a
+  // value already on disk always wins over a freshly fetched one.
+  const backfilled = planFieldsMissing(credentials.claudeAiOauth)
+    ? await fetchOAuthPlanFields(tokenData.access_token)
+    : {}
+  if (backfilled.subscriptionType || backfilled.rateLimitTier) {
+    credentials.claudeAiOauth = { ...backfilled, ...credentials.claudeAiOauth }
+  }
+
   const written = await store.write(credentials)
   if (!written) return false
 
   // Logged so it is observable whether Anthropic ever rolls the refresh-token
   // window — undefined here means the renewal countdown stays anchored to the
   // last interactive login.
-  claudeLog("token_refresh.success", { expiresAt, refreshTokenExpiresAt })
+  claudeLog("token_refresh.success", {
+    expiresAt,
+    refreshTokenExpiresAt,
+    backfilledPlan: Object.keys(backfilled),
+  })
   return true
 }
 


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

> Stacks on #795. The first commit here is that PR's; the second is this one. Read/merge #795 first.

The plan fields are written **once, at login, and never again**.

A credential file created before Meridian persisted them — or by a `claude login` that recorded `subscriptionType` without `rateLimitTier` — stays plan-blind for the life of the profile, because nothing else in the lifecycle ever asks. Measured on a ten-account host: **eight of ten profiles carried no plan at all**, and re-running an interactive login on each one just to learn the plan is not a reasonable ask.

## Why the refresh path

`GET /api/oauth/profile` needs a valid access token. A token refresh is the **one other moment** in a profile's life that holds one — every other consumer reads credentials rather than minting them. So it is the only place the gap can be closed without an interactive re-login.

## What it costs

One extra GET **per profile**, not per refresh. The lookup is gated on either field being absent, so the next refresh reads the value this one wrote and skips it. A steady-state fleet does zero extra requests.

Three further properties, all deliberate:

- **One store write.** The fetched fields are merged into the same `claudeAiOauth` object before `store.write()`, so a backfilling refresh still writes once.
- **Disk always wins.** The fetched fields are spread *under* the stored ones, so a backfill can never overwrite what a login recorded — it can only fill a hole.
- **Best-effort.** `fetchOAuthPlanFields` already swallows its own failures and returns `{}`, so a profile endpoint that is down, slow or 401ing leaves the refresh itself completely untouched. A refresh never fails because of this.

`token_refresh.success` now logs which fields were backfilled, so a run that filled a gap is distinguishable from one that had nothing to do.

## The module move

The plan lookup moves from `src/proxy/profileCli.ts` to a new leaf module `src/proxy/oauthPlan.ts`, unchanged apart from the new `planFieldsMissing` predicate.

`profileCli` already imports `tokenRefresh` for the credential store, so the refresh path importing back would close a cycle. Both callers — login and refresh — now depend on the leaf instead. The existing plan-fields tests were repointed at the new module; no assertion changed.

## Verification

`npm run typecheck` clean. `npm test` green: **2568 pass, 0 fail**, including 10 new tests for the backfill — that it fires when either field is missing, that it does *not* fire when both are present, that a fetched value never overrides a stored one, that a failing lookup leaves the refresh succeeding, and that the whole thing is still a single store write.

This PR is AI generated, but under direct supervision and on request of Nowaker.
