### PR TITLE
fix: stop hidden passthrough turns from invalidating cache

### DIFF
--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -900,6 +900,50 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
   })
 
+  it("stream: preserves a settled checkpoint at the one-turn SDK boundary", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "single-turn-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_single_turn"),
+      toolUseBlockStart(0, "read", "single-turn-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("single-turn-tool"),
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x once" }],
+    }, "es-single-turn-boundary")
+    expect(first.status).toBe(200)
+    const firstBody = await first.text()
+    expect(firstBody).toContain('"type":"tool_use"')
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says X" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x once" },
+        { role: "assistant", content: [{ type: "tool_use", id: "single-turn-tool", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "single-turn-tool", content: "X" }] },
+      ],
+    }, "es-single-turn-boundary")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
   it("stream: closes at turn 1 while digest and canonical result drain invisibly", async () => {
     mockMessages = [
       messageStart("msg_es"),

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -95,53 +95,60 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).includePartialMessages).toBe(true)
   })
 
-  it("sets maxTurns to 3 in passthrough mode (thinking + tool_use + handoff fits in 3 turns)", () => {
-    const result = buildQueryOptions(makeContext({ passthrough: true }))
-    expect(result.options.maxTurns).toBe(3)
+  it("sets maxTurns to 1 in streaming passthrough so hidden denial turns cannot move the cache breakpoint", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: true }))
+    expect(result.options.maxTurns).toBe(1)
   })
 
-  it("sets maxTurns to 3 in passthrough mode with resume (rehydration fits within base budget)", () => {
-    const result = buildQueryOptions(makeContext({ passthrough: true, resumeSessionId: "sess-123" }))
-    expect(result.options.maxTurns).toBe(3)
+  it("sets maxTurns to 1 in streaming passthrough with resume", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: true, resumeSessionId: "sess-123" }))
+    expect(result.options.maxTurns).toBe(1)
   })
 
-  it("sets maxTurns to 4 in passthrough mode with deferred tools (+1 for the ToolSearch discovery turn, #547)", () => {
-    const result = buildQueryOptions(makeContext({ passthrough: true, hasDeferredTools: true }))
-    expect(result.options.maxTurns).toBe(4)
+  it("sets maxTurns to 2 in streaming passthrough with deferred tools (+1 for ToolSearch discovery)", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: true, hasDeferredTools: true }))
+    expect(result.options.maxTurns).toBe(2)
   })
 
-  it("sets maxTurns to 4 in passthrough mode when resume AND deferred tools are both active (resume rehydration is inline; only the discovery turn adds)", () => {
+  it("sets maxTurns to 2 in streaming passthrough when resume and deferred tools are both active", () => {
     const result = buildQueryOptions(makeContext({
       passthrough: true,
+      stream: true,
       resumeSessionId: "sess-123",
       hasDeferredTools: true,
     }))
+    expect(result.options.maxTurns).toBe(2)
+  })
+
+  it("sets maxTurns to 4 in streaming passthrough with advisor (base 1 + advisor 3)", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: true, advisorModel: "claude-opus-4-7" }))
     expect(result.options.maxTurns).toBe(4)
   })
 
-  it("sets maxTurns to 6 in passthrough mode with advisor (base 3 + 3 for advisor call/result/answer)", () => {
-    const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7" }))
-    expect(result.options.maxTurns).toBe(6)
+  it("sets maxTurns to 4 in streaming passthrough with advisor + resume", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: true, advisorModel: "claude-opus-4-7", resumeSessionId: "sess-123" }))
+    expect(result.options.maxTurns).toBe(4)
   })
 
-  it("sets maxTurns to 6 in passthrough mode with advisor + resume", () => {
-    const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7", resumeSessionId: "sess-123" }))
-    expect(result.options.maxTurns).toBe(6)
+  it("sets maxTurns to 5 in streaming passthrough with advisor + deferred tools", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: true, advisorModel: "claude-opus-4-7", hasDeferredTools: true }))
+    expect(result.options.maxTurns).toBe(5)
   })
 
-  it("sets maxTurns to 7 in passthrough mode with advisor + deferred tools (base 3 + discovery 1 + advisor 3)", () => {
-    const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7", hasDeferredTools: true }))
-    expect(result.options.maxTurns).toBe(7)
-  })
-
-  it("sets maxTurns to 7 in passthrough mode with advisor + resume + deferred tools (all three active)", () => {
+  it("sets maxTurns to 5 in streaming passthrough with advisor + resume + deferred tools", () => {
     const result = buildQueryOptions(makeContext({
       passthrough: true,
+      stream: true,
       advisorModel: "claude-opus-4-7",
       resumeSessionId: "sess-123",
       hasDeferredTools: true,
     }))
-    expect(result.options.maxTurns).toBe(7)
+    expect(result.options.maxTurns).toBe(5)
+  })
+
+  it("keeps the three-turn durability drain for non-streaming passthrough", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, stream: false }))
+    expect(result.options.maxTurns).toBe(3)
   })
 
   it("does not bump maxTurns in non-passthrough mode when advisor is set", () => {

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -164,13 +164,16 @@ export interface BuildQueryResult {
  *
  * Compute maxTurns based on which SDK features are active. Each phase the SDK
  * walks before returning control to the host costs a turn:
- *   - Base (3): turn 1 generates content (extended thinking + tool_use blocks
- *     captured by PreToolUse hook); turn 2 receives the deny and may emit a
- *     follow-up (text or further tool_use); turn 3 wraps the stream cleanly.
- *     Was 2 historically — bumped after telemetry showed opus[1m] requests with
- *     thinking + tool_use exhausting the 2-turn budget mid-handoff and returning
- *     500s on fresh (non-resume) requests. See errors.ts sdk_termination
- *     diagnostic + telemetry.
+ *   - Streaming base (1): turn 1 generates the client-visible content and tool_use blocks.
+ *     The PreToolUse denial is only a handoff acknowledgement; allowing the SDK
+ *     to run another model turn creates a hidden side branch that is discarded
+ *     by the next resumeSessionAt rewind. Besides wasting a model call, that
+ *     moves the automatic prompt-cache breakpoint onto the discarded branch,
+ *     so long tool loops rewrite the full conversation after the ancestor cache
+ *     entry expires. A one-turn SDK termination is recovered as a successful
+ *     tool_use response and its settled assistant checkpoint is persisted by
+ *     server.ts. Non-streaming retains the three-turn durability drain until
+ *     its synchronous recovery path can persist the same boundary safely.
  *   - Deferred tools (+1): a ToolSearch discovery is a real model round-trip
  *     that consumes a turn before the model can emit the real tool_use. The
  *     old model wrongly assumed a lone deferred set fit in base 3, so the
@@ -183,9 +186,10 @@ export interface BuildQueryResult {
 function computePassthroughMaxTurns(
   hasDeferredTools: boolean,
   advisorModel: string | undefined,
+  stream: boolean,
 ): number {
   const deferredBump = hasDeferredTools ? 1 : 0
-  const defaultBase = 3 + deferredBump
+  const defaultBase = (stream ? 1 : 3) + deferredBump
   // The base is the SDK's internal-loop budget before it must return control.
   // It's normally enough (the capture path drops re-emitted duplicates and
   // stops the loop when the model starts repeating), but wide parallel tool
@@ -318,7 +322,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       // is not in PATH — causing subprocess spawns to fail.
       executable: "node" as const,
       maxTurns: passthrough
-        ? computePassthroughMaxTurns(hasDeferredTools, ctx.advisorModel)
+        ? computePassthroughMaxTurns(hasDeferredTools, ctx.advisorModel, stream)
         : 200,
       cwd: workingDirectory,
       model,

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -164,16 +164,23 @@ export interface BuildQueryResult {
  *
  * Compute maxTurns based on which SDK features are active. Each phase the SDK
  * walks before returning control to the host costs a turn:
- *   - Streaming base (1): turn 1 generates the client-visible content and tool_use blocks.
- *     The PreToolUse denial is only a handoff acknowledgement; allowing the SDK
- *     to run another model turn creates a hidden side branch that is discarded
- *     by the next resumeSessionAt rewind. Besides wasting a model call, that
- *     moves the automatic prompt-cache breakpoint onto the discarded branch,
- *     so long tool loops rewrite the full conversation after the ancestor cache
- *     entry expires. A one-turn SDK termination is recovered as a successful
- *     tool_use response and its settled assistant checkpoint is persisted by
- *     server.ts. Non-streaming retains the three-turn durability drain until
- *     its synchronous recovery path can persist the same boundary safely.
+ *   - Streaming base (1): turn 1 generates the client-visible content and
+ *     tool_use blocks. The PreToolUse denial means "hand this call to the
+ *     client"; it is not model feedback that needs another Claude turn. The
+ *     old base (3) let the SDK feed that denial back to Claude and drain to a
+ *     canonical result. That produced a hidden side branch which the next
+ *     client tool_result discarded by rewinding to the tool-bearing assistant
+ *     with resumeSessionAt. The hidden branch wasted a model call and moved the
+ *     automatic prompt-cache breakpoint onto history the client could not
+ *     reuse. With base 1, max_turns is the expected handoff boundary: server.ts
+ *     returns the captured tool_use as success and persists the settled
+ *     assistant UUID/tool IDs for the next client-driven turn.
+ *   - Non-streaming base (3): keep the historical durability drain. The base
+ *     was originally 2, but opus[1m] requests with extended thinking + tool_use
+ *     could exhaust it while processing the denial and return HTTP 500 on a
+ *     fresh request. Unlike streaming, the synchronous path does not yet
+ *     persist the one-turn checkpoint safely, so lowering this would restore
+ *     that failure mode. See errors.ts sdk_termination recovery/diagnostics.
  *   - Deferred tools (+1): a ToolSearch discovery is a real model round-trip
  *     that consumes a turn before the model can emit the real tool_use. The
  *     old model wrongly assumed a lone deferred set fit in base 3, so the

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4051,13 +4051,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 return
               }
 
-              if (passthrough && streamedToolUseIds.size > 0 && !sawCanonicalResult) {
-                // The client may already have advanced past this tool turn, so
-                // a failed hidden drain invalidates even an older cached mapping.
-                evictSession(profileSessionId, profileScopedCwd, body.messages || [])
-                claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream", reason: "drain_error" })
-              }
-
               const stderrOutput = stderrLines.join("\n").trim()
               if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
                 error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
@@ -4109,6 +4102,36 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 capturedToolUses: capturedToolUses.length,
                 abortIsOurs: sawDuplicateToolUse,
               }) && messageStartEmitted
+
+              // maxTurns=1 is the normal passthrough tool handoff. By the time
+              // the SDK reports that boundary, the iterator has observed the
+              // assistant tool-use UUID and its synthetic denial, so the
+              // checkpoint is settled and the subprocess has flushed its
+              // transcript while terminating. Preserve that checkpoint instead
+              // of evicting it: the next request rewinds here and appends the
+              // client's real tool_result without traversing a hidden digest
+              // branch. Other drain failures remain unsafe and are evicted.
+              const recoverableCheckpoint =
+                canRecoverAsToolUse &&
+                sdkTerm.reason === "max_turns" &&
+                Boolean(currentSessionId) &&
+                Boolean(nextPassthroughToolCallAssistantUuid) &&
+                Boolean(nextPassthroughToolCallIds?.length) &&
+                earlyStopFired &&
+                !isIndependentSession &&
+                !sawDuplicateToolUse
+
+              if (
+                passthrough &&
+                streamedToolUseIds.size > 0 &&
+                !sawCanonicalResult &&
+                !recoverableCheckpoint
+              ) {
+                // The client may already have advanced past this tool turn, so
+                // a failed hidden drain invalidates even an older cached mapping.
+                evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream", reason: "drain_error" })
+              }
 
               if (canRecoverAsToolUse) {
                 // Log the recovery at session level (not error) — it's a
@@ -4172,6 +4195,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 ), "recover_message_stop")
 
                 recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
+
+                if (recoverableCheckpoint) {
+                  storeSession(
+                    profileSessionId,
+                    body.messages || [],
+                    currentSessionId!,
+                    profileScopedCwd,
+                    sdkUuidMap,
+                    lastUsage,
+                    nextPassthroughToolCallAssistantUuid!,
+                    nextPassthroughToolCallIds!,
+                  )
+                  commitSessionTurn()
+                  claudeLog("passthrough.checkpoint_persisted", {
+                    mode: "stream",
+                    reason: "single_turn_boundary",
+                    toolCalls: nextPassthroughToolCallIds!.length,
+                  })
+                }
+
                 // Record as success — the client got a usable response.
                 const recoverTotalMs = Date.now() - requestStartAt
                 const recoverQueueWaitMs = totalQueueWaitMs(requestMeta)


### PR DESCRIPTION
## Summary

- limit streaming passthrough to the one client-visible model turn
- treat the resulting `max_turns` boundary as a successful tool handoff when the assistant checkpoint is fully settled
- persist that tool-bearing assistant checkpoint so the next client tool result resumes the same cache lineage
- retain the three-turn non-streaming budget and the existing deferred-tool and advisor allowances

## Previous data flow

Passthrough tools execute in the coding client, but Meridian must expose them through the Claude Agent SDK. Previously, streaming passthrough used a three-turn base budget:

```text
client request
  -> Claude turn 1: thinking + tool_use
  -> Meridian PreToolUse hook captures and denies SDK-side execution
  -> Claude turn 2: receives the synthetic denial and generates a hidden digest, retry, or follow-up
  -> SDK drain/canonical result
  -> Meridian returns only the original client-visible tool_use
  -> client executes the tool
  -> next request rewinds to the tool-bearing assistant with resumeSessionAt
```

The hidden turn was not part of the client conversation. The next request discarded it by rewinding to the visible assistant checkpoint. However, the hidden turn still consumed a model call and could move the automatic prompt-cache breakpoint onto the discarded branch. After the reusable ancestor cache entry expired, subsequent tool steps recreated the growing conversation prefix instead of reading the cache.

A two-turn budget had also failed historically: some fresh `opus[1m]` requests with extended thinking and tool use exhausted the budget while processing the synthetic denial and surfaced HTTP 500. Raising the shared base to three prevented that termination, but did not solve the hidden-branch cache divergence.

## New streaming data flow

For streaming passthrough, the denial means only that the client owns tool execution. It does not need another Claude turn:

```text
client request
  -> Claude turn 1: thinking + tool_use
  -> Meridian streams and captures the complete tool_use
  -> PreToolUse denial becomes iterator-visible
  -> Meridian records the settled assistant UUID and exact tool IDs
  -> maxTurns=1 ends the SDK invocation
  -> Meridian recovers that expected boundary as stop_reason=tool_use
  -> Meridian persists the settled assistant checkpoint
  -> client executes the tool
  -> next request appends the real tool_result at that same checkpoint
```

This keeps the client conversation, SDK resume point, and prompt-cache lineage on the same branch. There is no hidden digest turn to bill or later discard.

## Compatibility and safety

Non-streaming passthrough remains at a base of three turns. Its synchronous path does not yet persist the one-turn checkpoint with the same guarantees, so retaining three avoids reintroducing the historical `opus[1m]` HTTP 500 failure.

Streaming checkpoint persistence is allowed only when all of the following are true:

- termination reason is `max_turns`
- at least one captured tool call can be returned
- the SDK session and tool-bearing assistant UUID are known
- every expected tool denial has settled
- the exact pending tool ID set is available
- the request is not an independent session
- no duplicate-tool abort occurred

Other noncanonical failures continue to evict the session rather than preserving a potentially unsafe checkpoint. Deferred ToolSearch discovery still receives one additional turn, and advisor execution retains its existing three-turn allowance.

## Validation

- full test suite
- TypeScript typecheck
- production build
- provider-backed streaming smoke test covering three sequential client tool calls, stable session continuation, cache reuse, and a final text response without hidden model turns