### PR TITLE
fix(plugin): route hidden opencode agents on a distinct session key

### DIFF
--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -50,6 +50,15 @@ const BUILTIN_AGENT_MODES: Record<string, string> = {
   compaction: "subagent",
 }
 
+/**
+ * Single-turn hidden agents (title/summary/compaction) run concurrently
+ * with the primary build turn under the SAME opencode sessionID, which
+ * meridian's turn coordinator refuses as "session advanced while waiting".
+ * They are one-shot, so route them on a distinct key instead of the shared
+ * one — meridian then treats them as independent and they can't collide.
+ */
+const HEADERLESS_AGENTS = new Set(["title", "summary", "compaction"])
+
 const MeridianPlugin: Plugin = async () => {
   // Modes from the merged config, per plugin instance. Replaced wholesale on
   // every config-hook fire so a reload can't leave stale entries behind.
@@ -82,16 +91,29 @@ const MeridianPlugin: Plugin = async () => {
       // Only inject headers for Anthropic provider requests
       if (incoming.model.providerID !== "anthropic") return
 
-      // Session tracking
-      output.headers["x-opencode-session"] = incoming.sessionID
+      const { name, mode } = resolve(incoming.agent)
+      const isSubagent = mode === "subagent"
+      const isHeaderless = HEADERLESS_AGENTS.has(name)
+
       output.headers["x-opencode-request"] = incoming.message.id
 
-      const { name, mode } = resolve(incoming.agent)
+      if (isHeaderless) {
+        // opencode's binary natively sends x-session-affinity / X-Session-Id
+        // for all non-opencode providers, and getSessionId falls back to it —
+        // so omitting x-opencode-session alone isn't enough. Overwrite with a
+        // distinct key so the turn coordinator doesn't serialize these against
+        // the primary build turn.
+        const distinctKey = `${incoming.sessionID}:headerless:${name}`
+        output.headers["x-session-affinity"] = distinctKey
+        output.headers["X-Session-Id"] = distinctKey
+      } else {
+        output.headers["x-opencode-session"] = incoming.sessionID
+      }
 
       // The proxy expects primary|subagent. "all" agents can act as either;
       // without per-request context, treat them as primary (full tier) to
       // preserve capability.
-      output.headers["x-opencode-agent-mode"] = mode === "subagent" ? "subagent" : "primary"
+      output.headers["x-opencode-agent-mode"] = isSubagent ? "subagent" : "primary"
       // Strip non-ASCII characters (e.g. zero-width spaces) that cause
       // "Header has invalid value" errors in Node.js / undici.
       output.headers["x-opencode-agent-name"] = name.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"

--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -52,10 +52,10 @@ const BUILTIN_AGENT_MODES: Record<string, string> = {
 
 /**
  * Single-turn hidden agents (title/summary/compaction) run concurrently
- * with the primary build turn under the same opencode sessionID, which
+ * with the primary build turn under the SAME opencode sessionID, which
  * meridian's turn coordinator refuses as "session advanced while waiting".
- * Strip their session-identity headers so meridian routes them headerless
- * (no lease, fingerprint cache skipped) and they can't collide with build.
+ * They are one-shot, so route them on a distinct key instead of the shared
+ * one — meridian then treats them as independent and they can't collide.
  */
 const HEADERLESS_AGENTS = new Set(["title", "summary", "compaction"])
 
@@ -99,12 +99,13 @@ const MeridianPlugin: Plugin = async () => {
 
       if (isHeaderless) {
         // opencode's binary natively sends x-session-affinity / X-Session-Id
-        // for all non-opencode providers, and getSessionId falls back to it.
-        // Delete them so getSessionId returns undefined and meridian takes
-        // its headerless path (no lease, no fingerprint cache) instead of
-        // serializing these against the primary build turn.
-        delete output.headers["x-session-affinity"]
-        delete output.headers["X-Session-Id"]
+        // for all non-opencode providers, and getSessionId falls back to it —
+        // so omitting x-opencode-session alone isn't enough. Overwrite with a
+        // distinct key so the turn coordinator doesn't serialize these against
+        // the primary build turn.
+        const distinctKey = `${incoming.sessionID}:headerless:${name}`
+        output.headers["x-session-affinity"] = distinctKey
+        output.headers["X-Session-Id"] = distinctKey
       } else {
         output.headers["x-opencode-session"] = incoming.sessionID
       }

--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -52,10 +52,10 @@ const BUILTIN_AGENT_MODES: Record<string, string> = {
 
 /**
  * Single-turn hidden agents (title/summary/compaction) run concurrently
- * with the primary build turn under the SAME opencode sessionID, which
+ * with the primary build turn under the same opencode sessionID, which
  * meridian's turn coordinator refuses as "session advanced while waiting".
- * They are one-shot, so route them on a distinct key instead of the shared
- * one — meridian then treats them as independent and they can't collide.
+ * Strip their session-identity headers so meridian routes them headerless
+ * (no lease, fingerprint cache skipped) and they can't collide with build.
  */
 const HEADERLESS_AGENTS = new Set(["title", "summary", "compaction"])
 
@@ -99,13 +99,12 @@ const MeridianPlugin: Plugin = async () => {
 
       if (isHeaderless) {
         // opencode's binary natively sends x-session-affinity / X-Session-Id
-        // for all non-opencode providers, and getSessionId falls back to it —
-        // so omitting x-opencode-session alone isn't enough. Overwrite with a
-        // distinct key so the turn coordinator doesn't serialize these against
-        // the primary build turn.
-        const distinctKey = `${incoming.sessionID}:headerless:${name}`
-        output.headers["x-session-affinity"] = distinctKey
-        output.headers["X-Session-Id"] = distinctKey
+        // for all non-opencode providers, and getSessionId falls back to it.
+        // Delete them so getSessionId returns undefined and meridian takes
+        // its headerless path (no lease, no fingerprint cache) instead of
+        // serializing these against the primary build turn.
+        delete output.headers["x-session-affinity"]
+        delete output.headers["X-Session-Id"]
       } else {
         output.headers["x-opencode-session"] = incoming.sessionID
       }

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -118,4 +118,28 @@ describe("plugin/meridian.ts agent-mode header", () => {
     await hooks.config?.({ agent: {} })
     expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("subagent")
   })
+
+  // title/summary/compaction race the primary build turn under the same
+  // opencode sessionID; the plugin overrides their affinity headers with a
+  // distinct key so they can't collide.
+  it("headerless agents get a distinct affinity key instead of x-opencode-session", async () => {
+    const hooks = await instance()
+    for (const name of ["title", "summary", "compaction"]) {
+      const h = await headersFor(hooks, name)
+      expect(h["x-opencode-session"]).toBeUndefined()
+      expect(h["x-session-affinity"]).toBe(`ses_test:headerless:${name}`)
+      expect(h["X-Session-Id"]).toBe(`ses_test:headerless:${name}`)
+      expect(h["x-opencode-request"]).toBe("msg_test")
+      expect(h["x-opencode-agent-mode"]).toBe("subagent")
+      expect(h["x-opencode-agent-name"]).toBe(name)
+    }
+  })
+
+  it("non-headerless agents keep x-opencode-session and emit no affinity headers", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "build")
+    expect(h["x-opencode-session"]).toBe("ses_test")
+    expect(h["x-session-affinity"]).toBeUndefined()
+    expect(h["X-Session-Id"]).toBeUndefined()
+  })
 })

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -23,9 +23,8 @@ async function headersFor(
   hooks: Hooks,
   agent: unknown,
   providerID = "anthropic",
-  preexisting: Record<string, string> = {},
 ): Promise<Record<string, string>> {
-  const output = { headers: { ...preexisting } }
+  const output = { headers: {} as Record<string, string> }
   await hooks["chat.headers"]!(
     {
       sessionID: "ses_test",
@@ -121,30 +120,19 @@ describe("plugin/meridian.ts agent-mode header", () => {
   })
 
   // title/summary/compaction race the primary build turn under the same
-  // opencode sessionID; the plugin strips their session-identity headers so
-  // meridian routes them headerless and they can't collide.
-  it("headerless agents get no session or affinity headers", async () => {
+  // opencode sessionID; the plugin overrides their affinity headers with a
+  // distinct key so they can't collide.
+  it("headerless agents get a distinct affinity key instead of x-opencode-session", async () => {
     const hooks = await instance()
     for (const name of ["title", "summary", "compaction"]) {
       const h = await headersFor(hooks, name)
       expect(h["x-opencode-session"]).toBeUndefined()
-      expect(h["x-session-affinity"]).toBeUndefined()
-      expect(h["X-Session-Id"]).toBeUndefined()
+      expect(h["x-session-affinity"]).toBe(`ses_test:headerless:${name}`)
+      expect(h["X-Session-Id"]).toBe(`ses_test:headerless:${name}`)
       expect(h["x-opencode-request"]).toBe("msg_test")
       expect(h["x-opencode-agent-mode"]).toBe("subagent")
       expect(h["x-opencode-agent-name"]).toBe(name)
     }
-  })
-
-  it("headerless agents drop the affinity headers opencode's binary sets", async () => {
-    const hooks = await instance()
-    const h = await headersFor(hooks, "title", "anthropic", {
-      "x-session-affinity": "ses_test",
-      "X-Session-Id": "ses_test",
-    })
-    expect(h["x-session-affinity"]).toBeUndefined()
-    expect(h["X-Session-Id"]).toBeUndefined()
-    expect(h["x-opencode-session"]).toBeUndefined()
   })
 
   it("non-headerless agents keep x-opencode-session and emit no affinity headers", async () => {

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -23,8 +23,9 @@ async function headersFor(
   hooks: Hooks,
   agent: unknown,
   providerID = "anthropic",
+  preexisting: Record<string, string> = {},
 ): Promise<Record<string, string>> {
-  const output = { headers: {} as Record<string, string> }
+  const output = { headers: { ...preexisting } }
   await hooks["chat.headers"]!(
     {
       sessionID: "ses_test",
@@ -120,19 +121,30 @@ describe("plugin/meridian.ts agent-mode header", () => {
   })
 
   // title/summary/compaction race the primary build turn under the same
-  // opencode sessionID; the plugin overrides their affinity headers with a
-  // distinct key so they can't collide.
-  it("headerless agents get a distinct affinity key instead of x-opencode-session", async () => {
+  // opencode sessionID; the plugin strips their session-identity headers so
+  // meridian routes them headerless and they can't collide.
+  it("headerless agents get no session or affinity headers", async () => {
     const hooks = await instance()
     for (const name of ["title", "summary", "compaction"]) {
       const h = await headersFor(hooks, name)
       expect(h["x-opencode-session"]).toBeUndefined()
-      expect(h["x-session-affinity"]).toBe(`ses_test:headerless:${name}`)
-      expect(h["X-Session-Id"]).toBe(`ses_test:headerless:${name}`)
+      expect(h["x-session-affinity"]).toBeUndefined()
+      expect(h["X-Session-Id"]).toBeUndefined()
       expect(h["x-opencode-request"]).toBe("msg_test")
       expect(h["x-opencode-agent-mode"]).toBe("subagent")
       expect(h["x-opencode-agent-name"]).toBe(name)
     }
+  })
+
+  it("headerless agents drop the affinity headers opencode's binary sets", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "title", "anthropic", {
+      "x-session-affinity": "ses_test",
+      "X-Session-Id": "ses_test",
+    })
+    expect(h["x-session-affinity"]).toBeUndefined()
+    expect(h["X-Session-Id"]).toBeUndefined()
+    expect(h["x-opencode-session"]).toBeUndefined()
   })
 
   it("non-headerless agents keep x-opencode-session and emit no affinity headers", async () => {


### PR DESCRIPTION
# Why
This error started happening to me in opencode:
```
AI_APICallError: This session advanced while the request was waiting.
Retry with the latest conversation history or use a distinct session ID.
```
on meridian's npm version 1.62.5.

opencode-ai@1.18.18

# Why error occurred (regression)
- Aug 11 (be7c3ab): Latest npm version that day was 1.61.0 - worked on this version for me.
- Aug 16 (83b2f5c, PR #825 "fix: coordinate SDK/session concurrency and add graceful shutdown"): introduced the turn coordinator and the "session advanced while the request was waiting" error string. Shipped in 1.62.2. - this seems to have introduced this error for me

1.62.5's commit (#839, 91aeaf5) tried to fix this class of issue, it made declaresConcurrentFlow true when x-opencode-agent-mode: subagent is present, which exempts a request from the refusal. But the exemption applies to the subagent request (title), which is the lease holder, build is the one refused, and build is primary, so it isn't exempted. This is the gap this PR plugin fix closes (by routing title-gen on a distinct session key so it serializes against itself, not against build).

# Explanation
title/summary/compaction run concurrently with the primary build turn under the same opencode sessionID, so meridian's turn coordinator refuses the queued request as "session advanced while waiting". Override the built-in affinity headers with a distinct key for these one-shot agents so they're treated as independent and can't collide with build.

For context, you have this: https://github.com/rynfar/meridian/blob/main/docs/configuration.md#concurrent-requests-to-the-same-session, but the plugin was sending the same session key for these agents as for build, so they serialized against each other

# Tested
I tested in opencode, the error is gone