### PR TITLE
feat: keep the last good usage reading when a check fails

### DIFF
--- a/src/__tests__/cached-facts.test.ts
+++ b/src/__tests__/cached-facts.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Provenance markers for remembered values — pure functions, no mocks, plus the
+ * profile page's contract that it actually renders them.
+ *
+ * The behaviour under test is a reader's question: is this number one the
+ * check just took, one it took earlier and could not confirm, or one it has
+ * never taken at all? The first two look identical on screen without a marker,
+ * and the third used to look like nothing at all.
+ */
+
+import { describe, it, expect, test } from "bun:test"
+import {
+  CACHED_TEXT,
+  NEVER_READ_TEXT,
+  cachedTag,
+  factProvenance,
+  renderFactValue,
+} from "../telemetry/cachedFacts"
+import { profilePageHtml } from "../telemetry/profilePage"
+
+describe("factProvenance", () => {
+  it("calls a value from the check that just ran live", () => {
+    expect(factProvenance("max", false)).toBe("live")
+  })
+
+  it("calls a value the failed check inherited cached", () => {
+    expect(factProvenance("max", true)).toBe("cached")
+  })
+
+  it("calls an absent value never, whether or not the check failed", () => {
+    expect(factProvenance(null, true)).toBe("never")
+    expect(factProvenance(undefined, false)).toBe("never")
+  })
+
+  it("treats an empty string as absent rather than as a live reading of nothing", () => {
+    expect(factProvenance("", false)).toBe("never")
+    expect(factProvenance("", true)).toBe("never")
+  })
+})
+
+describe("cachedTag", () => {
+  it("marks a cached value", () => {
+    expect(cachedTag("cached")).toContain(CACHED_TEXT)
+    expect(cachedTag("cached")).toContain("cached-tag")
+  })
+
+  it("leaves a live value unmarked", () => {
+    expect(cachedTag("live")).toBe("")
+  })
+
+  it("does not mark a value that was never read — there is nothing to date", () => {
+    expect(cachedTag("never")).toBe("")
+  })
+})
+
+describe("renderFactValue", () => {
+  it("renders a live value with no marker at all", () => {
+    const html = renderFactValue("alice@example.com", false)
+    expect(html).toBe('<span class="detail-value">alice@example.com</span>')
+    expect(html).not.toContain(CACHED_TEXT)
+  })
+
+  it("renders a cached value with the marker to the right of it", () => {
+    const html = renderFactValue("alice@example.com", true) ?? ""
+    expect(html).toContain("alice@example.com")
+    expect(html).toContain(CACHED_TEXT)
+    // "to the right of each value" — the marker follows the value, never leads it.
+    expect(html.indexOf("alice@example.com")).toBeLessThan(html.indexOf(CACHED_TEXT))
+  })
+
+  it("renders never-known differently from known-but-stale rather than collapsing both", () => {
+    const stale = renderFactValue("20x", true)
+    const never = renderFactValue(null, true)
+
+    expect(stale).not.toBe(never)
+    // The stale one still carries the figure; the never one must not invent it.
+    expect(stale).toContain("20x")
+    expect(never).not.toContain("20x")
+    expect(never).toContain(NEVER_READ_TEXT)
+    // And a never-read value is not dated — claiming "(cached)" would assert a
+    // reading that was never taken.
+    expect(never).not.toContain(CACHED_TEXT)
+  })
+
+  it("omits the row when a SUCCESSFUL check found no value — not applicable, not stale", () => {
+    expect(renderFactValue(null, false)).toBeNull()
+    expect(renderFactValue("", false)).toBeNull()
+  })
+
+  it("keeps the caller's status class alongside detail-value", () => {
+    expect(renderFactValue("\u2713 Authenticated", false, "status-ok"))
+      .toContain('class="detail-value status-ok"')
+    expect(renderFactValue(null, true, "status-err"))
+      .toContain("detail-unknown")
+  })
+
+  it("escapes the value — emails and plan names come from a credential file", () => {
+    const html = renderFactValue('<img src=x onerror="alert(1)">', true) ?? ""
+    expect(html).not.toContain("<img")
+    expect(html).toContain("&lt;img")
+    expect(html).toContain(CACHED_TEXT)
+  })
+})
+
+describe("the profile page renders the marker", () => {
+  test("the page styles the marker and the never-read stand-in", () => {
+    expect(profilePageHtml).toContain(".cached-tag")
+    expect(profilePageHtml).toContain(".detail-unknown")
+  })
+
+  test("the page's inline script can emit both states", () => {
+    expect(profilePageHtml).toContain(CACHED_TEXT)
+    expect(profilePageHtml).toContain(NEVER_READ_TEXT)
+  })
+
+  test("the marker is muted rather than competing with the value it annotates", () => {
+    expect(profilePageHtml).toMatch(/\.cached-tag\s*\{[^}]*var\(--muted\)/)
+  })
+})

--- a/src/__tests__/oauth-usage.test.ts
+++ b/src/__tests__/oauth-usage.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test, beforeEach } from "bun:test"
-import { fetchOAuthUsage, fetchOAuthUsageResult, resetOAuthUsageCache } from "../proxy/oauthUsage"
+import { fetchOAuthUsage, fetchOAuthUsageResult, resetOAuthUsageCache, toUsageEntry } from "../proxy/oauthUsage"
 import type { CredentialStore } from "../proxy/tokenRefresh"
 
 const SAMPLE_RESPONSE = {
@@ -502,5 +502,141 @@ describe("fetchOAuthUsageResult", () => {
     })
     expect(second.snapshot?.stale).toBe(true)
     expect(second.error).toBeNull()
+  })
+})
+
+describe("failure provenance", () => {
+  beforeEach(() => {
+    resetOAuthUsageCache()
+  })
+
+  test("a first-ever failure has a reason and nothing to fall back on", async () => {
+    const { fetchImpl } = countingFetch(() =>
+      new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+
+    const result = await fetchOAuthUsageResult({
+      force: true, store: makeStore(null), profileId: "cold", fetchImpl,
+    })
+
+    expect(result.snapshot).toBeNull()
+    expect(result.lastGood).toBeNull()
+    expect(result.failure?.reason).toBe("no_token")
+    expect(result.failure?.consecutiveFailures).toBe(1)
+  })
+
+  test("a failure after a success keeps the reading and dates it", async () => {
+    const { fetchImpl } = countingFetch(calls => calls === 1
+      ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+      : new Response("boom", { status: 500 }))
+    const opts = { force: true, store: makeStore("t"), profileId: "after-success", fetchImpl }
+
+    const good = await fetchOAuthUsageResult(opts)
+    expect(good.failure).toBeNull()
+
+    const failed = await fetchOAuthUsageResult(opts)
+    expect(failed.snapshot?.stale).toBe(true)
+    expect(failed.snapshot?.fetchedAt).toBe(good.snapshot!.fetchedAt)
+    expect(failed.failure?.reason).toBe("upstream_error")
+    expect(failed.failure?.consecutiveFailures).toBe(1)
+  })
+
+  test("counts the run of consecutive failed checks", async () => {
+    const { fetchImpl } = countingFetch(() => new Response("boom", { status: 500 }))
+    const opts = { force: true, store: makeStore("t"), profileId: "run", fetchImpl }
+
+    await fetchOAuthUsageResult(opts)
+    await fetchOAuthUsageResult(opts)
+    const third = await fetchOAuthUsageResult(opts)
+
+    expect(third.failure?.consecutiveFailures).toBe(3)
+    expect(third.failure?.reason).toBe("upstream_error")
+  })
+
+  test("a success clears the run rather than zeroing it", async () => {
+    const { fetchImpl } = countingFetch(calls => calls <= 2
+      ? new Response("boom", { status: 500 })
+      : new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+    const opts = { force: true, store: makeStore("t"), profileId: "recovers", fetchImpl }
+
+    await fetchOAuthUsageResult(opts)
+    expect((await fetchOAuthUsageResult(opts)).failure?.consecutiveFailures).toBe(2)
+
+    const recovered = await fetchOAuthUsageResult(opts)
+    expect(recovered.snapshot?.stale).toBeUndefined()
+    expect(recovered.failure).toBeNull()
+  })
+
+  // The page polls every 10s against a backoff measured in minutes, so counting
+  // polls the cooldown refused would report the poll interval, not the account.
+  test("polls the cooldown turns away do not advance the count", async () => {
+    const { fetchImpl, getCalls } = countingFetch(() =>
+      new Response("rate limited", { status: 429, headers: { "Retry-After": "120" } }))
+    const opts = { force: true, store: makeStore("t"), profileId: "suppressed-run", fetchImpl }
+
+    expect((await fetchOAuthUsageResult(opts)).failure?.consecutiveFailures).toBe(1)
+    await fetchOAuthUsageResult(opts)
+    const third = await fetchOAuthUsageResult(opts)
+
+    expect(third.failure?.consecutiveFailures).toBe(1)
+    expect(third.failure?.reason).toBe("rate_limited")
+    expect(getCalls()).toBe(1)
+  })
+})
+
+describe("toUsageEntry", () => {
+  beforeEach(() => {
+    resetOAuthUsageCache()
+  })
+
+  test("a profile never read has no figures and is not called stale", async () => {
+    const { fetchImpl } = countingFetch(() =>
+      new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+
+    const entry = toUsageEntry(await fetchOAuthUsageResult({
+      force: true, store: makeStore(null), profileId: "entry-cold", fetchImpl,
+    }))
+
+    expect(entry.windows).toEqual([])
+    expect(entry.fetchedAt).toBeNull()
+    expect(entry.stale).toBe(false)
+    expect(entry.error).toBe("no_token")
+    expect(entry.failure?.reason).toBe("no_token")
+  })
+
+  test("a reading taken by the check that just ran is not stale", async () => {
+    const fetchImpl = fixedFetch(() => new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 }))
+
+    const entry = toUsageEntry(await fetchOAuthUsageResult({
+      force: true, store: makeStore("t"), profileId: "entry-fresh", fetchImpl,
+    }))
+
+    expect(entry.windows.length).toBeGreaterThan(0)
+    expect(entry.fetchedAt).not.toBeNull()
+    expect(entry.stale).toBe(false)
+    expect(entry.error).toBeNull()
+    expect(entry.failure).toBeNull()
+  })
+
+  // The whole point of the change: figures outlive the window `staleOr` will
+  // serve them in, and arrive labelled with when they were taken and why they
+  // have stopped moving.
+  test("keeps the last good reading past the stale bound, labelled", async () => {
+    const { fetchImpl } = countingFetch(calls => calls === 1
+      ? new Response(JSON.stringify(SAMPLE_RESPONSE), { status: 200 })
+      : new Response("boom", { status: 500 }))
+    const store = makeStore("t")
+
+    const good = await fetchOAuthUsageResult({ force: true, store, profileId: "entry-aged", fetchImpl })
+    const aged = await fetchOAuthUsageResult({
+      force: true, store, profileId: "entry-aged", fetchImpl, staleMaxMs: 0,
+    })
+    expect(aged.snapshot).toBeNull()
+
+    const entry = toUsageEntry(aged)
+    expect(entry.windows).toEqual(good.snapshot!.windows)
+    expect(entry.fetchedAt).toBe(good.snapshot!.fetchedAt)
+    expect(entry.stale).toBe(true)
+    expect(entry.error).toBe("upstream_error")
+    expect(entry.failure?.consecutiveFailures).toBe(1)
   })
 })

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -106,11 +106,78 @@ export interface OAuthUsageSnapshot {
  */
 export type OAuthUsageError = "no_token" | "rate_limited" | "upstream_error"
 
-/** A usage fetch outcome: the snapshot, or why there isn't one. */
-export interface OAuthUsageResult {
+/** What a fetch produced, before provenance is attached. Internal: every
+ *  public exit goes through `withProvenance`. */
+interface RawUsageResult {
   snapshot: OAuthUsageSnapshot | null
   /** Set only when `snapshot` is null. */
   error: OAuthUsageError | null
+}
+
+/**
+ * The run of failed checks since the last successful one.
+ *
+ * `consecutiveFailures` counts checks that actually reached the credential
+ * store or upstream — not polls the 429 cooldown turned away before they got
+ * there. The quota page polls every 10s while a backoff runs for a minute or
+ * more, so counting suppressed polls would report six failures for one refusal,
+ * which says more about the poll interval than about the account.
+ */
+export interface OAuthUsageFailure {
+  reason: OAuthUsageError
+  /** Always >= 1 — a success clears the record rather than zeroing it. */
+  consecutiveFailures: number
+  lastFailureAt: number
+}
+
+/** A usage fetch outcome: the snapshot, or why there isn't one. */
+export interface OAuthUsageResult extends RawUsageResult {
+  /** The failing run in progress, or null when the last check succeeded.
+   *  Independent of `snapshot`/`error`: a stale snapshot served inside the
+   *  bound reports `error: null`, and a reader still needs to know the figures
+   *  are standing in for a check that didn't land. */
+  failure: OAuthUsageFailure | null
+  /** Last successful reading for this profile at any age — including past the
+   *  point `staleOr` stops serving it as `snapshot`. Lets a display keep the
+   *  last known numbers, labelled, instead of blanking. */
+  lastGood: OAuthUsageSnapshot | null
+}
+
+/** The per-profile usage shape the quota routes serve. */
+export interface UsageEntryFields {
+  windows: OAuthUsageWindow[]
+  extraUsage: OAuthExtraUsageInfo | null
+  fetchedAt: number | null
+  /** True when the figures are a previous reading rather than one taken by the
+   *  check that just ran. */
+  stale: boolean
+  error: OAuthUsageError | null
+  failure: OAuthUsageFailure | null
+}
+
+/**
+ * Shape a fetch result for a consumer that renders it to a human.
+ *
+ * Three states a caller must be able to tell apart, and which bare numbers
+ * cannot:
+ *   never read      — no figures at all: `fetchedAt` null, `stale` false.
+ *   read and fresh  — `stale` false, `failure` null.
+ *   read then stale — figures as of `fetchedAt`, `stale` true, `failure` saying
+ *                     why the newer check didn't land and how many in a row.
+ *
+ * A window sitting at 0% and a profile that has never been read flatten to the
+ * same numbers, so the distinction has to travel as its own field.
+ */
+export function toUsageEntry(result: OAuthUsageResult): UsageEntryFields {
+  const shown = result.snapshot ?? result.lastGood
+  return {
+    windows: shown?.windows ?? [],
+    extraUsage: shown?.extraUsage ?? null,
+    fetchedAt: shown?.fetchedAt ?? null,
+    stale: shown != null && (result.snapshot === null || result.snapshot.stale === true),
+    error: result.error,
+    failure: result.failure,
+  }
 }
 
 const CACHE_TTL_MS_DEFAULT = 30_000
@@ -122,9 +189,27 @@ const RATE_LIMIT_BACKOFF_MS_DEFAULT = 60_000
 
 /** Per-profile cache. Key = profileId (or DEFAULT_KEY for the unscoped default). */
 const cacheByProfile = new Map<string, OAuthUsageSnapshot>()
-const inflightByProfile = new Map<string, Promise<OAuthUsageResult>>()
+const inflightByProfile = new Map<string, Promise<RawUsageResult>>()
 const rateLimitedUntilByProfile = new Map<string, number>()
+const failureByProfile = new Map<string, OAuthUsageFailure>()
 const DEFAULT_KEY = "__default__"
+
+function recordFailure(cacheKey: string, reason: OAuthUsageError): void {
+  const prev = failureByProfile.get(cacheKey)
+  failureByProfile.set(cacheKey, {
+    reason,
+    consecutiveFailures: (prev?.consecutiveFailures ?? 0) + 1,
+    lastFailureAt: Date.now(),
+  })
+}
+
+function withProvenance(cacheKey: string, result: RawUsageResult): OAuthUsageResult {
+  return {
+    ...result,
+    failure: failureByProfile.get(cacheKey) ?? null,
+    lastGood: cacheByProfile.get(cacheKey) ?? null,
+  }
+}
 
 const WINDOW_TYPES: Array<keyof RawOAuthUsageResponse> = [
   "five_hour",
@@ -314,19 +399,25 @@ function missingReason(cacheKey: string): OAuthUsageError {
 export async function fetchOAuthUsageResult(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageResult> {
   // If the caller injected real test deps, run the real impl. This keeps
   // oauth-usage unit tests isolated from any test-set _testOverride.
+  const cacheKey = opts?.profileId ?? DEFAULT_KEY
   if (_testOverride && !opts?.fetchImpl && !opts?.store) {
     const snapshot = await _testOverride(opts)
+    if (snapshot) {
+      failureByProfile.delete(cacheKey)
+      return withProvenance(cacheKey, { snapshot, error: null })
+    }
     // The override returns a bare snapshot-or-null, so the reason has to come
     // from the one piece of real state that outlives it: the 429 cooldown.
     // Defaulting to "no_token" here would make the override contradict the
     // cooldown the same process just recorded.
-    const error = snapshot ? null : missingReason(opts?.profileId ?? DEFAULT_KEY)
-    return { snapshot, error }
+    const error = missingReason(cacheKey)
+    recordFailure(cacheKey, error)
+    return withProvenance(cacheKey, { snapshot: null, error })
   }
-  return fetchOAuthUsageImpl(opts)
+  return withProvenance(cacheKey, await fetchOAuthUsageImpl(opts))
 }
 
-async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsageResult> {
+async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<RawUsageResult> {
   const ttl = opts?.ttlMs ?? CACHE_TTL_MS_DEFAULT
   const cacheKey = opts?.profileId ?? DEFAULT_KEY
   const fetchImpl = opts?.fetchImpl ?? globalThis.fetch
@@ -335,7 +426,12 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   // On transient failure, serve the last-good snapshot (bounded) instead of
   // null — a credential-read blip or upstream 5xx should not blank the
   // consumer's usage display until the next successful fetch.
-  const staleOr = (reason: string, error: OAuthUsageError): OAuthUsageResult => {
+  //
+  // `attempted` marks a check that actually reached the credential store or
+  // upstream. The 429 cooldown turns polls away before either, and those must
+  // not advance the failure count — see OAuthUsageFailure.
+  const staleOr = (reason: string, error: OAuthUsageError, attempted = true): RawUsageResult => {
+    if (attempted) recordFailure(cacheKey, error)
     const last = cacheByProfile.get(cacheKey)
     if (last && Date.now() - last.fetchedAt < staleMaxMs) {
       claudeLog("oauth_usage.serving_stale", { profile: cacheKey, reason, ageMs: Date.now() - last.fetchedAt })
@@ -356,7 +452,7 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
   // private usage endpoint permanently rate-limited.
   const rateLimitedUntil = rateLimitedUntilByProfile.get(cacheKey)
   if (rateLimitedUntil !== undefined) {
-    if (Date.now() < rateLimitedUntil) return staleOr("rate_limited", "rate_limited")
+    if (Date.now() < rateLimitedUntil) return staleOr("rate_limited", "rate_limited", false)
     rateLimitedUntilByProfile.delete(cacheKey)
   }
 
@@ -415,6 +511,7 @@ async function fetchOAuthUsageImpl(opts?: FetchOAuthUsageOpts): Promise<OAuthUsa
       }
 
       rateLimitedUntilByProfile.delete(cacheKey)
+      failureByProfile.delete(cacheKey)
       const snapshot = buildSnapshot(result)
       cacheByProfile.set(cacheKey, snapshot)
       return { snapshot, error: null }
@@ -435,4 +532,5 @@ export function resetOAuthUsageCache(): void {
   cacheByProfile.clear()
   inflightByProfile.clear()
   rateLimitedUntilByProfile.clear()
+  failureByProfile.clear()
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -11,7 +11,7 @@ import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { linkRequestAbort } from "./requestAbort"
 import { AbortableSemaphore, getProcessSdkSemaphore, type SemaphoreLease } from "./concurrency"
 import { closeServerWithGracePeriod, trackServerConnections } from "./shutdown"
-import { fetchOAuthUsage, fetchOAuthUsageResult } from "./oauthUsage"
+import { fetchOAuthUsage, fetchOAuthUsageResult, toUsageEntry } from "./oauthUsage"
 import { resolveSdkWorkingDirectory } from "./cwd"
 import type { Context } from "hono"
 import { DEFAULT_PROXY_CONFIG } from "./types"
@@ -5319,21 +5319,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // came to be labelled `no_token`. Older consumers that only switch on
   // `no_token` fall through to their default branch, which is why these are new
   // values rather than reuses.
+  //
+  // When the check that just ran produced nothing, `windows`/`extraUsage` are
+  // the last successful reading rather than empty, marked `stale: true` with
+  // `fetchedAt` saying when it was taken, and `failure` saying why the newer
+  // check didn't land and how many have failed in a row. `error` keeps its old
+  // meaning exactly — set when there was nothing fresh AND no recent-enough
+  // reading to stand in — so a consumer ignoring the new fields is unaffected.
   app.get("/v1/usage/quota/all", async (c) => {
     const profilesList = getEffectiveProfiles(finalConfig.profiles)
     const activeId = getActiveProfileId() || finalConfig.defaultProfile || profilesList[0]?.id || null
 
     if (profilesList.length === 0) {
       // Single-account mode — just return the default OAuth account's data.
-      const { snapshot: oauth, error } = await fetchOAuthUsageResult({})
       return c.json({
         profiles: [{
           id: "default",
           isActive: true,
-          windows: oauth?.windows ?? [],
-          extraUsage: oauth?.extraUsage ?? null,
-          fetchedAt: oauth?.fetchedAt ?? null,
-          error,
+          ...toUsageEntry(await fetchOAuthUsageResult({})),
         }],
         activeProfile: "default",
         asOf: Date.now(),
@@ -5351,21 +5354,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           windows: [] as any[],
           extraUsage: null,
           fetchedAt: null,
+          stale: false,
           error: "not_oauth" as const,
+          failure: null,
         }
       }
-      const { snapshot: oauth, error } = await fetchOAuthUsageResult({
-        profileId: p.id,
-        claudeConfigDir: p.claudeConfigDir,
-      })
       return {
         id: p.id,
         isActive: p.id === activeId,
         type,
-        windows: oauth?.windows ?? [],
-        extraUsage: oauth?.extraUsage ?? null,
-        fetchedAt: oauth?.fetchedAt ?? null,
-        error,
+        ...toUsageEntry(await fetchOAuthUsageResult({
+          profileId: p.id,
+          claudeConfigDir: p.claudeConfigDir,
+        })),
       }
     }))
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4773,6 +4773,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         loggedIn: auth?.loggedIn ?? false,
         lastCheckedAt: cacheInfo.lastCheckedAt || null,
         lastSuccessAt: cacheInfo.lastSuccessAt || null,
+        // Additive: which reading the three fields above came from. A failed
+        // check returns getClaudeAuthStatusAsync's lastKnownGood rather than
+        // nothing, so they routinely hold a remembered value in the exact shape
+        // of a fresh one. "never" — failed with nothing to fall back on — is a
+        // different fact from "cached" and must not render as the same blank.
+        authProvenance: cacheInfo.isFailure ? (auth ? "cached" : "never") : "live",
       }
     }))
     const routingModeNow = getRoutingMode(process.env.MERIDIAN_ROUTING ?? getSetting("routing"))

--- a/src/telemetry/cachedFacts.ts
+++ b/src/telemetry/cachedFacts.ts
@@ -1,0 +1,94 @@
+/**
+ * Provenance for values a page shows from a remembered reading.
+ *
+ * Lives outside the inline-HTML template for the same reason profileUsage.ts
+ * does: profilePage.ts is one big template literal that runs in the browser, so
+ * these can't be imported at runtime. The page mirrors them in its inline
+ * script and these TS versions guard the behavior via tests.
+ *
+ * Three states rather than two, because "no value" is two different facts and a
+ * reader has to be able to tell them apart:
+ *
+ *   live   — read by the check that just ran.
+ *   cached — read earlier; the check that just ran could not confirm it. Still
+ *            the best answer available, so it is shown, and marked so nobody
+ *            reads a remembered figure as a current one.
+ *   never  — never successfully read for this profile. Rendering this as
+ *            `cached` would claim a reading that was never taken; rendering it
+ *            as nothing at all drops the row entirely, so an account whose plan
+ *            size became unreadable looks identical to one that never had it.
+ */
+
+/** Which of the three readings produced the value on screen. */
+export type FactProvenance = "live" | "cached" | "never"
+
+/** Shown in place of a value that has never been read successfully. */
+export const NEVER_READ_TEXT = "never read"
+
+/** The marker's wording. Nowaker's own: short enough to sit after a value
+ *  without wrapping the row. */
+export const CACHED_TEXT = "(cached)"
+
+/**
+ * Classify a value by how it was obtained.
+ *
+ * `stale` means the check that just ran failed and `value` is what an earlier
+ * one left behind. An empty string counts as absent: the auth status and usage
+ * routes both normalize "not present" to null, but a blank plan string reaching
+ * the page would otherwise render as a live reading of nothing.
+ */
+export function factProvenance(value: string | null | undefined, stale: boolean): FactProvenance {
+  if (value == null || value === "") return "never"
+  return stale ? "cached" : "live"
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+}
+
+/** Mirrors the `esc` helpers in the page templates. Values reaching here are
+ *  account emails and plan names from a credential file, so they are escaped
+ *  rather than trusted. */
+function esc(value: string): string {
+  return String(value).replace(/[&<>"']/g, (ch) => HTML_ESCAPES[ch] ?? ch)
+}
+
+/**
+ * The marker that sits to the right of one cached value, or '' for a value read
+ * by the check that just ran.
+ *
+ * Per value rather than per card: a profile card routinely mixes the two — a
+ * live status beside a remembered email — so a single banner over the card
+ * would mislabel whichever half it doesn't apply to.
+ */
+export function cachedTag(provenance: FactProvenance): string {
+  return provenance === "cached" ? '<span class="cached-tag">' + CACHED_TEXT + "</span>" : ""
+}
+
+/**
+ * Render one `.detail-value` cell for a profile fact.
+ *
+ * `extraClass` carries the caller's own status colouring (the Status row is
+ * green or red); it is joined onto `.detail-value` rather than replacing it.
+ * Returns null when the row should be omitted — a fact that is absent from a
+ * check that SUCCEEDED is genuinely not applicable to this account (an API-key
+ * profile has no plan), which is neither a stale reading nor a failure to read.
+ */
+export function renderFactValue(
+  value: string | null | undefined,
+  stale: boolean,
+  extraClass = "",
+): string | null {
+  const provenance = factProvenance(value, stale)
+  if (provenance === "never" && !stale) return null
+
+  const classes = "detail-value" + (extraClass ? " " + extraClass : "")
+  if (provenance === "never") {
+    return '<span class="' + classes + ' detail-unknown">' + NEVER_READ_TEXT + "</span>"
+  }
+  return '<span class="' + classes + '">' + esc(String(value)) + cachedTag(provenance) + "</span>"
+}

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -97,6 +97,7 @@ export const profilePageHtml = `<!DOCTYPE html>
     margin-bottom: 10px; display: flex; align-items: center; gap: 8px;
   }
   .usage-as-of { font-size: 10px; color: var(--muted); text-transform: none; letter-spacing: 0; opacity: 0.7; }
+  .usage-stale-note { font-size: 11px; color: var(--yellow); line-height: 1.4; margin: -2px 0 10px; }
   .usage-grid {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 8px;
@@ -258,6 +259,20 @@ async function refresh() {
 
 function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
+// "last 4 checks failed (rate limited upstream)" — the run of failed checks
+// since the last good reading, or '' when the last check succeeded. Reasons map
+// through a fixed vocabulary rather than being echoed, so nothing the server
+// sends reaches the DOM.
+function describeFailedRun(failure) {
+  if (!failure) return '';
+  var why = failure.reason === 'rate_limited' ? 'rate limited upstream'
+    : failure.reason === 'no_token' ? 'no credentials readable'
+    : 'usage endpoint unavailable';
+  var n = Math.floor(Number(failure.consecutiveFailures));
+  if (!isFinite(n) || n < 1) n = 1;
+  return (n > 1 ? 'last ' + n + ' checks failed' : 'last check failed') + ' (' + why + ')';
+}
+
 function renderUsageSection(profileQuota) {
   // No quota data for this profile yet (cold start or fetch failed) — hide
   // entirely so we don't render an empty box.
@@ -270,6 +285,12 @@ function renderUsageSection(profileQuota) {
   });
   var extra = formatExtraUsage(profileQuota.extraUsage);
 
+  var failedRun = describeFailedRun(profileQuota.failure);
+
+  // No figures at all means this profile has never been read successfully —
+  // the route serves the last good reading at any age, so an empty windows
+  // array is no longer "the stale window lapsed". Saying so keeps it distinct
+  // from a profile genuinely sitting at 0%.
   if (windows.length === 0 && !extra) {
     if (profileQuota.error === 'no_token') {
       return '<div class="usage-section">'
@@ -278,12 +299,13 @@ function renderUsageSection(profileQuota) {
         + '</div>';
     }
     // Credentials are fine here — Anthropic is throttling the usage endpoint
-    // and the backoff has no snapshot left to serve. Saying "run claude login"
-    // would send the user chasing a problem they don't have.
+    // and there has never been a reading to fall back on. Saying "run claude
+    // login" would send the user chasing a problem they don't have.
     if (profileQuota.error === 'rate_limited') {
       return '<div class="usage-section">'
         + '<div class="usage-section-title">Usage</div>'
-        + '<div class="usage-empty">Usage data is rate limited upstream — retrying shortly.</div>'
+        + '<div class="usage-empty">No reading yet — '
+        +   esc(failedRun || 'rate limited upstream') + ', retrying.</div>'
         + '</div>';
     }
     return ''; // nothing fetched yet
@@ -291,6 +313,15 @@ function renderUsageSection(profileQuota) {
 
   var asOf = profileQuota.fetchedAt
     ? '<span class="usage-as-of">updated ' + timeAgo(profileQuota.fetchedAt) + '</span>'
+    : '';
+
+  // Figures are only ever this old because a later check failed, so the note
+  // and the "updated Xm ago" beside the title answer the two halves of the
+  // same question: how old these numbers are, and why they haven't moved.
+  var staleNote = failedRun
+    ? '<div class="usage-stale-note">'
+      + esc(failedRun.charAt(0).toUpperCase() + failedRun.slice(1))
+      + ' — figures below are the last successful read.</div>'
     : '';
 
   var cards = windows.map(function (w) {
@@ -326,6 +357,7 @@ function renderUsageSection(profileQuota) {
 
   return '<div class="usage-section">'
     + '<div class="usage-section-title">Usage' + asOf + '</div>'
+    + staleNote
     + (cards ? '<div class="usage-grid">' + cards + '</div>' : '')
     + extraBlock
     + '</div>';

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -42,6 +42,8 @@ export const profilePageHtml = `<!DOCTYPE html>
   }
   .detail-label { color: var(--muted); }
   .detail-value { font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; font-size: 12px; }
+  .cached-tag { color: var(--muted); font-size: 10px; font-style: italic; margin-left: 6px; white-space: nowrap; }
+  .detail-unknown { color: var(--muted); font-style: italic; }
   .status-ok { color: var(--green); }
   .status-err { color: var(--red); }
   .switch-btn {
@@ -259,6 +261,26 @@ async function refresh() {
 
 function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
+// Mirrors src/telemetry/cachedFacts.ts (unit-tested there). Marked per value
+// rather than per card: a card mixes a live status with a remembered email, so
+// one banner across it would mislabel whichever half it doesn't apply to.
+function factProvenance(value, stale) {
+  if (value == null || value === '') return 'never';
+  return stale ? 'cached' : 'live';
+}
+function cachedTag(provenance) {
+  return provenance === 'cached' ? '<span class="cached-tag">(cached)</span>' : '';
+}
+function renderFactValue(value, stale, extraClass) {
+  var provenance = factProvenance(value, stale);
+  if (provenance === 'never' && !stale) return null;
+  var classes = 'detail-value' + (extraClass ? ' ' + extraClass : '');
+  if (provenance === 'never') {
+    return '<span class="' + classes + ' detail-unknown">never read</span>';
+  }
+  return '<span class="' + classes + '">' + esc(String(value)) + cachedTag(provenance) + '</span>';
+}
+
 // "last 4 checks failed (rate limited upstream)" — the run of failed checks
 // since the last good reading, or '' when the last check succeeded. Reasons map
 // through a fixed vocabulary rather than being echoed, so nothing the server
@@ -286,6 +308,7 @@ function renderUsageSection(profileQuota) {
   var extra = formatExtraUsage(profileQuota.extraUsage);
 
   var failedRun = describeFailedRun(profileQuota.failure);
+  var usageTag = cachedTag(profileQuota.stale ? 'cached' : 'live');
 
   // No figures at all means this profile has never been read successfully —
   // the route serves the last good reading at any age, so an empty windows
@@ -334,7 +357,7 @@ function renderUsageSection(profileQuota) {
     return '<div class="usage-card status-' + esc(status) + '" title="' + esc(tip) + '">'
       + '<div class="usage-row">'
       +   '<span class="usage-label">' + esc(label) + '</span>'
-      +   '<span class="usage-pct">' + pctRound + '%</span>'
+      +   '<span class="usage-pct">' + pctRound + '%' + usageTag + '</span>'
       + '</div>'
       + '<div class="usage-bar"><div class="usage-fill" style="width:' + (pct * 100).toFixed(1) + '%"></div></div>'
       + (reset ? '<div class="usage-reset">' + esc(reset) + '</div>' : '')
@@ -346,7 +369,7 @@ function renderUsageSection(profileQuota) {
     extraBlock = '<div class="usage-extra status-' + esc(extra.status) + '">'
       +   '<div class="usage-extra-row">'
       +     '<span class="usage-label">Extra usage</span>'
-      +     '<span class="usage-pct">' + extra.utilizationPct + '%</span>'
+      +     '<span class="usage-pct">' + extra.utilizationPct + '%' + usageTag + '</span>'
       +   '</div>'
       +   '<div class="usage-bar"><div class="usage-fill" style="width:' + extra.utilizationPct + '%"></div></div>'
       +   '<div class="usage-extra-row" style="margin-top:4px">'
@@ -397,18 +420,19 @@ function render(data, quotaData) {
     html += '</div>';
 
     html += '<div class="profile-details">';
+    var authProvenance = p.authProvenance || 'live';
+    var authStale = authProvenance !== 'live';
     html += '<span class="detail-label">Status</span>';
-    html += '<span class="detail-value ' + (p.loggedIn ? 'status-ok' : 'status-err') + '">'
-      + (p.loggedIn ? '\u2713 Authenticated' : '\u2717 Not logged in') + '</span>';
+    html += renderFactValue(
+      authProvenance === 'never' ? null : (p.loggedIn ? '\u2713 Authenticated' : '\u2717 Not logged in'),
+      authStale,
+      p.loggedIn ? 'status-ok' : 'status-err');
 
-    if (p.email) {
-      html += '<span class="detail-label">Email</span>';
-      html += '<span class="detail-value">' + esc(p.email) + '</span>';
-    }
-    if (p.subscriptionType) {
-      html += '<span class="detail-label">Plan</span>';
-      html += '<span class="detail-value">' + esc(p.subscriptionType) + '</span>';
-    }
+    var emailCell = renderFactValue(p.email, authStale);
+    if (emailCell) html += '<span class="detail-label">Email</span>' + emailCell;
+
+    var planCell = renderFactValue(p.subscriptionType, authStale);
+    if (planCell) html += '<span class="detail-label">Plan</span>' + planCell;
     if (p.lastSuccessAt) {
       html += '<span class="detail-label">Last Verified</span>';
       html += '<span class="detail-value" style="color:var(--green)">' + timeAgo(p.lastSuccessAt) + '</span>';


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

## What this changes

When the OAuth usage endpoint refuses, the profiles page no longer throws away the last good reading. It keeps the bars, percentages and reset countdowns on screen, says when that reading was taken, and says which check failed, why, and how many have failed in a row.

Before, `renderUsageSection` replaced the entire usage block with one sentence:

> Usage data is rate limited upstream — retrying shortly.

A reading that was often only minutes old vanished along with it. Across a twelve-account fleet the endpoint refuses often enough for this to be a daily occurrence rather than a theoretical one.

## It turned out to be a rendering change, not a new cache

The first thing I checked was whether a cache already existed. It does: `src/proxy/oauthUsage.ts` keeps a per-profile snapshot with a 30-second TTL and a 15-minute stale fallback, and `staleOr` already served the last good snapshot on transient failure.

So no new cache was added, which is much the better outcome. What was missing was **provenance** — the data reached the consumer as bare numbers, with no way to tell three states apart:

| state | before | after |
|---|---|---|
| never read | empty `windows`, `error` set | empty `windows`, `stale: false`, `fetchedAt: null` |
| read and fresh | numbers | numbers, `stale: false`, `failure: null` |
| read then stale | numbers, indistinguishable from fresh | numbers, `stale: true`, `fetchedAt` dated, `failure` explaining |

A window sitting at 0% and a profile that has never been read flatten to the same numbers, so the distinction has to travel as its own field rather than being inferred from emptiness.

## API

`fetchOAuthUsageResult` gains two fields:

- `failure` — `{ reason, consecutiveFailures, lastFailureAt }`, or `null` when the last check succeeded. The reason reuses the `OAuthUsageError` vocabulary from #789, so a rate limit stays distinguishable from an auth failure: one is temporary and the other wants `claude login`.
- `lastGood` — the last successful snapshot at any age, including past the 15-minute bound within which `staleOr` will serve it as `snapshot`.

`toUsageEntry` shapes those into the per-profile wire fields `/v1/usage/quota/all` serves, adding `stale` and `failure` next to the existing `windows`, `extraUsage`, `fetchedAt` and `error`.

**`error` keeps its exact previous meaning** — set only when there was nothing fresh *and* no recent-enough reading to stand in. A consumer that ignores the new fields behaves as it did before.

## Why the failure count skips cooldown-suppressed polls

`consecutiveFailures` counts checks that actually reached the credential store or upstream. The 429 cooldown turns polls away before either, and those do not advance the count.

The profiles page polls every 10 seconds; the backoff runs for a minute or more. Counting suppressed polls would report six failures for one refusal — a number that describes the poll interval, not the account.

## What it looks like

Read and fresh, unchanged:

> **USAGE**  ·  updated just now
> `[5h 36%]` `[7d 5%]`

Read then stale:

> **USAGE**  ·  updated 6m ago
> Last check failed (rate limited upstream) — figures below are the last successful read.
> `[5h 36%]` `[7d 5%]`

> **USAGE**  ·  updated 41m ago
> Last 4 checks failed (usage endpoint unavailable) — figures below are the last successful read.
> `[5h 36%]` `[7d 5%]`

Never read at all, which is the one case where there is genuinely nothing to show:

> **USAGE**
> No reading yet — last check failed (rate limited upstream), retrying.

The note uses `--yellow` at 11px, matching `.usage-empty`'s size for informational lines, and sits between the section title and the bar grid. Reasons map through a fixed vocabulary in `describeFailedRun` rather than being echoed, so nothing the server sends reaches the DOM.

## Testing

Nine new unit tests covering the state machine:

- a first-ever failure with nothing cached
- a failure after a success, which keeps the reading and dates it
- three consecutive failures counting to 3
- a success clearing the run rather than zeroing it
- cooldown-suppressed polls not advancing the count
- `toUsageEntry` for each of never-read, read-and-fresh, and stale-past-the-bound

`bunx tsc --noEmit` is clean.

The provenance work adds 16 tests in `src/__tests__/cached-facts.test.ts`: thirteen over the pure module (each of the three states, the omit case, escaping, ordering of the marker after the value, and the status-class join) and three asserting the page itself renders the marker.

`bunx tsc --noEmit` and the full `bun run test` gate both exit 0 on this branch: **2781 passing before the provenance commit, 2797 after**, with no failures in either run. An earlier revision of this description reported 105 pre-existing failures; that reflected the local `~/.config/meridian` state at the time, since several integration tests read the developer's real account list. Measured today the suite is green.

A control run confirms the new tests are load-bearing rather than decorative: with `cachedFacts.ts` present but `profilePage.ts` and `server.ts` reverted to their previous state, **exactly the three page-contract tests fail** while the thirteen module tests pass. With the module removed as well, the test file fails to import at all.

The rendered output of all six states was verified in a browser against a fixture server serving the real page module — no console errors or warnings, checked at desktop width and at 420px where the bar grid reflows to one column.

## Marking a remembered value as remembered

Keeping the reading was only half of it. A figure the check took thirty seconds ago and a figure it took an hour ago and could not re-confirm rendered identically, so a reader still had no way to tell a current number from a remembered one — which is the whole point of having kept it.

Every value now carries its provenance immediately to the right of itself:

> **USAGE**  ·  updated 6m ago
> Last check failed (rate limited upstream) — figures below are the last successful read.
> `[5h 36% (cached)]` `[7d 5% (cached)]`

Per value rather than once per card, because a card routinely mixes the two — the auth status can be live while the email and plan beside it are what an earlier check left behind. One banner across the card would mislabel whichever half it did not apply to. A value read by the check that just ran carries no marker at all.

### "No value" was two different facts wearing one blank

An account whose plan became unreadable and an account that never had a plan both rendered as a missing row. That is the more misleading of the two: a missing row reads as "no such thing" rather than "could not look".

`src/telemetry/cachedFacts.ts` names the three states and renders each distinctly:

| state | meaning | rendering |
|---|---|---|
| `live` | read by the check that just ran | the value, unmarked |
| `cached` | read earlier; the check that just ran could not confirm it | the value, followed by `(cached)` |
| `never` | never read successfully for this profile | `never read`, muted |

`renderFactValue` returns `null` for a fourth case — a value absent from a check that *succeeded*, which is genuinely not applicable to that account rather than unreadable — so those rows stay omitted exactly as before.

### `/profiles/list` gains `authProvenance`

`getClaudeAuthStatusAsync` already returns its `lastKnownGood` when a check fails, so `email`, `subscriptionType` and `loggedIn` were routinely remembered values wearing the exact shape of fresh ones, and the route had no way to admit it. `authProvenance` is `"live"`, `"cached"` or `"never"` accordingly.

The field is additive. A consumer ignoring it sees exactly what it saw before.

### The inline mirror is checked, not assumed

`profilePage.ts` is one template literal that runs in the browser and cannot import, so it mirrors the module in its inline script — the convention `profileUsage.ts` already documents. Rather than trust that the copy still matches, the inlined block was extracted from the rendered page, executed, and diffed against the module across all three states plus a hostile value, an empty string, and both status-class variants. All eleven cases agree.

## Scope

The diff stays inside the usage section of `src/telemetry/profilePage.ts`, which has concurrent changes landing in other areas of the same file.

This PR is AI generated, but under direct supervision and on request of Nowaker.

