### PR TITLE
feat(profiles): show the organization an account belongs to, and its details on hover

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -204,6 +204,9 @@ export async function runCli(
     enableDiskProfileDiscovery()
   }
 
+  const { enableOrganizationLookup } = await import("../src/proxy/organizationName")
+  enableOrganizationLookup()
+
   const proxy = await start({ port, host, idleTimeoutSeconds, pluginDir, pluginConfigPath, profiles, defaultProfile, version, installProcessErrorHandlers: true })
 
   // Handle EADDRINUSE — preserve CLI behavior of exiting on port conflict

--- a/src/__tests__/organization-name.test.ts
+++ b/src/__tests__/organization-name.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for organizationName.ts.
+ *
+ * The pure readers are exercised directly. The persistence round trip goes
+ * through the real module with MERIDIAN_CONFIG_DIR redirected, the same
+ * arrangement settings-unit.test.ts uses — a re-implementation of the JSON
+ * handling would pass regardless of what the module actually did.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, rmSync, readFileSync, writeFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  ORGANIZATION_REFRESH_AFTER_MS,
+  enableOrganizationLookup,
+  extractOrganizationName,
+  fetchOrganizationName,
+  organizationNames,
+  organizationNeedsRefresh,
+  readOrganizations,
+  refreshOrganizationNameSoon,
+  rememberOrganizationName,
+  resetOrganizationLookupForTesting,
+} from "../proxy/organizationName"
+import type { CredentialStore } from "../proxy/tokenRefresh"
+
+function storeWithToken(token: string | null): CredentialStore {
+  return {
+    read: async () => (token ? { claudeAiOauth: { accessToken: token } } : null),
+    write: async () => true,
+    describe: () => "test-store",
+  } as unknown as CredentialStore
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } })
+}
+
+describe("extractOrganizationName", () => {
+  test("reads organization.name", () => {
+    expect(extractOrganizationName({ organization: { name: "Acme Inc" } })).toBe("Acme Inc")
+  })
+
+  test("trims surrounding whitespace", () => {
+    expect(extractOrganizationName({ organization: { name: "  Acme Inc  " } })).toBe("Acme Inc")
+  })
+
+  test("a missing or unusable name yields null rather than a placeholder", () => {
+    expect(extractOrganizationName({ organization: {} })).toBeNull()
+    expect(extractOrganizationName({ organization: { name: null } })).toBeNull()
+    expect(extractOrganizationName({ organization: { name: "   " } })).toBeNull()
+    expect(extractOrganizationName({ organization: null })).toBeNull()
+    expect(extractOrganizationName({})).toBeNull()
+    expect(extractOrganizationName(null)).toBeNull()
+    expect(extractOrganizationName("Acme")).toBeNull()
+  })
+
+  test("an absurdly long name is treated as garbage", () => {
+    expect(extractOrganizationName({ organization: { name: "x".repeat(5000) } })).toBeNull()
+  })
+
+  test("reads the shape Anthropic actually returns, ignoring its other fields", () => {
+    const body = {
+      account: { uuid: "a", email: "someone@example.com" },
+      organization: {
+        uuid: "o",
+        name: "Nowaker's Org",
+        organization_type: "claude_max",
+        rate_limit_tier: "default_claude_max_20x",
+      },
+    }
+    expect(extractOrganizationName(body)).toBe("Nowaker's Org")
+  })
+})
+
+describe("readOrganizations", () => {
+  test("keeps well-formed records", () => {
+    expect(readOrganizations({ work: { name: "Acme", fetchedAt: 5 } })).toEqual({ work: { name: "Acme", fetchedAt: 5 } })
+  })
+
+  test("drops records with no usable name", () => {
+    const raw = { a: { name: "Acme", fetchedAt: 1 }, b: { name: "" }, c: { name: 7 }, d: null, e: "Acme" }
+    expect(readOrganizations(raw)).toEqual({ a: { name: "Acme", fetchedAt: 1 } })
+  })
+
+  test("a missing timestamp reads as never fetched rather than dropping the name", () => {
+    expect(readOrganizations({ work: { name: "Acme" } })).toEqual({ work: { name: "Acme", fetchedAt: 0 } })
+  })
+
+  test("non-object input yields an empty map", () => {
+    for (const raw of [undefined, null, "Acme", ["Acme"]]) expect(readOrganizations(raw)).toEqual({})
+  })
+})
+
+describe("organizationNeedsRefresh", () => {
+  test("an unknown profile needs one", () => {
+    expect(organizationNeedsRefresh(undefined, 1_000)).toBe(true)
+  })
+
+  test("a fresh record does not", () => {
+    expect(organizationNeedsRefresh({ name: "Acme", fetchedAt: 1_000 }, 1_000 + ORGANIZATION_REFRESH_AFTER_MS - 1)).toBe(false)
+  })
+
+  test("an aged record does", () => {
+    expect(organizationNeedsRefresh({ name: "Acme", fetchedAt: 1_000 }, 1_000 + ORGANIZATION_REFRESH_AFTER_MS)).toBe(true)
+  })
+
+  test("a record recovered without a timestamp is refreshed at the first opportunity", () => {
+    expect(organizationNeedsRefresh({ name: "Acme", fetchedAt: 0 }, Date.now())).toBe(true)
+  })
+})
+
+describe("fetchOrganizationName", () => {
+  test("returns the name for a token that works", async () => {
+    const name = await fetchOrganizationName(storeWithToken("tok"), async () =>
+      jsonResponse({ organization: { name: "Acme Inc" } }))
+    expect(name).toBe("Acme Inc")
+  })
+
+  test("sends the access token as a bearer credential", async () => {
+    const calls: Array<{ url: string; auth: string | null }> = []
+    await fetchOrganizationName(storeWithToken("tok"), async (url, init) => {
+      calls.push({ url, auth: new Headers(init?.headers).get("authorization") })
+      return jsonResponse({ organization: { name: "Acme" } })
+    })
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.url).toBe("https://api.anthropic.com/api/oauth/profile")
+    expect(calls[0]?.auth).toBe("Bearer tok")
+  })
+
+  test("no token means no request at all", async () => {
+    let called = false
+    const name = await fetchOrganizationName(storeWithToken(null), async () => {
+      called = true
+      return jsonResponse({ organization: { name: "Acme" } })
+    })
+    expect(name).toBeNull()
+    expect(called).toBe(false)
+  })
+
+  test("an upstream error yields null instead of throwing", async () => {
+    const name = await fetchOrganizationName(storeWithToken("tok"), async () => jsonResponse({}, 500))
+    expect(name).toBeNull()
+  })
+
+  test("a network failure yields null instead of throwing", async () => {
+    const name = await fetchOrganizationName(storeWithToken("tok"), async () => { throw new Error("ECONNREFUSED") })
+    expect(name).toBeNull()
+  })
+
+  test("a body that is not JSON yields null instead of throwing", async () => {
+    const name = await fetchOrganizationName(storeWithToken("tok"), async () => new Response("<html>nope</html>"))
+    expect(name).toBeNull()
+  })
+})
+
+describe("persistence and background refresh", () => {
+  const tempDir = join(tmpdir(), `meridian-organization-name-${process.pid}`)
+  const cacheFile = join(tempDir, "organizations.json")
+  let savedConfigDir: string | undefined
+
+  beforeEach(() => {
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    rmSync(tempDir, { recursive: true, force: true })
+    mkdirSync(tempDir, { recursive: true })
+    process.env.MERIDIAN_CONFIG_DIR = tempDir
+    resetOrganizationLookupForTesting()
+  })
+
+  afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
+    rmSync(tempDir, { recursive: true, force: true })
+    resetOrganizationLookupForTesting()
+  })
+
+  test("an unknown profile has no organization", () => {
+    expect(organizationNames()).toEqual({})
+  })
+
+  test("a name survives a write and read", () => {
+    rememberOrganizationName("work", "Acme Inc")
+    expect(organizationNames().work?.name).toBe("Acme Inc")
+  })
+
+  test("remembering one profile leaves the others alone", () => {
+    rememberOrganizationName("work", "Acme Inc")
+    rememberOrganizationName("side", "Globex")
+    const all = organizationNames()
+    expect(all.work?.name).toBe("Acme Inc")
+    expect(all.side?.name).toBe("Globex")
+  })
+
+  test("the cache file is written with owner-only permissions", () => {
+    rememberOrganizationName("work", "Acme Inc")
+    expect(statSync(cacheFile).mode & 0o777).toBe(0o600)
+  })
+
+  test("corrupt JSON reads as empty instead of throwing", () => {
+    writeFileSync(cacheFile, "not json{{{")
+    expect(() => organizationNames()).not.toThrow()
+    expect(organizationNames()).toEqual({})
+  })
+
+  test("the cache is Meridian's own file, not a credential file", () => {
+    rememberOrganizationName("work", "Acme Inc")
+    const raw = JSON.parse(readFileSync(cacheFile, "utf-8"))
+    expect(Object.keys(raw)).toEqual(["work"])
+    expect(raw.work.fetchedAt).toBeGreaterThan(0)
+  })
+
+  test("a background refresh stores what it learned", async () => {
+    refreshOrganizationNameSoon("work", {
+      store: storeWithToken("tok"),
+      fetchImpl: async () => jsonResponse({ organization: { name: "Acme Inc" } }),
+    })
+    await Bun.sleep(20)
+    expect(organizationNames().work?.name).toBe("Acme Inc")
+  })
+
+  test("a failed lookup leaves the previous name in place", async () => {
+    rememberOrganizationName("work", "Acme Inc")
+    refreshOrganizationNameSoon("work", {
+      store: storeWithToken("tok"),
+      fetchImpl: async () => jsonResponse({}, 500),
+      retryAfterMs: 0,
+    })
+    await Bun.sleep(20)
+    expect(organizationNames().work?.name).toBe("Acme Inc")
+  })
+
+  test("a second attempt inside the retry window does not call upstream again", async () => {
+    let calls = 0
+    const opts = {
+      store: storeWithToken("tok"),
+      fetchImpl: async () => { calls++; return jsonResponse({ organization: { name: "Acme Inc" } }) },
+    }
+    refreshOrganizationNameSoon("work", opts)
+    await Bun.sleep(20)
+    refreshOrganizationNameSoon("work", opts)
+    await Bun.sleep(20)
+    expect(calls).toBe(1)
+  })
+
+  test("the retry floor is per profile, not global", async () => {
+    const seen: string[] = []
+    const opts = (name: string) => ({
+      store: storeWithToken("tok"),
+      fetchImpl: async () => { seen.push(name); return jsonResponse({ organization: { name } }) },
+    })
+    refreshOrganizationNameSoon("work", opts("Acme Inc"))
+    refreshOrganizationNameSoon("side", opts("Globex"))
+    await Bun.sleep(20)
+    expect(seen.sort()).toEqual(["Acme Inc", "Globex"])
+  })
+
+  test("without an injected store the lookup stays disarmed until the CLI enables it", async () => {
+    // The guard that keeps the test suite from reading the developer's real
+    // ~/.claude credentials and calling Anthropic.
+    let called = false
+    refreshOrganizationNameSoon("work", { fetchImpl: async () => { called = true; return jsonResponse({}) } })
+    await Bun.sleep(20)
+    expect(called).toBe(false)
+    expect(organizationNames()).toEqual({})
+
+    enableOrganizationLookup()
+    refreshOrganizationNameSoon("work", {
+      store: storeWithToken("tok"),
+      fetchImpl: async () => jsonResponse({ organization: { name: "Acme Inc" } }),
+    })
+    await Bun.sleep(20)
+    expect(organizationNames().work?.name).toBe("Acme Inc")
+  })
+})

--- a/src/__tests__/profile-facts.test.ts
+++ b/src/__tests__/profile-facts.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for profileFacts.ts.
+ *
+ * The module ships browser source, so the tests evaluate that exact text
+ * rather than a TypeScript copy of it — what is asserted here is what both
+ * pages actually run.
+ */
+import { describe, test, expect } from "bun:test"
+import { profileFactsJs } from "../telemetry/profileFacts"
+import { landingHtml } from "../telemetry/landing"
+import { profilePageHtml } from "../telemetry/profilePage"
+
+interface Fact { label: string; value: string; tone: string }
+
+const evaluated = new Function(
+  profileFactsJs + "\nreturn { profileFacts: profileFacts, timeAgo: timeAgo };",
+)() as {
+  profileFacts: (p: Record<string, unknown>) => Fact[]
+  timeAgo: (ts: number | null | undefined) => string
+}
+
+const { profileFacts, timeAgo } = evaluated
+
+function labels(p: Record<string, unknown>): string[] {
+  return profileFacts(p).map(f => f.label)
+}
+
+function valueOf(p: Record<string, unknown>, label: string): string | undefined {
+  return profileFacts(p).find(f => f.label === label)?.value
+}
+
+describe("profileFacts", () => {
+  test("status is always stated, even for a profile with nothing else known", () => {
+    expect(labels({})).toEqual(["Status"])
+  })
+
+  test("a logged-in account reads as authenticated, in the affirmative tone", () => {
+    const status = profileFacts({ loggedIn: true })[0]!
+    expect(status.value).toBe("✓ Authenticated")
+    expect(status.tone).toBe("ok")
+  })
+
+  test("a logged-out account reads as not logged in, in the error tone", () => {
+    const status = profileFacts({ loggedIn: false })[0]!
+    expect(status.value).toBe("✗ Not logged in")
+    expect(status.tone).toBe("err")
+  })
+
+  test("the organization is stated when known", () => {
+    expect(valueOf({ organizationName: "Acme Inc" }, "Organization")).toBe("Acme Inc")
+  })
+
+  test("an unknown organization is omitted rather than rendered as a placeholder", () => {
+    expect(labels({ organizationName: null })).not.toContain("Organization")
+    expect(labels({ organizationName: "" })).not.toContain("Organization")
+    expect(labels({})).not.toContain("Organization")
+  })
+
+  test("the organization sits between the email and the plan", () => {
+    const rows = labels({ email: "a@b.c", organizationName: "Acme Inc", subscriptionType: "max" })
+    expect(rows).toEqual(["Status", "Email", "Organization", "Plan"])
+  })
+
+  test("email and plan are stated when known and omitted when not", () => {
+    expect(valueOf({ email: "a@b.c" }, "Email")).toBe("a@b.c")
+    expect(valueOf({ subscriptionType: "max" }, "Plan")).toBe("max")
+    expect(labels({ email: null, subscriptionType: null })).toEqual(["Status"])
+  })
+
+  test("last verified is stated in the affirmative tone", () => {
+    const fact = profileFacts({ lastSuccessAt: Date.now() }).find(f => f.label === "Last Verified")!
+    expect(fact.value).toBe("just now")
+    expect(fact.tone).toBe("ok")
+  })
+
+  test("last checked is omitted when it merely repeats last verified", () => {
+    const at = Date.now()
+    expect(labels({ lastSuccessAt: at, lastCheckedAt: at })).not.toContain("Last Checked")
+  })
+
+  test("last checked is stated when it differs from last verified", () => {
+    const at = Date.now()
+    expect(labels({ lastSuccessAt: at - 60_000, lastCheckedAt: at })).toContain("Last Checked")
+  })
+
+  test("last checked is stated when nothing ever verified", () => {
+    expect(labels({ loggedIn: false, lastCheckedAt: Date.now() })).toEqual(["Status", "Last Checked"])
+  })
+
+  test("the full set reads in card order", () => {
+    const at = Date.now()
+    expect(labels({
+      loggedIn: true,
+      email: "a@b.c",
+      organizationName: "Acme Inc",
+      subscriptionType: "max",
+      lastSuccessAt: at - 60_000,
+      lastCheckedAt: at,
+    })).toEqual(["Status", "Email", "Organization", "Plan", "Last Verified", "Last Checked"])
+  })
+})
+
+describe("timeAgo", () => {
+  test("an absent timestamp reads as a dash", () => {
+    expect(timeAgo(null)).toBe("—")
+    expect(timeAgo(0)).toBe("—")
+    expect(timeAgo(undefined)).toBe("—")
+  })
+
+  test("recent timestamps read in the coarsest unit that fits", () => {
+    const now = Date.now()
+    expect(timeAgo(now)).toBe("just now")
+    expect(timeAgo(now - 30_000)).toBe("30s ago")
+    expect(timeAgo(now - 5 * 60_000)).toBe("5m ago")
+    expect(timeAgo(now - 3 * 3_600_000)).toBe("3h ago")
+  })
+})
+
+describe("both pages render from this one builder", () => {
+  test("the landing page carries the shared source", () => {
+    expect(landingHtml).toContain("function profileFacts(p)")
+  })
+
+  test("the profiles page carries the shared source", () => {
+    expect(profilePageHtml).toContain("function profileFacts(p)")
+  })
+
+  test("neither page defines a second row list of its own", () => {
+    // The drift this module exists to prevent: a page that stops calling the
+    // builder and starts hand-writing rows again.
+    expect(landingHtml).toContain("profileFacts(entry)")
+    expect(profilePageHtml).toContain("profileFacts(p)")
+    expect(profilePageHtml).not.toContain("Last Verified<")
+  })
+
+  test("the shared source is emitted exactly once per page", () => {
+    expect(landingHtml.split("function profileFacts(p)").length - 1).toBe(1)
+    expect(profilePageHtml.split("function profileFacts(p)").length - 1).toBe(1)
+  })
+})

--- a/src/proxy/organizationName.ts
+++ b/src/proxy/organizationName.ts
@@ -1,0 +1,219 @@
+/**
+ * The organization an account belongs to, as Anthropic names it.
+ *
+ * `GET /api/oauth/profile` answers `organization.name` — the human label for
+ * the account behind a profile. A fleet whose profiles are called `work2` and
+ * `corp3` is told apart by that label and by nothing else on the card.
+ *
+ * WHERE IT IS KEPT. `.credentials.json` already holds `subscriptionType` and
+ * `rateLimitTier`, so it looks like the natural home — but those are Claude
+ * Code's OWN keys. Meridian writes that file to be indistinguishable from one
+ * `claude login` wrote, and a Meridian-invented key breaks that deliberately;
+ * worse, Claude Code rewrites the file on its next refresh and would drop the
+ * key, so it would not even survive. This is Meridian's own file, beside
+ * settings.json, and neither objection applies to it.
+ *
+ * WHY IT IS CACHED. The render path must not make an authenticated round trip
+ * per profile: two pages poll `/profiles/list` every 10s and a fleet is a dozen
+ * accounts, which is a dozen requests to Anthropic every ten seconds for a
+ * string that changes approximately never. So reads are synchronous and
+ * cache-only, and a stale entry is refreshed in the background — the response
+ * never waits on the network.
+ *
+ * Leaf module — no imports from server.ts or session/.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs"
+import { join, dirname } from "node:path"
+import { homedir } from "node:os"
+import { claudeLog } from "../logger"
+import { createPlatformCredentialStore, type CredentialStore } from "./tokenRefresh"
+
+const OAUTH_PROFILE_URL = "https://api.anthropic.com/api/oauth/profile"
+
+/** How old an entry may get before a background refresh is worth making. */
+export const ORGANIZATION_REFRESH_AFTER_MS = 24 * 60 * 60 * 1000
+
+/** Floor between two lookups for one profile, successful or not, so an
+ *  unreachable Anthropic cannot be retried once per 10s poll forever. */
+export const ORGANIZATION_RETRY_AFTER_MS = 5 * 60 * 1000
+
+/** Longest plausible organization name — a defence against a garbage body. */
+const MAX_ORGANIZATION_NAME_LENGTH = 200
+
+/** Same resolution as settings.ts, per call rather than at import, so tests
+ *  can redirect it (see `src/__tests__/preload.ts`). */
+function organizationsFile(): string {
+  const override = process.env.MERIDIAN_CONFIG_DIR
+  return override
+    ? join(override, "organizations.json")
+    : join(homedir(), ".config", "meridian", "organizations.json")
+}
+
+export interface OrganizationRecord {
+  name: string
+  fetchedAt: number
+}
+
+// --- Pure ------------------------------------------------------------------
+
+/**
+ * Read a record map out of whatever the file actually holds. Hand-editable and
+ * written by other versions, so an entry that is not a usable name is dropped
+ * rather than served.
+ */
+export function readOrganizations(raw: unknown): Record<string, OrganizationRecord> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {}
+  const out: Record<string, OrganizationRecord> = {}
+  for (const [id, value] of Object.entries(raw)) {
+    if (!id || typeof value !== "object" || value === null) continue
+    const record = value as { name?: unknown; fetchedAt?: unknown }
+    if (typeof record.name !== "string") continue
+    const name = record.name.trim()
+    if (!name || name.length > MAX_ORGANIZATION_NAME_LENGTH) continue
+    const fetchedAt = typeof record.fetchedAt === "number" && isFinite(record.fetchedAt) ? record.fetchedAt : 0
+    out[id] = { name, fetchedAt }
+  }
+  return out
+}
+
+/**
+ * Pull the name out of an `/api/oauth/profile` body.
+ *
+ * Nullable in principle even though every account measured has one, so an
+ * absent name yields null and the caller renders nothing rather than "unknown".
+ */
+export function extractOrganizationName(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null
+  const organization = (body as { organization?: unknown }).organization
+  if (typeof organization !== "object" || organization === null) return null
+  const name = (organization as { name?: unknown }).name
+  if (typeof name !== "string") return null
+  const trimmed = name.trim()
+  if (!trimmed || trimmed.length > MAX_ORGANIZATION_NAME_LENGTH) return null
+  return trimmed
+}
+
+export function organizationNeedsRefresh(
+  record: OrganizationRecord | undefined,
+  now: number,
+  refreshAfterMs: number = ORGANIZATION_REFRESH_AFTER_MS,
+): boolean {
+  if (!record) return true
+  return now - record.fetchedAt >= refreshAfterMs
+}
+
+// --- Persistence -----------------------------------------------------------
+
+/** Every organization on record, keyed by profile id. */
+export function organizationNames(): Record<string, OrganizationRecord> {
+  const file = organizationsFile()
+  try {
+    if (!existsSync(file)) return {}
+    return readOrganizations(JSON.parse(readFileSync(file, "utf-8")))
+  } catch {
+    return {}
+  }
+}
+
+export function rememberOrganizationName(profileId: string, name: string): void {
+  const file = organizationsFile()
+  const merged = { ...organizationNames(), [profileId]: { name, fetchedAt: Date.now() } }
+  try {
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, JSON.stringify(merged, null, 2) + "\n", { mode: 0o600 })
+  } catch (err) {
+    console.warn(`[meridian] Failed to write ${file}: ${err instanceof Error ? err.message : err}`)
+  }
+}
+
+// --- Lookup ----------------------------------------------------------------
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>
+
+/**
+ * Best-effort lookup for one account. Never throws and never fails its caller:
+ * a profile whose organization is unknown is strictly better than a page that
+ * will not render.
+ */
+export async function fetchOrganizationName(
+  store: CredentialStore,
+  fetchImpl: FetchLike = globalThis.fetch,
+): Promise<string | null> {
+  try {
+    const credentials = await store.read()
+    const token = credentials?.claudeAiOauth?.accessToken
+    if (!token) return null
+    const response = await fetchImpl(OAUTH_PROFILE_URL, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Cache-Control": "no-cache",
+      },
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!response.ok) {
+      claudeLog("organization.bad_response", { status: response.status })
+      return null
+    }
+    return extractOrganizationName(await response.json())
+  } catch (err) {
+    claudeLog("organization.lookup_failed", { error: err instanceof Error ? err.message : String(err) })
+    return null
+  }
+}
+
+/**
+ * Off by default, armed by the CLI at startup — the same guard
+ * `enableDiskProfileDiscovery` uses, and for a sharper reason: a background
+ * lookup for a profile with no config directory of its own would read the
+ * developer's real `~/.claude` credentials and call Anthropic from the test
+ * suite.
+ */
+let lookupEnabled = false
+
+export function enableOrganizationLookup(): void {
+  lookupEnabled = true
+}
+
+const lastAttemptAt = new Map<string, number>()
+const inflight = new Set<string>()
+
+export interface RefreshOrganizationOpts {
+  claudeConfigDir?: string
+  store?: CredentialStore
+  fetchImpl?: FetchLike
+  retryAfterMs?: number
+}
+
+/** Learn one profile's organization in the background. Returns immediately. */
+export function refreshOrganizationNameSoon(profileId: string, opts: RefreshOrganizationOpts = {}): void {
+  if (!lookupEnabled && !opts.store) return
+  if (inflight.has(profileId)) return
+  const now = Date.now()
+  const last = lastAttemptAt.get(profileId)
+  if (last !== undefined && now - last < (opts.retryAfterMs ?? ORGANIZATION_RETRY_AFTER_MS)) return
+  lastAttemptAt.set(profileId, now)
+  inflight.add(profileId)
+  void (async () => {
+    try {
+      const store = opts.store ?? createPlatformCredentialStore({ claudeConfigDir: opts.claudeConfigDir })
+      const name = await fetchOrganizationName(store, opts.fetchImpl)
+      if (name) {
+        rememberOrganizationName(profileId, name)
+        // Length rather than the value: this log is what gets pasted into an
+        // issue, and authDiscovery.ts redacts the same field for that reason.
+        claudeLog("organization.discovered", { profile: profileId, nameLength: name.length })
+      }
+    } finally {
+      inflight.delete(profileId)
+    }
+  })()
+}
+
+/** Reset module state — for testing only. */
+export function resetOrganizationLookupForTesting(): void {
+  lookupEnabled = false
+  lastAttemptAt.clear()
+  inflight.clear()
+}

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -81,6 +81,7 @@ import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
 import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { organizationNames, organizationNeedsRefresh, refreshOrganizationNameSoon } from "./organizationName"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -4757,6 +4758,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
   app.get("/profiles/list", async (c) => {
     const profiles = listProfiles(finalConfig.profiles, finalConfig.defaultProfile)
+    const organizations = organizationNames()
     // Enrich with live auth status
     const enriched = await Promise.all(profiles.map(async (p) => {
       const resolved = resolveProfile(finalConfig.profiles, finalConfig.defaultProfile, p.id)
@@ -4766,10 +4768,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         envOverrides
       )
       const cacheInfo = getAuthCacheInfo(p.id !== "default" ? p.id : undefined)
+      const organization = organizations[p.id]
+      // Only claude-max profiles have an OAuth account to ask about, and only
+      // their credentials are a directory this can name — an API-key profile
+      // would otherwise be looked up against the host's own ~/.claude and
+      // labelled with an unrelated organization.
+      if (resolved.type === "claude-max" && organizationNeedsRefresh(organization, Date.now())) {
+        refreshOrganizationNameSoon(p.id, { claudeConfigDir: resolved.env.CLAUDE_CONFIG_DIR })
+      }
       return {
         ...p,
         email: auth?.email || null,
         subscriptionType: auth?.subscriptionType || null,
+        organizationName: organization?.name ?? null,
         loggedIn: auth?.loggedIn ?? false,
         lastCheckedAt: cacheInfo.lastCheckedAt || null,
         lastSuccessAt: cacheInfo.lastSuccessAt || null,

--- a/src/telemetry/landing.ts
+++ b/src/telemetry/landing.ts
@@ -9,6 +9,7 @@
  */
 
 import { profileBarCss, profileBarHtml, profileBarJs, themeCss } from "./profileBar"
+import { profileFactsJs } from "./profileFacts"
 
 export const landingHtml = `<!DOCTYPE html>
 <html lang="en">
@@ -52,6 +53,32 @@ export const landingHtml = `<!DOCTYPE html>
     color: var(--muted); opacity: 0; transition: opacity 0.15s; }
   .profile-card.switchable:hover .switch-hint { opacity: 1; }
   .profile-cost { font-size: 22px; font-weight: 700; font-variant-numeric: tabular-nums; color: var(--text); }
+
+  /* Account details on hover. Drawn rather than a title attribute: the native
+     tooltip cannot show a label/value list, and this one has to match the grid
+     on /profiles row for row. */
+  .prof-info { position: relative; display: inline-flex; }
+  .prof-info-dot { width: 14px; height: 14px; flex-shrink: 0; border-radius: 50%;
+    border: 1px solid var(--border); background: var(--surface2); color: var(--muted);
+    font-family: Georgia, 'Times New Roman', serif; font-style: italic; font-size: 10px;
+    font-weight: 700; line-height: 12px; text-align: center; cursor: help; }
+  .prof-info:hover .prof-info-dot, .prof-info:focus-within .prof-info-dot {
+    border-color: var(--accent); color: var(--accent); }
+  .prof-info-dot:focus-visible { outline: none; border-color: var(--accent); color: var(--accent); }
+  .prof-pop { position: absolute; top: calc(100% + 8px); left: -8px; z-index: 20;
+    min-width: 256px; padding: 12px 14px; background: var(--surface2);
+    border: 1px solid var(--border); border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+    opacity: 0; visibility: hidden; transition: opacity 0.12s;
+    text-align: left; font-weight: 400; letter-spacing: 0; text-transform: none; cursor: default; }
+  .prof-info:hover .prof-pop, .prof-info:focus-within .prof-pop { opacity: 1; visibility: visible; }
+  .prof-pop-type { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+    color: var(--accent2); margin-bottom: 8px; }
+  .prof-pop-grid { display: grid; grid-template-columns: auto 1fr; gap: 5px 14px; font-size: 11px; }
+  .prof-pop-label { color: var(--muted); white-space: nowrap; }
+  .prof-pop-value { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; word-break: break-word; }
+  .prof-pop-value.status-ok { color: var(--green); }
+  .prof-pop-value.status-err { color: var(--red); }
   .profile-sub { font-size: 11px; color: var(--muted); text-align: right; margin-bottom: 12px; }
   .usage-row { display: flex; align-items: center; gap: 10px; font-size: 12px; padding: 4px 0; }
   .usage-row .w-label { color: var(--muted); width: 64px; flex-shrink: 0; }
@@ -95,6 +122,7 @@ export const landingHtml = `<!DOCTYPE html>
   <div id="content"><div style="color:var(--muted);padding:40px;text-align:center">Loading…</div></div>
 </div>
 <script>
+` + profileFactsJs + `
 function ms(v){if(v==null||v===0)return '—';return v<1000?v+'ms':(v/1000).toFixed(1)+'s'}
 function esc(s){return String(s).replace(/[&<>"']/g,function(ch){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]})}
 function usd(v){if(v==null)return '—';if(v>0&&v<0.01)return '$'+v.toFixed(4);if(v<100)return '$'+v.toFixed(2);return '$'+Math.round(v).toLocaleString()}
@@ -139,6 +167,29 @@ function introSection(h){
     +'</div>';
 }
 
+function infoIcon(entry,type){
+  var facts=profileFacts(entry);
+  var rows='';
+  for(var i=0;i<facts.length;i++){
+    var f=facts[i];
+    var tone=f.tone==='ok'?' status-ok':f.tone==='err'?' status-err':'';
+    rows+='<span class="prof-pop-label">'+esc(f.label)+'</span>'
+      +'<span class="prof-pop-value'+tone+'">'+esc(f.value)+'</span>';
+  }
+  return '<span class="prof-info">'
+    +'<span class="prof-info-dot" tabindex="0" role="button" aria-label="Details for '+esc(entry.id)+'">i</span>'
+    +'<span class="prof-pop" role="tooltip">'
+    +'<span class="prof-pop-type">'+esc(type||'claude-max')+'</span>'
+    +'<span class="prof-pop-grid">'+rows+'</span>'
+    +'</span></span>';
+}
+
+// An open overlay is the hovered or focused element, so this needs no state of
+// its own and cannot be left stuck by an event that never arrives.
+function infoPopOpen(){
+  return !!document.querySelector('.prof-info:hover, .prof-info:focus-within');
+}
+
 function profileSection(q,s,pl,h){
   var byProfile=(s&&s.costEstimate&&s.costEstimate.byProfile)||{};
   var quotaByProfile={};
@@ -150,7 +201,9 @@ function profileSection(q,s,pl,h){
     // Real profiles exist: show exactly those. Traffic that predates
     // per-profile attribution (the synthetic "default" bucket) still
     // counts in the totals strip but doesn't render as a fake account.
-    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,configured:true});seen[p.id]=1}
+    // The whole entry rides along so the details overlay reads it directly —
+    // a copied field list here would have to grow every time profileFacts does.
+    for(var i=0;i<configured.length;i++){var p=configured[i];profs.push({id:p.id,label:p.id,type:p.type,isActive:!!p.isActive,configured:true,entry:p});seen[p.id]=1}
   }else{
     // Single-account setup: one card, labeled with the logged-in email.
     var email=(h&&h.auth&&h.auth.loggedIn&&h.auth.email)||'';
@@ -203,7 +256,7 @@ function profileSection(q,s,pl,h){
       }
     }
     cards+='<div class="profile-card'+(p.isActive?' active':'')+(switchable?' switchable':'')+'"'+(switchable?' data-profile="'+esc(p.id)+'" role="button" tabindex="0"':'')+'>'
-      +'<div class="profile-head"><span class="profile-name"><span class="prof-dot"></span>'+esc(p.label||p.id)+' '+badge+'</span>'
+      +'<div class="profile-head"><span class="profile-name"><span class="prof-dot"></span>'+(p.entry?infoIcon(p.entry,p.type):'')+esc(p.label||p.id)+' '+badge+'</span>'
       +'<span class="profile-cost">'+usd(cost?cost.estimatedUsd:0)+'</span></div>'
       +'<div class="profile-sub">'+(cost?cost.requests+' request'+(cost.requests===1?'':'s')+' · est. API value · 24h':'no traffic · 24h')+'</div>'
       +rows+'</div>';
@@ -268,15 +321,19 @@ function switchProfile(id){
     .catch(function(){});
 }
 document.getElementById('content').addEventListener('click',function(e){
+  // The card is itself the switch button, so the icon inside one has to opt
+  // out of it or reading an account would move all traffic to that account.
+  if(e.target.closest('.prof-info'))return;
   var card=e.target.closest('.profile-card.switchable');
   if(card&&card.dataset.profile)switchProfile(card.dataset.profile);
 });
 document.getElementById('content').addEventListener('keydown',function(e){
   if(e.key!=='Enter'&&e.key!==' ')return;
+  if(e.target.closest('.prof-info'))return;
   var card=e.target.closest('.profile-card.switchable');
   if(card&&card.dataset.profile){e.preventDefault();switchProfile(card.dataset.profile)}
 });
-refresh();setInterval(refresh,10000);
+refresh();setInterval(function(){if(!infoPopOpen())refresh()},10000);
 ` + profileBarJs + `
 </script>
 </body>

--- a/src/telemetry/profileFacts.ts
+++ b/src/telemetry/profileFacts.ts
@@ -1,0 +1,43 @@
+/**
+ * What a profile card states about an account, in one place.
+ *
+ * Two surfaces render the same list — the detail grid on /profiles and the
+ * hover overlay on the landing page — so the list lives here instead of being
+ * written twice and drifting apart the first time a row is added.
+ *
+ * Emitted as browser source rather than a TypeScript function because the
+ * pages are string templates concatenated at import time, the same arrangement
+ * `profileBarJs` uses. The unit tests evaluate this exact text, so what they
+ * assert is what the browser runs.
+ *
+ * Values are plain text; escaping is the page's job, since only the page knows
+ * whether it is filling a grid cell or an overlay row.
+ */
+export const profileFactsJs = `
+function timeAgo(ts) {
+  if (!ts) return '\u2014';
+  var s = Math.floor((Date.now() - ts) / 1000);
+  if (s < 5) return 'just now';
+  if (s < 60) return s + 's ago';
+  if (s < 3600) return Math.floor(s / 60) + 'm ago';
+  if (s < 86400) return Math.floor(s / 3600) + 'h ago';
+  return new Date(ts).toLocaleString();
+}
+
+function profileFacts(p) {
+  var facts = [];
+  facts.push({
+    label: 'Status',
+    value: p.loggedIn ? '\u2713 Authenticated' : '\u2717 Not logged in',
+    tone: p.loggedIn ? 'ok' : 'err'
+  });
+  if (p.email) facts.push({ label: 'Email', value: p.email, tone: '' });
+  if (p.organizationName) facts.push({ label: 'Organization', value: p.organizationName, tone: '' });
+  if (p.subscriptionType) facts.push({ label: 'Plan', value: p.subscriptionType, tone: '' });
+  if (p.lastSuccessAt) facts.push({ label: 'Last Verified', value: timeAgo(p.lastSuccessAt), tone: 'ok' });
+  if (p.lastCheckedAt && p.lastCheckedAt !== p.lastSuccessAt) {
+    facts.push({ label: 'Last Checked', value: timeAgo(p.lastCheckedAt), tone: '' });
+  }
+  return facts;
+}
+`

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -4,6 +4,7 @@
  */
 
 import { profileBarCss, profileBarHtml, profileBarJs, themeCss } from "./profileBar"
+import { profileFactsJs } from "./profileFacts"
 import { WINDOW_LABELS } from "./profileUsage"
 
 export const profilePageHtml = `<!DOCTYPE html>
@@ -184,6 +185,7 @@ export const profilePageHtml = `<!DOCTYPE html>
 </div>
 
 <script>
+` + profileFactsJs + `
 // Inlined from src/telemetry/profileUsage.ts. The TS source is unit-tested
 // (see profile-usage.test.ts) and the labels object is interpolated here so
 // the browser script and TS module share their data.
@@ -257,6 +259,14 @@ async function refresh() {
 }
 
 function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+function factRows(facts) {
+  return facts.map(function (f) {
+    var tone = f.tone === 'ok' ? ' status-ok' : f.tone === 'err' ? ' status-err' : '';
+    return '<span class="detail-label">' + esc(f.label) + '</span>'
+      + '<span class="detail-value' + tone + '">' + esc(f.value) + '</span>';
+  }).join('');
+}
 
 function renderUsageSection(profileQuota) {
   // No quota data for this profile yet (cold start or fetch failed) — hide
@@ -364,28 +374,7 @@ function render(data, quotaData) {
     html += '<span class="profile-badge badge-type">' + esc(p.type || 'claude-max') + '</span>';
     html += '</div>';
 
-    html += '<div class="profile-details">';
-    html += '<span class="detail-label">Status</span>';
-    html += '<span class="detail-value ' + (p.loggedIn ? 'status-ok' : 'status-err') + '">'
-      + (p.loggedIn ? '\u2713 Authenticated' : '\u2717 Not logged in') + '</span>';
-
-    if (p.email) {
-      html += '<span class="detail-label">Email</span>';
-      html += '<span class="detail-value">' + esc(p.email) + '</span>';
-    }
-    if (p.subscriptionType) {
-      html += '<span class="detail-label">Plan</span>';
-      html += '<span class="detail-value">' + esc(p.subscriptionType) + '</span>';
-    }
-    if (p.lastSuccessAt) {
-      html += '<span class="detail-label">Last Verified</span>';
-      html += '<span class="detail-value" style="color:var(--green)">' + timeAgo(p.lastSuccessAt) + '</span>';
-    }
-    if (p.lastCheckedAt && (!p.lastSuccessAt || p.lastCheckedAt !== p.lastSuccessAt)) {
-      html += '<span class="detail-label">Last Checked</span>';
-      html += '<span class="detail-value">' + timeAgo(p.lastCheckedAt) + '</span>';
-    }
-    html += '</div>';
+    html += '<div class="profile-details">' + factRows(profileFacts(p)) + '</div>';
 
     if (!p.loggedIn) {
       html += '<div style="margin-top:12px;padding:10px 14px;background:rgba(210,153,34,0.1);border:1px solid rgba(210,153,34,0.3);border-radius:8px;font-size:12px">';
@@ -414,16 +403,6 @@ function render(data, quotaData) {
 
   html += '</div>';
   document.getElementById('content').innerHTML = html;
-}
-
-function timeAgo(ts) {
-  if (!ts) return '\u2014';
-  var s = Math.floor((Date.now() - ts) / 1000);
-  if (s < 5) return 'just now';
-  if (s < 60) return s + 's ago';
-  if (s < 3600) return Math.floor(s/60) + 'm ago';
-  if (s < 86400) return Math.floor(s/3600) + 'h ago';
-  return new Date(ts).toLocaleString();
 }
 
 function copyCmd(btn) {


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Two related additions to the profile UI, sharing one new field.

**1. The organization an account belongs to.**

A fleet of accounts named `work2`, `corp3`, `personal2` gives no way to tell whose
subscription each one actually is. Anthropic already answers that: the same
`GET /api/oauth/profile` call Meridian makes for the plan also returns
`organization.name`. This keeps it.

It is stored in a Meridian-owned `organizations.json` beside `settings.json`,
**not** in `.credentials.json`. That file's keys are Claude Code's own, and
Claude Code rewrites it on its next token refresh - a Meridian-invented key
there would both break the "indistinguishable from `claude login`" property and
be dropped within hours. Fetching live per render is also out: eleven profiles
would mean eleven authenticated round trips on every page load. The cache is
refreshed opportunistically, off the request path, with a retry floor.

`GET /profiles/list` gains `organizationName`, present on every profile with
`null` when unknown, so a consumer can tell "no organization" from "this
Meridian is too old to answer". The `/profiles` card gains an `Organization`
row, omitted entirely when absent rather than rendered as "unknown".

The name is deliberately **not** added to `SAFE_AUTH_STRING_KEYS` - that
allowlist governs debug logs, which get pasted into issues. Rendering it on the
operator's own screen is fine; putting every account's organization into a
shareable log is not. The discovery log records the name's *length*, matching
what `authDiscovery.ts` already does for the same field.

**2. An (i) overlay on the home page.**

Each account card gets a small (i) after the status dot and before the name.
Hovering or focusing it draws a panel with the same label/value list the
`/profiles` card shows - type, status, organization, plan, when it was last
verified. Not a `title` attribute: the native tooltip cannot render a
label/value grid.

Both surfaces render from one shared builder (`src/telemetry/profileFacts.ts`),
so the two lists cannot drift - adding a row adds it in both places. That
builder ships browser source and its tests evaluate that exact text, so the
tested function and the shipped function are the same string.

The icon opts out of the card's click and keydown handlers: the card is itself
the switch button, so reading an account must not move all traffic to it. The
10s poll is suppressed while an overlay is open, so it cannot be yanked away
mid-read.

**Testing.** `tsc --noEmit -p tsconfig.json` clean. Full suite compared against
`main` with `comm` in both directions on the deduped failure set: identical,
zero new and zero disappeared, plus 48 new passing tests.

This PR is AI generated, but under direct supervision and on request of Nowaker.
