### PR TITLE
test: model OpenCode's real base headers in the plugin harness

### DIFF
--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -7,13 +7,45 @@
  * agent silently mapped to "primary" sends subagent traffic out at the
  * primary 1M tier, burning rate-limit budget and (field-observed) tripping
  * Anthropic's extra-usage metering on fresh subagent sessions.
+ *
+ * `headersFor` invokes the hook with OpenCode's real empty output object, then
+ * composes the final wire headers from OpenCode's base headers, model headers,
+ * and plugin output. It used to return only the plugin contribution, which made
+ * class of change look verified when it was a no-op: a header the plugin stops
+ * setting is still on the wire if OpenCode set it, and Meridian reads the wire.
+ *
+ * Extracted from the OpenCode 1.18.11 binary (bun-compiled; visible via
+ * `strings`), for any provider whose id does not start with "opencode" — which
+ * is every request that reaches Meridian:
+ *
+ *   headers: {
+ *     ...(providerID.startsWith("opencode")
+ *        ? { "x-opencode-session": sessionID, "x-opencode-request": user.id, ... }
+ *        : { "x-session-affinity": sessionID, "X-Session-Id": sessionID,
+ *            ...(parentSessionID ? {"x-parent-session-id": parentSessionID} : {}),
+ *            "User-Agent": Ri }),
+ *     ...model.headers,
+ *     ...f            // f = this plugin's chat.headers output — spread LAST
+ *   }
+ *
+ * Two facts follow, and both are load-bearing for anything that touches
+ * session identity:
+ *
+ *   1. OpenCode ALWAYS contributes `x-session-affinity` (and `X-Session-Id`)
+ *      on this path. A plugin cannot remove that key by declining to set one.
+ *   2. Plugin headers are spread LAST, so a plugin CAN override it.
  */
 import { describe, it, expect, test } from "bun:test"
+import { Hono } from "hono"
 import MeridianPlugin from "../../plugin/meridian"
 import { PRIORITY_ATTESTATION_HEADER } from "../../plugin/priority-attestation"
+import { openCodeAdapter } from "../proxy/adapters/opencode"
 import { verifyPriorityAttestation } from "../proxy/priorityAttestation"
 
 type Hooks = Awaited<ReturnType<typeof MeridianPlugin>>
+type ChatHeadersHook = NonNullable<Hooks["chat.headers"]>
+type AgentInputForTest = Parameters<ChatHeadersHook>[0]["agent"]
+type ChatHeadersOutput = Parameters<ChatHeadersHook>[1]
 
 async function instance(cfgAgents?: Record<string, { mode?: string; hidden?: boolean }>): Promise<Hooks> {
   const hooks = await MeridianPlugin({})
@@ -21,22 +53,57 @@ async function instance(cfgAgents?: Record<string, { mode?: string; hidden?: boo
   return hooks
 }
 
-async function headersFor(
+/** The native headers OpenCode places on the final request before plugin output. */
+function openCodeBaseHeaders(sessionID: string): Record<string, string> {
+  return {
+    "x-session-affinity": sessionID,
+    "X-Session-Id": sessionID,
+    "User-Agent": "opencode/1.18.11 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14",
+  }
+}
+
+async function pluginHeadersFor(
   hooks: Hooks,
-  agent: unknown,
+  agent: AgentInputForTest,
   providerID = "anthropic",
+  sessionID = "ses_test",
 ): Promise<Record<string, string>> {
-  const output = { headers: {} as Record<string, string> }
-  await hooks["chat.headers"]!(
+  const output: ChatHeadersOutput = { headers: {} }
+  const hook = hooks["chat.headers"]
+  if (!hook) throw new Error("chat.headers hook was not registered")
+  await hook(
     {
-      sessionID: "ses_test",
-      agent: agent as any,
+      sessionID,
+      agent,
       model: { providerID },
       message: { id: "msg_test", time: { created: Date.now() } },
     },
     output,
   )
   return output.headers
+}
+
+async function headersFor(
+  hooks: Hooks,
+  agent: AgentInputForTest,
+  providerID = "anthropic",
+  sessionID = "ses_test",
+  modelHeaders: Record<string, string> = {},
+): Promise<Record<string, string>> {
+  const pluginHeaders = await pluginHeadersFor(hooks, agent, providerID, sessionID)
+  return { ...openCodeBaseHeaders(sessionID), ...modelHeaders, ...pluginHeaders }
+}
+
+/** Resolve a header bag through a real Hono request, the way the proxy does. */
+async function sessionKeyFor(headers: Record<string, string>): Promise<string | undefined> {
+  let sessionKey: string | undefined
+  const app = new Hono()
+  app.get("/", (context) => {
+    sessionKey = openCodeAdapter.getSessionId(context)
+    return context.body(null)
+  })
+  await app.request("http://localhost/", { headers: new Headers(headers) })
+  return sessionKey
 }
 
 describe("plugin/meridian.ts agent-mode header", () => {
@@ -81,17 +148,31 @@ describe("plugin/meridian.ts agent-mode header", () => {
     expect(legacy["x-opencode-agent-mode"]).toBe("primary")
   })
 
-  it("session and request headers are always set for anthropic requests", async () => {
+  it("composes native, model, and plugin headers in final wire order", async () => {
     const hooks = await instance()
-    const h = await headersFor(hooks, "explore")
+    const h = await headersFor(hooks, "explore", "anthropic", "ses_test", {
+      "x-opencode-session": "model-spoof",
+      "x-opencode-request": "model-spoof",
+      "x-model-header": "present",
+    })
+    expect(h["x-session-affinity"]).toBe("ses_test")
+    expect(h["X-Session-Id"]).toBe("ses_test")
+    expect(h["User-Agent"]).toStartWith("opencode/1.18.11 ")
+    expect(h["x-model-header"]).toBe("present")
     expect(h["x-opencode-session"]).toBe("ses_test")
     expect(h["x-opencode-request"]).toBe("msg_test")
+    expect(h["x-opencode-agent-name"]).toBe("explore")
+    expect(h["x-opencode-agent-mode"]).toBe("subagent")
   })
 
-  it("non-anthropic providers get no headers", async () => {
+  it("keeps plugin output empty for other providers while retaining native headers", async () => {
     const hooks = await instance()
+    expect(await pluginHeadersFor(hooks, "title", "openrouter")).toEqual({})
+
     const h = await headersFor(hooks, "title", "openrouter")
-    expect(Object.keys(h)).toHaveLength(0)
+    expect(h["x-session-affinity"]).toBe("ses_test")
+    expect(h["X-Session-Id"]).toBe("ses_test")
+    expect(h["User-Agent"]).toStartWith("opencode/1.18.11 ")
   })
 
   it("agent names are sanitized to printable ASCII", async () => {
@@ -119,6 +200,54 @@ describe("plugin/meridian.ts agent-mode header", () => {
     expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("primary")
     await hooks.config?.({ agent: {} })
     expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  /**
+   * The proposition PR #845 believed it had proved, stated as a test.
+   *
+   * It stopped the plugin setting `x-opencode-session` for title/summary,
+   * expecting that to detach those one-shots from the user's conversation. It
+   * does not: OpenCode's own `x-session-affinity` survives, and
+   * `openCodeAdapter.getSessionId` reads `x-opencode-session ?? x-session-affinity`.
+   * With the old harness returning only `output.headers`, it could not see
+   * this, so the change shipped green CI on a no-op.
+   *
+   * These assert on the key Meridian DERIVES, not on any single header, so they
+   * stay true through any future reshuffle of which header carries the id.
+   */
+  describe("session identity as the proxy resolves it", () => {
+    it("retains a session key when x-opencode-session is absent", async () => {
+      const hooks = await instance()
+      const headers = await headersFor(hooks, "build")
+      delete headers["x-opencode-session"]
+      expect(await sessionKeyFor(headers)).toBe("ses_test")
+    })
+
+    it("uses native affinity as the base for agent scoping", async () => {
+      const hooks = await instance()
+      const title = await headersFor(hooks, "title")
+      const build = await headersFor(hooks, "build")
+      delete title["x-opencode-session"]
+      delete build["x-opencode-session"]
+
+      expect(title["x-session-affinity"]).toBe(build["x-session-affinity"])
+      expect(await sessionKeyFor(title)).toBe("ses_test#title")
+      expect(await sessionKeyFor(build)).toBe("ses_test")
+    })
+
+    it("resolves the user's turn and each internal one-shot to exact distinct keys", async () => {
+      const hooks = await instance()
+      const keys: Record<string, string | undefined> = {}
+      for (const agent of ["build", "title", "summary", "compaction"]) {
+        keys[agent] = await sessionKeyFor(await headersFor(hooks, agent))
+      }
+      expect(keys).toEqual({
+        build: "ses_test",
+        title: "ses_test#title",
+        summary: "ses_test#summary",
+        compaction: "ses_test#compaction",
+      })
+    })
   })
 })
 
@@ -157,8 +286,6 @@ describe("plugin/meridian.ts trusted routing attestation", () => {
     }, output)
     return output.headers
   }
-
-  type AgentInputForTest = string | { name?: string; mode?: string; hidden?: boolean }
 
   test("signs only an exact visible primary root human message", async () => {
     const saved = process.env.MERIDIAN_OPENCODE_ATTESTATION_KEY

--- a/src/__tests__/plugin-agent-mode.test.ts
+++ b/src/__tests__/plugin-agent-mode.test.ts
@@ -7,9 +7,37 @@
  * agent silently mapped to "primary" sends subagent traffic out at the
  * primary 1M tier, burning rate-limit budget and (field-observed) tripping
  * Anthropic's extra-usage metering on fresh subagent sessions.
+ *
+ * `headersFor` seeds `output.headers` with the headers OPENCODE ITSELF puts
+ * there before the hook runs. It used to seed `{}`, which modelled the
+ * plugin's contribution in isolation and made an entire class of change look
+ * verified when it was a no-op: a header the plugin stops setting is still on
+ * the wire if OpenCode set it, and Meridian reads the wire.
+ *
+ * Extracted from the OpenCode 1.18.11 binary (bun-compiled; visible via
+ * `strings`), for any provider whose id does not start with "opencode" — which
+ * is every request that reaches Meridian:
+ *
+ *   headers: {
+ *     ...(providerID.startsWith("opencode")
+ *        ? { "x-opencode-session": sessionID, "x-opencode-request": user.id, ... }
+ *        : { "x-session-affinity": sessionID, "X-Session-Id": sessionID,
+ *            ...(parentSessionID ? {"x-parent-session-id": parentSessionID} : {}),
+ *            "User-Agent": Ri }),
+ *     ...model.headers,
+ *     ...f            // f = this plugin's chat.headers output — spread LAST
+ *   }
+ *
+ * Two facts follow, and both are load-bearing for anything that touches
+ * session identity:
+ *
+ *   1. OpenCode ALWAYS contributes `x-session-affinity` (and `X-Session-Id`)
+ *      on this path. A plugin cannot remove that key by declining to set one.
+ *   2. Plugin headers are spread LAST, so a plugin CAN override it.
  */
 import { describe, it, expect } from "bun:test"
 import MeridianPlugin from "../../plugin/meridian"
+import { openCodeAdapter } from "../proxy/adapters/opencode"
 
 type Hooks = Awaited<ReturnType<typeof MeridianPlugin>>
 
@@ -19,15 +47,26 @@ async function instance(cfgAgents?: Record<string, { mode?: string }>): Promise<
   return hooks
 }
 
+/** The headers OpenCode puts on `output.headers` before the hook runs. */
+function openCodeBaseHeaders(sessionID: string): Record<string, string> {
+  return {
+    "x-session-affinity": sessionID,
+    "X-Session-Id": sessionID,
+    "User-Agent": "opencode/1.18.11 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14",
+  }
+}
+
 async function headersFor(
   hooks: Hooks,
   agent: unknown,
   providerID = "anthropic",
+  sessionID = "ses_test",
 ): Promise<Record<string, string>> {
-  const output = { headers: {} as Record<string, string> }
+  // Seeded, not empty — see the note at the top of this file.
+  const output = { headers: openCodeBaseHeaders(sessionID) }
   await hooks["chat.headers"]!(
     {
-      sessionID: "ses_test",
+      sessionID,
       agent: agent as any,
       model: { providerID },
       message: { id: "msg_test" },
@@ -35,6 +74,14 @@ async function headersFor(
     output,
   )
   return output.headers
+}
+
+/** Resolve a header bag the way the proxy does, so a test can assert on the
+ *  session key Meridian actually derives rather than on one header. */
+function sessionKeyFor(headers: Record<string, string>): string | undefined {
+  const lower: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v
+  return openCodeAdapter.getSessionId({ req: { header: (n: string) => lower[n.toLowerCase()] } } as any)
 }
 
 describe("plugin/meridian.ts agent-mode header", () => {
@@ -86,10 +133,20 @@ describe("plugin/meridian.ts agent-mode header", () => {
     expect(h["x-opencode-request"]).toBe("msg_test")
   })
 
-  it("non-anthropic providers get no headers", async () => {
+  it("non-anthropic providers get none of the plugin's headers", async () => {
     const hooks = await instance()
     const h = await headersFor(hooks, "title", "openrouter")
-    expect(Object.keys(h)).toHaveLength(0)
+    // Asserted per-key, not as an empty bag. OpenCode's own base headers are
+    // there regardless of provider, and "the bag is empty" would have quietly
+    // stopped being the same claim as "the plugin added nothing".
+    for (const k of [
+      "x-opencode-session",
+      "x-opencode-request",
+      "x-opencode-agent-mode",
+      "x-opencode-agent-name",
+    ]) {
+      expect(h[k]).toBeUndefined()
+    }
   })
 
   it("agent names are sanitized to printable ASCII", async () => {
@@ -117,5 +174,57 @@ describe("plugin/meridian.ts agent-mode header", () => {
     expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("primary")
     await hooks.config?.({ agent: {} })
     expect((await headersFor(hooks, "general"))["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  /**
+   * The proposition PR #845 believed it had proved, stated as a test.
+   *
+   * It stopped the plugin setting `x-opencode-session` for title/summary,
+   * expecting that to detach those one-shots from the user's conversation. It
+   * does not: OpenCode's own `x-session-affinity` survives, and
+   * `openCodeAdapter.getSessionId` reads `x-opencode-session ?? x-session-affinity`.
+   * With `output.headers` seeded as `{}` the old harness could not see this, so
+   * the change shipped a green CI on a no-op.
+   *
+   * These assert on the key Meridian DERIVES, not on any single header, so they
+   * stay true through any future reshuffle of which header carries the id.
+   */
+  describe("session identity as the proxy resolves it", () => {
+    it("a request keeps a session key even with no x-opencode-session at all", async () => {
+      const hooks = await instance()
+      const h = await headersFor(hooks, "build")
+      delete h["x-opencode-session"]      // what #845 did
+      expect(sessionKeyFor(h)).toBe("ses_test")   // still keyed, via x-session-affinity
+    })
+
+    it("dropping x-opencode-session does NOT separate a one-shot from the user's turn", async () => {
+      const hooks = await instance()
+      const title = await headersFor(hooks, "title")
+      const build = await headersFor(hooks, "build")
+      delete title["x-opencode-session"]
+      delete build["x-opencode-session"]
+      // Both fall back to the same x-session-affinity. Identical keys would be
+      // the collision back; they differ only because the proxy scopes by agent.
+      expect(title["x-session-affinity"]).toBe(build["x-session-affinity"])
+      expect(sessionKeyFor(title)).not.toBe(sessionKeyFor(build))
+    })
+
+    it("the plugin can override OpenCode's base header, because it is spread last", async () => {
+      const hooks = await instance()
+      const h = await headersFor(hooks, "build")
+      // Not a claim about today's plugin — a claim about the hook contract that
+      // any header-based fix depends on. Verified against the 1.18.11 binary.
+      h["x-session-affinity"] = "overridden"
+      expect(sessionKeyFor({ ...h, "x-opencode-session": undefined as any })).toBe("overridden")
+    })
+
+    it("the user's turn and each internal one-shot resolve to distinct keys", async () => {
+      const hooks = await instance()
+      const keys = new Set<string | undefined>()
+      for (const agent of ["build", "title", "summary", "compaction"]) {
+        keys.add(sessionKeyFor(await headersFor(hooks, agent)))
+      }
+      expect(keys.size).toBe(4)
+    })
   })
 })

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { describe, expect, test } from "bun:test"
+import { Hono } from "hono"
 import MeridianV2Plugin, {
   applyMeridianV2Headers,
   fallbackAgentTraits,
@@ -27,6 +28,17 @@ function coreHeaders(sessionID: string, parentID = "ses_parent"): Record<string,
   }
 }
 
+async function sessionKeyFor(headers: Record<string, string>): Promise<string | undefined> {
+  let sessionKey: string | undefined
+  const app = new Hono()
+  app.get("/", (context) => {
+    sessionKey = openCodeAdapter.getSessionId(context)
+    return context.body(null)
+  })
+  await app.request("http://localhost/", { headers: new Headers(headers) })
+  return sessionKey
+}
+
 function rewrite(
   agent: string,
   traits: AgentTraits = fallbackAgentTraits(agent),
@@ -45,7 +57,7 @@ describe("plugin/meridian-v2.ts export", () => {
 
 describe("plugin/meridian-v2.ts hidden parent-session one-shots", () => {
   for (const agent of ["title", "summary"]) {
-    test(`${agent} is detached from the parent session`, () => {
+    test(`${agent} is detached from the parent session`, async () => {
       const headers = rewrite(agent)
 
       expect(headers["x-opencode-session"]).toBeUndefined()
@@ -55,6 +67,7 @@ describe("plugin/meridian-v2.ts hidden parent-session one-shots", () => {
       expect(headers["x-meridian-source"]).toBe(`subagent-${agent}`)
       expect(headers["x-opencode-agent-mode"]).toBe("subagent")
       expect(headers["x-opencode-project"]).toBe("prj_1")
+      expect(await sessionKeyFor(headers)).toBeUndefined()
     })
   }
 
@@ -87,17 +100,13 @@ describe("plugin/meridian-v2.ts hidden parent-session one-shots", () => {
     expect(headers["x-meridian-source"]).toBeUndefined()
   })
 
-  test("compaction remains on the primary key but gets the subagent tier", () => {
+  test("compaction remains on the primary key but gets the subagent tier", async () => {
     const headers = rewrite("compaction", { mode: "primary", hidden: false })
 
     expect(headers["x-opencode-session"]).toBe("ses_abc")
     expect(headers["x-meridian-source"]).toBe("subagent-compaction")
     expect(headers["x-opencode-agent-mode"]).toBe("primary")
-
-    const sessionKey = Reflect.apply(openCodeAdapter.getSessionId, openCodeAdapter, [{
-      req: { header: (name: string) => headers[name.toLowerCase()] },
-    }])
-    expect(sessionKey).toBe("ses_abc")
+    expect(await sessionKeyFor(headers)).toBe("ses_abc")
   })
 
   test("exact beta built-ins fall back to their native primary traits", () => {
@@ -109,17 +118,18 @@ describe("plugin/meridian-v2.ts hidden parent-session one-shots", () => {
 
 describe("plugin/meridian-v2.ts primary and subagent identity", () => {
   for (const agent of ["build", "plan"]) {
-    test(`${agent} keeps the primary session`, () => {
+    test(`${agent} keeps the primary session`, async () => {
       const headers = rewrite(agent)
       expect(headers["x-opencode-session"]).toBe("ses_abc")
       expect(headers["x-session-affinity"]).toBe("ses_abc")
       expect(headers["x-session-id"]).toBe("ses_abc")
       expect(headers["x-opencode-agent-mode"]).toBe("primary")
+      expect(await sessionKeyFor(headers)).toBe("ses_abc")
     })
   }
 
   for (const agent of ["general", "explore", "code-reviewer"]) {
-    test(`${agent} keeps its own session as a subagent`, () => {
+    test(`${agent} keeps its own session as a subagent`, async () => {
       const traits = agent === "code-reviewer"
         ? { mode: "subagent" as const, hidden: false }
         : fallbackAgentTraits(agent)
@@ -129,6 +139,7 @@ describe("plugin/meridian-v2.ts primary and subagent identity", () => {
       expect(headers["x-opencode-agent-name"]).toBe(agent)
       expect(headers["x-opencode-agent-mode"]).toBe("subagent")
       expect(headers["x-meridian-source"]).toBeUndefined()
+      expect(await sessionKeyFor(headers)).toBe(`ses_abc#${agent}`)
     })
   }
 


### PR DESCRIPTION
## Problem

The V1 plugin harness returned only the plugin's `chat.headers` accumulator. OpenCode 1.18.11 builds the actual request in three stages:

1. native headers, including `x-session-affinity` and `X-Session-Id`;
2. `model.headers`;
3. plugin output, spread last.

Testing only stage 3 can make an identity change look effective when OpenCode's native affinity header still keeps the request keyed. PR #845 was the concrete example.

## Changes

- Invoke the V1 hook with its real empty output object.
- Compose native, model, and plugin headers in actual wire order.
- Keep the non-Anthropic plugin-output assertion exact while proving native headers remain.
- Resolve final V1 headers through a real Hono request and pin the exact keys for `build`, `title`, `summary`, and `compaction`.
- Use the same real proxy boundary for existing V2 header rewrites:
  - `title` and `summary` resolve to no adapter key;
  - primary and `compaction` requests retain the base key;
  - ordinary subagents receive `#agent` scope.
- Remove the V2 fake-context `Reflect.apply` workaround.
- Add no production code and no forbidden casts or suppression directives.

## Validation

Exact head: `38d7e6702a3903b971d20515a6e60c4a6255eef7`

- `npm test`: **3,122 passed, 1 skipped, 0 failed**
- focused V1/V2/session-key tests: **59 passed, 0 failed**
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run --json`
- `git diff --check origin/main...HEAD`
- added-line audit: no `as any`, `as unknown as`, `@ts-ignore`, or `@ts-expect-error`

Two independent read-only reviews found no remaining blocker after the exact merge-stage and proxy-boundary repairs.
