### PR TITLE
fix(routing): bench a weekly-capped profile until the weekly reset

### DIFF
--- a/src/__tests__/routing.test.ts
+++ b/src/__tests__/routing.test.ts
@@ -8,7 +8,7 @@
  * to the removed arm (minimal cache disruption).
  */
 import { describe, it, expect } from "bun:test"
-import { pickStickyProfile, getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, RENDEZVOUS_STABLE_GUARD, AssignmentStore } from "../proxy/routing"
+import { pickStickyProfile, getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, RENDEZVOUS_STABLE_GUARD, AssignmentStore , resolveCooldownUntil, cooldownCapMs } from "../proxy/routing"
 
 const PROFILES = ["personal", "work"]
 
@@ -250,5 +250,95 @@ describe("AssignmentStore", () => {
     expect(store.size).toBe(1)
     expect(store.get("a")).toBeUndefined()
     expect(store.get("b")).toBe("personal")
+  })
+})
+
+// #790: a weekly-capped profile matched no `five_hour` entry, fell through to
+// the 10-minute default, and was re-probed every 10 minutes — with a real
+// failing upstream request on the request path — for the rest of the weekly
+// window. These pin the reset actually chosen and, just as importantly, the
+// per-window cap: a single 6-hour bound silently flattens a weekly reset and
+// recreates the same loop at a slower interval.
+describe("resolveCooldownUntil (#790)", () => {
+  const NOW = 1_700_000_000_000
+  const MIN = 60_000
+  const HOUR = 60 * MIN
+  const DAY = 24 * HOUR
+  const DEFAULT_MS = 10 * MIN
+
+  it("benches to the weekly reset when the weekly window is exhausted", () => {
+    const until = resolveCooldownUntil(
+      [{ type: "seven_day", resetsAt: NOW + 3 * DAY, exhausted: true }],
+      NOW, DEFAULT_MS,
+    )
+    expect(until).toBe(NOW + 3 * DAY)
+  })
+
+  it("does not flatten a weekly reset to the five-hour cap", () => {
+    // The trap: with one 6-hour cap this returns NOW + 6h and the profile is
+    // re-probed every six hours for days instead of every ten minutes.
+    const until = resolveCooldownUntil(
+      [{ type: "seven_day", resetsAt: NOW + 5 * DAY, exhausted: true }],
+      NOW, DEFAULT_MS,
+    )
+    expect(until).toBeGreaterThan(NOW + 6 * HOUR)
+    expect(until).toBe(NOW + 5 * DAY)
+  })
+
+  it("prefers the weekly reset when both windows are exhausted", () => {
+    // Inside a weekly cap the account stays unusable after the five-hour
+    // window rolls over, so benching to the shorter reset resumes probing a
+    // still-capped account.
+    const until = resolveCooldownUntil([
+      { type: "five_hour", resetsAt: NOW + 2 * HOUR, exhausted: true },
+      { type: "seven_day", resetsAt: NOW + 4 * DAY, exhausted: true },
+    ], NOW, DEFAULT_MS)
+    expect(until).toBe(NOW + 4 * DAY)
+  })
+
+  it("keeps five-hour behaviour unchanged", () => {
+    const until = resolveCooldownUntil(
+      [{ type: "five_hour", resetsAt: NOW + 2 * HOUR, exhausted: true }],
+      NOW, DEFAULT_MS,
+    )
+    expect(until).toBe(NOW + 2 * HOUR)
+  })
+
+  it("still bounds an absurd reset, per window", () => {
+    expect(resolveCooldownUntil(
+      [{ type: "five_hour", resetsAt: NOW + 400 * DAY, exhausted: true }], NOW, DEFAULT_MS,
+    )).toBe(NOW + cooldownCapMs("five_hour"))
+    expect(resolveCooldownUntil(
+      [{ type: "seven_day", resetsAt: NOW + 400 * DAY, exhausted: true }], NOW, DEFAULT_MS,
+    )).toBe(NOW + cooldownCapMs("seven_day"))
+  })
+
+  it("treats a present-but-healthy window as no evidence", () => {
+    // A healthy account always carries both windows with future resets, so
+    // presence alone must never bench a profile.
+    const until = resolveCooldownUntil([
+      { type: "five_hour", resetsAt: NOW + 2 * HOUR, exhausted: false },
+      { type: "seven_day", resetsAt: NOW + 3 * DAY, exhausted: false },
+    ], NOW, DEFAULT_MS)
+    expect(until).toBe(NOW + DEFAULT_MS)
+  })
+
+  it("ignores a past or missing reset", () => {
+    expect(resolveCooldownUntil(
+      [{ type: "seven_day", resetsAt: NOW - HOUR, exhausted: true }], NOW, DEFAULT_MS,
+    )).toBe(NOW + DEFAULT_MS)
+    expect(resolveCooldownUntil(
+      [{ type: "seven_day", resetsAt: null, exhausted: true }], NOW, DEFAULT_MS,
+    )).toBe(NOW + DEFAULT_MS)
+  })
+
+  it("does not bench a whole profile for a per-model weekly cap", () => {
+    // Deliberate: sidelining an account for days because one model's budget ran
+    // out would be worse than the bug. Documented as a known remainder.
+    const until = resolveCooldownUntil([
+      { type: "seven_day_opus", resetsAt: NOW + 3 * DAY, exhausted: true },
+      { type: "seven_day_fable", resetsAt: NOW + 3 * DAY, exhausted: true },
+    ], NOW, DEFAULT_MS)
+    expect(until).toBe(NOW + DEFAULT_MS)
   })
 })

--- a/src/proxy/routing.ts
+++ b/src/proxy/routing.ts
@@ -210,3 +210,81 @@ export class AssignmentStore {
     return this.entries.size
   }
 }
+
+/**
+ * How long a profile stays benched when a usage window is exhausted (#790).
+ *
+ * Meridian benches a failing profile until its quota window resets. Reading
+ * that reset only from the `five_hour` window meant a weekly-capped profile
+ * matched nothing and fell through to the 10-minute default — so it was
+ * re-probed every 10 minutes, with a real failing upstream request on the
+ * request path, for however many days the weekly window had left.
+ *
+ * Only the ACCOUNT-WIDE windows bench a profile. Anthropic also reports
+ * per-model weekly budgets (`seven_day_opus`, `seven_day_fable`, …), and an
+ * exhausted one of those does not mean the account is unusable — sidelining a
+ * profile for days because a single model's budget ran out would be worse than
+ * the bug this fixes. Those cases keep the old default and are called out as a
+ * known remainder rather than silently mishandled.
+ */
+export type CooldownWindowType = "five_hour" | "seven_day"
+
+/** Account-wide windows, longest first — the order preference relies on it. */
+const COOLDOWN_WINDOWS: readonly CooldownWindowType[] = ["seven_day", "five_hour"]
+
+/**
+ * Upper bound on a reset for each window, guarding against a garbage value
+ * from upstream.
+ *
+ * This is per-window rather than one constant precisely because a single
+ * constant is how the fix fails silently: a 6-hour cap applied to a weekly
+ * reset flattens "resets in three days" to "resets in six hours" and quietly
+ * recreates the re-probe loop at a slower interval. A `five_hour` window
+ * cannot legitimately reset more than ~5h out; a `seven_day` one can reset up
+ * to 7 days out, so 8 days covers it with room for clock skew.
+ */
+const COOLDOWN_CAP_MS: Record<CooldownWindowType, number> = {
+  five_hour: 6 * 60 * 60_000,
+  seven_day: 8 * 24 * 60 * 60_000,
+}
+
+export function cooldownCapMs(type: CooldownWindowType): number {
+  return COOLDOWN_CAP_MS[type]
+}
+
+/** A usage window, normalized from either the rate-limit store or the OAuth snapshot. */
+export interface CooldownWindow {
+  type: string
+  resetsAt: number | null | undefined
+  /**
+   * Whether this window is actually spent. Presence proves nothing — a healthy
+   * account always carries both windows with future resets — so only genuine
+   * exhaustion may set this.
+   */
+  exhausted: boolean
+}
+
+/**
+ * The timestamp to bench a profile until, given its usage windows.
+ *
+ * Prefers the LONGEST exhausted account-wide window: a profile inside its
+ * weekly cap stays unusable even once the five-hour window rolls over, so
+ * benching only to the five-hour reset would resume probing a still-capped
+ * account. Falls back to `now + defaultMs` when nothing is exhausted, which
+ * keeps the conservative self-healing default for a mis-mark.
+ *
+ * Pure. Never returns a time in the past.
+ */
+export function resolveCooldownUntil(
+  windows: readonly CooldownWindow[],
+  now: number,
+  defaultMs: number,
+): number {
+  for (const type of COOLDOWN_WINDOWS) {
+    const match = windows.find(w => w.type === type && w.exhausted && (w.resetsAt ?? 0) > now)
+    if (match?.resetsAt) {
+      return Math.min(match.resetsAt, now + cooldownCapMs(type))
+    }
+  }
+  return now + defaultMs
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -80,7 +80,7 @@ import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
-import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore } from "./routing"
+import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
@@ -490,8 +490,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   const priorityExhaustion = new ProfileExhaustion()
   const PRIORITY_ASSIGNMENTS_MAX = 5000
   const priorityAssignments = new AssignmentStore(PRIORITY_ASSIGNMENTS_MAX)
+  // The per-window reset cap lives in routing.ts (cooldownCapMs): a single
+  // constant here is what let a 6-hour bound flatten a weekly reset (#790).
   const PRIORITY_DEFAULT_COOLDOWN_MS = 10 * 60_000
-  const PRIORITY_COOLDOWN_CAP_MS = 6 * 60 * 60_000
 
   function priorityProfileOrderSetting(): string[] | undefined {
     const env = process.env.MERIDIAN_PROFILE_ORDER
@@ -514,11 +515,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
    *  the conservative default so tier 2 isn't left refining a wrong mark
    *  it has no way to challenge. */
   function priorityCooldownUntil(profileId: string, now: number): number {
-    const fiveHour = rateLimitStore.getAll(profileId)
-      .find(e => e.rateLimitType === "five_hour" && (e.resetsAt ?? 0) > now
-        && (e.status === "rejected" || (e.utilization ?? 0) >= 1))
-    const until = fiveHour?.resetsAt ?? now + PRIORITY_DEFAULT_COOLDOWN_MS
-    return Math.min(until, now + PRIORITY_COOLDOWN_CAP_MS)
+    const windows = rateLimitStore.getAll(profileId).map(e => ({
+      type: e.rateLimitType ?? "",
+      resetsAt: e.resetsAt,
+      exhausted: e.status === "rejected" || (e.utilization ?? 0) >= 1,
+    }))
+    return resolveCooldownUntil(windows, now, PRIORITY_DEFAULT_COOLDOWN_MS)
   }
 
   /** Tier 2: the authoritative per-account reset from Anthropic's usage
@@ -570,12 +572,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     void fetchOAuthUsage({ profileId, claudeConfigDir: target?.claudeConfigDir, force: true })
       .then(usage => {
         if (!usage || usage.stale) return
-        const fiveHour = usage.windows.find(w => w.type === "five_hour")
-        if (!fiveHour || (fiveHour.utilization ?? 0) < 1) return
         const now = Date.now()
-        const resetsAt = fiveHour.resetsAt
-        if (!resetsAt || resetsAt <= now) return
-        const until = Math.min(resetsAt, now + PRIORITY_COOLDOWN_CAP_MS)
+        const windows = usage.windows.map(w => ({
+          type: w.type,
+          resetsAt: w.resetsAt,
+          exhausted: (w.utilization ?? 0) >= 1,
+        }))
+        // Sentinel: resolveCooldownUntil falls back to `now + defaultMs` when
+        // nothing is exhausted. Passing 0 makes that fallback identifiable, so
+        // a snapshot showing a healthy account refines nothing and tier 3's
+        // conservative default stands — the same early-return the five-hour-only
+        // version did with its `utilization < 1` guard.
+        const until = resolveCooldownUntil(windows, now, 0)
+        if (until <= now) return
         priorityExhaustion.mark(profileId, until, "rate_limit_error")
         claudeLog("priority.cooldown_refined", { profile: profileId, until, source: "oauth_usage" })
       })


### PR DESCRIPTION
Closes #790. Follow-up to #788.

## Problem

Weekly caps classify as `rate_limit_error` and fail over correctly. But the cooldown deciding *how long* to bench the failing profile only read the `five_hour` window:

- `priorityCooldownUntil` — filtered `rateLimitType === "five_hour"`
- `refinePriorityCooldown` — `usage.windows.find(w => w.type === "five_hour")`

A weekly-exhausted profile matches neither, falls through to the 10-minute default, and gets re-probed every 10 minutes — each probe a real failing upstream request **on the request path**, so a live request pays the latency — for however many days the weekly window has left.

## The trap this had to avoid

Both tiers clamped with `Math.min(resetsAt, now + 6h)`. Simply teaching them to read the weekly reset would leave that clamp flattening "resets in three days" into "resets in six hours" — the re-probe loop survives at a slower interval. It would read as correct and pass a test using a short mocked reset.

So the cap is now **per-window**: `five_hour` keeps 6h (it cannot legitimately reset further out), `seven_day` gets 8 days (7 plus skew).

## Changes

- One shared `resolveCooldownUntil` in `routing.ts`, used by both tiers. They previously duplicated the exhaustion test — the standard way two copies drift.
- **Longest exhausted window wins.** Inside a weekly cap the account stays unusable after the five-hour window rolls over, so benching to the shorter reset resumes probing a still-capped account.
- **Per-model budgets deliberately do not bench the profile.** `seven_day_opus`, `seven_day_fable` etc. running dry doesn't make the account unusable, and sidelining a profile for days because one model ran out would be worse than this bug. They keep the 10-minute default — a known remainder, stated rather than hidden.
- `PRIORITY_COOLDOWN_CAP_MS` deleted, not left dead.

## Preserved

Presence still proves nothing — a healthy account always carries both windows with future resets, so only `status === "rejected"` / `utilization >= 1` counts. `ProfileExhaustion.mark`'s never-shorten rule (`routing.ts`, `if (existing && existing.until >= until) return`) is untouched, so a healthy weekly snapshot can't walk back a real five-hour mark.

## Testing

Eight new tests, each mutation-checked:

| Mutation | Result |
|---|---|
| One 6h cap for both windows (the trap) | **3 fail** |
| Prefer `five_hour` over `seven_day` | **1 fail** |
| Ignore the `exhausted` flag | **1 fail** |

Full suite: **2557 pass, 0 fail.**

Verified against a real account, which showed `seven_day` at 83% utilization with a reset ~1 day out and a scoped `seven_day_fable` window alongside it — the exact shape this handles.