### PR TITLE
fix(session): retry a refused resume before abandoning the session

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { classifyError, extendedContextHint, isStaleSessionError, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
+import { classifyError, extendedContextHint, classifyResumeRefusal, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -259,37 +259,50 @@ describe("classifyError", () => {
     })
   })
 
-  describe("stale session detection", () => {
-    it("detects 'No message found with message.uuid' errors", () => {
-      expect(isStaleSessionError(new Error("No message found with message.uuid of: e663b687-6d08-4cc4-b9a9-5245ce8f1e07"))).toBe(true)
+  describe("resume refusal classification", () => {
+    const busyRefusal =
+      "Error: Session 3cff857d-114e-4be3-8a12-99842ad2326e is currently running as a background agent (bg). Use `claude agents` to find and attach to it, or add --fork-session to branch off a copy."
+
+    it("a lost message names itself, so an identical attempt is pointless", () => {
+      expect(classifyResumeRefusal(new Error("No message found with message.uuid of: e663b687-6d08-4cc4-b9a9-5245ce8f1e07"))).toBe("missing-message")
     })
 
-    it("detects the error embedded in longer messages", () => {
-      expect(isStaleSessionError(new Error("claude code returned an error result: No message found with message.uuid of: abc123"))).toBe(true)
+    it("reads the refusal out of a longer message", () => {
+      expect(classifyResumeRefusal(new Error("claude code returned an error result: No message found with message.uuid of: abc123"))).toBe("missing-message")
     })
 
-    it("detects 'No conversation found with session ID' errors", () => {
-      expect(isStaleSessionError(new Error("No conversation found with session ID: 2e9e868c-ab59-482c-ae28-3b60ec9cb95b"))).toBe(true)
+    it("a session that would not open is unresumable, not proven gone", () => {
+      expect(classifyResumeRefusal(new Error("No conversation found with session ID: 2e9e868c-ab59-482c-ae28-3b60ec9cb95b"))).toBe("unresumable")
+      expect(classifyResumeRefusal(new Error("No conversation found to continue"))).toBe("unresumable")
+      expect(classifyResumeRefusal(new Error("No conversations found to resume"))).toBe("unresumable")
+      expect(classifyResumeRefusal(new Error("No conversations found to resume."))).toBe("unresumable")
     })
 
-    it("detects 'No conversation found to continue' errors", () => {
-      expect(isStaleSessionError(new Error("No conversation found to continue"))).toBe(true)
+    it("a session held by a running agent is busy, so it can be branched", () => {
+      expect(classifyResumeRefusal(new Error(busyRefusal))).toBe("busy")
     })
 
-    it("detects 'No conversations found to resume' errors", () => {
-      expect(isStaleSessionError(new Error("No conversations found to resume"))).toBe(true)
-      expect(isStaleSessionError(new Error("No conversations found to resume."))).toBe(true)
+    it("finds the busy refusal on stderr when the error only carries the exit code", () => {
+      expect(classifyResumeRefusal(new Error("Claude Code process exited with code 1"), busyRefusal)).toBe("busy")
     })
 
-    it("returns false for unrelated errors", () => {
-      expect(isStaleSessionError(new Error("rate limit exceeded"))).toBe(false)
-      expect(isStaleSessionError(new Error("authentication failed"))).toBe(false)
+    it("leaves failures that are not about the resume unclassified", () => {
+      expect(classifyResumeRefusal(new Error("rate limit exceeded"))).toBeUndefined()
+      expect(classifyResumeRefusal(new Error("authentication failed"))).toBeUndefined()
+      expect(classifyResumeRefusal(new Error("Claude Code process exited with code 1"))).toBeUndefined()
     })
 
-    it("returns false for non-Error values", () => {
-      expect(isStaleSessionError("No message found with message.uuid")).toBe(false)
-      expect(isStaleSessionError(null)).toBe(false)
-      expect(isStaleSessionError(undefined)).toBe(false)
+    it("reads no wording off the value of a non-Error failure", () => {
+      expect(classifyResumeRefusal("No message found with message.uuid")).toBeUndefined()
+      expect(classifyResumeRefusal(null)).toBeUndefined()
+      expect(classifyResumeRefusal(undefined)).toBeUndefined()
+    })
+
+    it("still finds the busy refusal on stderr, whatever the failure value is", () => {
+      // The busy wording travels on stderr precisely because the failure often
+      // carries nothing but an exit code, so this one is not value-bound.
+      expect(classifyResumeRefusal("exit 1", busyRefusal)).toBe("busy")
+      expect(classifyResumeRefusal(null, busyRefusal)).toBe("busy")
     })
   })
 

--- a/src/__tests__/proxy-resume-refusal.test.ts
+++ b/src/__tests__/proxy-resume-refusal.test.ts
@@ -1,0 +1,210 @@
+/**
+ * A refused resume must not be mistaken for a lost session.
+ *
+ * The CLI refuses a --resume that lands while the previous subprocess for the
+ * same session is still exiting; one of its wordings ("No conversation found
+ * with session ID …") reads like the session is gone, although the session is
+ * intact and the next attempt succeeds. Treating that as terminal evicts the
+ * session and silently replays the whole conversation as a fresh one, throwing
+ * away the context the SDK side holds.
+ *
+ * So the refusal is retried first, and only a session that refuses every
+ * attempt is replayed fresh. A refusal that names a lost message inside the
+ * session is different — an identical attempt fails identically — and stays
+ * one-shot.
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop } from "./helpers"
+
+// Linear backoff is real time; the retry path is what is under test, not the wait.
+process.env.MERIDIAN_BUSY_RETRY_DELAY_MS = "5"
+
+let queryCalls: Array<Record<string, any>> = []
+let queryCallCount = 0
+/** How many leading attempts the CLI refuses with the missing-conversation wording. */
+let refuseAttempts = 1
+/** Refuse instead with a lost message inside the session. */
+let missingMessage = false
+/** Per-attempt wordings, when the refusal is not the same one every time. */
+let refusalScript: Array<"unresumable" | "busy"> = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    queryCallCount++
+    const callIndex = queryCallCount
+    queryCalls.push(opts.options || {})
+    const isStreaming = opts.options?.includePartialMessages === true
+    return (async function* () {
+      // The CLI refuses the resume while the previous subprocess for this
+      // session is still exiting. The session itself is intact.
+      const scripted = refusalScript[callIndex - 1]
+      if (scripted && opts.options?.resume) {
+        throw new Error(
+          scripted === "busy"
+            ? `Error: Session ${opts.options?.resume} is currently running as a background agent (bg). Use \`claude agents\` to find and attach to it, or add --fork-session to branch off a copy.`
+            : `No conversation found with session ID: ${opts.options?.resume}`
+        )
+      }
+      if (!scripted && callIndex <= refuseAttempts && opts.options?.resume) {
+        throw new Error(
+          missingMessage
+            ? "No message found with message.uuid of: 6f1c0f4e-0a1e-4d61-9a2f-7b0c1d2e3f40"
+            : `No conversation found with session ID: ${opts.options?.resume}`
+        )
+      }
+      if (isStreaming) {
+        yield messageStart(`msg-${callIndex}`)
+        yield textBlockStart(0)
+        yield textDelta(0, `response-${callIndex}`)
+        yield blockStop(0)
+        yield messageDelta("end_turn")
+        yield messageStop()
+      }
+      yield {
+        type: "assistant",
+        uuid: `uuid-${callIndex}`,
+        message: {
+          id: `msg-${callIndex}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: `response-${callIndex}` }],
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        session_id: "sdk-original",
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const priorMessages = [
+  { role: "user", content: "hello" },
+  { role: "assistant", content: "hi there" },
+  { role: "user", content: "do something" },
+  { role: "assistant", content: "done" },
+]
+const continuation = [...priorMessages, { role: "user", content: "and now continue" }]
+
+describe("Resume refusal", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    queryCalls = []
+    queryCallCount = 0
+    refuseAttempts = 1
+    missingMessage = false
+    refusalScript = []
+  })
+
+  it("retries the same resume instead of evicting the session (non-streaming)", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-transient-refusal"
+    storeSession(sessionId, priorMessages, "sdk-original", "/tmp/test")
+
+    const response = await post(app, { model: "sonnet", stream: false, messages: continuation }, { "x-opencode-session": sessionId })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.content.some((b: any) => b.type === "text")).toBe(true)
+
+    // The first call was the refused resume.
+    expect(queryCalls[0]!.resume).toBe("sdk-original")
+    // The refusal must be retried with the same session — not answered by a
+    // fresh full-history replay that abandons the session.
+    expect(queryCalls[1]!.resume).toBe("sdk-original")
+  })
+
+  it("retries the same resume instead of evicting the session (streaming)", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-transient-refusal-stream"
+    storeSession(sessionId, priorMessages, "sdk-original", "/tmp/test")
+
+    const response = await post(app, { model: "sonnet", stream: true, messages: continuation }, { "x-opencode-session": sessionId })
+    expect(response.status).toBe(200)
+    await response.text()
+
+    expect(queryCalls[0]!.resume).toBe("sdk-original")
+    expect(queryCalls[1]!.resume).toBe("sdk-original")
+  })
+
+  it("falls back to a fresh replay when every resume attempt is refused", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-gone-for-good"
+    refuseAttempts = Number.MAX_SAFE_INTEGER
+    storeSession(sessionId, priorMessages, "sdk-original", "/tmp/test")
+
+    const response = await post(app, { model: "sonnet", stream: false, messages: continuation }, { "x-opencode-session": sessionId })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.content.some((b: any) => b.type === "text")).toBe(true)
+
+    // Every attempt that carried a resume was refused, so the session cannot
+    // serve this turn and the last attempt must be a fresh full-history query.
+    // The resume is attempted once plus every retry, and never beyond that.
+    const last = queryCalls[queryCalls.length - 1]!
+    expect(last.resume).toBeUndefined()
+    expect(queryCalls.filter(c => c.resume === "sdk-original").length).toBe(4)
+    expect(queryCalls.length).toBe(5)
+  })
+
+  it("replays fresh when the refusal wording changes between attempts", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-mixed-refusals"
+    // The exit window produces either wording, so one request can see both. The
+    // spent retry budget must still reach the replay — the alternation cannot
+    // hand the client a refusal the same session would have recovered from.
+    refusalScript = ["unresumable", "unresumable", "unresumable", "busy", "busy"]
+    storeSession(sessionId, priorMessages, "sdk-original", "/tmp/test")
+
+    const response = await post(app, { model: "sonnet", stream: false, messages: continuation }, { "x-opencode-session": sessionId })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.content.some((b: any) => b.type === "text")).toBe(true)
+
+    const last = queryCalls[queryCalls.length - 1]!
+    expect(last.resume).toBeUndefined()
+  })
+
+  it("does not retry a refusal that names a lost message inside the session", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-missing-message"
+    missingMessage = true
+    storeSession(sessionId, priorMessages, "sdk-original", "/tmp/test")
+
+    const response = await post(app, { model: "sonnet", stream: false, messages: continuation }, { "x-opencode-session": sessionId })
+    expect(response.status).toBe(200)
+    await response.json()
+
+    // The session provably no longer holds a message the resume needs, so the
+    // refusal is answered by one fresh replay — not by repeating the attempt.
+    expect(queryCalls[0]!.resume).toBe("sdk-original")
+    expect(queryCalls.length).toBe(2)
+    expect(queryCalls[1]!.resume).toBeUndefined()
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -228,17 +228,43 @@ export function isExpiredTokenError(errMsg: string): boolean {
 }
 
 /**
- * Detect errors caused by stale session/message UUIDs.
- * These happen when the upstream Claude session no longer contains
- * the referenced message or conversation (expired, evicted server-side, etc.).
+ * Why the CLI refused a --resume, as far as the refusal itself can tell:
+ *
+ * - "busy": the session exists and is registered as a running agent. It can
+ *   be branched, so a caller out of retries may fork it.
+ * - "unresumable": the session as a whole could not be opened. This is not
+ *   proof that it is gone — a --resume landing while the session's previous
+ *   subprocess is still exiting is refused although the session is intact —
+ *   so a caller must retry before giving up on it, and has nothing to fork.
+ * - "missing-message": one message inside the session is gone, so an
+ *   identical attempt fails identically. Retrying is pointless.
+ *
+ * The three carry different recoveries, which is the whole reason they are
+ * one verdict rather than scattered text matches at each call site.
  */
-export function isStaleSessionError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
+export type ResumeRefusal = "busy" | "unresumable" | "missing-message"
+
+/**
+ * Classify a resume failure. Returns undefined for anything that is not a
+ * refusal of the resume itself (rate limits, auth, upstream faults), which
+ * the caller handles on its own paths.
+ *
+ * The busy refusal text arrives on stderr — the SDK error itself only carries
+ * the exit code — so captured stderr is part of the input.
+ */
+export function classifyResumeRefusal(error: unknown, stderr?: string): ResumeRefusal | undefined {
+  if (isBusySessionError(error, stderr)) return "busy"
+  if (!(error instanceof Error)) return undefined
   const msg = error.message
-  return msg.includes("No message found with message.uuid")
-    || msg.includes("No conversation found with session ID")
-    || msg.includes("No conversation found to continue")
-    || msg.includes("No conversations found to resume")
+  if (msg.includes("No message found with message.uuid")) return "missing-message"
+  if (
+    msg.includes("No conversation found with session ID") ||
+    msg.includes("No conversation found to continue") ||
+    msg.includes("No conversations found to resume")
+  ) {
+    return "unresumable"
+  }
+  return undefined
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -50,7 +50,7 @@ import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { classifyError, extractSdkTermination, formatSdkTermination, isStaleSessionError, isBusySessionError, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
+import { classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
@@ -419,14 +419,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   const PENDING_STORE_WAIT_MS = 3000
   const PENDING_STORE_AUTO_RESOLVE_MS = 10000
 
-  // #630: a --resume spawned while the session's previous subprocess is
-  // still exiting is refused ("currently running as a background agent",
-  // a consequence of #628's CLAUDE_CODE_SESSION_KIND=bg). The stale
-  // process exits within ~a second — retry the same resume with linear
-  // backoff, then fork the session as a last resort. Delay is overridable
-  // so tests don't sleep for real.
-  const BUSY_SESSION_MAX_RETRIES = 3
-  const BUSY_SESSION_RETRY_DELAY_MS = parseInt(process.env.MERIDIAN_BUSY_RETRY_DELAY_MS ?? "500", 10)
+  // A --resume spawned while the session's previous subprocess is still
+  // exiting is refused, in two wordings: "currently running as a background
+  // agent" (#630, a consequence of #628's CLAUDE_CODE_SESSION_KIND=bg) and
+  // "No conversation found …". Neither means the session is gone — the stale
+  // process exits within ~a second — so retry the same resume with linear
+  // backoff, and fork only what can be branched. Delay is overridable so
+  // tests don't sleep for real.
+  const RESUME_REFUSAL_MAX_RETRIES = 3
+  // The env name predates the wider refusal set and stays as it is: renaming it
+  // would silently drop anyone's existing override.
+  const RESUME_REFUSAL_RETRY_DELAY_MS = parseInt(process.env.MERIDIAN_BUSY_RETRY_DELAY_MS ?? "500", 10)
   const pendingSessionStores = new Map<string, { promise: Promise<void>; resolve: () => void }>()
   const registerPendingStore = (key: string): (() => void) => {
     let resolveFn: () => void = () => {}
@@ -1793,8 +1796,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
               let tokenRefreshed = false
               let didFreshBaseRetry = false
-              let busySessionRetries = 0
+              let resumeRefusalRetries = 0
               let busySessionFork = false
+              let sawUnresumableRefusal = false
               while (true) {
                 // Track whether response content was yielded.
                 // The SDK emits metadata (session_id etc.) before the API call;
@@ -1851,37 +1855,51 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // Never retry after response content was yielded — response is committed
                   if (didYieldContent) throw error
 
-                  // Retry: session still registered as a running bg agent (#630).
-                  // The previous subprocess for this session (early-stop drain or
-                  // slow exit) hasn't finished dying, so the CLI refused --resume
-                  // with exit 1. Surfacing that would be a deterministic failure —
-                  // the client's identical retry hits the same window. Wait for
-                  // the stale process to exit and retry the SAME resume; if the
-                  // session stays busy, fork it (full history, fresh id).
-                  if (resumeSessionId && isBusySessionError(error, stderrLines.slice(attemptStderrStart).join("\n"))) {
-                    if (busySessionRetries < BUSY_SESSION_MAX_RETRIES) {
-                      busySessionRetries++
-                      claudeLog("session.busy_retry", { mode: "non_stream", attempt: busySessionRetries, resumeSessionId })
-                      plog(`[PROXY] ${requestMeta.requestId} session busy (bg agent), retrying resume ${busySessionRetries}/${BUSY_SESSION_MAX_RETRIES}`)
-                      await new Promise((resolve) => setTimeout(resolve, BUSY_SESSION_RETRY_DELAY_MS * busySessionRetries))
+                  // Retry: the resume was refused, not answered. Both refusals
+                  // that mean "not right now" — the session is busy, or it could
+                  // not be opened at all — are produced in the exit window of
+                  // this session's previous subprocess (early-stop drain or slow
+                  // exit), with the session itself intact. Surfacing that would
+                  // be a deterministic failure (the client's identical retry
+                  // hits the same window) and evicting would destroy a live
+                  // session, so wait for the stale process to exit and retry the
+                  // SAME resume. A busy session can then be forked (full
+                  // history, fresh id); an unresumable one offers nothing to
+                  // branch and falls through to the replay below. The busy
+                  // wording only ever arrives on stderr, and only matters where
+                  // a resume was attempted, so the capture is read there alone.
+                  const refusal = classifyResumeRefusal(error, resumeSessionId ? stderrLines.slice(attemptStderrStart).join("\n") : undefined)
+                  if (refusal === "unresumable") sawUnresumableRefusal = true
+                  if (resumeSessionId && (refusal === "busy" || refusal === "unresumable")) {
+                    if (resumeRefusalRetries < RESUME_REFUSAL_MAX_RETRIES) {
+                      resumeRefusalRetries++
+                      claudeLog("session.resume_retry", { mode: "non_stream", refusal, attempt: resumeRefusalRetries, resumeSessionId })
+                      plog(`[PROXY] ${requestMeta.requestId} resume refused (${refusal}), retrying ${resumeRefusalRetries}/${RESUME_REFUSAL_MAX_RETRIES}`)
+                      await new Promise((resolve) => setTimeout(resolve, RESUME_REFUSAL_RETRY_DELAY_MS * resumeRefusalRetries))
                       continue
                     }
-                    if (!busySessionFork) {
+                    if (refusal === "busy" && !busySessionFork) {
                       busySessionFork = true
                       claudeLog("session.busy_fork", { mode: "non_stream", resumeSessionId })
-                      plog(`[PROXY] ${requestMeta.requestId} session still busy after ${BUSY_SESSION_MAX_RETRIES} retries — forking session`)
+                      plog(`[PROXY] ${requestMeta.requestId} session still busy after ${RESUME_REFUSAL_MAX_RETRIES} retries — forking session`)
                       continue
                     }
                   }
 
-                  // Retry: stale undo UUID — evict session and start fresh (one-shot)
-                  if (isStaleSessionError(error)) {
-                    claudeLog("session.stale_uuid_retry", {
+                  // The session cannot serve this turn: a message it must hold
+                  // is gone, or it refused to open and has now spent every
+                  // retry. Reaching here after such a refusal means the budget
+                  // is gone whatever the last attempt was refused with, so a
+                  // wording that alternates cannot escape to the client. Evict
+                  // and replay the history as a fresh session (one-shot).
+                  if (refusal === "missing-message" || sawUnresumableRefusal) {
+                    claudeLog("session.resume_replay", {
                       mode: "non_stream",
+                      refusal,
                       rollbackUuid: undoRollbackUuid,
                       resumeSessionId,
                     })
-                    plog(`[PROXY] Stale session UUID, evicting and retrying as fresh session`)
+                    plog(`[PROXY] ${requestMeta.requestId} session unusable (${refusal}), evicting and replaying as fresh session`)
                     evictSession(profileSessionId, profileScopedCwd, allMessages)
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
@@ -2610,8 +2628,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
                 let tokenRefreshed = false
                 let didFreshBaseRetry = false
-                let busySessionRetries = 0
+                let resumeRefusalRetries = 0
                 let busySessionFork = false
+                let sawUnresumableRefusal = false
 
                 while (true) {
                   // Track whether client-visible SSE events were yielded.
@@ -2655,32 +2674,40 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // Never retry after client-visible SSE events — response is committed
                     if (didYieldClientEvent) throw error
 
-                    // Retry: session still registered as a running bg agent (#630)
-                    // — see the non-stream branch above for the full rationale.
-                    if (resumeSessionId && isBusySessionError(error, stderrLines.slice(attemptStderrStart).join("\n"))) {
-                      if (busySessionRetries < BUSY_SESSION_MAX_RETRIES) {
-                        busySessionRetries++
-                        claudeLog("session.busy_retry", { mode: "stream", attempt: busySessionRetries, resumeSessionId })
-                        plog(`[PROXY] ${requestMeta.requestId} session busy (bg agent), retrying resume ${busySessionRetries}/${BUSY_SESSION_MAX_RETRIES}`)
-                        await new Promise((resolve) => setTimeout(resolve, BUSY_SESSION_RETRY_DELAY_MS * busySessionRetries))
+                    // Retry: the resume was refused, not answered — see the
+                    // non-stream branch above for the full rationale. The busy
+                    // wording only ever arrives on stderr, and only matters
+                    // where a resume was attempted, so the capture is read there
+                    // alone.
+                    const refusal = classifyResumeRefusal(error, resumeSessionId ? stderrLines.slice(attemptStderrStart).join("\n") : undefined)
+                    if (refusal === "unresumable") sawUnresumableRefusal = true
+                    if (resumeSessionId && (refusal === "busy" || refusal === "unresumable")) {
+                      if (resumeRefusalRetries < RESUME_REFUSAL_MAX_RETRIES) {
+                        resumeRefusalRetries++
+                        claudeLog("session.resume_retry", { mode: "stream", refusal, attempt: resumeRefusalRetries, resumeSessionId })
+                        plog(`[PROXY] ${requestMeta.requestId} resume refused (${refusal}), retrying ${resumeRefusalRetries}/${RESUME_REFUSAL_MAX_RETRIES}`)
+                        await new Promise((resolve) => setTimeout(resolve, RESUME_REFUSAL_RETRY_DELAY_MS * resumeRefusalRetries))
                         continue
                       }
-                      if (!busySessionFork) {
+                      if (refusal === "busy" && !busySessionFork) {
                         busySessionFork = true
                         claudeLog("session.busy_fork", { mode: "stream", resumeSessionId })
-                        plog(`[PROXY] ${requestMeta.requestId} session still busy after ${BUSY_SESSION_MAX_RETRIES} retries — forking session`)
+                        plog(`[PROXY] ${requestMeta.requestId} session still busy after ${RESUME_REFUSAL_MAX_RETRIES} retries — forking session`)
                         continue
                       }
                     }
 
-                    // Retry: stale undo UUID — evict and start fresh (one-shot)
-                    if (isStaleSessionError(error)) {
-                      claudeLog("session.stale_uuid_retry", {
+                    // The session cannot serve this turn — evict and replay
+                    // the history as a fresh session (one-shot). See the
+                    // non-stream branch above for the full rationale.
+                    if (refusal === "missing-message" || sawUnresumableRefusal) {
+                      claudeLog("session.resume_replay", {
                         mode: "stream",
+                        refusal,
                         rollbackUuid: undoRollbackUuid,
                         resumeSessionId,
                       })
-                      plog(`[PROXY] Stale session UUID, evicting and retrying as fresh session`)
+                      plog(`[PROXY] ${requestMeta.requestId} session unusable (${refusal}), evicting and replaying as fresh session`)
                       evictSession(profileSessionId, profileScopedCwd, allMessages)
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)


### PR DESCRIPTION
## Problem

The CLI refuses a `--resume` that lands while the previous subprocess for the same session is still exiting. One of its wordings — `No conversation found with session ID …` — reads like the session no longer exists, but it is intact on disk and the next attempt succeeds.

The proxy took that first refusal as terminal: it evicted the session and replayed the whole conversation as a fresh one. Nothing surfaces to the client — the response is a normal 200 — while the turn silently loses the context the SDK side held, re-primes the prompt cache from zero, and costs a full-history replay.

The other wording of the same race, `is currently running as a background agent`, already received retries. So one phrasing of one transient refusal was handled and the other destroyed a live session.

## Solution

Classify the refusal once, in `errors.ts`, instead of matching its text at each call site. Three verdicts, because the refusal genuinely distinguishes three situations with three different recoveries:

- **`busy`** — the session exists and is held by a running agent, so it can be branched.
- **`unresumable`** — it would not open. This is *not* proof it is gone.
- **`missing-message`** — a message inside it is gone, so an identical attempt fails identically.

Both "not right now" verdicts retry the same resume with linear backoff. Only `busy` is forked afterwards — an unresumable session offers nothing to branch, where the previous shape reported a doomed fork into nothing. A fresh replay becomes the last resort for a session that refused to open and then spent its retries, and stays the immediate answer for a lost message.

Since the wording can alternate inside one request, the replay is keyed on having seen an unresumable refusal at all rather than on what the last attempt was refused with; otherwise a mixed sequence exhausts the budget and the refusal escapes to the client.

Telemetry follows the same split: `session.resume_retry` / `session.resume_replay` carry the verdict, so a retry is no longer filed under a cause it may not have. The replay log line gains the request id it was missing. The delay env var keeps its name — renaming it would drop existing overrides.

**Cost of the change:** a session that truly cannot be resumed now pays the retry budget (0.5 s + 1 s + 1.5 s) before the fresh replay it previously got immediately. That includes the undo path when the rollback fails with the missing-conversation wording. Losing a live session was judged the worse outcome.

## Verification

`src/__tests__/proxy-resume-refusal.test.ts`, five cases through the HTTP layer with a mocked SDK. Against `main`, three fail:

- a transient refusal is retried with the same resume, streaming and non-streaming — on `main` the second query carries no resume at all, the session is already evicted;
- a session refused on every attempt still reaches a fresh full-history replay, and the resume is attempted exactly `1 + retries` times — on `main` it replays after a single refusal;
- a wording that alternates mid-request still replays instead of surfacing a 500 (red on an intermediate shape of this branch, green here);
- a refusal naming a lost message is answered by one fresh replay and never retried.

`errors.test.ts` pins each verdict, and pins that a rate limit, an auth failure and a bare exit code stay unclassified so the surrounding handlers keep them. The existing busy-refusal tests pass unchanged — that path's behavior, including its fork, is untouched.

Full suite green, `tsc --noEmit` clean.
