### PR TITLE
fix: give OpenCode's internal agents their own session key

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,6 +168,16 @@ Sessions map an agent's conversation ID to a Claude SDK session ID. Two caches w
 - **Session cache**: keyed by agent header (`x-opencode-session`)
 - **Fingerprint cache**: keyed by hash of first user message + working directory (fallback when no header)
 
+**A client's session header is not always a conversation identity.** OpenCode
+runs its internal one-shot agents (`title`, `summary`, `compaction`) under the
+*user's* session id, so `x-opencode-session` alone named two unrelated
+conversations at once — the title prompt and the user's chat. They shared one
+lineage and one turn lease, which cost the user's first turn either a 400
+`session_turn_conflict` or a cold-cache full replay. `openCodeAdapter.getSessionId`
+therefore appends the agent name for non-primary agents (`ses_x#title`), leaving
+the primary agent's key byte-identical to the header. An adapter whose client
+multiplexes agents over one session id needs the same treatment.
+
 Both are LRU with coordinated eviction — evicting from one removes the corresponding entry in the other.
 
 ### Lineage Verification

--- a/E2E.md
+++ b/E2E.md
@@ -91,6 +91,7 @@ kill $(lsof -ti :3456)
 | E36 | [Client detection after an upgrade (#733)](#e36-client-detection-after-an-upgrade-733) | **Automated**: `bun scripts/e2e-client-detection.mjs` — drives each installed client against a local stub, captures its real headers, and asserts the adapter Meridian resolves. **Run after upgrading any client**; costs no tokens | 2026-07-31 |
 | E37 | [WebFetch preflight scope (#748)](#e37-webfetch-preflight-scope-748) | **Automated**: `bun scripts/e2e-webfetch-preflight.mjs` — stubbed `claude` + isolated HOME: the toggle reaches the right adapter's `--settings`, and only `cherry` can actually run the built-in WebFetch, so the documented scope is asserted rather than assumed. **Run before releases touching sdkFeatures, query settings, or tool config**; costs no tokens | 2026-08-03 |
 | E38 | [Silent turns (#768)](#e38-silent-turns-768) | **Automated**: `bun scripts/e2e-silent-turn.mjs` — real CLI, SSE mode. Asserts four things per attempt: the client got text or a tool call; recovered content sits BEFORE the terminal `message_delta` (content behind it is dropped by a correct client); exactly one `message_delta` per message; and a third turn after a recovery still resumes. Attribution is read from `/telemetry/logs`, not stdout. Pair `MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` against `MERIDIAN_SILENT_TURN_RECOVERY=0` for the before/after. **Run before any release touching the passthrough tool loop, prompt assembly, or session resume** | 2026-08-11 |
+| E39 | [OpenCode internal-agent session key (#845)](#e39-opencode-internal-agent-session-key-845) | **Manual**, real OpenCode: its `title` agent runs under the USER'S session id, so the user's first turn used to queue behind it and then get HTTP 400 `session_turn_conflict`. Asserts the first turn succeeds, waits ~0ms on the session lease, and every later request is `lineage=continuation`. **Run after any OpenCode upgrade and before releases touching session keys or the turn coordinator** | 2026-08-19 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3397,3 +3398,79 @@ recovery-ON run against nothing tells you almost nothing.
 text deltas. Uninjected, both settings: 3/3 pass, no silences — the live rate is
 far below what a run this size can see, which is the whole reason injection
 exists.
+
+---
+
+## E39: OpenCode internal-agent session key (#845)
+
+**Verifies:** OpenCode's internal `title` agent cannot break or de-cache the
+user's conversation.
+
+OpenCode runs `title` (and `summary`, `compaction`) under the **user's** session
+id, and fires it concurrently with the user's first real turn. Both requests
+carried the same `x-opencode-session`, so they shared one lineage and one
+per-session turn lease. Whichever arrived first committed its own conversation
+under the shared key; the other was then measured against a history that was not
+its own.
+
+Mocked tests cover the key derivation and the HTTP outcome. This exists because
+neither can prove OpenCode still *sends* what the fix keys on — a client upgrade
+that renames or drops `x-opencode-agent-mode` / `x-opencode-agent-name` puts the
+collision straight back with every suite green.
+
+```bash
+# Isolated OpenCode config. OPENCODE_CONFIG_DIR alone is NOT enough — OpenCode
+# merges ~/.config/opencode/opencode.json on top of it, which drags in the real
+# config's MCP servers and can hang `init` for minutes. XDG_CONFIG_HOME is what
+# actually isolates it.
+BASE=/tmp/e39; rm -rf $BASE; mkdir -p $BASE/{proj,cfg}
+printf 'alpha\nbeta\ngamma\n' > $BASE/proj/notes.txt
+cat > $BASE/cfg/opencode.json <<'JSON'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["/absolute/path/to/meridian/plugin/meridian.ts"],
+  "provider": { "anthropic": { "options": { "apiKey": "dummy", "baseURL": "http://127.0.0.1:3499" } } },
+  "model": "anthropic/claude-haiku-4-5",
+  "small_model": "anthropic/claude-haiku-4-5"
+}
+JSON
+
+MERIDIAN_TELEMETRY_PERSIST=1 MERIDIAN_TELEMETRY_DB=$BASE/t.db MERIDIAN_PORT=3499 \
+  node dist/cli.js > $BASE/proxy.log 2>&1 &
+sleep 6
+
+cd $BASE/proj
+export OPENCODE_CONFIG_DIR=$BASE/cfg XDG_CONFIG_HOME=$BASE/xdg
+OUT=$(opencode run --model anthropic/claude-haiku-4-5 --format json \
+  "Read notes.txt and report how many lines it has." 2>&1)
+SID=$(echo "$OUT" | grep -o '"sessionID":"[^"]*"' | head -1 | cut -d'"' -f4)
+opencode run --model anthropic/claude-haiku-4-5 --session "$SID" --format json \
+  "Append a line 'delta' to notes.txt using the edit tool." >/dev/null 2>&1
+opencode run --model anthropic/claude-haiku-4-5 --session "$SID" --format json \
+  "Read notes.txt and list every line." >/dev/null 2>&1
+
+grep -c session_turn_conflict $BASE/proxy.log     # → 0
+grep 'agent=primary' $BASE/proxy.log | head -1    # → sessionWait=0ms, lineage=new
+grep -c 'lineage=continuation' $BASE/proxy.log    # → ≥1 per later request
+```
+
+**Pass criteria:**
+- No `session_turn_conflict` anywhere in the log, and no `"session advanced
+  while the request was waiting"` in any turn's JSON output
+- The first `agent=primary` request shows `sessionWait=0ms` — it does not queue
+  behind the `agent=subagent` title request
+- The title request appears with `agent=subagent` and a session key of its own
+- Every request after the first carries `lineage=continuation` with a non-zero
+  `cache_read`
+
+**Verified:** 2026-08-19, OpenCode 1.18.11. Before the fix, 3/3 runs: the title
+request took the lease, the user's turn waited 9,836 ms and returned HTTP 400
+`session_turn_conflict`, and OpenCode reported it as a non-retryable `APIError` —
+the first turn was simply lost. After: 0 conflicts, `sessionWait=0ms` on the
+user's turn, and 6/6 later requests `lineage=continuation` at 83-99% cache hit.
+
+**Related:** `node scripts/audit-token-spend.mjs` reports the same corpus by
+cause (cold starts vs discarded passthrough turns), which is how to tell a
+"Meridian costs more" report apart from a caching failure. On this machine's
+history: cold starts 35.4% of spend and 63.3% of all cache writes; discarded
+passthrough turns 1.2%.

--- a/scripts/audit-token-spend.mjs
+++ b/scripts/audit-token-spend.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Where did the tokens actually go?
+ *
+ * Reads the Claude Code subprocess transcripts Meridian's SDK sessions leave
+ * behind and reports spend by cause. This is GROUND TRUTH: every assistant
+ * message in a transcript carries the `usage` of the upstream API call that
+ * produced it, so the totals here are what the account was billed — not what
+ * Meridian's telemetry attributed per HTTP request, and not what a client's
+ * cost display shows.
+ *
+ * Written for one question that telemetry cannot answer: when a user reports
+ * "Meridian costs more", is it cold starts, discarded turns, or nothing at all?
+ * Point it at their config dir and the answer is one command.
+ *
+ *   node scripts/audit-token-spend.mjs [configDir ...]
+ *
+ * With no arguments it scans ~/.claude plus every profile dir in
+ * ~/.config/meridian/profiles. Pass explicit dirs to scope it (a profile, or a
+ * single project's transcripts).
+ *
+ * The four causes it separates, and why each is worth a line of its own:
+ *
+ *   cold starts     The FIRST API call of an SDK session pays a full cache
+ *                   write at 1.25x. Unavoidable once per session — so a high
+ *                   share here means too many sessions, i.e. resume is failing.
+ *   digest turns    Passthrough only. After Meridian's PreToolUse deny, the CLI
+ *                   calls the model again so it can react to the deny. Meridian
+ *                   forks past that turn at `resumeSessionAt`, so its output is
+ *                   discarded — and billed.
+ *   nudge turns     Passthrough only. A digest turn that produced no text trips
+ *                   the CLI's thinking-only nudge ("[Your previous response had
+ *                   no visible output…]"), costing one more full-prefix call.
+ *   uncached        Calls that read and wrote no cache at all. Expected below
+ *                   Anthropic's minimum cacheable prefix; a surprise above it.
+ *
+ * Costs are reported in INPUT-EQUIVALENT tokens — uncached input at 1x, cache
+ * read at 0.1x, cache write at 1.25x, output at 5x — so one number ranks causes
+ * across models without hardcoding prices. Multiply by a model's input rate for
+ * dollars.
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+const DENY_MARK = "forwarded to the client for execution"
+const NUDGE_MARK = "no visible output"
+
+/** Anthropic's price ratios relative to uncached input. */
+const W = { input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 5 }
+const equiv = (u) =>
+  (u.input ?? 0) * W.input + (u.cr ?? 0) * W.cacheRead + (u.cw ?? 0) * W.cacheWrite + (u.out ?? 0) * W.output
+
+function defaultRoots() {
+  const roots = [join(homedir(), ".claude", "projects")]
+  const profiles = join(homedir(), ".config", "meridian", "profiles")
+  try {
+    for (const p of readdirSync(profiles)) roots.push(join(profiles, p, "projects"))
+  } catch { /* no profiles configured */ }
+  return roots
+}
+
+function* transcripts(roots) {
+  for (const root of roots) {
+    // Accept either a `projects` root or a single project dir.
+    const dirs = []
+    try {
+      if (!statSync(root).isDirectory()) continue
+      const entries = readdirSync(root)
+      if (entries.some((e) => e.endsWith(".jsonl"))) dirs.push(root)
+      for (const e of entries) {
+        const d = join(root, e)
+        try { if (statSync(d).isDirectory()) dirs.push(d) } catch { /* unreadable */ }
+      }
+    } catch { continue }
+    for (const d of dirs) {
+      let files = []
+      try { files = readdirSync(d).filter((f) => f.endsWith(".jsonl")) } catch { continue }
+      for (const f of files) {
+        try { yield readFileSync(join(d, f), "utf8") } catch { /* unreadable */ }
+      }
+    }
+  }
+}
+
+const zero = () => ({ calls: 0, input: 0, cr: 0, cw: 0, out: 0 })
+const add = (a, u) => { a.calls++; a.input += u.input; a.cr += u.cr; a.cw += u.cw; a.out += u.out }
+
+const all = zero()
+const cold = zero()
+const digest = zero()
+const nudge = zero()
+const uncached = zero()
+let sessions = 0, passthroughSessions = 0
+
+for (const raw of transcripts(process.argv.slice(2).length ? process.argv.slice(2) : defaultRoots())) {
+  const isPassthrough = raw.includes(DENY_MARK)
+  let sawCall = false
+  // One API call writes several JSONL rows (one per content block); requestId
+  // is what identifies the call. Counting rows would multiply usage by 2-3x.
+  const seen = new Set()
+  let pending = null
+  for (const line of raw.split("\n")) {
+    if (!line) continue
+    let o
+    try { o = JSON.parse(line) } catch { continue }
+    if (o.type === "user") {
+      const c = o.message?.content
+      if (typeof c === "string" && c.includes(NUDGE_MARK)) { pending = "nudge"; continue }
+      if (Array.isArray(c) && c.some((b) => b?.type === "tool_result" && typeof b.content === "string" && b.content.includes(DENY_MARK))) {
+        pending = "digest"; continue
+      }
+      pending = null
+      continue
+    }
+    if (o.type !== "assistant" || !o.message?.usage) continue
+    if (o.requestId) {
+      if (seen.has(o.requestId)) continue
+      seen.add(o.requestId)
+    }
+    const raw_u = o.message.usage
+    const u = {
+      input: raw_u.input_tokens ?? 0,
+      cr: raw_u.cache_read_input_tokens ?? 0,
+      cw: raw_u.cache_creation_input_tokens ?? 0,
+      out: raw_u.output_tokens ?? 0,
+    }
+    add(all, u)
+    if (!sawCall) { add(cold, u); sawCall = true }
+    else if (pending === "digest") add(digest, u)
+    else if (pending === "nudge") add(nudge, u)
+    if (u.cr === 0 && u.cw === 0) add(uncached, u)
+    pending = null
+  }
+  if (sawCall) { sessions++; if (isPassthrough) passthroughSessions++ }
+}
+
+if (all.calls === 0) {
+  console.log("No transcripts found. Pass a config dir explicitly, e.g.:")
+  console.log("  node scripts/audit-token-spend.mjs ~/.config/meridian/profiles/personal/projects")
+  process.exit(0)
+}
+
+const total = equiv(all)
+const pct = (n) => (100 * n / total).toFixed(1).padStart(5) + "%"
+const num = (n) => n.toLocaleString().padStart(14)
+const row = (label, a) =>
+  console.log(`${label.padEnd(16)}${String(a.calls).padStart(7)}${num(Math.round(equiv(a)))}   ${pct(equiv(a))}`)
+
+console.log(`sessions: ${sessions} (${passthroughSessions} passthrough)   api calls: ${all.calls}`)
+console.log()
+console.log(`raw totals   uncached input ${all.input.toLocaleString()}  cache read ${all.cr.toLocaleString()}  cache write ${all.cw.toLocaleString()}  output ${all.out.toLocaleString()}`)
+console.log()
+console.log("cause             calls  input-equiv    share")
+console.log("-".repeat(52))
+row("ALL SPEND", all)
+row("cold starts", cold)
+row("digest turns", digest)
+row("nudge turns", nudge)
+row("uncached calls", uncached)
+console.log("-".repeat(52))
+const wasted = equiv(digest) + equiv(nudge)
+console.log(`discarded passthrough turns: ${Math.round(wasted).toLocaleString()} input-equiv (${(100 * wasted / total).toFixed(1)}%)`)
+console.log(`cold-start share of cache writes: ${all.cw ? (100 * cold.cw / all.cw).toFixed(1) : "0.0"}%`)
+console.log()
+console.log("A high cold-start share means resume is failing — check /telemetry for")
+console.log("lineage=new on a client that should be continuing a conversation.")

--- a/src/__tests__/opencode-internal-agent-session-key.test.ts
+++ b/src/__tests__/opencode-internal-agent-session-key.test.ts
@@ -1,0 +1,137 @@
+/**
+ * OpenCode's internal agents (title, summary, compaction) run under the USER'S
+ * OpenCode session id — the plugin faithfully forwards it as
+ * `x-opencode-session`, and OpenCode itself sends the same value as
+ * `x-session-affinity` even with no plugin installed.
+ *
+ * That made two unrelated conversations share one session key: "Generate a
+ * title for this conversation: …" and the user's actual chat. Observed live
+ * against OpenCode 1.18.11, three runs out of three:
+ *
+ *   seq 1  agent=title  tools=0  x-opencode-session: ses_fe4b…
+ *   seq 2  agent=build  tools=10 x-opencode-session: ses_fe4b…   ← same key
+ *
+ * The title turn arrives first, takes the per-session turn lease, and commits
+ * its own one-message lineage under the shared key. The user's real turn then
+ * waits 5–12s behind that lease and, on being granted it, finds a stored
+ * lineage from a different conversation — `unrelated-history`. Since #825 that
+ * is answered with HTTP 400 `session_turn_conflict`, which OpenCode reports as
+ * non-retryable; before #825 it fell through to a full-history replay against
+ * a cold prompt cache.
+ *
+ * Scoping the key by agent gives every non-primary agent its own lineage and
+ * its own lease, so neither outcome is reachable.
+ */
+import { describe, it, expect } from "bun:test"
+import { openCodeAdapter } from "../proxy/adapters/opencode"
+
+function ctx(headers: Record<string, string | undefined>) {
+  return { req: { header: (name: string) => headers[name.toLowerCase()] } } as any
+}
+
+const SESSION = "ses_fe4bfa3daffexvfr3lL7db1lcU"
+
+describe("openCodeAdapter.getSessionId — internal agent isolation", () => {
+  it("keeps the primary agent's key equal to the raw session id", () => {
+    expect(openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "primary",
+      "x-opencode-agent-name": "build",
+    }))).toBe(SESSION)
+  })
+
+  it("gives the title agent a key distinct from the user's conversation", () => {
+    const primary = openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "primary",
+      "x-opencode-agent-name": "build",
+    }))
+    const title = openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-agent-name": "title",
+    }))
+    expect(title).toBeDefined()
+    expect(title).not.toBe(primary)
+  })
+
+  it("separates distinct non-primary agents from each other", () => {
+    const title = openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-agent-name": "title",
+    }))
+    const summary = openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-agent-name": "summary",
+    }))
+    expect(title).not.toBe(summary)
+  })
+
+  it("is stable across turns of the same agent", () => {
+    const headers = {
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-agent-name": "explore",
+    }
+    expect(openCodeAdapter.getSessionId(ctx(headers))).toBe(openCodeAdapter.getSessionId(ctx(headers)))
+  })
+
+  it("falls back to x-session-affinity and still scopes by agent", () => {
+    expect(openCodeAdapter.getSessionId(ctx({
+      "x-session-affinity": SESSION,
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-agent-name": "title",
+    }))).not.toBe(SESSION)
+  })
+
+  it("leaves the key unscoped when no agent name is present (older plugins)", () => {
+    expect(openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "subagent",
+    }))).toBe(SESSION)
+  })
+
+  it("returns undefined with no session header at all", () => {
+    expect(openCodeAdapter.getSessionId(ctx({ "x-opencode-agent-name": "title" }))).toBeUndefined()
+  })
+
+  it("ignores an agent name that sanitizes to nothing", () => {
+    expect(openCodeAdapter.getSessionId(ctx({
+      "x-opencode-session": SESSION,
+      "x-opencode-agent-mode": "subagent",
+      "x-opencode-agent-name": "   ",
+    }))).toBe(SESSION)
+  })
+})
+
+/**
+ * Plugin-less OpenCode is deliberately NOT handled here.
+ *
+ * Captured live from OpenCode 1.18.11 with no plugin configured, the title
+ * one-shot and the user's turn are separated only by request shape:
+ *   seq 1  tools=0  msgs=1  x-session-affinity: ses_fe4c…   ← title one-shot
+ *   seq 2  tools=10 msgs=1  x-session-affinity: ses_fe4c…   ← the user's turn
+ *
+ * Scoping on that shape was implemented and reverted: "tool-less, one message"
+ * is equally the FIRST TURN of an ordinary tool-less chat, and keying it apart
+ * left turn 2 unable to resume it. It turned five suites red, including
+ * session-lineage's "resumes when messages are a strict continuation".
+ *
+ * So the shape is left alone, and this test pins that: an unkeyed-agent request
+ * keeps the raw session id, whatever it looks like. Plugin-less OpenCode stays
+ * exposed to the collision, which is consistent with `meridian setup` being
+ * required — it is warned about at startup and reported by /health.
+ */
+describe("openCodeAdapter.getSessionId — shape is never used to infer an agent", () => {
+  const AFFINITY = "ses_fe4c090d9ffeymDAOxKAoBeqQ2"
+
+  it("keeps the raw key for a tool-less single-message request", () => {
+    expect(openCodeAdapter.getSessionId(ctx({ "x-session-affinity": AFFINITY }))).toBe(AFFINITY)
+  })
+
+  it("keeps the raw key for a tool-bearing request", () => {
+    expect(openCodeAdapter.getSessionId(ctx({ "x-session-affinity": AFFINITY }))).toBe(AFFINITY)
+  })
+})

--- a/src/__tests__/opencode-internal-agent-session-key.test.ts
+++ b/src/__tests__/opencode-internal-agent-session-key.test.ts
@@ -122,7 +122,13 @@ describe("openCodeAdapter.getSessionId — internal agent isolation", () => {
  * So the shape is left alone, and this test pins that: an unkeyed-agent request
  * keeps the raw session id, whatever it looks like. Plugin-less OpenCode stays
  * exposed to the collision, which is consistent with `meridian setup` being
- * required — it is warned about at startup and reported by /health.
+ * required. Note where that guardrail stops short: /health always reports
+ * `plugin: not-configured`, but the startup warning in bin/cli.ts is gated on
+ * an OpenCode config FILE existing (so meridian stays quiet for the many
+ * clients that are not OpenCode). Run the documented step 2 alone —
+ * `ANTHROPIC_BASE_URL=… opencode`, no config file — and there is no warning at
+ * all. Closing that would mean warning at request time, when an OpenCode
+ * request arrives carrying no plugin headers; deliberately not done here.
  */
 describe("openCodeAdapter.getSessionId — shape is never used to infer an agent", () => {
   const AFFINITY = "ses_fe4c090d9ffeymDAOxKAoBeqQ2"

--- a/src/__tests__/opencode-title-agent-collision.test.ts
+++ b/src/__tests__/opencode-title-agent-collision.test.ts
@@ -1,0 +1,178 @@
+/**
+ * OpenCode's title agent must not be able to break or de-cache the user's turn.
+ *
+ * Reproduced live against OpenCode 1.18.11 (3/3 runs). OpenCode fires its
+ * internal `title` agent concurrently with the user's first real turn, and both
+ * carry the SAME session id:
+ *
+ *   seq 1  agent=title  mode=subagent  tools=0   msgs=1  x-opencode-session: ses_fe4b…
+ *   seq 2  agent=build  mode=primary   tools=10  msgs=1  x-opencode-session: ses_fe4b…
+ *
+ * One key meant one lineage and one per-session turn lease. The title turn wins
+ * the race and commits a one-message lineage under the shared key; the user's
+ * turn then waits behind the lease (5-12s observed) and is measured against a
+ * conversation that is not its own — `unrelated-history`.
+ *
+ * Two outcomes, both bad, both covered here:
+ *   - since #825: HTTP 400 `session_turn_conflict`, which OpenCode surfaces as
+ *     a non-retryable APIError and the user's first turn is simply lost.
+ *   - before #825: the same divergence silently fell through to a full-history
+ *     replay on a fresh SDK session — a cold prompt cache every time a title
+ *     was generated.
+ *
+ * This is an HTTP-layer test on purpose: the unit tests pin the derived key,
+ * and this pins what the client actually receives.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let mockMessages: unknown[] = []
+let capturedOptions: any[] = []
+
+/** Set to hold the title request inside query() so it keeps the turn lease
+ *  while the user's turn arrives — the live race, made deterministic. */
+let holdTitleUntil: Promise<void> | undefined
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedOptions.push(params.options || {})
+    const isTitle = typeof params.prompt === "string" && params.prompt.includes("Generate a title")
+    return (async function* () {
+      if (isTitle && holdTitleUntil) await holdTitleUntil
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const SESSION = "ses_fe4bfa3daffexvfr3lL7db1lcU"
+
+/** OpenCode's internal title one-shot: no tools, one message, subagent mode. */
+const TITLE_HEADERS = {
+  "x-opencode-session": SESSION,
+  "x-opencode-agent-mode": "subagent",
+  "x-opencode-agent-name": "title",
+}
+const TITLE_BODY = {
+  model: "claude-haiku-4-5",
+  max_tokens: 128,
+  stream: false,
+  messages: [{
+    role: "user",
+    content: 'Generate a title for this conversation:\n"Read notes.txt and tell me the second line."',
+  }],
+}
+
+/** The user's own turn, same OpenCode session id. */
+const USER_HEADERS = {
+  "x-opencode-session": SESSION,
+  "x-opencode-agent-mode": "primary",
+  "x-opencode-agent-name": "build",
+}
+const USER_TURN_1 = {
+  model: "claude-haiku-4-5",
+  max_tokens: 1024,
+  stream: false,
+  tools: [{ name: "read", description: "read a file", input_schema: { type: "object", properties: {} } }],
+  messages: [{ role: "user", content: "Read notes.txt and tell me the second line." }],
+}
+const USER_TURN_2 = {
+  ...USER_TURN_1,
+  messages: [
+    ...USER_TURN_1.messages,
+    { role: "assistant", content: "ok" },
+    { role: "user", content: "And the third line?" },
+  ],
+}
+
+describe("OpenCode title agent vs the user's conversation", () => {
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedOptions = []
+    holdTitleUntil = undefined
+    clearSessionCache()
+  })
+  afterEach(() => { holdTitleUntil = undefined; clearSessionCache() })
+
+  it("does not refuse the user's turn after a title turn on the same session id", async () => {
+    const app = createTestApp()
+    expect((await post(app, TITLE_BODY, TITLE_HEADERS)).status).toBe(200)
+    const userTurn = await post(app, USER_TURN_1, USER_HEADERS)
+    expect(userTurn.status).toBe(200)
+    const body = await userTurn.json() as any
+    expect(body.error?.message ?? "").not.toContain("session advanced")
+  })
+
+  it("lets the user's conversation resume after a title turn interleaves", async () => {
+    const app = createTestApp()
+    await post(app, USER_TURN_1, USER_HEADERS)
+    await post(app, TITLE_BODY, TITLE_HEADERS)
+    const turn2 = await post(app, USER_TURN_2, USER_HEADERS)
+    expect(turn2.status).toBe(200)
+    // The title turn must not have displaced the conversation's stored lineage:
+    // turn 2 still resumes the SDK session rather than replaying cold.
+    expect(capturedOptions.at(-1)?.resume).toBe("test-session")
+  })
+
+  it("keeps the title turn itself working and independent", async () => {
+    const app = createTestApp()
+    await post(app, USER_TURN_1, USER_HEADERS)
+    await post(app, USER_TURN_2, USER_HEADERS)
+    const title = await post(app, TITLE_BODY, TITLE_HEADERS)
+    expect(title.status).toBe(200)
+    // A one-shot has nothing of its own to resume, and must not inherit the
+    // user's session either.
+    expect(capturedOptions.at(-1)?.resume).toBeUndefined()
+  })
+  /**
+   * The live shape: the title turn is still in flight when the user's turn
+   * arrives, so the user's turn queues on the per-session turn lease and is
+   * then judged against whatever the title turn committed. This is what
+   * returned HTTP 400 `session_turn_conflict` against real OpenCode.
+   */
+  it("does not refuse the user's turn that queued behind an in-flight title turn", async () => {
+    const app = createTestApp()
+    let release!: () => void
+    holdTitleUntil = new Promise<void>((resolve) => { release = resolve })
+
+    const titlePromise = post(app, TITLE_BODY, TITLE_HEADERS)
+    // Let the title request reach query() and take the lease before the user's
+    // turn arrives, so the user's turn genuinely waits on it.
+    await new Promise((r) => setTimeout(r, 20))
+    const userPromise = post(app, USER_TURN_1, USER_HEADERS)
+    await new Promise((r) => setTimeout(r, 20))
+    release()
+
+    const [title, user] = await Promise.all([titlePromise, userPromise])
+    expect(title.status).toBe(200)
+    expect(user.status).toBe(200)
+    const userBody = await user.json() as any
+    expect(JSON.stringify(userBody)).not.toContain("session advanced")
+  })
+})

--- a/src/__tests__/opencode-title-agent-collision.test.ts
+++ b/src/__tests__/opencode-title-agent-collision.test.ts
@@ -33,13 +33,21 @@ let capturedOptions: any[] = []
 /** Set to hold the title request inside query() so it keeps the turn lease
  *  while the user's turn arrives — the live race, made deterministic. */
 let holdTitleUntil: Promise<void> | undefined
+/** Fired when the title request's generator body starts running. The lease is
+ *  taken in the route handler before the SDK call, so by this point the title
+ *  request definitively holds it — which is what makes the race a signal and
+ *  not a sleep. */
+let onTitleEnteredQuery: (() => void) | undefined
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedOptions.push(params.options || {})
     const isTitle = typeof params.prompt === "string" && params.prompt.includes("Generate a title")
     return (async function* () {
-      if (isTitle && holdTitleUntil) await holdTitleUntil
+      if (isTitle) {
+        onTitleEnteredQuery?.()
+        if (holdTitleUntil) await holdTitleUntil
+      }
       for (const msg of mockMessages) yield msg
     })()
   },
@@ -57,6 +65,7 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { telemetryStore } = await import("../telemetry")
 
 function createTestApp() {
   const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
@@ -116,9 +125,15 @@ describe("OpenCode title agent vs the user's conversation", () => {
     mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
     capturedOptions = []
     holdTitleUntil = undefined
+    onTitleEnteredQuery = undefined
+    telemetryStore.clear()
     clearSessionCache()
   })
-  afterEach(() => { holdTitleUntil = undefined; clearSessionCache() })
+  afterEach(() => {
+    holdTitleUntil = undefined
+    onTitleEnteredQuery = undefined
+    clearSessionCache()
+  })
 
   it("does not refuse the user's turn after a title turn on the same session id", async () => {
     const app = createTestApp()
@@ -159,14 +174,22 @@ describe("OpenCode title agent vs the user's conversation", () => {
   it("does not refuse the user's turn that queued behind an in-flight title turn", async () => {
     const app = createTestApp()
     let release!: () => void
+    let titleHasLease!: Promise<void>
     holdTitleUntil = new Promise<void>((resolve) => { release = resolve })
+    titleHasLease = new Promise<void>((resolve) => { onTitleEnteredQuery = resolve })
 
     const titlePromise = post(app, TITLE_BODY, TITLE_HEADERS)
-    // Let the title request reach query() and take the lease before the user's
-    // turn arrives, so the user's turn genuinely waits on it.
-    await new Promise((r) => setTimeout(r, 20))
+    // Signal, not sleep: wait until the title request is inside query(), which
+    // is after the route handler took the turn lease.
+    await titleHasLease
+
     const userPromise = post(app, USER_TURN_1, USER_HEADERS)
-    await new Promise((r) => setTimeout(r, 20))
+    // Give the user's turn time to reach the lease and block on it. Bounded,
+    // and the sessionQueueWaitMs assertion below fails loudly if it did not —
+    // a race harness that silently stops racing is worse than no test.
+    for (let i = 0; i < 50 && capturedOptions.length < 2; i++) {
+      await new Promise((r) => setTimeout(r, 2))
+    }
     release()
 
     const [title, user] = await Promise.all([titlePromise, userPromise])
@@ -174,5 +197,17 @@ describe("OpenCode title agent vs the user's conversation", () => {
     expect(user.status).toBe(200)
     const userBody = await user.json() as any
     expect(JSON.stringify(userBody)).not.toContain("session advanced")
+
+    // The title turn held its own lease for the whole duration of the user's
+    // turn, and the user's turn did not wait on it for a millisecond. That
+    // zero IS the fix: live, this wait was 9,836 ms and ended in a 400.
+    //
+    // Asserted as 0 rather than "> 0 to prove the harness raced": the harness
+    // is proven live by running this file against the unscoped key, where the
+    // wait is non-zero and the status is 400. Demanding contention here would
+    // be demanding the bug.
+    const userMetric = telemetryStore.getRecent({ limit: 10 }).find((m) => m.toolCount === 1)
+    expect(userMetric).toBeDefined()
+    expect(userMetric!.sessionQueueWaitMs ?? 0).toBe(0)
   })
 })

--- a/src/__tests__/pluginless-opencode-warning.test.ts
+++ b/src/__tests__/pluginless-opencode-warning.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Make plugin-less OpenCode visible, since it cannot be fixed silently.
+ *
+ * OpenCode 1.18.11 sends `x-session-affinity` natively, so a client with no
+ * Meridian plugin is fully keyed and never reaches the fingerprint fallback.
+ * That is why it breaks rather than degrades: its internal `title` agent runs
+ * under the SAME session id as the user's chat, so one real key names two
+ * unrelated conversations. Captured at the wire with no plugin configured:
+ *
+ *   seq 1  tools=0   msgs=1  x-session-affinity: ses_fe4c…   ← title one-shot
+ *   seq 2  tools=10  msgs=1  x-session-affinity: ses_fe4c…   ← the user's turn
+ *
+ * Both attempts of that run returned HTTP 400 `session_turn_conflict` after a
+ * ~8s wait. The agent-scoped session key that fixes this reads the plugin's
+ * `x-opencode-agent-mode`, so it cannot reach a client that sends none.
+ *
+ * Inferring the agent from request shape was tried and reverted — "tool-less,
+ * one message" is equally the first turn of an ordinary tool-less chat. So the
+ * exposure stays, and the least-bad thing is to stop it being SILENT. The
+ * startup warning in bin/cli.ts does not cover this: it is gated on an OpenCode
+ * config FILE existing, so the documented `ANTHROPIC_BASE_URL=… opencode` path
+ * with no config warns nothing at all.
+ *
+ * A request-time signal has no such gap and no false positives: a `opencode/`
+ * User-Agent arriving without the plugin's headers is definitionally the
+ * exposed case.
+ */
+import { describe, it, expect, beforeEach } from "bun:test"
+import { notePluginlessOpenCodeRequest, clearPluginlessWarnings } from "../proxy/setup"
+
+const OPENCODE_UA = "opencode/1.18.11 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14"
+
+describe("notePluginlessOpenCodeRequest", () => {
+  beforeEach(() => clearPluginlessWarnings())
+
+  it("warns for an OpenCode request carrying no plugin headers", () => {
+    const msg = notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA,
+      agentModeHeader: undefined,
+      sessionId: "ses_fe4c090d9ffeymDAOxKAoBeqQ2",
+    })
+    expect(msg).toBeDefined()
+    expect(msg).toContain("meridian setup")
+  })
+
+  it("stays quiet when the plugin's agent header is present", () => {
+    expect(notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA,
+      agentModeHeader: "primary",
+      sessionId: "ses_a",
+    })).toBeUndefined()
+  })
+
+  it("stays quiet for clients that are not OpenCode", () => {
+    // MERIDIAN_DEFAULT_AGENT defaults to opencode, so unrelated clients reach
+    // the OpenCode adapter. The User-Agent is what makes this unambiguous —
+    // warning them would be telling a Pi user to configure an OpenCode plugin.
+    for (const ua of [
+      "claude-cli/2.1.0",
+      "litellm/1.0",
+      "python-httpx/0.27",
+      "Charm-Crush/0.87",
+      undefined,
+    ]) {
+      expect(notePluginlessOpenCodeRequest({
+        userAgent: ua, agentModeHeader: undefined, sessionId: "ses_b",
+      })).toBeUndefined()
+    }
+  })
+
+  it("warns once per session, not once per request", () => {
+    const args = { userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_c" }
+    expect(notePluginlessOpenCodeRequest(args)).toBeDefined()
+    expect(notePluginlessOpenCodeRequest(args)).toBeUndefined()
+    expect(notePluginlessOpenCodeRequest(args)).toBeUndefined()
+  })
+
+  it("warns again for a different session", () => {
+    expect(notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_d",
+    })).toBeDefined()
+    expect(notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_e",
+    })).toBeDefined()
+  })
+
+  it("treats an empty agent-mode header as absent", () => {
+    expect(notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: "", sessionId: "ses_f",
+    })).toBeDefined()
+  })
+
+  it("handles a keyless request without warning on every one of them", () => {
+    const args = { userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: undefined }
+    expect(notePluginlessOpenCodeRequest(args)).toBeDefined()
+    expect(notePluginlessOpenCodeRequest(args)).toBeUndefined()
+  })
+
+  it("names the consequence, not just the missing plugin", () => {
+    const msg = notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_g",
+    })!
+    // An operator who reads only this line should understand why they care.
+    expect(msg.toLowerCase()).toContain("title")
+    expect(msg).toMatch(/cold cache|400/)
+  })
+
+  it("does not leak a whole session id into the log line", () => {
+    const full = "ses_fe4c090d9ffeymDAOxKAoBeqQ2"
+    const msg = notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: full,
+    })!
+    expect(msg).not.toContain(full)
+  })
+
+  it("is bounded — a long-lived proxy cannot grow one entry per session forever", () => {
+    for (let i = 0; i < 5000; i++) {
+      notePluginlessOpenCodeRequest({
+        userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: `ses_${i}`,
+      })
+    }
+    // The earliest sessions have been evicted, so they warn again rather than
+    // being remembered forever. That is the intended trade: bounded memory.
+    expect(notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_0",
+    })).toBeDefined()
+    // A recent one is still remembered.
+    expect(notePluginlessOpenCodeRequest({
+      userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_4999",
+    })).toBeUndefined()
+  })
+})
+
+/**
+ * The unit tests above pin the decision; this pins that the request path
+ * actually asks. A helper nobody calls is the classic way a warning like this
+ * ships dead.
+ */
+describe("plugin-less warning through the HTTP path", () => {
+  it("records a diagnostic for a plugin-less OpenCode request, and not for a plugin-ful one", async () => {
+    const { mock } = await import("bun:test")
+    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+      query: () => (async function* () {
+        yield {
+          type: "assistant",
+          uuid: "u1",
+          session_id: "test-session",
+          message: { id: "m1", type: "message", role: "assistant", model: "m",
+            content: [{ type: "text", text: "ok" }], stop_reason: "end_turn",
+            usage: { input_tokens: 1, output_tokens: 1 } },
+        }
+      })(),
+      createSdkMcpServer: () => ({ type: "sdk", name: "t", instance: { tool: () => {}, registerTool: () => ({}) } }),
+      tool: () => ({}),
+    }))
+    mock.module("../logger", () => ({ claudeLog: () => {}, withClaudeLogContext: (_c: unknown, f: () => unknown) => f() }))
+    mock.module("../mcpTools", () => ({
+      createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+    }))
+
+    const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+    const { diagnosticLog } = await import("../telemetry")
+    clearSessionCache()
+    clearPluginlessWarnings()
+    diagnosticLog.clear()
+
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const send = (headers: Record<string, string>) => app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ model: "claude-haiku-4-5", max_tokens: 32, stream: false,
+        messages: [{ role: "user", content: "hi" }] }),
+    }))
+
+    // Plugin-less: exactly what OpenCode 1.18.11 sends on its own.
+    await send({ "user-agent": OPENCODE_UA, "x-session-affinity": "ses_pluginless" })
+    const afterPluginless = diagnosticLog.getRecent({ limit: 50 })
+      .filter((l) => l.message.includes("without the Meridian plugin"))
+    expect(afterPluginless.length).toBe(1)
+    expect(afterPluginless[0]!.level).toBe("warn")
+
+    // Plugin-ful: the agent header is present, so nothing new is logged.
+    await send({
+      "user-agent": OPENCODE_UA,
+      "x-opencode-session": "ses_withplugin",
+      "x-opencode-agent-mode": "primary",
+      "x-opencode-agent-name": "build",
+    })
+    const afterPluginful = diagnosticLog.getRecent({ limit: 50 })
+      .filter((l) => l.message.includes("without the Meridian plugin"))
+    expect(afterPluginful.length).toBe(1)
+  })
+})

--- a/src/proxy/adapters/opencode.ts
+++ b/src/proxy/adapters/opencode.ts
@@ -18,8 +18,45 @@ import { resolvePassthrough } from "../../env"
 export const openCodeAdapter: AgentAdapter = {
   name: "opencode",
 
+  /**
+   * NOTE: OpenCode-specific. OpenCode runs its internal one-shot agents —
+   * `title`, `summary`, `compaction` — under the USER'S session id, so the
+   * raw header is not a conversation identity on its own. Verified live
+   * against OpenCode 1.18.11: the title turn and the user's build turn arrive
+   * within milliseconds of each other carrying the same `x-opencode-session`.
+   * OpenCode also sends that value as `x-session-affinity` natively, so a
+   * client with no plugin has no agent header and cannot be scoped here — see
+   * the note in the body, and `meridian setup` (required, warned about at
+   * startup and reported by /health).
+   *
+   * Sharing one key made two unrelated conversations share one lineage and one
+   * per-session turn lease. The title turn wins the race, commits its
+   * one-message lineage, and the user's real turn — after waiting 5-12s behind
+   * the lease — is measured against it as `unrelated-history`: refused with
+   * HTTP 400 `session_turn_conflict` since #825, and before that replayed in
+   * full against a cold prompt cache.
+   *
+   * Scoping by agent gives every non-primary agent its own lineage and lease.
+   * The primary agent's key is deliberately left byte-identical to the raw
+   * header so existing conversations, the shared session store, and the
+   * `x-opencode-session` contract are unaffected.
+   *
+   * Real task-tool subagents are scoped too, which is strictly better than the
+   * status quo: they also carried the parent's key, so their turns and the
+   * parent's competed for one lease and one lineage.
+   */
   getSessionId(c: Context): string | undefined {
-    return c.req.header("x-opencode-session") ?? c.req.header("x-session-affinity")
+    const base = c.req.header("x-opencode-session") ?? c.req.header("x-session-affinity")
+    if (!base) return undefined
+    // Only non-primary agents are scoped, and only when the plugin says so.
+    // Inferring the agent from the request's shape was tried and reverted: the
+    // only available signal — a tool-less single-message conversation — is also
+    // the first turn of an ordinary tool-less chat, so scoping on it broke
+    // resume for those on turn 2 (5 suites red, incl. session-lineage's strict
+    // continuation). A plugin too old to send the name gets today's behavior.
+    if (c.req.header("x-opencode-agent-mode") !== "subagent") return base
+    const agent = c.req.header("x-opencode-agent-name")?.trim()
+    return agent ? `${base}#${agent}` : base
   },
 
   /** NOTE: OpenCode-specific. The plugin marks client-managed subagent turns. */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -64,7 +64,7 @@ import {
   isDesignAuthFailure,
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
-import { checkPluginConfigured } from "./setup"
+import { checkPluginConfigured, notePluginlessOpenCodeRequest } from "./setup"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
@@ -1236,6 +1236,25 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
         // Session resume: look up cached Claude SDK session and classify mutation
         const agentSessionId = adapter.getSessionId(c, body)
+        // NOTE: agent-specific (opencode). A plugin-less OpenCode client cannot
+        // have its internal title/summary agents told apart from the user's
+        // conversation, and that exposure is otherwise silent — the startup
+        // warning is gated on an OpenCode config file existing. Once per
+        // session; the helper owns the bookkeeping.
+        const pluginlessWarning = notePluginlessOpenCodeRequest({
+          userAgent: c.req.header("user-agent"),
+          agentModeHeader: c.req.header("x-opencode-agent-mode"),
+          sessionId: agentSessionId,
+        })
+        if (pluginlessWarning) {
+          plog(`[PROXY] ${requestMeta.requestId} ${pluginlessWarning}`)
+          diagnosticLog.log({
+            level: "warn",
+            category: "session",
+            message: `${requestMeta.requestId} ${pluginlessWarning}`,
+            requestId: requestMeta.requestId,
+          })
+        }
         // Scope session keys by profile to isolate resume state across accounts.
         // For agents with session IDs (OpenCode): prefix the key.
         // For agents without (Pi): pass profile-scoped workingDirectory to fingerprint lookup.

--- a/src/proxy/setup.ts
+++ b/src/proxy/setup.ts
@@ -6,6 +6,8 @@
  *   - `meridian setup`  — writes the plugin entry
  *   - `meridian` startup — warns if plugin is missing
  *   - `GET /health`     — reports plugin status
+ *   - every request      — warns when an OpenCode client sends no plugin
+ *                          headers (see notePluginlessOpenCodeRequest)
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
@@ -13,6 +15,7 @@ import { homedir, platform } from "os"
 import { dirname, join } from "path"
 import { fileURLToPath } from "url"
 import { applyEdits, modify, parse as parseJsonc, type ParseError } from "jsonc-parser"
+import { LRUMap } from "../utils/lruMap"
 
 /**
  * Thrown when an existing OpenCode config can't be parsed (even tolerantly).
@@ -98,6 +101,80 @@ export function checkPluginConfigured(configPath?: string): boolean {
   if (config === null) return false
   const plugins: unknown[] = Array.isArray(config.plugin) ? config.plugin : []
   return plugins.some(p => typeof p === "string" && isMeridianEntry(p))
+}
+
+// ---------------------------------------------------------------------------
+// Request-time plugin check
+// ---------------------------------------------------------------------------
+
+/**
+ * Sessions already warned about. Bounded: a proxy that runs for weeks must not
+ * accumulate one entry per conversation forever. Eviction only costs a repeated
+ * warning, which is the harmless direction.
+ */
+const pluginlessWarned = new LRUMap<string, true>(256)
+
+/** Reset the warned-session memory. Used by tests. */
+export function clearPluginlessWarnings(): void {
+  pluginlessWarned.clear()
+}
+
+/**
+ * NOTE: OpenCode-specific. Warn when an OpenCode client reaches the proxy
+ * without the plugin's agent headers, once per session.
+ *
+ * This exists because the exposure it reports cannot be fixed from inside
+ * Meridian. OpenCode 1.18.11 sends `x-session-affinity` natively, so a
+ * plugin-less client is fully keyed and never reaches the fingerprint fallback
+ * — and its internal `title` / `summary` / `compaction` agents run under the
+ * SAME session id as the user's chat. One real key, two unrelated
+ * conversations. Live, both attempts of a plugin-less run returned HTTP 400
+ * `session_turn_conflict` on the user's first turn after an ~8s wait.
+ *
+ * The fix for that collision scopes the session key by agent, which it reads
+ * from the plugin's `x-opencode-agent-mode`. A client that sends none cannot be
+ * scoped, and inferring the agent from request shape was tried and reverted:
+ * "tool-less, one message" is equally the first turn of an ordinary tool-less
+ * chat, and keying that apart broke resume for it.
+ *
+ * So the remaining job is to stop the exposure being silent. The startup
+ * warning in `bin/cli.ts` does not cover it — that one is gated on an OpenCode
+ * config FILE existing, deliberately, so Meridian stays quiet for the many
+ * clients that are not OpenCode. Run the documented
+ * `ANTHROPIC_BASE_URL=… opencode` with no config file and nothing warns.
+ *
+ * Keyed on the `opencode/` User-Agent rather than the resolved adapter:
+ * `MERIDIAN_DEFAULT_AGENT` defaults to opencode, so unrelated clients land on
+ * that adapter, and telling a Pi user to configure an OpenCode plugin is worse
+ * than saying nothing. The User-Agent has no such ambiguity.
+ *
+ * Returns the message to log, or undefined when there is nothing to say.
+ * Stateful but I/O-free — the caller owns the logging.
+ */
+export function notePluginlessOpenCodeRequest(input: {
+  userAgent: string | undefined
+  /** The plugin's `x-opencode-agent-mode` header, if it sent one. */
+  agentModeHeader: string | undefined
+  /** Client session id — used only to warn once per conversation. */
+  sessionId: string | undefined
+}): string | undefined {
+  if (!input.userAgent?.toLowerCase().startsWith("opencode/")) return undefined
+  // A plugin old enough to omit the agent headers is equally unable to prevent
+  // the collision, so it gets the same warning.
+  if (input.agentModeHeader) return undefined
+
+  const key = input.sessionId || "(keyless)"
+  if (pluginlessWarned.get(key)) return undefined
+  pluginlessWarned.set(key, true)
+
+  // Truncated: the line is meant to be pasteable into an issue.
+  const shortId = input.sessionId ? `${input.sessionId.slice(0, 12)}…` : "(no session header)"
+  return (
+    `OpenCode request without the Meridian plugin's agent headers (session ${shortId}). ` +
+    `OpenCode runs its internal title/summary agents under your session id, so Meridian ` +
+    `cannot tell them apart from your conversation: the first turn of each session can fail ` +
+    `with a 400 or replay against a cold cache. Fix: meridian setup (or update the plugin).`
+  )
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What users are reporting

Higher cost, OpenCode specifically. This started as a prompt-caching
investigation; caching turned out to be fine, and the actual defect is a session
key collision that both inflates cost *and* breaks the first turn.

## Root cause

OpenCode runs its internal one-shot agents — `title`, `summary`, `compaction` —
under the **user's** OpenCode session id, and fires `title` concurrently with the
user's first real turn. Both requests arrive carrying the same
`x-opencode-session`, so Meridian keyed two unrelated conversations — and one
per-session turn lease — to a single identity.

Reproduced against OpenCode 1.18.11, 3/3 runs, with and without the plugin
(captured at the wire):

```
seq 1  agent=title  mode=subagent  tools=0   msgs=1  x-opencode-session: ses_fe4b…
seq 2  agent=build  mode=primary   tools=10  msgs=1  x-opencode-session: ses_fe4b…
```

The title turn wins the race and commits its one-message lineage under the shared
key. The user's turn waits behind the lease — **9,836 ms observed** — and is then
measured against a conversation that is not its own: `unrelated-history`.

- **Since #825** (v1.62.x, three days old) that is answered with HTTP 400
  `session_turn_conflict`. OpenCode reports it as a non-retryable `APIError`, so
  the user's first turn is lost outright.
- **Before #825** the same divergence fell through silently to a full-history
  replay on a fresh SDK session — a cold prompt cache every time a title was
  generated.

## Fix

`openCodeAdapter.getSessionId` appends the agent name for non-primary agents
(`ses_x#title`). The primary agent's key stays byte-identical to the header, so
existing conversations, the shared session store and the `x-opencode-session`
contract are untouched. Real task-tool subagents are scoped too, which is
strictly better — they also carried the parent's key and competed for its lease
and lineage.

## What was tried and rejected

Inferring the agent from request shape. The only available signal — a tool-less
single-message conversation — is equally the **first turn of an ordinary
tool-less chat**, and keying it apart left turn 2 unable to resume. It turned
five suites red, including session-lineage's "resumes when messages are a strict
continuation". Plugin-less OpenCode therefore stays exposed, consistent with
`meridian setup` being required.

Where that guardrail stops short, stated precisely: `/health` always reports
`plugin: not-configured`, but the startup warning in `bin/cli.ts` is gated on an
OpenCode config **file** existing — deliberately, so meridian stays quiet for the
many clients that are not OpenCode. A user who runs only the documented step 2
(`ANTHROPIC_BASE_URL=… opencode`, no config file) gets no warning at all. Closing
that means warning at request time, when an OpenCode request arrives carrying no
plugin headers — **added in `dfdb8926`**.

`notePluginlessOpenCodeRequest` warns once per session when a `opencode/`
User-Agent arrives without `x-opencode-agent-mode`. Keyed on the User-Agent
rather than the resolved adapter: `MERIDIAN_DEFAULT_AGENT` defaults to opencode,
so Pi, LiteLLM and bare curl land on that adapter too, and telling a Pi user to
configure an OpenCode plugin is worse than silence. Bounded in an `LRUMap(256)`
so a long-running proxy cannot accumulate an entry per conversation; eviction
only costs a repeated warning. The message names the consequence rather than the
missing plugin, and truncates the session id so the line is pasteable into an
issue. A plugin too old to send the agent headers gets the same warning — it is
equally unable to prevent the collision.

Verified live against plugin-less OpenCode 1.18.11 — fires once, to the console
and `/telemetry/logs` at `level=warn`, on a run whose second request still
returns the 400 it warns about, which is the point:

```
OpenCode request without the Meridian plugin's agent headers (session ses_fe3f24bc…).
OpenCode runs its internal title/summary agents under your session id, so Meridian
cannot tell them apart from your conversation: the first turn of each session can fail
with a 400 or replay against a cold cache. Fix: meridian setup (or update the plugin).
```

11 tests, one through the HTTP path — a helper nobody calls is the classic way a
warning like this ships dead. Verified red without the wiring
(`Expected: 1, Received: 0`).

| OpenCode config | Before | After |
|---|---|---|
| plugin installed (documented setup) | 400 on first turn, or cold-cache replay | fixed — 0ms wait, resumes at 83-99% hit |
| plugin missing/old, config file exists | broken, one startup warning | still broken, warned per session with the reason |
| plugin missing, no config file | broken, **completely silent** | still broken, warned per session with the reason |

That third row is the documented `ANTHROPIC_BASE_URL=… opencode` quickstart.

## Validation

Both symptoms are red without the fix and green with it
(`opencode-title-agent-collision.test.ts`): the resume assertion covers the cost
path, and a deterministic in-flight race covers the 400.

Live, headless OpenCode 1.18.11, 3 turns with tool calls:

| | before | after |
|---|---|---|
| user's first turn | HTTP 400 `session_turn_conflict` (3/3) | 200 (3/3) |
| its `sessionWait` | 9,836 ms | 0 ms |
| later requests | — | 6/6 `lineage=continuation`, 83–99% cache hit |

Full suite: **2,786 pass, 0 fail**. `tsc --noEmit` clean.

## Where the cost actually goes

`scripts/audit-token-spend.mjs` (added here) attributes real billed spend from
the subprocess transcripts by cause — the transcripts carry per-API-call `usage`,
so these are billed totals, not per-request attribution. On this machine's 7,826
sessions / 38,797 API calls:

```
cause             calls  input-equiv    share
ALL SPEND         38797   657,555,077   100.0%
cold starts        7826   232,629,743    35.4%
digest turns       1150     5,639,922     0.9%
nudge turns        1292     2,412,753     0.4%
uncached calls     8817       425,068     0.1%
cold-start share of cache writes: 63.3%
```

**Cold starts dominate** — 63.3% of all cache writes. The discarded passthrough
turns (the intuitive suspect: after Meridian's deny the CLI calls the model again
and Meridian forks past that turn, so it is billed and thrown away) are 6.6% of
API calls but **1.2%** of spend. Not worth destabilising the deny wording for;
documented rather than changed.

Hypotheses tested and rejected, so they don't get re-litigated:

- **Broad cache failure for OpenCode** — no: 92–99% hit on the main path, measured.
- **`CLAUDE_CODE_SESSION_KIND=bg` suppressing cache writes** — no: `skipCacheWrite`
  in the CLI is reached only from `extract_memories` / `auto_dream`.
- **Beta stripping killing caching** — not implicated: OpenCode sends only
  `structured-outputs-*`; nothing was stripped in any run.
- **Keyless tool-result turns forced to `independent-request`** — unreachable for
  OpenCode 1.18.11: it sends `x-session-affinity` natively.
- **`continue: false` on the deny hook to stop the loop early** — the CLI ignores it.
- **`MERIDIAN_PASSTHROUGH_MAX_TURNS=1`** — removes both discarded turns (output
  −64%) but drops cache reads to zero, so it is net worse on any real conversation.
- **Small/tool-less prompts uncached** — real, negligible: 162,865 tokens across
  38,784 calls, essentially all under Anthropic's minimum cacheable prefix.

Adds E39 to `E2E.md`, including the isolation footgun that cost an hour here:
`OPENCODE_CONFIG_DIR` does **not** isolate OpenCode's config — it merges
`~/.config/opencode/opencode.json` on top, dragging in the real config's MCP
servers and hanging `init`. `XDG_CONFIG_HOME` is what actually isolates it.

