### PR TITLE
feat(health): /livez and /readyz, because /health answers neither question

### DIFF
--- a/src/__tests__/probes-unit.test.ts
+++ b/src/__tests__/probes-unit.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the liveness/readiness probes.
+ *
+ * The decision logic is pure so every branch is provable without an HTTP
+ * server, a subprocess or a credential file - which is the same reason the
+ * probes themselves touch none of those at request time.
+ */
+
+import { describe, expect, test } from "bun:test"
+import { livenessReport, readinessReport, renderProbe } from "../proxy/probes"
+
+const READY = { profileCount: 3, claudeExecutableResolved: true }
+
+describe("livenessReport", () => {
+  test("passes", () => {
+    expect(livenessReport().ok).toBe(true)
+  })
+
+  // Pinned deliberately: the value of a liveness probe is everything it does
+  // NOT depend on. A check added here is a way for a working process to be
+  // killed over somebody else's outage, so growing this list is the
+  // regression, not a feature.
+  test("has no checks at all, which is the design", () => {
+    expect(livenessReport().checks).toEqual([])
+  })
+})
+
+describe("readinessReport", () => {
+  test("is ready with profiles and a resolved executable", () => {
+    const report = readinessReport(READY)
+    expect(report.ok).toBe(true)
+    expect(report.checks.every(c => c.ok)).toBe(true)
+  })
+
+  // MERIDIAN_CONFIG_DIR relocates the whole config directory, so an instance
+  // pointed at an empty one has no accounts while its neighbour is fine. That
+  // is exactly the per-instance failure readiness exists to route around.
+  test("is not ready with no profiles, and says which check failed", () => {
+    const report = readinessReport({ ...READY, profileCount: 0 })
+    expect(report.ok).toBe(false)
+    const failed = report.checks.find(c => c.name === "profiles")
+    expect(failed?.ok).toBe(false)
+    expect(failed?.detail).toContain("no profiles configured")
+  })
+
+  test("is not ready with no Claude executable, and names the fix", () => {
+    const report = readinessReport({ ...READY, claudeExecutableResolved: false })
+    expect(report.ok).toBe(false)
+    expect(report.checks.find(c => c.name === "claude-executable")?.detail).toContain("MERIDIAN_CLAUDE_PATH")
+  })
+
+  test("reports both failures rather than stopping at the first", () => {
+    const report = readinessReport({ profileCount: 0, claudeExecutableResolved: false })
+    expect(report.checks.filter(c => !c.ok).map(c => c.name)).toEqual(["profiles", "claude-executable"])
+  })
+
+  // A passing check carries no detail: the string exists to explain a failure,
+  // and "ok" repeated per check is noise in the surface a load balancer polls.
+  test("a passing check has no detail", () => {
+    expect(readinessReport(READY).checks.every(c => c.detail === undefined)).toBe(true)
+  })
+})
+
+describe("renderProbe", () => {
+  test("the terse pass is two bytes, because it is polled every few seconds", () => {
+    expect(renderProbe("readyz", readinessReport(READY), false)).toBe("ok\n")
+  })
+
+  // Even without ?verbose, a failure names what failed - a 503 nobody can
+  // explain is a 503 somebody switches off.
+  test("the terse failure names the failing check and omits the passing one", () => {
+    const out = renderProbe("readyz", readinessReport({ ...READY, profileCount: 0 }), false)
+    expect(out).toContain("[-]profiles failed: no profiles configured")
+    expect(out).not.toContain("claude-executable")
+    expect(out.trimEnd().endsWith("readyz check failed")).toBe(true)
+  })
+
+  test("verbose lists every check and the verdict", () => {
+    const out = renderProbe("readyz", readinessReport(READY), true)
+    expect(out).toBe("[+]profiles ok\n[+]claude-executable ok\nreadyz check passed\n")
+  })
+
+  test("verbose names the kind it was asked about", () => {
+    expect(renderProbe("livez", livenessReport(), true)).toBe("livez check passed\n")
+  })
+
+  test("every rendering ends with a newline, so curl output is not glued to a prompt", () => {
+    for (const verbose of [true, false]) {
+      for (const report of [livenessReport(), readinessReport(READY), readinessReport({ profileCount: 0, claudeExecutableResolved: false })]) {
+        expect(renderProbe("readyz", report, verbose).endsWith("\n")).toBe(true)
+      }
+    }
+  })
+})

--- a/src/__tests__/proxy-settings-auth.test.ts
+++ b/src/__tests__/proxy-settings-auth.test.ts
@@ -91,10 +91,23 @@ describe("MERIDIAN_API_KEY — /settings/api/* (regression for #477)", () => {
 // Audit: any sensitive route added in the future must go through requireAuth.
 // ---------------------------------------------------------------------------
 describe("auth audit: every registered prefix is protected when MERIDIAN_API_KEY is set", () => {
-  // Routes that are *intentionally* public. Both serve read-only,
-  // non-sensitive content (landing page; auth status). If you're adding to
-  // this list, that's a security review. When in doubt, gate it.
-  const PUBLIC_PREFIXES = new Set(["/", "/health"])
+  // Routes that are *intentionally* public. They serve read-only,
+  // non-sensitive content (landing page; auth status; the two probes). If
+  // you're adding to this list, that's a security review. When in doubt, gate
+  // it.
+  //
+  // The review for `/livez` and `/readyz`, since this list is where it belongs:
+  //
+  //   what they emit  `ok`, or a check NAME and pass/fail per check. No
+  //                   account, no email, no token, no profile id - strictly
+  //                   less than `/health` beside them, which answers with the
+  //                   signed-in email and subscription type to anyone.
+  //   why not gated   a 401 is what a load balancer reads as "this backend is
+  //                   down". Gating these would make every instance look
+  //                   unhealthy the moment MERIDIAN_API_KEY is set, so an auth
+  //                   setting would become a total outage of whatever sits in
+  //                   front - the failure this pair exists to prevent.
+  const PUBLIC_PREFIXES = new Set(["/", "/health", "/livez", "/readyz"])
 
   it("rejects unauthenticated requests to every non-public route prefix", async () => {
     const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })

--- a/src/proxy/probes.ts
+++ b/src/proxy/probes.ts
@@ -1,0 +1,118 @@
+/**
+ * Liveness and readiness as two DIFFERENT questions, because the existing
+ * `/health` answers a third one and is wrong when used as either.
+ *
+ * `/health` verifies the ACTIVE profile's auth: it spawns `claude auth status`
+ * and returns 503 when that profile is logged out. As a liveness probe that is
+ * a restart loop waiting to happen - a logged-out account is not fixed by
+ * killing the process, and a supervisor pointed at it will keep killing a
+ * perfectly healthy proxy until somebody re-authenticates. As a readiness probe
+ * it is wrong in the other direction: it inspects one profile out of however
+ * many are configured, and its own catch-all answers `degraded` with status
+ * **200**, so an instance that cannot verify auth at all reads as ready.
+ *
+ * So:
+ *
+ *   /livez   is this PROCESS still turning - would a restart help?
+ *   /readyz  should traffic be sent to THIS instance rather than another?
+ *
+ * Named after kube-apiserver's own endpoints, and shaped like them - plain
+ * text `ok`, with `?verbose` listing every check - so a Kubernetes probe, a
+ * Caddy `health_uri` and a person with curl all read the same thing.
+ */
+
+export type ProbeKind = "livez" | "readyz"
+
+export interface ProbeCheck {
+  readonly name: string
+  readonly ok: boolean
+  /** Why it failed. Absent when it passed. */
+  readonly detail?: string
+}
+
+export interface ProbeReport {
+  readonly ok: boolean
+  readonly checks: readonly ProbeCheck[]
+}
+
+/**
+ * Liveness passes unconditionally, and that is the design rather than a stub.
+ *
+ * Reaching this function at all means the event loop is turning and the HTTP
+ * server is answering, which is the entire question. Every dependency added
+ * here - a subprocess, a credential file, a reachable upstream - is another
+ * way for this process to be killed over somebody else's outage, and a
+ * liveness probe that restarts a working process is strictly worse than no
+ * liveness probe at all.
+ */
+export function livenessReport(): ProbeReport {
+  return { ok: true, checks: [] }
+}
+
+export interface ReadinessInput {
+  /** Profiles this instance would actually serve from. */
+  readonly profileCount: number
+  /** Whether a Claude executable resolves for this instance. */
+  readonly claudeExecutableResolved: boolean
+}
+
+/**
+ * Readiness admits only checks that are PER-INSTANCE.
+ *
+ * The point of readiness is to move traffic somewhere better, so a check that
+ * two instances fail together cannot move it anywhere - it can only take every
+ * instance out at once and turn a clear error into a 502. That is why the
+ * credentials are deliberately not checked here even though a proxy with no
+ * usable token serves nothing: instances share those files, so an outage of
+ * them is not a reason to prefer one instance over another, and the honest
+ * answer to the caller is the provider's own 401 rather than a gateway error.
+ *
+ * What remains is genuinely local to one process:
+ *
+ *   profiles           an instance whose configuration and whose
+ *                      `profiles.json` are both empty has no account to serve
+ *                      from, while a neighbour reading a populated one is
+ *                      fine. In a container that is entirely per-instance: the
+ *                      file lives under that container's own HOME, so a
+ *                      missing mount takes exactly one replica out.
+ *   claude-executable  resolved from `MERIDIAN_CLAUDE_PATH`, this install's
+ *                      own `node_modules`, or its platform package - all
+ *                      per-instance, and without one no request can be served
+ *                      (#478).
+ */
+export function readinessReport(input: ReadinessInput): ProbeReport {
+  const checks: ProbeCheck[] = [
+    {
+      name: "profiles",
+      ok: input.profileCount > 0,
+      ...(input.profileCount > 0 ? {} : { detail: "no profiles configured" }),
+    },
+    {
+      name: "claude-executable",
+      ok: input.claudeExecutableResolved,
+      ...(input.claudeExecutableResolved
+        ? {}
+        : { detail: "no Claude executable resolved (set MERIDIAN_CLAUDE_PATH or install @anthropic-ai/claude-code)" }),
+    },
+  ]
+  return { ok: checks.every(c => c.ok), checks }
+}
+
+/**
+ * kube-apiserver's own output shape: `[+]name ok` per check, a verdict line,
+ * and a bare `ok` when everything passed and nobody asked for detail.
+ *
+ * The terse form is the one a load balancer polls every few seconds, so it
+ * stays two bytes; the failing form names the checks that failed even without
+ * `?verbose`, because a 503 nobody can explain is a 503 somebody disables.
+ */
+export function renderProbe(kind: ProbeKind, report: ProbeReport, verbose: boolean): string {
+  const line = (c: ProbeCheck) => (c.ok ? `[+]${c.name} ok` : `[-]${c.name} failed: ${c.detail ?? "unknown"}`)
+  if (!verbose) {
+    if (report.ok) return "ok\n"
+    return `${report.checks.filter(c => !c.ok).map(line).join("\n")}\n${kind} check failed\n`
+  }
+  const lines = report.checks.map(line)
+  lines.push(`${kind} check ${report.ok ? "passed" : "failed"}`)
+  return `${lines.join("\n")}\n`
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -65,7 +65,8 @@ import {
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveClaudeExecutableSync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
+import { livenessReport, readinessReport, renderProbe } from "./probes"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
@@ -4670,6 +4671,33 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return c.body(body, 200, {
       "Content-Type": "text/plain; version=0.0.4; charset=utf-8",
     })
+  })
+
+  // Liveness — would restarting this process help? Answered without touching
+  // anything: no subprocess, no credential read, no upstream. /health is NOT
+  // this, and pointing a supervisor at it is a restart loop, because it 503s
+  // when the active profile is logged out and no restart re-authenticates an
+  // account. See ./probes.ts.
+  app.get("/livez", (c) => {
+    return c.text(renderProbe("livez", livenessReport(), c.req.query("verbose") !== undefined), 200)
+  })
+
+  // Readiness — should traffic come HERE rather than to another instance? Only
+  // per-instance checks earn a place; one that every instance fails together
+  // cannot move traffic anywhere and only turns a clear error into a 502.
+  app.get("/readyz", (c) => {
+    const report = readinessReport({
+      profileCount: listProfiles(finalConfig.profiles, finalConfig.defaultProfile).length,
+      // Cached answer first, so the steady state costs nothing; the sync
+      // lookup runs only before the first SDK call has populated that cache,
+      // where the alternative is reporting a freshly started instance unready.
+      claudeExecutableResolved:
+        (getResolvedClaudeExecutableInfo() ?? resolveClaudeExecutableSync()) !== null,
+    })
+    return c.text(
+      renderProbe("readyz", report, c.req.query("verbose") !== undefined),
+      report.ok ? 200 : 503,
+    )
   })
 
   // Health check endpoint — verifies auth status


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

`/health` is the only health surface Meridian has, and it answers a question
that is neither of the two an orchestrator asks.

**As a liveness probe it is a restart loop waiting to happen.** It verifies the
*active profile's* auth and returns 503 when that profile is logged out. No
number of restarts re-authenticates an account, so a supervisor pointed at it
kills a perfectly healthy proxy over and over until a human runs `claude login`.

**As a readiness probe it fails in the other direction.** It inspects one
profile out of however many are configured, and its own catch-all returns
`degraded` with status **200** - so an instance that cannot verify auth *at
all* reads as ready.

This adds the two endpoints that answer the two questions, named and shaped
after kube-apiserver's own so a Kubernetes probe, a Caddy `health_uri` and a
person with `curl` all read the same thing:

| | question | checks |
|---|---|---|
| `GET /livez` | is this PROCESS turning - would a restart help? | none |
| `GET /readyz` | should traffic come to THIS instance rather than another? | `profiles`, `claude-executable` |

```
$ curl -s localhost:3456/readyz
ok

$ curl -s 'localhost:3456/readyz?verbose'
[+]profiles ok
[+]claude-executable ok
readyz check passed

$ curl -s localhost:3456/readyz          # an instance with no profiles.json
[-]profiles failed: no profiles configured
readyz check failed
```

## Liveness passes unconditionally, and that is the design

Reaching the handler at all means the event loop is turning and the HTTP server
is answering, which is the entire question. Every dependency added there - a
subprocess, a credential read, a reachable upstream - is another way for this
process to be killed over somebody else's outage, and a liveness probe that
restarts a working process is strictly worse than no liveness probe at all.

## Readiness admits only PER-INSTANCE checks

The point of readiness is to move traffic somewhere better, so a check that two
instances fail *together* cannot move it anywhere - it can only take every
instance out at once and turn a clear error into a 502.

That rule is why the credentials are deliberately **not** checked here, even
though a proxy with no usable token serves nothing: instances share those files,
so their loss is no reason to prefer one instance over another, and the honest
answer to the caller is the provider's own 401 rather than a gateway error.

What is left is genuinely local to one process:

- **`profiles`** - an instance whose config and whose `profiles.json` are both
  empty has no account to serve from while a neighbour reading a populated one
  is fine. In a container that is entirely per-instance: the file is under that
  container's own `HOME`, so a missing mount takes exactly one replica out.
- **`claude-executable`** - resolved from `MERIDIAN_CLAUDE_PATH`, this install's
  own `node_modules`, or its platform package, all per-instance, and without one
  no request can be served (#478). The cached answer is used first so the steady
  state costs nothing; the sync lookup runs only before the first SDK call has
  populated that cache, where the alternative is reporting a freshly started
  instance unready.

## Both are public, on purpose

They emit `ok`, or a check *name* and pass/fail - no account, no email, no
token, no profile id. That is strictly less than `/health` beside them already
gives any unauthenticated caller, which answers with the signed-in email and
subscription type.

Gating them would be worse than useless: a 401 is what a load balancer reads as
"this backend is down", so setting `MERIDIAN_API_KEY` would make every instance
look unhealthy at once and take down whatever sits in front - the exact failure
this pair exists to prevent. The auth-audit test added in #477 caught the new
routes immediately, which is the test doing its job; its allowlist now carries
that review beside the entry rather than in a commit message nobody will find.

## Measured, not only unit-tested

Against a real instance on a spare port:

- with no `profiles.json` reachable at all, `/readyz` answered **503** naming
  the failed check while `/health` answered **200**;
- with the real config, both answered 200 and `?verbose` listed both checks;
- a probe costs **5ms** end to end, including `curl`'s own startup.

## Tests

12 new unit tests covering every branch of the decision logic and the render
shape, including the two that matter most: liveness passing with no checks at
all, and the terse failing form still naming the failed check, because a 503
nobody can explain is a 503 somebody disables.

`tsc --noEmit` clean. Full suite run on this branch and on `main`, failure sets
compared with `comm` in both directions rather than by count: **identical**
(102 pre-existing failures either side, none introduced, none fixed).

## Where this is used

Behind a Caddy `reverse_proxy` with two Meridian instances and
`lb_policy first`, `/readyz` is what decides which one serves. Verified by
stopping the primary: the vhost kept answering 200, served by the standby, and
returned to the primary by itself when it came back.

This PR is AI generated, but under direct supervision and on request of Nowaker.
