### PR TITLE
fix(errors): classify exhausted usage credits

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -611,6 +611,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's 'You're out of usage credits' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You're out of usage credits. /model to switch models.")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -219,6 +219,16 @@ describe("priority routing", () => {
     expect(body.content[0]?.text).toContain("prof-personal")
   }, 20_000)
 
+  it("fails over on the CLI's 'You're out of usage credits' wording", async () => {
+    failureMessage = "Claude Code returned an error result: You're out of usage credits. /model to switch models."
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
+  }, 20_000)
+
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {
     failingDirs.add("prof-work")
     failingDirs.add("prof-personal")

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -103,7 +103,8 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // variants seen so far and the daily/monthly/5-hour ones that would
   // otherwise be the next report.
   if (lower.includes("429") || lower.includes("rate limit") || lower.includes("too many requests")
-    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")) {
+    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")
+    || lower.includes("out of usage credits")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""


### PR DESCRIPTION
## Summary

- classify Claude Code's `You're out of usage credits` result as `rate_limit_error`
- return the existing 429 error shape instead of a generic API error
- allow priority routing to retry the next configured profile for this live-observed wording
- add direct classifier and HTTP failover regressions

## Testing

- `./build.sh` from the four-repo `local/dev-stack` workspace: passed
- focused classifier and priority-routing tests: 146 passed, 0 failed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm test`: 2595 passed, 5 failed; the same five unrelated SDK/system-prompt tests fail on clean `origin/main` (2593 passed, 5 failed)
- `git diff --check`: passed