### PR TITLE
feat(profiles): follow mode adopts the followed instance's profiles, not just its active one

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_DEFAULT_AGENT` | — | `opencode` | Default adapter for unrecognized agents: `opencode`, `forgecode`, `pi`, `crush`, `droid`, `cherry`, `claudecode`, `passthrough`. Requires restart. |
 | `MERIDIAN_ROUTING` | — | `active` | Session-to-profile routing: `active` (all traffic to the active profile), `sticky` ([sticky session routing](profiles.md#sticky-session-routing)), or `priority` ([priority failover](profiles.md#priority-failover-routing)) |
 | `MERIDIAN_PROFILE_ORDER` | — | *(config order)* | Priority-mode pool order, comma-separated, highest priority first (e.g. `work,personal`). Also editable at `/settings`. |
+| `MERIDIAN_FOLLOW_ACTIVE` | `CLAUDE_PROXY_FOLLOW_ACTIVE` | unset | Base URL of another Meridian instance to take the active profile from, e.g. `http://127.0.0.1:3456`. For a development instance running beside a primary one — see [Following another instance's active profile](#following-another-instances-active-profile). |
 | `MERIDIAN_PASSTHROUGH_EARLY_STOP` | — | `1` | Set to `0` to disable [digest-turn elimination](#how-tool-calling-works-in-passthrough) and restore the old end-of-turn behavior |
 | `MERIDIAN_SILENT_TURN_RECOVERY` | `CLAUDE_PROXY_SILENT_TURN_RECOVERY` | `1` | Set to `0` to stop spending a recovery turn on a [silent turn](#silent-turns). Detection and telemetry stay on either way |
 | `MERIDIAN_UPSTREAM_IDLE_MS` | `CLAUDE_PROXY_UPSTREAM_IDLE_MS` | `90000` | Milliseconds the upstream stream may go quiet before the turn is treated as stalled. Raise it for long-thinking turns that were being killed mid-flight; `0` disables the guard entirely. Applies to the recovery turn too. |
@@ -50,6 +51,59 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_PLUGIN_CONFIG` | — | `~/.config/meridian/plugins.json` | Plugin manifest path |
 
 †Sonnet 1M requires Extra Usage on all plans including Max ([docs](https://code.claude.com/docs/en/model-config#extended-context)). Opus 1M is included with Max/Team/Enterprise at no extra cost. Fable 1M is also included at no Extra Usage cost, verified live on both Max and Team.
+
+### Following another instance's active profile
+
+`MERIDIAN_FOLLOW_ACTIVE=http://127.0.0.1:3456` makes an instance take its
+active profile from the instance at that URL instead of from its own
+`settings.json`.
+
+This exists for running a development build beside a primary instance and
+comparing them. `MERIDIAN_CONFIG_DIR` relocates `settings.json` and nothing
+else, so a second instance keeps its **own** `activeProfile` — whatever moves
+the primary's active profile (a click in the UI, `meridian profile use`, an
+external scheduler) leaves the second instance serving from a different
+account, and the comparison is no longer like-for-like.
+
+The value is a Meridian base URL. A bare `host:port` is accepted and assumed
+to be `http`. The followed instance is polled every 10s on `GET /profiles/list`
+and the value is cached, so the request path never waits on the network.
+
+What it does and does not change:
+
+- **Replaces exactly one input** to profile resolution — the active profile.
+  An explicit `x-meridian-profile` header still wins, per request.
+- **Refuses to follow a profile this instance does not have.** The local active
+  profile is used instead and the reason is reported; routing to a name that is
+  not configured here would silently resolve to an unrelated account.
+- **Never fails closed.** If the followed instance is down, slow, or answers
+  something unusable, the last known value keeps being served. If a good value
+  has never been read, the local active profile is used. A poll failure is
+  logged once per outage, not once per poll.
+- **A value that has not been confirmed for two minutes is still served**, and
+  is flagged `stale` on `/profiles/list` and in the header chip. Falling back
+  to the local value on a timeout would split the comparison exactly when you
+  are least likely to notice.
+- **`POST /profiles/active` is refused with `409`**, naming the followed URL.
+  A local write would be shadowed on the next resolution and erased by the next
+  poll — a picker that appears to work and silently doesn't. The web UI's
+  account cards stop being clickable and `meridian profile use` prints the
+  refusal.
+- **No effect under `MERIDIAN_ROUTING=priority`** for unpinned requests, which
+  are dispatched across the pool without consulting the active profile. Startup
+  says so if both are set.
+- **Following your own address is refused** at startup: the followed value
+  could never change and local switching would be refused, freezing the active
+  profile permanently.
+
+The mode is announced at startup and surfaced on `/profiles/list` as a `follow`
+object (`url`, `activeProfile`, `followedValue`, `reason`, `stale`,
+`lastSyncedAt`, `lastError`), which the shared header chip renders on every
+page.
+
+Limitation: the poll sends no credentials, so a followed instance behind
+`MERIDIAN_API_KEY` will always fail the poll and the follower will fall back to
+its local active profile.
 
 ### Subprocess traffic
 

--- a/src/__tests__/follow-active-integration.test.ts
+++ b/src/__tests__/follow-active-integration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * HTTP surface of follow mode: what `/profiles/list` reports, and what
+ * `POST /profiles/active` does when this instance does not own its active
+ * profile.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mock } from "bun:test"
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => (async function* () {
+    yield {
+      type: "assistant",
+      message: { type: "assistant", content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: `session-${Date.now()}`,
+    }
+  })(),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+// Pass through the real resolveSdkModelDefaults — mock.module is process-global
+// in Bun, and stubbing it as () => ({}) leaks to proxy-env-stripping.test.ts.
+import { resolveSdkModelDefaults } from "../proxy/models"
+
+mock.module("../proxy/models", () => ({
+  mapModelToClaudeModel: () => "sonnet",
+  resolveClaudeExecutableAsync: async () => "claude",
+  resolveSdkModelDefaults,
+  getClaudeAuthStatusAsync: async () => ({ loggedIn: true, email: "test@test.com", subscriptionType: "max" }),
+  getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
+  hasExtendedContext: () => false,
+  stripExtendedContext: (m: string) => m,
+  isClosedControllerError: (e: unknown) => e instanceof Error && e.message.includes("controller is closed"),
+  recordExtendedContextUnavailable: () => {},
+  isExtendedContextKnownUnavailable: () => false,
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { resetActiveProfile, setActiveProfile } = await import("../proxy/profiles")
+const { resetFollowActive, setFollowStateForTesting } = await import("../proxy/followActive")
+const { clearSessionCache } = await import("../proxy/session/cache")
+
+const FOLLOWED = "http://127.0.0.1:3456"
+const profiles = [
+  { id: "personal", claudeConfigDir: "/home/.claude" },
+  { id: "work", claudeConfigDir: "/home/.claude-work" },
+]
+
+beforeEach(() => {
+  resetActiveProfile()
+  resetFollowActive()
+  clearSessionCache()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+})
+
+afterEach(() => {
+  resetFollowActive()
+  resetActiveProfile()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+})
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles })
+  return app
+}
+
+function req(url: string, init?: RequestInit): Request {
+  return new Request(`http://localhost${url}`, init)
+}
+
+function following(profileId: string, at = Date.now()): void {
+  process.env.MERIDIAN_FOLLOW_ACTIVE = FOLLOWED
+  setFollowStateForTesting({ lastGood: { profileId, at } })
+}
+
+describe("GET /profiles/list under follow mode", () => {
+  test("no follow block when the mode is off", async () => {
+    const res = await createTestApp().fetch(req("/profiles/list"))
+    const body = await res.json() as Record<string, unknown>
+    expect(body.follow).toBeUndefined()
+  })
+
+  test("activeProfile and isActive report the followed value", async () => {
+    setActiveProfile("personal")
+    following("work")
+
+    const res = await createTestApp().fetch(req("/profiles/list"))
+    const body = await res.json() as {
+      activeProfile: string
+      profiles: Array<{ id: string; isActive: boolean }>
+      follow: { url: string; activeProfile: string | null; reason: string | null; stale: boolean }
+    }
+
+    expect(body.activeProfile).toBe("work")
+    expect(body.profiles.find(p => p.id === "work")?.isActive).toBe(true)
+    expect(body.profiles.find(p => p.id === "personal")?.isActive).toBe(false)
+    expect(body.follow).toMatchObject({ url: FOLLOWED, activeProfile: "work", reason: null, stale: false })
+  })
+
+  test("a followed profile this instance lacks is reported, not routed to", async () => {
+    setActiveProfile("personal")
+    following("randall-personal")
+
+    const res = await createTestApp().fetch(req("/profiles/list"))
+    const body = await res.json() as {
+      activeProfile: string
+      follow: { activeProfile: string | null; followedValue: string | null; reason: string | null }
+    }
+
+    expect(body.activeProfile).toBe("personal")
+    expect(body.follow).toMatchObject({
+      activeProfile: null,
+      followedValue: "randall-personal",
+      reason: "unknown-profile",
+    })
+  })
+})
+
+describe("POST /profiles/active under follow mode", () => {
+  test("refuses with 409 and names what is in charge", async () => {
+    setActiveProfile("personal")
+    following("work")
+
+    const res = await createTestApp().fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "personal" }),
+    }))
+
+    expect(res.status).toBe(409)
+    const body = await res.json() as { error: string; following: { url: string; activeProfile: string | null } }
+    expect(body.error).toContain(FOLLOWED)
+    expect(body.error).toContain("MERIDIAN_FOLLOW_ACTIVE")
+    expect(body.error).toContain("x-meridian-profile")
+    expect(body.following).toMatchObject({ url: FOLLOWED, activeProfile: "work" })
+  })
+
+  test("the refusal does not change what is served", async () => {
+    setActiveProfile("personal")
+    following("work")
+    const app = createTestApp()
+
+    await app.fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "personal" }),
+    }))
+
+    const body = await (await app.fetch(req("/profiles/list"))).json() as { activeProfile: string }
+    expect(body.activeProfile).toBe("work")
+  })
+
+  test("refuses even before a followed value has arrived", async () => {
+    process.env.MERIDIAN_FOLLOW_ACTIVE = FOLLOWED
+
+    const res = await createTestApp().fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "work" }),
+    }))
+
+    expect(res.status).toBe(409)
+  })
+
+  test("switching still works when the mode is off", async () => {
+    const res = await createTestApp().fetch(req("/profiles/active", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ profile: "work" }),
+    }))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ success: true, activeProfile: "work" })
+  })
+})

--- a/src/__tests__/follow-active.test.ts
+++ b/src/__tests__/follow-active.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Follow-the-active-profile mode — MERIDIAN_FOLLOW_ACTIVE.
+ *
+ * The decision logic is pure so every branch is provable without a second
+ * Meridian instance running: followed value present, absent, unknown here,
+ * stale, and the followed instance being down mid-flight.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+
+import {
+  parseFollowTarget,
+  isSelfTarget,
+  readActiveProfile,
+  decideFollowedProfile,
+  followedActiveProfile,
+  followStatus,
+  followTarget,
+  isFollowEnabled,
+  pollFollowedActiveProfile,
+  resetFollowActive,
+  setFollowStateForTesting,
+  FOLLOW_STALE_AFTER_MS,
+} from "../proxy/followActive"
+import { resolveProfile, resolveActiveProfileId, setActiveProfile, resetActiveProfile } from "../proxy/profiles"
+
+const FOLLOWED = "http://127.0.0.1:3456"
+const realFetch = globalThis.fetch
+
+function follow(url = FOLLOWED): void {
+  process.env.MERIDIAN_FOLLOW_ACTIVE = url
+}
+
+// Bun's `fetch` type carries a `preconnect` member, so a bare function is not
+// assignable — keep the real one rather than reaching for a cast.
+function stubFetch(impl: () => Promise<Response>): void {
+  globalThis.fetch = Object.assign(() => impl(), { preconnect: realFetch.preconnect })
+}
+
+beforeEach(() => {
+  resetFollowActive()
+  resetActiveProfile()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+})
+
+afterEach(() => {
+  resetFollowActive()
+  resetActiveProfile()
+  delete process.env.MERIDIAN_FOLLOW_ACTIVE
+  globalThis.fetch = realFetch
+})
+
+describe("parseFollowTarget", () => {
+  test("unset or blank is off", () => {
+    expect(parseFollowTarget(undefined).kind).toBe("off")
+    expect(parseFollowTarget("").kind).toBe("off")
+    expect(parseFollowTarget("   ").kind).toBe("off")
+  })
+
+  test("normalizes a full URL and strips the trailing slash", () => {
+    expect(parseFollowTarget("http://127.0.0.1:3456")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+    expect(parseFollowTarget("http://127.0.0.1:3456/")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+    expect(parseFollowTarget("http://127.0.0.1:3456/profiles/list")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+  })
+
+  test("assumes http for a bare host:port", () => {
+    expect(parseFollowTarget("127.0.0.1:3456")).toEqual({ kind: "on", url: "http://127.0.0.1:3456" })
+    expect(parseFollowTarget("meridian.internal:8080")).toEqual({ kind: "on", url: "http://meridian.internal:8080" })
+  })
+
+  test("accepts https", () => {
+    expect(parseFollowTarget("https://meridian.example.com")).toEqual({ kind: "on", url: "https://meridian.example.com" })
+  })
+
+  test("rejects a non-http scheme without throwing", () => {
+    const parsed = parseFollowTarget("ftp://host:21")
+    expect(parsed.kind).toBe("invalid")
+  })
+
+  test("rejects a value with no host without throwing", () => {
+    expect(parseFollowTarget("http://").kind).toBe("invalid")
+  })
+})
+
+describe("isSelfTarget", () => {
+  test("same port and same host is self", () => {
+    expect(isSelfTarget("http://127.0.0.1:3456", "127.0.0.1", 3456)).toBe(true)
+  })
+
+  test("loopback spellings are the same machine", () => {
+    expect(isSelfTarget("http://localhost:3456", "127.0.0.1", 3456)).toBe(true)
+    expect(isSelfTarget("http://127.0.0.1:3456", "localhost", 3456)).toBe(true)
+    expect(isSelfTarget("http://[::1]:3456", "127.0.0.1", 3456)).toBe(true)
+  })
+
+  test("a different port is a different instance", () => {
+    expect(isSelfTarget("http://127.0.0.1:3456", "127.0.0.1", 3458)).toBe(false)
+  })
+
+  test("a non-loopback host is a different instance", () => {
+    expect(isSelfTarget("http://10.0.0.5:3456", "127.0.0.1", 3456)).toBe(false)
+  })
+
+  test("implicit scheme ports are compared", () => {
+    expect(isSelfTarget("https://localhost", "127.0.0.1", 443)).toBe(true)
+    expect(isSelfTarget("http://localhost", "127.0.0.1", 80)).toBe(true)
+  })
+})
+
+describe("readActiveProfile", () => {
+  test("reads and trims a string value", () => {
+    expect(readActiveProfile({ activeProfile: "work" })).toBe("work")
+    expect(readActiveProfile({ activeProfile: "  work  " })).toBe("work")
+  })
+
+  test("rejects rubbish bodies", () => {
+    expect(readActiveProfile(null)).toBeUndefined()
+    expect(readActiveProfile("<html>502 Bad Gateway</html>")).toBeUndefined()
+    expect(readActiveProfile({})).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: 42 })).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: null })).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: "" })).toBeUndefined()
+    expect(readActiveProfile({ activeProfile: "x".repeat(500) })).toBeUndefined()
+  })
+})
+
+describe("decideFollowedProfile", () => {
+  const now = 1_000_000
+
+  test("follows a known value", () => {
+    const outcome = decideFollowedProfile({ lastGood: { profileId: "work", at: now } }, ["personal", "work"], now)
+    expect(outcome).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("falls back to local when no value has ever been read", () => {
+    expect(decideFollowedProfile({}, ["personal", "work"], now)).toEqual({ follow: false, reason: "no-value" })
+  })
+
+  test("refuses to follow a profile this instance does not have", () => {
+    const outcome = decideFollowedProfile({ lastGood: { profileId: "randall-personal", at: now } }, ["personal", "work"], now)
+    expect(outcome).toEqual({ follow: false, reason: "unknown-profile", followedValue: "randall-personal" })
+  })
+
+  test("an empty profile list can follow nothing", () => {
+    const outcome = decideFollowedProfile({ lastGood: { profileId: "work", at: now } }, [], now)
+    expect(outcome).toEqual({ follow: false, reason: "unknown-profile", followedValue: "work" })
+  })
+
+  test("an unconfirmed value is still followed, flagged stale", () => {
+    const state = { lastGood: { profileId: "work", at: now - FOLLOW_STALE_AFTER_MS - 1 } }
+    expect(decideFollowedProfile(state, ["work"], now)).toEqual({ follow: true, profileId: "work", stale: true })
+  })
+
+  test("the followed instance being down keeps the last known value", () => {
+    const state = {
+      lastGood: { profileId: "work", at: now - 30_000 },
+      lastPollAt: now,
+      lastError: { message: "fetch failed", at: now },
+    }
+    expect(decideFollowedProfile(state, ["personal", "work"], now)).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("unknown-profile beats stale — a fallback is not a resolution", () => {
+    const state = { lastGood: { profileId: "gone", at: now - FOLLOW_STALE_AFTER_MS - 1 } }
+    expect(decideFollowedProfile(state, ["work"], now)).toEqual({ follow: false, reason: "unknown-profile", followedValue: "gone" })
+  })
+})
+
+describe("configuration", () => {
+  test("off by default", () => {
+    expect(isFollowEnabled()).toBe(false)
+    expect(followTarget()).toBeUndefined()
+    expect(followedActiveProfile(["work"])).toBeUndefined()
+    expect(followStatus(["work"])).toBeUndefined()
+  })
+
+  test("an unusable value leaves follow mode off rather than failing", () => {
+    follow("ftp://nope")
+    expect(isFollowEnabled()).toBe(false)
+    expect(followedActiveProfile(["work"])).toBeUndefined()
+  })
+
+  test("the CLAUDE_PROXY_ alias works", () => {
+    process.env.CLAUDE_PROXY_FOLLOW_ACTIVE = FOLLOWED
+    try {
+      expect(followTarget()).toEqual({ url: FOLLOWED })
+    } finally {
+      delete process.env.CLAUDE_PROXY_FOLLOW_ACTIVE
+    }
+  })
+})
+
+describe("polling the followed instance", () => {
+  function respond(body: unknown, status = 200): void {
+    stubFetch(async () =>
+      new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } }))
+  }
+
+  function refuseConnection(): void {
+    stubFetch(async () => { throw new Error("connect ECONNREFUSED") })
+  }
+
+  test("a good response becomes the followed value", async () => {
+    follow()
+    respond({ activeProfile: "work", profiles: [] })
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["personal", "work"])).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("does nothing when follow mode is off", async () => {
+    let called = false
+    stubFetch(async () => { called = true; return new Response("{}") })
+    await pollFollowedActiveProfile()
+    expect(called).toBe(false)
+  })
+
+  test("a network failure keeps the last known value", async () => {
+    follow()
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+
+    refuseConnection()
+    await pollFollowedActiveProfile()
+
+    expect(followedActiveProfile(["work"])).toEqual({ follow: true, profileId: "work", stale: false })
+    expect(followStatus(["work"])?.lastError).toContain("ECONNREFUSED")
+  })
+
+  test("a non-200 keeps the last known value", async () => {
+    follow()
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+
+    respond({ error: "unauthorized" }, 401)
+    await pollFollowedActiveProfile()
+
+    expect(followedActiveProfile(["work"])).toEqual({ follow: true, profileId: "work", stale: false })
+    expect(followStatus(["work"])?.lastError).toBe("HTTP 401")
+  })
+
+  test("a rubbish body keeps the last known value", async () => {
+    follow()
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+
+    respond({ something: "else" })
+    await pollFollowedActiveProfile()
+
+    expect(followedActiveProfile(["work"])).toEqual({ follow: true, profileId: "work", stale: false })
+  })
+
+  test("an unreachable instance that has never answered yields no value", async () => {
+    follow()
+    refuseConnection()
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["work"])).toEqual({ follow: false, reason: "no-value" })
+  })
+
+  test("picks up a change on the followed instance", async () => {
+    follow()
+    respond({ activeProfile: "personal" })
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["personal", "work"])).toMatchObject({ profileId: "personal" })
+
+    respond({ activeProfile: "work" })
+    await pollFollowedActiveProfile()
+    expect(followedActiveProfile(["personal", "work"])).toMatchObject({ profileId: "work" })
+  })
+})
+
+describe("followStatus", () => {
+  test("reports the value in effect", () => {
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(followStatus(["personal", "work"])).toMatchObject({
+      url: FOLLOWED,
+      activeProfile: "work",
+      followedValue: "work",
+      reason: null,
+      stale: false,
+    })
+  })
+
+  test("reports the fallback and why, keeping the raw followed value visible", () => {
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "randall-personal", at: Date.now() } })
+    expect(followStatus(["personal", "work"])).toMatchObject({
+      activeProfile: null,
+      followedValue: "randall-personal",
+      reason: "unknown-profile",
+    })
+  })
+})
+
+describe("resolveProfile under follow mode", () => {
+  const profiles = [
+    { id: "personal", claudeConfigDir: "/home/.claude" },
+    { id: "work", claudeConfigDir: "/home/.claude-work" },
+  ]
+
+  test("the followed value replaces the local active profile", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined).id).toBe("work")
+    expect(resolveActiveProfileId(["personal", "work"])).toBe("work")
+  })
+
+  test("an explicit header still wins over the followed value", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined, "personal").id).toBe("personal")
+  })
+
+  test("a followed profile this instance lacks falls back to the local one", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "randall-personal", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+  })
+
+  test("no followed value yet falls back to the local one", () => {
+    setActiveProfile("personal")
+    follow()
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+  })
+
+  test("follow mode off leaves resolution exactly as it was", () => {
+    setActiveProfile("personal")
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() } })
+    expect(resolveProfile(profiles, undefined).id).toBe("personal")
+  })
+
+  test("a stale followed value is still served", () => {
+    setActiveProfile("personal")
+    follow()
+    setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() - FOLLOW_STALE_AFTER_MS - 1 } })
+    expect(resolveProfile(profiles, undefined).id).toBe("work")
+    expect(followStatus(["personal", "work"])?.stale).toBe(true)
+  })
+})

--- a/src/__tests__/follow-active.test.ts
+++ b/src/__tests__/follow-active.test.ts
@@ -19,9 +19,18 @@ import {
   pollFollowedActiveProfile,
   resetFollowActive,
   setFollowStateForTesting,
+  readFollowedRoster,
+  adoptedProfiles,
   FOLLOW_STALE_AFTER_MS,
 } from "../proxy/followActive"
-import { resolveProfile, resolveActiveProfileId, setActiveProfile, resetActiveProfile } from "../proxy/profiles"
+import {
+  resolveProfile,
+  resolveActiveProfileId,
+  setActiveProfile,
+  resetActiveProfile,
+  getEffectiveProfiles,
+  shareableCredentialDir,
+} from "../proxy/profiles"
 
 const FOLLOWED = "http://127.0.0.1:3456"
 const realFetch = globalThis.fetch
@@ -337,5 +346,169 @@ describe("resolveProfile under follow mode", () => {
     setFollowStateForTesting({ lastGood: { profileId: "work", at: Date.now() - FOLLOW_STALE_AFTER_MS - 1 } })
     expect(resolveProfile(profiles, undefined).id).toBe("work")
     expect(followStatus(["personal", "work"])?.stale).toBe(true)
+  })
+})
+
+describe("shareableCredentialDir", () => {
+  test("a file-backed profile reports where its credentials are", () => {
+    expect(shareableCredentialDir({ id: "p", type: "claude-max", env: { CLAUDE_CONFIG_DIR: "/c/p" } })).toBe("/c/p")
+  })
+
+  test("an inline secret is never reported, even alongside a directory", () => {
+    expect(shareableCredentialDir({ id: "p", type: "api", env: { ANTHROPIC_API_KEY: "sk-not-a-real-key" } })).toBeNull()
+    expect(shareableCredentialDir({
+      id: "p",
+      type: "oauth-token",
+      env: { CLAUDE_CODE_OAUTH_TOKEN: "not-a-real-token", CLAUDE_CONFIG_DIR: "/c/p" },
+    })).toBeNull()
+  })
+
+  test("a profile with no override has no directory to share", () => {
+    expect(shareableCredentialDir({ id: "p", type: "claude-max", env: {} })).toBeNull()
+  })
+})
+
+describe("readFollowedRoster", () => {
+  const entry = (id: string, credentialDir: string | null) => ({ id, credentialDir })
+
+  test("a body with no profiles array carries no roster", () => {
+    expect(readFollowedRoster(null)).toBeUndefined()
+    expect(readFollowedRoster({})).toBeUndefined()
+    expect(readFollowedRoster({ profiles: "nope" })).toBeUndefined()
+  })
+
+  test("an instance too old to report credentialDir is not read as an empty roster", () => {
+    expect(readFollowedRoster({ profiles: [{ id: "personal" }, { id: "work" }] })).toBeUndefined()
+  })
+
+  test("splits what can be adopted from what cannot", () => {
+    expect(readFollowedRoster({
+      profiles: [entry("personal", "/c/personal"), entry("api-only", null), entry("work", "/c/work")],
+    })).toEqual({
+      adoptable: [
+        { id: "personal", credentialDir: "/c/personal" },
+        { id: "work", credentialDir: "/c/work" },
+      ],
+      unadoptable: ["api-only"],
+    })
+  })
+
+  test("an all-unadoptable roster is a roster, not an absence", () => {
+    expect(readFollowedRoster({ profiles: [entry("api-only", null)] }))
+      .toEqual({ adoptable: [], unadoptable: ["api-only"] })
+  })
+
+  test("garbage entries are dropped rather than adopted", () => {
+    const roster = readFollowedRoster({
+      profiles: [
+        entry("ok", "/c/ok"),
+        { id: 7, credentialDir: "/c/seven" },
+        { id: "   ", credentialDir: "/c/blank" },
+        entry("overlong", `/${"x".repeat(5_000)}`),
+        "not an object",
+      ],
+    })
+    expect(roster?.adoptable).toEqual([{ id: "ok", credentialDir: "/c/ok" }])
+    expect(roster?.unadoptable).toEqual(["overlong"])
+  })
+})
+
+describe("the roster rides the poll that is already happening", () => {
+  function listBody(activeProfile: string, profiles: Array<{ id: string; credentialDir: string | null }>): Response {
+    return new Response(JSON.stringify({ activeProfile, profiles }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }
+
+  test("one request carries both the active profile and the roster", async () => {
+    follow()
+    let calls = 0
+    stubFetch(async () => {
+      calls++
+      return listBody("work", [
+        { id: "personal", credentialDir: "/c/personal" },
+        { id: "work", credentialDir: "/c/work" },
+      ])
+    })
+    await pollFollowedActiveProfile()
+    expect(calls).toBe(1)
+    expect(adoptedProfiles().map(p => p.id)).toEqual(["personal", "work"])
+    expect(followStatus(["personal", "work"])?.activeProfile).toBe("work")
+  })
+
+  test("a failed poll keeps the roster it already had", async () => {
+    follow()
+    stubFetch(async () => listBody("work", [{ id: "work", credentialDir: "/c/work" }]))
+    await pollFollowedActiveProfile()
+    stubFetch(async () => { throw new Error("connection refused") })
+    await pollFollowedActiveProfile()
+    expect(adoptedProfiles().map(p => p.id)).toEqual(["work"])
+  })
+
+  test("a successful poll withdraws a profile the followed instance dropped", async () => {
+    follow()
+    stubFetch(async () => listBody("work", [
+      { id: "work", credentialDir: "/c/work" },
+      { id: "gone", credentialDir: "/c/gone" },
+    ]))
+    await pollFollowedActiveProfile()
+    stubFetch(async () => listBody("work", [{ id: "work", credentialDir: "/c/work" }]))
+    await pollFollowedActiveProfile()
+    expect(adoptedProfiles().map(p => p.id)).toEqual(["work"])
+  })
+
+  test("status names what was adopted and what could not be", async () => {
+    follow()
+    stubFetch(async () => listBody("work", [
+      { id: "work", credentialDir: "/c/work" },
+      { id: "api-only", credentialDir: null },
+    ]))
+    await pollFollowedActiveProfile()
+    const status = followStatus(["work"])
+    expect(status?.adoptedProfiles).toEqual(["work"])
+    expect(status?.unadoptableProfiles).toEqual(["api-only"])
+    expect(status?.rosterSyncedAt).toBeGreaterThan(0)
+  })
+
+  test("nothing is adopted when follow mode is off", () => {
+    expect(adoptedProfiles()).toEqual([])
+  })
+})
+
+describe("adopted profiles join the effective list", () => {
+  const local = [{ id: "personal", claudeConfigDir: "/local/personal" }]
+
+  function adopt(profiles: Array<{ id: string; credentialDir: string | null }>, active?: string): void {
+    setFollowStateForTesting({
+      lastGood: { profileId: active ?? profiles[0]!.id, at: Date.now() },
+      lastRoster: { roster: readFollowedRoster({ profiles })!, at: Date.now() },
+    })
+  }
+
+  test("a profile only the followed instance has becomes servable here", () => {
+    follow()
+    adopt([{ id: "kwiat-personal", credentialDir: "/shared/kwiat-personal" }])
+    expect(getEffectiveProfiles(local).map(p => p.id)).toEqual(["personal", "kwiat-personal"])
+    expect(resolveProfile(local, undefined, "kwiat-personal").env)
+      .toEqual({ CLAUDE_CONFIG_DIR: "/shared/kwiat-personal" })
+  })
+
+  test("a local entry outranks the mirror for the same id", () => {
+    follow()
+    adopt([{ id: "personal", credentialDir: "/shared/personal" }])
+    expect(getEffectiveProfiles(local)).toEqual(local)
+  })
+
+  test("follow mode off adopts nothing", () => {
+    adopt([{ id: "kwiat-personal", credentialDir: "/shared/kwiat-personal" }])
+    expect(getEffectiveProfiles(local).map(p => p.id)).toEqual(["personal"])
+  })
+
+  test("the followed active profile resolves instead of falling back to the local one", () => {
+    setActiveProfile("personal")
+    follow()
+    adopt([{ id: "kwiat-personal", credentialDir: "/shared/kwiat-personal" }], "kwiat-personal")
+    expect(resolveProfile(local, undefined).id).toBe("kwiat-personal")
   })
 })

--- a/src/__tests__/preload.ts
+++ b/src/__tests__/preload.ts
@@ -10,6 +10,12 @@ import { join } from "node:path"
 // Auth middleware reads this at request time; clear it so tests don't need API keys
 delete process.env.MERIDIAN_API_KEY
 
+// Follow mode replaces the active profile for EVERY profile resolution, so a
+// developer with this exported in their shell would silently change what the
+// profile/routing suites resolve to.
+delete process.env.MERIDIAN_FOLLOW_ACTIVE
+delete process.env.CLAUDE_PROXY_FOLLOW_ACTIVE
+
 // Point settings.ts at a throwaway directory so the suite never reads the
 // developer's real ~/.config/meridian/settings.json. A live
 // `routing: "priority"` setting made the sticky- and priority-routing

--- a/src/proxy/followActive.ts
+++ b/src/proxy/followActive.ts
@@ -1,0 +1,391 @@
+/**
+ * Follow-the-active-profile mode — `MERIDIAN_FOLLOW_ACTIVE`.
+ *
+ * Makes a development instance take its active profile from ANOTHER Meridian
+ * instance instead of from its own `settings.json`, so the two serve from the
+ * same account and a side-by-side comparison is like-for-like.
+ *
+ * The problem it solves: `MERIDIAN_CONFIG_DIR` relocates `settings.json` and
+ * nothing else, so a second instance keeps its own `activeProfile`. Whatever
+ * moves the primary's active profile — a UI click, the CLI, an external fleet
+ * scheduler — has no effect on the second instance, which quietly serves from
+ * a different account. Measured on one box: the primary was on one profile
+ * while the dev instance served the same instant from another.
+ *
+ * What this changes: exactly ONE input to `resolveProfile` — the active
+ * profile. The precedence chain around it is untouched, so an explicit
+ * `x-meridian-profile` header still wins, and sticky/priority routing behave
+ * as they always did (priority mode does not consult the active profile at
+ * all for unpinned requests, so follow mode is a no-op there).
+ *
+ * Degradation is the design constraint, not an afterthought. The followed
+ * instance is polled in the background and the last good value is cached; the
+ * request path never waits on the network. If the followed instance is down,
+ * slow, or answers rubbish, the last known value keeps being served — and if
+ * there has never been a good value, the local active profile is used. A dev
+ * convenience must not be able to take an instance offline.
+ *
+ * Leaf module — no imports from server.ts, session/ or profiles.ts.
+ */
+
+import { env } from "../env"
+
+/**
+ * Poll cadence. The followed value changes on the order of minutes (a human
+ * clicking, or a scheduler rotating accounts), so a fetch per request would be
+ * absurd; 10s bounds the divergence window without making the followed
+ * instance do meaningful work — `/profiles/list` serves its auth status from a
+ * 60s cache that the instance's own 45s keepalive already keeps warm.
+ */
+export const FOLLOW_POLL_INTERVAL_MS = 10_000
+
+/** Per-poll timeout. Short: a slow followed instance must not accumulate polls. */
+export const FOLLOW_FETCH_TIMEOUT_MS = 2_000
+
+/**
+ * How long a value may go unconfirmed before it is REPORTED stale.
+ *
+ * Staleness deliberately does not change routing. Falling back to the local
+ * value after a timeout would silently split the comparison exactly when you
+ * are least likely to notice, and the local value is not more correct — it is
+ * just different. A stale-but-known followed value remains the best available
+ * answer to "what is the primary on?"; the dev instance's own `activeProfile`
+ * is arbitrary. So a stale value is still followed, and is flagged as stale
+ * everywhere the mode is surfaced.
+ */
+export const FOLLOW_STALE_AFTER_MS = 120_000
+
+/** Longest plausible profile id — a defence against a garbage response body. */
+const MAX_PROFILE_ID_LENGTH = 128
+
+// --- Pure: configuration parsing ------------------------------------------
+
+export type FollowTarget =
+  | { kind: "off" }
+  | { kind: "on"; url: string }
+  | { kind: "invalid"; raw: string; message: string }
+
+/**
+ * Parse the env var value into a normalized base URL.
+ *
+ * A bare `host:port` is accepted and assumed to be http, because that is what
+ * anyone types first and `new URL()` would otherwise read `127.0.0.1` as a
+ * scheme. Trailing slashes are stripped so callers can concatenate paths.
+ *
+ * A malformed value yields "invalid" rather than throwing: the caller warns
+ * and runs without follow mode. Refusing to start on a typo would take an
+ * instance offline, which is the one outcome this feature must never cause.
+ */
+export function parseFollowTarget(raw: string | undefined): FollowTarget {
+  const trimmed = raw?.trim()
+  if (!trimmed) return { kind: "off" }
+  const withScheme = trimmed.includes("://") ? trimmed : `http://${trimmed}`
+  let parsed: URL
+  try {
+    parsed = new URL(withScheme)
+  } catch {
+    return { kind: "invalid", raw: trimmed, message: "not a URL" }
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { kind: "invalid", raw: trimmed, message: `unsupported scheme "${parsed.protocol}"` }
+  }
+  if (!parsed.hostname) {
+    return { kind: "invalid", raw: trimmed, message: "no host" }
+  }
+  return { kind: "on", url: `${parsed.protocol}//${parsed.host}` }
+}
+
+/** Loopback spellings that all mean "this machine". */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]", "0.0.0.0", "::", "[::]"])
+
+/**
+ * Whether a follow target addresses the instance doing the following.
+ *
+ * Self-follow is a deadlock, not a harmless no-op: the instance would follow
+ * its own active profile (so the value never changes) while refusing local
+ * writes (so nothing can change it), leaving the profile frozen forever. It is
+ * also the realistic typo — copying the wrong port out of a unit file.
+ */
+export function isSelfTarget(url: string, selfHost: string, selfPort: number): boolean {
+  const target = parseFollowTarget(url)
+  if (target.kind !== "on") return false
+  const parsed = new URL(target.url)
+  const targetPort = parsed.port ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80
+  if (targetPort !== selfPort) return false
+  const targetHost = parsed.hostname.toLowerCase()
+  const ownHost = selfHost.toLowerCase()
+  if (targetHost === ownHost) return true
+  return LOOPBACK_HOSTS.has(targetHost) && LOOPBACK_HOSTS.has(ownHost)
+}
+
+// --- Pure: response reading -----------------------------------------------
+
+/**
+ * Extract `activeProfile` from a `/profiles/list` body.
+ *
+ * Deliberately paranoid about the shape. The followed instance may be a
+ * different version, a different program listening on a recycled port, or an
+ * error page — "answers rubbish" is one of the failure modes this must
+ * survive, and a non-string or absurdly long value must be treated as no
+ * value at all rather than routed to.
+ */
+export function readActiveProfile(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null) return undefined
+  const value = (body as { activeProfile?: unknown }).activeProfile
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.length > MAX_PROFILE_ID_LENGTH) return undefined
+  return trimmed
+}
+
+// --- Pure: the decision ---------------------------------------------------
+
+export interface FollowState {
+  /** Last value successfully read, and when it was last CONFIRMED by a poll. */
+  lastGood?: { profileId: string; at: number }
+  /** When the most recent poll completed, successful or not. */
+  lastPollAt?: number
+  /** Most recent poll failure. Cleared on the next success. */
+  lastError?: { message: string; at: number }
+}
+
+export type FollowOutcome =
+  | { follow: true; profileId: string; stale: boolean }
+  | { follow: false; reason: "no-value" | "unknown-profile"; followedValue?: string }
+
+/**
+ * Decide whether the followed value should be used, given what this instance
+ * actually has. Pure — the whole point is that every branch is testable
+ * without a second instance running.
+ *
+ * `unknown-profile` is a fallback, not a resolution: routing to a profile this
+ * instance does not have would resolve to "first configured profile" deeper in
+ * `resolveProfile` and silently serve from an unrelated account. Using the
+ * local choice and saying so is the smaller surprise.
+ */
+export function decideFollowedProfile(
+  state: FollowState,
+  availableIds: readonly string[],
+  now: number,
+  staleAfterMs: number = FOLLOW_STALE_AFTER_MS,
+): FollowOutcome {
+  const good = state.lastGood
+  // No good value yet — the followed instance has been unreachable (or has
+  // answered rubbish) for this instance's entire lifetime.
+  if (!good) return { follow: false, reason: "no-value" }
+  if (!availableIds.includes(good.profileId)) {
+    return { follow: false, reason: "unknown-profile", followedValue: good.profileId }
+  }
+  return { follow: true, profileId: good.profileId, stale: now - good.at >= staleAfterMs }
+}
+
+// --- Stateful: configuration, cache, polling ------------------------------
+
+let cachedRaw: string | undefined
+let cachedTarget: FollowTarget = { kind: "off" }
+let warnedInvalid: string | undefined
+let disabledReason: string | undefined
+let state: FollowState = {}
+let pollTimer: ReturnType<typeof setInterval> | undefined
+let bannerLogged = false
+let errorLogged = false
+
+/**
+ * The followed instance's base URL, or undefined when not following.
+ *
+ * Resolved per call rather than frozen at import time, matching `settings.ts`'s
+ * treatment of MERIDIAN_CONFIG_DIR — a value captured at import would be fixed
+ * before any test (or embedding host) could set it. Parsing is memoized on the
+ * raw string so the request path does not build a URL object per call.
+ */
+export function followTarget(): { url: string } | undefined {
+  if (disabledReason) return undefined
+  const raw = env("FOLLOW_ACTIVE")
+  if (raw !== cachedRaw) {
+    cachedRaw = raw
+    cachedTarget = parseFollowTarget(raw)
+  }
+  if (cachedTarget.kind === "invalid") {
+    if (warnedInvalid !== cachedTarget.raw) {
+      warnedInvalid = cachedTarget.raw
+      console.warn(
+        `[PROXY] MERIDIAN_FOLLOW_ACTIVE="${cachedTarget.raw}" is not usable (${cachedTarget.message}). ` +
+        `Expected a Meridian base URL, e.g. http://127.0.0.1:3456. Follow mode is OFF; ` +
+        `this instance uses its own active profile.`
+      )
+    }
+    return undefined
+  }
+  return cachedTarget.kind === "on" ? { url: cachedTarget.url } : undefined
+}
+
+/** Whether this instance takes its active profile from another one. */
+export function isFollowEnabled(): boolean {
+  return followTarget() !== undefined
+}
+
+/**
+ * The follow decision for a given profile list, or undefined when not
+ * following. Called on the request path — synchronous, cache-only, no I/O.
+ */
+export function followedActiveProfile(availableIds: readonly string[]): FollowOutcome | undefined {
+  if (!isFollowEnabled()) return undefined
+  return decideFollowedProfile(state, availableIds, Date.now())
+}
+
+/** Follow state as surfaced by `/profiles/list`. Undefined when not following. */
+export interface FollowStatus {
+  /** Base URL of the followed instance. */
+  url: string
+  /** Value actually in effect, or null when falling back to the local one. */
+  activeProfile: string | null
+  /** Last value read from the followed instance, even if unusable here. */
+  followedValue: string | null
+  /** Why the followed value is not in effect, when it isn't. */
+  reason: "no-value" | "unknown-profile" | null
+  /** Followed value has not been confirmed recently — still in effect. */
+  stale: boolean
+  /** When the followed value was last confirmed. */
+  lastSyncedAt: number | null
+  /** Most recent poll failure, if the last poll failed. */
+  lastError: string | null
+}
+
+export function followStatus(availableIds: readonly string[]): FollowStatus | undefined {
+  const target = followTarget()
+  if (!target) return undefined
+  const outcome = decideFollowedProfile(state, availableIds, Date.now())
+  return {
+    url: target.url,
+    activeProfile: outcome.follow ? outcome.profileId : null,
+    followedValue: state.lastGood?.profileId ?? null,
+    reason: outcome.follow ? null : outcome.reason,
+    stale: outcome.follow ? outcome.stale : false,
+    lastSyncedAt: state.lastGood?.at ?? null,
+    lastError: state.lastError?.message ?? null,
+  }
+}
+
+/**
+ * Read the followed instance's active profile once and update the cache.
+ *
+ * Never throws and never clears a good value on failure: a failed poll leaves
+ * the last known value in place, which is what "degrade, never fail" means
+ * here. Exported so tests can drive it without a timer.
+ */
+export async function pollFollowedActiveProfile(): Promise<void> {
+  const target = followTarget()
+  if (!target) return
+  const now = Date.now()
+  try {
+    const res = await fetch(`${target.url}/profiles/list`, {
+      signal: AbortSignal.timeout(FOLLOW_FETCH_TIMEOUT_MS),
+      headers: { accept: "application/json" },
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const value = readActiveProfile(await res.json())
+    if (!value) throw new Error("response carried no usable activeProfile")
+    const previous = state.lastGood?.profileId
+    state = { lastGood: { profileId: value, at: now }, lastPollAt: now }
+    // Log transitions only. A line per poll would be 8,640 lines a day; the
+    // interesting events are "we picked up a change" and "we recovered".
+    if (previous !== value) {
+      console.warn(
+        `[PROXY] Active profile now following "${value}" from ${target.url}` +
+        (previous ? ` (was "${previous}")` : "")
+      )
+    } else if (errorLogged) {
+      console.warn(`[PROXY] Recovered contact with ${target.url}; still following "${value}".`)
+    }
+    errorLogged = false
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    state = { ...state, lastPollAt: now, lastError: { message, at: now } }
+    if (!errorLogged) {
+      errorLogged = true
+      console.warn(
+        `[PROXY] Could not read the active profile from ${target.url} (${message}). ` +
+        (state.lastGood
+          ? `Continuing on the last known value "${state.lastGood.profileId}".`
+          : `No value has ever been read; using this instance's own active profile.`)
+      )
+    }
+  }
+}
+
+/**
+ * Arm the background poll. Idempotent.
+ *
+ * `self` is the address this instance actually bound (the configured port may
+ * be 0), used only for the self-follow guard.
+ */
+export function startFollowPolling(self?: { host: string; port: number }): void {
+  if (pollTimer) return
+  const target = followTarget()
+  if (!target) return
+  if (self && isSelfTarget(target.url, self.host, self.port)) {
+    disabledReason =
+      `MERIDIAN_FOLLOW_ACTIVE (${target.url}) points at this instance's own address. ` +
+      `Following yourself would freeze the active profile permanently — the followed value ` +
+      `could never change and local switching would be refused. Follow mode is OFF.`
+    console.warn(`[PROXY] ${disabledReason}`)
+    return
+  }
+  void pollFollowedActiveProfile()
+  pollTimer = setInterval(() => { void pollFollowedActiveProfile() }, FOLLOW_POLL_INTERVAL_MS)
+  if (pollTimer.unref) pollTimer.unref()
+}
+
+/** Stop the background poll. Idempotent. */
+export function stopFollowPolling(): void {
+  if (!pollTimer) return
+  clearInterval(pollTimer)
+  pollTimer = undefined
+}
+
+/**
+ * Announce the mode once at startup.
+ *
+ * Not gated on `silent`, matching the treatment of other non-default operating
+ * modes: MERIDIAN_SILENT suppresses routine chatter, and this is not routine —
+ * it changes where a core piece of this instance's state comes from. An
+ * instance silently following another is exactly the hour-long confusion this
+ * line exists to prevent.
+ *
+ * @param routingMode current routing mode, so the one combination where follow
+ *   mode does nothing useful says so instead of being discovered the hard way.
+ */
+export function logFollowBanner(routingMode?: string): void {
+  if (bannerLogged) return
+  const target = followTarget()
+  if (!target) return
+  bannerLogged = true
+  console.warn(
+    `[PROXY] FOLLOWING ACTIVE PROFILE (MERIDIAN_FOLLOW_ACTIVE=${target.url}): ` +
+    `this instance takes its active profile from ${target.url}, not from its own settings. ` +
+    `Local switching is refused; the x-meridian-profile header still overrides per request.`
+  )
+  if (routingMode === "priority") {
+    console.warn(
+      `[PROXY] Routing is "priority", which dispatches unpinned requests across the pool ` +
+      `without consulting the active profile — follow mode will have no visible effect on them.`
+    )
+  }
+}
+
+/** Reset all module state — for testing only. */
+export function resetFollowActive(): void {
+  stopFollowPolling()
+  cachedRaw = undefined
+  cachedTarget = { kind: "off" }
+  warnedInvalid = undefined
+  disabledReason = undefined
+  state = {}
+  bannerLogged = false
+  errorLogged = false
+}
+
+/** Seed the cache directly — for testing only. */
+export function setFollowStateForTesting(next: FollowState): void {
+  state = next
+}

--- a/src/proxy/followActive.ts
+++ b/src/proxy/followActive.ts
@@ -138,11 +138,132 @@ export function readActiveProfile(body: unknown): string | undefined {
   return trimmed
 }
 
+// --- Pure: the roster -----------------------------------------------------
+
+/** Longest plausible credential directory — a defence against a garbage body. */
+const MAX_CREDENTIAL_DIR_LENGTH = 4_096
+
+/** A profile the followed instance has, and where its credentials live. */
+export interface FollowedProfile {
+  id: string
+  /** Absolute CLAUDE_CONFIG_DIR, on a filesystem both instances can read. */
+  credentialDir: string
+}
+
+export interface FollowedRoster {
+  /** Profiles this instance can serve by pointing at the same directory. */
+  adoptable: FollowedProfile[]
+  /** Profiles it cannot, because their credentials are an inline secret. */
+  unadoptable: string[]
+}
+
+/**
+ * Extract the profile roster from a `/profiles/list` body.
+ *
+ * Following one scalar is not enough. `MERIDIAN_CONFIG_DIR` gives a second
+ * instance its own `profiles.json` — that is the whole point of it — so the
+ * two rosters diverge the moment an account is added to either. The followed
+ * value then names a profile this instance does not have, `decideFollowedProfile`
+ * returns "unknown-profile", and the dev instance serves from an unrelated
+ * account: exactly the divergence follow mode exists to prevent. Measured on
+ * one box, a profile added to the primary was still absent from the follower
+ * minutes later, and its traffic 429'd against the wrong account.
+ *
+ * Adoptability is decided by the SENDER, which is the only side that can. A
+ * profile authenticated by a file both instances can read crosses as a path; a
+ * profile authenticated by an inline API key or OAuth token cannot cross at
+ * all, because the secret must not leave the process that holds it. The sender
+ * reports the second kind by id alone so this instance can say why an account
+ * it can see is one it cannot serve.
+ *
+ * Returns undefined — distinct from an empty roster — when the body carries no
+ * roster information at all. `credentialDir` is emitted for EVERY profile, null
+ * included, so its total absence means the followed instance predates this and
+ * cannot answer the question. Guessing "nothing is adoptable" there would warn
+ * about accounts that are merely unreported.
+ */
+export function readFollowedRoster(body: unknown): FollowedRoster | undefined {
+  if (typeof body !== "object" || body === null) return undefined
+  const entries = (body as { profiles?: unknown }).profiles
+  if (!Array.isArray(entries)) return undefined
+  const adoptable: FollowedProfile[] = []
+  const unadoptable: string[] = []
+  let sawField = false
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null) continue
+    const record = entry as { id?: unknown; credentialDir?: unknown }
+    if (typeof record.id !== "string") continue
+    const id = record.id.trim()
+    if (!id || id.length > MAX_PROFILE_ID_LENGTH) continue
+    if (!("credentialDir" in record)) continue
+    sawField = true
+    const dir = record.credentialDir
+    if (typeof dir === "string" && dir.trim() && dir.length <= MAX_CREDENTIAL_DIR_LENGTH) {
+      adoptable.push({ id, credentialDir: dir.trim() })
+    } else {
+      unadoptable.push(id)
+    }
+  }
+  return sawField ? { adoptable, unadoptable } : undefined
+}
+
+/** Whether two rosters name the same profiles at the same locations. */
+function sameRoster(a: FollowedRoster | undefined, b: FollowedRoster | undefined): boolean {
+  if (!a || !b) return a === b
+  if (a.adoptable.length !== b.adoptable.length) return false
+  if (a.unadoptable.length !== b.unadoptable.length) return false
+  return (
+    a.adoptable.every((p, i) => p.id === b.adoptable[i]!.id && p.credentialDir === b.adoptable[i]!.credentialDir) &&
+    a.unadoptable.every((id, i) => id === b.unadoptable[i])
+  )
+}
+
+/**
+ * Report a roster change once, when it happens.
+ *
+ * Transitions only, matching the active-profile line beside it: a line per
+ * poll would be 8,640 a day. An account appearing or disappearing is the
+ * event worth a line, and a relocation is reported separately because the
+ * roster is the same size and nothing else would show it.
+ */
+function logRosterChange(previous: FollowedRoster | undefined, next: FollowedRoster, url: string): void {
+  const before = new Map((previous?.adoptable ?? []).map(p => [p.id, p.credentialDir]))
+  const added = next.adoptable.filter(p => !before.has(p.id)).map(p => p.id)
+  const moved = next.adoptable.filter(p => before.has(p.id) && before.get(p.id) !== p.credentialDir).map(p => p.id)
+  const after = new Set(next.adoptable.map(p => p.id))
+  const removed = [...before.keys()].filter(id => !after.has(id))
+  if (added.length || removed.length || moved.length) {
+    console.warn(
+      `[PROXY] Profiles from ${url}: now serving ${next.adoptable.length}` +
+      (added.length ? `; added ${added.join(", ")}` : "") +
+      (removed.length ? `; withdrew ${removed.join(", ")}` : "") +
+      (moved.length ? `; relocated ${moved.join(", ")}` : "") + "."
+    )
+  }
+  const unadoptableChanged =
+    next.unadoptable.length !== (previous?.unadoptable.length ?? 0) ||
+    next.unadoptable.some((id, i) => id !== previous?.unadoptable[i])
+  if (next.unadoptable.length && unadoptableChanged) {
+    console.warn(
+      `[PROXY] ${url} also has ${next.unadoptable.join(", ")}, which cannot be taken from it: ` +
+      `their credentials are an inline key or token rather than a file on this machine, and a ` +
+      `secret is never sent over this link. Configure them here to serve them here.`
+    )
+  }
+}
+
 // --- Pure: the decision ---------------------------------------------------
 
 export interface FollowState {
   /** Last value successfully read, and when it was last CONFIRMED by a poll. */
   lastGood?: { profileId: string; at: number }
+  /**
+   * Last roster successfully read. Kept across a failed poll for the same
+   * reason `lastGood` is: a followed instance that has gone quiet has not
+   * withdrawn its accounts, and dropping them would strand every session
+   * pinned to one.
+   */
+  lastRoster?: { roster: FollowedRoster; at: number }
   /** When the most recent poll completed, successful or not. */
   lastPollAt?: number
   /** Most recent poll failure. Cleared on the next success. */
@@ -233,6 +354,18 @@ export function followedActiveProfile(availableIds: readonly string[]): FollowOu
   return decideFollowedProfile(state, availableIds, Date.now())
 }
 
+/**
+ * Profiles contributed by the followed instance. Called on the request path
+ * through `getEffectiveProfiles` — synchronous, cache-only, no I/O.
+ *
+ * Empty until the first successful poll, so an instance whose followed peer is
+ * down starts with its own profiles rather than none.
+ */
+export function adoptedProfiles(): readonly FollowedProfile[] {
+  if (!isFollowEnabled()) return []
+  return state.lastRoster?.roster.adoptable ?? []
+}
+
 /** Follow state as surfaced by `/profiles/list`. Undefined when not following. */
 export interface FollowStatus {
   /** Base URL of the followed instance. */
@@ -249,12 +382,19 @@ export interface FollowStatus {
   lastSyncedAt: number | null
   /** Most recent poll failure, if the last poll failed. */
   lastError: string | null
+  /** Profile ids taken from the followed instance and served here. */
+  adoptedProfiles: string[]
+  /** Profile ids it has that cannot be adopted, so a UI can say why. */
+  unadoptableProfiles: string[]
+  /** When the roster was last confirmed, or null if never read. */
+  rosterSyncedAt: number | null
 }
 
 export function followStatus(availableIds: readonly string[]): FollowStatus | undefined {
   const target = followTarget()
   if (!target) return undefined
   const outcome = decideFollowedProfile(state, availableIds, Date.now())
+  const roster = state.lastRoster
   return {
     url: target.url,
     activeProfile: outcome.follow ? outcome.profileId : null,
@@ -263,6 +403,9 @@ export function followStatus(availableIds: readonly string[]): FollowStatus | un
     stale: outcome.follow ? outcome.stale : false,
     lastSyncedAt: state.lastGood?.at ?? null,
     lastError: state.lastError?.message ?? null,
+    adoptedProfiles: (roster?.roster.adoptable ?? []).map(p => p.id),
+    unadoptableProfiles: roster?.roster.unadoptable ?? [],
+    rosterSyncedAt: roster?.at ?? null,
   }
 }
 
@@ -283,10 +426,18 @@ export async function pollFollowedActiveProfile(): Promise<void> {
       headers: { accept: "application/json" },
     })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const value = readActiveProfile(await res.json())
+    const body = await res.json()
+    const value = readActiveProfile(body)
     if (!value) throw new Error("response carried no usable activeProfile")
     const previous = state.lastGood?.profileId
-    state = { lastGood: { profileId: value, at: now }, lastPollAt: now }
+    const roster = readFollowedRoster(body)
+    const previousRoster = state.lastRoster?.roster
+    state = {
+      lastGood: { profileId: value, at: now },
+      lastRoster: roster ? { roster, at: now } : state.lastRoster,
+      lastPollAt: now,
+    }
+    if (roster && !sameRoster(roster, previousRoster)) logRosterChange(previousRoster, roster, target.url)
     // Log transitions only. A line per poll would be 8,640 lines a day; the
     // interesting events are "we picked up a change" and "we recovered".
     if (previous !== value) {

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -8,7 +8,8 @@
  *
  * Profile selection priority:
  *   1. x-meridian-profile request header (per-request override)
- *   2. Active profile (set via POST /profiles/active or UI)
+ *   2. Active profile (set via POST /profiles/active or UI, or taken from
+ *      another instance under MERIDIAN_FOLLOW_ACTIVE — see followActive.ts)
  *   3. First configured profile (or implicit "default" if none configured)
  *
  * This is a leaf module — no imports from server.ts or session/.
@@ -19,6 +20,7 @@ import { join } from "node:path"
 import { homedir } from "node:os"
 import { setSetting, getSetting } from "./settings"
 import { pickStickyProfile, type RoutingMode } from "./routing"
+import { followedActiveProfile } from "./followActive"
 
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 
@@ -96,15 +98,55 @@ export function setActiveProfile(profileId: string): void {
 }
 
 /**
- * Get the current active profile ID.
+ * Get the LOCAL active profile ID — this instance's own choice, ignoring
+ * follow mode. Callers that want the profile actually in effect want
+ * `resolveActiveProfileId` instead.
  */
 export function getActiveProfileId(): string | undefined {
   return activeProfileId
 }
 
+/** Last followed value warned about, so the warning is once per value. */
+let warnedUnknownFollowed: string | undefined
+
+/**
+ * The active profile actually in effect: the followed instance's choice under
+ * MERIDIAN_FOLLOW_ACTIVE, otherwise this instance's own.
+ *
+ * This is the ONE input follow mode replaces. Everything around it — the
+ * header override, sticky assignment, the config default, the first-profile
+ * fallback — is unchanged.
+ *
+ * @param availableIds profile IDs this instance actually has, so a followed
+ *   value it cannot serve is rejected here rather than resolving to an
+ *   unrelated account further down `resolveProfile`.
+ */
+export function resolveActiveProfileId(availableIds: readonly string[]): string | undefined {
+  const outcome = followedActiveProfile(availableIds)
+  if (!outcome) return activeProfileId
+  if (outcome.follow) {
+    warnedUnknownFollowed = undefined
+    return outcome.profileId
+  }
+  if (outcome.reason === "unknown-profile" && outcome.followedValue !== warnedUnknownFollowed) {
+    warnedUnknownFollowed = outcome.followedValue
+    console.warn(
+      `[meridian] Followed instance is on profile "${outcome.followedValue}", which is not configured here. ` +
+      `Using this instance's own active profile instead.`
+    )
+  }
+  return activeProfileId
+}
+
+/** The active profile in effect, resolved against the effective profile list. */
+export function getEffectiveActiveProfileId(configProfiles: ProfileConfig[] | undefined): string | undefined {
+  return resolveActiveProfileId(getEffectiveProfiles(configProfiles).map(p => p.id))
+}
+
 /** Reset active profile — for testing only. */
 export function resetActiveProfile(): void {
   activeProfileId = undefined
+  warnedUnknownFollowed = undefined
 }
 
 /**
@@ -199,7 +241,8 @@ export function resolveProfile(
       : undefined
 
   // Priority: header > sticky > active > config default > first profile
-  const resolvedId = requestedId || stickyId || activeProfileId || defaultProfile || effective[0]!.id
+  const activeId = resolveActiveProfileId(effective.map(p => p.id))
+  const resolvedId = requestedId || stickyId || activeId || defaultProfile || effective[0]!.id
   const profile = effective.find(p => p.id === resolvedId)
 
   if (!profile) {
@@ -252,7 +295,7 @@ export function listProfiles(
   const effective = getEffectiveProfiles(profiles)
   if (effective.length === 0) return []
 
-  const currentActive = activeProfileId || defaultProfile || effective[0]!.id
+  const currentActive = resolveActiveProfileId(effective.map(p => p.id)) || defaultProfile || effective[0]!.id
   return effective.map(p => ({
     id: p.id,
     type: p.type ?? "claude-max",

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -20,7 +20,7 @@ import { join } from "node:path"
 import { homedir } from "node:os"
 import { setSetting, getSetting } from "./settings"
 import { pickStickyProfile, type RoutingMode } from "./routing"
-import { followedActiveProfile } from "./followActive"
+import { adoptedProfiles, followedActiveProfile } from "./followActive"
 
 const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
 
@@ -186,11 +186,33 @@ export function enableDiskProfileDiscovery(): void {
 
 export function getEffectiveProfiles(configProfiles: ProfileConfig[] | undefined): ProfileConfig[] {
   const fromConfig = configProfiles ?? []
-  if (!diskDiscoveryEnabled) return fromConfig
-  const fromDisk = loadProfilesFromDisk()
-  // Config (env var) takes precedence; disk fills in anything not already defined
   const configIds = new Set(fromConfig.map(p => p.id))
-  return [...fromConfig, ...fromDisk.filter(p => !configIds.has(p.id))]
+  // Config (env var) takes precedence; disk fills in anything not already defined
+  const fromDisk = diskDiscoveryEnabled ? loadProfilesFromDisk().filter(p => !configIds.has(p.id)) : []
+  const localIds = new Set([...configIds, ...fromDisk.map(p => p.id)])
+  // Adopted last: an id spelled out locally is an explicit local statement and
+  // outranks the mirror, the same way config already outranks disk.
+  const adopted = adoptedProfiles()
+    .filter(p => !localIds.has(p.id))
+    .map(p => ({ id: p.id, claudeConfigDir: p.credentialDir }))
+  return [...fromConfig, ...fromDisk, ...adopted]
+}
+
+/**
+ * Where another instance on this machine could read this profile's credentials,
+ * or null when it could not.
+ *
+ * The test is that the resolved environment is a config directory and NOTHING
+ * else. That is what makes it derived rather than a second opinion about
+ * profile types: a profile whose credentials are an inline API key or OAuth
+ * token carries that secret in its env, fails the test, and is reported by id
+ * alone. A secret must never leave the process holding it, so there is no
+ * shape of this function that returns one.
+ */
+export function shareableCredentialDir(resolved: ResolvedProfile): string | null {
+  const keys = Object.keys(resolved.env)
+  if (keys.length !== 1 || keys[0] !== "CLAUDE_CONFIG_DIR") return null
+  return resolved.env.CLAUDE_CONFIG_DIR ?? null
 }
 
 /** Check if any profiles are available from any source */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -80,7 +80,7 @@ import { runTransformHook, buildPipeline, createRequestContext } from "./transfo
 import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
-import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, resolveActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, resolveActiveProfileId, getEffectiveProfiles, restoreActiveProfile, shareableCredentialDir, type ResolvedProfile } from "./profiles"
 import { followStatus, startFollowPolling, stopFollowPolling, logFollowBanner, FOLLOW_POLL_INTERVAL_MS } from "./followActive"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
@@ -4774,6 +4774,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         loggedIn: auth?.loggedIn ?? false,
         lastCheckedAt: cacheInfo.lastCheckedAt || null,
         lastSuccessAt: cacheInfo.lastSuccessAt || null,
+        // Present for EVERY profile, null included, so a follower can tell an
+        // instance too old to answer (field absent) from one saying this
+        // profile cannot be shared (field null). Never a secret — see
+        // shareableCredentialDir.
+        credentialDir: shareableCredentialDir(resolved),
       }
     }))
     const routingModeNow = getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing"))

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -80,7 +80,8 @@ import { runTransformHook, buildPipeline, createRequestContext } from "./transfo
 import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
-import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, resolveActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { followStatus, startFollowPolling, stopFollowPolling, logFollowBanner, FOLLOW_POLL_INTERVAL_MS } from "./followActive"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -4784,12 +4785,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           exhausted: priorityExhaustion.snapshot(),
         }
       : {}
+    // Additive: follow state, so UIs can say where the active profile comes
+    // from and why switching is refused. Absent unless MERIDIAN_FOLLOW_ACTIVE.
+    const follow = followStatus(profiles.map(p => p.id))
     return c.json({
       profiles: enriched,
-      activeProfile: getActiveProfileId() || finalConfig.defaultProfile || profiles[0]?.id || "default",
+      activeProfile: resolveActiveProfileId(profiles.map(p => p.id)) || finalConfig.defaultProfile || profiles[0]?.id || "default",
       // Additive (#383): current routing mode so UIs can surface it.
       routing: routingModeNow,
       ...priorityInfo,
+      ...(follow ? { follow } : {}),
     })
   })
 
@@ -4799,6 +4804,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   })
 
   app.post("/profiles/active", async (c) => {
+    // Refuse rather than accept-and-lose. Under follow mode the write would
+    // persist locally, be shadowed by the followed value on the very next
+    // resolve, and be erased by the next poll — a picker that appears to work
+    // and silently doesn't. 409 because the request is well-formed and
+    // conflicts with the instance's operating mode, not with its input.
+    const following = followStatus(getEffectiveProfiles(finalConfig.profiles).map(p => p.id))
+    if (following) {
+      return c.json({
+        error: `This instance follows ${following.url} for its active profile (MERIDIAN_FOLLOW_ACTIVE). ` +
+          `Switch there instead — a local change would be overwritten within ` +
+          `${Math.round(FOLLOW_POLL_INTERVAL_MS / 1000)}s. ` +
+          `For a single request, send the x-meridian-profile header.`,
+        following,
+      }, 409)
+    }
     let body: { profile?: string }
     try {
       body = await c.req.json() as { profile?: string }
@@ -5209,7 +5229,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const requestedProfile = c.req.query("profile")
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
     const targetProfileId = requestedProfile
-      || getActiveProfileId()
+      || resolveActiveProfileId(profilesList.map(p => p.id))
       || finalConfig.defaultProfile
       || profilesList[0]?.id
       || null
@@ -5321,7 +5341,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // values rather than reuses.
   app.get("/v1/usage/quota/all", async (c) => {
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
-    const activeId = getActiveProfileId() || finalConfig.defaultProfile || profilesList[0]?.id || null
+    const activeId = resolveActiveProfileId(profilesList.map(p => p.id)) || finalConfig.defaultProfile || profilesList[0]?.id || null
 
     if (profilesList.length === 0) {
       // Single-account mode — just return the default OAuth account's data.
@@ -5589,6 +5609,10 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     hostname: finalConfig.host,
     overrideGlobalObjects: false,
   }, (info) => {
+    // Armed here, not before serve(), because the self-follow guard needs the
+    // port actually bound — the configured one may be 0.
+    startFollowPolling({ host: finalConfig.host, port: info.port })
+    logFollowBanner(getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing")))
     if (!finalConfig.silent) {
       console.log(`Meridian running at http://${finalConfig.host}:${info.port}`)
       console.log(`Telemetry dashboard: http://${finalConfig.host}:${info.port}/telemetry`)
@@ -5670,6 +5694,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       closePromise ??= (async () => {
         clearInterval(profileTokenRefreshInterval)
         if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+        stopFollowPolling()
         stopBackgroundRefresh()
 
         // Stop admitting new requests, then give whatever is already in flight

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -187,8 +187,10 @@ function profileSection(q,s,pl,h){
     }
     if(!rows)rows='<div class="no-usage">no usage data yet</div>';
     var isPriority=pl&&pl.routing==='priority';
-    var switchable=multi&&p.configured&&!p.isActive&&!isPriority;
+    var follow=pl&&pl.follow;
+    var switchable=multi&&p.configured&&!p.isActive&&!isPriority&&!follow;
     var badge=isPriority?'':p.isActive?'<span class="active-pill">Active</span>':switchable?'<span class="switch-hint">Click to activate</span>':'';
+    if(follow&&p.isActive)badge+=' <span class="pool-chip">'+(follow.activeProfile?'following '+esc(follow.url):'local — '+esc(follow.url)+' unreachable')+(follow.stale?' · stale':'')+'</span>';
     if(isPriority){
       var orderIdx=(pl.profileOrder||[]).indexOf(p.id);
       if(orderIdx>=0)badge+='<span class="pool-chip">#'+(orderIdx+1)+' in pool</span>';
@@ -264,7 +266,7 @@ function render(h,s,q,pl){
 function switchProfile(id){
   fetch('/profiles/active',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({profile:id})})
     .then(function(r){return r.json()})
-    .then(function(data){if(data.success){refresh();if(window.meridianHeaderRefresh)window.meridianHeaderRefresh()}})
+    .then(function(data){if(data.success){refresh();if(window.meridianHeaderRefresh)window.meridianHeaderRefresh()}else if(data.error)alert(data.error)})
     .catch(function(){});
 }
 document.getElementById('content').addEventListener('click',function(e){

--- a/src/telemetry/profileBar.ts
+++ b/src/telemetry/profileBar.ts
@@ -123,6 +123,10 @@ export const profileBarCss = `
   .meridian-header .mh-profile .mh-profile-type {
     color: var(--muted, #8b949e); font-size: 10px;
   }
+  .meridian-header .mh-profile.following { border-color: var(--accent2, #bc8cff); }
+  .meridian-header .mh-profile .mh-profile-follow {
+    color: var(--accent2, #bc8cff); font-size: 10px;
+  }
   .meridian-header .mh-status {
     display: inline-flex; align-items: center; gap: 6px;
     font-size: 11px; color: var(--muted, #8b949e); white-space: nowrap;
@@ -191,7 +195,20 @@ export const profileBarJs = `
     fetch('/profiles/list').then(function(r) { return r.json(); }).then(function(data) {
       var current = (data.profiles || []).find(function(p) { return p.isActive; });
       if (!current) { profileChip.classList.remove('visible'); return; }
-      profileChip.innerHTML = esc(current.id) + ' <span class="mh-profile-type">' + esc(current.type || '') + '</span>';
+      // Follow mode: say so on every page. An instance quietly taking its
+      // active profile from another one, with a picker that won't stick, is
+      // otherwise an hour of confusion.
+      var follow = data.follow;
+      var followLabel = follow ? (follow.activeProfile ? 'following' : 'follow: local') : '';
+      if (follow && follow.stale) followLabel += ' (stale)';
+      profileChip.innerHTML = esc(current.id) + ' <span class="mh-profile-type">' + esc(current.type || '') + '</span>'
+        + (follow ? ' <span class="mh-profile-follow">' + esc(followLabel) + '</span>' : '');
+      profileChip.classList.toggle('following', !!follow);
+      profileChip.title = follow
+        ? 'Active profile follows ' + follow.url + ' (MERIDIAN_FOLLOW_ACTIVE)'
+          + (follow.activeProfile ? '' : ' — no usable value from it, using the local profile')
+          + '. Switching here is refused; switch on the followed instance.'
+        : 'Active profile — switch from the home page';
       profileChip.classList.add('visible');
     }).catch(function() {});
   }

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -445,6 +445,7 @@ async function switchProfile(id) {
   });
   const data = await res.json();
   if (data.success) refresh();
+  else if (data.error) alert(data.error);
 }
 
 refresh();


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

`MERIDIAN_FOLLOW_ACTIVE` follows one scalar. `MERIDIAN_CONFIG_DIR` gives a second instance its own `profiles.json` - that is the whole point of it - so the two rosters diverge the moment an account is added to either. The followed value then names a profile the follower does not have, `decideFollowedProfile` returns `unknown-profile`, and the dev instance quietly serves from an unrelated account: exactly the divergence follow mode exists to prevent.

Measured on one box: a profile added to the primary and made active was still absent from the follower minutes later, and traffic routed through the follower 429'd against the account it fell back to. The workaround was to copy `profiles.json` across by hand, which is the tell - the follower wanted the primary's roster and had no way to ask for it.

## How

**The roster rides the poll that already happens.** `followActive.ts` fetches `/profiles/list` every 10s for the active profile; that response already enumerates the profiles, so recording them costs no extra request and cannot drift from the active value it arrived with.

**Adoptability is decided by the sender**, which is the only side that can. `shareableCredentialDir` returns a path only when a profile's resolved env is a config directory and NOTHING else, so a profile authenticated by an inline API key or OAuth token fails the test and is reported by id alone. There is no shape of that function that returns a secret, and the test asserts it for both inline kinds. Deriving it from the resolved env rather than from `ProfileType` keeps it a consequence of how the profile is actually served rather than a second opinion about it.

**`credentialDir` is emitted for EVERY profile, `null` included.** Absence therefore means the followed instance predates this change and cannot answer the question, which is a different thing from "nothing here is adoptable" - guessing the latter would warn about accounts that are merely unreported. `readFollowedRoster` returns `undefined` for the first and a roster with an empty `adoptable` list for the second.

**Precedence puts adopted profiles last.** An id spelled out in config or on local disk is an explicit local statement and outranks the mirror, the same way config already outranks disk.

**Degradation matches the active profile's.** The last good roster survives a failed poll, because an instance that has gone quiet has not withdrawn its accounts and dropping them would strand every session pinned to one. A successful poll that no longer lists a profile does withdraw it - that is a mirror doing its job.

**Nothing is written to disk.** The adopted roster is cache, read synchronously on the request path through `getEffectiveProfiles`, so an instance running with credentials read-only adopts profiles without attempting a credential write.

Follow status gains `adoptedProfiles`, `unadoptableProfiles` and `rosterSyncedAt` so a UI can say which accounts came from where, and why one it can see is one it cannot serve.

## Depends on

This builds on the `MERIDIAN_FOLLOW_ACTIVE` branch, which is not yet merged. GitHub refuses a fork-only base branch (`base: invalid`), so this PR is based on `main` and its diff therefore also contains that commit. Review the top commit only.

## Tests

`src/__tests__/follow-active.test.ts` gains 18 tests covering the roster read (old instance, all-unadoptable, garbage entries), the shared poll, failed-poll retention, withdrawal on a successful poll, adoption precedence, and that an inline secret is never reported. 55 pass in that file; the full suite shows no new failures against this base.

This PR is AI generated, but under direct supervision and on request of Nowaker.
