### PR TITLE
fix: preserve passthrough session cache lineage

### DIFF
--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -14,6 +14,7 @@ import {
   measureSuffixOverlap,
   verifyLineage,
   normalizeContextUsage,
+  withClientAssistantUuid,
   MIN_SUFFIX_FOR_COMPACTION,
   type SessionState,
 } from "../proxy/session/lineage"
@@ -920,5 +921,25 @@ describe("verifyLineage compaction that reaches the end of the incoming array", 
     const result = verifyLineage(session, compacted)
     expect(result.type).toBe("compaction")
     if (result.type === "compaction") expect(result.resumeFrom).toBeLessThan(compacted.length)
+  })
+})
+
+
+describe("withClientAssistantUuid", () => {
+  it("overwrites parallel SDK fragments at one future client-assistant slot", () => {
+    let map: Array<string | null> = [null]
+    map = withClientAssistantUuid(map, 1, "assistant-fragment-1")
+    map = withClientAssistantUuid(map, 1, "assistant-fragment-2")
+    expect(map).toEqual([null, "assistant-fragment-2"])
+  })
+
+  it("clears an older fragment when a later assistant UUID is missing", () => {
+    const map = withClientAssistantUuid([null, "older-fragment"], 1, undefined)
+    expect(map).toEqual([null, null])
+  })
+
+  it("pads missing client user slots without shifting the assistant UUID", () => {
+    expect(withClientAssistantUuid([null, "prior-assistant"], 3, "next-assistant"))
+      .toEqual([null, "prior-assistant", null, "next-assistant"])
   })
 })

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for message parsing utilities.
  */
 import { describe, it, expect } from "bun:test"
-import { frameReplayTurns, framePassthroughContinuation, PASSTHROUGH_CONTINUATION_LEAD_IN, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall, extractSystemText } from "../proxy/messages"
+import { frameReplayTurns, normalizeContent, getLastUserMessage, extractAdvisorModel, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, buildToolUseIndex, describeToolCall, extractSystemText } from "../proxy/messages"
 
 const img = (id: string) => ({ type: "image", source: { type: "base64", media_type: "image/png", data: id } })
 function userMsg(content: unknown) {
@@ -542,34 +542,6 @@ describe("frameReplayTurns (#619)", () => {
     expect(out).not.toContain("Human:")
     expect(out).toEndWith("final question")
     expect(out).toContain("[your bash ls]:")
-  })
-})
-
-describe("framePassthroughContinuation", () => {
-  // The deny boundary fork places the spent "end your turn now" deny
-  // immediately before this delta. Without the lead-in the model obeys it and
-  // answers with an empty text block (see the doc comment on the constant).
-  const delta = "[your shell ls]:\nfile.txt"
-
-  it("puts the lead-in ahead of the delta and keeps the delta terminal", () => {
-    const out = framePassthroughContinuation(delta)
-    expect(out).toStartWith(PASSTHROUGH_CONTINUATION_LEAD_IN)
-    expect(out).toEndWith(delta)
-  })
-
-  it("says the end-turn instruction is discharged", () => {
-    expect(framePassthroughContinuation(delta).toLowerCase()).toContain("discharged")
-  })
-
-  it("leaves an empty delta alone — the lead-in must never be the whole turn", () => {
-    expect(framePassthroughContinuation("")).toBe("")
-  })
-
-  it("adds no transcript markers for the model to imitate (#496)", () => {
-    const out = framePassthroughContinuation(delta)
-    expect(out).not.toContain("Human:")
-    expect(out).not.toContain("[Assistant:")
-    expect(out).not.toContain("<conversation_history>")
   })
 })
 

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1,26 +1,65 @@
 /**
  * Integration tests for the passthrough early stop — full HTTP layer, mocked SDK.
  *
- * The mock counts how many messages the proxy actually CONSUMES from the SDK
- * stream. With early stop, consumption must halt at the deny tool_result —
- * the digest-turn message (turn 2) is never pulled, which in production means
- * the digest API call never generates (the billed waste this feature removes).
+ * The mock counts how many messages the proxy consumes from the SDK stream.
+ * Tool turns must close to the client at turn 1 while the proxy invisibly drains
+ * the hidden digest through a canonical result; only then is the assistant UUID
+ * known durable enough for resumeSessionAt.
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
-import { assistantMessage, messageStart, toolUseBlockStart, inputJsonDelta, blockStop, messageDelta } from "./helpers"
-import { PASSTHROUGH_CONTINUATION_LEAD_IN } from "../proxy/messages"
+import { assistantMessage, messageStart, textBlockStart, textDelta, toolUseBlockStart, inputJsonDelta, blockStop, messageDelta, messageStop } from "./helpers"
 
 let mockMessages: any[] = []
 let yieldedCount = 0
 let capturedQueryParams: any = null
+let capturedQueryParamsAll: any[] = []
+let mockTerminalError: Error | undefined
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
+    capturedQueryParamsAll.push(params)
+    const terminalError = mockTerminalError
+    const preHook = params?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
     return (async function* () {
+      let sawSyntheticDeny = false
+      let sawResult = false
       for (const msg of mockMessages) {
         yieldedCount++
+        if (msg?.type === "test_pre_tool_hook") {
+          if (preHook) {
+            await preHook({
+              tool_name: msg.tool_name,
+              tool_use_id: msg.tool_use_id,
+              tool_input: msg.tool_input,
+            }, undefined, { signal: new AbortController().signal })
+          }
+          continue
+        }
+        if (msg?.type === "user" && msg?.message?.content?.some((b: any) => b?.type === "tool_result")) {
+          sawSyntheticDeny = true
+        }
+        if (msg?.type === "result") sawResult = true
         yield msg
+        if (preHook && msg?.type === "assistant" && Array.isArray(msg?.message?.content)) {
+          for (const block of msg.message.content) {
+            if (block?.type !== "tool_use") continue
+            void Promise.resolve(preHook({
+              tool_name: block.name,
+              tool_use_id: block.id,
+              tool_input: block.input,
+            }, undefined, { signal: new AbortController().signal }))
+          }
+        }
+      }
+      if (terminalError) throw terminalError
+      // Real SDK queries terminate with a result, and that boundary is the only
+      // persistence acknowledgement the live PTY transport gave us. Most test
+      // fixtures predate that distinction, so synthesize the canonical result
+      // after tool-deny flows unless a fixture provided one explicitly.
+      if (sawSyntheticDeny && !sawResult) {
+        yieldedCount++
+        yield { type: "result", subtype: "success", is_error: false, session_id: "test-session" }
       }
     })()
   },
@@ -42,6 +81,8 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer } = await import("../proxy/server")
+const { clearSessionCache } = await import("../proxy/session/cache")
+const { evictSharedSession } = await import("../proxy/sessionStore")
 
 function userDenyMessage(toolUseId: string) {
   return {
@@ -56,19 +97,25 @@ function userDenyMessage(toolUseId: string) {
   }
 }
 
+const TEST_RUN_ID = crypto.randomUUID()
+
 const READ_TOOL = {
   name: "read",
   description: "Read a file",
   input_schema: { type: "object", properties: { file_path: { type: "string" } }, required: ["file_path"] },
 }
 
+const usedSessionKeys = new Set<string>()
+
 async function post(app: any, body: any, sessionHeader = "es-session") {
+  const sessionKey = `${sessionHeader}-${TEST_RUN_ID}`
+  usedSessionKeys.add(sessionKey)
   return app.fetch(new Request("http://localhost/v1/messages", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "x-api-key": "dummy",
-      "x-opencode-session": sessionHeader,
+      "x-opencode-session": sessionKey,
       "user-agent": "opencode/1.0.0",
     },
     body: JSON.stringify(body),
@@ -93,23 +140,30 @@ describe("Integration: passthrough early stop", () => {
     mockMessages = []
     yieldedCount = 0
     capturedQueryParams = null
+    capturedQueryParamsAll = []
+    mockTerminalError = undefined
   })
 
   afterEach(() => {
+    for (const key of usedSessionKeys) evictSharedSession(key)
+    usedSessionKeys.clear()
+    clearSessionCache()
     if (savedPassthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = savedPassthrough
     else delete process.env.MERIDIAN_PASSTHROUGH
     if (savedEarlyStop !== undefined) process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = savedEarlyStop
     else delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
   })
 
-  it("non-stream: stops consuming at the deny — digest turn never pulled, abort fired", async () => {
+  it("non-stream: drains the hidden digest to a canonical result without leaking it", async () => {
+    const hiddenDigest = assistantMessage([{ type: "text", text: "TURN2_GARBAGE_DIGEST" }])
+    hiddenDigest.message.stop_reason = "end_turn"
     mockMessages = [
       assistantMessage([
         { type: "text", text: "Reading the file." },
         { type: "tool_use", id: "tu1", name: "read", input: { file_path: "/etc/hostname" } },
       ]),
       userDenyMessage("tu1"),
-      assistantMessage([{ type: "text", text: "TURN2_GARBAGE_DIGEST" }]),
+      hiddenDigest,
     ]
 
     const response = await post(app, {
@@ -122,14 +176,14 @@ describe("Integration: passthrough early stop", () => {
 
     const body = await response.json() as any
     expect(response.status).toBe(200)
+    // The hidden digest ends normally, but must not overwrite turn 1's wire contract.
     expect(body.stop_reason).toBe("tool_use")
     const types = body.content.map((b: any) => b.type)
     expect(types).toContain("tool_use")
     expect(JSON.stringify(body.content)).not.toContain("TURN2_GARBAGE_DIGEST")
-    // The money assertion: only turn 1 + the deny were consumed.
-    expect(yieldedCount).toBe(2)
-    // The proxy aborted the SDK query (kills the digest turn in production).
-    expect(capturedQueryParams.options.abortController?.signal?.aborted).toBe(true)
+    // Turn 1 + deny + hidden digest + canonical result were consumed.
+    expect(yieldedCount).toBe(4)
+    expect(capturedQueryParams.options.abortController?.signal?.aborted ?? false).toBe(false)
   })
 
   it("non-stream: the early-stopped session is stored and the next turn resumes it", async () => {
@@ -164,23 +218,20 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resume).toBe("test-session")
   })
 
-  it("non-stream: a deny-boundary continuation tells the model the end-turn deny is spent", async () => {
-    // The fork puts the persisted deny — "do not generate further text, end
-    // your turn now" — immediately before this delta, where it is the nearest
-    // instruction in context. Live, the model obeyed it and returned an empty
-    // text block with stop_reason end_turn, three times in 500 requests, each
-    // on a session's second turn. The prompt has to say the deny is discharged.
-    mockMessages = [
-      assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
-      userDenyMessage("tu1"),
-    ]
+  it("non-stream: resumes at the assistant tool-use boundary with structured real results", async () => {
+    const assistantToolTurn = assistantMessage([
+      { type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } },
+    ])
+    const assistantForkUuid = assistantToolTurn.uuid
+    const syntheticDeny = userDenyMessage("tu1")
+    mockMessages = [assistantToolTurn, syntheticDeny]
     const first = await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
       stream: false,
       tools: [READ_TOOL],
       messages: [{ role: "user", content: "read x" }],
-    }, "es-lead-in")
+    }, "es-assistant-boundary")
     expect(first.status).toBe(200)
 
     mockMessages = [assistantMessage([{ type: "text", text: "the file says hi" }])]
@@ -194,14 +245,229 @@ describe("Integration: passthrough early stop", () => {
         { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }] },
         { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "hi" }] },
       ],
-    }, "es-lead-in")
+    }, "es-assistant-boundary")
     expect(second.status).toBe(200)
-    // Forked from the boundary, and the prompt carries the discharge.
-    expect(capturedQueryParams.options.resumeSessionAt).toBeTruthy()
-    const prompt = capturedQueryParams.prompt as string
-    expect(prompt).toContain(PASSTHROUGH_CONTINUATION_LEAD_IN)
-    // The tool result stays terminal — the lead-in is framing, not the answer.
-    expect(prompt.indexOf(PASSTHROUGH_CONTINUATION_LEAD_IN)).toBeLessThan(prompt.indexOf("hi"))
+
+    // resumeSessionAt only accepts SDKAssistantMessage UUIDs. The synthetic
+    // user denial is a discarded side branch, not the canonical checkpoint.
+    expect(capturedQueryParams.options.resume).toBe("test-session")
+    expect(capturedQueryParams.options.resumeSessionAt).toBe(assistantForkUuid)
+    expect(capturedQueryParams.options.resumeSessionAt).not.toBe(syntheticDeny.uuid)
+    // Normal passthrough continuation reuses the session ID. Forking is for
+    // semantic branches (undo) or the bounded busy-session fallback only.
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+
+    const promptMessages: any[] = []
+    for await (const message of capturedQueryParams.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].type).toBe("user")
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tu1", content: "hi" },
+    ])
+  })
+
+  it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
+    const firstToolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },
+    ])
+    mockMessages = [firstToolTurn, userDenyMessage("tu-round-1")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a" }],
+    }, "es-repeated-boundary")).status).toBe(200)
+
+    const secondToolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-round-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [secondToolTurn, userDenyMessage("tu-round-2")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read a" },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-1", content: "A" }] },
+      ],
+    }, "es-repeated-boundary")).status).toBe(200)
+    const secondQuery = capturedQueryParamsAll[1]
+    expect(secondQuery.options.resume).toBe("test-session")
+    expect(secondQuery.options.resumeSessionAt).toBe(firstToolTurn.uuid)
+    expect(secondQuery.options.forkSession).toBeUndefined()
+    const secondPrompt: any[] = []
+    for await (const message of secondQuery.prompt) secondPrompt.push(message)
+    expect(secondPrompt[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tu-round-1", content: "A" },
+    ])
+
+    mockMessages = [assistantMessage([{ type: "text", text: "done" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read a" },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-1", content: "A" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-2", name: "read", input: { file_path: "b" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-2", content: "B" }] },
+      ],
+    }, "es-repeated-boundary")).status).toBe(200)
+    const thirdQuery = capturedQueryParamsAll[2]
+    expect(thirdQuery.options.resume).toBe("test-session")
+    expect(thirdQuery.options.resumeSessionAt).toBe(secondToolTurn.uuid)
+    expect(thirdQuery.options.forkSession).toBeUndefined()
+    const thirdPrompt: any[] = []
+    for await (const message of thirdQuery.prompt) thirdPrompt.push(message)
+    expect(thirdPrompt[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tu-round-2", content: "B" },
+    ])
+  })
+
+  it("non-stream: falls back to a fresh replay for partial parallel results", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "partial-1", name: "read", input: { file_path: "a" } },
+      { type: "tool_use", id: "partial-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("partial-1"), userDenyMessage("partial-2")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read both" }],
+    }, "es-partial-results")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "safe replay" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read both" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "partial-1", content: "A" }] },
+      ],
+    }, "es-partial-results")).status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(typeof capturedQueryParams.prompt).toBe("string")
+  })
+
+  it("non-stream: preserves a nested multimodal tool_result wrapper", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "image-result", name: "read", input: { file_path: "image.png" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("image-result")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read image" }],
+    }, "es-image-result")).status).toBe(200)
+
+    const nestedImage = {
+      type: "image",
+      source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+    }
+    mockMessages = [assistantMessage([{ type: "text", text: "I see it" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read image" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "image-result", content: [nestedImage] }] },
+      ],
+    }, "es-image-result")).status).toBe(200)
+
+    const promptMessages: any[] = []
+    for await (const message of capturedQueryParams.prompt) promptMessages.push(message)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "image-result", content: [nestedImage] },
+    ])
+  })
+
+  it("non-stream: maps parallel SDK fragments to one final undo UUID", async () => {
+    const firstFragment = assistantMessage([
+      { type: "tool_use", id: "undo-parallel-1", name: "read", input: { file_path: "a" } },
+    ])
+    const finalFragment = assistantMessage([
+      { type: "tool_use", id: "undo-parallel-2", name: "read", input: { file_path: "b" } },
+    ])
+    const combinedToolTurn = [...firstFragment.message.content, ...finalFragment.message.content]
+    mockMessages = [
+      firstFragment,
+      finalFragment,
+      userDenyMessage("undo-parallel-1"),
+      userDenyMessage("undo-parallel-2"),
+    ]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read both for undo" }],
+    }, "es-parallel-undo")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "both read" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read both for undo" },
+        { role: "assistant", content: combinedToolTurn },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "undo-parallel-1", content: "A" },
+          { type: "tool_result", tool_use_id: "undo-parallel-2", content: "B" },
+        ] },
+      ],
+    }, "es-parallel-undo")).status).toBe(200)
+    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+
+    mockMessages = [assistantMessage([{ type: "text", text: "changed direction" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read both for undo" },
+        { role: "assistant", content: combinedToolTurn },
+        { role: "user", content: "instead, take a different direction" },
+      ],
+    }, "es-parallel-undo")).status).toBe(200)
+    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
+    expect(capturedQueryParams.options.forkSession).toBe(true)
+
+    // The first undo must retain UUIDs for the preserved prefix so another
+    // branch from that prefix still rolls back to the final parallel fragment.
+    mockMessages = [assistantMessage([{ type: "text", text: "changed again" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read both for undo" },
+        { role: "assistant", content: combinedToolTurn },
+        { role: "user", content: "take yet another direction" },
+      ],
+    }, "es-parallel-undo")).status).toBe(200)
+    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
+    expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
   it("non-stream: a plain resume with no deny boundary stays bare", async () => {
@@ -231,7 +497,7 @@ describe("Integration: passthrough early stop", () => {
     }, "es-no-boundary")
     expect(second.status).toBe(200)
     expect(capturedQueryParams.options.resume).toBe("test-session")
-    expect(capturedQueryParams.prompt as string).not.toContain(PASSTHROUGH_CONTINUATION_LEAD_IN)
+    expect(capturedQueryParams.prompt).toBe("and again")
   })
 
   it("non-stream: waits for ALL parallel denies before stopping", async () => {
@@ -259,7 +525,7 @@ describe("Integration: passthrough early stop", () => {
     const ids = body.content.filter((b: any) => b.type === "tool_use").map((b: any) => b.id)
     expect(ids).toContain("tu1")
     expect(ids).toContain("tu2")
-    expect(yieldedCount).toBe(3) // turn1 + two denies; digest never pulled
+    expect(yieldedCount).toBe(5) // turn1 + two denies + hidden digest + result
   })
 
   it("non-stream: text-only answers are unaffected (no tool calls, no abort)", async () => {
@@ -283,7 +549,7 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.abortController?.signal?.aborted ?? false).toBe(false)
   })
 
-  it("kill switch: MERIDIAN_PASSTHROUGH_EARLY_STOP=0 restores full drain", async () => {
+  it("kill switch restores the legacy full drain", async () => {
     process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
     mockMessages = [
       assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
@@ -300,13 +566,151 @@ describe("Integration: passthrough early stop", () => {
     })
 
     expect(response.status).toBe(200)
-    expect(yieldedCount).toBe(3) // everything drained, old behavior
+    expect(yieldedCount).toBe(4) // assistant + deny + digest + canonical result
   })
 
-  // #742: the early stop fires on deny-settlement alone. When the SDK surfaces a
-  // wide parallel set as separate assistant turns, every deny the tracker KNOWS
-  // about can settle while a LATER tool_use block is still mid-input_json_delta.
-  // flushOpenClientBlocks then force-emits its content_block_stop, so the client
+  it("non-stream: a producer-side digest hook queued before the visible deny is pruned", async () => {
+    const visibleTurn = assistantMessage([
+      { type: "tool_use", id: "visible-race-tool", name: "read", input: { file_path: "visible" } },
+    ])
+    const hiddenTurn = assistantMessage([
+      { type: "tool_use", id: "hidden-race-tool", name: "read", input: { file_path: "hidden" } },
+    ])
+    mockMessages = [
+      visibleTurn,
+      // The producer can start the hidden turn and run its hook before the
+      // consumer pulls the already-queued visible deny from the iterator.
+      { type: "test_pre_tool_hook", tool_name: "read", tool_use_id: "hidden-race-tool", tool_input: { file_path: "hidden" } },
+      userDenyMessage("visible-race-tool"),
+      hiddenTurn,
+      userDenyMessage("hidden-race-tool"),
+    ]
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read visible only" }],
+    }, "es-hidden-hook-race")
+    const firstBody = await first.json() as any
+    expect(first.status).toBe(200)
+    expect(firstBody.content.filter((b: any) => b.type === "tool_use").map((b: any) => b.id)).toEqual([
+      "visible-race-tool",
+    ])
+
+    mockMessages = [assistantMessage([{ type: "text", text: "visible result accepted" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read visible only" },
+        { role: "assistant", content: firstBody.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "visible-race-tool", content: "VISIBLE" }] },
+      ],
+    }, "es-hidden-hook-race")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(visibleTurn.uuid)
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).not.toBe(hiddenTurn.uuid)
+  })
+
+  it("hidden non-stream digest UUID does not replace the visible checkpoint", async () => {
+    const visibleToolTurn = assistantMessage([
+      { type: "tool_use", id: "kill-undo-tool", name: "read", input: { file_path: "x" } },
+    ])
+    const hiddenDigestTurn = assistantMessage([{ type: "text", text: "hidden digest" }])
+    mockMessages = [visibleToolTurn, userDenyMessage("kill-undo-tool"), hiddenDigestTurn]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x for kill-switch undo" }],
+    }, "es-kill-switch-undo")).status).toBe(200)
+
+    // The hidden digest is drained internally and never belongs in the
+    // client-echoed assistant message.
+    const echoedAssistant = [...visibleToolTurn.message.content]
+    mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x for kill-switch undo" },
+        { role: "assistant", content: echoedAssistant },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "kill-undo-tool", content: "X" }] },
+      ],
+    }, "es-kill-switch-undo")).status).toBe(200)
+    expect(capturedQueryParams.options.resumeSessionAt).toBe(visibleToolTurn.uuid)
+    expect(capturedQueryParams.options.resumeSessionAt).not.toBe(hiddenDigestTurn.uuid)
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+  })
+
+  it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
+    const firstFragment = assistantMessage([
+      { type: "tool_use", id: "late-tu-1", name: "read", input: { file_path: "a" } },
+    ])
+    const finalFragment = assistantMessage([
+      { type: "tool_use", id: "late-tu-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [
+      messageStart("msg_late_parallel"),
+      toolUseBlockStart(0, "read", "late-tu-1"),
+      inputJsonDelta(0, '{"file_path":"a"}'),
+      blockStop(0),
+      toolUseBlockStart(1, "read", "late-tu-2"),
+      inputJsonDelta(1, '{"file_path":"b"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      firstFragment,
+      userDenyMessage("late-tu-1"),
+      // The SDK can expose a deny before the final per-block assistant
+      // metadata. This later fragment must extend, not follow, the checkpoint.
+      finalFragment,
+      userDenyMessage("late-tu-2"),
+    ]
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a and b" }],
+    }, "es-late-parallel")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockMessages = [assistantMessage([{ type: "text", text: "both complete" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read a and b" },
+        { role: "assistant", content: [
+          { type: "tool_use", id: "late-tu-1", name: "read", input: { file_path: "a" } },
+          { type: "tool_use", id: "late-tu-2", name: "read", input: { file_path: "b" } },
+        ] },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "late-tu-1", content: "A" },
+          { type: "tool_result", tool_use_id: "late-tu-2", content: "B" },
+        ] },
+      ],
+    }, "es-late-parallel")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(finalFragment.uuid)
+  })
+
+  // #742: a deny can become iterator-visible while a later tool_use block is
+  // still mid-input_json_delta. Freezing or closing solely from the tracker's
+  // currently-known set can force-emit that block's content_block_stop, so the client
   // gets a well-formed envelope wrapped around TRUNCATED JSON — invisible as a
   // wire error, which is why the envelope audit (framing) never caught it.
   //
@@ -325,7 +729,7 @@ describe("Integration: passthrough early stop", () => {
       toolUseBlockStart(1, "read", "tu2"),
       inputJsonDelta(1, '{"file_path":"y","note":"HEAD_'),
       // ...when tu1's deny lands. Every tool the tracker knows about is now
-      // denied, so the early stop fires with block 1 still open.
+      // denied, while block 1 remains open and must continue streaming.
       userDenyMessage("tu1"),
       // The rest of tu2's JSON. Before the fix these are never forwarded.
       inputJsonDelta(1, TAIL + '"}'),
@@ -366,7 +770,137 @@ describe("Integration: passthrough early stop", () => {
     expect(JSON.parse(blockOne).note).toBe("HEAD_" + TAIL)
   })
 
-  it("stream: closes cleanly after the deny — digest events never consumed", async () => {
+  it("stream: legacy early-stop kill switch evicts the consumer-broken tool tail", async () => {
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "kill-switch-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_kill_switch"),
+      toolUseBlockStart(0, "read", "kill-switch-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("kill-switch-tool"),
+      messageStart("msg_kill_switch_turn2"),
+    ]
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x with early stop disabled" }],
+    }, "es-stream-kill-switch")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockMessages = [assistantMessage([{ type: "text", text: "fresh after kill switch" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x with early stop disabled" },
+        { role: "assistant", content: [{ type: "tool_use", id: "kill-switch-tool", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "kill-switch-tool", content: "X" }] },
+      ],
+    }, "es-stream-kill-switch")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
+  })
+
+  it("stream: evicts an UUID-less turn-2-suppressed tail instead of plain-resuming it", async () => {
+    const assistantWithoutUuid = {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "uuidless-tool", name: "read", input: { file_path: "x" } }],
+      },
+      session_id: "test-session",
+    }
+    mockMessages = [
+      messageStart("msg_uuidless"),
+      toolUseBlockStart(0, "read", "uuidless-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      assistantWithoutUuid,
+      userDenyMessage("uuidless-tool"),
+      messageStart("msg_uuidless_turn2"),
+    ]
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x without a checkpoint" }],
+    }, "es-uuidless-stream")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockMessages = [assistantMessage([{ type: "text", text: "fresh replay" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x without a checkpoint" },
+        { role: "assistant", content: [{ type: "tool_use", id: "uuidless-tool", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "uuidless-tool", content: "X" }] },
+      ],
+    }, "es-uuidless-stream")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
+  })
+
+  it("stream: evicts the mapping when the hidden durability drain errors", async () => {
+    mockMessages = [
+      messageStart("msg_drain_error"),
+      toolUseBlockStart(0, "read", "drain-error-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      assistantMessage([{ type: "tool_use", id: "drain-error-tool", name: "read", input: { file_path: "x" } }]),
+      userDenyMessage("drain-error-tool"),
+    ]
+    mockTerminalError = new Error("Claude Code process exited with code 1")
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x before a drain error" }],
+    }, "es-stream-drain-error")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "fresh replay" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x before a drain error" },
+        { role: "assistant", content: [{ type: "tool_use", id: "drain-error-tool", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "drain-error-tool", content: "X" }] },
+      ],
+    }, "es-stream-drain-error")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
+  })
+
+  it("stream: closes at turn 1 while digest and canonical result drain invisibly", async () => {
     mockMessages = [
       messageStart("msg_es"),
       toolUseBlockStart(0, "read", "tu1"),
@@ -375,8 +909,14 @@ describe("Integration: passthrough early stop", () => {
       messageDelta("tool_use"),
       assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
       userDenyMessage("tu1"),
-      // digest turn events — must never be consumed:
+      // Hidden digest wire events are consumed but never enqueued after the
+      // client controller closes. A closed enqueue must not break the drain.
       messageStart("msg_turn2"),
+      textBlockStart(0),
+      textDelta(0, "TURN2_GARBAGE_DIGEST"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
       assistantMessage([{ type: "text", text: "TURN2_GARBAGE_DIGEST" }]),
     ]
 
@@ -394,17 +934,13 @@ describe("Integration: passthrough early stop", () => {
     expect(text).toContain("message_stop")
     expect(text).not.toContain("TURN2_GARBAGE_DIGEST")
 
-    // The client response completes at turn-1's stop_reason:"tool_use"; the
-    // drain + abort continue in the background. Wait for the abort to land
-    // before asserting consumption.
+    // The client response completes at turn 1; digest/result draining continues
+    // in the background and must not abort the SDK query.
     const deadline = Date.now() + 2000
-    while (
-      !capturedQueryParams.options.abortController?.signal?.aborted &&
-      Date.now() < deadline
-    ) {
+    while (yieldedCount < 15 && Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, 10))
     }
-    expect(capturedQueryParams.options.abortController?.signal?.aborted).toBe(true)
-    expect(yieldedCount).toBe(7) // up to and including the deny; turn-2 events never pulled
+    expect(capturedQueryParams.options.abortController?.signal?.aborted ?? false).toBe(false)
+    expect(yieldedCount).toBe(15)
   })
 })

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -14,10 +14,13 @@ import { describe, it, expect } from "bun:test"
 import {
   clientAbortDisposition,
   createEarlyStopTracker,
+  allForwardedCallsResolved,
   isClientForwardedToolUse,
+  isCompleteToolResultContinuation,
   noteAssistantContent,
+  noteAssistantMessage,
   noteUserContent,
-  resumeBoundaryUuid,
+  settledToolCallAssistantUuid,
   shouldEarlyStop,
 } from "../proxy/passthroughEarlyStop"
 
@@ -25,6 +28,11 @@ import { PASSTHROUGH_MCP_PREFIX } from "../proxy/passthroughTools"
 
 const toolUse = (id: string, name: string) => ({ type: "tool_use", id, name })
 const toolResult = (id: string) => ({ type: "tool_result", tool_use_id: id, is_error: true })
+const sdkAssistant = (uuid: unknown, content: unknown) => ({
+  type: "assistant",
+  uuid,
+  message: { role: "assistant", content },
+})
 
 describe("prefix cross-check", () => {
   it("tracker's duplicated prefix matches the passthrough MCP prefix", () => {
@@ -67,26 +75,26 @@ describe("clientAbortDisposition", () => {
     profileSessionId: "s1",
     currentSessionId: "claude-1",
     sawDuplicateToolUse: false,
-    resumeBoundaryUuid: "u1",
+    toolCallAssistantUuid: "a1",
     passthrough: true,
   }
 
-  it("stores the boundary when one was persisted before the abort", () => {
-    expect(clientAbortDisposition(base)).toEqual({ action: "store", resumeUuid: "u1" })
+  it("evicts even when an assistant UUID was observed before the abort", () => {
+    expect(clientAbortDisposition(base)).toEqual({ action: "evict" })
   })
 
-  it("evicts when no deny was persisted — nothing is safe to resume from", () => {
+  it("evicts when no assistant checkpoint exists — nothing is safe to resume from", () => {
     // The interrupted tail would make the SDK synthesize a continuation the
     // model answers with an empty turn, and every empty turn becomes the next
     // tail. A fresh replay is the cost of not wedging the conversation.
-    expect(clientAbortDisposition({ ...base, resumeBoundaryUuid: undefined })).toEqual({ action: "evict" })
+    expect(clientAbortDisposition({ ...base, toolCallAssistantUuid: undefined })).toEqual({ action: "evict" })
   })
 
   // A deny boundary is a passthrough concept. In internal mode the SDK runs the
   // tools itself, so a user message carrying tool_results is an ordinary turn —
   // persisting its uuid as a spent deny would make the next continuation fork
   // from a point that was never a boundary.
-  it("never records a deny boundary for an internal-mode abort", () => {
+  it("never records a passthrough checkpoint for an internal-mode abort", () => {
     expect(clientAbortDisposition({ ...base, passthrough: false })).toEqual({ action: "evict" })
   })
 
@@ -107,38 +115,66 @@ describe("clientAbortDisposition", () => {
   })
 })
 
-describe("resumeBoundaryUuid", () => {
-  const userMsg = (uuid: unknown, content: unknown) => ({
-    type: "user",
+describe("assistant resume checkpoint", () => {
+  const assistantMsg = (uuid: unknown, content: unknown) => ({
+    type: "assistant",
     uuid,
-    message: { role: "user", content },
+    message: { role: "assistant", content },
   })
 
-  it("returns the uuid of a user message carrying a tool_result", () => {
-    expect(resumeBoundaryUuid(userMsg("u1", [toolResult("t1")]))).toBe("u1")
+  it("stores the UUID of an assistant message carrying a forwarded tool_use", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistantMsg("a1", [toolUse("t1", "read")]))
+    expect(tracker.toolCallAssistantUuid).toBe("a1")
   })
 
-  it("returns the uuid when tool_results mix with other blocks", () => {
-    expect(resumeBoundaryUuid(userMsg("u2", [{ type: "text", text: "hi" }, toolResult("t1")]))).toBe("u2")
+  it("advances to the final assistant fragment for parallel tool calls", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistantMsg("a1", [toolUse("t1", "read")]))
+    noteAssistantMessage(tracker, assistantMsg("a2", [toolUse("t2", "grep")]))
+    noteUserContent(tracker, [toolResult("t1"), toolResult("t2")])
+    expect(settledToolCallAssistantUuid(tracker)).toBe("a2")
   })
 
-  it("ignores assistant messages", () => {
-    expect(resumeBoundaryUuid({ type: "assistant", uuid: "a1", message: { content: [toolResult("t1")] } })).toBeUndefined()
+  it("never accepts a user/tool-result UUID as a resume checkpoint", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, {
+      type: "user",
+      uuid: "u1",
+      message: { role: "user", content: [toolResult("t1")] },
+    })
+    expect(tracker.toolCallAssistantUuid).toBeUndefined()
   })
 
-  it("ignores user messages without tool_results", () => {
-    expect(resumeBoundaryUuid(userMsg("u3", [{ type: "text", text: "hi" }]))).toBeUndefined()
+  it("does not expose a boundary until every forwarded call settled", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistantMsg("a1", [
+      toolUse("t1", "read"),
+      toolUse("t2", "grep"),
+    ]))
+    noteUserContent(tracker, [toolResult("t1")])
+    expect(allForwardedCallsResolved(tracker)).toBe(false)
+    expect(settledToolCallAssistantUuid(tracker)).toBeUndefined()
+    noteUserContent(tracker, [toolResult("t2")])
+    expect(allForwardedCallsResolved(tracker)).toBe(true)
+    expect(settledToolCallAssistantUuid(tracker)).toBe("a1")
   })
 
-  it("ignores messages with no usable uuid", () => {
-    expect(resumeBoundaryUuid(userMsg(undefined, [toolResult("t1")]))).toBeUndefined()
-    expect(resumeBoundaryUuid(userMsg("", [toolResult("t1")]))).toBeUndefined()
+  it("fails closed when the tool-bearing assistant message has no usable UUID", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistantMsg(undefined, [toolUse("t1", "read")]))
+    noteUserContent(tracker, [toolResult("t1")])
+    expect(settledToolCallAssistantUuid(tracker)).toBeUndefined()
+    expect(shouldEarlyStop(tracker)).toBe(false)
   })
 
-  it("tolerates malformed content", () => {
-    expect(resumeBoundaryUuid(userMsg("u4", "just a string"))).toBeUndefined()
-    expect(resumeBoundaryUuid(null)).toBeUndefined()
-    expect(resumeBoundaryUuid({})).toBeUndefined()
+  it("invalidates an older checkpoint when a later tool-bearing message has no UUID", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistantMsg("a1", [toolUse("t1", "read")]))
+    noteAssistantMessage(tracker, assistantMsg(undefined, [toolUse("t2", "grep")]))
+    noteUserContent(tracker, [toolResult("t1"), toolResult("t2")])
+    expect(settledToolCallAssistantUuid(tracker)).toBeUndefined()
+    expect(shouldEarlyStop(tracker)).toBe(false)
   })
 })
 
@@ -156,7 +192,7 @@ describe("early-stop tracking", () => {
 
   it("stops after the single tool call's deny is observed", () => {
     const t = createEarlyStopTracker()
-    noteAssistantContent(t, [toolUse("t1", "mcp__oc__read")])
+    noteAssistantMessage(t, sdkAssistant("a-single", [toolUse("t1", "mcp__oc__read")]))
     expect(shouldEarlyStop(t)).toBe(false) // deny not yet persisted
     noteUserContent(t, [toolResult("t1")])
     expect(shouldEarlyStop(t)).toBe(true)
@@ -164,11 +200,11 @@ describe("early-stop tracking", () => {
 
   it("waits for ALL parallel tool calls' denies before stopping", () => {
     const t = createEarlyStopTracker()
-    noteAssistantContent(t, [
+    noteAssistantMessage(t, sdkAssistant("a-parallel", [
       { type: "text", text: "reading both" },
       toolUse("t1", "mcp__oc__read"),
       toolUse("t2", "mcp__oc__grep"),
-    ])
+    ]))
     noteUserContent(t, [toolResult("t1")])
     expect(shouldEarlyStop(t)).toBe(false) // t2's deny still pending — do NOT drop it
     noteUserContent(t, [toolResult("t2")])
@@ -177,7 +213,7 @@ describe("early-stop tracking", () => {
 
   it("fires only once (idempotent after stop)", () => {
     const t = createEarlyStopTracker()
-    noteAssistantContent(t, [toolUse("t1", "read")])
+    noteAssistantMessage(t, sdkAssistant("a-idempotent", [toolUse("t1", "read")]))
     noteUserContent(t, [toolResult("t1")])
     expect(shouldEarlyStop(t)).toBe(true)
     expect(shouldEarlyStop(t)).toBe(false)
@@ -190,7 +226,7 @@ describe("early-stop tracking", () => {
     noteUserContent(t, [toolResult("ts1")]) // real ToolSearch result
     expect(shouldEarlyStop(t)).toBe(false)
     // Turn 2: the actual client tool call
-    noteAssistantContent(t, [toolUse("t1", "mcp__oc__read")])
+    noteAssistantMessage(t, sdkAssistant("a-single", [toolUse("t1", "mcp__oc__read")]))
     noteUserContent(t, [toolResult("t1")])
     expect(shouldEarlyStop(t)).toBe(true)
   })
@@ -209,5 +245,41 @@ describe("early-stop tracking", () => {
     noteUserContent(t, undefined as unknown)
     noteUserContent(t, [{ type: "text", text: "hi" }])
     expect(shouldEarlyStop(t)).toBe(false)
+  })
+})
+
+
+describe("isCompleteToolResultContinuation", () => {
+  const result = (id: string, content: unknown = "ok") => ({ type: "tool_result", tool_use_id: id, content })
+
+  it("accepts one complete parallel result batch", () => {
+    expect(isCompleteToolResultContinuation([
+      { role: "user", content: [result("t1"), result("t2")] },
+    ], ["t1", "t2"])).toBe(true)
+  })
+
+  it("rejects a partial batch and an unknown result id", () => {
+    expect(isCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+    ], ["t1", "t2"])).toBe(false)
+    expect(isCompleteToolResultContinuation([
+      { role: "user", content: [result("unknown")] },
+    ], ["t1"])).toBe(false)
+  })
+
+  it("rejects multiple user messages so multimodal results stay on the final SDK input", () => {
+    expect(isCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "user", content: [{ type: "text", text: "continue" }] },
+    ], ["t1"])).toBe(false)
+  })
+
+  it("requires tool results before ordinary user content", () => {
+    expect(isCompleteToolResultContinuation([
+      { role: "user", content: [{ type: "text", text: "first" }, result("t1")] },
+    ], ["t1"])).toBe(false)
+    expect(isCompleteToolResultContinuation([
+      { role: "user", content: [result("t1"), { type: "text", text: "then continue" }] },
+    ], ["t1"])).toBe(true)
   })
 })

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -46,6 +46,29 @@ function toolTurn(toolId: string, toolName: string, input: Record<string, unknow
   }
 }
 
+
+function textTurn(text: string) {
+  return {
+    type: "assistant",
+    message: {
+      id: "msg_digest",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text }],
+      model: "claude-sonnet-4-5-20250929",
+      stop_reason: "end_turn",
+      usage: { input_tokens: 10, output_tokens: 10 },
+    },
+    parent_tool_use_id: null,
+    uuid: crypto.randomUUID(),
+    session_id: "test-session",
+  }
+}
+
+function canonicalResult() {
+  return { type: "result", subtype: "success", is_error: false, session_id: "test-session" }
+}
+
 function streamMessageStart() {
   return {
     type: "stream_event",
@@ -376,12 +399,12 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     }
   }
 
-  it("non-stream: both parallel reads are captured with full inputs; digest turn never consumed", async () => {
+  it("non-stream: both parallel reads are captured while the digest drains invisibly", async () => {
     mockTurns = [
       parallelReadTurn(),
       denyUser(["toolu_pa", "toolu_pb"]),
-      // Digest/fabrication turn — early stop must abort before this is consumed.
-      toolTurn("toolu_garbage", "get_time", { tz: "UTC" }),
+      textTurn("hidden digest"),
+      canonicalResult(),
     ]
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
 
@@ -395,12 +418,17 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     // Full inputs — no argument-less 'red read'.
     expect(toolUses.find((t: any) => t.id === "toolu_pa").input).toEqual({ filePath: "a.txt" })
     expect(toolUses.find((t: any) => t.id === "toolu_pb").input).toEqual({ filePath: "b.txt" })
-    // Early stop aborted the query after the denies were persisted.
-    expect(capturedController!.signal.aborted).toBe(true)
+    // Durability requires consuming the canonical result, never aborting.
+    expect(capturedController!.signal.aborted).toBe(false)
   })
 
   it("the parallel-capture session is stored — the follow-up RESUMES instead of fresh-replaying", async () => {
-    mockTurns = [parallelReadTurn(), denyUser(["toolu_pa", "toolu_pb"])]
+    mockTurns = [
+      parallelReadTurn(),
+      denyUser(["toolu_pa", "toolu_pb"]),
+      textTurn("hidden digest"),
+      canonicalResult(),
+    ]
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
     const first = await post(app, false)
     expect(first.status).toBe(200)
@@ -455,6 +483,8 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
       streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } }),
       parallelReadTurn(),
       denyUser(["toolu_pa", "toolu_pb"]),
+      textTurn("hidden digest"),
+      canonicalResult(),
     ]
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
 
@@ -472,13 +502,9 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     const startIdxs = events.filter((e: any) => e.event === "content_block_start").map((e: any) => e.data.index)
     const stopIdxs = events.filter((e: any) => e.event === "content_block_stop").map((e: any) => e.data.index)
     for (const idx of startIdxs) expect(stopIdxs).toContain(idx)
-    // The response ends at the turn boundary; the early-stop abort lands in
-    // the background drain a moment later — poll briefly.
-    const deadline = Date.now() + 1500
-    while (!capturedController!.signal.aborted && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 10))
-    }
-    expect(capturedController!.signal.aborted).toBe(true)
+    // The response ends at turn 1 while the digest drains invisibly through
+    // the canonical result. The SDK query must not be aborted.
+    expect(capturedController!.signal.aborted).toBe(false)
   })
 
   it("kill switch restores the legacy semantics: mid-hook abort + session NOT stored", async () => {

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -105,7 +105,7 @@ describe("Shared session store", () => {
     expect(byClaudeId?.messageBlockHashes).toEqual([["block-hash-a", "block-hash-b"]])
   })
 
-  it("should persist and clear the passthrough resume boundary", () => {
+  it("should persist and clear the passthrough assistant resume checkpoint", () => {
     storeSharedSession(
       "session-boundary",
       "claude-sess-boundary",
@@ -115,9 +115,11 @@ describe("Shared session store", () => {
       undefined,
       undefined,
       undefined,
-      "deny-uuid"
+      "assistant-uuid",
+      ["tool-1", "tool-2"]
     )
-    expect(lookupSharedSession("session-boundary")?.passthroughResumeUuid).toBe("deny-uuid")
+    expect(lookupSharedSession("session-boundary")?.passthroughToolCallAssistantUuid).toBe("assistant-uuid")
+    expect(lookupSharedSession("session-boundary")?.passthroughToolCallIds).toEqual(["tool-1", "tool-2"])
 
     storeSharedSession(
       "session-boundary",
@@ -128,9 +130,27 @@ describe("Shared session store", () => {
       undefined,
       undefined,
       undefined,
+      null,
       null
     )
-    expect(lookupSharedSession("session-boundary")?.passthroughResumeUuid).toBeUndefined()
+    expect(lookupSharedSession("session-boundary")?.passthroughToolCallAssistantUuid).toBeUndefined()
+    expect(lookupSharedSession("session-boundary")?.passthroughToolCallIds).toBeUndefined()
+  })
+
+  it("ignores legacy user-denial boundaries after upgrade", () => {
+    writeFileSync(join(tmpDir, "sessions.json"), JSON.stringify({
+      "legacy-boundary": {
+        claudeSessionId: "claude-legacy",
+        createdAt: 1,
+        lastUsedAt: 1,
+        messageCount: 1,
+        passthroughResumeUuid: "user-denial-uuid",
+      },
+    }))
+
+    // Force a one-time fresh replay instead of resuming the invalid tail.
+    expect(lookupSharedSession("legacy-boundary")).toBeUndefined()
+    expect(lookupSharedSessionByClaudeId("claude-legacy")).toBeUndefined()
   })
 
   it("should return the freshest match when multiple keys share a Claude session ID", () => {

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -33,6 +33,7 @@ let capturedResume: string | undefined
 let capturedResumeSessionAt: string | undefined
 let capturedForkSession: boolean | undefined
 let denyUuids: string[] = []
+let assistantToolUuids: string[] = []
 let timeline: string[] = []
 // Deny persistence delay — simulates the CLI's post-release deny latency that
 // makes the store land after the client response (the fast-client race).
@@ -54,11 +55,15 @@ const blockDelta = (idx: number, json: string) =>
   streamEvent({ type: "content_block_delta", index: idx, delta: { type: "input_json_delta", partial_json: json } })
 const blockStop = (idx: number) => streamEvent({ type: "content_block_stop", index: idx })
 const msgDelta = () => streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } })
-const assistantMsg = (blocks: any[]) => ({
-  type: "assistant",
-  message: { id: "m1", type: "message", role: "assistant", content: blocks, model: "claude-sonnet-4-5-20250929", stop_reason: "tool_use", usage: { input_tokens: 10, output_tokens: 30 } },
-  parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session",
-})
+const assistantMsg = (blocks: any[]) => {
+  const uuid = crypto.randomUUID()
+  if (blocks.some((block) => block?.type === "tool_use")) assistantToolUuids.push(uuid)
+  return {
+    type: "assistant",
+    message: { id: "m1", type: "message", role: "assistant", content: blocks, model: "claude-sonnet-4-5-20250929", stop_reason: "tool_use", usage: { input_tokens: 10, output_tokens: 30 } },
+    parent_tool_use_id: null, uuid, session_id: "test-session",
+  }
+}
 const denyMsg = (ids: string[]) => {
   const uuid = crypto.randomUUID()
   denyUuids.push(uuid)
@@ -131,10 +136,11 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       if (denyDelayMs > 0) await sleep(denyDelayMs)
       yield denyMsg(["tb1"])
       yield denyMsg(["tg1"])
-      // Early stop aborts here; nothing further should be pulled.
       timeline.push("post_denies")
       yield assistantMsg([{ type: "text", text: "turn 2 digest garbage" }])
       timeline.push("turn2_consumed")
+      yield { type: "result", subtype: "success", is_error: false, session_id: "test-session" }
+      timeline.push("canonical_result")
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
@@ -196,6 +202,7 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     capturedResumeSessionAt = undefined
     capturedForkSession = undefined
     denyUuids = []
+    assistantToolUuids = []
     clearSessionCache()
   })
 
@@ -219,13 +226,13 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     // Client contract: both tool blocks, fully terminated.
     expect(toolStarts.map((t: any) => t.id).sort()).toEqual(["tb1", "tg1"])
     expect(dangling).toEqual([])
-    // The client response ends at the turn boundary while the drain (denies →
-    // early stop → abort) finishes in the background — poll briefly for it.
+    // The client response ends at turn 1 while the digest drains invisibly to
+    // the canonical durability boundary in the background.
     const deadline = Date.now() + 1500
-    while (!capturedController!.signal.aborted && Date.now() < deadline) await sleep(10)
-    // Early stop aborted before the digest turn was consumed.
-    expect(capturedController!.signal.aborted).toBe(true)
-    expect(timeline).not.toContain("turn2_consumed")
+    while (!timeline.includes("canonical_result") && Date.now() < deadline) await sleep(10)
+    expect(capturedController!.signal.aborted).toBe(false)
+    expect(timeline).toContain("turn2_consumed")
+    expect(timeline).toContain("canonical_result")
   })
 
   it("kill switch: cancel path still cannot leave an unterminated block (flush guard)", async () => {
@@ -234,10 +241,7 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     const events = await postStream(app, "hold-2", [{ role: "user", content: "test tools" }])
     const { dangling } = envelope(events)
 
-    // Without the hold the mock cancels (legacy field behavior)...
     expect(timeline).toContain("CANCELED")
-    // ...but every started block is still closed before the stream ends —
-    // the render can no longer be `glob {}` "Tool execution aborted".
     expect(dangling).toEqual([])
   })
 
@@ -259,9 +263,10 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
         { type: "tool_result", tool_use_id: "tg1", content: "ok" },
       ]},
     ])
-    const resumeBoundary = denyUuids[1]
+    const resumeBoundary = assistantToolUuids[1]
     expect(capturedResume ?? "(fresh)").toBe("test-session")
     expect(capturedResumeSessionAt).toBe(resumeBoundary)
-    expect(capturedForkSession).toBe(true)
+    expect(denyUuids).not.toContain(capturedResumeSessionAt)
+    expect(capturedForkSession).toBeUndefined()
   })
 })

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -189,6 +189,16 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).resumeSessionAt).toBe("uuid-abc")
   })
 
+  it("resumes passthrough at an assistant boundary without creating a new session", () => {
+    const result = buildQueryOptions(makeContext({
+      resumeSessionId: "sdk-123",
+      resumeSessionAtUuid: "assistant-uuid",
+    }))
+    expect((result.options as any).resume).toBe("sdk-123")
+    expect((result.options as any).resumeSessionAt).toBe("assistant-uuid")
+    expect((result.options as any).forkSession).toBeUndefined()
+  })
+
   it("includes agents when provided", () => {
     const agents = { explore: { model: "sonnet" } }
     const result = buildQueryOptions(makeContext({ sdkAgents: agents }))

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -180,42 +180,6 @@ export function frameReplayTurns(turns: Array<{ role: string; text: string }>): 
 }
 
 /**
- * Lead-in for a passthrough continuation that forks from a deny boundary.
- *
- * Every forwarded tool call is denied with "do not generate further text —
- * end your turn now" (the nudge that stops the model fabricating results for
- * calls the client will execute). That deny is persisted as the tool_result,
- * and the deny boundary fork puts it IMMEDIATELY before the continuation's
- * user turn. So the last instruction in the model's context tells it to emit
- * no text — and the next thing it must do is answer. Observed live: the model
- * obeys the nearer instruction and returns thinking plus an EMPTY text block
- * with stop_reason "end_turn"; the CLI's own "previous response had no visible
- * output" nudge does not help, because the deny is still there. The proxy
- * forwards zero text deltas, reports 200, and the client's run goes quiet with
- * the tool results unanswered (three occurrences in 500 requests, all on a
- * session's second turn — where the deny is the largest thing in context).
- *
- * The deny cannot be rewritten after the fact: it lives in the CLI's session
- * file. So the continuation says plainly that the instruction is spent. Framing
- * only — no transcript markers, nothing for the model to imitate (#496/#619).
- */
-export const PASSTHROUGH_CONTINUATION_LEAD_IN =
-  "The tool calls from your previous turn were forwarded to the client, which has now executed them — " +
-  "their results follow. The instruction to end that turn without further text applied to it alone and " +
-  "is now discharged: continue the work and respond."
-
-/**
- * Prefix a passthrough continuation delta with the lead-in above.
- *
- * An empty delta is returned unchanged — there is nothing to answer, so the
- * lead-in would be the only content and would read as the user's own turn.
- */
-export function framePassthroughContinuation(delta: string): string {
-  if (!delta) return delta
-  return `${PASSTHROUGH_CONTINUATION_LEAD_IN}\n\n${delta}`
-}
-
-/**
  * Remove fields the Claude Agent SDK attaches to streamed events that are not
  * part of the public Anthropic streaming schema.
  *

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -8,14 +8,14 @@
  * thinking pass per tool step, roughly doubling per-step output spend and
  * adding a full model round-trip of latency.
  *
- * The fix: the SDK emits each denied call's tool_result as a `user` message in
- * the stream (verified against the real SDK) BEFORE it fires the digest turn's
- * API request. So the proxy can watch the stream, and the moment every
- * client-forwarded tool_use from the assistant turn has its deny persisted,
- * abort the query — the digest turn never generates. Because the denies are
- * already recorded in the SDK session history at that point, the session stays
- * coherent and can be stored + resumed (unlike the #580 duplicate-abort case,
- * which fires mid-hook before persistence).
+ * The SDK emits each denied call's tool_result as a `user` message before it
+ * fires the hidden digest turn. Those messages identify a stable assistant
+ * checkpoint, but they are NOT a durability acknowledgement: a live PTY E2E
+ * observed the assistant and deny in the iterator while neither existed in the
+ * session JSONL after an immediate abort. The proxy therefore freezes the
+ * assistant UUID/tool IDs at deny settlement, drains the hidden digest without
+ * forwarding it, and stores the checkpoint only after the SDK's canonical
+ * terminal result commits the transcript.
  *
  * Pure module — no I/O, no imports from server.ts or session/.
  */
@@ -29,10 +29,13 @@ const CLIENT_TOOL_PREFIX = "mcp__oc__"
 const INTERNAL_TOOLS = new Set(["ToolSearch"])
 
 export interface EarlyStopTracker {
-  /** tool_use ids of client-forwarded calls awaiting a persisted deny result */
+  /** tool_use ids of client-forwarded calls awaiting an iterator-observed deny */
   expected: Set<string>
   /** subset of `expected` whose tool_result has been observed in the stream */
   resolved: Set<string>
+  /** Last assistant message containing a forwarded tool_use.
+   *  The SDK's resumeSessionAt option only accepts assistant UUIDs. */
+  toolCallAssistantUuid?: string
   /** true once shouldEarlyStop has returned true — it fires at most once */
   fired: boolean
 }
@@ -72,7 +75,31 @@ export function noteAssistantContent(tracker: EarlyStopTracker, content: unknown
 }
 
 /**
- * Record persisted tool_results from a user message's content.
+ * Record one SDK assistant message and remember the only boundary type the
+ * Agent SDK supports for resumeSessionAt: an SDKAssistantMessage UUID.
+ *
+ * The SDK may surface parallel tool calls as multiple assistant messages. The
+ * final such message is an ancestor containing the complete tool-use turn, so
+ * updating the boundary for every forwarded call leaves the correct stable
+ * checkpoint.
+ */
+export function noteAssistantMessage(tracker: EarlyStopTracker, message: unknown): void {
+  const m = message as { type?: unknown; uuid?: unknown; message?: { content?: unknown } } | null | undefined
+  if (m?.type !== "assistant") return
+  const content = m.message?.content
+  const before = tracker.expected.size
+  noteAssistantContent(tracker, content)
+  if (tracker.expected.size > before) {
+    // A newer tool-bearing assistant message supersedes the older checkpoint.
+    // Fail closed when its UUID is absent: the older message may not contain
+    // every parallel call, so it is not a safe resumeSessionAt target.
+    tracker.toolCallAssistantUuid =
+      typeof m.uuid === "string" && m.uuid.length > 0 ? m.uuid : undefined
+  }
+}
+
+/**
+ * Record iterator-observed tool_results from a user message's content.
  *
  * Records EVERY tool_result id, not just already-expected ones: the CLI
  * dispatches hooks per-block while later blocks are still streaming, and it
@@ -93,22 +120,82 @@ export function noteUserContent(tracker: EarlyStopTracker, content: unknown): vo
 
 /**
  * True exactly once: when at least one client tool call was forwarded and
- * every forwarded call's deny has been observed in the stream. At that point
- * the digest turn hasn't generated yet — the caller should abort the query.
+ * every forwarded call's deny has been observed in the stream. The caller may
+ * freeze the checkpoint then, but must drain to a canonical SDK result before
+ * treating the UUID as durably resumable.
  */
-export function shouldEarlyStop(tracker: EarlyStopTracker): boolean {
-  if (tracker.fired) return false
+export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
   if (tracker.expected.size === 0) return false
   for (const id of tracker.expected) {
     if (!tracker.resolved.has(id)) return false
   }
+  return true
+}
+
+/**
+ * Verify that a resumed tool-result delta settles exactly the tool calls at the
+ * stored assistant checkpoint. Tool results must precede any ordinary user
+ * content, matching the Anthropic Messages protocol.
+ */
+export function isCompleteToolResultContinuation(
+  messages: Array<{ role?: unknown; content?: unknown }>,
+  expectedIds: readonly string[]
+): boolean {
+  if (expectedIds.length === 0 || messages.length === 0) return false
+  const expected = new Set(expectedIds)
+  const actual = new Set<string>()
+  const echoedCalls = new Set<string>()
+  let sawUser = false
+  let sawNonToolResult = false
+
+  for (const message of messages) {
+    // The client echoes the just-produced assistant tool_use before its user
+    // result. That assistant turn already exists at resumeSessionAt, so the
+    // structured SDK delta below intentionally filters it out.
+    if (message.role === "assistant" && !sawUser) {
+      if (Array.isArray(message.content)) {
+        for (const rawBlock of message.content) {
+          const block = rawBlock as { type?: unknown; id?: unknown } | null | undefined
+          if (block?.type !== "tool_use") continue
+          if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return false
+          echoedCalls.add(block.id)
+        }
+      }
+      continue
+    }
+    if (message.role !== "user" || !Array.isArray(message.content) || sawUser) return false
+    sawUser = true
+    for (const rawBlock of message.content) {
+      const block = rawBlock as { type?: unknown; tool_use_id?: unknown } | null | undefined
+      if (block?.type === "tool_result") {
+        if (sawNonToolResult || typeof block.tool_use_id !== "string") return false
+        if (!expected.has(block.tool_use_id) || actual.has(block.tool_use_id)) return false
+        actual.add(block.tool_use_id)
+      } else {
+        sawNonToolResult = true
+      }
+    }
+  }
+
+  return actual.size === expected.size &&
+    (echoedCalls.size === 0 || echoedCalls.size === expected.size)
+}
+
+/** The cache-stable assistant boundary after every forwarded call settled. */
+export function settledToolCallAssistantUuid(tracker: EarlyStopTracker): string | undefined {
+  return allForwardedCallsResolved(tracker) ? tracker.toolCallAssistantUuid : undefined
+}
+
+export function shouldEarlyStop(tracker: EarlyStopTracker): boolean {
+  // Without an assistant UUID there is no valid resumeSessionAt checkpoint.
+  // The caller still drains canonically, then evicts the unusable mapping.
+  if (tracker.fired || !settledToolCallAssistantUuid(tracker)) return false
   tracker.fired = true
   return true
 }
 
 /** What a client-aborted stream must do with its session mapping. */
 export type ClientAbortDisposition =
-  | { action: "store"; resumeUuid: string }
   | { action: "evict" }
   | { action: "none" }
 
@@ -116,63 +203,24 @@ export type ClientAbortDisposition =
  * Decide the fate of a session whose stream the CLIENT aborted (the user hit
  * stop, or the connection dropped).
  *
- * A client abort leaves the SDK session ending in an interrupted tail — the
- * same state the deny-boundary fix addresses for early stop. Resuming from
- * that tail makes the SDK synthesize a "Continue from where you left off."
- * turn, which the model answers with meta text ("No response requested.") or
- * an empty turn. Each empty turn then becomes the next tail, so the session
- * never recovers on its own: every following turn comes back empty until the
- * lineage is discarded.
- *
- * An early stop is meridian's own doing and always has a persisted deny to
- * fork from; a user interrupt is not an early stop and may have none. So:
- *
- * - a boundary was persisted → store it, and the next continuation forks
- *   there (lineage and prompt cache survive);
- * - no boundary → nothing is safe to resume from, so drop the mapping and let
- *   the next request replay into a fresh SDK session. A cache-miss replay is
- *   the cost of not wedging the conversation.
- *
- * `sawDuplicateToolUse` keeps the #552 rule: such a history holds a dangling
- * dropped call that diverges from the client's view and is never resumable.
+ * A client abort leaves the SDK session ending in an interrupted tail. Even an
+ * assistant UUID already seen in the iterator is not known durable until the
+ * canonical result: the live PTY regression yielded that UUID but never wrote
+ * it to JSONL after abort. Therefore every owned mapping is evicted; a replay
+ * costs one cache miss but cannot wedge on a missing or interrupted boundary.
  */
 export function clientAbortDisposition(input: {
   isIndependentSession: boolean
   profileSessionId?: string
   currentSessionId?: string
   sawDuplicateToolUse: boolean
-  resumeBoundaryUuid?: string
-  /** Only passthrough turns have deny boundaries. */
+  toolCallAssistantUuid?: string
+  /** Only passthrough turns create synthetic denial side branches. */
   passthrough: boolean
 }): ClientAbortDisposition {
   // Fork/subagent requests never write the cache, so they have nothing to undo.
   if (input.isIndependentSession || !input.profileSessionId) return { action: "none" }
-  // A "deny boundary" is a passthrough concept. In internal mode the SDK runs
-  // the tools itself, so a user message carrying tool_results is an ordinary
-  // turn — storing its uuid would mark a normal continuation point as a spent
-  // deny in the cross-process store, and the next continuation would fork from
-  // it. The interrupted tail is still unsafe to resume, so evict and replay.
-  if (!input.passthrough) return { action: "evict" }
-  if (input.currentSessionId && !input.sawDuplicateToolUse && input.resumeBoundaryUuid) {
-    return { action: "store", resumeUuid: input.resumeBoundaryUuid }
-  }
+  // Iterator-observed UUIDs are not durable across an interrupted query, in
+  // passthrough or internal mode. Evict and replay every owned mapping.
   return { action: "evict" }
-}
-
-/**
- * Resume boundary of an early-stopped session: the uuid of a persisted `user`
- * message carrying tool_results. The last one before the abort is the final
- * deny — continuations fork there instead of resuming the interrupted tail.
- */
-export function resumeBoundaryUuid(message: unknown): string | undefined {
-  const m = message as { type?: unknown; uuid?: unknown; message?: { content?: unknown } } | null | undefined
-  if (m?.type !== "user") return undefined
-  if (typeof m.uuid !== "string" || m.uuid.length === 0) return undefined
-  const content = m.message?.content
-  if (!Array.isArray(content)) return undefined
-  const hasResult = content.some((block) => {
-    const b = block as { type?: unknown } | null | undefined
-    return b?.type === "tool_result"
-  })
-  return hasResult ? m.uuid : undefined
 }

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -91,8 +91,9 @@ export interface QueryContext {
   resumeSessionId?: string
   /** Whether this is an undo operation */
   isUndo: boolean
-  /** Fork the resumed session at this SDK message UUID (undo rollback point
-   *  or passthrough deny boundary). Maps to the SDK's resumeSessionAt. */
+  /** Resume at this SDK assistant-message UUID (undo rollback point or
+   *  passthrough tool-use boundary). Maps to resumeSessionAt, which accepts
+   *  SDKAssistantMessage UUIDs only; forkSession separately chooses a new ID. */
   resumeSessionAtUuid?: string
   /** Fork the resumed session instead of attaching to it (#630 busy-session
    *  fallback — the original stays registered as a bg agent; the fork gets a

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, createEarlyStopTracker, noteAssistantContent, noteUserContent, resumeBoundaryUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { clientAbortDisposition, createEarlyStopTracker, isCompleteToolResultContinuation, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -70,7 +70,7 @@ import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
 import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
-import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns, framePassthroughContinuation, PASSTHROUGH_CONTINUATION_LEAD_IN } from "./messages"
+import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
 import { buildQueryOptions, type QueryContext } from "./query"
@@ -93,6 +93,7 @@ import {
   hashMessage,
   computeMessageHashes,
   normalizeContextUsage,
+  withClientAssistantUuid,
   type LineageResult,
   type TokenUsageIteration,
   type TokenUsage,
@@ -248,19 +249,27 @@ function stripCacheControlDeep(content: any): any {
   })
 }
 
-function normalizeStructuredUserContent(content: any): any {
+function normalizeStructuredUserContent(
+  content: any,
+  preserveToolResultWrapper = false
+): any {
   if (!Array.isArray(content)) return content
   const normalized: any[] = []
   for (const block of content) {
     if (!block || typeof block !== "object") continue
-    if (block.type === "tool_result" && Array.isArray(block.content) && hasMultimodalContent(block.content)) {
+    if (
+      !preserveToolResultWrapper &&
+      block.type === "tool_result" &&
+      Array.isArray(block.content) &&
+      hasMultimodalContent(block.content)
+    ) {
       normalized.push(...normalizeStructuredUserContent(block.content))
       continue
     }
     if (block.type === "tool_result" && Array.isArray(block.content)) {
       normalized.push({
         ...block,
-        content: normalizeStructuredUserContent(block.content),
+        content: normalizeStructuredUserContent(block.content, preserveToolResultWrapper),
       })
       continue
     }
@@ -1389,10 +1398,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           }, adapterBase)
         }
 
-        const isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
+        let isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
-        const resumeSessionId = cachedSession?.claudeSessionId
+        let resumeSessionId = cachedSession?.claudeSessionId
         // --- Passthrough mode ---
         // When enabled, ALL tool execution is forwarded to OpenCode instead of
         // being handled internally. This enables multi-model agent delegation
@@ -1414,8 +1423,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
-        // Early-stopped sessions resume from the persisted deny boundary, not the interrupted tail.
-        const passthroughResumeUuid = passthrough && isResume ? cachedSession?.passthroughResumeUuid : undefined
+        // Early-stopped sessions resume at the assistant tool-use turn, before synthetic denials.
+        let passthroughToolCallAssistantUuid = passthrough && isResume ? cachedSession?.passthroughToolCallAssistantUuid : undefined
+        const passthroughToolCallIds = passthrough && isResume ? cachedSession?.passthroughToolCallIds : undefined
 
         // Debug: log request details
         const msgSummary = body.messages?.map((m: any) => {
@@ -1513,16 +1523,39 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         messagesToConvert = allMessages
       }
 
-      // Check if any messages contain multimodal content (images, documents, files)
-      const hasMultimodal = messagesToConvert?.some((m: any) => hasMultimodalContent(m.content))
+      // Rewinding to a tool-use checkpoint is valid only when the immediate
+      // delta settles that exact batch. Partial, late, duplicate, or unknown
+      // results get one safe fresh replay rather than an invalid SDK resume.
+      if (
+        passthroughToolCallAssistantUuid &&
+        !isCompleteToolResultContinuation(messagesToConvert, passthroughToolCallIds ?? [])
+      ) {
+        claudeLog("passthrough.checkpoint_replay", {
+          expectedToolIds: passthroughToolCallIds?.length ?? 0,
+          reason: "incomplete_or_mismatched_results",
+        })
+        isResume = false
+        resumeSessionId = undefined
+        passthroughToolCallAssistantUuid = undefined
+        messagesToConvert = allMessages
+      }
 
-      // Build the prompt — either structured (multimodal) or text.
+      // Multimodal blocks and passthrough tool results must remain structured.
+      // In particular, a continuation resumed at an assistant tool_use expects
+      // the client's real tool_result blocks, not a flattened transcript string.
+      const hasMultimodal = messagesToConvert?.some((m: any) => hasMultimodalContent(m.content))
+      const hasPassthroughToolResults = Boolean(passthroughToolCallAssistantUuid) &&
+        messagesToConvert?.some((m: any) =>
+          m.role === "user" && Array.isArray(m.content) &&
+          m.content.some((block: any) => block?.type === "tool_result"))
+
+      // Build the prompt — either structured or text.
       // Structured prompts are stored as arrays so they can be replayed on retry.
       let structuredMessages: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> | undefined
       let textPrompt: string | undefined
 
-      if (hasMultimodal) {
-        // Structured messages preserve image/document/file blocks for Claude to see.
+      if (hasMultimodal || hasPassthroughToolResults) {
+        // Structured messages preserve image/document/file and tool_result blocks.
         // On resume, only send user messages (SDK has assistant context already).
         // On first request, include everything.
         structuredMessages = []
@@ -1533,7 +1566,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (m.role === "user") {
               structuredMessages.push({
                 type: "user" as const,
-                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControlDeep(m.content)) },
+                message: { role: "user" as const, content: normalizeStructuredUserContent(
+                  stripCacheControlDeep(m.content),
+                  Boolean(passthroughToolCallAssistantUuid)
+                ) },
                 parent_tool_use_id: null,
               })
             }
@@ -1544,7 +1580,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (m.role === "user") {
               structuredMessages.push({
                 type: "user" as const,
-                message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControlDeep(m.content)) },
+                message: { role: "user" as const, content: normalizeStructuredUserContent(
+                  stripCacheControlDeep(m.content),
+                  Boolean(passthroughToolCallAssistantUuid)
+                ) },
                 parent_tool_use_id: null,
               })
             } else {
@@ -1570,16 +1609,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           structuredMessages = consolidateMultimodalOntoLastUser(structuredMessages)
         }
 
-        // Same spent-deny problem as the text path — see
-        // framePassthroughContinuation. Carried as its own leading user turn so
-        // the multimodal blocks of the real delta are left untouched.
-        if (passthroughResumeUuid && structuredMessages.length > 0) {
-          structuredMessages.unshift({
-            type: "user" as const,
-            message: { role: "user" as const, content: PASSTHROUGH_CONTINUATION_LEAD_IN },
-            parent_tool_use_id: null,
-          })
-        }
       } else {
         // Text prompt — convert messages to string.
         // Sanitize each text block before flattening to strip orchestration
@@ -1609,14 +1638,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           })
         // Fresh (non-resume) replays get the #619 anti-self-play envelope:
         // history framed as context-only, the live user message terminal.
-        // Resume deltas are tail-only and stay bare — except when the resume
-        // forks from a deny boundary, where the spent "end your turn now" deny
-        // is the nearest instruction in context and silences the answer (see
-        // framePassthroughContinuation).
+        // Resume deltas are tail-only and stay bare.
         const resumeDelta = promptTurns.map((t: { text: string }) => t.text).filter(Boolean).join("\n\n") || ""
-        textPrompt = isResume
-          ? (passthroughResumeUuid ? framePassthroughContinuation(resumeDelta) : resumeDelta)
-          : frameReplayTurns(promptTurns)
+        textPrompt = isResume ? resumeDelta : frameReplayTurns(promptTurns)
       }
 
       // Create a fresh prompt value — can be called multiple times for retry
@@ -1655,13 +1679,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // model/client views diverged (#552 misattribution family).
       const droppedToolUseIds = new Set<string>()
       let sawDuplicateToolUse = false
-      // Early stop: the moment every forwarded tool call's deny is persisted
-      // (observed as a `user` tool_result in the stream), abort the query so
-      // the SDK's digest turn — a fully-billed, discarded model invocation
-      // (a whole thinking pass per tool step on always-thinking models) —
-      // never generates. Unlike the duplicate-abort above, the session history
-      // is coherent at that point (deny recorded), so the session is stored
-      // and resumed normally. Kill switch: MERIDIAN_PASSTHROUGH_EARLY_STOP=0.
+      // Stable checkpoint tracking: observe the forwarded assistant tool turn
+      // and every synthetic denial, but do NOT abort at that point. A live PTY
+      // E2E proved those iterator messages can precede the CLI's durable JSONL
+      // write; aborting there left only the initial user message on disk, so
+      // resumeSessionAt failed with `missing-message`. We therefore drain the
+      // hidden digest to a canonical SDK terminal result, suppress its content,
+      // and store the earlier assistant UUID only after the drain completes.
       const earlyStopEnabled = passthrough && process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP !== "0"
       const earlyStop = createEarlyStopTracker()
       let earlyStopFired = false
@@ -1846,7 +1870,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 //      lines the model then disowned. With early stop, the
                 //      fabricated-loop turns this rule guarded against never
                 //      generate (the query stops the moment every deny is
-                //      persisted), so same-tool-new-args calls are genuine
+                //      checkpointed), so same-tool-new-args calls are genuine
                 //      parallelism and are captured. The drop remains only
                 //      when the operator disables early stop.
                 //   3. Forced single tool (tool_choice:{type:"tool"} / structured
@@ -1856,11 +1880,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // instead of draining the whole turn budget.
                 const signature = toolUseSignature(toolName, toolInput)
                 const isExactDuplicate = capturedSignatures.has(signature)
+                // Once the real tool turn's checkpoint is complete, any later
+                // call belongs to the hidden digest turn. Never add it to the
+                // client-visible set, even when it uses a different tool/args.
+                const isPostCheckpointCall = earlyStopFired
                 const isSameToolRepeat = !earlyStopEnabled && !isExactDuplicate && capturedToolNames.has(toolName)
                 const exceedsForcedSingle = forceSingleToolUse && capturedToolUses.length >= 1
-                if (isExactDuplicate) {
+                if (isExactDuplicate || isPostCheckpointCall) {
                   droppedToolUseIds.add(input.tool_use_id)
-                  claudeLog("passthrough.duplicate_tool_use_dropped", { name: toolName })
+                  claudeLog("passthrough.duplicate_tool_use_dropped", {
+                    name: toolName,
+                    reason: isPostCheckpointCall ? "hidden_digest" : "exact_duplicate",
+                  })
                 } else if (isSameToolRepeat || exceedsForcedSingle) {
                   droppedToolUseIds.add(input.tool_use_id)
                   sawDuplicateToolUse = true
@@ -1916,11 +1947,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (earlyStopEnabled && turnGenerating && !requestAbort.controller.signal.aborted) {
                   await holdDenyUntilTurnEnd()
                 }
-                if (isExactDuplicate) {
+                if (isExactDuplicate || isPostCheckpointCall) {
                   return {
                     decision: "block" as const,
                     reason:
-                      "This exact tool call has already been forwarded to the client — do not repeat it. " +
+                      "This tool call has already been handled by the client-facing turn — do not repeat it. " +
                       "Do not call additional tools and do not generate further text — end your turn now.",
                   }
                 }
@@ -1975,7 +2006,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // RangeError when allMessages.length was 0. Cold-start requests
           // are now also rejected at the entrypoint (#450) but the defensive
           // initializer keeps any future reentry safe.
-          const sdkUuidMap: Array<string | null> = cachedSession?.sdkMessageUuids
+          let sdkUuidMap: Array<string | null> = (isResume || isUndo) && cachedSession?.sdkMessageUuids
             ? [...cachedSession.sdkMessageUuids]
             : []
           // Pad to current message count (the last user message has no UUID yet)
@@ -1984,7 +2015,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
           let lastStopReason: string | undefined
-          let nextPassthroughResumeUuid: string | undefined
+          let nextPassthroughToolCallAssistantUuid: string | undefined
+          let nextPassthroughToolCallIds: string[] | undefined
+          let sawCanonicalResult = false
 
           try {
             // Lazy-resolve executable if not already set (e.g. when using createProxyServer directly)
@@ -2035,7 +2068,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                    resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughResumeUuid, forkSession: busySessionFork || Boolean(passthroughResumeUuid) || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2257,22 +2290,45 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 claudeLog("passthrough.loop_break", { mode: "non_stream", assistantMessages, captured: capturedToolUses.length })
                 break
               }
-              // Early stop: abort before the digest turn generates (see the
-              // earlyStop declaration above). The deny tool_results arrive as
-              // `user` messages; when every forwarded call's deny is persisted,
-              // the SDK-side history is coherent and turn 2 hasn't fired yet.
-              if (earlyStopEnabled) {
-                if (message.type === "assistant") {
-                  noteAssistantContent(earlyStop, (message as any).message?.content)
-                } else if (message.type === "user") {
-                  nextPassthroughResumeUuid = resumeBoundaryUuid(message) ?? nextPassthroughResumeUuid
-                  noteUserContent(earlyStop, (message as any).message?.content)
-                  if (shouldEarlyStop(earlyStop)) {
-                    earlyStopFired = true
-                    claudeLog("passthrough.early_stop", { mode: "non_stream", captured: capturedToolUses.length })
-                    requestAbort.abort("passthrough turn complete")
-                    break
+              // Checkpoint settlement: the deny tool_results identify when all
+              // visible calls have been handled. Freeze that assistant boundary,
+              // then keep draining; iterator observation alone is not durable.
+              let assistantAddedForwardedCall = false
+              if (
+                passthrough &&
+                message.type === "assistant" &&
+                !earlyStopFired &&
+                earlyStop.resolved.size === 0
+              ) {
+                // Non-stream can expose a parallel tool turn as several
+                // assistant fragments. They all precede the first synthetic deny;
+                // later assistants are the hidden digest. Stop extending the
+                // checkpoint once any deny is consumed, and do not use the hook
+                // set as an oracle because a producer-side digest hook can race
+                // ahead of iterator consumption.
+                const expectedBefore = earlyStop.expected.size
+                noteAssistantMessage(earlyStop, message)
+                assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
+              } else if (passthrough && message.type === "user" && !earlyStopFired) {
+                noteUserContent(earlyStop, (message as any).message?.content)
+                if (earlyStopEnabled && shouldEarlyStop(earlyStop)) {
+                  nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
+                  nextPassthroughToolCallIds = [...earlyStop.expected]
+                  earlyStopFired = true
+                  // A digest hook can race just ahead of iterator consumption.
+                  // Retain only calls proven to belong to the visible assistant
+                  // checkpoint; later hooks see earlyStopFired and are dropped.
+                  for (let i = capturedToolUses.length - 1; i >= 0; i--) {
+                    if (!earlyStop.expected.has(capturedToolUses[i]!.id)) capturedToolUses.splice(i, 1)
                   }
+                  // The iterator boundary is not a durability acknowledgement.
+                  // Keep consuming through the hidden digest and canonical SDK
+                  // result before storing this assistant checkpoint.
+                  claudeLog("passthrough.checkpoint_ready", {
+                    mode: "non_stream",
+                    captured: capturedToolUses.length,
+                    toolCallAssistantUuid: nextPassthroughToolCallAssistantUuid,
+                  })
                 }
               }
               if (message.type === "assistant") {
@@ -2280,9 +2336,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // return without the CLI cancelling anything in flight.
                 releaseHeldDenies("assistant_message")
                 assistantMessages += 1
-                // Capture SDK assistant UUID for undo rollback
-                if ((message as any).uuid) {
-                  sdkUuidMap.push((message as any).uuid)
+                // One Anthropic assistant response may combine several SDK
+                // assistant fragments (for example parallel tool calls).
+                if (!passthrough || earlyStop.expected.size === 0 || assistantAddedForwardedCall) {
+                  sdkUuidMap = withClientAssistantUuid(
+                    sdkUuidMap,
+                    allMessages.length,
+                    (message as any).uuid
+                  )
                 }
                 if (!firstChunkAt) {
                   firstChunkAt = Date.now()
@@ -2356,7 +2417,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // Capture token usage from the assistant message
                 const msgUsage = message.message.usage as TokenUsage | undefined
                 if (msgUsage) lastUsage = { ...lastUsage, ...msgUsage }
-                if (typeof message.message.stop_reason === "string") {
+                if (!isPassthroughTurn2 && typeof message.message.stop_reason === "string") {
+                  // Hidden digest turns are consumed only for durability; they
+                  // must not replace the client-visible tool_use stop reason.
                   lastStopReason = message.message.stop_reason
                 }
               }
@@ -2368,6 +2431,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // wrong output_tokens (typically 1) for any non-trivial response.
               // Prefer the result usage when present. See issue #449.
               if (message.type === "result") {
+                sawCanonicalResult = true
                 const resultUsage = (message as { usage?: unknown }).usage as TokenUsage | undefined
                 if (resultUsage) {
                   lastUsage = { ...lastUsage, ...resultUsage }
@@ -2402,6 +2466,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           } catch (error) {
             // #592: mirror the loop-exit release on the failure path.
             releaseHeldDenies("non_stream_error")
+            if (passthrough && capturedToolUses.length > 0 && !sawCanonicalResult) {
+              // A failed durability drain must not leave either a newly cached
+              // checkpoint or an older mapping behind for the advanced client.
+              evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+              claudeLog("passthrough.noncanonical_session_evicted", { mode: "non_stream", reason: "drain_error" })
+            }
             const stderrOutput = stderrLines.join("\n").trim()
             if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
               error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
@@ -2613,25 +2683,31 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // block above for rationale (avoids polluting the parent's key).
           // Duplicate-aborted sessions (sawDuplicateToolUse) are never offered
           // for resume: that SIGTERM lands before the dropped call's deny is
-          // persisted, so the SDK-side history holds a dangling tool_use
-          // ("Stream closed") that diverges from the client's view — resuming
-          // it hands the model memory of a call whose result never arrives
-          // (#552). A fresh session rebuilt from client history is coherent by
-          // construction. Early-stop aborts (earlyStopFired) are different:
-          // they fire only AFTER every forwarded call's deny was observed in
-          // the stream (already persisted), so the history is coherent and the
-          // session is safe to store and resume.
+          // durably persisted, so the SDK-side history can diverge from the
+          // client's view (#552). Checkpoint-ready sessions, by contrast, reach
+          // this store only after the iterator drains to its canonical terminal
+          // result, which gives the CLI time to persist the assistant boundary.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
-                storeSession(
-                  profileSessionId,
-                  body.messages || [],
-                  currentSessionId,
-                  profileScopedCwd,
-                  sdkUuidMap,
-                  lastUsage,
-                  earlyStopFired ? nextPassthroughResumeUuid : null
-                )
-                commitSessionTurn()
+                const checkpointTurn = passthrough && contentBlocks.some((b) => b.type === "tool_use")
+                if (checkpointTurn && (!earlyStopFired || !sawCanonicalResult)) {
+                  // Iterator visibility is not durability. Never publish a
+                  // resumeSessionAt UUID unless the CLI reached its terminal
+                  // result and had a chance to commit the transcript.
+                  evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                  claudeLog("passthrough.noncanonical_session_evicted", { mode: "non_stream" })
+                } else {
+                  storeSession(
+                    profileSessionId,
+                    body.messages || [],
+                    currentSessionId,
+                    profileScopedCwd,
+                    sdkUuidMap,
+                    lastUsage,
+                    earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
+                    earlyStopFired ? nextPassthroughToolCallIds : null
+                  )
+                  commitSessionTurn()
+                }
               }
 
               const responseSessionId = currentSessionId || resumeSessionId || `session_${Date.now()}`
@@ -2678,13 +2754,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             let textCharsForwarded = 0
             let bytesSent = 0
             let streamClosed = false
-            // Early-stop drain: after the client stream closes at turn-1's
+            // Canonical drain: after the client stream closes at turn 1's
             // stop_reason:"tool_use", keep consuming SDK messages (nothing is
-            // forwarded — safeEnqueue no-ops once streamClosed) until every
-            // forwarded call's deny is persisted, then abort the query so the
-            // digest turn never generates. Without this the subprocess keeps
-            // running in the background and turn 2 is fully billed, invisibly.
+            // forwarded once streamClosed) through the hidden digest and final
+            // result. SDK iterator visibility is not a persistence barrier;
+            // only the canonical result made the assistant UUID durable in a
+            // live PTY E2E.
             let awaitingEarlyStopDrain = false
+            let exitedBeforeCanonicalTerminal = false
 
             claudeLog("upstream.start", { mode: "stream", model })
 
@@ -2713,7 +2790,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // Defensive: start empty so allMessages.length === 0 doesn't crash the
             // ReadableStream's start() with `RangeError: Invalid array length`.
             // Cold-start requests with no messages are also rejected upstream now (#450).
-            const sdkUuidMap: Array<string | null> = cachedSession?.sdkMessageUuids
+            let sdkUuidMap: Array<string | null> = (isResume || isUndo) && cachedSession?.sdkMessageUuids
               ? [...cachedSession.sdkMessageUuids]
               : []
             while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
@@ -2722,7 +2799,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             let lastUsage: TokenUsage | undefined
             let hasStructuredOutput = false
             let structuredOutput: unknown
-            let nextPassthroughResumeUuid: string | undefined
+            let nextPassthroughToolCallAssistantUuid: string | undefined
+            let nextPassthroughToolCallIds: string[] | undefined
+            let sawCanonicalResult = false
             // Silent-turn recovery state (see turnOutcome.ts). Kill switch:
             // MERIDIAN_SILENT_TURN_RECOVERY=0 leaves the detection and the
             // telemetry in place and skips only the extra model turn — so an
@@ -2776,48 +2855,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // extends the guarantee to ALL close paths (early stop, turn-2
             // suppression, drain-close). With the deny-hold in place blocks
             // normally complete before any close — this is the backstop.
-            // #742: the early stop fires on deny-settlement alone. When the SDK
-            // surfaces a wide parallel set as separate assistant turns, every
-            // deny the tracker KNOWS about can settle while a LATER tool_use
-            // block is still mid-input_json_delta. Closing then produced a
-            // well-formed envelope around TRUNCATED input JSON — the client
-            // rejects the call and the turn wedges. The envelope audit only
-            // measures framing, which is why this read as healthy (#675 triaged
-            // the same race as "client impact: none" on exactly that basis).
-            //
-            // So the stop is deferred while any forwarded block is open, and
-            // fired from the content_block_stop handler once the set empties.
-            let pendingEarlyStop = false
-            let pendingEarlyStopAt = 0
-
-            /** Emit the early-stop close. `reason` is recorded so the deferred
-             *  path is distinguishable from the immediate one in telemetry. */
-            const fireEarlyStop = (reason: "immediate" | "blocks_closed" | "deadline"): void => {
-              earlyStopFired = true
-              claudeLog("passthrough.early_stop", {
-                mode: "stream",
-                captured: capturedToolUses.length,
-                drained: awaitingEarlyStopDrain,
-                reason,
-                deferredMs: pendingEarlyStopAt ? Date.now() - pendingEarlyStopAt : 0,
-              })
-              pendingEarlyStop = false
-              // Still called: on the "deadline" path a block may genuinely be
-              // stuck open, and an unterminated block renders as an aborted
-              // ("red") tool call (#552). The backstop stays — it just no
-              // longer fires on the common ordering.
-              flushOpenClientBlocks("early_stop")
-              sendTerminalDelta("tool_use")
-              safeEnqueue(encoder.encode(
-                `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
-              ), "early_stop")
-              requestAbort.abort("passthrough turn complete")
-              awaitingEarlyStopDrain = false
-              if (!streamClosed) {
-                streamClosed = true
-                try { controller.close() } catch {}
-              }
-            }
+            // #742: never close a client turn merely because deny messages
+            // settled while a later parallel block is still streaming. The
+            // client closes only on the canonical turn-1 tool_use delta below,
+            // after its blocks are complete; the SDK then drains invisibly.
 
             const flushOpenClientBlocks = (source: string): void => {
               if (openClientBlocks.size === 0) return
@@ -2872,7 +2913,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     for await (const event of runSdkQueryAttempt(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
-                      resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughResumeUuid, forkSession: busySessionFork || Boolean(passthroughResumeUuid) || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -3099,57 +3140,65 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               try {
                 for await (const message of guardedResponse) {
                   if (streamClosed && !awaitingEarlyStopDrain) {
+                    exitedBeforeCanonicalTerminal = true
                     break
                   }
 
-                  // Capture session ID and assistant UUID from any SDK message
+                  // Capture session ID and only client-visible assistant
+                  // UUIDs. Hidden digest assistants share the same client slot
+                  // and must not replace its stable tool checkpoint.
                   if ((message as any).session_id) {
                     currentSessionId = (message as any).session_id
                   }
-                  if (message.type === "assistant" && (message as any).uuid) {
-                    sdkUuidMap.push((message as any).uuid)
+                  let assistantAddedForwardedCall = false
+                  if (earlyStopEnabled && message.type === "assistant" && !earlyStopFired) {
+                    const expectedBefore = earlyStop.expected.size
+                    noteAssistantMessage(earlyStop, message)
+                    assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
+                  } else if (earlyStopEnabled && message.type === "user" && !earlyStopFired) {
+                    noteUserContent(earlyStop, (message as any).message?.content)
                   }
-                  nextPassthroughResumeUuid = resumeBoundaryUuid(message) ?? nextPassthroughResumeUuid
-                  // Early stop: abort before the digest turn generates (see the
-                  // earlyStop declaration above). By deny time the client has
-                  // already received all turn-1 blocks and the stop_reason
-                  // message_delta, so mirror the turn-2 suppression path's
-                  // clean close (message_delta + message_stop) and abort.
-                  if (earlyStopEnabled) {
-                    if (message.type === "assistant") {
-                      noteAssistantContent(earlyStop, (message as any).message?.content)
-                    } else if (message.type === "user") {
-                      noteUserContent(earlyStop, (message as any).message?.content)
-                      // streamedToolUseIds ≥ 1 guarantees the client actually
-                      // received a tool_use block before we stop the query.
-                      // Normally the client stream is already closed by the
-                      // stop_reason:"tool_use" close above (drain mode) — the
-                      // emissions below only fire in the unusual case where the
-                      // denies arrive first (safeEnqueue no-ops when closed).
-                      if (shouldEarlyStop(earlyStop) && streamedToolUseIds.size > 0) {
-                        if (openClientBlocks.size > 0) {
-                          // A forwarded block is still streaming its input.
-                          // Defer rather than truncate it (#742); the deny that
-                          // completed the tracker belongs to a block that has
-                          // already closed, so the open one's stop is close
-                          // behind. Deliberately no `break` — the remaining
-                          // deltas must keep flowing to the client.
-                          if (!pendingEarlyStop) {
-                            pendingEarlyStop = true
-                            pendingEarlyStopAt = Date.now()
-                            claudeLog("passthrough.early_stop_deferred", {
-                              openBlocks: openClientBlocks.size,
-                              captured: capturedToolUses.length,
-                            })
-                          }
-                        } else {
-                          fireEarlyStop("immediate")
-                          break
-                        }
+                  if (earlyStopEnabled && !earlyStopFired) {
+                    // A deny may precede the last per-block assistant metadata.
+                    // The client-visible stream is the completeness oracle: wait
+                    // until generation ended, every block closed, and metadata
+                    // names exactly the full forwarded ID set. Recheck on both
+                    // assistant and user messages so either ordering can settle.
+                    const hasCompleteStreamedSet =
+                      streamedToolUseIds.size > 0 &&
+                      earlyStop.expected.size === streamedToolUseIds.size &&
+                      [...streamedToolUseIds].every((id) => earlyStop.expected.has(id))
+                    if (
+                      !turnGenerating &&
+                      openClientBlocks.size === 0 &&
+                      hasCompleteStreamedSet &&
+                      shouldEarlyStop(earlyStop)
+                    ) {
+                      nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
+                      nextPassthroughToolCallIds = [...earlyStop.expected]
+                      earlyStopFired = true
+                      for (let i = capturedToolUses.length - 1; i >= 0; i--) {
+                        if (!earlyStop.expected.has(capturedToolUses[i]!.id)) capturedToolUses.splice(i, 1)
                       }
+                      claudeLog("passthrough.checkpoint_ready", {
+                        mode: "stream",
+                        captured: capturedToolUses.length,
+                        toolCallAssistantUuid: nextPassthroughToolCallAssistantUuid,
+                      })
                     }
                   }
+                  if (
+                    message.type === "assistant" &&
+                    (!passthrough || earlyStop.expected.size === 0 || assistantAddedForwardedCall)
+                  ) {
+                    sdkUuidMap = withClientAssistantUuid(
+                      sdkUuidMap,
+                      allMessages.length,
+                      (message as any).uuid
+                    )
+                  }
                   if (message.type === "result") {
+                    sawCanonicalResult = true
                     const resultUsage = (message as { usage?: unknown }).usage as TokenUsage | undefined
                     if (resultUsage) lastUsage = { ...lastUsage, ...resultUsage }
                     if (outputFormat && "structured_output" in message) {
@@ -3159,6 +3208,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   }
 
                   if (message.type === "stream_event") {
+                    // Once turn 1 is closed to the client, all later wire events
+                    // belong to the hidden digest. Ignore them wholesale so a
+                    // closed-controller enqueue cannot break the durability
+                    // drain before the canonical result arrives.
+                    if (streamClosed && awaitingEarlyStopDrain) continue
                     streamEventsSeen += 1
                     if (!firstChunkAt) {
                       firstChunkAt = Date.now()
@@ -3220,15 +3274,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       // client sees stop_reason:"tool_use" and executes the tool itself.
                       if (messageStartEmitted) {
                         if (passthrough && streamedToolUseIds.size > 0) {
-                          flushOpenClientBlocks("turn2_suppression")
-                          sendTerminalDelta("tool_use")
-                          safeEnqueue(encoder.encode(
-                            `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
-                          ), "passthrough_turn2_stop")
+                          if (!streamClosed) {
+                            flushOpenClientBlocks("turn2_suppression")
+                            sendTerminalDelta("tool_use")
+                            safeEnqueue(encoder.encode(
+                              `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
+                            ), "passthrough_turn2_stop")
+                            streamClosed = true
+                            controller.close()
+                          }
+                          // Suppress the entire hidden digest turn, but drain it
+                          // through the canonical result so the transcript is durable.
+                          awaitingEarlyStopDrain = true
                           claudeLog("passthrough.turn2_suppressed", { mode: "stream", toolUses: streamedToolUseIds.size })
-                          streamClosed = true
-                          controller.close()
-                          break
+                          continue
                         }
                         continue
                       }
@@ -3415,12 +3474,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     } else if (eventType === "content_block_stop") {
                       const idx = (event as any).index
                       if (typeof idx === "number") openClientBlocks.delete(idx)
-                      // The block that was mid-stream when the denies settled
-                      // has now been forwarded intact — safe to close (#742).
-                      if (pendingEarlyStop && openClientBlocks.size === 0) {
-                        fireEarlyStop("blocks_closed")
-                        break
-                      }
                     }
 
                     // NOTE: agent-specific (passthrough mode) — close the client stream
@@ -3430,11 +3483,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // back to the model, and the model produces an incorrect fallback
                     // response which gets forwarded.
                     //
-                    // With early stop enabled, don't break — keep DRAINING the SDK
-                    // stream (nothing forwards after close) until every deny is
-                    // persisted, then abort so the digest turn never generates.
-                    // Without early stop (kill switch), break as before: the
-                    // subprocess finishes turn 2 in the background (billed).
+                    // With checkpoint draining enabled, don't break — keep
+                    // consuming invisibly through every deny, the digest, and the
+                    // canonical result that makes the assistant UUID durable.
+                    // Without it (kill switch), preserve the old wire
+                    // behavior by breaking here, then evict the noncanonical
+                    // session mapping because closing the query interrupts its tail.
                     if (
                       passthrough &&
                       eventType === "message_delta" &&
@@ -3455,6 +3509,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         awaitingEarlyStopDrain = true
                         continue
                       }
+                      exitedBeforeCanonicalTerminal = true
                       break
                     }
 
@@ -3547,24 +3602,32 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 plog(`[PROXY] ${requestMeta.requestId} discovered=${discoveredTools.size} (${newNames}) session_total=${allNames.length}`)
               }
 
-              // Store session for future resume.
-              // Fork/subagent requests don't write to the cache (see lookupSession
-              // block for rationale). Duplicate-aborted sessions are never
-              // offered for resume — their history holds a dangling dropped
-              // call that diverges from the client's view (#552). Early-stop
-              // aborts are safe to store: every deny was persisted before the
-              // abort. See the non-stream store above.
+              // Store only canonical, durable checkpoint turns. Fork/subagent
+              // requests and duplicate-aborted sessions never write the cache.
+              // A live PTY E2E proved assistant/deny iterator messages may be
+              // yielded before their JSONL records are committed, so a tool turn
+              // also requires both a valid assistant checkpoint and SDK result.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
-                storeSession(
-                  profileSessionId,
-                  body.messages || [],
-                  currentSessionId,
-                  profileScopedCwd,
-                  sdkUuidMap,
-                  lastUsage,
-                  earlyStopFired ? nextPassthroughResumeUuid : null
-                )
-                commitSessionTurn()
+                const checkpointTurn = passthrough && streamedToolUseIds.size > 0
+                if (
+                  exitedBeforeCanonicalTerminal ||
+                  (checkpointTurn && (!earlyStopFired || !sawCanonicalResult))
+                ) {
+                  evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                  claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream" })
+                } else {
+                  storeSession(
+                    profileSessionId,
+                    body.messages || [],
+                    currentSessionId,
+                    profileScopedCwd,
+                    sdkUuidMap,
+                    lastUsage,
+                    earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
+                    earlyStopFired ? nextPassthroughToolCallIds : null
+                  )
+                  commitSessionTurn()
+                }
               }
 
               // Last chance to save a silent turn. The three known causes are
@@ -3573,7 +3636,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               //
               // Runs only where recovery is still possible: the stream is open,
               // so the recovered answer can actually be forwarded. A turn that
-              // already closed (early stop, turn-2 suppression) carries tool
+              // already closed for a passthrough tool turn carries tool
               // calls by construction and is never silent.
               //
               // One classification, read twice: here, to decide whether a
@@ -3620,7 +3683,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // call made here comes back as a tool_result for a tool_use the
                 // resumable session never saw.
                 let recoverySessionId: string | undefined
-                let recoveryBoundaryUuid: string | undefined
+                let recoveryToolCallAssistantUuid: string | undefined
+                const recoveryEarlyStop = createEarlyStopTracker()
                 try {
                   // Bounded by the same idle limit as the main stream. Iterating
                   // the recovery query directly left a stalled recovery holding
@@ -3639,7 +3703,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // Fork rather than extend: the silent turn is now this
                     // session's tail, and appending to it is what compounds an
                     // empty turn into an empty session (#768 client-abort).
-                    resumeSessionAtUuid: nextPassthroughResumeUuid,
+                    resumeSessionAtUuid: nextPassthroughToolCallAssistantUuid,
                     forkSession: true,
                     sdkHooks, blockedTools: pipelineCtx.blockedTools,
                     incompatibleTools: pipelineCtx.incompatibleTools,
@@ -3662,7 +3726,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "silent_recovery")) {
                     const recoveryMessage = event as any
                     if (recoveryMessage.session_id) recoverySessionId = recoveryMessage.session_id
-                    recoveryBoundaryUuid = resumeBoundaryUuid(recoveryMessage) ?? recoveryBoundaryUuid
+                    if (recoveryMessage.type === "assistant") {
+                      noteAssistantMessage(recoveryEarlyStop, recoveryMessage)
+                    } else if (recoveryMessage.type === "user") {
+                      noteUserContent(recoveryEarlyStop, recoveryMessage.message?.content)
+                      recoveryToolCallAssistantUuid = settledToolCallAssistantUuid(recoveryEarlyStop)
+                    }
                     if (recoveryMessage.type !== "stream_event") continue
                     // Only text is lifted into the already-open message; the
                     // re-indexing handshake lives in createRecoveryLifter. A
@@ -3708,7 +3777,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   !isIndependentSession && !sawDuplicateToolUse
                 ) {
                   currentSessionId = recoverySessionId
-                  nextPassthroughResumeUuid = recoveryBoundaryUuid
+                  nextPassthroughToolCallAssistantUuid = recoveryToolCallAssistantUuid
+                  nextPassthroughToolCallIds = recoveryToolCallAssistantUuid
+                    ? [...recoveryEarlyStop.expected]
+                    : undefined
                   sdkUuidMap.length = 0
                   for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                   storeSession(
@@ -3718,7 +3790,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     profileScopedCwd,
                     sdkUuidMap,
                     lastUsage,
-                    recoveryBoundaryUuid ?? null
+                    recoveryToolCallAssistantUuid ?? null,
+                    recoveryToolCallAssistantUuid ? [...recoveryEarlyStop.expected] : null
                   )
                   commitSessionTurn()
                 }
@@ -3956,25 +4029,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   profileSessionId,
                   currentSessionId,
                   sawDuplicateToolUse,
-                  resumeBoundaryUuid: nextPassthroughResumeUuid,
+                  toolCallAssistantUuid: nextPassthroughToolCallAssistantUuid,
                   passthrough,
                 })
-                if (disposition.action === "store" && currentSessionId) {
-                  storeSession(
-                    profileSessionId,
-                    body.messages || [],
-                    currentSessionId,
-                    profileScopedCwd,
-                    sdkUuidMap,
-                    lastUsage,
-                    disposition.resumeUuid
-                  )
-                  commitSessionTurn()
-                } else if (disposition.action === "evict") {
+                if (disposition.action === "evict") {
                   evictSession(profileSessionId, profileScopedCwd, body.messages || [])
                 }
                 claudeLog("passthrough.client_abort_settled", { action: disposition.action })
                 return
+              }
+
+              if (passthrough && streamedToolUseIds.size > 0 && !sawCanonicalResult) {
+                // The client may already have advanced past this tool turn, so
+                // a failed hidden drain invalidates even an older cached mapping.
+                evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream", reason: "drain_error" })
               }
 
               const stderrOutput = stderrLines.join("\n").trim()
@@ -4013,10 +4082,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // tools and drives the next turn (the same outcome as a normal
               // tool-use cycle). Without this, the client sees a 500 even
               // though we already streamed everything it needs.
-              // "aborted" is accepted only for the proxy's own aborts — the
-              // single-step duplicate abort (sawDuplicateToolUse) or the
-              // early stop (earlyStopFired) — a client-disconnect abort must
-              // not be recorded as a recovered success.
+              // "aborted" is accepted only for the proxy's own remaining
+              // single-step duplicate abort. Checkpoint settlement no longer
+              // aborts, and a client-disconnect abort must not be recovered.
               // "upstream_idle" joins them for the same reason (#770): the guard
               // killed a stalled stream, but the tool calls were already
               // captured and are exactly what the client needs to make progress.
@@ -4027,7 +4095,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 reason: sdkTerm.reason,
                 passthrough,
                 capturedToolUses: capturedToolUses.length,
-                abortIsOurs: sawDuplicateToolUse || earlyStopFired,
+                abortIsOurs: sawDuplicateToolUse,
               }) && messageStartEmitted
 
               if (canRecoverAsToolUse) {
@@ -4255,6 +4323,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           cancel(reason) {
             requestAbort.abort(reason)
             requestAbort.detach()
+            if (!isIndependentSession) {
+              // Cancellation can terminate the iterator without producing the
+              // closed-controller error handled above. Evict synchronously so
+              // no interrupted tail remains resumable even if the SDK never yields.
+              evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+              claudeLog("passthrough.client_abort_settled", { action: "evict", source: "stream_cancel" })
+            }
           },
         })
 

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -187,7 +187,8 @@ export function lookupSession(
         messageHashes: shared.messageHashes,
         messageBlockHashes: shared.messageBlockHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
-        passthroughResumeUuid: shared.passthroughResumeUuid,
+        passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
+        passthroughToolCallIds: shared.passthroughToolCallIds,
         contextUsage: shared.contextUsage,
       }
       const result = classifyLineage(state, messages, sessionId)
@@ -217,7 +218,8 @@ export function lookupSession(
         messageHashes: shared.messageHashes,
         messageBlockHashes: shared.messageBlockHashes,
         sdkMessageUuids: shared.sdkMessageUuids,
-        passthroughResumeUuid: shared.passthroughResumeUuid,
+        passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
+        passthroughToolCallIds: shared.passthroughToolCallIds,
         contextUsage: shared.contextUsage,
       }
       const result = classifyLineage(state, messages, fp)
@@ -256,7 +258,8 @@ export function getSessionByClaudeId(claudeSessionId: string): SessionState | un
       messageHashes: shared.messageHashes,
       messageBlockHashes: shared.messageBlockHashes,
       sdkMessageUuids: shared.sdkMessageUuids,
-      passthroughResumeUuid: shared.passthroughResumeUuid,
+      passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
+      passthroughToolCallIds: shared.passthroughToolCallIds,
       contextUsage: shared.contextUsage,
     })
   }
@@ -275,7 +278,8 @@ export function storeSession(
   workingDirectory?: string,
   sdkMessageUuids?: Array<string | null>,
   contextUsage?: TokenUsage,
-  passthroughResumeUuid?: string | null
+  passthroughToolCallAssistantUuid?: string | null,
+  passthroughToolCallIds?: string[] | null
 ) {
   if (!claudeSessionId) return
   const lineageHash = computeLineageHash(messages)
@@ -289,7 +293,8 @@ export function storeSession(
     messageHashes,
     messageBlockHashes,
     sdkMessageUuids,
-    ...(passthroughResumeUuid ? { passthroughResumeUuid } : {}),
+    ...(passthroughToolCallAssistantUuid ? { passthroughToolCallAssistantUuid } : {}),
+    ...(passthroughToolCallIds ? { passthroughToolCallIds } : {}),
     ...(contextUsage ? { contextUsage } : {}),
   }
   // In-memory cache
@@ -313,8 +318,9 @@ export function storeSession(
       sdkMessageUuids,
       contextUsage,
       messageBlockHashes,
-      // undefined would preserve the stored boundary; a full store must rewrite it.
-      passthroughResumeUuid ?? null
+      // undefined would preserve the stored checkpoint; a full store must rewrite it.
+      passthroughToolCallAssistantUuid ?? null,
+      passthroughToolCallIds ?? null
     )
   }
 }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -56,10 +56,32 @@ export interface SessionState {
    *  Only assistant messages have UUIDs (user messages are null).
    *  Used to find the rollback point for undo. */
   sdkMessageUuids?: Array<string | null>
-  /** Last persisted passthrough deny — continuations of an early-stopped session fork here. */
-  passthroughResumeUuid?: string
+  /** SDK assistant UUID immediately before synthetic passthrough denials.
+   *  Must be an assistant UUID: the Agent SDK rejects other resumeSessionAt boundaries. */
+  passthroughToolCallAssistantUuid?: string
+  /** Forwarded tool IDs that must be settled together at the checkpoint. */
+  passthroughToolCallIds?: string[]
   /** Last observed token usage for this session (from SDK message_start / message_delta events) */
   contextUsage?: TokenUsage
+}
+
+/**
+ * Associate SDK assistant events from the current upstream run with the single
+ * assistant message the Anthropic client will append after this request.
+ * Multiple SDK fragments overwrite the same future slot, leaving the final
+ * assistant UUID as the undo checkpoint for the consolidated client turn.
+ */
+export function withClientAssistantUuid(
+  existing: Array<string | null>,
+  clientMessageCount: number,
+  uuid: unknown
+): Array<string | null> {
+  const next = existing.slice(0, clientMessageCount + 1)
+  while (next.length < clientMessageCount) next.push(null)
+  // A later UUID-less assistant fragment must not leave an older fragment as
+  // the rollback point for a client message that contains both.
+  next[clientMessageCount] = typeof uuid === "string" && uuid.length > 0 ? uuid : null
+  return next
 }
 
 /**

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -38,8 +38,11 @@ export interface StoredSession {
   messageBlockHashes?: string[][]
   /** Per-message SDK assistant UUIDs for undo rollback (null for user messages) */
   sdkMessageUuids?: Array<string | null>
-  /** Uuid of the last persisted passthrough deny — resume boundary after an early stop. */
-  passthroughResumeUuid?: string
+  /** SDK assistant UUID immediately before synthetic passthrough denials.
+   *  Continuations resume the same session here, preserving the stable prefix. */
+  passthroughToolCallAssistantUuid?: string
+  /** Forwarded tool IDs pending at the stored assistant checkpoint. */
+  passthroughToolCallIds?: string[]
   /** Last observed token usage for this Claude session */
   contextUsage?: TokenUsage
   /** Previous Claude session ID preserved when the session mapping is replaced.
@@ -180,9 +183,18 @@ function writeStore(store: Record<string, StoredSession>): void {
   }
 }
 
+function hasLegacyUserDenialBoundary(session: StoredSession): boolean {
+  const legacy = (session as StoredSession & { passthroughResumeUuid?: unknown }).passthroughResumeUuid
+  return typeof legacy === "string" && legacy.length > 0 && !session.passthroughToolCallAssistantUuid
+}
+
 export function lookupSharedSession(key: string): StoredSession | undefined {
   const store = readStore()
-  return store[key]
+  const session = store[key]
+  // Versions 1.61.0–1.62.3 stored a user/tool_result UUID even though the SDK's
+  // resumeSessionAt accepts assistant UUIDs only. Replaying once is safer than
+  // resuming that invalid tail and re-triggering full-history cache churn.
+  return session && !hasLegacyUserDenialBoundary(session) ? session : undefined
 }
 
 export function lookupSharedSessionByClaudeId(claudeSessionId: string): StoredSession | undefined {
@@ -190,7 +202,7 @@ export function lookupSharedSessionByClaudeId(claudeSessionId: string): StoredSe
   let newest: StoredSession | undefined
 
   for (const session of sessions) {
-    if (session.claudeSessionId !== claudeSessionId) continue
+    if (session.claudeSessionId !== claudeSessionId || hasLegacyUserDenialBoundary(session)) continue
     if (!newest || session.lastUsedAt > newest.lastUsedAt) {
       newest = session
     }
@@ -208,7 +220,8 @@ export function storeSharedSession(
   sdkMessageUuids?: Array<string | null>,
   contextUsage?: TokenUsage,
   messageBlockHashes?: string[][],
-  passthroughResumeUuid?: string | null
+  passthroughToolCallAssistantUuid?: string | null,
+  passthroughToolCallIds?: string[] | null
 ): void {
   const path = getStorePath()
   const lockPath = `${path}.lock`
@@ -235,9 +248,12 @@ export function storeSharedSession(
       messageHashes: messageHashes ?? existing?.messageHashes,
       messageBlockHashes: messageBlockHashes ?? existing?.messageBlockHashes,
       sdkMessageUuids: sdkMessageUuids ?? existing?.sdkMessageUuids,
-      passthroughResumeUuid: passthroughResumeUuid === undefined
-        ? existing?.passthroughResumeUuid
-        : passthroughResumeUuid ?? undefined,
+      passthroughToolCallAssistantUuid: passthroughToolCallAssistantUuid === undefined
+        ? existing?.passthroughToolCallAssistantUuid
+        : passthroughToolCallAssistantUuid ?? undefined,
+      passthroughToolCallIds: passthroughToolCallIds === undefined
+        ? existing?.passthroughToolCallIds
+        : passthroughToolCallIds ?? undefined,
       contextUsage: contextUsage ?? existing?.contextUsage,
       ...(previousClaudeSessionId ? { previousClaudeSessionId } : {}),
     }


### PR DESCRIPTION
## Summary

- persist the SDK assistant UUID that contains the forwarded tool-call batch instead of the synthetic user-denial UUID
- resume the same SDK session at that assistant checkpoint without routine `forkSession`
- send the client's real `tool_result` blocks as structured SDK user input, including nested multimodal results
- persist and validate the exact pending tool IDs; partial, duplicate, late, or unknown batches fail safely to one fresh replay
- consolidate parallel SDK assistant fragments onto the single client-visible assistant slot used by undo
- ignore legacy invalid denial-boundary cache entries after upgrade

## Why

The previous passthrough path set `resumeSessionAt` to a user/tool-result UUID and enabled `forkSession` for every external-tool continuation. The SDK only accepts assistant-message UUIDs at that boundary, so normal continuations repeatedly lost stable lineage, created new SDK sessions, and rewrote the full prompt cache.

The corrected path rewinds the existing session to the assistant tool-use checkpoint, excludes Meridian's synthetic denial side branches, and appends the real tool results structurally.

## Safety

- early stop requires a valid assistant UUID; otherwise the SDK turn drains normally
- later UUID-less parallel fragments invalidate an older checkpoint
- incomplete/mismatched result batches never issue an invalid checkpoint resume
- ordinary continuations keep the session ID; undo and the existing busy-session fallback remain the only forks
- test session keys are cleaned from the shared store

## Validation

- `npm test`
- `npm run build`
- `git diff --check`
- independent read-only SDK semantics review approved the final diff

No provider-backed E2E was run, to avoid consuming subscription quota; all HTTP integration tests use the mocked SDK.
