### PR TITLE
fix(errors): classify an oversized prompt as a 400, not a retryable 500

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -237,6 +237,12 @@ describe("classifyError", () => {
       expect(canRecoverCapturedToolUses({ ...base, reason: "process_exit" })).toBe(false)
     })
 
+    // An overflow is rejected before generation, so there is nothing captured
+    // to deliver — and replaying the same oversized prompt cannot succeed.
+    it("does not recover a context overflow", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "context_overflow" })).toBe(false)
+    })
+
     // Without captured calls there is nothing to deliver, and outside
     // passthrough the client does not execute tools at all.
     it("requires captured tool calls", () => {
@@ -245,6 +251,55 @@ describe("classifyError", () => {
 
     it("requires passthrough", () => {
       expect(canRecoverCapturedToolUses({ ...base, reason: "max_turns", passthrough: false })).toBe(false)
+    })
+  })
+
+  describe("context overflow", () => {
+    it("classifies the CLI's bare wording", () => {
+      const r = classifyError("Claude Code returned an error result: Prompt is too long")
+      expect(r.status).toBe(400)
+      expect(r.type).toBe("invalid_request_error")
+    })
+
+    it("classifies the API's token-count wording", () => {
+      const r = classifyError('API Error: 400 {"type":"invalid_request_error","message":"prompt is too long: 215843 tokens > 200000 maximum"}')
+      expect(r.status).toBe(400)
+    })
+
+    it("classifies the max_tokens phrasing", () => {
+      const r = classifyError("input length and `max_tokens` exceed context limit: 197000 + 8192 > 200000")
+      expect(r.status).toBe(400)
+    })
+
+    it("classifies the OpenAI-compatible code", () => {
+      const r = classifyError("context_length_exceeded")
+      expect(r.status).toBe(400)
+    })
+
+    // The whole reason this branch sits above the crash branch. Without it the
+    // code-1 path returns 401 and tells the operator to run `claude login` —
+    // advice that cannot work here, for a cause it has hidden.
+    it("wins over a process exit carrying the overflow in stderr", () => {
+      const r = classifyError("Claude Code process exited with code 1\nSubprocess stderr: Prompt is too long")
+      expect(r.status).toBe(400)
+      expect(r.type).toBe("invalid_request_error")
+      expect(r.message).not.toContain("claude login")
+    })
+
+    // A 5xx reads as "transient, try again" to every client retry policy, which
+    // is what replays an unfixable request at full upstream cost.
+    it.each([
+      ["the CLI wording", "Prompt is too long"],
+      ["the OpenAI code", "context_length_exceeded"],
+    ])("never classifies %s as retryable", (_label, msg) => {
+      expect(classifyError(msg).status).toBeLessThan(500)
+    })
+
+    // Mirrors #796: the phrase is word-separated, so an identifier carrying the
+    // same words cannot steal the branch from the real cause.
+    it("ignores an incidental identifier", () => {
+      const r = classifyError("Error: ENOENT: no such file or directory, open '/repo/src/prompt-is-too-long.ts'")
+      expect(r.status).not.toBe(400)
     })
   })
 
@@ -465,6 +520,26 @@ describe("extractSdkTermination", () => {
       expect(t.reason).toBe("max_turns")
       expect(t.turns).toBe(3)
       expect(t.stderrTail).toContain("Custom betas")
+    })
+  })
+
+  describe("context_overflow", () => {
+    it("names an oversized prompt", () => {
+      const t = extractSdkTermination("Claude Code returned an error result: Prompt is too long")
+      expect(t.reason).toBe("context_overflow")
+    })
+
+    // Ordering guard: the overflow arrives as a process exit often enough that
+    // reading the exit first points the diagnostic log at the wrong thing.
+    it("wins over a process exit carrying the overflow in stderr", () => {
+      const t = extractSdkTermination("process exited with code 1\nSubprocess stderr: Prompt is too long")
+      expect(t.reason).toBe("context_overflow")
+      expect(t.stderrTail).toContain("Prompt is too long")
+    })
+
+    it("survives the round trip into a diagnostic log line", () => {
+      const t = extractSdkTermination("Prompt is too long")
+      expect(formatSdkTermination(t, { model: "sonnet" })).toContain("reason=context_overflow")
     })
   })
 

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -114,6 +114,22 @@ const HTTP_401 = /(?:^|[^0-9a-f])401(?![0-9a-f]|:\d)/
 const HTTP_429 = /(?:^|[^0-9a-f])429(?![0-9a-f]|:\d)/
 const HTTP_500 = /(?:^|[^0-9a-f])500(?![0-9a-f]|:\d)/
 const HTTP_503 = /(?:^|[^0-9a-f])503(?![0-9a-f]|:\d)/
+/** A request whose input exceeds the model's context window.
+ *
+ *  Distinct from a rate limit in the one way that matters to a caller: waiting
+ *  does not fix it. An identical retry burns a whole upstream turn to fail
+ *  identically, so this must not classify as a 5xx — see the branch in
+ *  classifyError for why the status code is the actual fix.
+ *
+ *  Wordings: the CLI's bare "Prompt is too long", the API's fuller
+ *  "prompt is too long: N tokens > M maximum" (same prefix), its max_tokens
+ *  phrasing (backtick-quoted upstream, matched loosely here), and the
+ *  OpenAI-compatible code the openai adapter can surface. */
+const CONTEXT_OVERFLOW_SIGNALS: readonly RegExp[] = [
+  /prompt is too long/,
+  /input length and .?max_tokens.? exceed context limit/,
+  /context[_ ]length[_ ]exceeded/,
+]
 
 /**
  * Detect specific SDK errors and return helpful messages to the client.
@@ -181,6 +197,24 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
       status: 402,
       type: "billing_error",
       message: "Claude Max subscription issue. Check your subscription status at https://claude.ai/settings/subscription"
+    }
+  }
+
+  // Context overflow. Ordered before the process-crash branch deliberately:
+  // when the CLI surfaces an oversized prompt by exiting rather than returning
+  // a result, that branch reads a bare code-1 exit as an auth failure and tells
+  // the operator to run `claude login` — advice that cannot work and that hides
+  // the real cause.
+  //
+  // The status code is the fix, not the wording. The default 500 reads as
+  // "transient, try again" to every client retry policy, so an overflow that
+  // can only ever fail identically gets replayed at full upstream cost. 400
+  // says the request itself is the problem.
+  if (CONTEXT_OVERFLOW_SIGNALS.some(rx => rx.test(lower))) {
+    return {
+      status: 400,
+      type: "invalid_request_error",
+      message: "Prompt exceeds the model's context window. Compact or trim the conversation before retrying — an identical retry fails the same way."
     }
   }
 
@@ -403,7 +437,7 @@ export function isExtraUsageRequiredError(errMsg: string): boolean {
  * collapses into a generic api_error.
  */
 export interface SdkTermination {
-  reason: "max_turns" | "process_exit" | "aborted" | "upstream_idle" | "unknown"
+  reason: "max_turns" | "process_exit" | "aborted" | "upstream_idle" | "context_overflow" | "unknown"
   /** Turn count when reason=max_turns and parseable. */
   turns?: number
   /** Exit code when reason=process_exit and parseable. */
@@ -513,6 +547,16 @@ export function extractSdkTermination(errMsg: string): SdkTermination {
     return {
       reason: "max_turns",
       ...(m ? { turns: Number(m[1]) } : {}),
+      ...(stderrTail ? { stderrTail } : {}),
+    }
+  }
+
+  // Same ordering rationale as classifyError: an oversized prompt that arrives
+  // as a process exit must name the overflow, not the exit, or the diagnostic
+  // log points at the wrong thing.
+  if (CONTEXT_OVERFLOW_SIGNALS.some(rx => rx.test(lower))) {
+    return {
+      reason: "context_overflow",
       ...(stderrTail ? { stderrTail } : {}),
     }
   }


### PR DESCRIPTION
## Problem

When a request exceeds the model's context window, the upstream error currently falls through `classifyError` into the generic process-crash / retryable-500 path. The client retries an identical oversized prompt and hits the same failure every time, with no message telling it the retry won't help.

## Fix

Detect context-overflow signals (CLI wording, API token-count wording, `max_tokens` phrasing, and the OpenAI-compatible variant) in `classifyError` and return a 400 `invalid_request_error` before the process-crash branch is reached, with a message telling the caller to compact/trim first. Also extends `SdkTermination.reason` with a `context_overflow` variant so `extractSdkTermination`/`formatSdkTermination` name it correctly instead of reporting an unknown process exit.

## How it works for users

A prompt that exceeds context now fails fast with a clear 400 instead of being silently retried as a 500.

## Changes

| File | Change |
|---|---|
| `src/proxy/errors.ts` | `CONTEXT_OVERFLOW_SIGNALS`, new `classifyError` branch (400), `context_overflow` added to `SdkTermination.reason`, matching branch in `extractSdkTermination` |
| `src/__tests__/errors.test.ts` | new — wording variants, ordering vs. process-exit/stderr, never-retryable table, `context_overflow` naming + round-trip through `formatSdkTermination`, `canRecoverCapturedToolUses` default-false case |

Closes #856