### PR TITLE
fix(concurrency): stop internal dispatch hops from taking a second queue slot

### DIFF
--- a/src/__tests__/proxy-concurrency-limiter.test.ts
+++ b/src/__tests__/proxy-concurrency-limiter.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The SDK concurrency limiter under priority routing.
+ *
+ * Priority routing dispatches by re-entering this same app over `app.fetch`
+ * (dispatchPriority), so one external request produces two passes through the
+ * queued route. The limiter counts passes, not external requests, so the outer
+ * pass holds a slot while waiting for an inner pass that needs one of its own.
+ * At N concurrent external requests every slot is held by a waiter and nothing
+ * can be admitted — a permanent deadlock, not a slowdown: on staging the
+ * counter reached 10/10 and every subsequent request timed out until the
+ * process was restarted, while /health kept answering.
+ *
+ * These tests fix the invariant the limiter is meant to express: one external
+ * request occupies exactly one slot, and the limit still bounds how many SDK
+ * subprocesses run at once.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let sdkActive = 0
+let sdkPeak = 0
+/** Held open while a test needs SDK calls to overlap observably. */
+let sdkGate: Promise<void> = Promise.resolve()
+let openGate: () => void = () => {}
+
+function gateClosed() {
+  sdkGate = new Promise<void>((resolve) => { openGate = resolve })
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => (async function* () {
+    sdkActive++
+    sdkPeak = Math.max(sdkPeak, sdkActive)
+    try {
+      await sdkGate
+      yield assistantMessage([{ type: "text", text: "ok" }])
+    } finally {
+      sdkActive--
+    }
+  })(),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetActiveProfile } = await import("../proxy/profiles")
+const { __setFetchOAuthUsageOverride } = await import("../proxy/oauthUsage")
+
+const PROFILES = [
+  { id: "work", claudeConfigDir: "/tmp/meridian-test-conc-work" },
+  { id: "personal", claudeConfigDir: "/tmp/meridian-test-conc-personal" },
+]
+
+/** MAX_CONCURRENT is read when the app is built, so set the env first. */
+function createTestApp(maxConcurrent: string) {
+  process.env.MERIDIAN_MAX_CONCURRENT = maxConcurrent
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work" })
+  return app
+}
+
+async function post(app: any, content: string) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-5",
+      max_tokens: 128,
+      stream: false,
+      messages: [{ role: "user", content }],
+    }),
+  }))
+}
+
+/**
+ * A deadlocked request never settles, so every assertion here needs a deadline
+ * — without one the failure is an expired test timeout that says nothing about
+ * which invariant broke.
+ */
+async function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${what} did not settle within ${ms}ms (queue deadlock)`)), ms)
+  })
+  try {
+    return await Promise.race([work, deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/** Waits for the SDK to have `n` calls in flight at once. */
+async function waitForSdkActive(n: number, ms: number) {
+  const until = Date.now() + ms
+  while (sdkActive < n) {
+    if (Date.now() > until) throw new Error(`only ${sdkActive}/${n} SDK calls in flight after ${ms}ms`)
+    await new Promise((r) => setTimeout(r, 5))
+  }
+}
+
+const savedEnv: Record<string, string | undefined> = {}
+
+describe("SDK concurrency limiter", () => {
+  beforeEach(() => {
+    sdkActive = 0
+    sdkPeak = 0
+    sdkGate = Promise.resolve()
+    clearSessionCache()
+    resetActiveProfile()
+    __setFetchOAuthUsageOverride(async () => null)
+    savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
+    savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    savedEnv.MERIDIAN_MAX_CONCURRENT = process.env.MERIDIAN_MAX_CONCURRENT
+    process.env.MERIDIAN_ROUTING = "priority"
+    process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
+  })
+
+  afterEach(() => {
+    openGate()
+    __setFetchOAuthUsageOverride(null)
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  // The whole defect in its smallest form: with a single slot, one request
+  // needs two and waits on itself forever.
+  it("serves a priority-routed request when only one slot exists", async () => {
+    const app = createTestApp("1")
+    const res = await withDeadline(post(app, "single slot"), 5_000, "one priority request")
+    expect(res.status).toBe(200)
+  }, 15_000)
+
+  // The invariant stated positively: the limit is a budget of external
+  // requests. With two slots, two requests must both reach the SDK — under the
+  // double-count only one gets through (the other's outer pass is queued), or
+  // neither does.
+  it("admits as many concurrent requests as it has slots", async () => {
+    gateClosed()
+    const app = createTestApp("2")
+    const inFlight = Promise.all([post(app, "slot a"), post(app, "slot b")])
+    await withDeadline(waitForSdkActive(2, 5_000), 6_000, "two concurrent SDK calls")
+    openGate()
+    const [a, b] = await withDeadline(inFlight, 5_000, "both priority requests")
+    expect(a.status).toBe(200)
+    expect(b.status).toBe(200)
+  }, 15_000)
+
+  // Guard on the other side: not re-entering the queue must not become "no
+  // queue at all". Six requests against two slots still run at most two SDK
+  // subprocesses at a time.
+  it("still bounds how many SDK calls run at once", async () => {
+    const app = createTestApp("2")
+    const results = await withDeadline(
+      Promise.all(Array.from({ length: 6 }, (_, i) => post(app, `burst ${i}`))),
+      15_000,
+      "a burst of six priority requests",
+    )
+    expect(results.map((r: Response) => r.status)).toEqual([200, 200, 200, 200, 200, 200])
+    expect(sdkPeak).toBeLessThanOrEqual(2)
+    expect(sdkPeak).toBeGreaterThan(0)
+  }, 30_000)
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { stream } from "hono/streaming"
 import { serve } from "@hono/node-server"
+import { AsyncLocalStorage } from "node:async_hooks"
 import type { Server } from "node:http"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -728,6 +729,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   const MAX_CONCURRENT_SESSIONS = parseInt((process.env.MERIDIAN_MAX_CONCURRENT ?? process.env.CLAUDE_PROXY_MAX_CONCURRENT) || "10", 10)
   let activeSessions = 0
   const sessionQueue: Array<{ resolve: () => void }> = []
+  // Priority routing dispatches by re-entering this app over `app.fetch`
+  // (dispatchPriority), so one external request makes two passes through the
+  // queued route. Counting both is a deadlock, not an over-count: the outer
+  // pass holds its slot for as long as the inner pass runs, so N concurrent
+  // requests hold all N slots while waiting for inner passes that can never be
+  // admitted, and the queue never drains again. The slot belongs to the
+  // external request; the inner pass is the same request continuing, and it is
+  // the only one of the two that spawns an SDK subprocess.
+  //
+  // The marker rides the async context rather than a header because a header
+  // reaches the limiter from the wire: any client could send it and opt out of
+  // the limit this exists to impose. It carries the outer pass's queue timings
+  // so the inner pass — the one that reports telemetry — still records the wait
+  // the external request actually served, rather than a zero of its own.
+  const insideSessionSlot = new AsyncLocalStorage<{ queueEnteredAt: number; queueStartedAt: number }>()
 
   async function acquireSession(): Promise<void> {
     if (activeSessions < MAX_CONCURRENT_SESSIONS) {
@@ -4082,10 +4098,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const requestId = c.req.header("x-request-id") || randomUUID()
     const queueEnteredAt = Date.now()
     claudeLog("request.enter", { requestId, endpoint })
+    // Already inside this request's slot — an internal dispatch hop, not a new
+    // arrival. Taking a second slot here is what deadlocks the pool.
+    const held = insideSessionSlot.getStore()
+    if (held) {
+      return handleMessages(c, { requestId, endpoint, ...held })
+    }
     await acquireSession()
     const queueStartedAt = Date.now()
     try {
-      return await handleMessages(c, { requestId, endpoint, queueEnteredAt, queueStartedAt })
+      return await insideSessionSlot.run({ queueEnteredAt, queueStartedAt }, () =>
+        handleMessages(c, { requestId, endpoint, queueEnteredAt, queueStartedAt }))
     } finally {
       releaseSession()
     }


### PR DESCRIPTION
Cherry-picked from #810 by @justprosh — `main` requires signed commits, so fork
PRs cannot be merged directly. Authorship is preserved on the commit.

Fixes #809. Closes #810.

## The bug

`dispatchPriority` re-enters the app over `app.fetch` (`server.ts:664`), and the route it re-enters is the queued one. So one external request makes two passes through `handleWithQueue` and takes two slots, the outer held for the whole life of the inner.

At N concurrent requests every slot is held by an outer pass waiting on an inner that can never be admitted — **the queue stops draining permanently.** `/health` keeps answering 200 throughout because it never enters the queue, so monitoring reports a healthy proxy that serves nothing.

## The fix

The slot belongs to the external request, not to the pass. The inner pass is that same request continuing, and it is the only one of the two that spawns an SDK subprocess, so it runs on the slot the outer already holds. Failover stays sequential, so one request still means one subprocess at a time.

The marker rides an `AsyncLocalStorage` rather than a header deliberately: a header reaches the limiter from the wire, so any client could send it and opt out of the limit this exists to impose. It also carries the outer pass's queue timings, so the inner pass — the one that records telemetry — reports the wait actually served rather than a zero of its own.

## Review notes

Verified rather than taken on trust:

- **Reverted `server.ts` to `main` and re-ran the new tests: all 3 fail**, with 5s/5s/15s timeouts — the deadlock signature. They pass with the fix.
- The re-entry is an in-process `await app.fetch(...)`, so the `AsyncLocalStorage` context genuinely propagates. This would not work across a real network boundary.
- **Composition checked.** Only `/v1/messages` and `/messages` are queued. `/v1/chat/completions` re-enters the queued route from *outside* the queue, so it takes exactly one slot before and after — unaffected. Stacking all three (`chat/completions` → `messages` → dispatch) still yields exactly one slot.
- The guard against degenerating into "no queueing at all" is real: the burst test asserts `sdkPeak <= 2` with `MAX_CONCURRENT=2`, **and** `sdkPeak > 0`.
- `releaseSession()` stays in the `finally`, so the slot is still freed if `handleMessages` throws inside `insideSessionSlot.run`.

## Testing

Full suite 2528 pass / 1 fail — that failure is `priority cooldown resolution … (#699)`, which reproduces identically on untouched `main`. Typecheck clean. Rebased onto `main` after #811; both changes' tests pass together.

## Severity note

This is a permanent deadlock rather than a degradation, and it presents as a healthy proxy. Worth considering a prompt patch release rather than batching.