### PR TITLE
fix: preserve the passthrough checkpoint when the SDK stops at its turn cap

### DIFF
--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -900,6 +900,50 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
   })
 
+  it("stream: preserves a settled checkpoint at the one-turn SDK boundary", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "single-turn-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_single_turn"),
+      toolUseBlockStart(0, "read", "single-turn-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("single-turn-tool"),
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x once" }],
+    }, "es-single-turn-boundary")
+    expect(first.status).toBe(200)
+    const firstBody = await first.text()
+    expect(firstBody).toContain('"type":"tool_use"')
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says X" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x once" },
+        { role: "assistant", content: [{ type: "tool_use", id: "single-turn-tool", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "single-turn-tool", content: "X" }] },
+      ],
+    }, "es-single-turn-boundary")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
   it("stream: closes at turn 1 while digest and canonical result drain invisibly", async () => {
     mockMessages = [
       messageStart("msg_es"),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4122,14 +4122,27 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 abortIsOurs: sawDuplicateToolUse,
               }) && messageStartEmitted
 
-              // maxTurns=1 is the normal passthrough tool handoff. By the time
-              // the SDK reports that boundary, the iterator has observed the
-              // assistant tool-use UUID and its synthetic denial, so the
-              // checkpoint is settled and the subprocess has flushed its
-              // transcript while terminating. Preserve that checkpoint instead
-              // of evicting it: the next request rewinds here and appends the
-              // client's real tool_result without traversing a hidden digest
-              // branch. Other drain failures remain unsafe and are evicted.
+              // A turn-cap stop is the one drain failure whose checkpoint is
+              // safe to keep, and the reason is specific: the SDK can only
+              // report `max_turns` from a `result` message it has already
+              // enqueued, and it awaits its transcript flush on `result`
+              // (Query.readMessages in the bundled agent SDK builds the error
+              // text from lastErrorResultText, which only a delivered result
+              // populates). So the transcript is committed by the time we see
+              // this — categorically unlike the abort-shaped failure that
+              // motivated the eviction, where a SIGTERM'd subprocess emits no
+              // result at all. That is the invariant passthroughEarlyStop.ts
+              // requires before a resumeSessionAt UUID may be published.
+              //
+              // Which also means `sawCanonicalResult` is already true here, so
+              // the eviction below would not have fired on this path anyway;
+              // naming the case in the guard is belt-and-braces, and the
+              // load-bearing half is the storeSession further down.
+              //
+              // Keeping it lets the next request rewind to the tool-use
+              // boundary and append the client's real tool_result, instead of
+              // replaying the conversation against a cold cache. Other drain
+              // failures remain unsafe and are evicted.
               const recoverableCheckpoint =
                 canRecoverAsToolUse &&
                 sdkTerm.reason === "max_turns" &&

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4070,13 +4070,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 return
               }
 
-              if (passthrough && streamedToolUseIds.size > 0 && !sawCanonicalResult) {
-                // The client may already have advanced past this tool turn, so
-                // a failed hidden drain invalidates even an older cached mapping.
-                evictSession(profileSessionId, profileScopedCwd, body.messages || [])
-                claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream", reason: "drain_error" })
-              }
-
               const stderrOutput = stderrLines.join("\n").trim()
               if (stderrOutput && error instanceof Error && !error.message.includes(stderrOutput)) {
                 error.message = `${error.message}\nSubprocess stderr: ${stderrOutput}`
@@ -4128,6 +4121,36 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 capturedToolUses: capturedToolUses.length,
                 abortIsOurs: sawDuplicateToolUse,
               }) && messageStartEmitted
+
+              // maxTurns=1 is the normal passthrough tool handoff. By the time
+              // the SDK reports that boundary, the iterator has observed the
+              // assistant tool-use UUID and its synthetic denial, so the
+              // checkpoint is settled and the subprocess has flushed its
+              // transcript while terminating. Preserve that checkpoint instead
+              // of evicting it: the next request rewinds here and appends the
+              // client's real tool_result without traversing a hidden digest
+              // branch. Other drain failures remain unsafe and are evicted.
+              const recoverableCheckpoint =
+                canRecoverAsToolUse &&
+                sdkTerm.reason === "max_turns" &&
+                Boolean(currentSessionId) &&
+                Boolean(nextPassthroughToolCallAssistantUuid) &&
+                Boolean(nextPassthroughToolCallIds?.length) &&
+                earlyStopFired &&
+                !isIndependentSession &&
+                !sawDuplicateToolUse
+
+              if (
+                passthrough &&
+                streamedToolUseIds.size > 0 &&
+                !sawCanonicalResult &&
+                !recoverableCheckpoint
+              ) {
+                // The client may already have advanced past this tool turn, so
+                // a failed hidden drain invalidates even an older cached mapping.
+                evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream", reason: "drain_error" })
+              }
 
               if (canRecoverAsToolUse) {
                 // Log the recovery at session level (not error) — it's a
@@ -4191,6 +4214,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 ), "recover_message_stop")
 
                 recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
+
+                if (recoverableCheckpoint) {
+                  storeSession(
+                    profileSessionId,
+                    body.messages || [],
+                    currentSessionId!,
+                    profileScopedCwd,
+                    sdkUuidMap,
+                    lastUsage,
+                    nextPassthroughToolCallAssistantUuid!,
+                    nextPassthroughToolCallIds!,
+                  )
+                  commitSessionTurn()
+                  claudeLog("passthrough.checkpoint_persisted", {
+                    mode: "stream",
+                    reason: "single_turn_boundary",
+                    toolCalls: nextPassthroughToolCallIds!.length,
+                  })
+                }
+
                 // Record as success — the client got a usable response.
                 const recoverTotalMs = Date.now() - requestStartAt
                 const recoverQueueWaitMs = totalQueueWaitMs(requestMeta)


### PR DESCRIPTION
Lands the safe half of **#850** by @chakflying, cherry-picked to preserve authorship. The `maxTurns` 3→1 half of that PR is deliberately **not** here — see below, with measurements.

## What this fixes

When a streaming passthrough turn ends on the SDK's turn cap, the streaming catch block evicted the session mapping and never called `storeSession` — the happy-path store is skipped because the iterator threw. So the client's real `tool_result` arrived against a fresh SDK session and replayed the whole conversation against a cold cache.

This preserves the settled early-stop checkpoint and stores it, so the next request rewinds to the tool-use boundary and appends the `tool_result` there. Other drain failures remain unsafe and are still evicted.

Credit where it's due: this is the diagnosis I missed. I tested `MERIDIAN_PASSTHROUGH_MAX_TURNS=1` earlier, watched cache reads drop to zero, and concluded the idea was net-negative. @chakflying found *why* it dropped — the missing store — rather than stopping at the symptom.

## Why the `maxTurns` half is held back

Measured on this branch (so the checkpoint store is in place), identical 3-turn tool-calling OpenCode session, billed usage read from the subprocess transcripts:

| | API calls | billed input-equiv | upstream time | session lease wait |
|---|---|---|---|---|
| default turn budget | 12 | 36,554 | 32,747 ms | 9,536 ms |
| `MERIDIAN_PASSTHROUGH_MAX_TURNS=1` | 7 | 21,574 | 17,335 ms | **0 ms** |

**−42% API calls, −41% billed spend, −47% upstream time.** The turn-budget change is worth *more* than the 1.2%-of-spend ceiling I measured across historical traffic — that average is diluted by long sessions and non-passthrough clients; in a short session the discarded turns were 20.2% of spend. The latency win is real too, and it is the argument #850 should have made: the drain holds the SDK slot **and** the per-session turn lease, so the next request in the session queues behind it.

Two blockers reproduced in that same run, though:

1. **The tool-less one-shot hard-500s.** `tools=0, mc=1` (OpenCode's `title` agent) → with a 1-turn budget there is no turn to recover in, `canRecoverCapturedToolUses` returns false at `src/proxy/errors.ts:420`, and the request returns `api_error`. Reviewed as ~0.003% of client-visible calls; in practice it lands on a request that fires **once per session**.
2. **The recovery path records no usage.** 4 of 7 requests logged `cache_read=0 cache_write=0 output=0` while the transcripts show real spend. `maxTurns=1` promotes that path from rare (~65 of 6,858 sessions) to universal, so `src/telemetry/pricing.ts` would price every passthrough tool turn at $0.00 — and `checkTokenHealth`, the "cache hit rate 0% on resume" alarm that is the one thing that would catch a broken checkpoint, is not called there either.

So the second half is worth landing, after: the recovery path carries `lastUsage`'s token fields + `cacheHitRate` and calls `logUsage`/`checkTokenHealth`; the advisor and deferred-tool budgets keep absolute headroom instead of stacking their bumps on a base of 1 (#547 was a regression from underestimating exactly that); and a tool-less turn degrades instead of 500ing.

## The second commit

`2f706ba2` corrects the comment that arrived with the cherry-pick. It opened *"maxTurns=1 is the normal passthrough tool handoff"*, which describes the half that isn't in this branch — on `main` a turn-cap stop is the rare exhaustion case, so the comment would have misdescribed its own code.

It also replaces the durability claim with a checkable one. The original said the subprocess "has flushed its transcript while terminating" — true, but not for a reason a reader can verify. The verifiable reason: the SDK reports `max_turns` only from a `result` message it has already enqueued, and it awaits the transcript flush on `result` (`Query.readMessages` builds the error text from `lastErrorResultText`, which only a delivered result populates). That is the acknowledgement `passthroughEarlyStop.ts` requires, and it is categorically unlike the abort-shaped failure the eviction was written for, where a SIGTERM'd subprocess emits no result at all.

Which also means `sawCanonicalResult` is already true on this path, so the eviction guard could not have fired here regardless — the `storeSession` is the load-bearing half. Recorded in the comment because a future reader would otherwise reasonably delete one of the two and keep the wrong one.

## Verification

- `passthrough-early-stop-integration`: 20 pass. The new case fails with the `server.ts` change reverted (`resume` → `undefined`) and passes with `query.ts` at `main`, confirming it covers this half and never covered `maxTurns`.
- Full suite **2,798 pass, 0 fail**; `tsc --noEmit` clean.
- Rebases cleanly on v1.62.6 — no textual or semantic interaction with `7ce53459`.

Original PR #850 sits at `BLOCKED` because `main` requires signed commits, which is not something the contributor can resolve from a fork; hence the cherry-pick.