### PR TITLE
fix: coordinate SDK/session concurrency and add graceful shutdown

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,8 @@ Agent (OpenCode) ◄── SSE Response ◄────────────�
 src/
 ├── proxy/
 │   ├── server.ts              ← HTTP layer: routes, SSE streaming, concurrency, request orchestration
+│   ├── concurrency.ts         ← Abortable SDK query semaphore and concurrency config parsing
+│   ├── shutdown.ts            ← Bounded HTTP drain and connection tracking
 │   ├── adapter.ts             ← AgentAdapter interface (extensibility point for multi-agent support)
 │   ├── adapters/
 │   │   ├── opencode.ts        ← OpenCode adapter (session headers, CWD extraction, tool config)
@@ -51,7 +53,8 @@ src/
 │   │   ├── index.ts           ← Barrel export
 │   │   ├── lineage.ts         ← Pure functions: hashing, lineage verification
 │   │   ├── fingerprint.ts     ← Conversation fingerprinting, client CWD extraction
-│   │   └── cache.ts           ← LRU session caches, lookup/store operations
+│   │   ├── cache.ts           ← LRU session caches, lookup/store operations
+│   │   └── turnCoordinator.ts ← Process-wide strict serialization for reliable session IDs
 │   ├── sessionStore.ts        ← Shared file store (cross-proxy session resume)
 │   ├── profiles.ts            ← Multi-profile support: resolve, list, switch auth contexts (leaf)
 │   ├── profileCli.ts          ← CLI commands for profile management (leaf, I/O)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ OpenCode-specific behavior is documented in `ARCHITECTURE.md` under "Agent-Speci
 
 ```
 server.ts          → HTTP routes, SSE streaming, concurrency (orchestration only)
+concurrency.ts     → Abortable SDK query semaphore, max-concurrency config
+shutdown.ts        → Bounded HTTP drain, socket tracking, forced close
 adapter.ts         → AgentAdapter interface (extensibility point)
 adapters/
   opencode.ts      → OpenCode-specific: headers, CWD, tool config
@@ -73,6 +75,7 @@ session/
   lineage.ts       → Hashing, lineage verification (PURE — no I/O)
   fingerprint.ts   → extractClientCwd, getConversationFingerprint
   cache.ts         → LRU caches, lookupSession, storeSession (stateful)
+  turnCoordinator.ts → Process-wide strict serialization for reliable session IDs
 ```
 
 ## Stable API Contract
@@ -90,7 +93,6 @@ External plugins depend on these interfaces. **Do not change without project own
 | `POST /v1/messages` request/response format | `server.ts` | All agents (Anthropic API contract) |
 | `GET /profiles/list` response shape | `server.ts` | Profile management UI and CLI |
 | `POST /profiles/active` request/response | `server.ts` | Profile switching from CLI and UI |
-
 If you need to modify any of these, open an issue first — breaking changes affect downstream plugin authors.
 
 ## Git & Workflow

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -212,6 +212,26 @@ export async function runCli(
       process.exit(1)
     }
   })
+
+  // Graceful shutdown: close() itself drains in-flight requests (bounded by
+  // MERIDIAN_SHUTDOWN_GRACE_MS) before releasing the port — see close() in
+  // startProxyServer. This handler just owns the process-exit decision, since
+  // only the CLI (not a library consumer embedding startProxyServer) should
+  // ever call process.exit() on a signal.
+  let shuttingDown = false
+  const handleShutdownSignal = (signal: NodeJS.Signals) => {
+    if (shuttingDown) return
+    shuttingDown = true
+    console.log(`\n[meridian] Received ${signal}, shutting down gracefully...`)
+    proxy.close()
+      .then(() => process.exit(0))
+      .catch((err) => {
+        console.error(`[meridian] Error during shutdown: ${err instanceof Error ? err.message : err}`)
+        process.exit(1)
+      })
+  }
+  process.on("SIGTERM", handleShutdownSignal)
+  process.on("SIGINT", handleShutdownSignal)
 }
 
 if (import.meta.main) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,11 +12,13 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_PORT` | `CLAUDE_PROXY_PORT` | `3456` | Port to listen on |
 | `MERIDIAN_HOST` | `CLAUDE_PROXY_HOST` | `127.0.0.1` | Host to bind to |
 | `MERIDIAN_PASSTHROUGH` | `CLAUDE_PROXY_PASSTHROUGH` | unset | Forward tool calls to client instead of executing |
-| `MERIDIAN_MAX_CONCURRENT` | `CLAUDE_PROXY_MAX_CONCURRENT` | `10` | Maximum concurrent SDK sessions |
+| `MERIDIAN_MAX_CONCURRENT` | `CLAUDE_PROXY_MAX_CONCURRENT` | `10` | Maximum SDK queries running concurrently within one Meridian process |
 | `MERIDIAN_MAX_SESSIONS` | `CLAUDE_PROXY_MAX_SESSIONS` | `1000` | In-memory LRU session cache size |
 | `MERIDIAN_MAX_STORED_SESSIONS` | `CLAUDE_PROXY_MAX_STORED_SESSIONS` | `10000` | File-based session store capacity |
 | `MERIDIAN_WORKDIR` | `CLAUDE_PROXY_WORKDIR` | `cwd()` | Default working directory for SDK |
 | `MERIDIAN_IDLE_TIMEOUT_SECONDS` | `CLAUDE_PROXY_IDLE_TIMEOUT_SECONDS` | `120` | HTTP keep-alive timeout |
+| `MERIDIAN_SHUTDOWN_GRACE_MS` | `CLAUDE_PROXY_SHUTDOWN_GRACE_MS` | `30000` | Milliseconds `close()` waits for in-flight `/v1/messages` requests to finish after it stops admitting new ones, before closing the port. See [Graceful shutdown](#graceful-shutdown). |
+| `MERIDIAN_SESSION_TURN_MAX_HOLD_MS` | `CLAUDE_PROXY_SESSION_TURN_MAX_HOLD_MS` | `600000` | Hard ceiling on how long one turn may hold its session's serialization lease. On timeout the lease is force-released with a warning and queued turns for that session proceed concurrently. See [Concurrent requests to the same session](#concurrent-requests-to-the-same-session). |
 | `MERIDIAN_TELEMETRY_SIZE` | `CLAUDE_PROXY_TELEMETRY_SIZE` | `1000` | Telemetry ring buffer size |
 | `MERIDIAN_NO_FILE_CHANGES` | `CLAUDE_PROXY_NO_FILE_CHANGES` | unset | Disable "Files changed" summary in responses |
 | `MERIDIAN_STRIP_THINKING` | `CLAUDE_PROXY_STRIP_THINKING` | unset | Set to `1` to strip raw `<thinking>` tags from user-authored prompt text. Off by default — `<thinking>` is a common chain-of-thought convention in hand-written prompts (#720); enable only if your harness is observed leaking it verbatim. |
@@ -120,6 +122,105 @@ Health response example:
 ```
 
 `plugin.opencode` is `"configured"` when `meridian setup` has been run, `"not-configured"` otherwise.
+
+## Graceful shutdown
+
+`meridian`'s CLI entry point calls `ProxyInstance.close()` on `SIGTERM`/`SIGINT`
+before exiting. `close()` stops admitting new requests immediately, then waits
+up to `MERIDIAN_SHUTDOWN_GRACE_MS` (default 30s) for whatever is already
+in-flight to finish naturally before closing the port. Library consumers that
+already call `close()` for their own shutdown handling (see the Stable API
+Contract) get this drain behavior automatically — no code change needed.
+
+While draining:
+
+- `GET /health` returns `503` with `{ "status": "draining", ... }` immediately,
+  ahead of the usual auth-status check, so a fleet manager or load balancer
+  polling this endpoint learns to stop routing here as fast as possible.
+- New `/v1/messages` requests (and `/v1/chat/completions`, `/v1/responses`,
+  which route through the same handler) are rejected with `503` and header
+  `x-meridian-draining: 1`:
+
+  ```json
+  HTTP/1.1 503
+  x-meridian-draining: 1
+  Content-Type: application/json
+
+  {
+    "type": "error",
+    "error": {
+      "type": "overloaded_error",
+      "message": "Meridian is shutting down and is not accepting new requests. Retry against another instance."
+    }
+  }
+  ```
+
+- Requests already in flight when draining started are left to finish; the
+  port only closes once they're all done or the grace period elapses,
+  whichever comes first. If the grace period elapses first, a warning is
+  logged and any remaining HTTP connections are forcibly closed.
+
+## Concurrent requests to the same session
+
+Requests that share a reliable session identity supplied by the client
+(currently a session header) are serialized: a request queued behind another
+one for the *same* session waits for the in-flight one to finish before its
+own conversation lineage is checked. Headerless requests are not strictly
+serialized because a conversation fingerprint is not unique enough to prove
+that two requests belong to the same logical chat.
+
+If, by the time it's dequeued, the earlier request has already committed a
+new turn *in the same profile's session scope* — and the waiting request's
+message history is no longer a valid continuation or compaction of that new
+state — Meridian returns:
+
+```json
+HTTP/1.1 400
+Content-Type: application/json
+
+{
+  "type": "error",
+  "error": {
+    "type": "invalid_request_error",
+    "message": "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
+  }
+}
+```
+
+The response uses the Anthropic-compatible `400 invalid_request_error`
+contract. Gateways and adapters should treat the message as a stale-session
+signal, not as account exhaustion:
+
+- **Do not treat it like `429 rate_limit_error`.** It never means the
+  account/profile is exhausted — the account is healthy, two requests just
+  raced for the same session. Failing over to a different account or profile
+  does not fix it and wastes a hop.
+- **Do not blindly retry the identical request body.** The message history
+  it was sent with is the thing that's stale; resending the same bytes will
+  usually just be reclassified as a fresh/diverged session on retry (a full
+  replay) rather than conflict again. Re-fetch the conversation's current
+  state from your own source of truth before resubmitting, or route the
+  follow-up to a distinct session ID if the two requests represent genuinely
+  independent turns.
+
+This only fires for requests that share a reliable session identity —
+unrelated and headerless sessions are never strictly serialized against each
+other and never see this concurrency error. Three further exemptions:
+
+- **Scoped per profile.** One session id backs an independent conversation
+  per profile, each with its own resume cache. Turns under different profiles
+  still serialize against each other (they share one id), but a commit under
+  one profile never refuses a queued turn from another.
+- **Declared concurrent flows are never refused.** A request whose
+  `x-meridian-source` starts with `fork-` or `subagent-` has told Meridian it
+  is knowingly running a parallel turn under a shared session key. Those
+  turns are still serialized, but a stale lineage costs them a replay rather
+  than a `400` — the behavior they had before serialization existed.
+- **The lease cannot wedge a session forever.** A turn holds its session's
+  serialization lease until its response body completes. If that never
+  happens, the lease is force-released after
+  `MERIDIAN_SESSION_TURN_MAX_HOLD_MS` (default 10 minutes) with a logged
+  warning, and queued turns for that session proceed concurrently.
 
 ## API Key Authentication
 

--- a/src/__tests__/concurrency.test.ts
+++ b/src/__tests__/concurrency.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import {
+  AbortableSemaphore,
+  getProcessSdkSemaphore,
+  resetProcessSdkSemaphoreForTests,
+  resolveMaxConcurrent,
+} from "../proxy/concurrency"
+
+describe("AbortableSemaphore", () => {
+  test("limits active leases and grants queued waiters FIFO", async () => {
+    const semaphore = new AbortableSemaphore(1)
+    const first = await semaphore.acquire()
+    const order: number[] = []
+    const secondP = semaphore.acquire().then(lease => { order.push(2); return lease })
+    const thirdP = semaphore.acquire().then(lease => { order.push(3); return lease })
+
+    expect(semaphore.snapshot).toEqual({ active: 1, queued: 2, limit: 1 })
+    first.release()
+    const second = await secondP
+    expect(order).toEqual([2])
+    second.release()
+    const third = await thirdP
+    expect(order).toEqual([2, 3])
+    third.release()
+    expect(semaphore.snapshot).toEqual({ active: 0, queued: 0, limit: 1 })
+  })
+
+  test("removes an aborted waiter without consuming capacity", async () => {
+    const semaphore = new AbortableSemaphore(1)
+    const first = await semaphore.acquire()
+    const controller = new AbortController()
+    const cancelled = semaphore.acquire(controller.signal)
+    const next = semaphore.acquire()
+    controller.abort("gone")
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" })
+    expect(semaphore.snapshot.queued).toBe(1)
+    first.release()
+    const lease = await next
+    expect(semaphore.snapshot.active).toBe(1)
+    lease.release()
+  })
+
+  test("release is idempotent", async () => {
+    const semaphore = new AbortableSemaphore(1)
+    const lease = await semaphore.acquire()
+    lease.release()
+    lease.release()
+    expect(semaphore.snapshot.active).toBe(0)
+  })
+})
+
+describe("resolveMaxConcurrent", () => {
+  const original = { ...process.env }
+  afterEach(() => {
+    process.env = { ...original }
+    resetProcessSdkSemaphoreForTests()
+  })
+
+  test("accepts primary and legacy positive integer values", () => {
+    expect(resolveMaxConcurrent({ MERIDIAN_MAX_CONCURRENT: "3" }, () => {})).toBe(3)
+    expect(resolveMaxConcurrent({ CLAUDE_PROXY_MAX_CONCURRENT: "4" }, () => {})).toBe(4)
+  })
+
+  test("uses the documented default silently when unset", () => {
+    const warnings: string[] = []
+    expect(resolveMaxConcurrent({}, message => warnings.push(message))).toBe(10)
+    expect(warnings).toEqual([])
+  })
+
+  test("falls back and warns at most once for invalid values", () => {
+    const warnings: string[] = []
+    expect(resolveMaxConcurrent({ MERIDIAN_MAX_CONCURRENT: "1.5" }, message => warnings.push(message))).toBe(10)
+    expect(resolveMaxConcurrent({ MERIDIAN_MAX_CONCURRENT: "0" }, message => warnings.push(message))).toBe(10)
+    expect(warnings).toHaveLength(1)
+  })
+})
+
+describe("getProcessSdkSemaphore", () => {
+  const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
+
+  afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    if (originalMax === undefined) delete process.env.MERIDIAN_MAX_CONCURRENT
+    else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
+  })
+
+  test("shares one semaphore across callers in the same process", () => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "3"
+    const first = getProcessSdkSemaphore()
+    const second = getProcessSdkSemaphore()
+    expect(second).toBe(first)
+    expect(first.limit).toBe(3)
+  })
+})

--- a/src/__tests__/graceful-shutdown.test.ts
+++ b/src/__tests__/graceful-shutdown.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test"
+import type { AddressInfo } from "node:net"
+import {
+  assistantMessage,
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+interface AttemptControl {
+  release: () => void
+  started: Promise<void>
+}
+
+let controls: AttemptControl[] = []
+let queryCalls = 0
+
+function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
+  let release = () => {}
+  let markStarted = () => {}
+  const wait = new Promise<void>(resolve => { release = resolve })
+  const started = new Promise<void>(resolve => { markStarted = resolve })
+  return { release, started, wait, markStarted }
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: () => {
+    queryCalls++
+    const control = deferredAttempt()
+    controls.push(control)
+    const sessionId = `sdk-drain-${queryCalls}`
+    const generator = (async function* () {
+      control.markStarted()
+      yield { ...messageStart(), session_id: sessionId }
+      await control.wait
+      yield { ...textBlockStart(0), session_id: sessionId }
+      yield { ...textDelta(0, "ok"), session_id: sessionId }
+      yield { ...blockStop(0), session_id: sessionId }
+      yield { ...messageDelta("end_turn"), session_id: sessionId }
+      yield { ...messageStop(), session_id: sessionId }
+      yield { ...assistantMessage([{ type: "text", text: "ok" }]), session_id: sessionId }
+    })()
+    return Object.assign(generator, { close: () => {} })
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, startProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function request(
+  sessionId: string,
+  stream = true,
+  messages: Array<{ role: string; content: string }> = [{ role: "user", content: "hi" }],
+): Request {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-opencode-session": sessionId },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      stream,
+      messages,
+    }),
+  })
+}
+
+/** Same request over a real socket, for the end-to-end `close()` drain test. */
+function post(base: string, sessionId: string, stream = true): Promise<Response> {
+  return fetch(`${base}/v1/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-opencode-session": sessionId },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      stream,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  })
+}
+
+async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptControl> {
+  const deadline = Date.now() + timeoutMs
+  while (!controls[index]) {
+    // A refused request never reaches the SDK, so without this the assertion
+    // "it was admitted" would surface as an opaque test-runner timeout.
+    if (Date.now() > deadline) throw new Error(`SDK attempt #${index} never started`)
+    await Bun.sleep(1)
+  }
+  const control = controls[index]!
+  await control.started
+  return control
+}
+
+describe("graceful shutdown", () => {
+  beforeEach(() => {
+    queryCalls = 0
+    controls = []
+    clearSessionCache()
+  })
+
+  it("exposes beginDrain and getInFlightCount, starting undrained with no in-flight requests", () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    expect(typeof server.beginDrain).toBe("function")
+    expect(typeof server.getInFlightCount).toBe("function")
+    expect(server.getInFlightCount!()).toBe(0)
+  })
+
+  it("/health reports 503 draining once beginDrain is called", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    server.beginDrain!()
+    const response = await server.app.fetch(new Request("http://localhost/health"))
+    expect(response.status).toBe(503)
+    const body = await response.json() as Record<string, unknown>
+    expect(body.status).toBe("draining")
+    expect(typeof body.version === "string" || body.version === undefined).toBe(true)
+  })
+
+  it("rejects new /v1/messages requests with 503 once draining, without invoking the SDK", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    server.beginDrain!()
+    const response = await server.app.fetch(request("drain-reject"))
+    expect(response.status).toBe(503)
+    expect(response.headers.get("x-meridian-draining")).toBe("1")
+    expect(await response.json()).toEqual({
+      type: "error",
+      error: {
+        type: "overloaded_error",
+        message: "Meridian is shutting down and is not accepting new requests. Retry against another instance.",
+      },
+    })
+    expect(queryCalls).toBe(0)
+  })
+
+  it("lets a request admitted before draining finish, and drops getInFlightCount back to 0", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    const responseP = server.app.fetch(request("drain-inflight"))
+    const control = await waitForControl(0)
+
+    await Bun.sleep(10)
+    expect(server.getInFlightCount!()).toBe(1)
+
+    server.beginDrain!()
+    expect(server.getInFlightCount!()).toBe(1)
+
+    control.release()
+    const response = await responseP
+    expect(response.status).toBe(200)
+    await response.text()
+    await Bun.sleep(10)
+    expect(server.getInFlightCount!()).toBe(0)
+  })
+
+  it("counts a same-session request while it waits for the active turn", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    const opening = [{ role: "user", content: "hi" }]
+    const continuation = [
+      ...opening,
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "continue" },
+    ]
+
+    const firstResponseP = server.app.fetch(request("drain-queued", true, opening))
+    const firstControl = await waitForControl(0)
+    const firstResponse = await firstResponseP
+    const secondResponseP = server.app.fetch(request("drain-queued", true, continuation))
+
+    await Bun.sleep(10)
+    expect(queryCalls).toBe(1)
+    expect(server.getInFlightCount!()).toBe(2)
+
+    firstControl.release()
+    await firstResponse.text()
+
+    const secondControl = await waitForControl(1)
+    const secondResponse = await secondResponseP
+    expect(server.getInFlightCount!()).toBe(1)
+
+    secondControl.release()
+    await secondResponse.text()
+    await Bun.sleep(10)
+    expect(server.getInFlightCount!()).toBe(0)
+  })
+
+  it("close() drains a live listener: refuses new work, waits for in-flight, frees the port", async () => {
+    // The tests above drive the Hono app directly, which cannot show that the
+    // drain gate and the socket teardown are actually wired into close() —
+    // that wiring is what every plugin's SIGTERM handler depends on.
+    const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    const base = `http://127.0.0.1:${(instance.server.address() as AddressInfo).port}`
+
+    const inFlightP = post(base, "e2e-drain")
+    const control = await waitForControl(0)
+    const inFlight = await inFlightP
+    expect(inFlight.status).toBe(200)
+
+    const closeP = instance.close()
+    let closed = false
+    void closeP.then(() => { closed = true })
+
+    // close() is idempotent: a second caller joins the same drain rather than
+    // starting a second teardown.
+    expect(instance.close()).toBe(closeP)
+
+    const health = await fetch(`${base}/health`)
+    expect(health.status).toBe(503)
+    expect((await health.json() as Record<string, unknown>).status).toBe("draining")
+
+    const refused = await post(base, "e2e-drain-refused")
+    expect(refused.status).toBe(503)
+    expect(refused.headers.get("x-meridian-draining")).toBe("1")
+    await refused.text()
+    expect(queryCalls).toBe(1)
+
+    // The listener stays up for those drain responses, so close() must still be
+    // pending — resolving here would mean cutting the in-flight stream off.
+    await Bun.sleep(20)
+    expect(closed).toBe(false)
+
+    control.release()
+    await inFlight.text()
+    await closeP
+    expect(closed).toBe(true)
+
+    let portStillAccepting = true
+    try {
+      await fetch(`${base}/health`)
+    } catch {
+      portStillAccepting = false
+    }
+    expect(portStillAccepting).toBe(false)
+  })
+})

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -73,6 +73,7 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
 const { resetActiveProfile } = await import("../proxy/profiles")
 const { __setFetchOAuthUsageOverride } = await import("../proxy/oauthUsage")
 const { rateLimitStore } = await import("../proxy/rateLimitStore")
@@ -132,6 +133,7 @@ afterEach(() => {
 
 describe("priority routing", () => {
   beforeEach(() => {
+    resetProcessSdkSemaphoreForTests()
     capturedEnvs = []
     failingDirs = new Set()
     // failureMessage resets in the file-level beforeEach, which runs first and
@@ -152,11 +154,13 @@ describe("priority routing", () => {
     // custom config dir — which is most of this project's users.
     savedEnv.CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR
     delete process.env.CLAUDE_CONFIG_DIR
+    savedEnv.MERIDIAN_MAX_CONCURRENT = process.env.MERIDIAN_MAX_CONCURRENT
     process.env.MERIDIAN_ROUTING = "priority"
     process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
   })
 
   afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
     for (const [k, v] of Object.entries(savedEnv)) {
       if (v === undefined) delete process.env[k]
       else process.env[k] = v
@@ -182,6 +186,18 @@ describe("priority routing", () => {
     expect(capturedEnvs.some((e) => e.includes("prof-work"))).toBe(true)
     expect(capturedEnvs[capturedEnvs.length - 1]).toContain("prof-personal")
   }, 20_000)
+
+  it("fails over without deadlocking when MAX_CONCURRENT is 1", async () => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "1"
+    failureMessage = SUBSCRIPTION_REFUSAL
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+
+    const res = await post(app, { "x-opencode-session": "priority-single-slot" })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
+  })
 
   it("fails over on the CLI's shorter 'You've hit your limit' wording", async () => {
     failureMessage = "Claude Code returned an error result: You've hit your limit · resets 6:40pm (UTC)"

--- a/src/__tests__/proxy-async-ops.test.ts
+++ b/src/__tests__/proxy-async-ops.test.ts
@@ -8,6 +8,10 @@ describe("proxy async ops", () => {
     const proxyA = await startProxyServer({ port: 0, host: "127.0.0.1" })
     const proxyB = await startProxyServer({ port: 0, host: "127.0.0.1" })
 
+    const firstClose = proxyA.close()
+    const repeatedClose = proxyA.close()
+    expect(repeatedClose).toBe(firstClose)
+    await Promise.all([firstClose, repeatedClose])
     await proxyA.close()
     await proxyB.close()
 

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import {
+  assistantMessage,
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+interface AttemptControl {
+  release: () => void
+  started: Promise<void>
+}
+
+let activeQueries = 0
+let maxActiveQueries = 0
+let queryCalls = 0
+let controls: AttemptControl[] = []
+let capturedParams: Array<{ options?: { resume?: string } }> = []
+
+function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
+  let release = () => {}
+  let markStarted = () => {}
+  const wait = new Promise<void>(resolve => { release = resolve })
+  const started = new Promise<void>(resolve => { markStarted = resolve })
+  return { release, started, wait, markStarted }
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { options?: { resume?: string } }) => {
+    capturedParams.push(params)
+    queryCalls++
+    const control = deferredAttempt()
+    controls.push(control)
+    const sessionId = `sdk-concurrency-${queryCalls}`
+    const generator = (async function* () {
+      activeQueries++
+      maxActiveQueries = Math.max(maxActiveQueries, activeQueries)
+      control.markStarted()
+      try {
+        yield { ...messageStart(), session_id: sessionId }
+        await control.wait
+        yield { ...textBlockStart(0), session_id: sessionId }
+        yield { ...textDelta(0, "ok"), session_id: sessionId }
+        yield { ...blockStop(0), session_id: sessionId }
+        yield { ...messageDelta("end_turn"), session_id: sessionId }
+        yield { ...messageStop(), session_id: sessionId }
+        yield { ...assistantMessage([{ type: "text", text: "ok" }]), session_id: sessionId }
+      } finally {
+        activeQueries--
+      }
+    })()
+    return Object.assign(generator, { close: () => {} })
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { telemetryStore } = await import("../telemetry")
+
+function request(
+  messages: Array<{ role: string; content: unknown }>,
+  sessionId: string,
+  stream = false,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-opencode-session": sessionId,
+      ...extraHeaders,
+    },
+    body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 128, stream, messages }),
+  })
+}
+
+async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptControl> {
+  const deadline = Date.now() + timeoutMs
+  while (!controls[index]) {
+    // A refused request never reaches the SDK, so without this the assertion
+    // "it was admitted" would surface as an opaque test-runner timeout.
+    if (Date.now() > deadline) throw new Error(`SDK attempt #${index} never started`)
+    await Bun.sleep(1)
+  }
+  const control = controls[index]!
+  await control.started
+  return control
+}
+
+describe("SDK and Session concurrency coordination", () => {
+  const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
+  const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+
+  beforeEach(() => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "1"
+    activeQueries = 0
+    maxActiveQueries = 0
+    queryCalls = 0
+    controls = []
+    capturedParams = []
+    clearSessionCache()
+    resetProcessSdkSemaphoreForTests()
+    telemetryStore.clear()
+  })
+
+  afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    if (originalMax === undefined) delete process.env.MERIDIAN_MAX_CONCURRENT
+    else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
+    if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+    else process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = originalHold
+  })
+
+  it("holds the SDK permit for the complete streaming lifecycle", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const first = await app.fetch(request([{ role: "user", content: "one" }], "stream-one", true))
+    const firstControl = await waitForControl(0)
+    const second = await app.fetch(request([{ role: "user", content: "two" }], "stream-two", true))
+
+    await Bun.sleep(10)
+    expect(queryCalls).toBe(1)
+    expect(activeQueries).toBe(1)
+
+    firstControl.release()
+    await first.text()
+    const secondControl = await waitForControl(1)
+    expect(maxActiveQueries).toBe(1)
+    secondControl.release()
+    await second.text()
+    expect(activeQueries).toBe(0)
+  })
+
+  it("shares the SDK permit across ProxyServer instances", async () => {
+    const firstApp = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const secondApp = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+
+    const first = await firstApp.fetch(request([{ role: "user", content: "one" }], "process-one", true))
+    const firstControl = await waitForControl(0)
+    const second = await secondApp.fetch(request([{ role: "user", content: "two" }], "process-two", true))
+
+    await Bun.sleep(10)
+    expect(queryCalls).toBe(1)
+    expect(activeQueries).toBe(1)
+
+    firstControl.release()
+    await first.text()
+    const secondControl = await waitForControl(1)
+    expect(maxActiveQueries).toBe(1)
+    secondControl.release()
+    await second.text()
+  })
+
+  it("uses the latest resume state for a continuation that waited", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [{ role: "user", content: "hello" }]
+    const continuation = [
+      ...opening,
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "continue" },
+    ]
+    const firstP = app.fetch(request(opening, "shared"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(continuation, "shared"))
+
+    await Bun.sleep(10)
+    expect(queryCalls).toBe(1)
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+
+    const secondControl = await waitForControl(1)
+    expect(capturedParams[1]?.options?.resume).toBe("sdk-concurrency-1")
+    secondControl.release()
+    expect((await secondP).status).toBe(200)
+  })
+
+  it("returns an Anthropic-compatible invalid request for a stale repeated branch", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const messages = [{ role: "user", content: "same request" }]
+    const firstP = app.fetch(request(messages, "conflict"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(messages, "conflict"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    const second = await secondP
+    expect(second.status).toBe(400)
+    expect(second.headers.get("x-meridian-conflict")).toBeNull()
+    expect(await second.json()).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID.",
+      },
+    })
+    expect(queryCalls).toBe(1)
+
+    // A refusal that never reaches telemetry is a refusal operators can't
+    // count, so the rate of concurrency conflicts stays invisible.
+    const conflicts = telemetryStore.getRecent().filter(m => m.error === "session_turn_conflict")
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0]!.status).toBe(400)
+    expect(conflicts[0]!.upstreamDurationMs).toBe(0)
+  })
+
+  it("does not refuse a turn because a DIFFERENT profile advanced the same session id", async () => {
+    // One client session id backs an independent conversation per profile, each
+    // with its own cache scope. A commit under "work" says nothing about the
+    // lineage a queued "personal" request carries, so it must not refuse it.
+    const app = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      silent: true,
+      profiles: [
+        { id: "work", claudeConfigDir: "/tmp/meridian-test-turn-work" },
+        { id: "personal", claudeConfigDir: "/tmp/meridian-test-turn-personal" },
+      ],
+      defaultProfile: "work",
+    }).app
+    const messages = [{ role: "user", content: "same request" }]
+    const firstP = app.fetch(request(messages, "cross-profile", false, { "x-meridian-profile": "work" }))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(messages, "cross-profile", false, { "x-meridian-profile": "personal" }))
+
+    // Still serialized — they share one client session id.
+    await Bun.sleep(10)
+    expect(queryCalls).toBe(1)
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    expect((await secondP).status).toBe(200)
+    expect(queryCalls).toBe(2)
+  })
+
+  it("lets a declared concurrent flow replay instead of refusing it", async () => {
+    // fork-/subagent- sources knowingly run parallel turns under one session
+    // key; a reclassification is their normal cost. Refusing them would break
+    // flows that worked before turn coordination existed.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const messages = [{ role: "user", content: "same request" }]
+    const firstP = app.fetch(request(messages, "declared-flow"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(
+      request(messages, "declared-flow", false, { "x-meridian-source": "subagent-scout" }),
+    )
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    expect((await secondP).status).toBe(200)
+    expect(queryCalls).toBe(2)
+  })
+
+  it("force-releases a wedged turn instead of deadlocking the session", async () => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "2"
+    process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = "50"
+    resetProcessSdkSemaphoreForTests()
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+
+    // Never released and never read: the response body stays open, so this
+    // request never finishes and would hold its lease for the lifetime of the
+    // process without the watchdog.
+    const wedged = await app.fetch(request([{ role: "user", content: "one" }], "wedged", true))
+    const wedgedControl = await waitForControl(0)
+
+    const secondP = app.fetch(request([{ role: "user", content: "two" }], "wedged", true))
+    // Only reachable once the wedged turn's lease is force-released.
+    const secondControl = await waitForControl(1)
+    expect(queryCalls).toBe(2)
+
+    secondControl.release()
+    await (await secondP).text()
+    wedgedControl.release()
+    await wedged.text()
+  })
+})

--- a/src/__tests__/proxy-request-cancellation.test.ts
+++ b/src/__tests__/proxy-request-cancellation.test.ts
@@ -108,7 +108,7 @@ describe("request cancellation propagation", () => {
     expect(capturedController).toBeDefined()
     expect(capturedController!.signal.aborted).toBe(true)
     expect(capturedController!.signal.reason).toBe("client timeout")
-    expect(response.status).toBeGreaterThanOrEqual(500)
+    expect(response.status).toBe(499)
   })
 
   it("aborts a streaming SDK query when the response body is cancelled", async () => {

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -107,7 +107,9 @@ describe("Phase 3: Concurrent request support", () => {
 
     const app = createTestApp()
 
-    // Fire two requests simultaneously (like OpenCode does with main + title gen)
+    // Fire two headerless requests simultaneously (like OpenCode does with
+    // main + title generation). A weak conversation fingerprint must not turn
+    // these independent requests into one strict session lock.
     const [r1, r2] = await Promise.all([
       postMessages(app, makeRequest({ stream: true })),
       postMessages(app, makeRequest({ stream: true })),

--- a/src/__tests__/session-turn-coordinator.test.ts
+++ b/src/__tests__/session-turn-coordinator.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test"
+import { SessionTurnCoordinator } from "../proxy/session/turnCoordinator"
+
+describe("session turn coordinator", () => {
+  test("serializes the same key but not different keys", async () => {
+    const coordinator = new SessionTurnCoordinator()
+    const first = await coordinator.acquire("id:a")
+    let sameResolved = false
+    const sameP = coordinator.acquire("id:a").then(lease => { sameResolved = true; return lease })
+    const other = await coordinator.acquire("id:b")
+    await Promise.resolve()
+    expect(sameResolved).toBe(false)
+    other.release()
+    first.release()
+    const same = await sameP
+    same.release()
+  })
+
+  test("reports advancement only after a preceding committed turn", async () => {
+    const coordinator = new SessionTurnCoordinator()
+    const first = await coordinator.acquire("id:a")
+    const secondP = coordinator.acquire("id:a")
+    // Twice on purpose: silent-turn recovery re-stores the same turn, which
+    // must count as one advancement, not two.
+    first.markCommitted("work:a")
+    first.markCommitted("work:a")
+    first.release()
+    const second = await secondP
+    expect(second.advancedWhileWaiting("work:a")).toBe(true)
+    second.release()
+
+    const failed = await coordinator.acquire("id:a")
+    const afterFailureP = coordinator.acquire("id:a")
+    failed.release()
+    const afterFailure = await afterFailureP
+    expect(afterFailure.advancedWhileWaiting("work:a")).toBe(false)
+    afterFailure.release()
+  })
+
+  test("reports advancement per scope, not across scopes", async () => {
+    // One client session id backing two profiles is two independent
+    // conversations: a commit under one must not invalidate the other.
+    const coordinator = new SessionTurnCoordinator()
+    const first = await coordinator.acquire("id:a")
+    const secondP = coordinator.acquire("id:a")
+    first.markCommitted("work:a")
+    first.release()
+
+    const second = await secondP
+    expect(second.advancedWhileWaiting("work:a")).toBe(true)
+    expect(second.advancedWhileWaiting("personal:a")).toBe(false)
+    second.release()
+  })
+
+  test("cancelled waiter does not block following waiter and state is cleaned", async () => {
+    const coordinator = new SessionTurnCoordinator()
+    const first = await coordinator.acquire("id:a")
+    const controller = new AbortController()
+    const cancelled = coordinator.acquire("id:a", controller.signal)
+    const nextP = coordinator.acquire("id:a")
+    controller.abort()
+    await expect(cancelled).rejects.toMatchObject({ name: "AbortError" })
+    first.release()
+    const next = await nextP
+    next.release()
+    expect(coordinator.size).toBe(0)
+  })
+})

--- a/src/__tests__/shutdown.test.ts
+++ b/src/__tests__/shutdown.test.ts
@@ -1,0 +1,78 @@
+import { createServer, get, type IncomingMessage, type ServerResponse } from "node:http"
+import { describe, expect, test } from "bun:test"
+import { closeServerWithGracePeriod, trackServerConnections } from "../proxy/shutdown"
+
+async function listen(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+) {
+  const server = createServer(handler)
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Expected TCP server address")
+  return { server, url: `http://127.0.0.1:${address.port}` }
+}
+
+describe("closeServerWithGracePeriod", () => {
+  test("allows an active request to finish naturally within the grace period", async () => {
+    let releaseResponse = () => {}
+    let markStarted = () => {}
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    const release = new Promise<void>((resolve) => { releaseResponse = resolve })
+    const warnings: string[] = []
+    let inFlight = 1
+    const { server, url } = await listen(async (request, response) => {
+      if (request.url === "/health") {
+        response.end("draining")
+        return
+      }
+      markStarted()
+      await release
+      inFlight = 0
+      response.end("ok")
+    })
+
+    const responseP = fetch(url)
+    await started
+    const closeP = closeServerWithGracePeriod(server, {
+      graceMs: 500,
+      getInFlightCount: () => inFlight,
+      warn: (message) => warnings.push(message),
+    })
+    expect(await (await fetch(`${url}/health`)).text()).toBe("draining")
+    releaseResponse()
+
+    await closeP
+    expect(await (await responseP).text()).toBe("ok")
+    expect(warnings).toEqual([])
+  })
+
+  test("forcibly closes a stuck connection when the grace period elapses", async () => {
+    let markStarted = () => {}
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    const warnings: string[] = []
+    const { server, url } = await listen((_request, response) => {
+      response.writeHead(200)
+      response.write("still running")
+      markStarted()
+    })
+    const connectionTracker = trackServerConnections(server)
+    const request = get(url)
+    request.on("error", () => {})
+    request.on("response", (response) => response.on("error", () => {}))
+    await started
+
+    const beganAt = Date.now()
+    await closeServerWithGracePeriod(server, {
+      graceMs: 20,
+      getInFlightCount: () => 1,
+      warn: (message) => warnings.push(message),
+      forceCloseConnections: () => connectionTracker.forceCloseAll(),
+    })
+
+    expect(Date.now() - beganAt).toBeLessThan(500)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain("forcing remaining HTTP connections closed")
+    connectionTracker.dispose()
+    request.destroy()
+  })
+})

--- a/src/__tests__/telemetry-prometheus.test.ts
+++ b/src/__tests__/telemetry-prometheus.test.ts
@@ -75,7 +75,7 @@ describe("renderPrometheusMetrics", () => {
     store.record(makeMetric())
 
     const output = renderPrometheusMetrics(store)
-    for (const phase of ["queue_wait", "proxy_overhead", "ttfb", "upstream", "total"]) {
+    for (const phase of ["queue_wait", "session_queue_wait", "sdk_queue_wait", "proxy_overhead", "ttfb", "upstream", "total"]) {
       expect(output).toContain(`phase="${phase}"`)
     }
   })

--- a/src/__tests__/telemetry-sqlite.test.ts
+++ b/src/__tests__/telemetry-sqlite.test.ts
@@ -145,6 +145,8 @@ describe("SqliteTelemetryStore", () => {
       sdkSessionId: "sess-abc",
       status: 200,
       queueWaitMs: 5,
+      sessionQueueWaitMs: 2,
+      sdkQueueWaitMs: 3,
       proxyOverheadMs: 12,
       ttfbMs: 120,
       upstreamDurationMs: 800,
@@ -175,6 +177,8 @@ describe("SqliteTelemetryStore", () => {
     expect(retrieved!.sessionDiscoveredCount).toBe(3)
     expect(retrieved!.messageCount).toBe(5)
     expect(retrieved!.sdkSessionId).toBe("sess-abc")
+    expect(retrieved!.sessionQueueWaitMs).toBe(2)
+    expect(retrieved!.sdkQueueWaitMs).toBe(3)
     expect(retrieved!.inputTokens).toBe(1200)
     expect(retrieved!.outputTokens).toBe(340)
     expect(retrieved!.cacheReadInputTokens).toBe(900)

--- a/src/proxy/concurrency.ts
+++ b/src/proxy/concurrency.ts
@@ -1,0 +1,133 @@
+export interface SemaphoreLease {
+  readonly waitedMs: number
+  release(): void
+}
+
+export interface SemaphoreSnapshot {
+  readonly active: number
+  readonly queued: number
+  readonly limit: number
+}
+
+interface Waiter {
+  readonly enqueuedAt: number
+  readonly resolve: (lease: SemaphoreLease) => void
+  readonly reject: (error: Error) => void
+  readonly signal?: AbortSignal
+  abortListener?: () => void
+}
+
+const DEFAULT_MAX_CONCURRENT = 10
+let didWarnInvalidMaxConcurrent = false
+let processSdkSemaphore: AbortableSemaphore | undefined
+
+export function requestCancelledError(reason?: unknown): Error {
+  if (reason instanceof Error) return reason
+  return new DOMException(
+    typeof reason === "string" && reason ? reason : "The request was cancelled",
+    "AbortError",
+  )
+}
+
+export function resolveMaxConcurrent(
+  source: NodeJS.ProcessEnv = process.env,
+  warn: (message: string) => void = console.warn,
+): number {
+  const raw = source.MERIDIAN_MAX_CONCURRENT ?? source.CLAUDE_PROXY_MAX_CONCURRENT
+  if (raw === undefined) return DEFAULT_MAX_CONCURRENT
+
+  if (raw && /^\d+$/.test(raw)) {
+    const parsed = Number(raw)
+    if (Number.isSafeInteger(parsed) && parsed > 0) return parsed
+  }
+
+  if (!didWarnInvalidMaxConcurrent) {
+    didWarnInvalidMaxConcurrent = true
+    warn(`[PROXY] Invalid MERIDIAN_MAX_CONCURRENT value \"${raw}\"; using default ${DEFAULT_MAX_CONCURRENT}`)
+  }
+  return DEFAULT_MAX_CONCURRENT
+}
+
+/** FIFO semaphore whose queued acquisitions can be cancelled safely. */
+export class AbortableSemaphore {
+  private activeCount = 0
+  private readonly waiters: Waiter[] = []
+
+  constructor(readonly limit: number) {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new RangeError("Semaphore limit must be a positive integer")
+    }
+  }
+
+  get snapshot(): SemaphoreSnapshot {
+    return { active: this.activeCount, queued: this.waiters.length, limit: this.limit }
+  }
+
+  acquire(signal?: AbortSignal): Promise<SemaphoreLease> {
+    if (signal?.aborted) return Promise.reject(requestCancelledError(signal.reason))
+
+    const enqueuedAt = Date.now()
+    if (this.activeCount < this.limit && this.waiters.length === 0) {
+      this.activeCount++
+      return Promise.resolve(this.createLease(enqueuedAt))
+    }
+
+    return new Promise<SemaphoreLease>((resolve, reject) => {
+      const waiter: Waiter = { enqueuedAt, resolve, reject, signal }
+      if (signal) {
+        waiter.abortListener = () => {
+          const index = this.waiters.indexOf(waiter)
+          if (index === -1) return
+          this.waiters.splice(index, 1)
+          reject(requestCancelledError(signal.reason))
+        }
+        signal.addEventListener("abort", waiter.abortListener, { once: true })
+      }
+      this.waiters.push(waiter)
+    })
+  }
+
+  private createLease(enqueuedAt: number): SemaphoreLease {
+    let released = false
+    return {
+      waitedMs: Date.now() - enqueuedAt,
+      release: () => {
+        if (released) return
+        released = true
+        this.activeCount--
+        this.grantNext()
+      },
+    }
+  }
+
+  private grantNext(): void {
+    while (this.activeCount < this.limit) {
+      const waiter = this.waiters.shift()
+      if (!waiter) return
+      if (waiter.abortListener && waiter.signal) {
+        waiter.signal.removeEventListener("abort", waiter.abortListener)
+      }
+      if (waiter.signal?.aborted) {
+        waiter.reject(requestCancelledError(waiter.signal.reason))
+        continue
+      }
+      this.activeCount++
+      waiter.resolve(this.createLease(waiter.enqueuedAt))
+    }
+  }
+}
+
+/**
+ * One SDK subprocess budget per process, shared by every ProxyServer instance.
+ * The environment is intentionally read once, when the first proxy asks for it.
+ */
+export function getProcessSdkSemaphore(): AbortableSemaphore {
+  processSdkSemaphore ??= new AbortableSemaphore(resolveMaxConcurrent())
+  return processSdkSemaphore
+}
+
+/** Reset process-scoped state between tests that override concurrency env vars. */
+export function resetProcessSdkSemaphoreForTests(): void {
+  processSdkSemaphore = undefined
+  didWarnInvalidMaxConcurrent = false
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2,7 +2,6 @@ import { Hono } from "hono"
 import { cors } from "hono/cors"
 import { stream } from "hono/streaming"
 import { serve } from "@hono/node-server"
-import { AsyncLocalStorage } from "node:async_hooks"
 import type { Server } from "node:http"
 import { homedir } from "node:os"
 import { join } from "node:path"
@@ -10,6 +9,8 @@ import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { linkRequestAbort } from "./requestAbort"
+import { AbortableSemaphore, getProcessSdkSemaphore } from "./concurrency"
+import { closeServerWithGracePeriod, trackServerConnections } from "./shutdown"
 import { fetchOAuthUsage, fetchOAuthUsageResult } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
@@ -100,6 +101,7 @@ import { getPriorityAssignmentKey } from "./session/fingerprint"
 // Re-export for backwards compatibility (existing tests import from here)
 
 import { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession, getSessionByClaudeId } from "./session/cache"
+import { processSessionTurns, type SessionTurnLease } from "./session/turnCoordinator"
 import { lookupSessionRecovery, listStoredSessions } from "./sessionStore"
 // Re-export for backwards compatibility (existing tests import from here)
 export { computeLineageHash, hashMessage, computeMessageHashes }
@@ -135,6 +137,65 @@ let claudeExecutable = ""
 // to abort the same hung model — see the coordination contract in
 // streamIdleGuard.ts.
 const UPSTREAM_IDLE_MS = envInt("UPSTREAM_IDLE_MS", 90_000)
+
+// Bounds how long ProxyInstance.close() waits for in-flight /v1/messages
+// requests to finish (after beginDrain() stops admitting new ones) before it
+// closes the HTTP server anyway. Plugins that already call close() for
+// graceful shutdown (see the Stable API Contract) get this drain for free.
+const SHUTDOWN_GRACE_MS = envInt("SHUTDOWN_GRACE_MS", 30_000)
+
+interface RequestMeta {
+  requestId: string
+  endpoint: string
+  queueEnteredAt: number
+  sessionQueueWaitMs: number
+  sdkQueueWaitMs: number
+  sdkActiveDurationMs: number
+  /** Start of the SDK attempt currently running — the TTFB anchor. */
+  currentSdkStartedAt?: number
+  /**
+   * Captured against the attempt that actually produced the first chunk, not
+   * against the request's first attempt: a fresh-replay or failover retry must
+   * not report the abandoned attempt's runtime as time-to-first-byte.
+   */
+  ttfbMs?: number
+  sessionTurnLease?: SessionTurnLease
+}
+
+interface HandleMessagesOptions {
+  body: any
+  forcedProfileId?: string
+}
+
+function totalQueueWaitMs(meta: RequestMeta): number {
+  return meta.sessionQueueWaitMs + meta.sdkQueueWaitMs
+}
+
+/**
+ * Derive an independent telemetry identity for one failover candidate.
+ *
+ * Each candidate is its own upstream attempt: sharing the caller's meta would
+ * make every attempt overwrite the previous one's telemetry row (same
+ * requestId) and inherit its accumulated SDK timings, so the surviving row
+ * would bill the winner for every account that refused first. The session-turn
+ * lease is deliberately shared by reference — the request holds exactly one
+ * turn no matter how many accounts it tries.
+ */
+function forkAttemptMeta(meta: RequestMeta, attempt: number): RequestMeta {
+  if (attempt === 0) return meta
+  return {
+    ...meta,
+    requestId: `${meta.requestId}.${attempt}`,
+    queueEnteredAt: Date.now(),
+    // The wait happened once, before the first attempt; re-reporting it on
+    // every row would multiply one queue delay across the whole failover.
+    sessionQueueWaitMs: 0,
+    sdkQueueWaitMs: 0,
+    sdkActiveDurationMs: 0,
+    currentSdkStartedAt: undefined,
+    ttfbMs: undefined,
+  }
+}
 
 function credentialStoreForProfile(profile: ResolvedProfile): CredentialStore | undefined {
   if (profile.type !== "claude-max") return undefined
@@ -411,15 +472,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // so silently-updated tool definitions force a rebuild.
   const sessionMcpCache = new LRUMap<string, { key: string; mcp: ReturnType<typeof createPassthroughMcpServer> }>(getMaxSessionsLimit())
 
-  // In-flight session stores. The streaming drain design ends the client's
-  // response at the turn boundary (fast), while deny persistence + the early
-  // stop + storeSession continue in the background for ~a second. A client
-  // that executes its tools quickly (small file reads) can send the follow-up
-  // BEFORE the store lands — its lookup misses and the conversation falls to
-  // a fresh replay. Follow-ups briefly await their session's pending store.
-  const PENDING_STORE_WAIT_MS = 3000
-  const PENDING_STORE_AUTO_RESOLVE_MS = 10000
-
   // A --resume spawned while the session's previous subprocess is still
   // exiting is refused, in two wordings: "currently running as a background
   // agent" (#630, a consequence of #628's CLAUDE_CODE_SESSION_KIND=bg) and
@@ -431,21 +483,58 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // The env name predates the wider refusal set and stays as it is: renaming it
   // would silently drop anyone's existing override.
   const RESUME_REFUSAL_RETRY_DELAY_MS = parseInt(process.env.MERIDIAN_BUSY_RETRY_DELAY_MS ?? "500", 10)
-  const pendingSessionStores = new Map<string, { promise: Promise<void>; resolve: () => void }>()
-  const registerPendingStore = (key: string): (() => void) => {
-    let resolveFn: () => void = () => {}
-    const promise = new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, PENDING_STORE_AUTO_RESOLVE_MS)
-      resolveFn = () => {
-        clearTimeout(timer)
-        resolve()
+
+  // Hard ceiling on how long one turn may hold its session lease. The lease is
+  // released when the request finishes, which for a stream means when the body
+  // completes — so any path that leaves that promise unsettled would wedge the
+  // session for the lifetime of the process. On timeout the session degrades to
+  // pre-coordination behavior (concurrent turns, possibly a replay), which is
+  // recoverable; a permanent deadlock is not. Read per instance (like the busy
+  // retry delay above) so tests don't have to wait out the real ceiling.
+  const SESSION_TURN_MAX_HOLD_MS = envInt("SESSION_TURN_MAX_HOLD_MS", 600_000)
+  // Default: share the process-wide budget, because the failure this guards
+  // against (many SDK subprocesses spawned at once) is a property of the host
+  // process, not of any one instance. `maxConcurrent` is the opt-out for
+  // embedders that deliberately want isolated budgets per instance.
+  const sdkSemaphore = finalConfig.maxConcurrent !== undefined
+    ? new AbortableSemaphore(finalConfig.maxConcurrent)
+    : getProcessSdkSemaphore()
+  const responseCompletions = new WeakMap<Response, Promise<void>>()
+
+  // Graceful shutdown (#drain): once true, handleWithQueue fast-fails new
+  // requests instead of queueing them, and /health reports it so a fleet
+  // manager (e.g. a gateway's account-pool scheduler) can stop routing here
+  // before the process actually exits. inFlightRequests only counts requests
+  // that were admitted past that gate, so it drains to 0 on its own — no
+  // separate bookkeeping of queued vs. active is needed.
+  let draining = false
+  let inFlightRequests = 0
+
+  async function* runSdkQueryAttempt(
+    params: Parameters<typeof query>[0],
+    signal: AbortSignal,
+    requestMeta: RequestMeta,
+    mode: string,
+  ) {
+    const lease = await sdkSemaphore.acquire(signal)
+    requestMeta.sdkQueueWaitMs += lease.waitedMs
+    const startedAt = Date.now()
+    requestMeta.currentSdkStartedAt = startedAt
+    let sdkQuery: ReturnType<typeof query> | undefined
+    try {
+      sdkQuery = query(params)
+      yield* guardUpstreamIdle(sdkQuery, UPSTREAM_IDLE_MS, (sinceLastMs) =>
+        claudeLog("upstream.stalled", { mode, sinceLastMs }))
+    } finally {
+      try {
+        // Production Query objects expose close(); test doubles and older SDK
+        // shims may be plain async generators whose iterator return() is
+        // already invoked by guardUpstreamIdle.
+        if (typeof sdkQuery?.close === "function") sdkQuery.close()
+      } finally {
+        requestMeta.sdkActiveDurationMs += Date.now() - startedAt
+        lease.release()
       }
-    })
-    const entry = { promise, resolve: resolveFn }
-    pendingSessionStores.set(key, entry)
-    return () => {
-      entry.resolve()
-      if (pendingSessionStores.get(key) === entry) pendingSessionStores.delete(key)
     }
   }
 
@@ -483,10 +572,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
   // --- Priority routing (opt-in, routing="priority") ---
   // Ordered account pool with per-request failover. The /v1/messages handler
-  // becomes a thin dispatcher in this mode: it re-enters itself with a pinned
-  // x-meridian-profile header per candidate (the same internal-hop pattern as
-  // /v1/chat/completions), so ALL failover logic lives here — no changes to
-  // the deep request machinery. State is per proxy instance.
+  // becomes a thin dispatcher in this mode: it calls handleMessages directly
+  // with a forcedProfileId per candidate, so ALL failover logic lives here —
+  // no changes to the deep request machinery. Calling in-process rather than
+  // re-entering over HTTP matters for more than speed: an internal hop would
+  // take a second slot from the same concurrency budget as its own parent and
+  // deadlock the pool whenever MERIDIAN_MAX_CONCURRENT is 1. State is per
+  // proxy instance.
   const priorityExhaustion = new ProfileExhaustion()
   const PRIORITY_ASSIGNMENTS_MAX = 5000
   const priorityAssignments = new AssignmentStore(PRIORITY_ASSIGNMENTS_MAX)
@@ -651,20 +743,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       },
       cancel(reason) { void reader.cancel(reason).catch(() => {}) },
     })
-    return { failed: false, errorPayload: null, errorType: null, response: new Response(rest, { status: res.status, headers: res.headers }) }
+    const response = new Response(rest, { status: res.status, headers: res.headers })
+    const completion = responseCompletions.get(res)
+    if (completion) responseCompletions.set(response, completion)
+    return { failed: false, errorPayload: null, errorType: null, response }
   }
 
-  async function dispatchPriority(c: Context, orderedCandidateIds: string[], sessionKey: string | null, wantsStream: boolean): Promise<Response> {
-    const bodyBuf = await c.req.arrayBuffer()
+  async function dispatchPriority(c: Context, body: any, requestMeta: RequestMeta, orderedCandidateIds: string[], sessionKey: string | null, wantsStream: boolean): Promise<Response> {
     let lastError: unknown = null
     let lastStatus = 429
     let previous: string | null = null
     let previousReason = "rate_limit_error"
-    for (const candidate of orderedCandidateIds) {
-      const headers = new Headers(c.req.raw.headers)
-      headers.set("x-meridian-profile", candidate)
-      headers.set("x-meridian-priority-dispatch", "1")
-      const inner = await app.fetch(new Request(c.req.url, { method: "POST", headers, body: bodyBuf }))
+    for (const [attempt, candidate] of orderedCandidateIds.entries()) {
+      const inner = await handleMessages(c, forkAttemptMeta(requestMeta, attempt), { body, forcedProfileId: candidate })
       const sniffed = await sniffAccountFailure(inner)
       if (!sniffed.failed) {
         if (sessionKey) priorityAssignments.set(sessionKey, candidate)
@@ -674,6 +765,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }
         return sniffed.response
       }
+      await responseCompletions.get(inner)?.catch(() => {})
       const reason = sniffed.errorType
       // Only a quota refusal has a reset to look up. Both cooldown tiers read
       // the account's five-hour window, which says nothing about entitlement:
@@ -723,52 +815,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return c.html(landingHtml)
   })
 
-  // --- Concurrency Control ---
-  // Each request spawns an SDK subprocess (cli.js, ~11MB). Spawning multiple
-  // simultaneously can crash the process. Serialize SDK queries with a queue.
-  const MAX_CONCURRENT_SESSIONS = parseInt((process.env.MERIDIAN_MAX_CONCURRENT ?? process.env.CLAUDE_PROXY_MAX_CONCURRENT) || "10", 10)
-  let activeSessions = 0
-  const sessionQueue: Array<{ resolve: () => void }> = []
-  // Priority routing dispatches by re-entering this app over `app.fetch`
-  // (dispatchPriority), so one external request makes two passes through the
-  // queued route. Counting both is a deadlock, not an over-count: the outer
-  // pass holds its slot for as long as the inner pass runs, so N concurrent
-  // requests hold all N slots while waiting for inner passes that can never be
-  // admitted, and the queue never drains again. The slot belongs to the
-  // external request; the inner pass is the same request continuing, and it is
-  // the only one of the two that spawns an SDK subprocess.
-  //
-  // The marker rides the async context rather than a header because a header
-  // reaches the limiter from the wire: any client could send it and opt out of
-  // the limit this exists to impose. It carries the outer pass's queue timings
-  // so the inner pass — the one that reports telemetry — still records the wait
-  // the external request actually served, rather than a zero of its own.
-  const insideSessionSlot = new AsyncLocalStorage<{ queueEnteredAt: number; queueStartedAt: number }>()
-
-  async function acquireSession(): Promise<void> {
-    if (activeSessions < MAX_CONCURRENT_SESSIONS) {
-      activeSessions++
-      return
-    }
-    return new Promise<void>((resolve) => {
-      sessionQueue.push({ resolve })
-    })
-  }
-
-  function releaseSession(): void {
-    activeSessions--
-    const next = sessionQueue.shift()
-    if (next) {
-      activeSessions++
-      next.resolve()
-    }
-  }
-
   const handleMessages = async (
     c: Context,
-    requestMeta: { requestId: string; endpoint: string; queueEnteredAt: number; queueStartedAt: number }
+    requestMeta: RequestMeta,
+    options: HandleMessagesOptions,
   ) => {
-    const requestStartAt = Date.now()
+    const requestStartAt = requestMeta.queueEnteredAt
     const requestAbort = linkRequestAbort(c.req.raw.signal)
     let streamOwnsAbortLink = false
 
@@ -776,7 +828,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // Hoist adapter detection before try so it's available in the catch block for telemetry
       const adapter = detectAdapter(c)
       try {
-        const body = await c.req.json()
+        const body = options.body
 
         // Validate required fields
         if (!Array.isArray(body.messages)) {
@@ -829,7 +881,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // ordered pool with per-request failover. Pinned requests (explicit
         // x-meridian-profile — including our own internal hops) bypass the
         // pool entirely and take the normal path below.
-        if (routingMode === "priority" && !c.req.header("x-meridian-profile")) {
+        if (routingMode === "priority" && !options.forcedProfileId && !c.req.header("x-meridian-profile")) {
           const effectivePool = getEffectiveProfiles(finalConfig.profiles)
           if (effectivePool.length > 1) {
             const { order, unknown } = resolvePriorityOrder(effectivePool.map(p => p.id), priorityProfileOrderSetting())
@@ -862,13 +914,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               first = pick?.id ?? order[0]!
             }
             const candidates = [first, ...order.filter(id => id !== first && !priorityExhaustion.isExhausted(id))]
-            return dispatchPriority(c, candidates, sessionKey, body.stream === true)
+            return dispatchPriority(c, body, requestMeta, candidates, sessionKey, body.stream === true)
           }
         }
         const profile = resolveProfile(
           finalConfig.profiles,
           finalConfig.defaultProfile,
-          c.req.header("x-meridian-profile") || undefined,
+          options.forcedProfileId || c.req.header("x-meridian-profile") || undefined,
           routingMode === "sticky"
             ? { routingMode, stickySessionKey: adapter.getSessionId(c, body) }
             : undefined
@@ -1086,6 +1138,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // For agents without (Pi): pass profile-scoped workingDirectory to fingerprint lookup.
         const profileSessionId = profile.id !== "default" && agentSessionId
           ? `${profile.id}:${agentSessionId}` : agentSessionId
+        // The turn lease is keyed by the raw client session id (the profile
+        // isn't resolved yet when it's acquired, and under priority routing it
+        // can differ per attempt), but "did this session advance" is only
+        // meaningful within one profile's cache scope — so commits and the
+        // conflict check below both carry profileSessionId.
+        const commitSessionTurn = () => {
+          if (profileSessionId) requestMeta.sessionTurnLease?.markCommitted(profileSessionId)
+        }
         // Use the client-local CWD for fingerprint bucketing so that two
         // independent client projects don't collide on the same first-user-
         // message hash even when they share an SDK cwd on the proxy host.
@@ -1135,20 +1195,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const isIndependentSession =
           (!agentSessionId && (requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-"))) ||
           isClientDrivenLoop || false
-        // If the previous turn's background drain is still persisting this
-        // session (streaming early stop), wait briefly so the lookup below
-        // sees the stored session instead of falling to a fresh replay.
-        if (!isIndependentSession && profileSessionId) {
-          const pendingStore = pendingSessionStores.get(profileSessionId)
-          if (pendingStore) {
-            const waitStart = Date.now()
-            await Promise.race([
-              pendingStore.promise,
-              new Promise((resolve) => setTimeout(resolve, PENDING_STORE_WAIT_MS)),
-            ])
-            claudeLog("session.pending_store_awaited", { waitedMs: Date.now() - waitStart })
-          }
-        }
         let lineageResult: LineageResult = isIndependentSession
           ? { type: "diverged", reason: "independent-request" }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
@@ -1160,6 +1206,77 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // prevent leaking the old session's conversation history.
         if (lineageResult.type === "undo" && adapterBase === "opencode" && !agentSessionId) {
           lineageResult = { type: "diverged", reason: "missing-session-header" }
+        }
+        // Clients that declare a concurrent flow (x-meridian-source fork-/
+        // subagent-) knowingly run parallel turns under one session key — see
+        // the keyed fork/subagent note above. Serializing them is still worth
+        // doing, but a reclassification is their normal cost; refusing them
+        // would break flows that worked before turn coordination existed.
+        const declaresConcurrentFlow =
+          requestSource?.startsWith("fork-") === true || requestSource?.startsWith("subagent-") === true
+        if (
+          profileSessionId &&
+          !declaresConcurrentFlow &&
+          requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
+          lineageResult.type !== "continuation" &&
+          lineageResult.type !== "compaction"
+        ) {
+          const reason = lineageResult.type === "diverged" ? lineageResult.reason : lineageResult.type
+          const message = "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
+          claudeLog("session.concurrent_conflict", {
+            reason,
+            sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+          })
+          diagnosticLog.session(
+            `${requestMeta.requestId} session.concurrent_conflict reason=${reason} wait=${requestMeta.sessionQueueWaitMs}ms`,
+            requestMeta.requestId,
+          )
+          // Every other terminal path records; this one must too, or the single
+          // event operators most need to count — how often concurrency actually
+          // refuses a turn — is invisible in /telemetry, SQLite and Prometheus.
+          // The error tag is deliberately more specific than the wire type so a
+          // conflict can be separated from ordinary request-validation errors.
+          const conflictTotalMs = Date.now() - requestStartAt
+          const conflictQueueWaitMs = totalQueueWaitMs(requestMeta)
+          telemetryStore.record({
+            requestId: requestMeta.requestId,
+            timestamp: Date.now(),
+            adapter: adapter.name,
+            model,
+            requestModel: requestedModel,
+            mode: stream ? "stream" : "non-stream",
+            isResume: false,
+            isPassthrough: envBool("PASSTHROUGH"),
+            hasDeferredTools: undefined,
+            deferredToolCount: undefined,
+            toolCount: body.tools?.length ?? 0,
+            lineageType: lineageResult.type,
+            messageCount: Array.isArray(body.messages) ? body.messages.length : 0,
+            sdkSessionId: undefined,
+            status: 400,
+            queueWaitMs: conflictQueueWaitMs,
+            sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+            sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
+            proxyOverheadMs: Math.max(0, conflictTotalMs - conflictQueueWaitMs),
+            ttfbMs: null,
+            // The turn is refused before any SDK query is spawned.
+            upstreamDurationMs: 0,
+            totalDurationMs: conflictTotalMs,
+            contentBlocks: 0,
+            textEvents: 0,
+            error: "session_turn_conflict",
+            profileId: profile.id,
+          })
+          return new Response(
+            JSON.stringify({ type: "error", error: { type: "invalid_request_error", message } }),
+            {
+              // Keep the public response within the Anthropic-compatible
+              // Messages API contract. The diagnostic event above retains the
+              // more specific reason for operators.
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            },
+          )
         }
         // Publish the decision to plugins. Core has always known WHICH message
         // stopped matching; the log line only ever reported how many matched
@@ -1227,7 +1344,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
         const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
         const toolCount = body.tools?.length ?? 0
-        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : c.req.header("x-meridian-priority-dispatch") ? "(priority)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} active=${activeSessions}/${MAX_CONCURRENT_SESSIONS} msgCount=${msgCount}`
+        const sdkSnapshot = sdkSemaphore.snapshot
+        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : options.forcedProfileId ? "(priority)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} sdkActive=${sdkSnapshot.active}/${sdkSnapshot.limit} sdkQueued=${sdkSnapshot.queued} sessionWait=${requestMeta.sessionQueueWaitMs}ms msgCount=${msgCount}`
         plog(`[PROXY] ${requestLogLine} msgs=${msgSummary}`)
         diagnosticLog.session(`${requestLogLine}`, requestMeta.requestId)
 
@@ -1246,7 +1364,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         claudeLog("request.received", {
           model,
           stream,
-          queueWaitMs: requestMeta.queueStartedAt - requestMeta.queueEnteredAt,
+          queueWaitMs: totalQueueWaitMs(requestMeta),
+          sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+          sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
           messageCount: Array.isArray(body.messages) ? body.messages.length : 0,
           hasSystemPrompt: Boolean(body.system)
         })
@@ -1829,7 +1949,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // consumer loop, attempt error, loop exit).
                 turnGenerating = true
                 try {
-                  for await (const event of query(buildQueryOptions({
+                  for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                     resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughResumeUuid, forkSession: busySessionFork || Boolean(passthroughResumeUuid) || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
@@ -1844,7 +1964,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
-                  }, requestAbort.controller))) {
+                  }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream")) {
                     // Capture Claude Max subscription quota updates emitted by
                     // the SDK as rate_limit_event. We snapshot them in this
                     // profile's slot of the (per-profile-scoped) rate limit
@@ -1919,7 +2039,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     evictSession(profileSessionId, profileScopedCwd, allMessages)
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
-                    yield* query(buildQueryOptions({
+                    yield* runSdkQueryAttempt(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
@@ -1935,7 +2055,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }, requestAbort.controller))
+                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh")
                     return
                   }
 
@@ -1969,7 +2089,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     evictSession(profileSessionId, profileScopedCwd, allMessages)
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
-                    yield* query(buildQueryOptions({
+                    yield* runSdkQueryAttempt(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
@@ -1985,7 +2105,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }, requestAbort.controller))
+                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh")
                     return
                   }
 
@@ -2083,10 +2203,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
                 if (!firstChunkAt) {
                   firstChunkAt = Date.now()
+                  // Anchored on the attempt that produced this chunk, not on
+                  // the handler's start: a request that replayed or failed
+                  // over would otherwise report the abandoned attempts as TTFB.
+                  requestMeta.ttfbMs ??= firstChunkAt - (requestMeta.currentSdkStartedAt ?? firstChunkAt)
                   claudeLog("upstream.first_chunk", {
                     mode: "non_stream",
                     model,
-                    ttfbMs: firstChunkAt - upstreamStartAt
+                    ttfbMs: requestMeta.ttfbMs
                   })
                 }
 
@@ -2341,7 +2465,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             hasToolUse
           })
 
-          const nonStreamQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+          const nonStreamQueueWaitMs = totalQueueWaitMs(requestMeta)
           checkTokenHealth(
             requestMeta.requestId,
             currentSessionId || resumeSessionId,
@@ -2371,9 +2495,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             sdkSessionId: currentSessionId || resumeSessionId,
             status: 200,
             queueWaitMs: nonStreamQueueWaitMs,
-            proxyOverheadMs: upstreamStartAt - requestStartAt - nonStreamQueueWaitMs,
-            ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
-            upstreamDurationMs: Date.now() - upstreamStartAt,
+            sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+            sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
+            proxyOverheadMs: Math.max(0, totalDurationMs - nonStreamQueueWaitMs - requestMeta.sdkActiveDurationMs),
+            ttfbMs: requestMeta.ttfbMs ?? null,
+            upstreamDurationMs: requestMeta.sdkActiveDurationMs,
             totalDurationMs,
             contentBlocks: contentBlocks.length,
             textEvents: 0,
@@ -2422,6 +2548,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   lastUsage,
                   earlyStopFired ? nextPassthroughResumeUuid : null
                 )
+                commitSessionTurn()
               }
 
               const responseSessionId = currentSessionId || resumeSessionId || `session_${Date.now()}`
@@ -2450,8 +2577,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }
 
         const encoder = new TextEncoder()
+        let resolveStreamCompletion = () => {}
+        const streamCompletion = new Promise<void>((resolve) => {
+          resolveStreamCompletion = resolve
+        })
         const readable = new ReadableStream({
-          async start(controller) {
+          start(controller) {
+            return (async () => {
             const upstreamStartAt = Date.now()
             let firstChunkAt: number | undefined
             let heartbeatCount = 0
@@ -2552,13 +2684,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // argument-less aborted call (#552 "red reads") — the recovery
             // path closes these explicitly before its final frames.
             const openClientBlocks = new Set<number>()
-
-            // Announce this request's eventual storeSession to follow-ups: the
-            // drain design ends the client response before the store lands, so
-            // a fast follow-up must await it (see pendingSessionStores).
-            const resolvePendingStore = passthrough && earlyStopEnabled && !isIndependentSession && profileSessionId
-              ? registerPendingStore(profileSessionId)
-              : () => {}
 
             // Envelope integrity: every path that ends the client stream must
             // first terminate any content block whose start was forwarded but
@@ -2661,7 +2786,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // must not re-match a previous attempt's refusal text.
                   const attemptStderrStart = stderrLines.length
                   try {
-                    for await (const event of query(buildQueryOptions({
+                    for await (const event of runSdkQueryAttempt(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
                       resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughResumeUuid, forkSession: busySessionFork || Boolean(passthroughResumeUuid) || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
@@ -2676,7 +2801,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }, requestAbort.controller))) {
+                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream")) {
                       // Same SDK rate-limit capture as the non-stream path.
                       if ((event as any).type === "rate_limit_event") {
                         rateLimitStore.record(profile.id, (event as any).rate_limit_info)
@@ -2730,7 +2855,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       evictSession(profileSessionId, profileScopedCwd, allMessages)
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
-                      yield* query(buildQueryOptions({
+                      yield* runSdkQueryAttempt(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
@@ -2746,7 +2871,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
-                      }, requestAbort.controller))
+                      }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh")
                       return
                     }
 
@@ -2776,7 +2901,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       evictSession(profileSessionId, profileScopedCwd, allMessages)
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
-                      yield* query(buildQueryOptions({
+                      yield* runSdkQueryAttempt(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
@@ -2792,7 +2917,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
-                      }, requestAbort.controller))
+                      }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh")
                       return
                     }
 
@@ -2954,10 +3079,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     streamEventsSeen += 1
                     if (!firstChunkAt) {
                       firstChunkAt = Date.now()
+                      // See the non-stream site: TTFB belongs to the attempt
+                      // that actually delivered, not to the first one tried.
+                      requestMeta.ttfbMs ??= firstChunkAt - (requestMeta.currentSdkStartedAt ?? firstChunkAt)
                       claudeLog("upstream.first_chunk", {
                         mode: "stream",
                         model,
-                        ttfbMs: firstChunkAt - upstreamStartAt
+                        ttfbMs: requestMeta.ttfbMs
                       })
                     }
 
@@ -3353,8 +3481,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   lastUsage,
                   earlyStopFired ? nextPassthroughResumeUuid : null
                 )
+                commitSessionTurn()
               }
-              resolvePendingStore()
 
               // Last chance to save a silent turn. The three known causes are
               // fixed; this catches the class — including causes not yet found —
@@ -3416,7 +3544,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // an open SSE response and its concurrency slot with nothing
                   // to time it out — the client waits forever on a request that
                   // had already produced a deliverable turn.
-                  for await (const event of guardUpstreamIdle(query(buildQueryOptions({
+                  for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: SILENT_TURN_NUDGE,
                     model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     // The nudge asks for prose, but a tool call is an equally
@@ -3448,9 +3576,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
-                  }, requestAbort.controller)), UPSTREAM_IDLE_MS, (sinceLastMs) =>
-                    claudeLog("upstream.stalled", { mode: "silent_recovery", model, sinceLastMs }),
-                  )) {
+                  }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "silent_recovery")) {
                     const recoveryMessage = event as any
                     if (recoveryMessage.session_id) recoverySessionId = recoveryMessage.session_id
                     recoveryBoundaryUuid = resumeBoundaryUuid(recoveryMessage) ?? recoveryBoundaryUuid
@@ -3511,6 +3637,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     lastUsage,
                     recoveryBoundaryUuid ?? null
                   )
+                  commitSessionTurn()
                 }
                 claudeLog("response.silent_turn_recovery_result", {
                   mode: "stream",
@@ -3651,7 +3778,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   textEventsForwarded
                 })
 
-                const streamQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+                const streamQueueWaitMs = totalQueueWaitMs(requestMeta)
                 checkTokenHealth(
                   requestMeta.requestId,
                   currentSessionId || resumeSessionId,
@@ -3681,9 +3808,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   sdkSessionId: currentSessionId || resumeSessionId,
                   status: 200,
                   queueWaitMs: streamQueueWaitMs,
-                  proxyOverheadMs: upstreamStartAt - requestStartAt - streamQueueWaitMs,
-                  ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
-                  upstreamDurationMs: Date.now() - upstreamStartAt,
+                  sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+                  sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
+                  proxyOverheadMs: Math.max(0, streamTotalDurationMs - streamQueueWaitMs - requestMeta.sdkActiveDurationMs),
+                  ttfbMs: requestMeta.ttfbMs ?? null,
+                  upstreamDurationMs: requestMeta.sdkActiveDurationMs,
                   totalDurationMs: streamTotalDurationMs,
                   contentBlocks: eventsForwarded,
                   textEvents: textEventsForwarded,
@@ -3757,15 +3886,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     lastUsage,
                     disposition.resumeUuid
                   )
+                  commitSessionTurn()
                 } else if (disposition.action === "evict") {
                   evictSession(profileSessionId, profileScopedCwd, body.messages || [])
                 }
                 claudeLog("passthrough.client_abort_settled", { action: disposition.action })
-                resolvePendingStore()
                 return
               }
 
-              resolvePendingStore()
               const stderrOutput = stderrLines.join("\n").trim()
               if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
                 error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
@@ -3883,7 +4011,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
                 // Record as success — the client got a usable response.
                 const recoverTotalMs = Date.now() - requestStartAt
-                const recoverQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+                const recoverQueueWaitMs = totalQueueWaitMs(requestMeta)
                 telemetryStore.record({
                   requestId: requestMeta.requestId,
                   timestamp: Date.now(),
@@ -3903,9 +4031,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   sdkSessionId: resumeSessionId,
                   status: 200,
                   queueWaitMs: recoverQueueWaitMs,
-                  proxyOverheadMs: upstreamStartAt - requestStartAt - recoverQueueWaitMs,
-                  ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
-                  upstreamDurationMs: Date.now() - upstreamStartAt,
+                  sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+                  sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
+                  proxyOverheadMs: Math.max(0, recoverTotalMs - recoverQueueWaitMs - requestMeta.sdkActiveDurationMs),
+                  ttfbMs: requestMeta.ttfbMs ?? null,
+                  upstreamDurationMs: requestMeta.sdkActiveDurationMs,
                   totalDurationMs: recoverTotalMs,
                   contentBlocks: eventsForwarded + unseenToolUses.length,
                   textEvents: textEventsForwarded,
@@ -3935,7 +4065,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // streaming errors would not appear in /telemetry/requests at all
               // (the success path's record call never runs when this catch fires).
               const streamErrTotalMs = Date.now() - requestStartAt
-              const streamErrQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+              const streamErrQueueWaitMs = totalQueueWaitMs(requestMeta)
               telemetryStore.record({
                 requestId: requestMeta.requestId,
                 timestamp: Date.now(),
@@ -3955,9 +4085,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 sdkSessionId: resumeSessionId,
                 status: streamErr.status,
                 queueWaitMs: streamErrQueueWaitMs,
-                proxyOverheadMs: upstreamStartAt - requestStartAt - streamErrQueueWaitMs,
-                ttfbMs: firstChunkAt ? firstChunkAt - upstreamStartAt : null,
-                upstreamDurationMs: Date.now() - upstreamStartAt,
+                sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+                sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
+                proxyOverheadMs: Math.max(0, streamErrTotalMs - streamErrQueueWaitMs - requestMeta.sdkActiveDurationMs),
+                ttfbMs: requestMeta.ttfbMs ?? null,
+                upstreamDurationMs: requestMeta.sdkActiveDurationMs,
                 totalDurationMs: streamErrTotalMs,
                 contentBlocks: eventsForwarded,
                 textEvents: textEventsForwarded,
@@ -4033,6 +4165,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             } finally {
               requestAbort.detach()
             }
+            })().finally(() => {
+              resolveStreamCompletion()
+            })
           },
           cancel(reason) {
             requestAbort.abort(reason)
@@ -4042,7 +4177,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         const streamSessionId = resumeSessionId || `session_${Date.now()}`
         streamOwnsAbortLink = true
-        return new Response(readable, {
+        const streamResponse = new Response(readable, {
           headers: {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -4050,6 +4185,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             "X-Claude-Session-ID": streamSessionId
           }
         })
+        responseCompletions.set(streamResponse, streamCompletion)
+        return streamResponse
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error)
         claudeLog("error.unhandled", {
@@ -4058,7 +4195,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         })
 
         // Detect specific error types and return helpful messages
-        const classified = classifyError(errMsg)
+        const classified = requestAbort.controller.signal.aborted
+          ? { status: 499, type: "request_cancelled", message: "The request was cancelled" }
+          : classifyError(errMsg)
 
         claudeLog("proxy.error", { error: errMsg, classified: classified.type })
 
@@ -4073,7 +4212,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           requestMeta.requestId,
         )
 
-        const errorQueueWaitMs = requestMeta.queueStartedAt - requestMeta.queueEnteredAt
+        const errorQueueWaitMs = totalQueueWaitMs(requestMeta)
+        const errorTotalMs = Date.now() - requestStartAt
         telemetryStore.record({
           requestId: requestMeta.requestId,
           timestamp: Date.now(),
@@ -4091,10 +4231,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           sdkSessionId: undefined,
           status: classified.status,
           queueWaitMs: errorQueueWaitMs,
-          proxyOverheadMs: Date.now() - requestStartAt - errorQueueWaitMs,
+          sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+          sdkQueueWaitMs: requestMeta.sdkQueueWaitMs,
+          proxyOverheadMs: Math.max(0, errorTotalMs - errorQueueWaitMs - requestMeta.sdkActiveDurationMs),
           ttfbMs: null,
-          upstreamDurationMs: Date.now() - requestStartAt,
-          totalDurationMs: Date.now() - requestStartAt,
+          upstreamDurationMs: requestMeta.sdkActiveDurationMs,
+          totalDurationMs: errorTotalMs,
           contentBlocks: 0,
           textEvents: 0,
           error: classified.type,
@@ -4111,22 +4253,110 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   }
 
   const handleWithQueue = async (c: Context, endpoint: string) => {
+    if (draining) {
+      return new Response(JSON.stringify({
+        type: "error",
+        error: { type: "overloaded_error", message: "Meridian is shutting down and is not accepting new requests. Retry against another instance." },
+      }), { status: 503, headers: { "Content-Type": "application/json", "x-meridian-draining": "1" } })
+    }
     const requestId = c.req.header("x-request-id") || randomUUID()
     const queueEnteredAt = Date.now()
     claudeLog("request.enter", { requestId, endpoint })
-    // Already inside this request's slot — an internal dispatch hop, not a new
-    // arrival. Taking a second slot here is what deadlocks the pool.
-    const held = insideSessionSlot.getStore()
-    if (held) {
-      return handleMessages(c, { requestId, endpoint, ...held })
+    let sessionTurnLease: SessionTurnLease | undefined
+    let finished = false
+    let leaseReleased = false
+    let leaseWatchdog: ReturnType<typeof setTimeout> | undefined
+    inFlightRequests++
+    // Releasing the lease is deliberately separate from finishing the request:
+    // the watchdog must be able to unblock the session without also corrupting
+    // the in-flight count that the shutdown drain reads.
+    const releaseSessionTurn = (forced: boolean) => {
+      if (leaseReleased || !sessionTurnLease) return
+      leaseReleased = true
+      if (leaseWatchdog) clearTimeout(leaseWatchdog)
+      if (forced) {
+        claudeLog("session.turn_lease_forced", { requestId, heldMs: SESSION_TURN_MAX_HOLD_MS })
+        plog(`[PROXY] ${requestId} session turn lease force-released after ${SESSION_TURN_MAX_HOLD_MS}ms`)
+      }
+      sessionTurnLease.release()
     }
-    await acquireSession()
-    const queueStartedAt = Date.now()
+    const finishRequest = () => {
+      if (finished) return
+      finished = true
+      releaseSessionTurn(false)
+      inFlightRequests--
+    }
+
+    let body: any
     try {
-      return await insideSessionSlot.run({ queueEnteredAt, queueStartedAt }, () =>
-        handleMessages(c, { requestId, endpoint, queueEnteredAt, queueStartedAt }))
-    } finally {
-      releaseSession()
+      try {
+        body = await c.req.json()
+      } catch (error) {
+        if (c.req.raw.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+          finishRequest()
+          return new Response(JSON.stringify({
+            type: "error",
+            error: { type: "request_cancelled", message: "The request was cancelled" },
+          }), { status: 499, headers: { "Content-Type": "application/json" } })
+        }
+        finishRequest()
+        return new Response(JSON.stringify({
+          type: "error",
+          error: { type: "invalid_request_error", message: "Request body must be valid JSON" },
+        }), { status: 400, headers: { "Content-Type": "application/json" } })
+      }
+
+      // Fingerprints are intentionally excluded here: they only hash the first
+      // user message + cwd and cannot distinguish independent headerless chats.
+      // Strict serialization is safe only when the adapter supplies a reliable
+      // client-session identity.
+      if (Array.isArray(body?.messages)) {
+        const adapter = detectAdapter(c)
+        const agentSessionId = adapter.getSessionId(c, body)
+        if (agentSessionId) {
+          try {
+            sessionTurnLease = await processSessionTurns.acquire(
+              `session:${agentSessionId}`,
+              c.req.raw.signal,
+            )
+            leaseWatchdog = setTimeout(() => releaseSessionTurn(true), SESSION_TURN_MAX_HOLD_MS)
+            leaseWatchdog.unref?.()
+          } catch (error) {
+            if (c.req.raw.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+              finishRequest()
+              return new Response(JSON.stringify({
+                type: "error",
+                error: { type: "request_cancelled", message: "The request was cancelled" },
+              }), { status: 499, headers: { "Content-Type": "application/json" } })
+            }
+            throw error
+          }
+        }
+      }
+
+      const requestMeta: RequestMeta = {
+        requestId,
+        endpoint,
+        queueEnteredAt,
+        sessionQueueWaitMs: sessionTurnLease?.waitedMs ?? 0,
+        sdkQueueWaitMs: 0,
+        sdkActiveDurationMs: 0,
+        sessionTurnLease,
+      }
+      const response = await handleMessages(c, requestMeta, { body })
+      const completion = responseCompletions.get(response)
+      if (completion) {
+        // .finally() re-throws whatever it settled with, so the catch is what
+        // keeps a future rejecting completion from surfacing as an unhandled
+        // rejection. It runs after finishRequest, which fires either way.
+        void completion.finally(finishRequest).catch(() => {})
+      } else {
+        finishRequest()
+      }
+      return response
+    } catch (error) {
+      finishRequest()
+      throw error
     }
   }
 
@@ -4241,6 +4471,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
   // Health check endpoint — verifies auth status
   app.get("/health", async (c) => {
+    // Checked first and unconditionally: a fleet manager routing on this
+    // endpoint (e.g. a gateway's account-pool scheduler) needs to learn
+    // "stop sending here" as fast as possible during shutdown, without
+    // waiting on an auth-status round trip.
+    if (draining) {
+      return c.json({
+        status: "draining",
+        version: serverVersion,
+        message: "Meridian is shutting down; route new requests to another instance.",
+      }, 503)
+    }
     try {
       // Use active profile's auth context for health check
       const healthProfile = resolveProfile(finalConfig.profiles, finalConfig.defaultProfile)
@@ -4505,6 +4746,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       method: "POST",
       headers: internalHeaders,
       body: JSON.stringify(anthropicBody),
+      signal: c.req.raw.signal,
     })
     const internalRes = await app.fetch(internalReq)
 
@@ -4533,10 +4775,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
     // Streaming: translate Anthropic SSE events to OpenAI SSE chunks
     const encoder = new TextEncoder()
+    let internalReader: { cancel(reason?: unknown): Promise<void> } | undefined
     const readable = new ReadableStream({
       async start(controller) {
         const reader = internalRes.body?.getReader()
         if (!reader) { controller.close(); return }
+        internalReader = reader
 
         const decoder = new TextDecoder()
         let buffer = ""
@@ -4582,6 +4826,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           }
           controller.close()
         }
+      },
+      cancel(reason) {
+        return internalReader?.cancel(reason)
       },
     })
 
@@ -4643,6 +4890,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       method: "POST",
       headers: internalHeaders,
       body: JSON.stringify(anthropicBody),
+      signal: c.req.raw.signal,
     })
     const internalRes = await app.fetch(internalReq)
 
@@ -4666,10 +4914,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
     // Streaming: translate Anthropic SSE → Responses SSE.
     const encoder = new TextEncoder()
+    let internalReader: { cancel(reason?: unknown): Promise<void> } | undefined
     const readable = new ReadableStream({
       async start(controller) {
         const reader = internalRes.body?.getReader()
         if (!reader) { controller.close(); return }
+        internalReader = reader
 
         const decoder = new TextDecoder()
         let buffer = ""
@@ -4704,6 +4954,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         } finally {
           controller.close()
         }
+      },
+      cancel(reason) {
+        return internalReader?.cancel(reason)
       },
     })
 
@@ -5089,7 +5342,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     }
   }
 
-  return { app, config: finalConfig, initPlugins: initPluginsAsync }
+  return {
+    app,
+    config: finalConfig,
+    initPlugins: initPluginsAsync,
+    beginDrain: () => { draining = true },
+    getInFlightCount: () => inFlightRequests,
+  }
 }
 
 /**
@@ -5118,7 +5377,7 @@ export function installProxyProcessErrorHandlers(): void {
 
 export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promise<ProxyInstance> {
   claudeExecutable = await resolveClaudeExecutableAsync()
-  const { app, config: finalConfig, initPlugins } = createProxyServer(config)
+  const { app, config: finalConfig, initPlugins, beginDrain, getInFlightCount } = createProxyServer(config)
   if (initPlugins) await initPlugins()
 
   if (finalConfig.installProcessErrorHandlers) {
@@ -5152,6 +5411,7 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
   const idleMs = finalConfig.idleTimeoutSeconds * 1000
   server.keepAliveTimeout = idleMs
   server.headersTimeout = idleMs + 1000
+  const connectionTracker = trackServerConnections(server)
 
   server.on("error", (error: NodeJS.ErrnoException) => {
     if (error.code === "EADDRINUSE" && !finalConfig.silent) {
@@ -5203,16 +5463,33 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
     if (authKeepaliveInterval.unref) authKeepaliveInterval.unref()
   }
 
+  let closePromise: Promise<void> | undefined
   return {
     server,
     config: finalConfig,
-    async close() {
-      clearInterval(profileTokenRefreshInterval)
-      if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
-      stopBackgroundRefresh()
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()))
-      })
+    close() {
+      closePromise ??= (async () => {
+        clearInterval(profileTokenRefreshInterval)
+        if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+        stopBackgroundRefresh()
+
+        // Stop admitting new requests, then give whatever is already in flight
+        // up to SHUTDOWN_GRACE_MS to finish naturally before pulling the plug.
+        // This makes existing "call close() on SIGTERM" plugin code (see the
+        // Stable API Contract) graceful for free, with no signature change.
+        beginDrain?.()
+        try {
+          await closeServerWithGracePeriod(server, {
+            graceMs: SHUTDOWN_GRACE_MS,
+            getInFlightCount: () => getInFlightCount?.() ?? 0,
+            warn: finalConfig.silent ? undefined : (message) => console.warn(message),
+            forceCloseConnections: () => connectionTracker.forceCloseAll(),
+          })
+        } finally {
+          connectionTracker.dispose()
+        }
+      })()
+      return closePromise
     },
   }
 }

--- a/src/proxy/session/turnCoordinator.ts
+++ b/src/proxy/session/turnCoordinator.ts
@@ -1,0 +1,138 @@
+export interface SessionTurnLease {
+  readonly waitedMs: number
+  /**
+   * True when a turn committed under `scopeKey` while this request waited.
+   * Scoped because one client session id can back several independent
+   * conversations — one per profile — and a commit under one profile says
+   * nothing about the lineage a queued request from another profile carries.
+   */
+  advancedWhileWaiting(scopeKey: string): boolean
+  markCommitted(scopeKey: string): void
+  release(): void
+}
+
+interface SessionTurnWaiter {
+  readonly arrivedAt: number
+  readonly versions: Map<string, number>
+  readonly resolve: (lease: SessionTurnLease) => void
+  readonly reject: (error: Error) => void
+  readonly signal?: AbortSignal
+  abortListener?: () => void
+}
+
+interface SessionTurnState {
+  held: boolean
+  /** Commit counter per profile-scoped session key sharing this client id. */
+  versions: Map<string, number>
+  waiters: SessionTurnWaiter[]
+}
+
+function cancellationError(reason?: unknown): Error {
+  if (reason instanceof Error) return reason
+  return new DOMException(
+    typeof reason === "string" && reason ? reason : "The request was cancelled",
+    "AbortError",
+  )
+}
+
+/** Serialize turns for one reliable logical client-session identity. */
+export class SessionTurnCoordinator {
+  private readonly turns = new Map<string, SessionTurnState>()
+
+  get size(): number {
+    return this.turns.size
+  }
+
+  acquire(key: string, signal?: AbortSignal): Promise<SessionTurnLease> {
+    if (signal?.aborted) return Promise.reject(cancellationError(signal.reason))
+
+    let state = this.turns.get(key)
+    if (!state) {
+      state = { held: false, versions: new Map(), waiters: [] }
+      this.turns.set(key, state)
+    }
+
+    const arrivedAt = Date.now()
+    // Snapshot on ARRIVAL, not on grant: "advanced while waiting" is measured
+    // against the state this request was built from.
+    const arrivedVersions = new Map(state.versions)
+    if (!state.held && state.waiters.length === 0) {
+      state.held = true
+      return Promise.resolve(this.createLease(key, state, arrivedAt, arrivedVersions))
+    }
+
+    return new Promise<SessionTurnLease>((resolve, reject) => {
+      const waiter: SessionTurnWaiter = {
+        arrivedAt,
+        versions: arrivedVersions,
+        resolve,
+        reject,
+        signal,
+      }
+      if (signal) {
+        waiter.abortListener = () => {
+          const index = state!.waiters.indexOf(waiter)
+          if (index === -1) return
+          state!.waiters.splice(index, 1)
+          reject(cancellationError(signal.reason))
+          this.cleanup(key, state!)
+        }
+        signal.addEventListener("abort", waiter.abortListener, { once: true })
+      }
+      state!.waiters.push(waiter)
+    })
+  }
+
+  private createLease(
+    key: string,
+    state: SessionTurnState,
+    arrivedAt: number,
+    arrivedVersions: Map<string, number>,
+  ): SessionTurnLease {
+    let released = false
+    // Per scope, not a single flag: one turn legitimately stores its session
+    // more than once (silent-turn recovery re-commits), and that must count as
+    // one advancement — but a commit under a different scope is its own event.
+    const committedScopes = new Set<string>()
+    return {
+      waitedMs: Date.now() - arrivedAt,
+      // Safe to read lazily: only the current holder can commit, so nothing
+      // can advance between this lease being granted and being released.
+      advancedWhileWaiting: (scopeKey: string) =>
+        (state.versions.get(scopeKey) ?? 0) > (arrivedVersions.get(scopeKey) ?? 0),
+      markCommitted: (scopeKey: string) => {
+        if (released || committedScopes.has(scopeKey)) return
+        committedScopes.add(scopeKey)
+        state.versions.set(scopeKey, (state.versions.get(scopeKey) ?? 0) + 1)
+      },
+      release: () => {
+        if (released) return
+        released = true
+        state.held = false
+        while (state.waiters.length > 0) {
+          const waiter = state.waiters.shift()!
+          if (waiter.abortListener && waiter.signal) {
+            waiter.signal.removeEventListener("abort", waiter.abortListener)
+          }
+          if (waiter.signal?.aborted) {
+            waiter.reject(cancellationError(waiter.signal.reason))
+            continue
+          }
+          state.held = true
+          waiter.resolve(this.createLease(key, state, waiter.arrivedAt, waiter.versions))
+          return
+        }
+        this.cleanup(key, state)
+      },
+    }
+  }
+
+  private cleanup(key: string, state: SessionTurnState): void {
+    if (!state.held && state.waiters.length === 0 && this.turns.get(key) === state) {
+      this.turns.delete(key)
+    }
+  }
+}
+
+/** Process-wide coordinator; cache eviction must never clear active leases. */
+export const processSessionTurns = new SessionTurnCoordinator()

--- a/src/proxy/shutdown.ts
+++ b/src/proxy/shutdown.ts
@@ -1,0 +1,96 @@
+import type { Server } from "node:http"
+import type { Socket } from "node:net"
+
+export interface CloseServerOptions {
+  graceMs: number
+  getInFlightCount(): number
+  warn?: (message: string) => void
+  forceCloseConnections?: () => void
+}
+
+export interface ServerConnectionTracker {
+  forceCloseAll(): void
+  dispose(): void
+}
+
+/** Track sockets from server startup so forced shutdown works across runtimes. */
+export function trackServerConnections(server: Server): ServerConnectionTracker {
+  const sockets = new Set<Socket>()
+  const onConnection = (socket: Socket) => {
+    sockets.add(socket)
+    socket.once("close", () => sockets.delete(socket))
+  }
+  server.on("connection", onConnection)
+
+  return {
+    forceCloseAll() {
+      // Native Node closes HTTP(S) connections efficiently. Explicit socket
+      // destruction is the compatibility backstop for runtimes whose Node API
+      // shim exposes closeAllConnections() without fully implementing it.
+      server.closeAllConnections()
+      for (const socket of sockets) socket.destroy()
+    },
+    dispose() {
+      server.off("connection", onConnection)
+      sockets.clear()
+    },
+  }
+}
+
+/**
+ * Keep serving drain responses while active HTTP work finishes, then stop the
+ * server. Connections still open at the hard deadline are forcibly closed.
+ */
+export async function closeServerWithGracePeriod(
+  server: Server,
+  options: CloseServerOptions,
+): Promise<void> {
+  const graceMs = Math.max(0, options.graceMs)
+  const deadlineAt = Date.now() + graceMs
+
+  // Keep the listener alive during the drain window so health checks and new
+  // message requests can receive the explicit draining response. Stop early
+  // when all admitted message requests have completed.
+  while (options.getInFlightCount() > 0) {
+    const remainingMs = deadlineAt - Date.now()
+    if (remainingMs <= 0) break
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, Math.min(50, remainingMs))
+      timer.unref?.()
+    })
+  }
+
+  const closePromise = new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+
+  const remainingGraceMs = Math.max(0, deadlineAt - Date.now())
+  if (remainingGraceMs > 0) {
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const deadline = new Promise<"timeout">((resolve) => {
+      timeout = setTimeout(() => resolve("timeout"), remainingGraceMs)
+      timeout.unref?.()
+    })
+
+    try {
+      const outcome = await Promise.race([
+        closePromise.then(() => "closed" as const),
+        deadline,
+      ])
+      if (outcome === "closed") return
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
+  }
+
+  const remaining = options.getInFlightCount()
+  options.warn?.(
+    `[PROXY] Grace period elapsed with ${remaining} request(s) still in flight after ${graceMs}ms; forcing remaining HTTP connections closed.`,
+  )
+
+  // Call after server.close() to avoid accepting a new connection between the
+  // force-close and the server entering its closed state (Node.js guidance).
+  if (options.forceCloseConnections) options.forceCloseConnections()
+  else server.closeAllConnections()
+  await closePromise
+}

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -24,6 +24,15 @@ export interface ProxyConfig {
    * library consumer has already installed; the bundled CLI passes `true`.
    */
   installProcessErrorHandlers?: boolean
+  /**
+   * Cap concurrent SDK subprocess spawns for THIS instance only. Left unset
+   * (the default), instances share one process-wide budget from
+   * `MERIDIAN_MAX_CONCURRENT` — spawning many subprocesses at once is what
+   * exhausts the host, and that limit is a property of the process, not of any
+   * one proxy. Set this only when an embedder deliberately wants an isolated
+   * budget per instance.
+   */
+  maxConcurrent?: number
 }
 
 export interface ProxyInstance {
@@ -43,6 +52,14 @@ export interface ProxyServer {
   config: ProxyConfig
   /** Load plugins from disk and wire them into the request pipeline */
   initPlugins?(): Promise<void>
+  /**
+   * Stop admitting new `/v1/messages` requests (fast-fails with 503) and
+   * report `/health` as `draining`. Used by `startProxyServer`'s `close()`
+   * to drain in-flight requests before the HTTP server actually shuts down.
+   */
+  beginDrain?(): void
+  /** Count of requests admitted past the draining gate that haven't finished yet. */
+  getInFlightCount?(): number
 }
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {

--- a/src/telemetry/dashboard.ts
+++ b/src/telemetry/dashboard.ts
@@ -38,7 +38,6 @@ export const dashboardHtml = `<!DOCTYPE html>
   .waterfall-seg { height: 100%; border-radius: 2px; min-width: 2px; }
   .waterfall-seg.queue { background: var(--queue); }
   .waterfall-seg.overhead { background: var(--yellow); }
-  .waterfall-seg.ttfb { background: var(--ttfb); }
   .waterfall-seg.response { background: var(--upstream); }
   .legend { display: flex; gap: 16px; margin-bottom: 12px; font-size: 12px; color: var(--muted); }
   .legend-dot { width: 10px; height: 10px; border-radius: 2px; display: inline-block; margin-right: 4px; vertical-align: middle; }
@@ -296,6 +295,8 @@ function render(s, reqs, logs) {
   html += '<div class="section"><div class="section-title">Percentiles</div>'
     + '<table class="pct-table"><thead><tr><th>Phase</th><th>p50</th><th>p95</th><th>p99</th><th>Min</th><th>Max</th><th>Avg</th></tr></thead><tbody>'
     + pctRow('Queue Wait', 'var(--queue)', s.queueWait)
+    + pctRow('Session Queue', 'var(--queue)', s.sessionQueueWait)
+    + pctRow('SDK Queue', 'var(--queue)', s.sdkQueueWait)
     + pctRow('Proxy Overhead', 'var(--yellow)', s.proxyOverhead)
     + pctRow('TTFB', 'var(--ttfb)', s.ttfb)
     + pctRow('Upstream', 'var(--upstream)', s.upstreamDuration)
@@ -310,7 +311,6 @@ function render(s, reqs, logs) {
   html += '<div class="legend">'
     + '<span><span class="legend-dot" style="background:var(--queue)"></span>Queue</span>'
     + '<span><span class="legend-dot" style="background:var(--yellow)"></span>Proxy</span>'
-    + '<span><span class="legend-dot" style="background:var(--ttfb)"></span>TTFB</span>'
     + '<span><span class="legend-dot" style="background:var(--upstream)"></span>Response</span>'
     + '</div>'
     + '<table><thead><tr><th>Time</th><th>Adapter</th><th>Model</th><th>Mode</th><th>Session</th><th>Status</th>'
@@ -322,10 +322,11 @@ function render(s, reqs, logs) {
     const statusClass = r.error ? 'status-err' : 'status-ok';
     const statusText = r.error ? r.error : r.status;
     const scale = 280 / maxTotal;
+    const sessionQW = r.sessionQueueWaitMs || 0;
+    const sdkQW = r.sdkQueueWaitMs || 0;
     const qW = Math.max(r.queueWaitMs * scale, 2);
     const ohW = Math.max((r.proxyOverheadMs || 0) * scale, 0);
-    const ttfbW = Math.max((r.ttfbMs || 0) * scale, 0);
-    const respW = Math.max((r.upstreamDurationMs - (r.ttfbMs || 0)) * scale, 2);
+    const respW = Math.max(r.upstreamDurationMs * scale, 2);
 
     const lineageBadge = r.lineageType ? '<span style="font-size:10px;padding:1px 5px;border-radius:3px;background:' + ({continuation:'var(--green)',compaction:'var(--yellow)',undo:'var(--purple)',diverged:'var(--red)',new:'var(--muted)'}[r.lineageType] || 'var(--muted)') + ';color:var(--bg)">' + r.lineageType + '</span>' : '';
     const envBadge = (r.envelopeViolations && r.envelopeViolations.length > 0) ? ' <span style="font-size:10px;padding:1px 5px;border-radius:3px;background:var(--red);color:var(--bg)" title="' + r.envelopeViolations.join(', ') + '">envelope×' + r.envelopeViolations.length + '</span>' : '';
@@ -341,16 +342,15 @@ function render(s, reqs, logs) {
       + '<td>' + r.mode + (r.hasDeferredTools ? (function() { var sessDisc = r.sessionDiscoveredCount || 0; var loaded = ((r.toolCount || 0) - (r.deferredToolCount || 0)) + sessDisc; var deferred = Math.max(0, (r.deferredToolCount || 0) - sessDisc); var newDisc = r.discoveredTools || []; return '<br><span style="font-size:10px;color:var(--purple)">loaded=' + loaded + ' deferred=' + deferred + '</span>' + (newDisc.length > 0 ? '<br><span style="font-size:10px;color:var(--green)">+' + newDisc.join(', +') + '</span>' : ''); })() : '') + '</td>'
       + '<td class="mono">' + sessionShort + ' ' + lineageBadge + envBadge + '<br><span style="font-size:10px;color:var(--muted)">' + msgCount + ' msgs</span></td>'
       + '<td class="' + statusClass + '">' + statusText + '</td>'
-      + '<td class="mono">' + ms(r.queueWaitMs) + '</td>'
+      + '<td class="mono">' + ms(r.queueWaitMs) + '<br><span style="font-size:9px;color:var(--muted)">session ' + ms(sessionQW) + ' / sdk ' + ms(sdkQW) + '</span></td>'
       + '<td class="mono">' + ms(r.proxyOverheadMs) + '</td>'
       + '<td class="mono">' + ms(r.ttfbMs) + '</td>'
       + '<td class="mono">' + ms(r.totalDurationMs) + '</td>'
       + '<td class="mono">' + (r.inputTokens != null ? (r.inputTokens > 1000 ? Math.round(r.inputTokens/1000) + 'k' : r.inputTokens) + ' in<br>' + (r.outputTokens > 1000 ? Math.round(r.outputTokens/1000) + 'k' : r.outputTokens || 0) + ' out' : '—') + '</td>'
       + '<td class="mono">' + (r.cacheHitRate != null ? '<span style="color:' + (r.cacheHitRate > 0.5 ? 'var(--green)' : r.cacheHitRate > 0 ? 'var(--yellow)' : 'var(--red)') + '">' + Math.round(r.cacheHitRate * 100) + '%</span>' : '—') + '</td>'
-      + '<td><div class="waterfall">'
+      + '<td><div class="waterfall" title="Queue, then proxy overhead, then upstream response. A request that replayed upstream sums every attempt into the response segment, while TTFB counts only the attempt that produced the first chunk.">'
       + '<div class="waterfall-seg queue" style="width:' + qW + 'px"></div>'
       + '<div class="waterfall-seg overhead" style="width:' + ohW + 'px"></div>'
-      + '<div class="waterfall-seg ttfb" style="width:' + ttfbW + 'px"></div>'
       + '<div class="waterfall-seg response" style="width:' + respW + 'px"></div>'
       + '</div></td>'
       + '</tr>';

--- a/src/telemetry/percentiles.ts
+++ b/src/telemetry/percentiles.ts
@@ -43,6 +43,8 @@ export function computeSummary(
       envelopeViolationCount: 0,
       requestsPerMinute: 0,
       queueWait: emptyPhase,
+      sessionQueueWait: emptyPhase,
+      sdkQueueWait: emptyPhase,
       proxyOverhead: emptyPhase,
       ttfb: emptyPhase,
       upstreamDuration: emptyPhase,
@@ -70,6 +72,8 @@ export function computeSummary(
   const requestsPerMinute = (metrics.length / spanMs) * 60_000
 
   const queueWaits = metrics.map(m => m.queueWaitMs)
+  const sessionQueueWaits = metrics.map(m => m.sessionQueueWaitMs ?? 0)
+  const sdkQueueWaits = metrics.map(m => m.sdkQueueWaitMs ?? 0)
   const overheads = metrics.map(m => m.proxyOverheadMs)
   const ttfbs = metrics.filter(m => m.ttfbMs !== null).map(m => m.ttfbMs!)
   const upstreams = metrics.map(m => m.upstreamDurationMs)
@@ -119,6 +123,8 @@ export function computeSummary(
     envelopeViolationCount,
     requestsPerMinute: Math.round(requestsPerMinute * 100) / 100,
     queueWait: computePercentiles(queueWaits),
+    sessionQueueWait: computePercentiles(sessionQueueWaits),
+    sdkQueueWait: computePercentiles(sdkQueueWaits),
     proxyOverhead: computePercentiles(overheads),
     ttfb: ttfbs.length > 0 ? computePercentiles(ttfbs) : { p50: 0, p95: 0, p99: 0, min: 0, max: 0, avg: 0 },
     upstreamDuration: computePercentiles(upstreams),

--- a/src/telemetry/prometheus.ts
+++ b/src/telemetry/prometheus.ts
@@ -12,6 +12,8 @@ const DURATION_BUCKETS = [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30
 
 const PHASES: { key: string; extract: (m: RequestMetric) => number | null }[] = [
   { key: "queue_wait", extract: (m) => m.queueWaitMs },
+  { key: "session_queue_wait", extract: (m) => m.sessionQueueWaitMs ?? 0 },
+  { key: "sdk_queue_wait", extract: (m) => m.sdkQueueWaitMs ?? 0 },
   { key: "proxy_overhead", extract: (m) => m.proxyOverheadMs },
   { key: "ttfb", extract: (m) => m.ttfbMs },
   { key: "upstream", extract: (m) => m.upstreamDurationMs },

--- a/src/telemetry/sqlite.ts
+++ b/src/telemetry/sqlite.ts
@@ -25,6 +25,8 @@ CREATE TABLE IF NOT EXISTS metrics (
   sdk_session_id       TEXT,
   status               INTEGER NOT NULL,
   queue_wait_ms        REAL    NOT NULL,
+  session_queue_wait_ms REAL   NOT NULL DEFAULT 0,
+  sdk_queue_wait_ms     REAL   NOT NULL DEFAULT 0,
   proxy_overhead_ms    REAL    NOT NULL,
   ttfb_ms              REAL,
   upstream_duration_ms REAL    NOT NULL,
@@ -55,6 +57,8 @@ const METRICS_MIGRATIONS = [
   "ALTER TABLE metrics ADD COLUMN request_source TEXT",
   "ALTER TABLE metrics ADD COLUMN profile_id TEXT",
   "ALTER TABLE metrics ADD COLUMN envelope_violations TEXT",
+  "ALTER TABLE metrics ADD COLUMN session_queue_wait_ms REAL NOT NULL DEFAULT 0",
+  "ALTER TABLE metrics ADD COLUMN sdk_queue_wait_ms REAL NOT NULL DEFAULT 0",
 ]
 
 const LOGS_SCHEMA = `
@@ -103,7 +107,7 @@ class SqliteTelemetryStore implements ITelemetryStore {
         is_resume, is_passthrough, lineage_type,
         has_deferred_tools, deferred_tool_count, tool_count, discovered_tools, session_discovered_count,
         message_count, sdk_session_id,
-        status, queue_wait_ms, proxy_overhead_ms, ttfb_ms,
+        status, queue_wait_ms, session_queue_wait_ms, sdk_queue_wait_ms, proxy_overhead_ms, ttfb_ms,
         upstream_duration_ms, total_duration_ms, content_blocks, text_events, error,
         input_tokens, output_tokens, cache_read_input_tokens,
         cache_creation_input_tokens, cache_hit_rate, profile_id, envelope_violations
@@ -112,7 +116,7 @@ class SqliteTelemetryStore implements ITelemetryStore {
         @isResume, @isPassthrough, @lineageType,
         @hasDeferredTools, @deferredToolCount, @toolCount, @discoveredTools, @sessionDiscoveredCount,
         @messageCount, @sdkSessionId,
-        @status, @queueWaitMs, @proxyOverheadMs, @ttfbMs,
+        @status, @queueWaitMs, @sessionQueueWaitMs, @sdkQueueWaitMs, @proxyOverheadMs, @ttfbMs,
         @upstreamDurationMs, @totalDurationMs, @contentBlocks, @textEvents, @error,
         @inputTokens, @outputTokens, @cacheReadInputTokens,
         @cacheCreationInputTokens, @cacheHitRate, @profileId, @envelopeViolations
@@ -144,6 +148,8 @@ class SqliteTelemetryStore implements ITelemetryStore {
         sdkSessionId: metric.sdkSessionId ?? null,
         status: metric.status,
         queueWaitMs: metric.queueWaitMs,
+        sessionQueueWaitMs: metric.sessionQueueWaitMs ?? 0,
+        sdkQueueWaitMs: metric.sdkQueueWaitMs ?? 0,
         proxyOverheadMs: metric.proxyOverheadMs,
         ttfbMs: metric.ttfbMs ?? null,
         upstreamDurationMs: metric.upstreamDurationMs,
@@ -346,6 +352,8 @@ function rowToMetric(r: Record<string, unknown>): RequestMetric {
     sdkSessionId: (r.sdk_session_id as string) ?? undefined,
     status: r.status as number,
     queueWaitMs: r.queue_wait_ms as number,
+    sessionQueueWaitMs: (r.session_queue_wait_ms as number) ?? 0,
+    sdkQueueWaitMs: (r.sdk_queue_wait_ms as number) ?? 0,
     proxyOverheadMs: r.proxy_overhead_ms as number,
     ttfbMs: (r.ttfb_ms as number) ?? null,
     upstreamDurationMs: r.upstream_duration_ms as number,

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -84,6 +84,12 @@ export interface RequestMetric {
   /** Time spent waiting in the concurrency queue (ms) */
   queueWaitMs: number
 
+  /** Time spent waiting for the logical Session turn lease (ms). */
+  sessionQueueWaitMs?: number
+
+  /** Cumulative time spent waiting for SDK query permits across attempts (ms). */
+  sdkQueueWaitMs?: number
+
   /** Time spent in proxy processing before SDK call — request parsing,
    *  session lookup, prompt building (ms). If this is high, the proxy
    *  is the bottleneck. Typically <50ms. */
@@ -173,6 +179,8 @@ export interface TelemetrySummary {
 
   /** Timing breakdowns by phase */
   queueWait: PhaseTiming
+  sessionQueueWait: PhaseTiming
+  sdkQueueWait: PhaseTiming
   proxyOverhead: PhaseTiming
   ttfb: PhaseTiming
   upstreamDuration: PhaseTiming


### PR DESCRIPTION
## Summary

- coordinate SDK subprocesses with an abortable process-wide semaphore and serialize turns for the same client session
- add graceful draining/shutdown behavior and expose separate session/SDK queue timing in telemetry
- document the new concurrency and shutdown controls and add focused regression coverage

## Testing

- `npm test` — 2576 passed, 1 skipped, 0 failed in the main suite; all serial suites passed
- `npm run build` — passed
