### PR TITLE
fix(telemetry): record the failing profile on the error-path row

### DIFF
--- a/src/__tests__/error-telemetry-profile.test.ts
+++ b/src/__tests__/error-telemetry-profile.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A refusal recorded on the error path must name the account that refused.
+ *
+ * Priority routing tries each profile in turn. Since #825 stopped forking
+ * `requestId` per attempt, every attempt files under the caller's id and
+ * `profileId` is the only thing that distinguishes them. The error-path
+ * telemetry row wrote `model: "unknown"` and no `profileId` at all, so
+ * "which account rate-limited me?" was unanswerable from telemetry. See #829.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let failingDirs = new Set<string>()
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
+    return (async function* () {
+      if ([...failingDirs].some(f => dir.includes(f))) {
+        throw new Error("429 rate limit reached for this account")
+      }
+      yield assistantMessage([{ type: "text", text: "ok from " + dir }])
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { resetActiveProfile } = await import("../proxy/profiles")
+const { rateLimitStore } = await import("../proxy/rateLimitStore")
+const { telemetryStore } = await import("../telemetry")
+
+const PROFILES = [
+  { id: "work", claudeConfigDir: "/tmp/meridian-errtel-work" },
+  { id: "personal", claudeConfigDir: "/tmp/meridian-errtel-personal" },
+]
+
+const savedEnv: Record<string, string | undefined> = {}
+
+describe("error-path telemetry records the profile that failed", () => {
+  beforeEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    clearSessionCache()
+    resetActiveProfile()
+    rateLimitStore.clear?.()
+    failingDirs = new Set()
+    savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
+    savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    process.env.MERIDIAN_ROUTING = "priority"
+    process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
+  })
+
+  afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  it("names the refusing profile on the failover refusal row", async () => {
+    failingDirs.add("meridian-errtel-work")
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
+    })
+
+    const clientId = `errtel-failover-${Date.now()}`
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-request-id": clientId },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+
+    const mine = telemetryStore.getRecent({ limit: 500 }).filter(m => m.requestId === clientId)
+    expect(mine.length).toBeGreaterThanOrEqual(2)
+
+    // The bug: this row had no profileId, so the only account named anywhere
+    // in telemetry was the one that succeeded.
+    const refusals = mine.filter(m => m.error !== null)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]!.profileId).toBe("work")
+
+    // ...and the served row still names the account that answered, unchanged.
+    const served = mine.filter(m => m.error === null)
+    expect(served).toHaveLength(1)
+    expect(served[0]!.profileId).toBe("personal")
+  })
+
+  it("records the dispatched model instead of a bare \"unknown\"", async () => {
+    failingDirs.add("meridian-errtel-work")
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
+    })
+
+    const clientId = `errtel-model-${Date.now()}`
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-request-id": clientId },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+
+    const refusal = telemetryStore.getRecent({ limit: 500 })
+      .find(m => m.requestId === clientId && m.error !== null)
+    expect(refusal).toBeDefined()
+    expect(refusal!.model).not.toBe("unknown")
+    expect(refusal!.requestModel).toBe("claude-sonnet-4-5")
+  })
+
+  it("still records a row when the request fails before profile resolution", async () => {
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
+    })
+
+    const clientId = `errtel-early-${Date.now()}`
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-request-id": clientId },
+      body: "{ not json",
+    }))
+    expect(res.status).toBe(400)
+    // No profile was ever chosen, so there is genuinely nothing to name — the
+    // fix must not fabricate one.
+    const rows = telemetryStore.getRecent({ limit: 500 }).filter(m => m.requestId === clientId)
+    for (const row of rows) expect(row.profileId).toBeUndefined()
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -910,6 +910,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
       // Hoist adapter detection before try so it's available in the catch block for telemetry
       const adapter = detectAdapter(c)
+      // Hoisted for the same reason: the outer catch records a telemetry row,
+      // but `profile`/`model` are block-scoped inside the try. Without these,
+      // a priority-routing failover files its refusal row with no profileId,
+      // so the row cannot say WHICH account refused — and since #825 stopped
+      // forking requestId per attempt, profileId is what distinguishes the
+      // attempts. Assigned as soon as each value is known; still undefined
+      // when the request fails before that point (early validation), which is
+      // exactly when the row genuinely has nothing to report. See #829.
+      let attemptedProfileId: string | undefined
+      let attemptedModel: string | undefined
+      let attemptedRequestModel: string | undefined
       try {
         const body = options.body
 
@@ -1008,6 +1019,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             ? { routingMode, stickySessionKey: adapter.getSessionId(c, body) }
             : undefined
         )
+        // Every routing mode funnels through this single resolveProfile call —
+        // the priority path re-enters handleMessages with forcedProfileId, so
+        // one assignment here covers failover attempts and direct requests.
+        attemptedProfileId = profile.id
 
         const authStatus = await getClaudeAuthStatusAsync(
           profile.id !== "default" ? profile.id : undefined,
@@ -1021,6 +1036,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
         const requestedModel = typeof body.model === "string" ? body.model : "sonnet"
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode)
+        // Captured for the outer catch's telemetry row (see #829): the model
+        // this attempt was dispatched with. Later [1m] fallbacks reassign the
+        // local `model` inside the retry loops and are deliberately not
+        // mirrored here — the dispatched model is what identifies the attempt,
+        // and mirroring would mean touching four sites in the retry control
+        // flow for no observability gain.
+        attemptedModel = model
+        attemptedRequestModel = typeof body.model === "string" ? body.model : undefined
         // Explicitly versioned ids override their tier's canonical pin for
         // this request (spread last in query.ts env, so they also beat
         // operator env) — a proxy must never substitute models. Bare aliases
@@ -4301,8 +4324,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           requestId: requestMeta.requestId,
           timestamp: Date.now(),
           adapter: adapter.name,
-          model: "unknown",
-          requestModel: undefined,
+          // #829: name the account that failed. On a priority-routing failover
+          // the refusal row is otherwise indistinguishable from any other
+          // attempt under the same requestId. Still "unknown"/absent when the
+          // request died before profile/model resolution.
+          profileId: attemptedProfileId,
+          model: attemptedModel ?? "unknown",
+          requestModel: attemptedRequestModel,
           mode: "non-stream",
           isResume: false,
           isPassthrough: envBool("PASSTHROUGH"),


### PR DESCRIPTION
Fixes #829

## Problem

The `telemetryStore.record(...)` call in the outer catch of `handleMessages` wrote `model: "unknown"` and no `profileId`. Under priority routing each failover attempt files its own row, and since #825 stopped forking `requestId` per attempt all attempts group under the caller's id -- so `profileId` is the only thing that distinguishes them. Without it the refusal row could not say **which account refused**; only the row for the profile that eventually succeeded named an account.

## Fix

Hoist `attemptedProfileId` / `attemptedModel` / `attemptedRequestModel` next to the already-hoisted `adapter` in `handleMessages`, and assign them as soon as each value is known, so the catch can read them.

## Why not `RequestMeta`

The issue floated carrying the candidate id on `RequestMeta`. Rejected: `RequestMeta` is forked per attempt by `forkAttemptMeta` and threaded through the SDK-timing plumbing, so adding a routing field there would put profile identity into a struct whose other fields are timing state, and would touch the failover control flow. The local hoist is three declarations and three assignments inside one function, changes no routing behaviour, and picks up the `model` / `requestModel` gap for free.

## Coverage notes

- Both routing paths are covered by a single assignment: the priority path re-enters `handleMessages` with `forcedProfileId`, so every mode funnels through the same `resolveProfile` call.
- Requests that die before profile resolution (malformed JSON, missing `messages`) still record `profileId: undefined` and `model: "unknown"` -- there is genuinely no account to name, and the fix does not fabricate one.
- Later `[1m]` context fallbacks reassign the local `model` inside the retry loops and are deliberately **not** mirrored; the dispatched model identifies the attempt, and mirroring would mean editing four sites in the retry control flow for no observability gain.
- No currently-correct row changes: the success and stream-error rows already carried `profile.id` and are untouched.

## Tests

New `src/__tests__/error-telemetry-profile.test.ts`:

1. a failover refusal row names the refusing profile (`work`) while the served row still names `personal`
2. the refusal row records the dispatched model, not a bare `"unknown"`, and carries `requestModel`
3. a request that fails before profile resolution still records a row with no fabricated `profileId`

Tests 1 and 2 fail on `main` (verified by stashing the fix) and pass with it; 3 guards against fabricating a profile id. Full `npm test` green, `tsc --noEmit` clean.
