### PR TITLE
fix: advertise 1M context on Team and Enterprise plans

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -280,8 +280,8 @@ export default function (pi: ExtensionAPI) {
         reasoning: true,
         input: ["text", "image"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 200000,
-        maxTokens: 32000,
+        contextWindow: 1000000,
+        maxTokens: 64000,
       },
     ],
   })
@@ -300,6 +300,23 @@ export default function (pi: ExtensionAPI) {
 ```
 
 Then pick a model with `/model` or `--provider meridian --model claude-opus-5`.
+
+**`contextWindow` must say `1000000`.** Provider models registered this way are
+static — Prime Agent never calls `GET /v1/models` for them — so this literal is
+the *only* thing driving the TUI footer and auto-compaction
+(`contextTokens > contextWindow - reserveTokens`). Meridian routes every primary
+`opus` request to the SDK's `opus[1m]` alias, so a `200000` here compacts the
+conversation at a fifth of the window you are actually paying for. Restart Prime
+Agent after editing: providers are registered once per process.
+
+Set it back to `200000` if you opt out of extended context on the proxy side —
+`MERIDIAN_1M_CONTEXT_SUPPORT=0`, `MERIDIAN_OPUS_MODEL=opus`, or a plan that
+doesn't include Opus 1M (Meridian then falls back to plain `opus` after one
+Extra-Usage rejection). Leaving `1000000` in that case surfaces as upstream
+errors on long conversations instead of local compaction.
+
+`maxTokens: 64000` is a conservative output cap; Opus 5 supports up to 128000
+and Meridian does not clamp it.
 
 Registering a **new** provider rather than overriding `anthropic` means
 installing this changes nothing until you select one of its models, so an

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test"
 
-import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resetWarnedTierOverrides, resolveSdkModelDefaults, CANONICAL_FABLE_MODEL, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resetWarnedTierOverrides, resolveSdkModelDefaults, subscriptionIncludesExtendedContext, CANONICAL_FABLE_MODEL, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
   const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
@@ -402,6 +402,37 @@ describe("hasExtendedContext", () => {
     expect(hasExtendedContext("opus")).toBe(false)
     expect(hasExtendedContext("sonnet")).toBe(false)
     expect(hasExtendedContext("haiku")).toBe(false)
+  })
+})
+
+describe("subscriptionIncludesExtendedContext", () => {
+  it("includes max and its usage variants", () => {
+    expect(subscriptionIncludesExtendedContext("max")).toBe(true)
+    expect(subscriptionIncludesExtendedContext("max_5x")).toBe(true)
+    expect(subscriptionIncludesExtendedContext("max_20x")).toBe(true)
+  })
+
+  it("includes team and enterprise", () => {
+    expect(subscriptionIncludesExtendedContext("team")).toBe(true)
+    expect(subscriptionIncludesExtendedContext("enterprise")).toBe(true)
+  })
+
+  it("excludes pro, free, and unknown tiers", () => {
+    expect(subscriptionIncludesExtendedContext("pro")).toBe(false)
+    expect(subscriptionIncludesExtendedContext("free")).toBe(false)
+    expect(subscriptionIncludesExtendedContext("something-else")).toBe(false)
+  })
+
+  it("is case and whitespace insensitive", () => {
+    expect(subscriptionIncludesExtendedContext("  Team ")).toBe(true)
+    expect(subscriptionIncludesExtendedContext("MAX_20X")).toBe(true)
+  })
+
+  it("excludes missing or empty tiers", () => {
+    expect(subscriptionIncludesExtendedContext(undefined)).toBe(false)
+    expect(subscriptionIncludesExtendedContext(null)).toBe(false)
+    expect(subscriptionIncludesExtendedContext("")).toBe(false)
+    expect(subscriptionIncludesExtendedContext("   ")).toBe(false)
   })
 })
 

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -279,6 +279,36 @@ export function hasExtendedContext(model: ClaudeModel): boolean {
   return model.endsWith("[1m]")
 }
 
+/**
+ * Subscription tiers that include the Opus/Fable 1M extended context window
+ * at no Extra Usage cost, per Anthropic's docs
+ * (https://code.claude.com/docs/en/model-config#extended-context): Max, Team,
+ * and Enterprise. Pro and unknown tiers are not included.
+ *
+ * Max is matched by prefix because the auth payload reports plan variants
+ * ("max", "max_5x", "max_20x", ...) rather than a bare tier name.
+ */
+const EXTENDED_CONTEXT_SUBSCRIPTION_PREFIXES: readonly string[] = ["max", "team", "enterprise"]
+
+/**
+ * Whether a subscription tier includes 1M context on the Opus/Fable tiers.
+ *
+ * This is the single source of truth for *advertising* the extended window
+ * (e.g. `GET /v1/models`). It deliberately does NOT gate routing:
+ * mapModelToClaudeModel stays optimistic and lets the runtime Extra-Usage
+ * fallback (recordExtendedContextUnavailable) downgrade when a plan turns out
+ * not to include it — an unknown or stale tier string must never silently cost
+ * a user their 1M window mid-conversation.
+ *
+ * Pure — string inspection only, no I/O.
+ */
+export function subscriptionIncludesExtendedContext(subscriptionType?: string | null): boolean {
+  if (!subscriptionType) return false
+  const normalized = subscriptionType.trim().toLowerCase()
+  if (!normalized) return false
+  return EXTENDED_CONTEXT_SUBSCRIPTION_PREFIXES.some((tier) => normalized.startsWith(tier))
+}
+
 /** Per-profile auth status cache for multi-account support */
 interface AuthCache {
   status: ClaudeAuthStatus | null

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -938,9 +938,15 @@ const FULL_CAPABILITIES: ModelCapabilities = Object.freeze({
 
 /**
  * Return the static list of available Claude models in OpenAI format.
- * Context windows reflect subscription capabilities.
+ *
+ * @param extendedContextIncluded - whether the caller's subscription includes
+ *   the 1M window on the Opus/Fable tiers (Max, Team, Enterprise). Callers
+ *   derive this from `subscriptionIncludesExtendedContext` in models.ts so the
+ *   advertised window matches what the proxy actually routes to. Sonnet stays
+ *   200k on every plan because Sonnet 1M is always billed as Extra Usage, and
+ *   Haiku has no 1M variant at all.
  */
-export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date.now() / 1000)): OpenAiModel[] {
+export function buildModelList(extendedContextIncluded: boolean, now = Math.floor(Date.now() / 1000)): OpenAiModel[] {
   return [
     {
       id: "claude-sonnet-5",
@@ -966,7 +972,7 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       created: now,
       owned_by: "anthropic",
       display_name: "Claude Opus 5",
-      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
       capabilities: FULL_CAPABILITIES,
     },
     {
@@ -975,7 +981,7 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       created: now,
       owned_by: "anthropic",
       display_name: "Claude Opus 4.6",
-      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
       capabilities: FULL_CAPABILITIES,
     },
     {
@@ -984,7 +990,7 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       created: now,
       owned_by: "anthropic",
       display_name: "Claude Opus 4.7",
-      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
       capabilities: FULL_CAPABILITIES,
     },
     {
@@ -993,7 +999,7 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       created: now,
       owned_by: "anthropic",
       display_name: "Claude Opus 4.8",
-      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
       capabilities: FULL_CAPABILITIES,
     },
     {
@@ -1002,7 +1008,7 @@ export function buildModelList(isMaxSubscription: boolean, now = Math.floor(Date
       created: now,
       owned_by: "anthropic",
       display_name: "Claude Fable 5",
-      context_window: isMaxSubscription ? 1_000_000 : 200_000,
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
       capabilities: FULL_CAPABILITIES,
     },
     {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -64,7 +64,7 @@ import {
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
 import { checkPluginConfigured } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
@@ -4727,11 +4727,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
   // --- Model Discovery ---
   // Returns available Claude models in OpenAI-compatible format.
-  // Context window reflects the subscription tier (Max = 1M, others = 200k).
+  // Context window reflects the subscription tier: Max/Team/Enterprise get 1M
+  // on the Opus/Fable tiers, everything else 200k. The tier check is shared
+  // with models.ts (subscriptionIncludesExtendedContext) — an "=== max"
+  // comparison here used to advertise 200k to Team accounts that Meridian was
+  // already routing to opus[1m] (#826).
   app.get("/v1/models", async (c) => {
     const authStatus = await getClaudeAuthStatusAsync()
-    const isMax = authStatus?.subscriptionType === "max"
-    return c.json({ object: "list", data: buildModelList(isMax) })
+    const extendedContext = subscriptionIncludesExtendedContext(authStatus?.subscriptionType)
+    return c.json({ object: "list", data: buildModelList(extendedContext) })
   })
 
   // --- Subscription Quota ---


### PR DESCRIPTION
## Problem

`meridian/claude-opus-5` reports a 200k context window to clients even though Meridian routes those requests to the SDK's `opus[1m]` alias. Two independent causes:

1. **`GET /v1/models`** gated the extended window on `subscriptionType === "max"`. A `team` (or `enterprise`) account got `context_window: 200000` while `mapModelToClaudeModel` was already handing it `opus[1m]` -- Meridian served 1M and advertised 200k.
2. **`docs/agents.md`** ships the Prime Agent `pi.registerProvider()` snippet with `contextWindow: 200000, maxTokens: 32000`. Provider model lists there are static literals (Prime Agent never calls `/v1/models` for a custom provider), so that number alone drives the TUI footer and auto-compaction. Anyone copying the snippet compacts at a fifth of the window they are paying for.

## Changes

- New pure predicate `subscriptionIncludesExtendedContext(subscriptionType)` in `src/proxy/models.ts`: `max*` (covers `max_5x`/`max_20x`), `team`, `enterprise`. It is the single source of truth for *advertising* the window and deliberately does **not** gate routing -- `mapModelToClaudeModel` stays optimistic and lets the runtime Extra-Usage fallback (`recordExtendedContextUnavailable`) downgrade, so an unknown or stale tier string can never silently cost a user their 1M window mid-conversation.
- `server.ts` `/v1/models` uses that predicate instead of its own literal tier comparison.
- `buildModelList`'s parameter renamed `isMaxSubscription` -> `extendedContextIncluded`, documenting why Sonnet stays 200k (Sonnet 1M is always Extra Usage) and Haiku has no 1M variant.
- `docs/agents.md`: snippet now uses `contextWindow: 1000000, maxTokens: 64000`, plus a note on when to set it back to `200000` (`MERIDIAN_1M_CONTEXT_SUPPORT=0`, `MERIDIAN_OPUS_MODEL=opus`, or a plan without Opus 1M) and a restart reminder.

## Tests

`subscriptionIncludesExtendedContext` unit tests in `src/__tests__/models.test.ts` (max variants, team/enterprise, pro/free/unknown, case + whitespace, null/undefined/empty). Full suite: 2557 pass, 0 fail; `tsc --noEmit` clean.
