### PR TITLE
fix(concurrency): follow env changes for the shared SDK semaphore budget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_PORT` | `CLAUDE_PROXY_PORT` | `3456` | Port to listen on |
 | `MERIDIAN_HOST` | `CLAUDE_PROXY_HOST` | `127.0.0.1` | Host to bind to |
 | `MERIDIAN_PASSTHROUGH` | `CLAUDE_PROXY_PASSTHROUGH` | unset | Forward tool calls to client instead of executing |
-| `MERIDIAN_MAX_CONCURRENT` | `CLAUDE_PROXY_MAX_CONCURRENT` | `10` | Maximum SDK queries running concurrently within one Meridian process |
+| `MERIDIAN_MAX_CONCURRENT` | `CLAUDE_PROXY_MAX_CONCURRENT` | `10` | Maximum SDK queries running concurrently within one Meridian process. The budget is shared by every proxy instance in the process, and is re-read whenever an instance starts — so raising or lowering it takes effect for a later instance without a restart. Embedders that need a distinct budget can pass `maxConcurrent` in `ProxyConfig`, which opts that instance out of the shared pool. |
 | `MERIDIAN_MAX_SESSIONS` | `CLAUDE_PROXY_MAX_SESSIONS` | `1000` | In-memory LRU session cache size |
 | `MERIDIAN_MAX_STORED_SESSIONS` | `CLAUDE_PROXY_MAX_STORED_SESSIONS` | `10000` | File-based session store capacity |
 | `MERIDIAN_WORKDIR` | `CLAUDE_PROXY_WORKDIR` | `cwd()` | Default working directory for SDK |

--- a/src/__tests__/concurrency.test.ts
+++ b/src/__tests__/concurrency.test.ts
@@ -47,6 +47,58 @@ describe("AbortableSemaphore", () => {
     lease.release()
     expect(semaphore.snapshot.active).toBe(0)
   })
+
+  test("raising the limit grants waiting acquisitions immediately, in order", async () => {
+    const semaphore = new AbortableSemaphore(1)
+    const held = await semaphore.acquire()
+    const order: number[] = []
+    const secondP = semaphore.acquire().then(lease => { order.push(2); return lease })
+    const thirdP = semaphore.acquire().then(lease => { order.push(3); return lease })
+    expect(semaphore.snapshot).toEqual({ active: 1, queued: 2, limit: 1 })
+
+    semaphore.setLimit(3)
+    const [second, third] = await Promise.all([secondP, thirdP])
+
+    expect(order).toEqual([2, 3])
+    expect(semaphore.snapshot).toEqual({ active: 3, queued: 0, limit: 3 })
+    held.release()
+    second.release()
+    third.release()
+  })
+
+  test("lowering the limit never revokes a live lease; it converges as they release", async () => {
+    const semaphore = new AbortableSemaphore(3)
+    const leases = [await semaphore.acquire(), await semaphore.acquire(), await semaphore.acquire()]
+
+    semaphore.setLimit(1)
+    // Work already underway keeps its permit: active is allowed to exceed the
+    // new budget until it drains.
+    expect(semaphore.snapshot).toEqual({ active: 3, queued: 0, limit: 1 })
+
+    let granted = false
+    const queued = semaphore.acquire().then(lease => { granted = true; return lease })
+
+    leases[0]!.release()
+    await Promise.resolve()
+    expect(granted).toBe(false)
+    leases[1]!.release()
+    await Promise.resolve()
+    expect(granted).toBe(false)
+
+    leases[2]!.release()
+    const lease = await queued
+    expect(semaphore.snapshot).toEqual({ active: 1, queued: 0, limit: 1 })
+    lease.release()
+  })
+
+  test("setLimit rejects values that are not positive integers", () => {
+    const semaphore = new AbortableSemaphore(2)
+    expect(() => semaphore.setLimit(0)).toThrow(RangeError)
+    expect(() => semaphore.setLimit(-1)).toThrow(RangeError)
+    expect(() => semaphore.setLimit(1.5)).toThrow(RangeError)
+    expect(() => semaphore.setLimit(Number.NaN)).toThrow(RangeError)
+    expect(semaphore.limit).toBe(2)
+  })
 })
 
 describe("resolveMaxConcurrent", () => {
@@ -90,5 +142,36 @@ describe("getProcessSdkSemaphore", () => {
     const second = getProcessSdkSemaphore()
     expect(second).toBe(first)
     expect(first.limit).toBe(3)
+  })
+
+  test("follows a later environment change without losing the shared instance", () => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "2"
+    const first = getProcessSdkSemaphore()
+    expect(first.limit).toBe(2)
+
+    // A second proxy starting later in the same process — or a test that sets
+    // the variable after the first proxy booted — used to be ignored outright.
+    process.env.MERIDIAN_MAX_CONCURRENT = "5"
+    const second = getProcessSdkSemaphore()
+    expect(second).toBe(first)
+    expect(second.limit).toBe(5)
+
+    process.env.MERIDIAN_MAX_CONCURRENT = "1"
+    expect(getProcessSdkSemaphore().limit).toBe(1)
+  })
+
+  test("returns to the default budget when the variable is unset again", () => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "2"
+    expect(getProcessSdkSemaphore().limit).toBe(2)
+    delete process.env.MERIDIAN_MAX_CONCURRENT
+    expect(getProcessSdkSemaphore().limit).toBe(10)
+  })
+
+  test("an invalid value falls back to the default rather than throwing", () => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "4"
+    const semaphore = getProcessSdkSemaphore()
+    process.env.MERIDIAN_MAX_CONCURRENT = "not-a-number"
+    expect(getProcessSdkSemaphore()).toBe(semaphore)
+    expect(semaphore.limit).toBe(10)
   })
 })

--- a/src/proxy/concurrency.ts
+++ b/src/proxy/concurrency.ts
@@ -48,19 +48,47 @@ export function resolveMaxConcurrent(
   return DEFAULT_MAX_CONCURRENT
 }
 
+function assertPositiveLimit(limit: number): number {
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new RangeError("Semaphore limit must be a positive integer")
+  }
+  return limit
+}
+
 /** FIFO semaphore whose queued acquisitions can be cancelled safely. */
 export class AbortableSemaphore {
   private activeCount = 0
+  private currentLimit: number
   private readonly waiters: Waiter[] = []
 
-  constructor(readonly limit: number) {
-    if (!Number.isSafeInteger(limit) || limit <= 0) {
-      throw new RangeError("Semaphore limit must be a positive integer")
-    }
+  constructor(limit: number) {
+    this.currentLimit = assertPositiveLimit(limit)
+  }
+
+  get limit(): number {
+    return this.currentLimit
+  }
+
+  /**
+   * Change the budget in place.
+   *
+   * Mutating beats swapping the instance: queued waiters and in-flight leases
+   * belong to this object, so replacing it would strand them holding permits
+   * nobody counts. Raising the limit immediately grants whoever is already
+   * waiting; lowering it never revokes a live lease — the extra permits simply
+   * stop being reissued as the current holders release, so the semaphore
+   * converges on the new budget without killing work already underway.
+   */
+  setLimit(next: number): void {
+    const limit = assertPositiveLimit(next)
+    if (limit === this.currentLimit) return
+    const raised = limit > this.currentLimit
+    this.currentLimit = limit
+    if (raised) this.grantNext()
   }
 
   get snapshot(): SemaphoreSnapshot {
-    return { active: this.activeCount, queued: this.waiters.length, limit: this.limit }
+    return { active: this.activeCount, queued: this.waiters.length, limit: this.currentLimit }
   }
 
   acquire(signal?: AbortSignal): Promise<SemaphoreLease> {
@@ -119,10 +147,20 @@ export class AbortableSemaphore {
 
 /**
  * One SDK subprocess budget per process, shared by every ProxyServer instance.
- * The environment is intentionally read once, when the first proxy asks for it.
+ *
+ * The identity of the semaphore is stable — every caller gets the same object,
+ * which is the whole point of a shared budget — but its limit is reconciled
+ * against the environment on each call. Caching the limit at first use made the
+ * value depend on which proxy happened to start first, so a later instance (or
+ * a test that set MERIDIAN_MAX_CONCURRENT) was silently ignored.
  */
 export function getProcessSdkSemaphore(): AbortableSemaphore {
-  processSdkSemaphore ??= new AbortableSemaphore(resolveMaxConcurrent())
+  const limit = resolveMaxConcurrent()
+  if (!processSdkSemaphore) {
+    processSdkSemaphore = new AbortableSemaphore(limit)
+    return processSdkSemaphore
+  }
+  processSdkSemaphore.setLimit(limit)
   return processSdkSemaphore
 }
 


### PR DESCRIPTION
`MERIDIAN_MAX_CONCURRENT` only worked if it was set before the *first* proxy instance in the process booted. After that the value was frozen, silently.

This came out of #825: CI failed on an untouched test, `SDK concurrency limiter > still bounds how many SDK calls run at once`, which had been asserting a bound that was never actually in effect — it only ever passed by being the first file to construct a proxy. That was patched there with `resetProcessSdkSemaphoreForTests()`; this PR fixes the cause.

## The cause

```ts
export function getProcessSdkSemaphore(): AbortableSemaphore {
  processSdkSemaphore ??= new AbortableSemaphore(resolveMaxConcurrent())
  return processSdkSemaphore
}
```

`AbortableSemaphore` took `constructor(readonly limit: number)`, so the limit was frozen at construction, and the singleton froze *which* environment reading won — whichever proxy started first. Consequences:

1. Changing `MERIDIAN_MAX_CONCURRENT` after first use was ignored.
2. Test outcomes depended on file order within a Bun process.
3. Anyone embedding two proxy instances in one process got the first one's budget for both.

## The fix

- `AbortableSemaphore` keeps a private limit behind a `get limit()` and gains `setLimit(next)`.
  - **Raising** grants queued waiters immediately, in FIFO order.
  - **Lowering** never revokes a live lease. `active` may temporarily exceed `limit`; the extra permits simply stop being reissued as holders release, so it converges without killing work in flight.
  - Non-positive / non-integer values throw `RangeError`, same rule as the constructor (shared `assertPositiveLimit`).
- `getProcessSdkSemaphore()` reconciles the limit against the environment on every call, **keeping the same object**. Identity is the point of a shared budget — swapping the instance would strand queued waiters and live leases holding permits nobody counts.
- Corrected the doc comment that claimed the environment is "intentionally read once", and the `docs/configuration.md` row.

`resetProcessSdkSemaphoreForTests()` stays (it still clears the one-shot invalid-value warning) but is no longer load-bearing for correctness.

## Verification

- 6 new tests in `src/__tests__/concurrency.test.ts`: raise-grants-in-order, lower-converges-without-revoking, `setLimit` validation, env change honoured after first use, unset returns to the default, invalid value falls back rather than throwing.
- **Proved they bite**: stashing `src/proxy/concurrency.ts` back to its pre-fix state fails 6 of the 13 tests in that file (`setLimit is not a function`, plus the three `getProcessSdkSemaphore` env assertions). Restored byte-identical afterwards.
- `npx tsc --noEmit` clean; full suite green.

## Not in scope

Per-instance `maxConcurrent` in `ProxyConfig` still opts an embedder out of the shared pool entirely — unchanged, and still the right escape hatch for genuinely isolated budgets.
