### PR TITLE
feat(auth): log every property Anthropic returns during authentication

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -31,6 +31,10 @@ Open the printed URL in a browser, sign in to the target Claude account, then pa
 meridian profile login work --headless
 ```
 
+The same login also records the account's plan (`subscriptionType`, `rateLimitTier`), read from Anthropic's OAuth profile endpoint — the token exchange itself returns no plan information. That is what lets `meridian profile list`, `/profiles/list`, `/health` and the dashboard tell a Max account from a Team one, and what makes `/v1/models` advertise the larger context window Max accounts actually have. If the lookup fails the login still succeeds and the plan simply stays unknown.
+
+> **⚠ A profile created by an older Meridian has no plan recorded, and a token refresh cannot backfill it** — the value is only ever written at login, and Anthropic's usage endpoint does not carry it. Re-run `meridian profile login <name> --headless` to repair such a profile.
+
 #### Headless / CI: register an OAuth token
 
 When a browser isn't available (containers, CI runners, remote shells), generate a long-lived OAuth token with `claude setup-token` and register it as a profile:

--- a/src/__tests__/auth-discovery.test.ts
+++ b/src/__tests__/auth-discovery.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the auth-payload describer.
+ *
+ * The module is pure, so these are direct assertions with no mocking. The
+ * property that matters most is the polarity: a key nobody has seen before must
+ * be reported by name and type while its contents stay out of the log, because
+ * the whole point is observing fields Anthropic adds after this code was
+ * written.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { authFieldPaths, describeAuthFields, SAFE_AUTH_STRING_KEYS } from "../proxy/authDiscovery"
+
+const TOKEN_RESPONSE = {
+  access_token: "sk-ant-oat01-secret-value",
+  refresh_token: "sk-ant-ort01-secret-value",
+  expires_in: 3600,
+  token_type: "Bearer",
+  scope: "user:profile user:inference",
+  account: { uuid: "0198fa2c-1111-2222-3333-444455556666", email_address: "person@example.com" },
+}
+
+const PROFILE_RESPONSE = {
+  organization: {
+    uuid: "0198fa2c-aaaa-bbbb-cccc-ddddeeeeffff",
+    name: "Some Company Inc",
+    organization_type: "claude_max",
+    rate_limit_tier: "default_claude_max_20x",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Redaction polarity — the property the whole module exists for
+// ---------------------------------------------------------------------------
+
+describe("describeAuthFields redaction", () => {
+  it("never prints a token, and says how long it was", () => {
+    const described = describeAuthFields(TOKEN_RESPONSE) as Record<string, unknown>
+
+    expect(described.access_token).toBe(`[string len=${TOKEN_RESPONSE.access_token.length}]`)
+    expect(described.refresh_token).toBe(`[string len=${TOKEN_RESPONSE.refresh_token.length}]`)
+    expect(JSON.stringify(described)).not.toContain("sk-ant")
+  })
+
+  it("redacts a key it has never seen rather than printing it", () => {
+    // The inverse of logger.ts's deny-list: a field Anthropic adds tomorrow is
+    // by definition not on any list somebody wrote today, so the default must
+    // be redaction or the first new credential-bearing field leaks.
+    const described = describeAuthFields({ some_future_secret: "hunter2" }) as Record<string, unknown>
+
+    expect(described.some_future_secret).toBe("[string len=7]")
+    expect(JSON.stringify(described)).not.toContain("hunter2")
+  })
+
+  it("still reports that the new key arrived, and what type it is", () => {
+    const payload = { some_future_secret: "hunter2", some_future_flag: true, some_future_count: 12 }
+    const described = describeAuthFields(payload) as Record<string, unknown>
+
+    expect(Object.keys(described).sort()).toEqual(["some_future_count", "some_future_flag", "some_future_secret"])
+    expect(described.some_future_flag).toBe(true)
+    expect(described.some_future_count).toBe(12)
+  })
+
+  it("keeps a person and an organization out of the log", () => {
+    const described = describeAuthFields(TOKEN_RESPONSE) as Record<string, unknown>
+    const account = described.account as Record<string, unknown>
+
+    expect(account.email_address).toBe(`[string len=${TOKEN_RESPONSE.account.email_address.length}]`)
+    expect(account.uuid).toBe(`[string len=${TOKEN_RESPONSE.account.uuid.length}]`)
+    expect(JSON.stringify(described)).not.toContain("person@example.com")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// What is allowed through — the fields the diagnosis is actually made of
+// ---------------------------------------------------------------------------
+
+describe("describeAuthFields allow-list", () => {
+  it("prints the plan tier verbatim, which is the field being diagnosed", () => {
+    const described = describeAuthFields(PROFILE_RESPONSE) as Record<string, unknown>
+    const org = described.organization as Record<string, unknown>
+
+    expect(org.organization_type).toBe("claude_max")
+    expect(org.rate_limit_tier).toBe("default_claude_max_20x")
+  })
+
+  it("prints scopes and token type, which carry no secret", () => {
+    const described = describeAuthFields(TOKEN_RESPONSE) as Record<string, unknown>
+
+    expect(described.token_type).toBe("Bearer")
+    expect(described.scope).toBe("user:profile user:inference")
+  })
+
+  it("redacts the organization's name and uuid even beside allowed siblings", () => {
+    const described = describeAuthFields(PROFILE_RESPONSE) as Record<string, unknown>
+    const org = described.organization as Record<string, unknown>
+
+    expect(org.name).toBe(`[string len=${PROFILE_RESPONSE.organization.name.length}]`)
+    expect(org.uuid).toBe(`[string len=${PROFILE_RESPONSE.organization.uuid.length}]`)
+    expect(JSON.stringify(described)).not.toContain("Some Company Inc")
+  })
+
+  it("does not allow an identity-bearing key onto the list by accident", () => {
+    for (const key of ["email", "email_address", "name", "display_name", "uuid", "access_token", "refresh_token"]) {
+      expect(SAFE_AUTH_STRING_KEYS.has(key)).toBe(false)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shapes that must not throw — this runs inside a login, and a crash here
+// would fail an authentication over a debug line.
+// ---------------------------------------------------------------------------
+
+describe("describeAuthFields shapes", () => {
+  it("passes null and undefined straight through", () => {
+    expect(describeAuthFields(null)).toBeNull()
+    expect(describeAuthFields(undefined)).toBeUndefined()
+    expect(describeAuthFields({ organization: null })).toEqual({ organization: null })
+  })
+
+  it("describes each element of an array under the array's own key", () => {
+    const described = describeAuthFields({ scopes: ["user:profile", "user:inference"] }) as Record<string, unknown>
+    expect(described.scopes).toEqual(["user:profile", "user:inference"])
+
+    const secrets = describeAuthFields({ keys: ["aaa", "bbbb"] }) as Record<string, unknown>
+    expect(secrets.keys).toEqual(["[string len=3]", "[string len=4]"])
+  })
+
+  it("handles a bare primitive and an empty object", () => {
+    expect(describeAuthFields(42)).toBe(42)
+    expect(describeAuthFields(true)).toBe(true)
+    expect(describeAuthFields({})).toEqual({})
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The key list — the line worth grepping across two logins
+// ---------------------------------------------------------------------------
+
+describe("authFieldPaths", () => {
+  it("reports nested keys as dotted paths", () => {
+    expect(authFieldPaths(PROFILE_RESPONSE)).toEqual([
+      "organization",
+      "organization.uuid",
+      "organization.name",
+      "organization.organization_type",
+      "organization.rate_limit_tier",
+    ])
+  })
+
+  it("names the field that is missing by its absence, not by a null", () => {
+    // Comparing two logins reduces to comparing two of these lists, which is
+    // the point: a profile whose response never carried rate_limit_tier is
+    // distinguishable from one where it arrived and was dropped downstream.
+    const paths = authFieldPaths({ organization: { organization_type: "claude_max" } })
+
+    expect(paths).toContain("organization.organization_type")
+    expect(paths).not.toContain("organization.rate_limit_tier")
+  })
+
+  it("returns nothing for a non-object", () => {
+    expect(authFieldPaths(null)).toEqual([])
+    expect(authFieldPaths(undefined)).toEqual([])
+    expect(authFieldPaths("string")).toEqual([])
+    expect(authFieldPaths(["a", "b"])).toEqual([])
+  })
+})

--- a/src/__tests__/profile-login-plan-fields.test.ts
+++ b/src/__tests__/profile-login-plan-fields.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for the plan fields a headless OAuth login persists.
+ *
+ * Anthropic's token endpoint returns no plan information, so the headless login
+ * reads it from `/api/oauth/profile` and writes `subscriptionType` /
+ * `rateLimitTier` alongside the tokens. Network is swapped via
+ * `globalThis.fetch`; the credential-building step is pure and asserted directly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import {
+  buildLoginCredentials,
+  extractPlanFields,
+  fetchOAuthPlanFields,
+  subscriptionTypeFromOrganizationType,
+} from "../proxy/profileCli"
+import type { CredentialStore } from "../proxy/tokenRefresh"
+
+/** Assign a mock to globalThis.fetch without TS complaining about `preconnect`. */
+function mockFetch(fn: (...args: unknown[]) => Promise<Response | never>): void {
+  globalThis.fetch = fn as typeof fetch
+}
+
+function makeSuccessResponse(body: object) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+const TOKEN_DATA = {
+  access_token: "the-access-token",
+  refresh_token: "the-refresh-token",
+  expires_in: 3600,
+  scope: "user:profile user:inference",
+}
+
+const MAX_PROFILE = {
+  organization: {
+    organization_type: "claude_max",
+    rate_limit_tier: "default_claude_max_20x",
+  },
+}
+
+// ---------------------------------------------------------------------------
+// organization_type → subscriptionType
+// ---------------------------------------------------------------------------
+
+describe("subscriptionTypeFromOrganizationType", () => {
+  it("strips the claude_ prefix the CLI also strips", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_max")).toBe("max")
+    expect(subscriptionTypeFromOrganizationType("claude_pro")).toBe("pro")
+    expect(subscriptionTypeFromOrganizationType("claude_team")).toBe("team")
+    expect(subscriptionTypeFromOrganizationType("claude_enterprise")).toBe("enterprise")
+  })
+
+  it("returns undefined rather than guessing at an unknown plan", () => {
+    expect(subscriptionTypeFromOrganizationType("claude_something_new")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("max")).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(null)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType(undefined)).toBeUndefined()
+    expect(subscriptionTypeFromOrganizationType("")).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Profile body → plan fields (snake_case on the wire, camelCase on disk)
+// ---------------------------------------------------------------------------
+
+describe("extractPlanFields", () => {
+  it("translates the snake_case wire names to the camelCase on-disk names", () => {
+    expect(extractPlanFields(MAX_PROFILE)).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("distinguishes a team account from a max one", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_team" } }))
+      .toEqual({ subscriptionType: "team" })
+  })
+
+  it("keeps the tier when only the plan is unrecognized", () => {
+    expect(extractPlanFields({ organization: { organization_type: "claude_future", rate_limit_tier: "some_tier" } }))
+      .toEqual({ rateLimitTier: "some_tier" })
+  })
+
+  it("returns an empty object for an absent or empty organization", () => {
+    expect(extractPlanFields(null)).toEqual({})
+    expect(extractPlanFields(undefined)).toEqual({})
+    expect(extractPlanFields({})).toEqual({})
+    expect(extractPlanFields({ organization: null })).toEqual({})
+    expect(extractPlanFields({ organization: {} })).toEqual({})
+  })
+
+  it("omits keys rather than setting them to undefined", () => {
+    const fields = extractPlanFields({ organization: { organization_type: null, rate_limit_tier: null } })
+    expect(Object.keys(fields)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The profile fetch — best-effort, never fatal
+// ---------------------------------------------------------------------------
+
+describe("fetchOAuthPlanFields", () => {
+  let originalFetch: typeof globalThis.fetch
+  let originalWarn: typeof console.warn
+  let warnings: unknown[][]
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+    originalWarn = console.warn
+    warnings = []
+    console.warn = (...args: unknown[]) => { warnings.push(args) }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    console.warn = originalWarn
+  })
+
+  it("returns the plan for a healthy response", async () => {
+    mockFetch(async () => makeSuccessResponse(MAX_PROFILE))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+  })
+
+  it("presents the access token as a bearer credential to the profile endpoint", async () => {
+    let seenUrl: unknown
+    let seenInit: RequestInit | undefined
+    mockFetch(async (url: unknown, init: unknown) => {
+      seenUrl = url
+      seenInit = init as RequestInit
+      return makeSuccessResponse(MAX_PROFILE)
+    })
+
+    await fetchOAuthPlanFields("the-access-token")
+
+    expect(seenUrl).toBe("https://api.anthropic.com/api/oauth/profile")
+    const headers = seenInit?.headers as Record<string, string>
+    expect(headers.Authorization).toBe("Bearer the-access-token")
+  })
+
+  it("returns an empty object on a non-ok response", async () => {
+    mockFetch(async () => new Response("Unauthorized", { status: 401 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the request throws", async () => {
+    mockFetch(async () => { throw new Error("network down") })
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+
+  it("returns an empty object when the body is not JSON", async () => {
+    mockFetch(async () => new Response("not-json", { status: 200 }))
+    expect(await fetchOAuthPlanFields("tok")).toEqual({})
+    expect(warnings.length).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// What actually lands on disk — the regression this change closes
+// ---------------------------------------------------------------------------
+
+describe("buildLoginCredentials", () => {
+  it("persists the plan alongside the tokens when it is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("max")
+    expect(creds.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("omits the keys entirely when the plan is unknown", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {})
+
+    // `subscriptionType: undefined` would write a null-ish key into a file the
+    // real CLI also parses — absence must mean absent, not present-and-empty.
+    expect("subscriptionType" in creds.claudeAiOauth).toBe(false)
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+    expect(JSON.stringify(creds)).not.toContain("subscriptionType")
+  })
+
+  it("writes only the field that is known", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, { subscriptionType: "team" })
+
+    expect(creds.claudeAiOauth.subscriptionType).toBe("team")
+    expect("rateLimitTier" in creds.claudeAiOauth).toBe(false)
+  })
+
+  it("still carries the tokens, scopes and expiry", () => {
+    const creds = buildLoginCredentials(TOKEN_DATA, {}, 1_000_000)
+
+    expect(creds.claudeAiOauth.accessToken).toBe("the-access-token")
+    expect(creds.claudeAiOauth.refreshToken).toBe("the-refresh-token")
+    expect(creds.claudeAiOauth.expiresAt).toBe(1_000_000 + 3600 * 1000)
+    expect(creds.claudeAiOauth.scopes).toEqual(["user:profile", "user:inference"])
+  })
+
+  it("prefers an absolute expires_at over expires_in", () => {
+    const creds = buildLoginCredentials({ ...TOKEN_DATA, expires_at: 42 }, {}, 1_000_000)
+    expect(creds.claudeAiOauth.expiresAt).toBe(42)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Once written, the value must survive every subsequent refresh.
+//
+// doRefresh rebuilds claudeAiOauth with a spread, so anything already on disk
+// is carried forward. Turning that spread into an explicit field list would
+// silently re-open the same hole one refresh cycle after each login.
+// ---------------------------------------------------------------------------
+
+describe("a refresh preserves an already-persisted plan", () => {
+  let originalFetch: typeof globalThis.fetch
+
+  beforeEach(() => { originalFetch = globalThis.fetch })
+  afterEach(async () => {
+    globalThis.fetch = originalFetch
+    const { resetInflightRefresh } = await import("../proxy/tokenRefresh")
+    resetInflightRefresh()
+  })
+
+  it("keeps subscriptionType and rateLimitTier across a token refresh", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+    })
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({
+      access_token: "rotated-access-token",
+      refresh_token: "rotated-refresh-token",
+      expires_in: 3600,
+    }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    expect(stored.claudeAiOauth.accessToken).toBe("rotated-access-token")
+    expect(stored.claudeAiOauth.subscriptionType).toBe("max")
+    expect(stored.claudeAiOauth.rateLimitTier).toBe("default_claude_max_20x")
+  })
+
+  it("does not invent a plan for a credential written before this change", async () => {
+    const { refreshOAuthToken } = await import("../proxy/tokenRefresh")
+
+    let stored = buildLoginCredentials(TOKEN_DATA, {})
+    const store: CredentialStore = {
+      async read() { return JSON.parse(JSON.stringify(stored)) },
+      async write(credentials) { stored = credentials; return true },
+    }
+
+    mockFetch(async () => makeSuccessResponse({ access_token: "rotated", expires_in: 3600 }))
+
+    expect(await refreshOAuthToken(store)).toBe(true)
+    // A refresh cannot repair an already-blind profile: only a re-login can.
+    expect("subscriptionType" in stored.claudeAiOauth).toBe(false)
+  })
+})

--- a/src/proxy/authDiscovery.ts
+++ b/src/proxy/authDiscovery.ts
@@ -1,0 +1,102 @@
+/**
+ * What Anthropic told us during authentication, rendered safe to log.
+ *
+ * Three payloads decide what Meridian knows about an account — the token
+ * endpoint's response, `GET /api/oauth/profile`, and `claude auth status` —
+ * and none of them is currently observable. When a field is absent, or renamed,
+ * or Anthropic starts returning a plan tier nobody has seen before, the only
+ * symptom downstream is a profile that reads `unknown`, with nothing in any log
+ * to say whether the field was missing from the response or dropped on the way
+ * to disk. That distinction is the whole of the diagnosis.
+ *
+ * The obstacle is that two of those payloads carry credentials, so they cannot
+ * simply be logged. `logger.ts`'s `sanitize()` redacts by key name, which is
+ * the wrong polarity here: it protects the names somebody already thought of,
+ * and a field discovered tomorrow is by definition not one of them.
+ *
+ * So this inverts it. Every string is redacted to its length unless its key is
+ * on an allow-list of values known to carry no secret. A new field is therefore
+ * reported by NAME and TYPE — enough to see it arrived and to decide what it is
+ * — while its contents stay out of the log until somebody deliberately adds it
+ * to the list.
+ *
+ * This is a leaf module — pure, no imports.
+ */
+
+/**
+ * String-valued keys whose contents are safe to print.
+ *
+ * Every one is either a duration, a timestamp, an enum Anthropic publishes, or
+ * the scope list that already appears in plaintext in the authorize URL. A key
+ * that identifies a person or an organization is deliberately absent: `email`,
+ * `email_address`, `name`, `display_name` and `uuid` are all reported by length
+ * only, because a debug log is routinely pasted into an issue.
+ */
+export const SAFE_AUTH_STRING_KEYS: ReadonlySet<string> = new Set([
+  "token_type",
+  "expires_at",
+  "expires_in",
+  "refresh_token_expires_at",
+  "refresh_token_expires_in",
+  "scope",
+  "scopes",
+  "organization_type",
+  "rate_limit_tier",
+  "billing_type",
+  "subscriptionType",
+  "rateLimitTier",
+])
+
+/**
+ * Non-string primitives are printed as they are.
+ *
+ * A boolean or a number cannot meaningfully be a credential — `true` and `3600`
+ * carry no secret — and they are exactly the fields worth reading: `loggedIn`,
+ * `expires_in`, and whatever `has_*` flag Anthropic adds next.
+ */
+function describeValue(key: string, value: unknown): unknown {
+  if (value === null || value === undefined) return value
+  if (typeof value === "string") {
+    return SAFE_AUTH_STRING_KEYS.has(key) ? value : `[string len=${value.length}]`
+  }
+  if (typeof value === "number" || typeof value === "boolean") return value
+  if (Array.isArray(value)) return value.map((item) => describeValue(key, item))
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = describeValue(k, v)
+    }
+    return out
+  }
+  return `[${typeof value}]`
+}
+
+/**
+ * Render a parsed auth response as a loggable field map.
+ *
+ * The shape mirrors the payload rather than flattening it, so a nested
+ * `organization.rate_limit_tier` reads the same way in the log as it does in
+ * Anthropic's documentation and in the code that consumes it.
+ */
+export function describeAuthFields(payload: unknown): unknown {
+  return describeValue("", payload)
+}
+
+/**
+ * The keys a payload actually carried, nested ones included, as dotted paths.
+ *
+ * Logged alongside the described payload because it is the line worth grepping:
+ * comparing two logins reduces to comparing two key lists, which answers "did
+ * this account's response even contain the field" without reading the values at
+ * all.
+ */
+export function authFieldPaths(payload: unknown, prefix = ""): string[] {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return []
+  const paths: string[] = []
+  for (const [key, value] of Object.entries(payload as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    paths.push(path)
+    paths.push(...authFieldPaths(value, path))
+  }
+  return paths
+}

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from "url"
 import { join, dirname } from "path"
 import { promisify } from "util"
 import { env } from "../env"
+import { claudeLog } from "../logger"
+import { authFieldPaths, describeAuthFields } from "./authDiscovery"
 
 const exec = promisify(execCallback)
 const execFile = promisify(execFileCallback)
@@ -351,6 +353,16 @@ export async function getClaudeAuthStatusAsync(profileId?: string, envOverrides?
         ...(envOverrides ? { env: { ...process.env, ...envOverrides } } : {}),
       })
       const parsed = JSON.parse(stdout) as ClaudeAuthStatus
+      // The same payload the CLI path logs, from the reader every HTTP route
+      // goes through. Both are logged because they can disagree: this one is
+      // TTL-cached per profile and falls back to a last-known-good value, so a
+      // field visible here may be minutes old while the CLI reads it live.
+      claudeLog("auth.status_discovered", {
+        source: "cli_async",
+        profile: profileId ?? "default",
+        fields: authFieldPaths(parsed),
+        payload: describeAuthFields(parsed),
+      })
       if (cache) {
         cache.status = parsed; cache.lastKnownGood = parsed
         cache.at = Date.now(); cache.isFailure = false; cache.lastSuccessAt = Date.now()
@@ -359,7 +371,13 @@ export async function getClaudeAuthStatusAsync(profileId?: string, envOverrides?
         cachedAuthStatusAt = Date.now(); cachedAuthStatusIsFailure = false
       }
       return parsed
-    } catch {
+    } catch (err) {
+      claudeLog("auth.status_failed", {
+        source: "cli_async",
+        profile: profileId ?? "default",
+        error: String(err),
+        servingLastKnownGood: Boolean(cache ? cache.lastKnownGood : lastKnownGoodAuthStatus),
+      })
       if (cache) {
         cache.isFailure = true; cache.at = Date.now(); cache.status = null
         return cache.lastKnownGood

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -17,7 +17,7 @@ import { join } from "node:path"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
-import { createPlatformCredentialStore } from "./tokenRefresh"
+import { createPlatformCredentialStore, type CredentialsFile } from "./tokenRefresh"
 
 const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
@@ -25,6 +25,18 @@ const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 export const OAUTH_REDIRECT_URI = "https://platform.claude.com/oauth/code/callback"
+/**
+ * Where the account's plan comes from — not the token endpoint.
+ *
+ * Everything Claude Code reads off a token response is `access_token`,
+ * `refresh_token`, `expires_in`, `scope`, `account.{uuid,email_address}` and
+ * `organization.uuid`. It derives `subscriptionType` / `rateLimitTier` from a
+ * separate authenticated GET here, then writes them into the same
+ * `.credentials.json` Meridian shares with it — so a headless login has to ask
+ * for them too. Note the host differs from OAUTH_TOKEN_URL; reached with the
+ * `user:profile` scope, already in OAUTH_SCOPES.
+ */
+const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
 const OAUTH_SCOPES = [
   "org:create_api_key",
   "user:profile",
@@ -156,6 +168,115 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
   }
 }
 
+interface OAuthProfileResponse {
+  organization?: {
+    organization_type?: string | null
+    rate_limit_tier?: string | null
+  } | null
+}
+
+export interface OAuthPlanFields {
+  subscriptionType?: string
+  rateLimitTier?: string
+}
+
+type CompleteOAuthTokenResponse = OAuthTokenResponse & { refresh_token: string }
+
+function hasRequiredTokens(tokenData: OAuthTokenResponse): tokenData is CompleteOAuthTokenResponse {
+  return Boolean(tokenData.access_token && tokenData.refresh_token)
+}
+
+/**
+ * Translate Anthropic's wire `organization_type` into the vocabulary the Claude
+ * CLI writes on disk — the wire value is prefixed (`claude_max`), the stored one
+ * is not (`max`). Mirroring the CLI's own mapping is what keeps a credential
+ * file Meridian writes indistinguishable from one `claude login` wrote, which
+ * matters because `claude auth status` reads it back and is what ultimately
+ * feeds `/profiles/list`, `/health` and the `max`-only branch of `/v1/models`.
+ *
+ * An unrecognized or absent type yields undefined so the caller omits the key,
+ * rather than inventing a plan for an account it could not identify.
+ */
+export function subscriptionTypeFromOrganizationType(
+  organizationType: string | null | undefined,
+): string | undefined {
+  switch (organizationType) {
+    case "claude_max": return "max"
+    case "claude_pro": return "pro"
+    case "claude_team": return "team"
+    case "claude_enterprise": return "enterprise"
+    default: return undefined
+  }
+}
+
+export function extractPlanFields(profile: OAuthProfileResponse | null | undefined): OAuthPlanFields {
+  const subscriptionType = subscriptionTypeFromOrganizationType(profile?.organization?.organization_type)
+  const rateLimitTier = profile?.organization?.rate_limit_tier
+  return {
+    ...(subscriptionType ? { subscriptionType } : {}),
+    ...(rateLimitTier ? { rateLimitTier } : {}),
+  }
+}
+
+/**
+ * Best-effort plan lookup for a freshly minted access token. Never throws and
+ * never fails the login: a profile whose plan is unknown is strictly better
+ * than no profile at all, and every consumer already treats it as optional.
+ */
+export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPlanFields> {
+  let response: Response
+  try {
+    response = await fetch(OAUTH_PROFILE_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+  } catch (err) {
+    console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+
+  if (!response.ok) {
+    console.warn(`[meridian] Could not read the account plan (${response.status}).`)
+    return {}
+  }
+
+  try {
+    return extractPlanFields(await response.json() as OAuthProfileResponse)
+  } catch (err) {
+    console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
+    return {}
+  }
+}
+
+/**
+ * Build the record a login writes to disk.
+ *
+ * Split out so the on-disk shape is directly assertable: the defect this closes
+ * was a field missing from this object literal, which no test of the
+ * surrounding prompt/fetch I/O would have caught. Plan fields spread in only
+ * when known — `subscriptionType: undefined` would write a null-ish key into a
+ * file the real CLI also parses.
+ */
+export function buildLoginCredentials(
+  tokenData: CompleteOAuthTokenResponse,
+  plan: OAuthPlanFields,
+  now: number = Date.now(),
+): CredentialsFile {
+  return {
+    claudeAiOauth: {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt: tokenData.expires_at ?? now + (tokenData.expires_in ?? 8 * 60 * 60) * 1000,
+      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
+      ...plan,
+    },
+  }
+}
+
 async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   const session = createManualOAuthSession()
   console.log("\x1b[33m⚠ Headless OAuth login: open this URL in a browser:\x1b[0m")
@@ -209,21 +330,14 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
     return false
   }
 
-  if (!tokenData.access_token || !tokenData.refresh_token) {
+  if (!hasRequiredTokens(tokenData)) {
     console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
     return false
   }
 
-  const expiresAt = tokenData.expires_at ?? Date.now() + (tokenData.expires_in ?? 8 * 60 * 60) * 1000
+  const plan = await fetchOAuthPlanFields(tokenData.access_token)
   const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write({
-    claudeAiOauth: {
-      accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
-      expiresAt,
-      scopes: tokenData.scope?.split(" ").filter(Boolean) ?? OAUTH_SCOPES,
-    },
-  })
+  return store.write(buildLoginCredentials(tokenData, plan))
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -14,6 +14,8 @@ import { createHash, randomBytes } from "node:crypto"
 import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { claudeLog } from "../logger"
+import { authFieldPaths, describeAuthFields } from "./authDiscovery"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
 import { setSetting } from "./settings"
@@ -161,8 +163,19 @@ function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; 
       env: { ...process.env, CLAUDE_CONFIG_DIR: configDir },
       stdio: ["pipe", "pipe", "pipe"],
     })
-    return JSON.parse(result.toString())
+    const status = JSON.parse(result.toString())
+    // The third payload, and the one every UI actually reads. It is also the
+    // narrowest: it reports the plan family and no tier, so a log that shows
+    // its full key list is what proves the missing field was never offered
+    // here rather than dropped by Meridian.
+    claudeLog("auth.status_discovered", {
+      source: "cli_sync",
+      fields: authFieldPaths(status),
+      payload: describeAuthFields(status),
+    })
+    return status
   } catch (err) {
+    claudeLog("auth.status_failed", { source: "cli_sync", error: String(err) })
     console.warn(`[meridian] Auth check failed for ${configDir}: ${err instanceof Error ? err.message : err}`)
     return { loggedIn: false }
   }
@@ -235,21 +248,38 @@ export async function fetchOAuthPlanFields(accessToken: string): Promise<OAuthPl
       signal: AbortSignal.timeout(10_000),
     })
   } catch (err) {
+    claudeLog("auth.profile_request_failed", { error: String(err) })
     console.warn(`[meridian] Could not read the account plan: ${err instanceof Error ? err.message : err}`)
     return {}
   }
 
   if (!response.ok) {
+    claudeLog("auth.profile_bad_response", { status: response.status })
     console.warn(`[meridian] Could not read the account plan (${response.status}).`)
     return {}
   }
 
+  let profile: OAuthProfileResponse
   try {
-    return extractPlanFields(await response.json() as OAuthProfileResponse)
+    profile = await response.json() as OAuthProfileResponse
   } catch (err) {
+    claudeLog("auth.profile_parse_failed", { error: String(err) })
     console.warn(`[meridian] Account plan response was not valid JSON: ${err instanceof Error ? err.message : err}`)
     return {}
   }
+
+  const plan = extractPlanFields(profile)
+  // Both halves are logged because they answer different questions. The paths
+  // say what Anthropic sent; the plan says what Meridian kept. A profile that
+  // ends up `unknown` is otherwise indistinguishable between "the field was
+  // never in the response" and "it arrived and we dropped it on the way to
+  // disk", and that distinction is the whole of the diagnosis.
+  claudeLog("auth.profile_discovered", {
+    fields: authFieldPaths(profile),
+    payload: describeAuthFields(profile),
+    plan,
+  })
+  return plan
 }
 
 /**
@@ -311,12 +341,14 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
       signal: AbortSignal.timeout(30_000),
     })
   } catch (err) {
+    claudeLog("auth.token_request_failed", { error: String(err) })
     console.error(`\x1b[31m✗ OAuth token exchange failed: ${err instanceof Error ? err.message : err}\x1b[0m`)
     return false
   }
 
   if (!response.ok) {
     const body = await response.text().catch(() => "")
+    claudeLog("auth.token_bad_response", { status: response.status, bodyLength: body.length })
     console.error(`\x1b[31m✗ OAuth token exchange failed (${response.status}).\x1b[0m`)
     if (body) console.error(`  ${body.slice(0, 300)}`)
     return false
@@ -326,9 +358,18 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
   try {
     tokenData = await response.json() as OAuthTokenResponse
   } catch (err) {
+    claudeLog("auth.token_parse_failed", { error: String(err) })
     console.error(`\x1b[31m✗ OAuth token response was invalid: ${err instanceof Error ? err.message : err}\x1b[0m`)
     return false
   }
+
+  // Logged before the required-token check, so a response that is missing one
+  // of them still says what it did contain — that case is exactly when the
+  // field list is worth having.
+  claudeLog("auth.token_discovered", {
+    fields: authFieldPaths(tokenData),
+    payload: describeAuthFields(tokenData),
+  })
 
   if (!hasRequiredTokens(tokenData)) {
     console.error("\x1b[31m✗ OAuth token response did not include the required tokens.\x1b[0m")
@@ -337,7 +378,14 @@ async function completeManualOAuthLogin(configDir: string): Promise<boolean> {
 
   const plan = await fetchOAuthPlanFields(tokenData.access_token)
   const store = createPlatformCredentialStore({ claudeConfigDir: configDir })
-  return store.write(buildLoginCredentials(tokenData, plan))
+  const credentials = buildLoginCredentials(tokenData, plan)
+  // What ends up on disk, which is not the same question as what arrived: the
+  // two lines together localize a lost field to the response or to this build.
+  claudeLog("auth.credentials_built", {
+    fields: authFieldPaths(credentials.claudeAiOauth),
+    payload: describeAuthFields(credentials.claudeAiOauth),
+  })
+  return store.write(credentials)
 }
 
 export async function profileAdd(id: string, options: AuthLoginOptions = {}): Promise<void> {

--- a/src/proxy/tokenRefresh.ts
+++ b/src/proxy/tokenRefresh.ts
@@ -51,7 +51,7 @@ export function configDirToCredentialsFile(claudeConfigDir: string): string {
   return join(resolve(claudeConfigDir), ".credentials.json")
 }
 
-interface OAuthCredentials {
+export interface OAuthCredentials {
   accessToken: string
   refreshToken: string
   expiresAt: number
@@ -70,7 +70,7 @@ interface OAuthCredentials {
   rateLimitTier?: string
 }
 
-interface CredentialsFile {
+export interface CredentialsFile {
   claudeAiOauth: OAuthCredentials
   [key: string]: unknown
 }


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

> Stacks on #795. The first commit here is that PR's; the second is this one. Read/merge #795 first.

Three payloads decide what Meridian knows about an account — the token endpoint's response, `GET /api/oauth/profile`, and `claude auth status` — and **none of them was observable**.

When a field is absent, renamed, or carries a plan tier nobody has seen before, the only symptom downstream is a profile that reads `unknown`. Nothing in any log says whether the field was missing from the response or dropped on the way to disk, and that distinction is the whole of the diagnosis.

## Why `sanitize()` was not enough

`logger.ts`'s `sanitize()` redacts **by key name**. That is the wrong polarity for this problem: it protects the names somebody already thought of, and a field discovered tomorrow is by definition not one of them. Two of these three payloads carry credentials, so they cannot simply be handed to it.

## The inversion

`src/proxy/authDiscovery.ts` flips the default. **Every string is redacted to its length** unless its key is on an allow-list of values known to carry no secret — durations, timestamps, published enums, and the scope list that already appears in plaintext in the authorize URL.

A field nobody has seen before is therefore reported by **name and type** — enough to see that it arrived and to decide what it is — while its contents stay out of the log until somebody deliberately adds the key to the list.

Non-string primitives print as they are: a boolean or a number cannot be a credential, and they are exactly the fields worth reading (`loggedIn`, `expires_in`, whatever `has_*` flag comes next).

Keys that identify a **person or an organization are deliberately absent** from the allow-list. `email`, `email_address`, `name`, `display_name` and `uuid` are reported by length only, because a debug log is routinely pasted into an issue.

## Two fields per site

Every site logs `fields` (the dotted key list of what arrived) *and* `payload` (the described value), because they answer different questions. Comparing two logins reduces to comparing two key lists — which answers "did this account's response even contain the field" without reading a single value.

| event | what it captures |
|---|---|
| `auth.token_discovered` | the token exchange, logged **before** the required-token check, so a response missing one still reports what it did contain |
| `auth.profile_discovered` | the profile endpoint, alongside the plan fields actually extracted from it |
| `auth.credentials_built` | what is about to be written to disk — so a lost field localizes to the response or to this build |
| `auth.status_discovered` | `claude auth status`, from **both** readers: the sync CLI one and the TTL-cached async one every HTTP route goes through, which can disagree with it |

Each failure branch gained a matching `auth.*_failed` line, so a lookup that never happened is distinguishable from one that returned nothing.

## Cost when switched off

All of it is behind `OPENCODE_CLAUDE_PROVIDER_DEBUG`, which already gates `claudeLog`. **With the variable unset this changes no output at all** — and no behaviour is altered on any path, in either case.

## Verification

`npm run typecheck` clean. `npm test` green: **2572 pass, 0 fail**, including 14 new unit tests for the describer — that an unknown string key is reduced to its length, that every allow-listed key prints through, that nesting and arrays are walked, that identifying keys stay redacted, and that the dotted path list includes nested keys.

This PR is AI generated, but under direct supervision and on request of Nowaker.
