### PR TITLE
feat(plugin): add the OpenCode v2 plugin on session.model.request

### DIFF
--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -1,0 +1,112 @@
+/**
+ * Meridian OpenCode plugin — **v2 line** (`@opencode-ai/cli@beta`, `opencode2`).
+ *
+ * The v1 plugin next to this file hooks `chat.headers`. That hook does not
+ * exist in opencode v2 at all, so on a v2 client the v1 plugin is inert: no
+ * agent tier, and — worse — no chance to fix what v2's core does on its own.
+ *
+ * What v2's core does: `SessionModelHeaders.make` stamps `x-opencode-session`
+ * (plus `x-session-affinity` / `X-Session-Id`) on **every** model request,
+ * including the `title` and `summary` one-shots that run inside the parent
+ * session and fire in parallel with the user's real turn. Both requests then
+ * carry the same session id, both contend for the proxy's per-session turn
+ * lease, and the loser — in practice the user's first turn — dies with
+ * `400 session_turn_conflict` ("This session advanced while the request was
+ * waiting"). Same failure the v1 fix addressed; v2 needs its own hook.
+ *
+ * This plugin uses v2's `session.model.request` hook, which fires for the
+ * one-shots too and may rewrite headers before the request goes out:
+ *   1. title/summary → session affinity stripped, `x-meridian-source:
+ *      subagent-<name>` added, so the proxy sees an explicitly parallel
+ *      stream instead of a contender for the session's turn (and its lineage
+ *      fingerprint fallback cannot glue them back onto the session — the
+ *      title prompt embeds the conversation's own first message).
+ *   2. every request → `x-opencode-agent-name` / `x-opencode-agent-mode`, so
+ *      the proxy picks the model tier per agent: primary gets the 1M
+ *      variants, subagents the 200k ones.
+ *
+ * compaction deliberately keeps its session id: the proxy needs it to attach
+ * the compaction to the lineage and already exempts it from the conflict
+ * check.
+ *
+ * Install (opencode v2) — add to ~/.config/opencode/opencode.json:
+ *   { "plugin": ["/absolute/path/to/plugin/meridian-v2.ts"] }
+ */
+
+/** Providers that point at a Meridian endpoint in practice. */
+const MERIDIAN_PROVIDERS = new Set(["anthropic", "meridian"])
+
+/**
+ * Modes of v2's built-in agents. Used when the agent lookup can't answer — a
+ * miss must not silently promote a subagent to the 1M tier.
+ */
+const BUILTIN_AGENT_MODES: Record<string, string> = {
+  build: "primary",
+  plan: "primary",
+  general: "subagent",
+  explore: "subagent",
+  title: "subagent",
+  summary: "subagent",
+  compaction: "subagent",
+}
+
+/** Utilities v2 runs inside the PARENT session, concurrently with its turn. */
+const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
+
+/**
+ * Header names that bind a request to a session. Spelled here exactly as
+ * `SessionModelHeaders.make` writes them — the hook hands over a plain
+ * record, so a case that does not match is a header left behind.
+ */
+const SESSION_AFFINITY_HEADERS = [
+  "x-opencode-session",
+  "x-session-affinity",
+  "X-Session-Id",
+  "x-parent-session-id",
+]
+
+interface ModelRequest {
+  sessionID: string
+  agent: string
+  model: { providerID?: string }
+  headers: Record<string, string>
+}
+
+export default {
+  id: "meridian",
+  setup(context: any) {
+    const resolveMode = async (agent: string): Promise<string> => {
+      try {
+        // v2 takes an object and answers { location, data: Agent.Info }.
+        const info = await context.agent?.get?.({ agentID: agent })
+        const mode = info?.data?.mode ?? info?.mode
+        if (typeof mode === "string") return mode
+      } catch {
+        // An agent the runtime cannot describe falls back to the table below.
+      }
+      return BUILTIN_AGENT_MODES[agent] ?? "primary"
+    }
+
+    return context.session.hook("model.request", async (input: ModelRequest) => {
+      if (!MERIDIAN_PROVIDERS.has(String(input.model?.providerID ?? ""))) return
+
+      // Strip non-ASCII characters (zero-width spaces and the like) that make
+      // undici reject the whole request with "Header has invalid value".
+      const name = String(input.agent ?? "unknown").replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
+      const mode = (await resolveMode(name)) === "subagent" ? "subagent" : "primary"
+
+      if (PARENT_SESSION_ONE_SHOTS.has(name)) {
+        for (const header of SESSION_AFFINITY_HEADERS) delete input.headers[header]
+        input.headers["x-meridian-source"] = `subagent-${name}`
+      } else {
+        // Core already sets this; restated so the header is present even if a
+        // future core stops stamping it, and so the value is the one this
+        // hook was handed rather than whatever survived another plugin.
+        input.headers["x-opencode-session"] = String(input.sessionID)
+      }
+
+      input.headers["x-opencode-agent-name"] = name
+      input.headers["x-opencode-agent-mode"] = mode
+    })
+  },
+}

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -90,12 +90,17 @@ export default {
     return context.session.hook("model.request", async (input: ModelRequest) => {
       if (!MERIDIAN_PROVIDERS.has(String(input.model?.providerID ?? ""))) return
 
-      // Strip non-ASCII characters (zero-width spaces and the like) that make
-      // undici reject the whole request with "Header has invalid value".
-      const name = String(input.agent ?? "unknown").replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
-      const mode = (await resolveMode(name)) === "subagent" ? "subagent" : "primary"
+      const raw = String(input.agent ?? "")
+      // The built-ins arrive under exactly these names. A user-defined agent
+      // that merely sanitizes to the same name is distinct and keeps affinity.
+      const isOneShot = PARENT_SESSION_ONE_SHOTS.has(raw)
+      const mode = (await resolveMode(raw)) === "subagent" ? "subagent" : "primary"
 
-      if (PARENT_SESSION_ONE_SHOTS.has(name)) {
+      // Strip non-ASCII characters (zero-width spaces and the like) only at
+      // the header boundary, where undici otherwise rejects the request.
+      const name = raw.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
+
+      if (isOneShot) {
         for (const header of SESSION_AFFINITY_HEADERS) delete input.headers[header]
         input.headers["x-meridian-source"] = `subagent-${name}`
       } else {

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -84,13 +84,28 @@ describe("plugin/meridian-v2.ts parent-session one-shots", () => {
 
   for (const agent of ["build", "compaction", "general", "explore"]) {
     test(`${agent} keeps the session header`, async () => {
-      const headers = await run(agent)
+      const headers = await run(agent, { parentID: "ses_parent" })
 
       expect(headers["x-opencode-session"]).toBe("ses_abc")
       expect(headers["x-session-affinity"]).toBe("ses_abc")
+      expect(headers["X-Session-Id"]).toBe("ses_abc")
+      expect(headers["x-parent-session-id"]).toBe("ses_parent")
       expect(headers["x-meridian-source"]).toBeUndefined()
     })
   }
+
+  test("an agent padded like a one-shot keeps the session header", async () => {
+    const headers = await run(" title ")
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBeUndefined()
+  })
+
+  test("an agent containing a zero-width character keeps the session header", async () => {
+    const headers = await run("ti\u200btle")
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+  })
 })
 
 describe("plugin/meridian-v2.ts agent mode", () => {
@@ -102,9 +117,15 @@ describe("plugin/meridian-v2.ts agent mode", () => {
   })
 
   test("a configured agent takes its mode from the runtime, not the table", async () => {
-    const headers = await run("reviewer", { modes: { reviewer: "subagent" } })
+    const headers = await run("réviewer", { modes: { "réviewer": "subagent" } })
 
     expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("a non-ASCII agent name is sanitized only for the header", async () => {
+    const headers = await run("réviewer")
+
+    expect(headers["x-opencode-agent-name"]).toBe("rviewer")
   })
 
   test("an unknown agent falls back to primary", async () => {

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the opencode **v2** plugin (plugin/meridian-v2.ts).
+ *
+ * The property under test is the one a v2 client gets wrong on its own: the
+ * core stamps session affinity on every model request, including the
+ * title/summary one-shots that run in parallel with the user's turn. The
+ * plugin must take that affinity off those two and declare them as parallel
+ * streams instead, while leaving every other agent's session intact.
+ */
+
+import { describe, expect, test } from "bun:test"
+import MeridianV2Plugin from "../../plugin/meridian-v2"
+
+/** Headers as v2's SessionModelHeaders.make writes them, verbatim. */
+function coreHeaders(sessionID: string, parentID?: string): Record<string, string> {
+  return {
+    "x-session-affinity": sessionID,
+    "X-Session-Id": sessionID,
+    ...(parentID ? { "x-parent-session-id": parentID } : {}),
+    "User-Agent": "opencode/2",
+    "x-opencode-project": "prj_1",
+    "x-opencode-session": sessionID,
+    "x-opencode-client": "opencode",
+  }
+}
+
+type Hook = (input: {
+  sessionID: string
+  agent: string
+  model: { providerID?: string }
+  headers: Record<string, string>
+}) => Promise<void> | void
+
+/** Runs the plugin's setup and returns the registered model.request hook. */
+function install(agentModes: Record<string, string> = {}): Hook {
+  let registered: Hook | undefined
+  const context = {
+    agent: {
+      get: async ({ agentID }: { agentID: string }) => {
+        const mode = agentModes[agentID]
+        return mode ? { data: { mode } } : undefined
+      },
+    },
+    session: {
+      hook: (name: string, callback: Hook) => {
+        if (name === "model.request") registered = callback
+        return Promise.resolve({ dispose: async () => {} })
+      },
+    },
+  }
+  MeridianV2Plugin.setup(context)
+  if (!registered) throw new Error("the plugin did not register a model.request hook")
+  return registered
+}
+
+async function run(
+  agent: string,
+  options: { providerID?: string; parentID?: string; modes?: Record<string, string> } = {},
+) {
+  const headers = coreHeaders("ses_abc", options.parentID)
+  await install(options.modes)({
+    sessionID: "ses_abc",
+    agent,
+    model: { providerID: options.providerID ?? "anthropic" },
+    headers,
+  })
+  return headers
+}
+
+describe("plugin/meridian-v2.ts parent-session one-shots", () => {
+  for (const agent of ["title", "summary"]) {
+    test(`${agent} goes out detached from the session`, async () => {
+      const headers = await run(agent, { parentID: "ses_parent" })
+
+      expect(headers["x-opencode-session"]).toBeUndefined()
+      expect(headers["x-session-affinity"]).toBeUndefined()
+      expect(headers["X-Session-Id"]).toBeUndefined()
+      expect(headers["x-parent-session-id"]).toBeUndefined()
+      expect(headers["x-meridian-source"]).toBe(`subagent-${agent}`)
+      // Everything the request needs that is not session affinity survives.
+      expect(headers["x-opencode-project"]).toBe("prj_1")
+    })
+  }
+
+  for (const agent of ["build", "compaction", "general", "explore"]) {
+    test(`${agent} keeps the session header`, async () => {
+      const headers = await run(agent)
+
+      expect(headers["x-opencode-session"]).toBe("ses_abc")
+      expect(headers["x-session-affinity"]).toBe("ses_abc")
+      expect(headers["x-meridian-source"]).toBeUndefined()
+    })
+  }
+})
+
+describe("plugin/meridian-v2.ts agent mode", () => {
+  test("a built-in subagent is not promoted to the primary tier", async () => {
+    const headers = await run("explore")
+
+    expect(headers["x-opencode-agent-name"]).toBe("explore")
+    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("a configured agent takes its mode from the runtime, not the table", async () => {
+    const headers = await run("reviewer", { modes: { reviewer: "subagent" } })
+
+    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("an unknown agent falls back to primary", async () => {
+    const headers = await run("something-custom")
+
+    expect(headers["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  test('"all" agents are treated as primary, as the proxy-side plugin does', async () => {
+    const headers = await run("switcher", { modes: { switcher: "all" } })
+
+    expect(headers["x-opencode-agent-mode"]).toBe("primary")
+  })
+})
+
+describe("plugin/meridian-v2.ts scope", () => {
+  test("a request to another provider is left untouched", async () => {
+    const headers = await run("title", { providerID: "openai" })
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBeUndefined()
+    expect(headers["x-opencode-agent-mode"]).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Follow-up to #845, for the **opencode v2** line.

## Problem

opencode v2 has no `chat.headers` hook at all, so `plugin/meridian.ts` (v1) is inert on a v2 client — no agent tier, and nothing standing between v2 core and the proxy. Worse, v2's core (`SessionModelHeaders.make`) stamps `x-opencode-session` — plus `x-session-affinity` / `X-Session-Id` — on **every** model request, including the `title`/`summary` one-shots, which run inside the parent session and fire in parallel with the user's real turn. Both requests then carry the same session id, contend for the per-session turn lease, and the loser — in practice the user's first turn — dies with `400 session_turn_conflict` (`This session advanced while the request was waiting`).

Field-observed on a stock v2 beta client: refused 1-message requests with multi-second session-queue waits, and the title exchange committed into the session lineage. Reproduced against 1.62.3 and current `main`.

## Fix

New `plugin/meridian-v2.ts`, installed the same way (path in `opencode.json`'s `plugin` array). It hooks v2's `session.model.request`, which fires for the one-shots too and may rewrite headers in place:

- **title/summary** — session affinity headers stripped, `x-meridian-source: subagent-<name>` added: an explicitly parallel stream, which the proxy neither queues on the session's turn lease nor glues back via the lineage fingerprint fallback (the title prompt embeds the conversation's own first message);
- **every request** — `x-opencode-agent-name` / `x-opencode-agent-mode` for tier selection, resolving agent modes from the runtime with the built-in table as fallback (`compaction` keeps its session id: the proxy needs it for lineage and already exempts it from the conflict check).

## Tests

`src/__tests__/plugin-v2-headers.test.ts`: one-shots go out detached (all four affinity spellings gone, source header set), ordinary agents keep their session header, mode resolution from runtime/config/fallback, other providers untouched.

## Note for fronted deployments

A fronting proxy that owns the `x-meridian-*` namespace upstream (stripping it from client input as a control-channel boundary) must make this declaration itself — the plugin fixes direct v2 clients.