### PR TITLE
feat(adapters): add Prime Agent adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-Meridian bridges the Claude Agent SDK (formerly the Claude Code SDK) to the standard Anthropic API. No OAuth interception. No binary patches. No hacks. Just pure, documented SDK calls. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, ForgeCode, Crush, Cline, Aider, Pi, Droid, Jcode, Open WebUI, Claude Code — connects to Meridian and gets Claude, with session management, streaming, and prompt caching handled natively by the SDK.
+Meridian bridges the Claude Agent SDK (formerly the Claude Code SDK) to the standard Anthropic API. No OAuth interception. No binary patches. No hacks. Just pure, documented SDK calls. Any tool that speaks the Anthropic or OpenAI protocol — OpenCode, ForgeCode, Crush, Cline, Aider, Pi, Prime Agent, Droid, Jcode, Open WebUI, Claude Code — connects to Meridian and gets Claude, with session management, streaming, and prompt caching handled natively by the SDK.
 
 > [!NOTE]
 > ### How Meridian works with Anthropic
@@ -104,6 +104,7 @@ The Claude Agent SDK provides programmatic access to Claude. But your favorite c
 | [Aider](https://github.com/paul-gauthier/aider) | ✅ Verified | Env vars — file editing, streaming; `--no-stream` broken (litellm bug) |
 | [Open WebUI](https://github.com/open-webui/open-webui) | ✅ Verified | OpenAI-compatible endpoints — set base URL to `http://127.0.0.1:3456` |
 | [Pi](https://github.com/mariozechner/pi-coding-agent) | ✅ Verified | models.json config (see [Agent Setup](docs/agents.md)) — full tool support via passthrough; detected via `x-meridian-agent: pi` header |
+| [Prime Agent](https://www.npmjs.com/package/prime-agent) | ✅ Verified | Extension config (see [Agent Setup](docs/agents.md)) — a Pi fork with its own `prime` adapter; single `ipython` tool via passthrough, RLM subagents get distinct session keys, sessions survive long idle gaps. The extension's `metadata.user_id` stamp is **required**, not optional. Cron/scheduled ticks are [not yet verified](docs/agents.md#prime-agent) |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Verified | `ANTHROPIC_BASE_URL` — remote clients share a Max subscription over the network; client CWD preserved in system prompt |
 | [Cherry Studio](https://github.com/CherryHQ/cherry-studio) | ✅ Verified | `cherry` adapter (see [Agent Setup](docs/agents.md)) — chat client with Claude's built-in web search via internal mode |
 | Jcode | ✅ Verified | `/v1/chat/completions` + `x-jcode-session` header — dedicated `jcode` adapter keeps append-only history intact, so retained sessions resume on one SDK session (90.9% cache hit on turn 2 of a two-turn Opus session) |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -250,6 +250,139 @@ Pi mimics Claude Code's User-Agent, so automatic detection isn't possible. The `
 
 Pi runs in passthrough mode by default — it executes its own tools and Meridian just forwards the `tool_use` blocks. Opt out with `MERIDIAN_PASSTHROUGH=0`.
 
+### Prime Agent
+
+[Prime Agent](https://www.npmjs.com/package/prime-agent) is a fork of Pi with a
+different prompt and tool surface, so it uses its own `prime` adapter rather
+than Pi's. Its only tool by default is `ipython`, a persistent kernel in the
+client — passthrough is effectively required, and internal mode
+(`MERIDIAN_PASSTHROUGH=0`) drops that tool entirely.
+
+Connect it with an extension. Save as `.prime/agent/extensions/meridian.ts` in
+a project, or `~/.prime/agent/extensions/meridian.ts` globally:
+
+```typescript
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+const MERIDIAN_PROVIDER = "meridian"
+
+export default function (pi: ExtensionAPI) {
+  pi.registerProvider(MERIDIAN_PROVIDER, {
+    name: "Meridian (Claude Max)",
+    baseUrl: "http://127.0.0.1:3456",
+    apiKey: "MERIDIAN_API_KEY",       // env var name, or any literal if auth is off
+    api: "anthropic-messages",
+    headers: { "x-meridian-agent": "prime" },
+    models: [
+      {
+        id: "claude-opus-5",
+        name: "Claude Opus 5 (Meridian)",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 32000,
+      },
+    ],
+  })
+
+  // Required, not an optimisation — see below.
+  pi.on("before_provider_request", (event: any, ctx: any) => {
+    if (ctx?.model?.provider !== MERIDIAN_PROVIDER) return undefined
+    const sessionId = ctx?.sessionManager?.getSessionId?.()
+    if (typeof sessionId !== "string" || !sessionId) return undefined
+    return {
+      ...(event.payload as Record<string, unknown>),
+      metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+    }
+  })
+}
+```
+
+Then pick a model with `/model` or `--provider meridian --model claude-opus-5`.
+
+Registering a **new** provider rather than overriding `anthropic` means
+installing this changes nothing until you select one of its models, so an
+already-running agent is unaffected.
+
+**The `before_provider_request` hook is required.** Prime Agent sends no session
+identity of its own, and under passthrough every tool round ends in a
+`tool_result` — which Meridian treats as a self-contained request needing no
+session resume. Each round then replays the whole conversation into a fresh
+session, and since that replay strips the assistant's `tool_use` blocks by
+design, the model loses track of what it has already run. Stamping
+`metadata.user_id` makes each round a continuation instead, so the SDK keeps the
+real tool calls in its own session state. `getSessionId()` is distinct per
+agent, so RLM children get their own keys rather than colliding with the parent.
+
+Detection is by the `x-meridian-agent: prime` header above, or
+`MERIDIAN_DEFAULT_AGENT=prime`. There is deliberately no User-Agent rule: in
+API-key mode Prime Agent sends the generic `Anthropic/JS <version>` that every
+Anthropic SDK client sends, so matching on it would misroute unrelated traffic.
+
+**Known limitation — file-change tracking.** Meridian reads file changes out of
+`ipython` cells for `%%bash` bodies, `!` shell escapes, and `await edit(path=…)`
+calls. It does **not** parse arbitrary Python writes (`open(p, "w").write(…)`,
+`Path.write_text`, library calls), which would need real dataflow analysis. Those
+edits still happen; they just don't appear in Meridian's file-change summary.
+
+#### What was verified, and what wasn't
+
+Measured on 2026-08-13/14 against Prime Agent 0.7.2:
+
+| Verified | How |
+|---|---|
+| Adapter selection, live turns | Real `prime-agent` binary through Meridian |
+| Tool-round session continuity | 45/45 rounds resumed as continuations across 12 sessions |
+| RLM children get distinct keys | Parent and depth-1 child carried different `metadata.user_id` on the wire |
+| Works with `codeSystemPrompt` off | 6 multi-round loops per arm; preset on vs off scored identically |
+| Survives long idle gaps | 7-minute silence, then `lineage=continuation` and the model recalled a codeword set before the gap |
+| Not metered as a third-party app | Negative control → full 18KB prompt → control again, all passing with the preset off |
+
+**Not verified: cron/scheduled tick delivery.** Two attempts, neither
+conclusive. Against a shared supervisor the scheduler fired (`runs=3`) but no
+request reached Meridian. Against an isolated supervisor, `schedule add` itself
+hung and never persisted the job. Session continuity across a worker restart is
+likewise untested.
+
+Four constraints make this awkward to exercise, all learned the hard way:
+
+- Only *resident* workers can be scheduled against. `print`, `rpc` and `json`
+  create **client-owned** workers, which Prime Agent deliberately omits from
+  schedules — so every headless mode is structurally ineligible. A resident
+  worker needs an interactive session, which needs a TTY (a pty works).
+- The `--daemon-socket` flag must come **before** the subcommand:
+  `prime-agent --daemon-socket <path> schedule list`. Placed after, it is
+  rejected as an unknown option, which reads misleadingly like the subcommand
+  cannot target a custom socket.
+- `PRIME_AGENT_CODING_AGENT_DIR` does **not** isolate a session from a shared
+  supervisor. The supervisor writes sessions into whichever agent directory
+  *it* was started with, so a test run against an already-running daemon lands
+  its sessions in that daemon's store. The supervisor socket is likewise global
+  per UID (`$TMPDIR/prime-agent-<uid>/daemon.sock`), so real isolation needs
+  `--daemon-socket` *and* a matching `PRIME_AGENT_CODING_AGENT_DIR`.
+- A dangling `~/.cache/meridian` makes Meridian return
+  `500 ENOENT … mkdir '~/.cache/meridian'` on affected requests. The client
+  retries and appears to hang, which is easy to misread as the agent stalling.
+  Check that path resolves before diagnosing anything else.
+
+A resident worker configured this way *does* reach Meridian — verified — so the
+remaining gap is specifically the scheduler, not the transport.
+
+The long-idle result above covers the part Meridian owns — a turn arriving on a
+session after a quiet gap resumes rather than replaying.
+
+Also not verified: the real client driving its own IPython kernel through a full
+tool loop. Kernel provisioning stalled in the isolated test environment; the
+tool-round evidence above comes from replaying Prime Agent's exact prompt and
+tool schema rather than from its kernel.
+
+**The metering result is a dated snapshot, not a property of the prompt.** It
+means "not flagged on this account at this moment" — the same classifier was
+observed changing its answer within a single day during the OpenClaw work. If
+you hit `400 You're out of extra usage` on Prime Agent traffic, re-measure
+before assuming the prompt is fine.
+
 ### Claude Code
 
 Claude Code can point at Meridian like any other Anthropic API client. The

--- a/docs/superpowers/specs/2026-08-12-prime-agent-support-design.md
+++ b/docs/superpowers/specs/2026-08-12-prime-agent-support-design.md
@@ -1,0 +1,285 @@
+# Prime Agent support in Meridian
+
+**Date:** 2026-08-12
+**Status:** approved, in implementation
+**Scope:** interactive sessions, RLM recursive subagents, and daemon/cron mode
+
+## What Prime Agent is
+
+`prime-agent` (npm, v0.7.2 at time of writing) is a **fork of Pi**, not Pi. Its
+dependencies are `@earendil-works/pi-agent-core`, `pi-ai` and `pi-tui` —
+republished Pi packages — and its `package.json` carries
+`piConfig: { name: "prime-agent", configDir: ".prime/agent" }`.
+
+The transport layer is Pi's, unchanged: the official `@anthropic-ai/sdk`,
+`stream: true` on every request, and the same OAuth-vs-API-key client branch.
+
+Everything above the transport is different, and that is what this design has to
+account for.
+
+### Measured, not assumed
+
+The facts below came from capturing prime-agent's real traffic against a local
+recording server (`/tmp/prime-probe/mock-anthropic.mjs`) — no tokens spent, no
+account touched.
+
+| Fact | Value |
+|---|---|
+| User-Agent (API-key mode) | `Anthropic/JS 0.91.1` — **not** `claude-cli/` |
+| Session header | none |
+| `metadata` on the wire | absent by default |
+| Tools offered | exactly one: `ipython` (`{ code: string }`) |
+| System prompt | ~17 KB, one text block |
+| First line | `You are a general purpose agent that uses code to solve tasks.` |
+| CWD line | `Working directory: <cwd>` (line 5) — **no** `Current` prefix |
+
+The `Current working directory:` form does exist, but only in the
+`customPrompt` branch of `buildSystemPrompt`, where it is appended near the end
+after project context files. The default RLM prompt uses `Working directory:`
+near the top.
+
+## Decisions
+
+### 1. Its own `prime` adapter, not a Pi instance or a widened Pi adapter
+
+Reusing Pi would inherit two concrete defects:
+
+- **CWD.** `extractPiCwd` matches `/Current working directory:/`. On
+  prime-agent's default prompt that returns `undefined`, losing per-project
+  fingerprint bucketing and the SDK subprocess chdir.
+- **Tools.** The Pi adapter assumes `read/write/edit/bash/glob/grep`.
+  prime-agent offers exactly one tool, `ipython`.
+
+Widening the Pi adapter to cover both was rejected: it conflates two harnesses
+under one name, gives prime-agent no row in `/settings` or the supported-harness
+table, silently changes Pi's behaviour, and leaves future divergence between the
+fork and upstream nowhere to live.
+
+### 2. CWD parsing must be line-anchored
+
+Prefer `Current working directory:` when present, else the **first**
+line-anchored `Working directory:`.
+
+Line anchoring is not cosmetic. The captured prompt contains, in prose:
+
+> ... use kernel-level equivalents that survive across calls: `%cd <dir>` for the
+> working directory and ...
+
+An unanchored match would pick that up. The regex must require start-of-line.
+
+### 3. File-change extraction covers `ipython`, and admits its limit
+
+The only default tool is `ipython`, whose input is a Python/`%%bash` cell. The
+adapter extracts:
+
+- `%%bash` cell bodies, routed through the existing `extractFileChangesFromBash`
+- `await edit(path=...)` calls, prime-agent's documented targeted-edit skill
+- `bash` and `edit` as first-class tools, for users who enable them via `-t`
+
+It deliberately does **not** attempt to parse arbitrary Python writes
+(`open(path, "w").write(...)`, `pathlib.Path.write_text`, library calls). A
+fragile parser that silently half-works is worse than a documented gap, and file
+tracking is a reporting nicety here, not a correctness requirement. The gap goes
+in the docs.
+
+### 4. No User-Agent detection
+
+In API-key mode prime-agent sends `Anthropic/JS <version>`, which every other
+`@anthropic-ai/sdk` client also sends. A User-Agent rule would misroute
+unrelated traffic. Selection is via `x-meridian-agent: prime` (set in the
+provider config) or `MERIDIAN_DEFAULT_AGENT=prime`.
+
+The existing `claude-cli/` env-var tiebreaker in `detectAdapter` already covers
+the case where prime-agent is run with an OAuth token, since that branch sets
+`user-agent: claude-cli/<version>`.
+
+### 5. `codeSystemPrompt: false` by default
+
+prime-agent ships ~17 KB of its own harness doctrine — RLM control semantics,
+subagent delegation guidance, continual-harness state. Layering Claude Code's
+~28 KB preset on top duplicates and contradicts it. Same rationale as
+`codex`, `jcode` and `cherry`.
+
+**Confirmed by measurement, 2026-08-13.** Six multi-round `ipython` loops per
+arm, driven through Meridian with the real captured Prime Agent prompt and its
+real single-tool schema, cells executed locally. Both arms scored identically on
+what matters: every run called only `ipython`, ran all three requested steps in
+order, and finished. The preset bought nothing measurable, so OFF stays — same
+behaviour, ~28KB less prompt per request.
+
+One caveat recorded rather than buried: most samples in *both* arms re-ran the
+final cell before answering. Because it appears equally with the preset on, it
+is a property of the task and model, not of this setting — but it is why the
+strict "no duplicate cells" score was 1/6 and 2/6 rather than 6/6.
+
+### 6. Session identity comes from the client, and needs no core change
+
+This is the load-bearing decision for subagents and daemon mode.
+
+prime-agent sends no session header and no `metadata`. Under passthrough every
+tool round ends in `user[tool_result]`, which trips Meridian's
+`isClientDrivenLoop` bypass (`src/proxy/server.ts:1108`):
+
+```ts
+const isClientDrivenLoop = adapterBase !== "claude-code" && !agentSessionId && lastIsToolResult
+```
+
+Those requests get no fingerprint resume and no cache write — a fresh SDK
+session every tool round.
+
+**Measured.** A 19-round tool loop with no session key logged `lineage=new
+session=new` on every round, confirming the bypass fires for Prime Agent
+traffic exactly as predicted.
+
+**Why it matters — correctness, not just cost.** On a fresh (non-resume)
+session Meridian sends the whole conversation (`server.ts:1291`) but flattens
+it, and `flattenAssistantContent` (`server.ts:211`) drops every assistant
+`tool_use` block by design (#111, #386). The model then sees tool *results*
+with no record of having made the calls — the failure the comment at
+`server.ts:232` names directly (#552). Observed live: asked to run three
+distinct cells, the model called `2+2`, received `4`, and called `2+2` again,
+seven times over.
+
+Declaring a session key removes the whole class of problem, because a resumed
+session sends only new messages and the SDK keeps the real `tool_use` blocks in
+its own state. Proven with a deterministic two-turn A/B against Meridian:
+
+| | turn 1 | turn 2 (ends in `tool_result`) |
+|---|---|---|
+| with `metadata.user_id` | `lineage=new session=new` | `lineage=continuation session=8d6857de` |
+| without | `lineage=new session=new` | `lineage=new session=new` |
+
+**Not measured.** #734 attributes prompt-cache decay to this shape, and an
+earlier draft of this document asserted the same. That consequence was *not*
+reproduced: `cache_read` sat flat at 7k across all 19 rounds while the
+conversation grew to 37 messages, which is consistent with a static-prefix
+floor but indistinguishable from "the conversation was too small to cache" —
+the tool results in the probe were single digits. Establishing the cost claim
+needs a run with substantial content in context. Until then the session churn
+is the fact, and the cost consequence is reported-but-unverified at this scale.
+
+**The bypass is correct and stays.** N concurrent RLM children, all headerless,
+would otherwise collide on one `(firstUserMessage, cwd)` fingerprint and resume
+each other's sessions. The fix is to give prime-agent a real session key, not to
+weaken the guard.
+
+The Pi adapter already reads `metadata.user_id` via
+`extractClaudeCodeSessionId` (`adapters/claudecode.ts:55`), which accepts an
+object or a JSON string carrying a non-empty `session_id`. The `prime` adapter
+uses the same precedence: `x-session-affinity ?? extractClaudeCodeSessionId`.
+
+Client side, a prime-agent extension supplies the key. **Verified working:**
+`ctx.sessionManager.getSessionId()` returns a UUID (present even for
+`--no-session` in-memory sessions), and a `before_provider_request` handler that
+returns a modified payload puts it on the wire in exactly the expected shape:
+
+```json
+{"metadata": {"user_id": "{\"session_id\":\"019ff7d6-34fd-74cc-88fb-089a483a9f2d\"}"}}
+```
+
+`before_provider_request` rewrites the payload, not transport headers, which is
+why `metadata` is the route rather than `x-session-affinity`.
+
+### 7. The connection config registers a new provider, never overrides `anthropic`
+
+```ts
+pi.registerProvider("meridian", {
+  name: "Meridian (Claude Max)",
+  baseUrl: "http://127.0.0.1:3456",
+  apiKey: "MERIDIAN_API_KEY",
+  api: "anthropic-messages",
+  headers: { "x-meridian-agent": "prime" },
+  models: [ /* claude-opus-5, ... */ ],
+})
+```
+
+Registering a *new* provider means nothing changes until a model is selected, so
+an already-running prime-agent is unaffected by installing it.
+
+## Scrub
+
+**`pi-scrub` does not apply.** Proven, not inferred: run against the captured
+17,227-byte prompt it returns a byte-identical string. Its two regexes target
+Pi's `operating inside pi, a coding agent harness` identity line and its
+`Pi documentation` block, neither of which exists in prime-agent's prompt.
+
+Whether prime-agent needs a scrub *at all* is an open empirical question,
+answered the same way OpenClaw was: capture the real prompt, establish a
+negative control, replay section-by-section against a Max account, and identify
+which sections — if any — trip `400 You're out of extra usage` on their own.
+
+Prior suspicion, explicitly held as suspicion and not as a finding: the RLM
+prompt is dense with the autonomous-bot shape that tripped OpenClaw — recursive
+spawning, agent-to-agent messaging, scheduling, and literal
+"this Prime Agent session" brand tells.
+
+Outcome is one of: a new public `meridian-plugin-prime-scrub` repo (content-scoped
+like `pi-scrub`, so it fires even when prime-agent traffic lands on another
+adapter), or nothing.
+
+**Measured 2026-08-14: nothing.** With `codeSystemPrompt` off (the shipped
+default), the negative control passed, the full 18,588-byte prompt passed, and
+the control passed again on re-check. No section tripped anything, so there was
+nothing to bisect and no scrub to build.
+
+An earlier run of the same script returned all-PASS while
+`codeSystemPrompt` was left `true` from the preset comparison. That result was
+discarded rather than reported: the Claude Code preset prepends ~28KB of Claude
+Code identity, which is precisely what would mask a third-party fingerprint, so
+a pass under those conditions says nothing about how Prime Agent actually ships.
+
+The result is a dated snapshot of a system we cannot see. A PASS is weaker
+evidence than a FAIL would be — a failure localises to specific text, a pass
+only means "not flagged on this account at this moment", and the same classifier
+changed its answer within a day during the OpenClaw work.
+
+## Safety constraints on the work itself
+
+The owner has a live prime-agent daemon running. Nothing in this work may touch
+it.
+
+- All testing runs under `PRIME_AGENT_CODING_AGENT_DIR=/tmp/prime-probe/agent`,
+  giving separate sessions, leases and session-artifacts.
+- **`PRIME_AGENT_CODING_AGENT_DIR` is NOT sufficient on its own.** The
+  supervisor socket is global per UID — `$TMPDIR/prime-agent-<uid>/daemon.sock`
+  — not per agent directory. Two runs with different agent dirs still contend
+  for one supervisor and its launch lock. A test run hung indefinitely on
+  `daemon.sock.lock` for exactly this reason once a second daemon was running.
+  Every test run must also pass `--daemon-socket /tmp/prime-probe/test-daemon.sock`
+  to get a genuinely private supervisor.
+- **Never run `prime-agent shutdown`** without `--daemon-socket` pointed at the
+  test socket — it stops the supervisor *and every worker* on that socket.
+- **Never kill by process name.** `pkill -f prime-agent` matches the owner's
+  daemon, its detached workers (whose argv is just `prime-agent`), and its
+  IPython kernels. This was done once during this work and killed a live
+  daemon. Stop test processes by task/PID, and check parentage before killing
+  anything: the kernels that appear mid-run are usually the owner's, spawned by
+  their worker, not the test's.
+- **Never write to `~/.prime/agent/extensions/`** — global extensions are picked
+  up by running workers on start or `/reload`. Extensions are passed with `-e`
+  or kept project-local.
+- The recording mock stands in for the API wherever a real completion is not
+  required, so most verification costs nothing.
+
+## Testing
+
+**Unit.** Both CWD forms; the in-prose `working directory` false positive;
+file-change extraction for `ipython` cells, `%%bash` bodies, `edit`, `bash`;
+transform parity with the adapter; detection precedence; feature defaults.
+
+**Integration** (HTTP layer, mocked SDK). Passthrough tool round-trip;
+`metadata.user_id` producing a session key; two concurrent children not
+colliding on one fingerprint.
+
+**End-to-end** (isolated agent dir). Interactive turn; tool-driving turn; an RLM
+child; the **session-key proof** — the same session resumes rather than
+fresh-replaying across tool rounds, which is the #734 regression check;
+prime-agent operating correctly with `codeSystemPrompt` off; daemon mode with a
+short cron interval; one deliberately long idle gap to exercise the
+`upstream_idle` path from #801.
+
+## Out of scope
+
+- Parsing arbitrary Python file writes out of IPython cells
+- ACP mode, MCP integrations, the `prime-inference` provider
+- Any change to the `isClientDrivenLoop` guard — it is correct as written

--- a/src/__tests__/fixtures/prime-agent-system-prompt-head.txt
+++ b/src/__tests__/fixtures/prime-agent-system-prompt-head.txt
@@ -1,0 +1,40 @@
+You are a general purpose agent that uses code to solve tasks.
+You solve tasks by breaking down problems into sub-tasks, writing and executing code, observing results, and iterating one step at a time.
+When you are done, stop calling tools and state your final answer.
+
+Working directory: /home/dev/project
+Conversation log: /tmp/prime-probe/agent/sessions/019ff7d8-a502-74c9-ab03-df4562e50f22.jsonl
+Recursive agent depth: 0
+Pre-installed Python packages: requests, httpx, yaml (PyYAML), tomli, dotenv (python-dotenv), pandas, numpy, scipy, bs4 (Beautiful Soup), lxml, pydantic, tyro.
+Install additional packages with `uv pip install <pkg>` (this is a uv-managed venv with no pip module).
+
+Installed Python skill modules (pre-imported): `agent_message`, `agent_observe`, `attach_image`, `compact`, `edit`, `goal`, `refine`, `rlm_heartbeat`, `websearch`.
+Read each skill's SKILL.md for its API. Inspect a module with `help(<skill>)` or `dir(<skill>)`, then inspect a documented callable with `inspect.signature(<skill>.<function>)`.
+Each skill is also available as a shell command by the same name: `<skill> ...`. Discover its CLI usage with `<skill> --help`.
+For targeted existing-file edits, prefer the pre-imported async `edit` skill from IPython: `old = '''...'''; new = '''...'''; await edit(path="pkg/file.py", old_str=old, new_str=new)`. Use exact old/new strings; if the text contains triple double quotes, use triple single-quoted variables or build `old`/`new` from inspected file slices.
+Agent messaging is restricted to your parent, siblings, and direct children; roots are siblings, and deeper communication relays through the intermediate child.
+Agent observation is restricted to your parent, siblings, and direct children; roots are siblings, and deeper inspection relays through the intermediate child.
+
+A callable `rlm` is already in your global namespace. `await rlm('sub-task')` spawns a child and returns immediately after task admission with `rlm_child_id`, `name`, `session_dir`, and `model`; it never waits for or returns the child's answer.
+Choose a stable child name with `await rlm('sub-task', name='api-reviewer')`; names must be unique among siblings. If omitted, the host generates a readable unique name.
+A child inherits your model. If a different model is explicitly requested, use `await rlm.find_models(...)` and an exact returned selector. An unavailable requested model fails spawn; decide whether to retry or omit `model`.
+Children reply explicitly with `await agent_message.send(message, receiver_role='parent')` when an answer is needed. Replies and follow-ups arrive as ordinary agent messages; not every task requires a reply.
+Use `await agent_message.list_agents()` to discover family and `await rlm.list_subagents()` to recover direct child handles. Use `agent_message.send(..., receiver_role='child', receiver_name=child.name)` for follow-ups.
+Use `agent_observe` to inspect a child's rollout. Observation is restricted to your parent, siblings, and direct children; relay through the intermediate child for deeper descendants.
+Spawn independent children in separate calls and end your turn instead of awaiting completion. Multiple replies may arrive over multiple turns. Delete a direct child explicitly with `await rlm.delete_subagent(child)` when it is no longer needed.
+
+IPython is the agent's long-lived notebook: a persistent control environment for reasoning, context management, state, tool orchestration, and recursive subcalls. Use it to keep intermediate variables, inspect and transform outputs, write small helper functions, and preserve useful state across turns or compaction.
+
+Do not assume IPython is the native runtime of the external thing being investigated. A repository, package, service, dataset, paper, website, benchmark, or API may have its own environment and normal interface. Evaluate external systems through their own interface, then use IPython to coordinate the process and analyze what comes back.
+
+When running shell commands from IPython, use `%%bash` cells. If you use `%%bash`, it must be the first line of the code cell: no comments, spaces, blank lines, imports, or Python statements before it. Avoid `!cmd` shell escapes for project commands so shell behavior is explicit and multi-line commands share one shell context.
+
+Important: do not install dependencies into the IPython kernel just to make an external project import or run there. If a project import, test, script, CLI, or dependency check is needed, run it through that project's own environment and normal command interface. For example, in a Python repo use its documented commands, `uv run ...`, `.venv/bin/python ...`, or the active project interpreter from the repo root. Treat failures from that native environment as the relevant result.
+
+Use Python for reading, searching, and editing files — it gives you reusable variables you can slice, filter, and act on without re-reading. Always assign read/search results to named variables so you can revisit them later.
+
+Each `%%bash` cell runs in a throw-away subshell, so shell-level state (`cd`, `export`, `source`, shell variables) does NOT carry to later cells. Keep dependent shell steps inside one `%%bash` cell when they need shared shell state, or use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'` (or `%env VAR=...`) for environment variables — these apply to all subsequent `%%bash` calls.
+
+Python state in the kernel, by contrast, persists across cells: named variables, helper functions, classes, imports, notes, parsed outputs, and helper data structures all remain available in every later turn. Tool calls are themselves Python `await` expressions, so their return values can be bound to variables and composed into program logic just like any other call.
+
+Continual harness state is available as `rlm.harness` and `rlm.get_harness_state()`. CRUD calls are local to this Prime Agent session by default: `rlm.harness.create_memory(...)`, `rlm.harness.update_memory(...)`, `rlm.harness.delete_memory(...)`, `rlm.harness.create_skill(...)`, `rlm.harness.update_skill(...)`, `rlm.harness.delete_skill(...)`, `rlm.harness.create_subagent(...)`, `rlm.harness.update_subagent(...)`, `rlm.harness.delete_subagent(...)`, `rlm.harness.create_prompt_note(...)`, `rlm.harness.update_prompt_note(...)`, `rlm.harness.delete_prompt_note(...)`, plus `rlm.harness.record_refinement(...)` and `rlm.harness.overview()`. Use `global_=True` only for stable cross-session lessons; Python reserves `global`, so literal `global=True` is invalid syntax.

--- a/src/__tests__/prime-adapter.test.ts
+++ b/src/__tests__/prime-adapter.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import {
+  primeAdapter,
+  extractPrimeCwd,
+  extractFileChangesFromIpythonCell,
+  extractPrimeFileChanges,
+} from "../proxy/adapters/prime"
+import { detectAdapter } from "../proxy/adapters/detect"
+import { getAdapterTransforms } from "../proxy/transforms/registry"
+import { primeTransforms } from "../proxy/transforms/prime"
+import { createRequestContext, runTransformHook } from "../proxy/transform"
+
+/**
+ * The first 40 lines of a real Prime Agent 0.7.2 system prompt, captured on the
+ * wire against a local recording server. Paths were neutralised; nothing else
+ * was altered. Line 5 carries the working directory; line 36 mentions
+ * "working directory" in prose, which is exactly the false positive the CWD
+ * regex has to survive.
+ */
+const REAL_PROMPT_HEAD = readFileSync(
+  join(import.meta.dir, "fixtures", "prime-agent-system-prompt-head.txt"),
+  "utf8",
+)
+
+function ctxWith(headers: Record<string, string> = {}) {
+  return {
+    req: {
+      header: (name?: string) => (name ? headers[name.toLowerCase()] : headers),
+    },
+  } as any
+}
+
+describe("extractPrimeCwd", () => {
+  it("reads the RLM prompt's Working directory line", () => {
+    const body = { system: "You are a general purpose agent.\nWorking directory: /home/dev/project\n" }
+    expect(extractPrimeCwd(body)).toBe("/home/dev/project")
+  })
+
+  it("reads the customPrompt branch's Current working directory line", () => {
+    // buildSystemPrompt's customPrompt branch appends this near the END, after
+    // project context files, and emits no `Working directory:` line at all.
+    const body = { system: "My own prompt.\n\n# Project Context\n\n## AGENTS.md\n\nstuff\n\nCurrent date: 2026-08-12\nCurrent working directory: /srv/app" }
+    expect(extractPrimeCwd(body)).toBe("/srv/app")
+  })
+
+  it("ignores the line quoted mid-sentence in user context", () => {
+    // Project context files are inlined into this same prompt, so an AGENTS.md
+    // that mentions the line in passing must not be mistaken for the real cwd.
+    // This is what start-of-line anchoring buys.
+    const quoted = "# Project Context\n\n## AGENTS.md\n\nRemember to set Working directory: /tmp/example before running.\n"
+    expect(extractPrimeCwd({ system: quoted })).toBeUndefined()
+  })
+
+  it("does not trip on the prompt's prose mention of working directories", () => {
+    // Real line from the captured prompt — lowercase and no colon, so it never
+    // matched. Pinned so a future loosening of the pattern has to notice.
+    const prose = "use kernel-level equivalents that survive across calls: `%cd <dir>` for the working directory and `os.environ['VAR'] = '...'`"
+    expect(extractPrimeCwd({ system: prose })).toBeUndefined()
+  })
+
+  it("extracts the right path from a real captured prompt", () => {
+    expect(extractPrimeCwd({ system: REAL_PROMPT_HEAD })).toBe("/home/dev/project")
+  })
+
+  it("prefers the harness line over later user content", () => {
+    const body = {
+      system: [
+        "Working directory: /real/project",
+        "# Project Context",
+        "## AGENTS.md",
+        "Current working directory: /a/path/quoted/in/a/doc",
+      ].join("\n"),
+    }
+    expect(extractPrimeCwd(body)).toBe("/real/project")
+  })
+
+  it("joins array-form system blocks", () => {
+    const body = {
+      system: [
+        { type: "text", text: "You are a general purpose agent." },
+        { type: "text", text: "Working directory: /home/dev/project" },
+      ],
+    }
+    expect(extractPrimeCwd(body)).toBe("/home/dev/project")
+  })
+
+  it("returns undefined when there is no system prompt or no cwd line", () => {
+    expect(extractPrimeCwd({})).toBeUndefined()
+    expect(extractPrimeCwd({ system: "" })).toBeUndefined()
+    expect(extractPrimeCwd({ system: "no directory here" })).toBeUndefined()
+  })
+
+  it("ignores a trailing-empty cwd value", () => {
+    expect(extractPrimeCwd({ system: "Working directory:   " })).toBeUndefined()
+  })
+})
+
+describe("extractFileChangesFromIpythonCell", () => {
+  it("treats a %%bash cell as shell", () => {
+    const cell = "%%bash\necho hi > /tmp/out.txt"
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([
+      { operation: "wrote", path: "/tmp/out.txt" },
+    ])
+  })
+
+  it("tolerates blank lines before the %%bash magic", () => {
+    const cell = "\n\n%%bash\necho hi > /tmp/out.txt"
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([
+      { operation: "wrote", path: "/tmp/out.txt" },
+    ])
+  })
+
+  it("picks up the pre-imported edit skill", () => {
+    const cell = 'old = "a"\nnew = "b"\nawait edit(path="src/index.ts", old_str=old, new_str=new)'
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([
+      { operation: "edited", path: "src/index.ts" },
+    ])
+  })
+
+  it("handles both quote styles and repeated edits", () => {
+    const cell = "await edit(path='a.ts', old_str=x, new_str=y)\nawait edit(path=\"b.ts\", old_str=x, new_str=y)"
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([
+      { operation: "edited", path: "a.ts" },
+      { operation: "edited", path: "b.ts" },
+    ])
+  })
+
+  it("is not stateful across calls", () => {
+    // The edit regex is module-scoped with /g. matchAll keeps it stateless;
+    // this pins that, so a future switch back to exec-with-an-early-break
+    // (which would leave lastIndex dangling) gets caught.
+    const cell = 'await edit(path="a.ts", old_str=x, new_str=y)'
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([{ operation: "edited", path: "a.ts" }])
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([{ operation: "edited", path: "a.ts" }])
+  })
+
+  it("picks up ! shell escapes inside a Python cell", () => {
+    const cell = 'x = 1\n!echo hi > /tmp/escaped.txt\nprint(x)'
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([
+      { operation: "wrote", path: "/tmp/escaped.txt" },
+    ])
+  })
+
+  it("returns nothing for a plain Python write — the documented gap", () => {
+    // Deliberate: parsing arbitrary Python writes needs dataflow analysis, and
+    // a parser that silently half-works is worse than a stated limitation.
+    const cell = 'open("/tmp/x.txt", "w").write("hi")'
+    expect(extractFileChangesFromIpythonCell(cell)).toEqual([])
+  })
+
+  it("returns nothing for a read-only cell", () => {
+    expect(extractFileChangesFromIpythonCell('src = open("a.ts").read()')).toEqual([])
+  })
+})
+
+describe("extractPrimeFileChanges", () => {
+  it("routes the ipython tool through the cell extractor", () => {
+    expect(extractPrimeFileChanges("ipython", { code: "%%bash\necho hi > /tmp/a" })).toEqual([
+      { operation: "wrote", path: "/tmp/a" },
+    ])
+  })
+
+  it("handles opt-in edit / write / bash tools", () => {
+    expect(extractPrimeFileChanges("edit", { path: "/a.ts" })).toEqual([
+      { operation: "edited", path: "/a.ts" },
+    ])
+    expect(extractPrimeFileChanges("write", { file_path: "/b.ts" })).toEqual([
+      { operation: "wrote", path: "/b.ts" },
+    ])
+    expect(extractPrimeFileChanges("bash", { command: "echo hi > /c.txt" })).toEqual([
+      { operation: "wrote", path: "/c.txt" },
+    ])
+  })
+
+  it("ignores unknown tools and malformed input", () => {
+    expect(extractPrimeFileChanges("websearch", { query: "x" })).toEqual([])
+    expect(extractPrimeFileChanges("ipython", {})).toEqual([])
+    expect(extractPrimeFileChanges("ipython", null)).toEqual([])
+    expect(extractPrimeFileChanges("edit", {})).toEqual([])
+  })
+})
+
+describe("primeAdapter.getSessionId", () => {
+  it("prefers an explicit x-session-affinity header", () => {
+    const c = ctxWith({ "x-session-affinity": "orchestrator-key" })
+    const body = { metadata: { user_id: JSON.stringify({ session_id: "from-body" }) } }
+    expect(primeAdapter.getSessionId(c, body)).toBe("orchestrator-key")
+  })
+
+  it("falls back to metadata.user_id, the shape the extension supplies", () => {
+    // Captured verbatim from the wire: before_provider_request stamps
+    // ctx.sessionManager.getSessionId() into metadata.user_id.
+    const body = {
+      metadata: { user_id: JSON.stringify({ session_id: "019ff7d8-a616-745d-8cb2-97544a6accac" }) },
+    }
+    expect(primeAdapter.getSessionId(ctxWith(), body)).toBe("019ff7d8-a616-745d-8cb2-97544a6accac")
+  })
+
+  it("gives an RLM child a different key from its parent", () => {
+    // Both ids are real, captured from one run: root at depth 0, child at
+    // depth 1. Distinct keys are what stop concurrent children colliding on a
+    // shared fingerprint.
+    const parent = { metadata: { user_id: JSON.stringify({ session_id: "019ff7d8-a616-745d-8cb2-97544a6accac" }) } }
+    const child = { metadata: { user_id: JSON.stringify({ session_id: "019ff7d8-ace2-7060-91dd-0212014a849e" }) } }
+    const a = primeAdapter.getSessionId(ctxWith(), parent)
+    const b = primeAdapter.getSessionId(ctxWith(), child)
+    expect(a).toBeDefined()
+    expect(b).toBeDefined()
+    expect(a).not.toBe(b)
+  })
+
+  it("returns undefined for a stock request that does not opt in", () => {
+    // Prime Agent without the extension sends no session identity at all.
+    expect(primeAdapter.getSessionId(ctxWith(), { model: "x", messages: [] })).toBeUndefined()
+    expect(primeAdapter.getSessionId(ctxWith(), { metadata: { user_id: "plain-string" } })).toBeUndefined()
+    expect(primeAdapter.getSessionId(ctxWith(), { metadata: { user_id: JSON.stringify({}) } })).toBeUndefined()
+  })
+})
+
+describe("prime adapter configuration", () => {
+  it("uses its own MCP server name", () => {
+    expect(primeAdapter.getMcpServerName()).toBe("prime")
+  })
+
+  it("defaults to passthrough — its only tool lives in the client", () => {
+    expect(primeAdapter.usesPassthrough!()).toBe(true)
+  })
+
+  it("forwards thinking blocks", () => {
+    expect(primeAdapter.supportsThinking!()).toBe(true)
+  })
+
+  it("registers no SDK subagents — RLM children are the client's own", () => {
+    expect(primeAdapter.buildSdkAgents!({}, [])).toEqual({})
+  })
+})
+
+describe("prime adapter detection", () => {
+  const savedDefault = process.env.MERIDIAN_DEFAULT_AGENT
+  beforeEach(() => { delete process.env.MERIDIAN_DEFAULT_AGENT })
+  afterEach(() => {
+    if (savedDefault === undefined) delete process.env.MERIDIAN_DEFAULT_AGENT
+    else process.env.MERIDIAN_DEFAULT_AGENT = savedDefault
+  })
+
+  it("selects prime via x-meridian-agent", () => {
+    expect(detectAdapter(ctxWith({ "x-meridian-agent": "prime" })).name).toBe("prime")
+  })
+
+  it("accepts the npm package name as an alias", () => {
+    expect(detectAdapter(ctxWith({ "x-meridian-agent": "prime-agent" })).name).toBe("prime")
+  })
+
+  it("does NOT select prime from the Anthropic SDK User-Agent", () => {
+    // Prime Agent sends `Anthropic/JS <version>` in API-key mode. So does every
+    // other SDK client, which is why there is no UA heuristic — matching on it
+    // would misroute unrelated traffic.
+    const adapter = detectAdapter(ctxWith({ "user-agent": "Anthropic/JS 0.91.1" }))
+    expect(adapter.name).not.toBe("prime")
+  })
+
+  it("resolves the claude-cli collision in favour of prime when configured", () => {
+    // Prime Agent run with an OAuth token sends claude-cli/<version>, same as
+    // Pi. The existing env tiebreaker covers it.
+    process.env.MERIDIAN_DEFAULT_AGENT = "prime"
+    expect(detectAdapter(ctxWith({ "user-agent": "claude-cli/1.2.3" })).name).toBe("prime")
+  })
+})
+
+describe("prime transform parity", () => {
+  function makeCtx(body: any = {}) {
+    return createRequestContext({
+      adapter: "prime",
+      body,
+      headers: new Headers(),
+      model: "sonnet",
+      messages: [],
+      stream: false,
+      workingDirectory: "/tmp",
+    })
+  }
+
+  it("is registered under the adapter name", () => {
+    expect(getAdapterTransforms("prime")).toBe(primeTransforms)
+  })
+
+  it("matches allowedMcpTools", () => {
+    const ctx = runTransformHook(primeTransforms, "onRequest", makeCtx(), "prime")
+    expect([...ctx.allowedMcpTools]).toEqual([...primeAdapter.getAllowedMcpTools()])
+  })
+
+  it("matches blockedTools and incompatibleTools", () => {
+    const ctx = runTransformHook(primeTransforms, "onRequest", makeCtx(), "prime")
+    expect([...ctx.blockedTools]).toEqual([...primeAdapter.getBlockedBuiltinTools()])
+    expect([...ctx.incompatibleTools]).toEqual([...primeAdapter.getAgentIncompatibleTools()])
+  })
+
+  it("matches supportsThinking and passthrough", () => {
+    const ctx = runTransformHook(primeTransforms, "onRequest", makeCtx(), "prime")
+    expect(ctx.supportsThinking).toBe(primeAdapter.supportsThinking!())
+    expect(ctx.passthrough).toBe(primeAdapter.usesPassthrough!())
+  })
+
+  it("shares one file-change implementation with the adapter", () => {
+    const ctx = runTransformHook(primeTransforms, "onRequest", makeCtx(), "prime")
+    const cell = { code: 'await edit(path="a.ts", old_str=x, new_str=y)' }
+    expect(ctx.extractFileChangesFromToolUse!("ipython", cell))
+      .toEqual(primeAdapter.extractFileChangesFromToolUse!("ipython", cell))
+  })
+})

--- a/src/proxy/adapters/detect.ts
+++ b/src/proxy/adapters/detect.ts
@@ -12,6 +12,7 @@ import { droidAdapter } from "./droid"
 import { crushAdapter } from "./crush"
 import { passthroughAdapter } from "./passthrough"
 import { piAdapter } from "./pi"
+import { primeAdapter } from "./prime"
 import { forgeCodeAdapter } from "./forgecode"
 import { claudeCodeAdapter } from "./claudecode"
 import { openAiAdapter } from "./openai"
@@ -26,6 +27,13 @@ const ADAPTER_MAP: Record<string, AgentAdapter> = {
   crush: crushAdapter,
   passthrough: passthroughAdapter,
   pi: piAdapter,
+  // Prime Agent — a Pi fork. Its User-Agent in API-key mode is the generic
+  // `Anthropic/JS <version>`, shared with every other Anthropic SDK client, so
+  // there is deliberately no UA heuristic: selection is by this explicit tag
+  // (set in the provider config) or MERIDIAN_DEFAULT_AGENT=prime. Both the
+  // canonical name and the npm package name are accepted.
+  prime: primeAdapter,
+  "prime-agent": primeAdapter,
   forgecode: forgeCodeAdapter,
   "claude-code": claudeCodeAdapter,
   claudecode: claudeCodeAdapter,

--- a/src/proxy/adapters/prime.ts
+++ b/src/proxy/adapters/prime.ts
@@ -1,0 +1,320 @@
+/**
+ * Prime Agent adapter.
+ *
+ * Prime Agent (npm `prime-agent`) is a FORK of Pi, not Pi. Its dependencies are
+ * `@earendil-works/pi-agent-core` / `pi-ai` / `pi-tui` — republished Pi packages
+ * — and its transport layer is Pi's unchanged: the official `@anthropic-ai/sdk`,
+ * `stream: true` on every request, the same OAuth-vs-API-key client branch.
+ *
+ * Everything above the transport differs, which is why it gets its own adapter
+ * rather than riding Pi's. Measured on 2026-08-12 by capturing real traffic
+ * against a local recording server (prime-agent 0.7.2):
+ *
+ * - User-Agent (API-key mode): `Anthropic/JS <version>` — NOT `claude-cli/`.
+ * - No session header, and no `metadata` on the wire by default.
+ * - Exactly ONE tool is offered: `ipython` ({ code: string }). Not Pi's
+ *   read/write/edit/bash/glob/grep. `bash` and `edit` exist only when a user
+ *   opts into them with `-t`.
+ * - System prompt ~17-19KB, one text block, opening "You are a general purpose
+ *   agent that uses code to solve tasks."
+ * - CWD arrives as `Working directory: <path>` — no `Current` prefix.
+ *
+ * Detection: the User-Agent is the generic Anthropic SDK one, shared with every
+ * other SDK client, so a UA heuristic would misroute unrelated traffic. Select
+ * with `x-meridian-agent: prime` (set in the provider config) or
+ * `MERIDIAN_DEFAULT_AGENT=prime`. Running Prime Agent with an OAuth token makes
+ * it send `claude-cli/<version>`, which the existing env-var tiebreaker in
+ * detect.ts already resolves.
+ */
+
+import type { Context } from "hono"
+import type { AgentAdapter } from "../adapter"
+import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
+import { normalizeContent } from "../messages"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../tools"
+import { resolvePassthrough } from "../../env"
+import { extractClaudeCodeSessionId } from "./claudecode"
+
+const PRIME_MCP_SERVER_NAME = "prime"
+
+/**
+ * Internal-mode fallback tools.
+ *
+ * Prime Agent's real tool is `ipython`, a persistent kernel living in the
+ * client — the proxy cannot provide it over MCP. Passthrough is therefore the
+ * only mode in which Prime Agent works as designed. This set exists so that a
+ * user who explicitly sets MERIDIAN_PASSTHROUGH=0 still gets a usable file/shell
+ * surface rather than nothing, and is documented as a degraded mode.
+ */
+const PRIME_ALLOWED_MCP_TOOLS: readonly string[] = [
+  `mcp__${PRIME_MCP_SERVER_NAME}__read`,
+  `mcp__${PRIME_MCP_SERVER_NAME}__write`,
+  `mcp__${PRIME_MCP_SERVER_NAME}__edit`,
+  `mcp__${PRIME_MCP_SERVER_NAME}__bash`,
+  `mcp__${PRIME_MCP_SERVER_NAME}__glob`,
+  `mcp__${PRIME_MCP_SERVER_NAME}__grep`,
+]
+
+/**
+ * The RLM prompt's own working-directory line (default branch of
+ * buildSystemPrompt), emitted near the top — line 5 in every capture, ahead of
+ * any user-supplied context.
+ */
+const RLM_CWD_LINE = /^Working directory:[ \t]*(.+)$/m
+
+/**
+ * The customPrompt branch's form, appended near the END, after project context
+ * files. Prime Agent never emits both: the default branch produces only
+ * `Working directory:`, the customPrompt branch only `Current working
+ * directory:`.
+ */
+const CUSTOM_PROMPT_CWD_LINE = /^Current working directory:[ \t]*(.+)$/m
+
+/**
+ * Extract the client's working directory from Prime Agent's system prompt.
+ *
+ * Both patterns are anchored to start-of-line. In harness-generated text that
+ * anchoring is not currently load-bearing — a capture of the real prompt
+ * contains exactly one `Working directory:` occurrence and it is already at
+ * line start (the prompt does discuss "the working directory" in prose, but
+ * lowercase and without a colon, so it never matched either way).
+ *
+ * The anchor guards user-supplied content instead. Project context files are
+ * inlined into this same prompt under `# Project Context`, so an AGENTS.md that
+ * quotes the line mid-sentence — "set Working directory: /tmp/example first" —
+ * would otherwise be read as the client's real cwd.
+ *
+ * `Working directory:` is tried first because in the common (default-prompt)
+ * case it sits at line 5, ahead of any user content that might introduce the
+ * other spelling. The customPrompt branch emits no such line, so it falls
+ * through to `Current working directory:`.
+ */
+function extractPrimeCwd(body: any): string | undefined {
+  let systemText = ""
+  if (typeof body?.system === "string") {
+    systemText = body.system
+  } else if (Array.isArray(body?.system)) {
+    systemText = body.system
+      .filter((b: any) => b?.type === "text" && b.text)
+      .map((b: any) => b.text)
+      .join("\n")
+  }
+  if (!systemText) return undefined
+
+  const match = systemText.match(RLM_CWD_LINE) ?? systemText.match(CUSTOM_PROMPT_CWD_LINE)
+  return match?.[1]?.trim() || undefined
+}
+
+/**
+ * `await edit(path="...", old_str=..., new_str=...)` — Prime Agent's
+ * pre-imported targeted-edit skill, called from inside an IPython cell.
+ * Both quote styles, optional `await`, optional whitespace.
+ */
+const EDIT_SKILL_CALL = /\bedit\s*\(\s*path\s*=\s*(['"])(.+?)\1/g
+
+/** `!cmd` IPython shell escapes. Discouraged by the prompt, but they execute. */
+const SHELL_ESCAPE_LINE = /^[ \t]*!(.+)$/
+
+/**
+ * Map an `ipython` cell to file changes.
+ *
+ * Handles the two forms that are cheap to read accurately:
+ *
+ *   1. `%%bash` cells. A cell magic must be the first line of the cell (Prime
+ *      Agent's own prompt states this), so the whole remaining cell is shell
+ *      and goes through the existing bash extractor.
+ *   2. `edit(path=...)` calls and `!cmd` shell escapes inside a Python cell.
+ *
+ * It deliberately does NOT parse arbitrary Python writes — `open(p, "w")`,
+ * `Path.write_text`, library calls, anything behind a variable. That would need
+ * real dataflow analysis, and a parser that silently half-works is worse than a
+ * documented gap: file-change summaries are a reporting nicety here, not
+ * correctness. The limitation is stated in docs/agents.md.
+ */
+function extractFileChangesFromIpythonCell(code: string): FileChange[] {
+  const lines = code.split("\n")
+  const firstMeaningful = lines.find((l) => l.trim().length > 0) ?? ""
+
+  if (/^[ \t]*%%bash\b/.test(firstMeaningful)) {
+    const bodyStart = lines.indexOf(firstMeaningful) + 1
+    return extractFileChangesFromBash(lines.slice(bodyStart).join("\n"))
+  }
+
+  const changes: FileChange[] = []
+
+  for (const line of lines) {
+    const escaped = line.match(SHELL_ESCAPE_LINE)
+    if (escaped?.[1]) changes.push(...extractFileChangesFromBash(escaped[1]))
+  }
+
+  // matchAll rather than exec-in-a-loop: it iterates over an internal clone, so
+  // the module-scoped /g regex can never carry lastIndex between calls.
+  for (const m of code.matchAll(EDIT_SKILL_CALL)) {
+    if (m[2]) changes.push({ operation: "edited", path: m[2] })
+  }
+
+  return changes
+}
+
+/**
+ * Map a client-side tool_use block to file changes.
+ *
+ * In passthrough mode the SDK never executes tools, so PostToolUse hooks never
+ * fire and file changes have to be read back out of the conversation.
+ *
+ * `ipython` is the only tool Prime Agent offers by default; `bash` and `edit`
+ * appear only when a user opts into them with `-t`.
+ *
+ * Shared with transforms/prime.ts so the two cannot drift.
+ */
+function extractPrimeFileChanges(toolName: string, toolInput: unknown): FileChange[] {
+  const input = toolInput as Record<string, unknown> | null | undefined
+
+  if (toolName === "ipython" && typeof input?.code === "string") {
+    return extractFileChangesFromIpythonCell(input.code)
+  }
+
+  const filePath = input?.path ?? input?.file_path ?? input?.filePath
+  if (toolName === "edit" && filePath) {
+    return [{ operation: "edited", path: String(filePath) }]
+  }
+  if (toolName === "write" && filePath) {
+    return [{ operation: "wrote", path: String(filePath) }]
+  }
+  if (toolName === "bash" && input?.command) {
+    return extractFileChangesFromBash(String(input.command))
+  }
+  return []
+}
+
+export const primeAdapter: AgentAdapter = {
+  name: "prime",
+
+  /**
+   * `x-session-affinity` stays authoritative for orchestrators that set it.
+   *
+   * The body fallback is what makes recursive subagents and daemon mode work.
+   * Prime Agent sends no session identity of its own, and under passthrough
+   * every tool round ends in `user[tool_result]` — which trips the
+   * `isClientDrivenLoop` bypass in server.ts: no session key means an
+   * independent request, so no lineage lookup and a fresh SDK session every
+   * tool round.
+   *
+   * Measured: a 19-round tool loop with no key logged `lineage=new
+   * session=new` on every single round. #734 attributes prompt-cache decay to
+   * exactly this shape; that consequence was NOT reproduced here, because the
+   * probe conversation was too small to tell a static-prefix floor apart from
+   * "there was nothing more to cache" (cache_read sat at 7k throughout, but so
+   * did the whole conversation). Treat the churn as the established fact and
+   * the cost consequence as reported-but-unverified at this scale.
+   *
+   * That bypass is CORRECT and stays: N concurrent RLM children, all
+   * headerless, would otherwise collide on one (firstUserMessage, cwd)
+   * fingerprint and resume each other's sessions. The fix is for the client to
+   * declare a key, which a Prime Agent extension does from
+   * `before_provider_request` using `ctx.sessionManager.getSessionId()`.
+   *
+   * Verified on the wire: a root agent and its RLM child carry distinct
+   * `metadata.user_id` session ids, so children get distinct keys rather than
+   * colliding. `extractClaudeCodeSessionId` is strict — `metadata.user_id` must
+   * be, or parse to, an object with a non-empty string `session_id` — so
+   * clients that don't opt in are unaffected.
+   */
+  getSessionId(c: Context, body?: unknown): string | undefined {
+    return c.req.header("x-session-affinity") ?? extractClaudeCodeSessionId(body)
+  },
+
+  extractWorkingDirectory(body: any): string | undefined {
+    return extractPrimeCwd(body)
+  },
+
+  /**
+   * Prime Agent normally runs on the same host as the proxy, so the SDK
+   * subprocess can chdir into the client's project. Exposing the same parse
+   * here decouples fingerprint bucketing from MERIDIAN_WORKDIR, so two
+   * unrelated Prime Agent projects don't share a fingerprint namespace just
+   * because the proxy is pinned to one cwd.
+   */
+  extractClientWorkingDirectory(body: any): string | undefined {
+    return extractPrimeCwd(body)
+  },
+
+  normalizeContent(content: any): string {
+    return normalizeContent(content)
+  },
+
+  /**
+   * Prime Agent's tool is lowercase `ipython`, which doesn't collide with the
+   * SDK's PascalCase built-ins. Block them anyway to prevent ambiguity.
+   */
+  getBlockedBuiltinTools(): readonly string[] {
+    return BLOCKED_BUILTIN_TOOLS
+  },
+
+  getAgentIncompatibleTools(): readonly string[] {
+    return CLAUDE_CODE_ONLY_TOOLS
+  },
+
+  getMcpServerName(): string {
+    return PRIME_MCP_SERVER_NAME
+  },
+
+  getAllowedMcpTools(): readonly string[] {
+    return PRIME_ALLOWED_MCP_TOOLS
+  },
+
+  /**
+   * Prime Agent spawns subagents through its own RLM runtime (`await
+   * rlm('sub-task')`), which are separate conversations making their own API
+   * calls. That is not SDK agent routing, so there are no definitions to build.
+   */
+  buildSdkAgents(_body: any, _mcpToolNames: readonly string[]): Record<string, any> {
+    return {}
+  },
+
+  /** Prime Agent renders thinking, and supports adaptive thinking levels. */
+  supportsThinking(): boolean {
+    return true
+  },
+
+  /** No PreToolUse hooks — Prime Agent executes its own tools. */
+  buildSdkHooks(_body: any, _sdkAgents: Record<string, any>): undefined {
+    return undefined
+  },
+
+  buildSystemContextAddendum(_body: any, _sdkAgents: Record<string, any>): string {
+    return ""
+  },
+
+  /**
+   * Passthrough is effectively required, not merely preferred: Prime Agent's
+   * only tool is a persistent IPython kernel living in the client, which the
+   * proxy cannot execute on its behalf. In internal mode the client's `ipython`
+   * tool is dropped and only the MCP fallback set above is exposed.
+   *
+   * Default ON, opt out via MERIDIAN_PASSTHROUGH=0 — same shape as the
+   * pi/claudecode/opencode adapters, so the escape hatch stays available even
+   * though it is a degraded mode.
+   */
+  usesPassthrough(): boolean {
+    return resolvePassthrough(true)
+  },
+
+  extractFileChangesFromToolUse(toolName: string, toolInput: unknown): FileChange[] {
+    return extractPrimeFileChanges(toolName, toolInput)
+  },
+}
+
+/**
+ * Exported so transforms/prime.ts can share the exact same implementations
+ * rather than keeping a hand-copied duplicate in step (the transform-parity
+ * test catches drift, but not sharing is simply better). The import direction
+ * is transforms → adapters, matching transforms/cherry.ts; the adapter
+ * deliberately does NOT re-export primeTransforms, which would close the cycle.
+ */
+export {
+  extractPrimeCwd,
+  extractFileChangesFromIpythonCell,
+  extractPrimeFileChanges,
+  PRIME_ALLOWED_MCP_TOOLS,
+}

--- a/src/proxy/sdkFeatures.ts
+++ b/src/proxy/sdkFeatures.ts
@@ -108,6 +108,23 @@ const ADAPTER_DEFAULTS: Record<string, Partial<AdapterFeatures>> = {
   cherry: {
     codeSystemPrompt: false,
   },
+  // Prime Agent ships ~17-19KB of its own harness doctrine — RLM control
+  // semantics, subagent delegation guidance, continual-harness state. Layering
+  // Claude Code's ~28KB preset on top duplicates and contradicts it, so keep
+  // the preset OFF (same rationale as codex/jcode/cherry). Users can flip it on
+  // via the settings UI.
+  //
+  // Measured rather than assumed: 6 multi-round `ipython` loops per arm, driven
+  // through Meridian with the real captured Prime Agent prompt and tool schema.
+  // Both arms scored identically on what matters — every run called only
+  // `ipython`, ran all three requested steps in order, and finished. The preset
+  // bought nothing, so OFF keeps the behaviour and saves ~28KB per request.
+  // (Both arms also re-ran the final cell in most samples; since it appears
+  // equally with the preset on, it is a property of the task and model, not of
+  // this setting.)
+  prime: {
+    codeSystemPrompt: false,
+  },
   // Codex CLI endpoint (/v1/responses). Codex ships its own ~21KB harness
   // instructions; keep the Claude Code preset OFF so they aren't overridden
   // (same rationale as openai). Passthrough is forced in the adapter itself.

--- a/src/proxy/transforms/prime.ts
+++ b/src/proxy/transforms/prime.ts
@@ -1,0 +1,38 @@
+import type { Transform, RequestContext } from "../transform"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS } from "../tools"
+import { resolvePassthrough } from "../../env"
+import { PRIME_ALLOWED_MCP_TOOLS, extractPrimeFileChanges } from "../adapters/prime"
+
+/**
+ * Resolve passthrough for Prime Agent. Mirrors the adapter's `usesPassthrough()`
+ * so transform and adapter agree (enforced by the transform-parity test).
+ *
+ * Default ON. Prime Agent's only tool is a persistent IPython kernel living in
+ * the client, which the proxy cannot execute on its behalf — internal mode drops
+ * it and falls back to the MCP tool set, a deliberately degraded path. Opt out
+ * with MERIDIAN_PASSTHROUGH=0.
+ */
+function resolvePrimePassthrough(): boolean {
+  return resolvePassthrough(true)
+}
+
+export const primeTransforms: Transform[] = [
+  {
+    name: "prime-core",
+    adapters: ["prime"],
+    onRequest(ctx: RequestContext): RequestContext {
+      return {
+        ...ctx,
+        blockedTools: BLOCKED_BUILTIN_TOOLS,
+        incompatibleTools: CLAUDE_CODE_ONLY_TOOLS,
+        allowedMcpTools: PRIME_ALLOWED_MCP_TOOLS,
+        sdkAgents: {},
+        passthrough: resolvePrimePassthrough(),
+        supportsThinking: true,
+        // Shared with the adapter rather than re-implemented, so the two
+        // cannot drift apart.
+        extractFileChangesFromToolUse: extractPrimeFileChanges,
+      }
+    },
+  },
+]

--- a/src/proxy/transforms/registry.ts
+++ b/src/proxy/transforms/registry.ts
@@ -3,6 +3,7 @@ import { openCodeTransforms } from "./opencode"
 import { crushTransforms } from "./crush"
 import { droidTransforms } from "./droid"
 import { piTransforms } from "./pi"
+import { primeTransforms } from "./prime"
 import { forgeCodeTransforms } from "./forgecode"
 import { passthroughTransforms } from "./passthrough"
 import { cherryTransforms } from "./cherry"
@@ -14,6 +15,10 @@ const ADAPTER_TRANSFORMS: Record<string, readonly Transform[]> = {
   crush: crushTransforms,
   droid: droidTransforms,
   pi: piTransforms,
+  // Prime Agent is a Pi fork with a different tool surface (one `ipython`
+  // tool, not Pi's read/write/edit/bash/glob/grep), so it needs its own
+  // config rather than sharing Pi's.
+  prime: primeTransforms,
   forgecode: forgeCodeTransforms,
   passthrough: passthroughTransforms,
   cherry: cherryTransforms,


### PR DESCRIPTION
Adds a `prime` adapter for [Prime Agent](https://www.npmjs.com/package/prime-agent), a fork of Pi.

## Why its own adapter

Prime Agent's dependencies are `@earendil-works/pi-agent-core` / `pi-ai` / `pi-tui` and its transport is Pi's unchanged — but everything above the transport differs. Riding Pi's adapter would inherit two concrete defects:

- **CWD.** `extractPiCwd` matches `Current working directory:`. Prime Agent's default RLM prompt emits `Working directory:` near the top, so CWD came back undefined — losing per-project fingerprint bucketing and the SDK chdir.
- **Tools.** Pi's adapter assumes `read/write/edit/bash/glob/grep`. Prime Agent offers exactly one tool, `ipython`.

Measured against 0.7.2 by capturing real traffic against a local recording server (no tokens spent):

| | |
|---|---|
| User-Agent (API-key mode) | `Anthropic/JS <version>` — **not** `claude-cli/` |
| Session identity | none sent |
| Tools | exactly one: `ipython` (`{code: string}`) |
| CWD line | `Working directory:` — no `Current` prefix |

## Session identity is required, not an optimisation

Prime Agent sends no session header and no `metadata`. Under passthrough every tool round ends in `user[tool_result]`, tripping the `isClientDrivenLoop` bypass — each round becomes a fresh replay. Since replays strip assistant `tool_use` blocks by design (#111/#386), the model loses track of what it already ran.

`getSessionId` therefore falls back to `extractClaudeCodeSessionId`, and `docs/agents.md` documents the extension that supplies it from `ctx.sessionManager.getSessionId()`. The bypass itself is untouched — it is correct for genuinely headerless concurrent flows.

## Design notes

- **No User-Agent heuristic.** In API-key mode Prime Agent sends the generic Anthropic SDK UA that every SDK client sends; matching on it would misroute unrelated traffic. Selection is `x-meridian-agent: prime` or `MERIDIAN_DEFAULT_AGENT=prime`. The existing `claude-cli/` env tiebreaker already covers the OAuth-token case.
- **CWD patterns are line-anchored.** Project context files are inlined into the same prompt, so an AGENTS.md quoting the line mid-sentence would otherwise be read as the real cwd.
- **IPython file tracking is deliberately partial.** `%%bash` bodies, `!` escapes and `await edit(path=…)` calls are parsed; arbitrary Python writes are not. That needs real dataflow analysis, and a parser that silently half-works is worse than a documented gap.
- **`codeSystemPrompt` defaults off** — measured, not assumed (below).

## Verified

| Claim | Evidence |
|---|---|
| Adapter selection, live turns | Real `prime-agent` binary through Meridian |
| Tool-round continuity | 45/45 rounds resumed as continuations, 12 sessions |
| RLM children get distinct keys | Parent and depth-1 child on the wire |
| Works with `codeSystemPrompt` off | 6 multi-round loops per arm; on and off scored identically |
| Survives long idle gaps | 7-min silence → `lineage=continuation`, model recalled a codeword set before the gap |
| Not metered as third-party | Negative control → full 18KB prompt → control re-check, all passing with the preset **off** |
| `pi-scrub` does not apply | Byte-identical no-op on the real prompt |

## Not verified

Stated plainly in `docs/agents.md` rather than left implied:

- Prime Agent's own cron/scheduled tick delivery, and continuity across a worker restart. Scheduling requires an active session and the `schedule` subcommand only reaches the default supervisor socket (it rejects `--daemon-socket`), so it could not be exercised in isolation from a live daemon.
- The real client driving its own IPython kernel through a full tool loop — kernel provisioning stalled in the isolated environment. Tool-round evidence comes from replaying Prime Agent's exact prompt and tool schema.

The metering result is a **dated snapshot**, not a property of the prompt: it means "not flagged on this account at this moment". The same classifier changed its answer within a day during the OpenClaw work.

## Testing

37 new unit tests, mutation-checked — reverting the line anchor, the pattern ordering, or the `code` handling each turns its tests red. Full suite 2525 pass / 1 fail; that failure is `priority cooldown resolution … (#699)`, which reproduces identically on untouched `main`.