### PR TITLE
fix(plugin): detach title/summary requests from the session turn lease

### DIFF
--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -50,6 +50,16 @@ const BUILTIN_AGENT_MODES: Record<string, string> = {
   compaction: "subagent",
 }
 
+/**
+ * One-shot utilities OpenCode runs inside the PARENT session instead of a
+ * child one (unlike general/explore, which carry their own session id), and
+ * concurrently with the user's turn. They are detached from the session in
+ * chat.headers — see the comment there.
+ * compaction is deliberately absent: the proxy excludes it from turn conflict
+ * itself and needs its session id to attach the compaction to the lineage.
+ */
+const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
+
 const MeridianPlugin: Plugin = async () => {
   // Modes from the merged config, per plugin instance. Replaced wholesale on
   // every config-hook fire so a reload can't leave stale entries behind.
@@ -82,11 +92,22 @@ const MeridianPlugin: Plugin = async () => {
       // Only inject headers for Anthropic provider requests
       if (incoming.model.providerID !== "anthropic") return
 
-      // Session tracking
-      output.headers["x-opencode-session"] = incoming.sessionID
-      output.headers["x-opencode-request"] = incoming.message.id
-
       const { name, mode } = resolve(incoming.agent)
+
+      // Session tracking
+      output.headers["x-opencode-request"] = incoming.message.id
+      if (PARENT_SESSION_ONE_SHOTS.has(name)) {
+        // title/summary run inside the PARENT session and fire in parallel with
+        // the user's real turn: carrying its session id makes them race it for
+        // the per-session turn lease, and the loser gets 400
+        // session_turn_conflict. Dropping the session header alone is not
+        // enough — the fingerprint fallback would glue them back onto the same
+        // session (title's first user message is the conversation's own), so
+        // declare a parallel stream, which routes them to their own lineage.
+        output.headers["x-meridian-source"] = `subagent-${name}`
+      } else {
+        output.headers["x-opencode-session"] = incoming.sessionID
+      }
 
       // The proxy expects primary|subagent. "all" agents can act as either;
       // without per-request context, treat them as primary (full tier) to

--- a/plugin/meridian.ts
+++ b/plugin/meridian.ts
@@ -51,12 +51,12 @@ const BUILTIN_AGENT_MODES: Record<string, string> = {
 }
 
 /**
- * One-shot utilities OpenCode runs inside the PARENT session instead of a
- * child one (unlike general/explore, which carry their own session id), and
- * concurrently with the user's turn. They are detached from the session in
- * chat.headers — see the comment there.
- * compaction is deliberately absent: the proxy excludes it from turn conflict
- * itself and needs its session id to attach the compaction to the lineage.
+ * One-shot utilities OpenCode runs inside the parent session, concurrently
+ * with the real turn: its session id would make them race it for the proxy's
+ * turn lease (400 session_turn_conflict); x-meridian-source keeps the lineage
+ * fingerprint fallback from gluing them back onto the session. compaction
+ * stays session-bound — the proxy needs its id to attach the compaction to
+ * the lineage and already exempts it from the conflict check.
  */
 const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
 
@@ -97,13 +97,6 @@ const MeridianPlugin: Plugin = async () => {
       // Session tracking
       output.headers["x-opencode-request"] = incoming.message.id
       if (PARENT_SESSION_ONE_SHOTS.has(name)) {
-        // title/summary run inside the PARENT session and fire in parallel with
-        // the user's real turn: carrying its session id makes them race it for
-        // the per-session turn lease, and the loser gets 400
-        // session_turn_conflict. Dropping the session header alone is not
-        // enough — the fingerprint fallback would glue them back onto the same
-        // session (title's first user message is the conversation's own), so
-        // declare a parallel stream, which routes them to their own lineage.
         output.headers["x-meridian-source"] = `subagent-${name}`
       } else {
         output.headers["x-opencode-session"] = incoming.sessionID

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -119,3 +119,59 @@ describe("plugin/meridian.ts agent-mode header", () => {
     expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("subagent")
   })
 })
+
+/**
+ * title/summary run in the PARENT session and fire in parallel with the user's
+ * real turn, so sending the session id makes them race it for the per-session
+ * turn lease — the loser gets 400 session_turn_conflict. They must go out
+ * without the session header AND with x-meridian-source, which is what keeps
+ * the proxy's fingerprint fallback from gluing them back onto the session.
+ */
+describe("plugin/meridian.ts parent-session one-shots", () => {
+  it("title is detached from the session and declares a parallel stream", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "title")
+    expect(h["x-opencode-session"]).toBeUndefined()
+    expect(h["x-meridian-source"]).toBe("subagent-title")
+    expect(h["x-opencode-request"]).toBe("msg_test")
+    expect(h["x-opencode-agent-name"]).toBe("title")
+    expect(h["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  it("summary is detached from the session and declares a parallel stream", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "summary")
+    expect(h["x-opencode-session"]).toBeUndefined()
+    expect(h["x-meridian-source"]).toBe("subagent-summary")
+  })
+
+  it("legacy object agent shape is detached too", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, { name: "title", mode: "subagent" })
+    expect(h["x-opencode-session"]).toBeUndefined()
+    expect(h["x-meridian-source"]).toBe("subagent-title")
+  })
+
+  it("primary agents keep the session header and get no source header", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "build")
+    expect(h["x-opencode-session"]).toBe("ses_test")
+    expect(h["x-meridian-source"]).toBeUndefined()
+  })
+
+  it("compaction keeps the session header — the proxy needs it for lineage", async () => {
+    const hooks = await instance()
+    const h = await headersFor(hooks, "compaction")
+    expect(h["x-opencode-session"]).toBe("ses_test")
+    expect(h["x-meridian-source"]).toBeUndefined()
+  })
+
+  it("subagent-mode agents with their own session id keep the session header", async () => {
+    const hooks = await instance()
+    for (const agent of ["general", "explore"]) {
+      const h = await headersFor(hooks, agent)
+      expect(h["x-opencode-session"]).toBe("ses_test")
+      expect(h["x-meridian-source"]).toBeUndefined()
+    }
+  })
+})

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -120,13 +120,6 @@ describe("plugin/meridian.ts agent-mode header", () => {
   })
 })
 
-/**
- * title/summary run in the PARENT session and fire in parallel with the user's
- * real turn, so sending the session id makes them race it for the per-session
- * turn lease — the loser gets 400 session_turn_conflict. They must go out
- * without the session header AND with x-meridian-source, which is what keeps
- * the proxy's fingerprint fallback from gluing them back onto the session.
- */
 describe("plugin/meridian.ts parent-session one-shots", () => {
   it("title is detached from the session and declares a parallel stream", async () => {
     const hooks = await instance()


### PR DESCRIPTION
## Problem

OpenCode's `title`/`summary` utilities run inside the parent session and fire in parallel with the user's real turn. The plugin tagged them with the same `x-opencode-session`, so both requests raced for the per-session turn lease — the loser died with `400 session_turn_conflict`. In practice the loser was usually the user's first turn, and the title exchange got committed into the session lineage.

## Fix

`chat.headers` now sends these one-shots:

- **without `x-opencode-session`** — no shared turn lease, nothing to conflict with;
- **with `x-meridian-source: subagent-<name>`** — an explicitly parallel stream, so the fingerprint fallback cannot glue them back onto the session (the title prompt embeds the conversation's own first message).

`compaction` keeps its session id: the proxy needs it for lineage and already exempts compaction from the conflict check.

## Tests

New describe block in `plugin-agent-mode.test.ts`: `title`/`summary` (string and legacy object shapes) go out detached, `build`/`compaction`/`general`/`explore` keep the session header.

## Note

Under sticky routing these one-shots lose profile affinity — they are cheap one-offs, any profile can serve them.