### PR TITLE
feat: rename a profile from the CLI and the web UI

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -46,7 +46,7 @@ See https://github.com/rynfar/meridian for full documentation.`)
 }
 
 if (args[0] === "profile") {
-  const { profileAdd, profileAddOauthToken, profileList, profileRemove, profileSwitch, profileLogin, profileHelp } = await import("../src/proxy/profileCli")
+  const { profileAdd, profileAddOauthToken, profileList, profileRemove, profileRename, profileSwitch, profileLogin, profileHelp } = await import("../src/proxy/profileCli")
   const subcommand = args[1]
   const profileId = args[2]
   const headless = args.includes("--headless")
@@ -62,6 +62,7 @@ if (args[0] === "profile") {
   }
   else if (subcommand === "list" || subcommand === "ls") profileList()
   else if (subcommand === "remove" && profileId) profileRemove(profileId)
+  else if (subcommand === "rename" && profileId && args[3]) profileRename(profileId, args[3])
   else if (subcommand === "switch" && profileId) await profileSwitch(profileId)
   else if (subcommand === "login" && profileId) await profileLogin(profileId, { headless })
   else profileHelp()

--- a/src/__tests__/profile-rename.test.ts
+++ b/src/__tests__/profile-rename.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for profileRename.ts and the alias half of profiles.ts.
+ *
+ * Everything on disk here lives in a throwaway config dir — no test may read,
+ * move or write anything under the developer's real ~/.config/meridian.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  applyProfileRename,
+  isValidProfileId,
+  planProfileRename,
+  reclaimAlias,
+} from "../proxy/profileRename"
+import {
+  findProfileByIdOrAlias,
+  listProfiles,
+  resolveProfile,
+  resetActiveProfile,
+  type ProfileConfig,
+} from "../proxy/profiles"
+import { setSetting, getSetting } from "../proxy/settings"
+
+const PROFILES_DIR = "/cfg/meridian/profiles"
+
+beforeEach(() => {
+  resetActiveProfile()
+})
+
+describe("isValidProfileId", () => {
+  test("accepts letters, numbers, hyphens and underscores", () => {
+    for (const id of ["work", "Work2", "my-profile", "my_profile", "a"]) {
+      expect(isValidProfileId(id)).toBe(true)
+    }
+  })
+
+  test("rejects empty and anything outside the charset", () => {
+    for (const id of ["", "with space", "dot.name", "slash/name", "..", "emoji🙂", "quote\"name"]) {
+      expect(isValidProfileId(id)).toBe(false)
+    }
+  })
+})
+
+describe("reclaimAlias", () => {
+  test("drops the name from whichever profile redirects it", () => {
+    const profiles: ProfileConfig[] = [
+      { id: "z", aliases: ["x", "y"] },
+      { id: "other" },
+    ]
+    const next = reclaimAlias(profiles, "x")
+    expect(next[0]!.aliases).toEqual(["y"])
+    expect(next[1]).toBe(profiles[1]!)
+  })
+
+  test("removes the key entirely when the last alias goes", () => {
+    const next = reclaimAlias([{ id: "z", aliases: ["x"] }], "x")
+    expect(next[0]!.aliases).toBeUndefined()
+    expect("aliases" in next[0]!).toBe(false)
+  })
+
+  test("leaves the list untouched when nothing redirects that name", () => {
+    const profiles: ProfileConfig[] = [{ id: "z", aliases: ["x"] }]
+    expect(reclaimAlias(profiles, "nothing")[0]).toBe(profiles[0]!)
+  })
+})
+
+describe("planProfileRename — refusals", () => {
+  const profiles: ProfileConfig[] = [
+    { id: "work", claudeConfigDir: join(PROFILES_DIR, "work") },
+    { id: "personal", claudeConfigDir: join(PROFILES_DIR, "personal") },
+  ]
+
+  test("refuses a profile that does not exist", () => {
+    const result = planProfileRename(profiles, "ghost", "new", PROFILES_DIR)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('"ghost" not found')
+  })
+
+  test("refuses a target that already exists", () => {
+    const result = planProfileRename(profiles, "work", "personal", PROFILES_DIR)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain('"personal" already exists')
+  })
+
+  test("refuses an invalid target name", () => {
+    const result = planProfileRename(profiles, "work", "not a name", PROFILES_DIR)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toContain("Invalid profile name")
+  })
+
+  test("refuses renaming a profile to the name it already has", () => {
+    const result = planProfileRename(profiles, "work", "work", PROFILES_DIR)
+    expect(result.ok).toBe(false)
+  })
+
+  test("a refusal plans nothing at all", () => {
+    const before = JSON.stringify(profiles)
+    planProfileRename(profiles, "work", "personal", PROFILES_DIR)
+    expect(JSON.stringify(profiles)).toBe(before)
+  })
+})
+
+describe("planProfileRename — what moves", () => {
+  test("renames the entry, rewrites its config dir, and moves the credentials", () => {
+    const profiles: ProfileConfig[] = [{ id: "work", claudeConfigDir: join(PROFILES_DIR, "work") }]
+    const result = planProfileRename(profiles, "work", "employer", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.profiles[0]!.id).toBe("employer")
+    expect(result.plan.profiles[0]!.claudeConfigDir).toBe(join(PROFILES_DIR, "employer"))
+    expect(result.plan.dirMove).toEqual({
+      from: join(PROFILES_DIR, "work"),
+      to: join(PROFILES_DIR, "employer"),
+    })
+  })
+
+  test("moves the isolation dir of an oauth-token profile", () => {
+    const profiles: ProfileConfig[] = [{ id: "ci", type: "oauth-token", oauthToken: "placeholder" }]
+    const result = planProfileRename(profiles, "ci", "builder", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.dirMove).toEqual({
+      from: join(PROFILES_DIR, "ci"),
+      to: join(PROFILES_DIR, "builder"),
+    })
+  })
+
+  test("does not touch credentials it never owned (imported ~/.claude)", () => {
+    const profiles: ProfileConfig[] = [{ id: "work", claudeConfigDir: "/home/someone/.claude" }]
+    const result = planProfileRename(profiles, "work", "employer", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.dirMove).toBeUndefined()
+    expect(result.plan.profiles[0]!.claudeConfigDir).toBe("/home/someone/.claude")
+  })
+
+  test("an api profile has no directory to move", () => {
+    const profiles: ProfileConfig[] = [{ id: "direct", type: "api", apiKey: "placeholder" }]
+    const result = planProfileRename(profiles, "direct", "vendor", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.dirMove).toBeUndefined()
+  })
+})
+
+describe("planProfileRename — aliases", () => {
+  test("the old name becomes an alias of the new one", () => {
+    const result = planProfileRename([{ id: "x" }], "x", "y", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.aliases).toEqual(["x"])
+    expect(result.plan.profiles[0]!.aliases).toEqual(["x"])
+  })
+
+  test("collapses chains: x→y then y→z leaves z answering to both", () => {
+    const first = planProfileRename([{ id: "x" }], "x", "y", PROFILES_DIR)
+    expect(first.ok).toBe(true)
+    if (!first.ok) return
+    const second = planProfileRename(first.plan.profiles, "y", "z", PROFILES_DIR)
+    expect(second.ok).toBe(true)
+    if (!second.ok) return
+    expect(second.plan.profiles[0]!.id).toBe("z")
+    expect(second.plan.profiles[0]!.aliases!.sort()).toEqual(["x", "y"])
+  })
+
+  test("renaming back to a former name does not alias a profile to itself", () => {
+    const result = planProfileRename([{ id: "y", aliases: ["x"] }], "y", "x", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.profiles[0]!.id).toBe("x")
+    expect(result.plan.profiles[0]!.aliases).toEqual(["y"])
+  })
+
+  test("renaming TO a name another profile redirects reclaims it", () => {
+    const profiles: ProfileConfig[] = [
+      { id: "z", aliases: ["x", "y"] },
+      { id: "w" },
+    ]
+    const result = planProfileRename(profiles, "w", "x", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.plan.profiles.find(p => p.id === "z")!.aliases).toEqual(["y"])
+    expect(result.plan.profiles.find(p => p.id === "x")!.aliases).toEqual(["w"])
+  })
+
+  test("aliases never accumulate duplicates", () => {
+    const result = planProfileRename([{ id: "y", aliases: ["x"] }], "y", "z", PROFILES_DIR)
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const again = planProfileRename(result.plan.profiles, "z", "y", PROFILES_DIR)
+    expect(again.ok).toBe(true)
+    if (!again.ok) return
+    expect(again.plan.profiles[0]!.aliases!.sort()).toEqual(["x", "z"])
+  })
+})
+
+describe("alias resolution", () => {
+  test("a request naming the old profile is served by the renamed one", () => {
+    const profiles: ProfileConfig[] = [
+      { id: "employer", claudeConfigDir: "/cfg/employer", aliases: ["work"] },
+    ]
+    const resolved = resolveProfile(profiles, undefined, "work")
+    expect(resolved.id).toBe("employer")
+    expect(resolved.env).toEqual({ CLAUDE_CONFIG_DIR: "/cfg/employer" })
+  })
+
+  test("a real profile always wins over an alias of the same name", () => {
+    const profiles: ProfileConfig[] = [
+      { id: "employer", claudeConfigDir: "/cfg/employer", aliases: ["work"] },
+      { id: "work", claudeConfigDir: "/cfg/work" },
+    ]
+    const resolved = resolveProfile(profiles, undefined, "work")
+    expect(resolved.id).toBe("work")
+    expect(resolved.env).toEqual({ CLAUDE_CONFIG_DIR: "/cfg/work" })
+  })
+
+  test("order on disk cannot change which one wins", () => {
+    const profiles: ProfileConfig[] = [
+      { id: "work", claudeConfigDir: "/cfg/work" },
+      { id: "employer", claudeConfigDir: "/cfg/employer", aliases: ["work"] },
+    ]
+    expect(resolveProfile(profiles, undefined, "work").id).toBe("work")
+  })
+
+  test("once the alias is reclaimed the redirect is gone", () => {
+    const renamed: ProfileConfig[] = [{ id: "employer", aliases: ["work"] }]
+    const afterAdd = [...reclaimAlias(renamed, "work"), { id: "work", claudeConfigDir: "/cfg/work" }]
+    expect(resolveProfile(afterAdd, undefined, "work").id).toBe("work")
+    expect(findProfileByIdOrAlias(afterAdd, "work")!.id).toBe("work")
+  })
+
+  test("an unknown name still falls back to the first profile", () => {
+    const profiles: ProfileConfig[] = [{ id: "employer", aliases: ["work"] }, { id: "other" }]
+    expect(resolveProfile(profiles, undefined, "nothing").id).toBe("employer")
+  })
+
+  test("listProfiles exposes aliases only when there are some", () => {
+    const listed = listProfiles([{ id: "employer", aliases: ["work"] }, { id: "solo" }], undefined)
+    expect(listed[0]!.aliases).toEqual(["work"])
+    expect(listed[1]!.aliases).toBeUndefined()
+  })
+})
+
+describe("applyProfileRename", () => {
+  let root: string
+  let profilesDir: string
+  let configFile: string
+  let savedConfigDir: string | undefined
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "meridian-rename-"))
+    profilesDir = join(root, "profiles")
+    configFile = join(root, "profiles.json")
+    mkdirSync(profilesDir, { recursive: true })
+    savedConfigDir = process.env.MERIDIAN_CONFIG_DIR
+    process.env.MERIDIAN_CONFIG_DIR = root
+  })
+
+  afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.MERIDIAN_CONFIG_DIR = savedConfigDir
+    else delete process.env.MERIDIAN_CONFIG_DIR
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function seed(profiles: ProfileConfig[]): void {
+    writeFileSync(configFile, JSON.stringify(profiles, null, 2))
+  }
+
+  function readConfig(): ProfileConfig[] {
+    return JSON.parse(readFileSync(configFile, "utf-8"))
+  }
+
+  test("moves the credential directory and the config entry together", () => {
+    const workDir = join(profilesDir, "work")
+    mkdirSync(workDir)
+    writeFileSync(join(workDir, ".credentials.json"), "{}")
+    seed([{ id: "work", claudeConfigDir: workDir }])
+
+    const result = applyProfileRename("work", "employer", { profilesDir, configFile })
+
+    expect(result.ok).toBe(true)
+    expect(existsSync(workDir)).toBe(false)
+    expect(existsSync(join(profilesDir, "employer", ".credentials.json"))).toBe(true)
+    const saved = readConfig()
+    expect(saved[0]!.id).toBe("employer")
+    expect(saved[0]!.claudeConfigDir).toBe(join(profilesDir, "employer"))
+    expect(saved[0]!.aliases).toEqual(["work"])
+  })
+
+  test("refuses when the destination directory is already occupied", () => {
+    mkdirSync(join(profilesDir, "work"))
+    mkdirSync(join(profilesDir, "employer"))
+    seed([{ id: "work", claudeConfigDir: join(profilesDir, "work") }])
+
+    const result = applyProfileRename("work", "employer", { profilesDir, configFile })
+
+    expect(result.ok).toBe(false)
+    expect(existsSync(join(profilesDir, "work"))).toBe(true)
+    expect(readConfig()[0]!.id).toBe("work")
+  })
+
+  test("refuses a duplicate without moving anything", () => {
+    mkdirSync(join(profilesDir, "work"))
+    seed([
+      { id: "work", claudeConfigDir: join(profilesDir, "work") },
+      { id: "personal" },
+    ])
+
+    const result = applyProfileRename("work", "personal", { profilesDir, configFile })
+
+    expect(result.ok).toBe(false)
+    expect(existsSync(join(profilesDir, "work"))).toBe(true)
+    expect(readConfig()[0]!.id).toBe("work")
+  })
+
+  test("puts the credentials back when the profile list cannot be written", () => {
+    if (process.getuid?.() === 0) return // root ignores the read-only bit
+    const workDir = join(profilesDir, "work")
+    mkdirSync(workDir)
+    seed([{ id: "work", claudeConfigDir: workDir }])
+    chmodSync(configFile, 0o444)
+
+    const result = applyProfileRename("work", "employer", { profilesDir, configFile })
+
+    expect(result.ok).toBe(false)
+    expect(existsSync(workDir)).toBe(true)
+    expect(existsSync(join(profilesDir, "employer"))).toBe(false)
+    chmodSync(configFile, 0o644)
+    expect(readConfig()[0]!.id).toBe("work")
+  })
+
+  test("the active pointer follows the rename", () => {
+    seed([{ id: "work", claudeConfigDir: join(profilesDir, "work") }])
+    setSetting("activeProfile", "work")
+
+    const result = applyProfileRename("work", "employer", { profilesDir, configFile })
+
+    expect(result.ok).toBe(true)
+    expect(getSetting("activeProfile")).toBe("employer")
+  })
+
+  test("renaming a different profile leaves the active pointer alone", () => {
+    seed([{ id: "work" }, { id: "personal" }])
+    setSetting("activeProfile", "personal")
+
+    applyProfileRename("work", "employer", { profilesDir, configFile })
+
+    expect(getSetting("activeProfile")).toBe("personal")
+  })
+
+  test("a renamed profile still resolves under its old name", () => {
+    seed([{ id: "work", claudeConfigDir: join(profilesDir, "work") }])
+
+    const result = applyProfileRename("work", "employer", { profilesDir, configFile })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(resolveProfile(result.profiles, undefined, "work").id).toBe("employer")
+  })
+})

--- a/src/__tests__/profile-switch-integration.test.ts
+++ b/src/__tests__/profile-switch-integration.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
   clearSessionCache()
 })
 
-function createTestApp(profiles?: Array<{ id: string; claudeConfigDir?: string }>) {
+function createTestApp(profiles?: Array<{ id: string; claudeConfigDir?: string; aliases?: string[] }>) {
   const { app } = createProxyServer({
     port: 0,
     host: "127.0.0.1",
@@ -148,6 +148,67 @@ describe("Profile switch API", () => {
       body: JSON.stringify({ profile: "anything" }),
     }))
     expect(res.status).toBe(400)
+  })
+})
+
+describe("Profile rename API", () => {
+  const profiles = [
+    { id: "personal", claudeConfigDir: "/home/.claude" },
+    { id: "employer", claudeConfigDir: "/home/.claude-work", aliases: ["work"] },
+  ]
+
+  // Only the paths that refuse BEFORE touching disk are exercised here: the
+  // route writes to the real ~/.config/meridian/profiles.json, which no test
+  // may touch. Everything past the refusals is unit-tested against a temp dir
+  // in profile-rename.test.ts.
+  test("POST /profiles/rename requires both names", async () => {
+    const app = createTestApp(profiles)
+
+    const res = await app.fetch(req("/profiles/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ from: "personal" }),
+    }))
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string }
+    expect(body.error).toContain("'from' or 'to'")
+  })
+
+  test("POST /profiles/rename rejects a malformed body", async () => {
+    const app = createTestApp(profiles)
+
+    const res = await app.fetch(req("/profiles/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{ not json",
+    }))
+    expect(res.status).toBe(400)
+  })
+
+  test("POST /profiles/rename refuses when credentials are read-only", async () => {
+    const app = createTestApp(profiles)
+    process.env.MERIDIAN_CREDENTIALS_READONLY = "1"
+    try {
+      const res = await app.fetch(req("/profiles/rename", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from: "personal", to: "renamed" }),
+      }))
+      expect(res.status).toBe(403)
+      const body = await res.json() as { error: string }
+      expect(body.error).toContain("MERIDIAN_CREDENTIALS_READONLY")
+    } finally {
+      delete process.env.MERIDIAN_CREDENTIALS_READONLY
+    }
+  })
+
+  test("GET /profiles/list surfaces the names a rename left behind", async () => {
+    const app = createTestApp(profiles)
+
+    const res = await app.fetch(req("/profiles/list"))
+    const body = await res.json() as { profiles: Array<{ id: string; aliases?: string[] }> }
+    expect(body.profiles.find(p => p.id === "employer")!.aliases).toEqual(["work"])
+    expect(body.profiles.find(p => p.id === "personal")!.aliases).toBeUndefined()
   })
 })
 

--- a/src/proxy/profileCli.ts
+++ b/src/proxy/profileCli.ts
@@ -11,16 +11,25 @@
 
 import { execFileSync, spawnSync } from "node:child_process"
 import { createHash, randomBytes } from "node:crypto"
-import { mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs"
+import { mkdirSync, rmSync, existsSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
+import { envBool } from "../env"
 import { resolveClaudeExecutableSync } from "./models"
 import type { ProfileConfig } from "./profiles"
-import { setSetting } from "./settings"
+import {
+  applyProfileRename,
+  defaultProfilesConfigFile,
+  defaultProfilesDir,
+  loadProfileConfigFrom,
+  reclaimAlias,
+  saveProfileConfigTo,
+} from "./profileRename"
+import { getSetting, setSetting } from "./settings"
 import { createPlatformCredentialStore } from "./tokenRefresh"
 
-const PROFILES_DIR = join(homedir(), ".config", "meridian", "profiles")
-const CONFIG_FILE = join(homedir(), ".config", "meridian", "profiles.json")
+const PROFILES_DIR = defaultProfilesDir()
+const CONFIG_FILE = defaultProfilesConfigFile()
 const OAUTH_AUTHORIZE_URL = "https://claude.com/cai/oauth/authorize"
 export const OAUTH_TOKEN_URL = "https://platform.claude.com/v1/oauth/token"
 export const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
@@ -116,18 +125,12 @@ export function parseAuthorizationCodeInput(input: string): ParsedAuthorizationC
 }
 
 function loadProfileConfig(): ProfileConfig[] {
-  if (!existsSync(CONFIG_FILE)) return []
-  try {
-    return JSON.parse(readFileSync(CONFIG_FILE, "utf-8"))
-  } catch (err) {
-    console.warn(`[meridian] Failed to read ${CONFIG_FILE}: ${err instanceof Error ? err.message : err}`)
-    return []
-  }
+  return loadProfileConfigFrom(CONFIG_FILE)
 }
 
 function saveProfileConfig(profiles: ProfileConfig[]): void {
   ensureProfilesDir()
-  writeFileSync(CONFIG_FILE, `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
+  saveProfileConfigTo(CONFIG_FILE, profiles)
 }
 
 function getAuthStatus(configDir: string): { loggedIn: boolean; email?: string; subscriptionType?: string } {
@@ -232,12 +235,13 @@ export async function profileAdd(id: string, options: AuthLoginOptions = {}): Pr
     process.exit(1)
   }
 
-  const profiles = loadProfileConfig()
+  let profiles = loadProfileConfig()
   if (profiles.find(p => p.id === id)) {
     console.error(`\x1b[31m✗ Profile "${id}" already exists.\x1b[0m`)
     console.error(`  Run: meridian profile list`)
     process.exit(1)
   }
+  profiles = reclaimAlias(profiles, id)
 
   // Offer to import existing ~/.claude credentials if this is the first profile
   // and the default config dir has valid, active auth
@@ -338,12 +342,13 @@ export async function profileAddOauthToken(id: string, tokenArg: string | undefi
     process.exit(1)
   }
 
-  const profiles = loadProfileConfig()
+  let profiles = loadProfileConfig()
   if (profiles.find(p => p.id === id)) {
     console.error(`\x1b[31m✗ Profile "${id}" already exists.\x1b[0m`)
     console.error(`  Run: meridian profile list`)
     process.exit(1)
   }
+  profiles = reclaimAlias(profiles, id)
 
   let token = tokenArg?.trim() ?? ""
   if (!token) {
@@ -374,15 +379,19 @@ export function profileList(): void {
 
   console.log("Profiles:\n")
   for (const p of profiles) {
+    let status: string
     if (p.oauthToken || p.type === "oauth-token") {
-      console.log(`  ${p.id.padEnd(20)} \x1b[32m✓ OAuth token\x1b[0m`)
-      continue
+      status = "\x1b[32m✓ OAuth token\x1b[0m"
+    } else {
+      const auth = getAuthStatus(p.claudeConfigDir ?? "")
+      status = auth.loggedIn
+        ? `\x1b[32m✓ ${auth.email} (${auth.subscriptionType || "unknown"})\x1b[0m`
+        : "\x1b[31m✗ not logged in\x1b[0m"
     }
-    const auth = getAuthStatus(p.claudeConfigDir ?? "")
-    const status = auth.loggedIn
-      ? `\x1b[32m✓ ${auth.email} (${auth.subscriptionType || "unknown"})\x1b[0m`
-      : "\x1b[31m✗ not logged in\x1b[0m"
     console.log(`  ${p.id.padEnd(20)} ${status}`)
+    if (p.aliases && p.aliases.length > 0) {
+      console.log(`  ${"".padEnd(20)} \x1b[90malso answers to: ${p.aliases.join(", ")}\x1b[0m`)
+    }
   }
   console.log()
   printEnvHint(profiles)
@@ -434,6 +443,27 @@ export function profileRemove(id: string): void {
   if (profiles.length > 0) {
     printEnvHint(profiles)
   }
+}
+
+export function profileRename(from: string, to: string): void {
+  if (envBool("CREDENTIALS_READONLY")) {
+    console.error("\x1b[31m✗ MERIDIAN_CREDENTIALS_READONLY=1 — this instance may not modify credentials.\x1b[0m")
+    console.error("  Rename the profile from the instance that owns them.")
+    process.exit(1)
+  }
+
+  const wasActive = getSetting("activeProfile") === from
+  const result = applyProfileRename(from, to, { profilesDir: PROFILES_DIR, configFile: CONFIG_FILE })
+  if (!result.ok) {
+    console.error(`\x1b[31m✗ ${result.error}\x1b[0m`)
+    if (result.hint) console.error(`  ${result.hint}`)
+    process.exit(1)
+  }
+
+  console.log(`\x1b[32m✓ Profile "${from}" renamed to "${to}".\x1b[0m`)
+  console.log(`  Requests naming ${result.aliases.map(a => `"${a}"`).join(", ")} are served by "${to}" until the name is added again.`)
+  if (wasActive) console.log(`  Active profile is now "${to}".`)
+  printEnvHint(result.profiles)
 }
 
 export async function profileSwitch(id: string): Promise<void> {
@@ -588,6 +618,7 @@ Commands:
   meridian profile add <name> --oauth-token [TOKEN] Add a profile from a \`claude setup-token\` value
                                                     (if TOKEN is omitted, you will be prompted; input is hidden)
   meridian profile list                             List profiles and auth status
+  meridian profile rename <old> <new>               Rename a profile; <old> keeps routing to it until reused
   meridian profile remove <name>                    Remove a profile
   meridian profile switch <name>                    Switch the active profile (requires running proxy)
   meridian profile login <name> [--headless]        Re-authenticate an existing profile (claude-max only)
@@ -601,5 +632,6 @@ Examples:
                                                     # Add headless CI profile (token from CLI argument)
   meridian profile login work --headless            # Re-authenticate via OAuth URL/code prompt
   meridian profile switch work                      # Switch to work account
+  meridian profile rename work employer             # Rename; "work" still routes to it
   meridian profile list                             # Show all profiles`)
 }

--- a/src/proxy/profileRename.ts
+++ b/src/proxy/profileRename.ts
@@ -1,0 +1,221 @@
+/**
+ * Profile renaming.
+ *
+ * A rename has to move everything that names a profile: its entry in
+ * profiles.json and, when its credentials live under
+ * ~/.config/meridian/profiles/<id>, the credential directory itself. Renaming
+ * the entry alone would leave the profile pointing at a directory that is no
+ * longer its own — an account logged out by a cosmetic change — so both are
+ * planned together and applied as one step that either happens or does not.
+ *
+ * The old name survives as an ALIAS on the renamed profile. It is a redirect,
+ * not a second name: after `x` is renamed to `y`, `x-meridian-profile: x` is
+ * served by `y`, and the moment `x` is claimed again — by `profile add x`, or
+ * by renaming something else to `x` — the redirect is dropped.
+ *
+ * Chains are collapsed on write. Renaming x→y and later y→z leaves z holding
+ * both "x" and "y", so resolution is a single lookup and no alias can dangle
+ * at an intermediate name that no longer exists.
+ *
+ * This is a leaf module — no imports from server.ts or session/.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { homedir } from "node:os"
+import { getSetting, setSetting } from "./settings"
+import type { ProfileConfig } from "./profiles"
+
+/** Profile names are restricted to exactly what `meridian profile add` accepts. */
+const INVALID_PROFILE_ID = /[^a-zA-Z0-9_-]/
+
+export function isValidProfileId(id: string): boolean {
+  return id.length > 0 && !INVALID_PROFILE_ID.test(id)
+}
+
+export function defaultProfilesDir(): string {
+  return join(homedir(), ".config", "meridian", "profiles")
+}
+
+export function defaultProfilesConfigFile(): string {
+  return join(homedir(), ".config", "meridian", "profiles.json")
+}
+
+export function loadProfileConfigFrom(file: string): ProfileConfig[] {
+  if (!existsSync(file)) return []
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf-8"))
+    return Array.isArray(parsed) ? parsed : []
+  } catch (err) {
+    console.warn(`[meridian] Failed to read ${file}: ${err instanceof Error ? err.message : err}`)
+    return []
+  }
+}
+
+export function saveProfileConfigTo(file: string, profiles: ProfileConfig[]): void {
+  mkdirSync(dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(profiles, null, 2)}\n`, { mode: 0o600 })
+}
+
+/**
+ * Drop `name` from every profile's alias list — a real profile is claiming the
+ * name, so the redirect has to stop. Profiles with nothing to drop are
+ * returned as-is.
+ */
+export function reclaimAlias(profiles: ProfileConfig[], name: string): ProfileConfig[] {
+  return profiles.map(p => {
+    if (!p.aliases?.includes(name)) return p
+    const remaining = p.aliases.filter(a => a !== name)
+    const next: ProfileConfig = { ...p }
+    if (remaining.length > 0) next.aliases = remaining
+    else delete next.aliases
+    return next
+  })
+}
+
+export interface ProfileRenamePlan {
+  /** The complete profile list as it should be written to disk. */
+  profiles: ProfileConfig[]
+  /** Credential directory to move, when this profile keeps one under profilesDir. */
+  dirMove?: { from: string; to: string }
+  /** Aliases the renamed profile ends up carrying, chains already collapsed. */
+  aliases: string[]
+}
+
+export type ProfileRenameResult =
+  | { ok: true; plan: ProfileRenamePlan }
+  | { ok: false; error: string; hint?: string }
+
+/**
+ * Pure: decide what a rename would change. Refuses rather than corrupting —
+ * an unknown source, an occupied target, or a name the charset rejects each
+ * come back as an error with nothing planned.
+ */
+export function planProfileRename(
+  profiles: ProfileConfig[],
+  from: string,
+  to: string,
+  profilesDir: string,
+): ProfileRenameResult {
+  if (!isValidProfileId(to)) {
+    return {
+      ok: false,
+      error: `Invalid profile name "${to}".`,
+      hint: "Use only letters, numbers, hyphens, underscores.",
+    }
+  }
+  const target = profiles.find(p => p.id === from)
+  if (!target) {
+    return { ok: false, error: `Profile "${from}" not found.`, hint: "Run: meridian profile list" }
+  }
+  if (from === to) {
+    return { ok: false, error: `Profile "${from}" is already called that.` }
+  }
+  if (profiles.some(p => p.id === to)) {
+    return { ok: false, error: `Profile "${to}" already exists.`, hint: "Run: meridian profile list" }
+  }
+
+  const oldDir = join(profilesDir, from)
+  const newDir = join(profilesDir, to)
+  // Only a directory Meridian named after the profile moves. A profile that
+  // imported ~/.claude points at credentials that were never ours to rename.
+  const ownsDir = target.claudeConfigDir === oldDir
+  // oauth-token profiles have no claudeConfigDir on the entry, but the SDK is
+  // pinned to profilesDir/<id> for isolation (see profiles.ts) — that
+  // directory is named after the profile too, so it moves with it.
+  const isOauthToken = Boolean(target.oauthToken) || target.type === "oauth-token"
+
+  // Collapse chains: the renamed profile keeps every alias it already had and
+  // gains the name it is leaving behind. Filtering `to` covers renaming a
+  // profile back to one of its own former names.
+  const aliases = [...new Set([...(target.aliases ?? []), from])].filter(a => a !== to)
+
+  const renamed: ProfileConfig = { ...target, id: to, aliases }
+  if (ownsDir) renamed.claudeConfigDir = newDir
+
+  // Renaming TO a name another profile still redirects from claims it back.
+  const next = reclaimAlias(profiles, to).map(p => (p.id === from ? renamed : p))
+
+  const plan: ProfileRenamePlan = { profiles: next, aliases }
+  if (ownsDir || isOauthToken) plan.dirMove = { from: oldDir, to: newDir }
+  return { ok: true, plan }
+}
+
+export interface ApplyProfileRenameOptions {
+  /** Directory holding per-profile credential dirs. Defaults to the real one. */
+  profilesDir?: string
+  /** profiles.json path. Defaults to the real one. */
+  configFile?: string
+}
+
+export type ApplyProfileRenameResult =
+  | { ok: true; from: string; to: string; aliases: string[]; profiles: ProfileConfig[] }
+  | { ok: false; error: string; hint?: string }
+
+/**
+ * Apply a rename to disk: credentials first, then the profile list, then the
+ * active pointer. If the profile list cannot be written the credential move is
+ * undone, so the profile is never left naming a directory that moved out from
+ * under it.
+ */
+export function applyProfileRename(
+  from: string,
+  to: string,
+  options: ApplyProfileRenameOptions = {},
+): ApplyProfileRenameResult {
+  const profilesDir = options.profilesDir ?? defaultProfilesDir()
+  const configFile = options.configFile ?? defaultProfilesConfigFile()
+
+  const profiles = loadProfileConfigFrom(configFile)
+  const planned = planProfileRename(profiles, from, to, profilesDir)
+  if (!planned.ok) return planned
+  const { plan } = planned
+
+  // Credentials move first: a directory rename within one filesystem is
+  // atomic, and until profiles.json is written nothing else has changed — so
+  // a failure here leaves the profile exactly as it was.
+  let movedDir: { from: string; to: string } | undefined
+  if (plan.dirMove && existsSync(plan.dirMove.from)) {
+    if (existsSync(plan.dirMove.to)) {
+      return {
+        ok: false,
+        error: `Cannot rename to "${to}": ${plan.dirMove.to} already exists.`,
+        hint: "Remove or move that directory, then retry.",
+      }
+    }
+    try {
+      renameSync(plan.dirMove.from, plan.dirMove.to)
+      movedDir = plan.dirMove
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Could not move credentials for "${from}": ${err instanceof Error ? err.message : err}`,
+      }
+    }
+  }
+
+  try {
+    saveProfileConfigTo(configFile, plan.profiles)
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    if (movedDir) {
+      try {
+        renameSync(movedDir.to, movedDir.from)
+      } catch (undoErr) {
+        const undoReason = undoErr instanceof Error ? undoErr.message : String(undoErr)
+        return {
+          ok: false,
+          error: `Could not write ${configFile} (${reason}), and could not move credentials back (${undoReason}).`,
+          hint: `Profile "${from}" still expects its credentials at ${movedDir.from} — move ${movedDir.to} back by hand.`,
+        }
+      }
+    }
+    return { ok: false, error: `Could not write ${configFile}: ${reason}` }
+  }
+
+  // The active profile is stored as a name, so it has to follow the rename or
+  // the instance is left pointing at a profile that no longer exists.
+  if (getSetting("activeProfile") === from) setSetting("activeProfile", to)
+
+  return { ok: true, from, to, aliases: plan.aliases, profiles: plan.profiles }
+}

--- a/src/proxy/profiles.ts
+++ b/src/proxy/profiles.ts
@@ -52,6 +52,15 @@ export function loadProfilesFromDisk(): ProfileConfig[] {
   }
 }
 
+/**
+ * Drop the cached disk profiles so the next read hits the file. Called after
+ * a mutation this process performed (e.g. a rename via the UI), where waiting
+ * out the TTL would show the caller their own stale profile list.
+ */
+export function invalidateDiskProfileCache(): void {
+  diskProfilesCacheAt = 0
+}
+
 export type ProfileType = "claude-max" | "api" | "oauth-token"
 
 export interface ProfileConfig {
@@ -72,6 +81,13 @@ export interface ProfileConfig {
   baseUrl?: string
   /** Long-lived OAuth token from `claude setup-token` (oauth-token profiles) */
   oauthToken?: string
+  /**
+   * Former names left behind by `meridian profile rename`. Each is a redirect,
+   * not a second name: requests naming one are served by this profile until
+   * the name is claimed again. Chains are collapsed on write (see
+   * profileRename.ts), so every alias points straight at its current profile.
+   */
+  aliases?: string[]
 }
 
 export interface ResolvedProfile {
@@ -168,7 +184,11 @@ export interface ResolveProfileOptions {
  * Resolve a profile from the configuration.
  *
  * Priority: header > sticky assignment (routing="sticky" only) > active >
- * config default > first profile. The sticky step exists so multi-account
+ * config default > first profile. Whatever that yields is matched against
+ * profile ids first and rename aliases second, so a name a rename left behind
+ * keeps routing without ever shadowing a live profile.
+ *
+ * The sticky step exists so multi-account
  * setups can distribute sessions across profiles WITHOUT losing per-account
  * prompt caching — see routing.ts. With routingMode unset/"active" the
  * chain is exactly the pre-#383 behavior.
@@ -200,7 +220,7 @@ export function resolveProfile(
 
   // Priority: header > sticky > active > config default > first profile
   const resolvedId = requestedId || stickyId || activeProfileId || defaultProfile || effective[0]!.id
-  const profile = effective.find(p => p.id === resolvedId)
+  const profile = findProfileByIdOrAlias(effective, resolvedId)
 
   if (!profile) {
     console.warn(`[meridian] Unknown profile "${resolvedId}". Using first configured profile.`)
@@ -208,6 +228,18 @@ export function resolveProfile(
   }
 
   return buildResolvedProfile(profile)
+}
+
+/**
+ * Look a profile up by id, then by alias. Real profiles ALWAYS win: an alias
+ * is only a redirect left behind by a rename, and a stale one must never
+ * shadow a live account that has since taken the name.
+ */
+export function findProfileByIdOrAlias(
+  profiles: ProfileConfig[],
+  id: string
+): ProfileConfig | undefined {
+  return profiles.find(p => p.id === id) ?? profiles.find(p => p.aliases?.includes(id))
 }
 
 /**
@@ -248,7 +280,7 @@ function buildResolvedProfile(profile: ProfileConfig): ResolvedProfile {
 export function listProfiles(
   profiles: ProfileConfig[] | undefined,
   defaultProfile: string | undefined
-): Array<{ id: string; type: ProfileType; isActive: boolean }> {
+): Array<{ id: string; type: ProfileType; isActive: boolean; aliases?: string[] }> {
   const effective = getEffectiveProfiles(profiles)
   if (effective.length === 0) return []
 
@@ -257,5 +289,6 @@ export function listProfiles(
     id: p.id,
     type: p.type ?? "claude-max",
     isActive: p.id === currentActive,
+    ...(p.aliases && p.aliases.length > 0 ? { aliases: p.aliases } : {}),
   }))
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -80,7 +80,7 @@ import { runTransformHook, buildPipeline, createRequestContext } from "./transfo
 import { getAdapterTransforms } from "./transforms/registry"
 import { loadPlugins, getActiveTransforms } from "./plugins/loader"
 import type { LoadedPlugin } from "./plugins/types"
-import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, type ResolvedProfile } from "./profiles"
+import { resolveProfile, listProfiles, setActiveProfile, getActiveProfileId, getEffectiveProfiles, restoreActiveProfile, invalidateDiskProfileCache, type ResolvedProfile } from "./profiles"
 import { getRoutingMode, resolvePriorityOrder, choosePriorityProfile, ProfileExhaustion, AssignmentStore, resolveCooldownUntil } from "./routing"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
@@ -4835,6 +4835,41 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     })
     plog(`[PROXY] Active profile switched to: ${body.profile} (from ${previousProfile ?? "unset"}, ua: ${(c.req.header("user-agent") || "unknown").slice(0, 60)}) (session + rate-limit caches cleared)`)
     return c.json({ success: true, activeProfile: body.profile })
+  })
+
+  app.post("/profiles/rename", async (c) => {
+    let body: { from?: string; to?: string }
+    try {
+      body = await c.req.json() as { from?: string; to?: string }
+    } catch {
+      return c.json({ error: "Invalid JSON in request body" }, 400)
+    }
+    if (!body.from || !body.to) {
+      return c.json({ error: "Missing 'from' or 'to' in request body" }, 400)
+    }
+    if (envBool("CREDENTIALS_READONLY")) {
+      return c.json({ error: "MERIDIAN_CREDENTIALS_READONLY=1 — this instance may not modify credentials." }, 403)
+    }
+    const { applyProfileRename } = await import("./profileRename")
+    const result = applyProfileRename(body.from, body.to)
+    if (!result.ok) {
+      return c.json({ error: result.hint ? `${result.error} ${result.hint}` : result.error }, 400)
+    }
+    // The renamed profile is on disk now; drop the TTL cache so this caller's
+    // very next /profiles/list shows the new name instead of its own stale one.
+    invalidateDiskProfileCache()
+    // applyProfileRename moved the persisted pointer; this process holds its
+    // own copy in memory and has to be told as well.
+    if (getActiveProfileId() === body.from) setActiveProfile(body.to)
+    claudeLog("profile.renamed", {
+      from: result.from,
+      to: result.to,
+      aliases: result.aliases,
+      userAgent: c.req.header("user-agent")?.slice(0, 120) ?? null,
+      origin: c.req.header("origin") ?? c.req.header("referer")?.slice(0, 120) ?? null,
+    })
+    plog(`[PROXY] Profile renamed: ${result.from} -> ${result.to} (still answers to: ${result.aliases.join(", ")})`)
+    return c.json({ success: true, from: result.from, to: result.to, aliases: result.aliases })
   })
 
   // --- Plugin management routes ---

--- a/src/telemetry/profilePage.ts
+++ b/src/telemetry/profilePage.ts
@@ -31,6 +31,21 @@ export const profilePageHtml = `<!DOCTYPE html>
   .profile-card.active { border-color: var(--accent); }
   .profile-card-header { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
   .profile-name { font-size: 16px; font-weight: 600; }
+  .profile-card-actions { margin-left: auto; display: flex; align-items: center; gap: 6px; }
+  .icon-btn {
+    background: var(--bg); color: var(--muted); border: 1px solid var(--border);
+    border-radius: 4px; padding: 4px 6px; cursor: pointer; display: inline-flex;
+    align-items: center; transition: all 0.15s;
+  }
+  .icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .rename-input {
+    background: var(--surface2); color: var(--text); border: 1px solid var(--accent);
+    border-radius: 6px; padding: 4px 8px; font-size: 14px; font-weight: 600;
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace; width: 200px;
+  }
+  .rename-input:focus { outline: none; }
+  .rename-hint { font-size: 11px; color: var(--muted); }
+  .rename-error { font-size: 12px; color: var(--red); margin-bottom: 12px; }
   .profile-badge {
     font-size: 10px; padding: 2px 8px; border-radius: 4px; text-transform: uppercase;
     letter-spacing: 0.5px; font-weight: 500;
@@ -177,8 +192,14 @@ export const profilePageHtml = `<!DOCTYPE html>
     <div style="font-size:13px;margin-top:8px">
       <code>meridian profile list</code> \u2014 show all profiles and auth status<br>
       <code>meridian profile login &lt;name&gt;</code> \u2014 re-authenticate an expired profile<br>
+      <code>meridian profile rename &lt;old&gt; &lt;new&gt;</code> \u2014 rename a profile (or use the pencil above)<br>
       <code>meridian profile remove &lt;name&gt;</code> \u2014 remove a profile
     </div>
+    <p style="font-size:13px;color:var(--muted);margin-top:12px">
+      Renaming keeps the old name working: requests still naming it are served by
+      the renamed profile, so nothing breaks mid-flight. That redirect is dropped
+      as soon as the old name is taken again by a new profile.
+    </p>
   </div>
 </div>
 </div>
@@ -237,8 +258,70 @@ function formatExtraUsage(eu) {
 // Cache the last seen quota response so the /profiles/list refresh can
 // keep showing usage even if a single /v1/usage/quota/all call fails.
 var lastQuota = null;
+// Last profile payload, so a rename can redraw from cache without refetching.
+var lastProfiles = null;
+// Profile whose name is being edited in place, and the error from the last
+// rejected attempt. While editing, the poll is suspended — it rewrites
+// innerHTML, which would blank the input mid-keystroke.
+var editingProfile = null;
+var renameError = null;
+
+var ICON_PENCIL = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M11.013 1.427a1.75 1.75 0 012.474 0l1.086 1.086a1.75 1.75 0 010 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 01-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61zm1.414 1.06a.25.25 0 00-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 000-.354l-1.086-1.086zM11.189 6.25L9.75 4.81l-6.286 6.287a.25.25 0 00-.064.108l-.558 1.953 1.953-.558a.249.249 0 00.108-.064l6.286-6.286z"/></svg>';
+var ICON_CHECK = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"/></svg>';
+var ICON_X = '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z"/></svg>';
+
+function focusRenameInput() {
+  var el = document.getElementById('rename-input');
+  if (el) { el.focus(); el.select(); }
+}
+
+function redraw() {
+  if (lastProfiles) render(lastProfiles, lastQuota);
+}
+
+function startRename(id) {
+  editingProfile = id;
+  renameError = null;
+  redraw();
+  focusRenameInput();
+}
+
+function cancelRename() {
+  editingProfile = null;
+  renameError = null;
+  redraw();
+}
+
+async function commitRename(from) {
+  var input = document.getElementById('rename-input');
+  if (!input) return;
+  var to = input.value.trim();
+  if (!to || to === from) { cancelRename(); return; }
+  var data;
+  try {
+    var res = await fetch('/profiles/rename', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: from, to: to })
+    });
+    data = await res.json();
+  } catch (err) {
+    data = { error: 'Could not reach Meridian.' };
+  }
+  if (data && data.success) {
+    editingProfile = null;
+    renameError = null;
+    await refresh();
+    if (window.meridianHeaderRefresh) window.meridianHeaderRefresh();
+    return;
+  }
+  renameError = (data && data.error) || 'Rename failed.';
+  redraw();
+  focusRenameInput();
+}
 
 async function refresh() {
+  if (editingProfile) return;
   try {
     var [profilesRes, quotaRes] = await Promise.all([
       fetch('/profiles/list'),
@@ -250,6 +333,7 @@ async function refresh() {
       try { quota = await quotaRes.json(); } catch (_) { quota = null; }
     }
     if (quota) lastQuota = quota;
+    lastProfiles = profiles;
     render(profiles, lastQuota);
   } catch {
     document.getElementById('content').innerHTML = '<div class="empty-state"><h2>Could not load profiles</h2><p>Is Meridian running?</p></div>';
@@ -359,10 +443,28 @@ function render(data, quotaData) {
     const isActive = p.id === active;
     html += '<div class="profile-card' + (isActive ? ' active' : '') + '">';
     html += '<div class="profile-card-header">';
-    html += '<span class="profile-name">' + esc(p.id) + '</span>';
-    if (isActive) html += '<span class="profile-badge badge-active">active</span>';
-    html += '<span class="profile-badge badge-type">' + esc(p.type || 'claude-max') + '</span>';
+    if (editingProfile === p.id) {
+      html += '<input class="rename-input" id="rename-input" value="' + esc(p.id) + '" spellcheck="false" autocomplete="off"'
+        + ' onkeydown="if(event.key===&quot;Enter&quot;){event.preventDefault();commitRename(&quot;' + esc(p.id) + '&quot;)}'
+        + 'else if(event.key===&quot;Escape&quot;){cancelRename()}">';
+      html += '<span class="rename-hint">Enter to save \u00b7 Esc to cancel</span>';
+      html += '<span class="profile-card-actions">';
+      html += '<button class="icon-btn" title="Save new name" onclick="commitRename(&quot;'+esc(p.id)+'&quot;)">' + ICON_CHECK + '</button>';
+      html += '<button class="icon-btn" title="Cancel" onclick="cancelRename()">' + ICON_X + '</button>';
+      html += '</span>';
+    } else {
+      html += '<span class="profile-name">' + esc(p.id) + '</span>';
+      if (isActive) html += '<span class="profile-badge badge-active">active</span>';
+      html += '<span class="profile-badge badge-type">' + esc(p.type || 'claude-max') + '</span>';
+      html += '<span class="profile-card-actions">';
+      html += '<button class="icon-btn" title="Rename profile" onclick="startRename(&quot;'+esc(p.id)+'&quot;)">' + ICON_PENCIL + '</button>';
+      html += '</span>';
+    }
     html += '</div>';
+
+    if (editingProfile === p.id && renameError) {
+      html += '<div class="rename-error">' + esc(renameError) + '</div>';
+    }
 
     html += '<div class="profile-details">';
     html += '<span class="detail-label">Status</span>';
@@ -376,6 +478,11 @@ function render(data, quotaData) {
     if (p.subscriptionType) {
       html += '<span class="detail-label">Plan</span>';
       html += '<span class="detail-value">' + esc(p.subscriptionType) + '</span>';
+    }
+    if (p.aliases && p.aliases.length > 0) {
+      html += '<span class="detail-label">Former names</span>';
+      html += '<span class="detail-value" title="Requests naming these are served by this profile, until the name is added again">'
+        + p.aliases.map(esc).join(', ') + '</span>';
     }
     if (p.lastSuccessAt) {
       html += '<span class="detail-label">Last Verified</span>';


### PR DESCRIPTION
# DRAFT - please do not review or merge yet

Adds renaming a profile, from the CLI and from the web UI, with the old name
left behind as a redirect so nothing breaks mid-flight.

## What you get

- `meridian profile rename <old> <new>` in the CLI.
- A pencil control to the right of the name on each `/profiles` card, which
  renames in place (Enter to save, Esc to cancel).
- `POST /profiles/rename` behind the same auth as the other profile routes.
- `x-meridian-profile: <old>` keeps routing, to the **new** profile, until the
  old name is claimed again.

## The rename moves everything that names a profile

Its entry in `profiles.json` is the obvious half. The other is the credential
directory at `~/.config/meridian/profiles/<id>` - browser-login profiles point
at it explicitly via `claudeConfigDir`, and oauth-token profiles are pinned to
it for SDK isolation. Renaming the entry alone would leave a profile naming a
directory that is no longer its own, which logs that account out over a
cosmetic change.

So the two are planned together and applied as one step: credentials move
first (a directory rename within one filesystem, atomic), and if
`profiles.json` cannot then be written, the move is undone. A profile that
imported `~/.claude` is left alone - those credentials were never ours to
rename.

## The alias is a redirect, not a second name

After `x` is renamed to `y`, `y` is the profile and `x` is a pointer that
exists only so in-flight callers and stale configs keep working.

- **Resolution checks real profiles first, aliases second.** A stale alias can
  never shadow a live account that has since taken the name.
- **Claiming the name back drops the redirect.** `meridian profile add x`, or
  renaming anything else to `x`, reclaims it at that moment.
- **Chains are collapsed on write, not followed on read.** Renaming x -> y and
  later y -> z leaves z holding both `x` and `y`, so resolution stays a single
  lookup and no alias can dangle at an intermediate name that no longer exists.

Former names are visible in `meridian profile list` and on the profile card - a
redirect nobody can see is a trap.

## Refusals change nothing

An unknown source, an occupied target, a name outside the charset
`profile add` already enforces (letters, numbers, hyphens, underscores), and a
destination credential directory that already exists are each rejected before
any write happens.

The active-profile pointer follows the rename, on disk and in the running
process, so a fleet is never left pointing at a name that is gone. An instance
started with `MERIDIAN_CREDENTIALS_READONLY=1` refuses on both surfaces, since
a rename writes credentials.

## Shape

The planner is pure and lives in its own leaf module (`src/proxy/profileRename.ts`),
so the CLI and the HTTP route share one set of rules rather than two
implementations that drift. `planProfileRename` decides; `applyProfileRename`
is the only thing that touches disk.

## Testing

`bun run test`: **2663 pass, 0 fail** across 156 files in the main suite, plus
all 10 sequential suites green (3, 12, 4, 4, 3, 12, 10, 11, 8, 79 - each 0
fail). 32 new unit tests cover chain collapse, reclaim dropping the alias,
aliases never shadowing a real profile, the credential-dir move, the rollback,
and every refusal; 4 new integration tests cover the route.

Manually exercised end to end against a throwaway `HOME`, never the developer's
real profiles: the CLI for all six behaviours above, and the pencil in a real
browser for the happy path, both refusal messages, Esc, poll suppression while
editing, and the header chip following a rename of the active profile.

This PR is AI generated, but under direct supervision and on request of Nowaker.