### PR TITLE
fix: route native subagents to base model tiers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -145,6 +145,7 @@ Agent-specific behavior is isolated behind the `AgentAdapter` interface (`adapte
 | Method | What It Does |
 |--------|-------------|
 | `getSessionId(c)` | Extract session ID from request headers |
+| `getAgentMode(c, body)` | Normalize an adapter-specific primary/subagent declaration |
 | `extractWorkingDirectory(body)` | Parse working directory from request body |
 | `normalizeContent(content)` | Normalize message content for hashing |
 | `getBlockedBuiltinTools()` | SDK tools replaced by agent's MCP equivalents |
@@ -156,7 +157,7 @@ Agent-specific behavior is isolated behind the `AgentAdapter` interface (`adapte
 
 | Logic | Location | Status |
 |-------|----------|--------|
-| `buildAgentDefinitions` | `agentDefs.ts` | Parses OpenCode Task tool format. To be adapter method. |
+| `buildAgentDefinitions` | `agentDefs.ts`, `transforms/opencode.ts` | Pure OpenCode Task parser invoked by the adapter transform. |
 | Passthrough mode | `passthroughTools.ts` | Agent-agnostic but OpenCode-motivated. Keep as-is. |
 | `ALLOWED_MCP_TOOLS` usage in `server.ts` | Line ~176 | Used for `buildAgentDefinitions`. Move when adapter handles agent defs. |
 

--- a/E2E.md
+++ b/E2E.md
@@ -992,32 +992,41 @@ curl -s -X POST http://127.0.0.1:3456/auth/refresh
 
 ## E23: Subagent Model Selection
 
-**Verifies:** When the `x-opencode-agent-mode: subagent` header is present, the proxy selects the base model (200k) instead of the 1M variant, conserving rate limit budget for the primary agent. The `meridian-agent-mode.ts` plugin sets this header automatically based on the agent's runtime `mode` field.
+**Verifies:** When the `x-opencode-agent-mode: subagent` header or a generic `x-meridian-source: subagent-*` declaration is present, the proxy selects the base model (200k) instead of the 1M variant, conserving rate limit budget for the primary agent. The `meridian-agent-mode.ts` plugin sets the OpenCode header automatically based on the agent's runtime `mode` field. SDK-native Task agent definitions also receive the matching base tier explicitly, so they do not inherit an `opus[1m]` parent.
 
 ### Part A — header routing (curl, no plugin needed)
 
 ```bash
-# Primary agent → sonnet[1m]
+# Primary agent → opus[1m]
 curl -s http://127.0.0.1:3456/v1/messages \
   -H "Content-Type: application/json" \
   -H "x-api-key: dummy" \
   -H "x-opencode-agent-mode: primary" \
-  -d '{"model":"claude-sonnet-4-6","max_tokens":10,"stream":false,"messages":[{"role":"user","content":"hi"}]}' > /dev/null
-# Proxy log: model=sonnet[1m] ... agent=primary
+  -d '{"model":"claude-opus-4-6","max_tokens":10,"stream":false,"messages":[{"role":"user","content":"hi"}]}' > /dev/null
+# Proxy log: model=opus[1m] ... agent=primary
 
-# Subagent → sonnet (base)
+# Subagent → opus (base)
 curl -s http://127.0.0.1:3456/v1/messages \
   -H "Content-Type: application/json" \
   -H "x-api-key: dummy" \
   -H "x-opencode-agent-mode: subagent" \
-  -d '{"model":"claude-sonnet-4-6","max_tokens":10,"stream":false,"messages":[{"role":"user","content":"hi"}]}' > /dev/null
-# Proxy log: model=sonnet ... agent=subagent
+  -d '{"model":"claude-opus-4-6","max_tokens":10,"stream":false,"messages":[{"role":"user","content":"hi"}]}' > /dev/null
+# Proxy log: model=opus ... agent=subagent
+
+# Generic source declaration (works across adapters) → base opus
+curl -s http://127.0.0.1:3456/v1/messages \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: dummy" \
+  -H "x-meridian-source: subagent-reviewer" \
+  -d '{"model":"claude-opus-4-6","max_tokens":10,"stream":false,"messages":[{"role":"user","content":"hi"}]}' > /dev/null
+# Proxy log: model=opus ... source=subagent-reviewer agent=subagent
 ```
 
 **Pass criteria (Part A):**
-- Primary request proxy log: `model=sonnet[1m] ... agent=primary`
-- Subagent request proxy log: `model=sonnet ... agent=subagent` — base model, no `[1m]`
-- No header → `model=sonnet[1m]` (default primary behaviour)
+- Primary request proxy log: `model=opus[1m] ... agent=primary`
+- Subagent request proxy log: `model=opus ... agent=subagent` — base model, no `[1m]`
+- Generic `subagent-*` source: base tier and `agent=subagent`, even outside OpenCode
+- No header → `model=opus[1m]` (default primary behaviour)
 
 ### Part B — plugin integration (requires OpenCode)
 
@@ -1036,17 +1045,17 @@ cp /path/to/meridian/examples/opencode-plugin/meridian-agent-mode.ts ./meridian-
 **Test:**
 ```bash
 # Run a task that uses the Task tool to spawn the researcher agent
-opencode run --model anthropic/claude-sonnet-4-6 \
+opencode run --model anthropic/claude-opus-4-6 \
   "Use the researcher agent to find out what day it is, then summarise."
 ```
 
 **Pass criteria (Part B):**
-- Primary session log line: `model=sonnet[1m] agent=primary`
-- Subagent session log line: `model=sonnet agent=subagent`
+- Primary session log line: `model=opus[1m] agent=primary`
+- Subagent session log line: `model=opus agent=subagent`
 - Both requests succeed — no errors
 - Two distinct proxy log entries visible (parent + subagent turn)
 
-**What's being tested:** `mapModelToClaudeModel()` `agentMode` parameter in `models.ts`, `x-opencode-agent-mode` header reading in `server.ts`, and the `meridian-agent-mode.ts` plugin's use of `(incoming.agent as any).mode` to detect subagents without any API calls.
+**What's being tested:** `mapModelToClaudeModel()` subagent tier selection in `models.ts`, OpenCode agent-mode extraction through its adapter, generic `x-meridian-source` fallback in `server.ts`, base-tier SDK agent definitions in `agentDefs.ts`, and the `meridian-agent-mode.ts` plugin's use of the runtime agent mode without any API calls.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,7 +221,11 @@ other and never see this concurrency error. Three further exemptions:
   `x-meridian-source` starts with `fork-` or `subagent-` has told Meridian it
   is knowingly running a parallel turn under a shared session key. Those
   turns are still serialized, but a stale lineage costs them a replay rather
-  than a `400` — the behavior they had before serialization existed.
+  than a `400` — the behavior they had before serialization existed. A
+  `subagent-` source also selects the base 200k model tier (for example,
+  `opus` instead of `opus[1m]`) across adapters. Headerless subagent flows skip
+  the shared fingerprint cache to avoid colliding with their parent; provide a
+  distinct session key for multi-turn subagents that need warm cache resume.
 - **The lease cannot wedge a session forever.** A turn holds its session's
   serialization lease until its response body completes. If that never
   happens, the lease is force-released after

--- a/src/__tests__/adapter.test.ts
+++ b/src/__tests__/adapter.test.ts
@@ -39,6 +39,13 @@ describe("openCodeAdapter", () => {
     expect(openCodeAdapter.getSessionId(mockContext as any)).toBeUndefined()
   })
 
+  it("extracts the OpenCode agent mode through the adapter boundary", () => {
+    const mockContext = {
+      req: { header: (name: string) => name === "x-opencode-agent-mode" ? "subagent" : undefined }
+    }
+    expect(openCodeAdapter.getAgentMode!(mockContext as any)).toBe("subagent")
+  })
+
   it("extracts working directory from system prompt env block", () => {
     const body = {
       system: "<env>\n  Working directory: /Users/test/project\n</env>"
@@ -104,6 +111,12 @@ describe("openCodeAdapter.buildSdkAgents", () => {
       expect((def as any).prompt.toLowerCase()).toContain(name.toLowerCase())
       expect((def as any).model).toBe("inherit")
     }
+  })
+
+  it("assigns native Task agents the base Opus tier for an Opus request", () => {
+    const body = { model: "claude-opus-5", tools: [SAMPLE_TASK_TOOL] }
+    const agents = openCodeAdapter.buildSdkAgents!(body, [])
+    for (const def of Object.values(agents)) expect((def as any).model).toBe("opus")
   })
 
   it("passes mcpToolNames to agent definitions", () => {

--- a/src/__tests__/adapter.test.ts
+++ b/src/__tests__/adapter.test.ts
@@ -46,6 +46,11 @@ describe("openCodeAdapter", () => {
     expect(openCodeAdapter.getAgentMode!(mockContext as any)).toBe("subagent")
   })
 
+  it("returns undefined when the OpenCode agent mode header is missing", () => {
+    const mockContext = { req: { header: () => undefined } }
+    expect(openCodeAdapter.getAgentMode!(mockContext as any)).toBeUndefined()
+  })
+
   it("extracts working directory from system prompt env block", () => {
     const body = {
       system: "<env>\n  Working directory: /Users/test/project\n</env>"

--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -109,12 +109,21 @@ describe("buildAgentDefinitions", () => {
     const defs = buildAgentDefinitions("No agents here")
     expect(Object.keys(defs)).toHaveLength(0)
   })
+
+  it("applies an explicit base tier to parsed agents, defaults, and aliases", () => {
+    const defs = buildAgentDefinitions(SAMPLE_TASK_DESCRIPTION, undefined, "opus")
+    expect(Object.keys(defs).length).toBeGreaterThan(0)
+    for (const def of Object.values(defs)) expect(def.model).toBe("opus")
+    expect(defs.general?.model).toBe("opus")
+    expect(defs["general-purpose"]?.model).toBe("opus")
+  })
 })
 
 describe("mapModelTier", () => {
-  it("should map opus models", () => {
-    expect(mapModelTier("anthropic/claude-opus-4-6")).toBe("opus[1m]")
-    expect(mapModelTier("claude-opus-4")).toBe("opus[1m]")
+  it("should map opus models to the SDK's base subagent tier", () => {
+    expect(mapModelTier("anthropic/claude-opus-4-6")).toBe("opus")
+    expect(mapModelTier("claude-opus-4")).toBe("opus")
+    expect(mapModelTier("opus[1m]")).toBe("opus")
   })
 
   it("should map sonnet models", () => {
@@ -409,6 +418,11 @@ describe("buildAgentDefinitionsFromTool (regex with enum fallback)", () => {
     const defs = buildAgentDefinitionsFromTool(omoStyleTool)
     expect(defs["oracle"]!.model).toBe("inherit")
     expect(defs["oracle"]!.prompt).toContain(`"oracle" agent`)
+  })
+
+  it("applies the selected tier to enum-derived agents and injected defaults", () => {
+    const defs = buildAgentDefinitionsFromTool(omoStyleTool, undefined, "opus")
+    for (const def of Object.values(defs)) expect(def.model).toBe("opus")
   })
 })
 

--- a/src/__tests__/proxy-agent-definitions.test.ts
+++ b/src/__tests__/proxy-agent-definitions.test.ts
@@ -130,6 +130,12 @@ describe("mapModelTier", () => {
     expect(mapModelTier("anthropic/claude-sonnet-4-5")).toBe("sonnet")
   })
 
+  it("should map fable and mythos models to the base fable tier", () => {
+    expect(mapModelTier("claude-fable-5")).toBe("fable")
+    expect(mapModelTier("claude-mythos-5")).toBe("fable")
+    expect(mapModelTier("fable[1m]")).toBe("fable")
+  })
+
   it("should map haiku models", () => {
     expect(mapModelTier("anthropic/claude-haiku-4-5")).toBe("haiku")
   })

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -269,6 +269,24 @@ describe("SDK and Session concurrency coordination", () => {
     expect(queryCalls).toBe(2)
   })
 
+  it("lets an OpenCode subagent mode replay instead of refusing it", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const messages = [{ role: "user", content: "same request" }]
+    const firstP = app.fetch(request(messages, "declared-mode"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(
+      request(messages, "declared-mode", false, { "x-opencode-agent-mode": "subagent" }),
+    )
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    expect((await secondP).status).toBe(200)
+    expect(queryCalls).toBe(2)
+  })
+
   it("force-releases a wedged turn instead of deadlocking the session", async () => {
     process.env.MERIDIAN_MAX_CONCURRENT = "2"
     process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = "50"

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -250,7 +250,7 @@ describe("SDK agents option", () => {
     const oracle = capturedQueryParams.options.agents["oracle"]
     expect(oracle.description).toContain("Read-only consultation")
     expect(oracle.prompt).toContain("oracle")
-    expect(oracle.model).toBe("inherit")
+    expect(oracle.model).toBe("sonnet")
   })
 
   it("should not pass agents when no Task tool in request", async () => {

--- a/src/__tests__/proxy-source-keyed-session.test.ts
+++ b/src/__tests__/proxy-source-keyed-session.test.ts
@@ -96,6 +96,19 @@ describe("explicit session keys override the independence guard", () => {
     expect(capturedOptions[1].resume).toBe("test-session")
   })
 
+  it("keyed OpenCode subagent mode resumes across turns", async () => {
+    const app = createTestApp()
+    const headers = {
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-session": "opencode-subagent-run",
+    }
+    expect((await post(app, TURN_1, headers)).status).toBe(200)
+    expect((await post(app, TURN_2, headers)).status).toBe(200)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[0].resume).toBeUndefined()
+    expect(capturedOptions[1].resume).toBe("test-session")
+  })
+
   it("pi subagent-worker WITHOUT a session key keeps the independence guard (no resume)", async () => {
     const app = createTestApp()
     const headers = { "x-meridian-agent": "pi", "x-meridian-source": "subagent-worker" }

--- a/src/__tests__/proxy-source-skip-cache.test.ts
+++ b/src/__tests__/proxy-source-skip-cache.test.ts
@@ -110,6 +110,15 @@ describe("x-meridian-source: fingerprint cache skip for independent sessions", (
     expect(result.type).toBe("diverged")
   })
 
+  it("does NOT write a headerless OpenCode subagent mode to the fingerprint cache", async () => {
+    const app = createTestApp()
+    const cwd = process.cwd()
+    await post(app, BASE_BODY, { "x-opencode-agent-mode": "subagent" })
+
+    const result = lookupSession(undefined, nextTurn, cwd)
+    expect(result.type).toBe("diverged")
+  })
+
   it("DOES write to the fingerprint cache when source=main", async () => {
     // Sanity: main requests (non-fork, non-subagent) must still populate the
     // cache so the normal resume optimization works for regular chat turns.

--- a/src/__tests__/proxy-subagent-model-selection.test.ts
+++ b/src/__tests__/proxy-subagent-model-selection.test.ts
@@ -143,6 +143,22 @@ describe("Subagent model selection", () => {
     expect(capturedModel).toBe("opus")
   })
 
+  it("preserves the legacy OpenCode mode header on non-OpenCode adapters", async () => {
+    await post({ ...BASE_REQUEST, model: "claude-opus-4-6" }, {
+      "x-meridian-agent": "pi",
+      "x-opencode-agent-mode": "subagent",
+    })
+    expect(capturedModel).toBe("opus")
+  })
+
+  it("lets a generic subagent source override a conflicting primary mode", async () => {
+    await post({ ...BASE_REQUEST, model: "claude-opus-4-6" }, {
+      "x-opencode-agent-mode": "primary",
+      "x-meridian-source": "subagent-reviewer",
+    })
+    expect(capturedModel).toBe("opus")
+  })
+
   it("keeps an Opus primary on 1M while native Task agents use base opus", async () => {
     const response = await post({ ...BASE_REQUEST, model: "claude-opus-4-6", tools: [TASK_TOOL] }, {
       "x-opencode-agent-mode": "primary",

--- a/src/__tests__/proxy-subagent-model-selection.test.ts
+++ b/src/__tests__/proxy-subagent-model-selection.test.ts
@@ -9,9 +9,11 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
 let capturedModel: string | null = null
+let capturedOptions: any = null
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
+    capturedOptions = opts.options
     capturedModel = opts.options?.model ?? null
     return (async function* () {
       yield {
@@ -30,7 +32,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       }
     })()
   },
-  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { registerTool: () => {} } }),
   tool: () => ({}),
 }))
 
@@ -89,10 +91,17 @@ const BASE_REQUEST = {
   messages: [{ role: "user", content: "hi" }],
 }
 
+const TASK_TOOL = {
+  name: "Task",
+  description: "Available agent types:\n- reviewer: Reviews code",
+  input_schema: { type: "object", properties: {} },
+}
+
 describe("Subagent model selection", () => {
   beforeEach(() => {
     clearSessionCache()
     capturedModel = null
+    capturedOptions = null
   })
 
   it("primary agent gets sonnet (200k) for max subscription", async () => {
@@ -119,6 +128,32 @@ describe("Subagent model selection", () => {
   it("primary agent with opus gets opus[1m]", async () => {
     await post({ ...BASE_REQUEST, model: "claude-opus-4-6" }, { "x-opencode-agent-mode": "primary" })
     expect(capturedModel).toBe("opus[1m]")
+  })
+
+  it("a generic subagent source selects base opus without the OpenCode mode header", async () => {
+    await post({ ...BASE_REQUEST, model: "claude-opus-4-6" }, { "x-meridian-source": "subagent-reviewer" })
+    expect(capturedModel).toBe("opus")
+  })
+
+  it("a non-OpenCode adapter can select base opus through the generic source", async () => {
+    await post({ ...BASE_REQUEST, model: "claude-opus-4-6" }, {
+      "x-meridian-agent": "pi",
+      "x-meridian-source": "subagent-reviewer",
+    })
+    expect(capturedModel).toBe("opus")
+  })
+
+  it("keeps an Opus primary on 1M while native Task agents use base opus", async () => {
+    const response = await post({ ...BASE_REQUEST, model: "claude-opus-4-6", tools: [TASK_TOOL] }, {
+      "x-opencode-agent-mode": "primary",
+    })
+    if (response.status !== 200) throw new Error(await response.text())
+    expect(capturedModel).toBe("opus[1m]")
+    expect(Object.keys(capturedOptions.agents).length).toBeGreaterThan(0)
+    for (const def of Object.values(capturedOptions.agents) as any[]) {
+      expect(def.model).toBe("opus")
+    }
+    expect(capturedOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-4-6")
   })
 
   it("haiku is unaffected by agent mode", async () => {

--- a/src/__tests__/transform-parity.test.ts
+++ b/src/__tests__/transform-parity.test.ts
@@ -65,6 +65,20 @@ describe("OpenCode transform parity", () => {
     expect(ctx.sdkAgents).toEqual(openCodeAdapter.buildSdkAgents!(body, openCodeAdapter.getAllowedMcpTools()))
   })
 
+  it("matches base-tier SDK agents for an Opus Task request", () => {
+    const body = {
+      model: "claude-opus-5",
+      tools: [{
+        name: "Task",
+        description: "Available agent types:\n- reviewer: Reviews code",
+        input_schema: { type: "object", properties: {} },
+      }],
+    }
+    const ctx = runTransformHook(openCodeTransforms, "onRequest", makeCtx("opencode", body), "opencode")
+    expect(ctx.sdkAgents).toEqual(openCodeAdapter.buildSdkAgents!(body, openCodeAdapter.getAllowedMcpTools()))
+    for (const def of Object.values(ctx.sdkAgents)) expect(def.model).toBe("opus")
+  })
+
   it("matches buildSystemContextAddendum with no agents", () => {
     const body = { tools: [] }
     const ctx = runTransformHook(

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -24,6 +24,12 @@ export interface AgentIdentity {
   getSessionId(c: Context, body?: unknown): string | undefined
 
   /**
+   * Optional client-declared agent mode. Adapters own their header/protocol
+   * details; the proxy uses the normalized value for model-tier selection.
+   */
+  getAgentMode?(c: Context, body?: unknown): string | undefined
+
+  /**
    * Extract the SDK subprocess working directory from the request body.
    *
    * This path must exist on the proxy host because it becomes the SDK

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -11,7 +11,7 @@ import { type FileChange, extractFileChangesFromBash } from "../fileChanges"
 import { normalizeContent } from "../messages"
 import { extractClientCwd } from "../session/fingerprint"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../tools"
-import { buildAgentDefinitionsFromTool } from "../agentDefs"
+import { buildAgentDefinitionsFromTool, mapModelTier } from "../agentDefs"
 import { fuzzyMatchAgentName } from "../agentMatch"
 import { resolvePassthrough } from "../../env"
 
@@ -20,6 +20,11 @@ export const openCodeAdapter: AgentAdapter = {
 
   getSessionId(c: Context): string | undefined {
     return c.req.header("x-opencode-session") ?? c.req.header("x-session-affinity")
+  },
+
+  /** NOTE: OpenCode-specific. The plugin marks client-managed subagent turns. */
+  getAgentMode(c: Context): string | undefined {
+    return c.req.header("x-opencode-agent-mode")
   },
 
   extractWorkingDirectory(body: any): string | undefined {
@@ -75,7 +80,7 @@ export const openCodeAdapter: AgentAdapter = {
     if (!Array.isArray(body.tools)) return {}
     const taskTool = body.tools.find((t: any) => t.name === "task" || t.name === "Task")
     if (!taskTool) return {}
-    return buildAgentDefinitionsFromTool(taskTool, [...mcpToolNames])
+    return buildAgentDefinitionsFromTool(taskTool, [...mcpToolNames], mapModelTier(body.model))
   },
 
   /**

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -27,7 +27,7 @@ const DEFAULT_AGENT_TYPES: Record<string, string> = {
 }
 
 /** SDK-compatible agent definition */
-export type AgentModelTier = "sonnet" | "opus" | "haiku" | "inherit"
+export type AgentModelTier = "sonnet" | "opus" | "haiku" | "fable" | "inherit"
 
 export interface AgentDefinition {
   description: string
@@ -64,8 +64,8 @@ export function parseAgentDescriptions(taskDescription: string): Map<string, str
 /**
  * Map an OpenCode model string to an SDK model tier.
  *
- * The SDK only accepts 'sonnet' | 'opus' | 'haiku' | 'inherit'.
- * We map based on the model name pattern, defaulting to 'inherit'
+ * Agent definitions must use base model aliases rather than extended-context
+ * variants. We map based on the model name pattern, defaulting to 'inherit'
  * for non-Anthropic models (they'll use the parent session's model).
  */
 export function mapModelTier(model?: string): AgentModelTier {
@@ -75,6 +75,7 @@ export function mapModelTier(model?: string): AgentModelTier {
   // parent would keep native Task subagents on the expensive 1M window;
   // selecting "opus" explicitly preserves the intended 200k subagent tier.
   if (lower.includes("opus")) return "opus"
+  if (lower.includes("fable") || lower.includes("mythos")) return "fable"
   if (lower.includes("haiku")) return "haiku"
   if (lower.includes("sonnet")) return "sonnet"
   return "inherit"

--- a/src/proxy/agentDefs.ts
+++ b/src/proxy/agentDefs.ts
@@ -27,10 +27,12 @@ const DEFAULT_AGENT_TYPES: Record<string, string> = {
 }
 
 /** SDK-compatible agent definition */
+export type AgentModelTier = "sonnet" | "opus" | "haiku" | "inherit"
+
 export interface AgentDefinition {
   description: string
   prompt: string
-  model?: "sonnet" | "opus" | "haiku" | "inherit"
+  model?: AgentModelTier
   tools?: string[]
   disallowedTools?: string[]
 }
@@ -66,10 +68,13 @@ export function parseAgentDescriptions(taskDescription: string): Map<string, str
  * We map based on the model name pattern, defaulting to 'inherit'
  * for non-Anthropic models (they'll use the parent session's model).
  */
-export function mapModelTier(model?: string): "sonnet" | "opus" | "opus[1m]" | "haiku" | "inherit" {
+export function mapModelTier(model?: string): AgentModelTier {
   if (!model) return "inherit"
   const lower = model.toLowerCase()
-  if (lower.includes("opus")) return "opus[1m]"
+  // AgentDefinition only accepts base SDK tiers. Inheriting an opus[1m]
+  // parent would keep native Task subagents on the expensive 1M window;
+  // selecting "opus" explicitly preserves the intended 200k subagent tier.
+  if (lower.includes("opus")) return "opus"
   if (lower.includes("haiku")) return "haiku"
   if (lower.includes("sonnet")) return "sonnet"
   return "inherit"
@@ -81,15 +86,17 @@ export function mapModelTier(model?: string): "sonnet" | "opus" | "opus[1m]" | "
  * Each agent gets:
  * - description: from the Task tool text (user-configured)
  * - prompt: instructional prompt incorporating the description
- * - model: 'inherit' (uses parent session model — all requests go through our proxy)
+ * - model: the caller-selected base SDK tier; unknown models inherit the parent
  * - tools: undefined (inherit all tools from parent)
  *
  * @param taskDescription - The full Task tool description text from OpenCode
  * @param mcpToolNames - Optional list of MCP tool names to make available to agents
+ * @param modelTier - Base SDK tier for native Task subagents
  */
 export function buildAgentDefinitions(
   taskDescription: string,
-  mcpToolNames?: string[]
+  mcpToolNames?: string[],
+  modelTier: AgentModelTier = "inherit"
 ): Record<string, AgentDefinition> {
   const descriptions = parseAgentDescriptions(taskDescription)
   const agents: Record<string, AgentDefinition> = {}
@@ -98,7 +105,7 @@ export function buildAgentDefinitions(
     agents[name] = {
       description,
       prompt: buildAgentPrompt(name, description),
-      model: "inherit",
+      model: modelTier,
       // Give agents access to MCP tools if provided
       ...(mcpToolNames?.length ? { tools: [...mcpToolNames] } : {}),
     }
@@ -107,7 +114,7 @@ export function buildAgentDefinitions(
   // Inject defaults only when parsing yielded at least one agent.
   // If parsing yielded nothing, leave empty so the SDK uses its built-in types.
   if (descriptions.size > 0) {
-    ensureDefaultAgents(agents, mcpToolNames)
+    ensureDefaultAgents(agents, mcpToolNames, modelTier)
     addCaseVariants(agents)
   }
 
@@ -120,14 +127,15 @@ export function buildAgentDefinitions(
  */
 function ensureDefaultAgents(
   agents: Record<string, AgentDefinition>,
-  mcpToolNames?: string[]
+  mcpToolNames: string[] | undefined,
+  modelTier: AgentModelTier
 ): void {
   for (const [name, description] of Object.entries(DEFAULT_AGENT_TYPES)) {
     if (!agents[name]) {
       agents[name] = {
         description,
         prompt: buildAgentPrompt(name, description),
-        model: "inherit",
+        model: modelTier,
         ...(mcpToolNames?.length ? { tools: [...mcpToolNames] } : {}),
       }
     }
@@ -196,11 +204,12 @@ export function parseAgentNamesFromSchema(taskTool: unknown): string[] {
 
 export function buildAgentDefinitionsFromTool(
   taskTool: unknown,
-  mcpToolNames?: string[]
+  mcpToolNames?: string[],
+  modelTier: AgentModelTier = "inherit"
 ): Record<string, AgentDefinition> {
   const rawDescription = getNested(taskTool, "description")
   const description = typeof rawDescription === "string" ? rawDescription : ""
-  const fromDescription = buildAgentDefinitions(description, mcpToolNames)
+  const fromDescription = buildAgentDefinitions(description, mcpToolNames, modelTier)
   if (Object.keys(fromDescription).length > 0) return fromDescription
 
   const names = parseAgentNamesFromSchema(taskTool)
@@ -213,11 +222,11 @@ export function buildAgentDefinitionsFromTool(
     agents[name] = {
       description: desc,
       prompt: buildAgentPrompt(name, desc),
-      model: "inherit",
+      model: modelTier,
       ...(mcpToolNames?.length ? { tools: [...mcpToolNames] } : {}),
     }
   }
-  ensureDefaultAgents(agents, mcpToolNames)
+  ensureDefaultAgents(agents, mcpToolNames, modelTier)
   addCaseVariants(agents)
   return agents
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1022,12 +1022,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           profile.id !== "default" ? profile.id : undefined,
           Object.keys(profile.env).length > 0 ? profile.env : undefined
         )
-        const agentMode = c.req.header("x-opencode-agent-mode") ?? null
         // Opaque tag clients can send to distinguish concurrent request flows
         // from the same conversation (e.g., pylon's main chat vs. memory-extract fork vs. subagent).
         // Logged for observability; fork-*/subagent-* values also skip fingerprint cache (see below).
         // Examples: "main", "fork-memory-extract", "subagent-scout".
         const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
+        const declaredAgentMode = adapter.getAgentMode?.(c, body) ?? null
+        // A generic subagent source and an adapter-specific mode declaration
+        // describe the same semantic fact. Treat either as authoritative so a
+        // client cannot accidentally get cache isolation without the base model
+        // tier (or the base tier without safe headerless cache isolation).
+        const isSubagentRequest =
+          declaredAgentMode === "subagent" || requestSource?.startsWith("subagent-") === true
+        const agentMode = isSubagentRequest ? "subagent" : declaredAgentMode
         const requestedModel = typeof body.model === "string" ? body.model : "sonnet"
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode)
         // Explicitly versioned ids override their tier's canonical pin for
@@ -1251,12 +1258,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // each flow writes different message hashes to the shared key.
         //
         // When x-meridian-source marks a request as an independent fork or
-        // subagent, skip fingerprint lookup (no reclassification) and skip the
-        // write at end of turn (no cache pollution). The main conversation
-        // keeps its cache entry intact across forks.
+        // either supported signal marks it as a subagent, skip fingerprint
+        // lookup (no reclassification) and skip the write at end of turn (no
+        // cache pollution). The main conversation keeps its cache entry intact.
         //
-        // Opt-in via header value: clients that don't set the header are
-        // unaffected — behavior is byte-identical to today.
+        // Clients that declare neither an independent source nor a subagent
+        // mode retain the normal fingerprint-cache behavior.
         // Client-driven passthrough loop: the last message is a tool_result,
         // i.e. the client executed a forwarded tool and is sending the result
         // back to continue its own loop. These requests are self-contained
@@ -1278,14 +1285,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // as unrelated headerless workflow requests.
         const isClientDrivenLoop = adapterBase !== "claude-code" && !agentSessionId && lastIsToolResult
         // The fork/subagent independence guard protects HEADERLESS flows from
-        // colliding on the shared (firstUserMessage, cwd) fingerprint. An
+        // colliding on the shared (firstUserMessage, cwd) fingerprint. Adapter
+        // mode and generic source declarations share the subagent behavior. An
         // explicit session key can't collide — distinct flows carry distinct
         // keys — so keyed requests resume normally even when marked as a
         // fork/subagent source. Without this, pylon's long-lived subagent
         // workers fresh-replayed every turn: prompt-cache hits decayed to the
         // static-prefix floor and turn latency grew with conversation length.
         const isIndependentSession =
-          (!agentSessionId && (requestSource?.startsWith("fork-") || requestSource?.startsWith("subagent-"))) ||
+          (!agentSessionId && (requestSource?.startsWith("fork-") || isSubagentRequest)) ||
           isClientDrivenLoop || false
         let lineageResult: LineageResult = isIndependentSession
           ? { type: "diverged", reason: "independent-request" }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1027,7 +1027,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // Logged for observability; fork-*/subagent-* values also skip fingerprint cache (see below).
         // Examples: "main", "fork-memory-extract", "subagent-scout".
         const requestSource = c.req.header("x-meridian-source")?.slice(0, 64) || undefined
-        const declaredAgentMode = adapter.getAgentMode?.(c, body) ?? null
+        // NOTE: OpenCode-specific legacy fallback. Older integrations sent
+        // this header even when another adapter was selected; preserve that
+        // behavior while adapters migrate to the normalized extension point.
+        const declaredAgentMode =
+          adapter.getAgentMode?.(c, body) ?? c.req.header("x-opencode-agent-mode") ?? null
         // A generic subagent source and an adapter-specific mode declaration
         // describe the same semantic fact. Treat either as authoritative so a
         // client cannot accidentally get cache isolation without the base model
@@ -1307,13 +1311,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (lineageResult.type === "undo" && adapterBase === "opencode" && !agentSessionId) {
           lineageResult = { type: "diverged", reason: "missing-session-header" }
         }
-        // Clients that declare a concurrent flow (x-meridian-source fork-/
-        // subagent-) knowingly run parallel turns under one session key — see
+        // Clients that declare a concurrent flow (a fork source or either
+        // subagent signal) knowingly run parallel turns under one session key — see
         // the keyed fork/subagent note above. Serializing them is still worth
         // doing, but a reclassification is their normal cost; refusing them
         // would break flows that worked before turn coordination existed.
         const declaresConcurrentFlow =
-          requestSource?.startsWith("fork-") === true || requestSource?.startsWith("subagent-") === true
+          requestSource?.startsWith("fork-") === true || isSubagentRequest
         if (
           profileSessionId &&
           !declaresConcurrentFlow &&

--- a/src/proxy/transforms/opencode.ts
+++ b/src/proxy/transforms/opencode.ts
@@ -1,7 +1,7 @@
 import type { Transform, RequestContext } from "../transform"
 import { extractFileChangesFromBash, type FileChange } from "../fileChanges"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, ALLOWED_MCP_TOOLS } from "../tools"
-import { buildAgentDefinitionsFromTool } from "../agentDefs"
+import { buildAgentDefinitionsFromTool, mapModelTier } from "../agentDefs"
 import { fuzzyMatchAgentName } from "../agentMatch"
 import { resolvePassthrough } from "../../env"
 
@@ -32,7 +32,7 @@ export const openCodeTransforms: Transform[] = [
       if (Array.isArray(body.tools)) {
         const taskTool = body.tools.find((t: any) => t.name === "task" || t.name === "Task")
         if (taskTool) {
-          sdkAgents = buildAgentDefinitionsFromTool(taskTool, [...allowedMcpTools])
+          sdkAgents = buildAgentDefinitionsFromTool(taskTool, [...allowedMcpTools], mapModelTier(body.model))
         }
       }
 


### PR DESCRIPTION
## Summary
- assign SDK-native Task agents an explicit base model tier instead of inheriting 1M parents
- unify adapter agent-mode and generic subagent-source routing
- preserve keyed subagent session resume while isolating headerless fingerprints

## Validation
- npm test (2,766 passed, 1 skipped)
- npm run typecheck
- npm run build
- live three-turn Opus subagent-source session: new -> continuation -> continuation, 98% cache hits on resumed turns
- live Opus primary request with Task definitions accepted by the real SDK while remaining on opus[1m]
