### PR TITLE
fix(plugins): derive the known-adapter list from the registry

### DIFF
--- a/src/__tests__/plugin-validation.test.ts
+++ b/src/__tests__/plugin-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { validateTransform } from "../proxy/plugins/validation"
+import { listAdapterNames } from "../proxy/adapters/detect"
 
 describe("validateTransform", () => {
   it("accepts a valid transform with name and onRequest", () => {
@@ -84,5 +85,37 @@ describe("validateTransform", () => {
     })
     expect(result.valid).toBe(true)
     expect(result.warnings ?? []).not.toContain("jcode")
+  })
+})
+
+// #791: the adapter list used to be hand-maintained here and drifted every
+// time an adapter was added — it was missing claude-code, cherry and codex
+// before prime missed it again. A plugin scoped to a real adapter was then
+// reported as referencing an unknown one, which reads as the plugin being
+// wrong rather than the list being stale. Deriving it from the registry is
+// what makes that impossible; this pins it.
+describe("adapter scoping stays in step with the registry (#791)", () => {
+  it("accepts every adapter the registry knows, with no warnings", () => {
+    for (const name of listAdapterNames()) {
+      const result = validateTransform({ name: "p", adapters: [name], onRequest: () => {} })
+      expect(result.valid).toBe(true)
+      expect(result.warnings).toBeUndefined()
+    }
+  })
+
+  it("accepts the adapters added since the hand-kept list was written", () => {
+    const result = validateTransform({
+      name: "p",
+      adapters: ["prime", "claude-code", "cherry", "codex"],
+      onRequest: () => {},
+    })
+    expect(result.valid).toBe(true)
+    expect(result.warnings).toBeUndefined()
+  })
+
+  it("still warns about an adapter that genuinely does not exist", () => {
+    const result = validateTransform({ name: "p", adapters: ["not-an-adapter"], onRequest: () => {} })
+    expect(result.valid).toBe(true)
+    expect(result.warnings).toEqual(["not-an-adapter"])
   })
 })

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -144,6 +144,14 @@ describe("priority routing", () => {
     resetActiveProfile()
     savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
     savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    // A profile with no claudeConfigDir of its own inherits the ambient
+    // CLAUDE_CONFIG_DIR, so the SDK mock sees the developer's real config
+    // directory instead of falling back to its "default" sentinel. A test that
+    // fails such a profile by adding "default" to failingDirs then never fails
+    // it at all. Green in CI, red on any machine that runs Claude Code with a
+    // custom config dir — which is most of this project's users.
+    savedEnv.CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
+    delete process.env.CLAUDE_CONFIG_DIR
     process.env.MERIDIAN_ROUTING = "priority"
     process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
   })
@@ -454,6 +462,14 @@ describe("priority cooldown resolution", () => {
     resetActiveProfile()
     savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
     savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    // A profile with no claudeConfigDir of its own inherits the ambient
+    // CLAUDE_CONFIG_DIR, so the SDK mock sees the developer's real config
+    // directory instead of falling back to its "default" sentinel. A test that
+    // fails such a profile by adding "default" to failingDirs then never fails
+    // it at all. Green in CI, red on any machine that runs Claude Code with a
+    // custom config dir — which is most of this project's users.
+    savedEnv.CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
+    delete process.env.CLAUDE_CONFIG_DIR
     process.env.MERIDIAN_ROUTING = "priority"
     process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
     rateLimitStore.clear()
@@ -798,6 +814,14 @@ describe("keyless priority affinity", () => {
     // and the shared `savedEnv` object is restored wholesale in afterEach.
     savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
     savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    // A profile with no claudeConfigDir of its own inherits the ambient
+    // CLAUDE_CONFIG_DIR, so the SDK mock sees the developer's real config
+    // directory instead of falling back to its "default" sentinel. A test that
+    // fails such a profile by adding "default" to failingDirs then never fails
+    // it at all. Green in CI, red on any machine that runs Claude Code with a
+    // custom config dir — which is most of this project's users.
+    savedEnv.CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
+    delete process.env.CLAUDE_CONFIG_DIR
     process.env.MERIDIAN_ROUTING = "priority"
     process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
   })

--- a/src/proxy/plugins/validation.ts
+++ b/src/proxy/plugins/validation.ts
@@ -1,4 +1,20 @@
-const KNOWN_ADAPTERS = ["opencode", "openai", "jcode", "crush", "droid", "pi", "forgecode", "passthrough"]
+import { listAdapterNames } from "../adapters/detect"
+
+/**
+ * Adapters a plugin may scope itself to.
+ *
+ * Derived from the adapter registry rather than hand-listed, because the
+ * hand-kept copy drifted every time an adapter was added and nothing failed
+ * loudly enough to notice: it was already missing `claude-code`, `cherry` and
+ * `codex` before `prime` missed it again (#791). The symptom is a plugin
+ * scoped to a perfectly real adapter being reported as referencing an unknown
+ * one — which reads as the plugin being wrong rather than this list being
+ * stale.
+ *
+ * Adapter INSTANCES (#476) are deliberately absent. Plugins scope to a base
+ * adapter and apply to its instances automatically, so an instance name is not
+ * something a plugin should be declaring.
+ */
 const KNOWN_HOOKS = ["onRequest", "onResponse", "onTelemetry", "onSession", "onToolUse", "onToolResult", "onError"]
 
 export interface ValidationResult {
@@ -31,8 +47,9 @@ export function validateTransform(exported: unknown): ValidationResult {
 
   const warnings: string[] = []
   if (Array.isArray(obj.adapters)) {
+    const known = listAdapterNames()
     for (const adapter of obj.adapters) {
-      if (typeof adapter === "string" && !KNOWN_ADAPTERS.includes(adapter)) {
+      if (typeof adapter === "string" && !known.includes(adapter)) {
         warnings.push(adapter)
       }
     }


### PR DESCRIPTION
Closes #791.

## The drift

`KNOWN_ADAPTERS` in `src/proxy/plugins/validation.ts` was hand-maintained:

```js
["opencode", "openai", "jcode", "crush", "droid", "pi", "forgecode", "passthrough"]
```

Already missing `claude-code`, `cherry` and `codex` — and `prime` (#808) missed it again, which is what surfaced this. A plugin scoped to `adapters: ["prime"]` was reported as referencing an unknown adapter, which reads as the plugin being wrong rather than this list being stale.

`detect.ts` already derives its settings list from the registry for exactly this reason, with a comment recording the same repeated drift. This does the same for plugin validation, so the list cannot fall behind again.

Adapter instances (#476) stay out deliberately: plugins scope to a base adapter and apply to its instances automatically, so an instance name is not something a plugin should declare.

## Also: the priority-routing test that fails outside CI

`priority cooldown resolution > does not attempt an OAuth usage fetch for a non-claude-max profile (#699)` fails on any machine that runs Claude Code with a custom `CLAUDE_CONFIG_DIR`.

A profile with no `claudeConfigDir` of its own inherits the ambient one, so the SDK mock sees a real config directory rather than its `"default"` sentinel:

```
capturedEnvs: ["/Users/rynfar/.claude-alt"]
failingDirs:  ["default"]
```

`dir.includes("default")` is false, the request never fails, the profile is never benched, and the assertion about the bench breaks. Green in CI (no such env var), red for most of this project's actual users.

The suite already pins `MERIDIAN_ROUTING` and `MERIDIAN_PROFILE_ORDER` for determinism; `CLAUDE_CONFIG_DIR` was simply missed. Fixed across all three `beforeEach` blocks rather than patching the one test.

## Testing

Three new validation tests, mutation-checked — restoring the hand-kept list fails two of them, and a genuinely unknown adapter still warns, so the check isn't merely disabled. The env fix is likewise mutation-checked: removing all three `delete`s brings the failure back.

**Full suite green: 2538 pass, 0 fail.** This is the first fully-clean run — that `#699` failure had been present on `main` throughout.