### PR TITLE
perf: stop billing the passthrough digest turn by capping maxTurns at 1

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -92,6 +92,7 @@ kill $(lsof -ti :3456)
 | E37 | [WebFetch preflight scope (#748)](#e37-webfetch-preflight-scope-748) | **Automated**: `bun scripts/e2e-webfetch-preflight.mjs` — stubbed `claude` + isolated HOME: the toggle reaches the right adapter's `--settings`, and only `cherry` can actually run the built-in WebFetch, so the documented scope is asserted rather than assumed. **Run before releases touching sdkFeatures, query settings, or tool config**; costs no tokens | 2026-08-03 |
 | E38 | [Silent turns (#768)](#e38-silent-turns-768) | **Automated**: `bun scripts/e2e-silent-turn.mjs` — real CLI, SSE mode. Asserts four things per attempt: the client got text or a tool call; recovered content sits BEFORE the terminal `message_delta` (content behind it is dropped by a correct client); exactly one `message_delta` per message; and a third turn after a recovery still resumes. Attribution is read from `/telemetry/logs`, not stdout. Pair `MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` against `MERIDIAN_SILENT_TURN_RECOVERY=0` for the before/after. **Run before any release touching the passthrough tool loop, prompt assembly, or session resume** | 2026-08-11 |
 | E39 | [OpenCode internal-agent session key (#845)](#e39-opencode-internal-agent-session-key-845) | **Manual**, real OpenCode: its `title` agent runs under the USER'S session id, so the user's first turn used to queue behind it and then get HTTP 400 `session_turn_conflict`. Asserts the first turn succeeds, waits ~0ms on the session lease, and every later request is `lineage=continuation`. **Run after any OpenCode upgrade and before releases touching session keys or the turn coordinator** | 2026-08-19 |
+| E40 | [Passthrough digest-turn cap](#e40-passthrough-digest-turn-cap) | **Automated**: `bun scripts/e2e-digest-turn-cap.mjs` — real SDK. Asserts the capped tool turn generates no digest text, costs materially less than uncapped on an identical prompt, still RESUMES at its captured checkpoint, leaves text-only turns returning `success`, and does not truncate parallel tool calls. **Run before any release touching the passthrough tool loop, `maxTurns`, or the early-stop checkpoint** | 2026-08-20 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3474,3 +3475,53 @@ cause (cold starts vs discarded passthrough turns), which is how to tell a
 "Meridian costs more" report apart from a caching failure. On this machine's
 history: cold starts 35.4% of spend and 63.3% of all cache writes; discarded
 passthrough turns 1.2%.
+
+---
+
+## E40: Passthrough digest-turn cap
+
+**What it proves:** that capping `maxTurns` at 1 for passthrough turns removes
+the billed digest turn *without* costing the session.
+
+**Why it needs a live SDK:** the thing under test is the SDK's own turn
+accounting — when it decides a turn is finished, when it declines to start
+another, and whether it still flushes its transcript on the way out. A mocked
+SDK can only replay assumptions about that; this asserts them.
+
+```bash
+bun scripts/e2e-digest-turn-cap.mjs
+```
+
+**Pass criteria** (the script asserts all of these and exits non-zero on any):
+
+- Capped, the tool call still reaches the client, the SDK stops with
+  `subtype: error_max_turns`, and **no digest text is generated**
+- Uncapped (`maxTurns: 3`) *does* generate digest text, costs more, and emits
+  more output tokens on the identical prompt
+- The capped session **resumes** at the captured assistant UUID and answers from
+  the client's real `tool_result`
+- A text-only turn returns `success`, not `error_max_turns`
+- Parallel tool calls are all still forwarded
+
+**Do not assert an assistant-message count.** The SDK splits one turn across
+several assistant messages — a thinking message, then one per parallel tool
+call — so the count tracks the model's phrasing, not turns. The digest turn's
+signature is text produced *after* the tool call.
+
+**If the resume check ever fails, take the cap off.** It is the claim #837 was
+defending: a lost transcript costs a full cold replay on every tool call, which
+is far worse than the digest turn the cap removes.
+
+**Verified:** 2026-08-20, sonnet. Capped vs uncapped on one tool call:
+121 vs 244 output tokens and $0.0046 vs $0.0469 (10.3x) in one run, $0.0046 vs
+$0.7687 (168x) in another where the uncapped digest turn wrote a large cache
+entry. Through the live proxy (E17 shape): output 306 → 144 and cache_read
+12k → 4k on the tool turn. The discarded digest text was captured verbatim —
+*"I attempted to read that file, but the tool call w…"* — content the client
+never sees and the account is billed for.
+
+**Related:** `node scripts/audit-token-spend.mjs` attributes historical spend by
+cause. Read its `digest turns` line against the corpus it scanned: a machine
+running mostly internal-mode Claude Code has almost no passthrough transcripts,
+so a `0.0%` there means "little passthrough traffic here", not "the digest turn
+is cheap". Per-turn cost is what E40 measures.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -379,7 +379,13 @@ MERIDIAN_PASSTHROUGH=0 meridian   # force internal
 
 For large tool sets (>15 tools), non-core tools are automatically deferred via the SDK's ToolSearch mechanism. Core tools (read, write, edit, bash, glob, grep) are always loaded eagerly. The deferral threshold is configurable with `MERIDIAN_DEFER_TOOL_THRESHOLD`.
 
-**Digest-turn elimination** — after a tool call is captured, the SDK would normally invoke the model one more time to "digest" the denial before ending the turn. That extra invocation is discarded by the proxy but fully billed — measured at ~400+ wasted output tokens and 2–3× extra latency per tool step (and on always-thinking models like Fable, a full thinking pass each time). Meridian now aborts the SDK query the moment every tool call's denial is persisted, so the digest turn never generates. Sessions remain resumable and tool-result attribution is unaffected. Kill switch: `MERIDIAN_PASSTHROUGH_EARLY_STOP=0` restores the old behavior.
+**Digest-turn elimination** — after a tool call is captured, the SDK would normally invoke the model one more time to "digest" the denial before ending the turn. That extra invocation is discarded by the proxy but fully billed — and on always-thinking models like Fable it costs a full thinking pass each time.
+
+Meridian eliminates it by capping `maxTurns` at 1 for passthrough turns, so the SDK stops at the tool-use boundary rather than starting the digest turn. The capped stop arrives as the SDK's `error_max_turns` result, which is safe to keep: the SDK can only report that from a `result` it has already enqueued, and it flushes its transcript on `result` — so the session is durably committed at the tool boundary and the next request resumes from it with the client's real `tool_result`. A turn that ends on its own (plain text, no tools) never asks for a second turn and so never trips the cap.
+
+Measured against the live SDK (sonnet, one tool call), capped vs. uncapped: **66 vs 159 output tokens and 0 vs ~127k cache-read tokens** — the digest turn drags the CLI's full context along with it. Parallel tool calls are unaffected: the SDK surfaces them within a single turn, so all of them still reach the client.
+
+The cap is lifted for the cases that genuinely need the SDK to keep going — deferred tools (ToolSearch discovery is a real round-trip), a configured advisor, and structured output — and an explicit `MERIDIAN_PASSTHROUGH_MAX_TURNS` always wins. Kill switch: `MERIDIAN_PASSTHROUGH_EARLY_STOP=0` restores the uncapped multi-turn behavior.
 
 ### Silent turns
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ Environment variables, endpoints, authentication, SDK feature toggles, passthrou
 | `MERIDIAN_ROUTING` | — | `active` | Session-to-profile routing: `active` (all traffic to the active profile), `sticky` ([sticky session routing](profiles.md#sticky-session-routing)), or `priority` ([priority failover](profiles.md#priority-failover-routing)) |
 | `MERIDIAN_PROFILE_ORDER` | — | *(config order)* | Priority-mode pool order, comma-separated, highest priority first (e.g. `work,personal`). Also editable at `/settings`. |
 | `MERIDIAN_PASSTHROUGH_EARLY_STOP` | — | `1` | Set to `0` to disable [digest-turn elimination](#how-tool-calling-works-in-passthrough) and restore the old end-of-turn behavior |
+| `MERIDIAN_PASSTHROUGH_MAX_TURNS` | `CLAUDE_PROXY_PASSTHROUGH_MAX_TURNS` | *(unset — capped at 1)* | Pin the passthrough SDK turn budget. **Setting this opts out of [digest-turn elimination](#how-tool-calling-works-in-passthrough)** — an explicit value always wins over the cap, so a turn budget set to work around an older issue keeps paying for the discarded digest turn. Unset it unless you still need it. |
 | `MERIDIAN_SILENT_TURN_RECOVERY` | `CLAUDE_PROXY_SILENT_TURN_RECOVERY` | `1` | Set to `0` to stop spending a recovery turn on a [silent turn](#silent-turns). Detection and telemetry stay on either way |
 | `MERIDIAN_UPSTREAM_IDLE_MS` | `CLAUDE_PROXY_UPSTREAM_IDLE_MS` | `90000` | Milliseconds the upstream stream may go quiet before the turn is treated as stalled. Raise it for long-thinking turns that were being killed mid-flight; `0` disables the guard entirely. Applies to the recovery turn too. |
 | `MERIDIAN_SUPPRESS_SCRATCHPAD` | — | `1` | Set to `0` to let the SDK advertise its proxy-host scratchpad directory in passthrough mode |
@@ -386,6 +387,22 @@ Meridian eliminates it by capping `maxTurns` at 1 for passthrough turns, so the 
 Measured against the live SDK (sonnet, one tool call), capped vs. uncapped: **66 vs 159 output tokens and 0 vs ~127k cache-read tokens** — the digest turn drags the CLI's full context along with it. Parallel tool calls are unaffected: the SDK surfaces them within a single turn, so all of them still reach the client.
 
 The cap is lifted for the cases that genuinely need the SDK to keep going — deferred tools (ToolSearch discovery is a real round-trip), a configured advisor, and structured output — and an explicit `MERIDIAN_PASSTHROUGH_MAX_TURNS` always wins. Kill switch: `MERIDIAN_PASSTHROUGH_EARLY_STOP=0` restores the uncapped multi-turn behavior.
+
+> **Upgrade note.** If you previously set `MERIDIAN_PASSTHROUGH_MAX_TURNS` — most
+> likely to give deep orchestration chains more headroom (#494) — you will not
+> get this saving: an explicit budget wins over the cap by design, so every tool
+> call still pays for a digest turn. Try unsetting it. The reason the override
+> was needed is largely gone: it existed because wide parallel tool calls could
+> exhaust the budget, and under the cap the SDK stops at the tool boundary
+> instead of competing for turns with its own internal loop. If unsetting it
+> causes trouble, that is worth an issue rather than a permanent pin.
+>
+> Two other behaviours change with the cap, both deliberate. A passthrough tool
+> turn now ends on the SDK's `max_turns` result rather than a clean `success` —
+> that is the normal, expected shape, and `passthrough.checkpoint_persisted` in
+> `/telemetry/logs` is what confirms the session was preserved. And a turn that
+> hits the cap having produced content but no forwardable tool call is reported
+> as `stop_reason: "max_tokens"` (truncated) instead of failing the request.
 
 ### Silent turns
 

--- a/scripts/e2e-digest-turn-cap.mjs
+++ b/scripts/e2e-digest-turn-cap.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: does the passthrough turn cap actually stop the billed digest turn,
+ * and is the capped session still resumable?
+ *
+ * In passthrough the PreToolUse hook denies every client tool call, and the SDK
+ * then runs one more model turn to digest that denial. The proxy discards that
+ * turn; Anthropic bills it. #609 removed it by aborting the query at the deny;
+ * #837 replaced the abort with a drain (the abort lost the transcript), which
+ * silently reintroduced the cost. The fix caps `maxTurns` at 1 so the SDK stops
+ * at the tool boundary instead — the digest never generates, and the terminal
+ * result still arrives to commit the transcript.
+ *
+ * Four claims, and the last two are what make the cap safe rather than merely
+ * cheap:
+ *
+ *   1. Capped, a tool turn yields NO second assistant turn. This is the cost
+ *      claim; everything else is the safety envelope around it.
+ *   2. Capped costs materially less than uncapped on the same prompt. Asserted
+ *      as a ratio, not a fixed number, because absolute tokens move with the
+ *      model and the CLI's own context.
+ *   3. A capped session RESUMES at the captured assistant UUID and answers from
+ *      the client's real tool_result. This is the claim #837 was defending; if
+ *      it ever fails, the cap must come off, because a lost transcript costs a
+ *      full cold replay per tool call — far worse than the digest turn.
+ *   4. A text-only turn is unaffected. It never asks for a second turn, so it
+ *      must return a normal success, not error_max_turns. If this regresses,
+ *      every non-tool passthrough turn starts 500ing.
+ *
+ * Costs a few cents of real tokens and needs Claude Max: it drives the actual
+ * Agent SDK, because the thing under test is the SDK's own turn accounting.
+ *
+ * Run before any release touching the passthrough tool loop, maxTurns, or the
+ * early-stop checkpoint.
+ *
+ *   bun scripts/e2e-digest-turn-cap.mjs
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-digest-cap-"))
+const DATA = join(WORKDIR, "data.txt")
+const CONTENT = "hello from data.txt"
+writeFileSync(DATA, CONTENT + "\n")
+
+const claudeExecutable = await resolveClaudeExecutableAsync()
+const failures = []
+function check(ok, label, detail) {
+  console.log(`  ${ok ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`)
+  if (!ok) failures.push(label)
+}
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/** Mirrors the passthrough shape buildQueryOptions produces. */
+function options(maxTurns, extra = {}) {
+  return {
+    executable: "node",
+    maxTurns,
+    cwd: WORKDIR,
+    model: "sonnet",
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          return { decision: "block", reason: "forwarded to client — end your turn now." }
+        }],
+      }],
+    },
+    ...extra,
+  }
+}
+
+async function drive(prompt, maxTurns, extra) {
+  const out = { assistantTurns: 0, toolCalls: [], subtype: null, cost: 0, outputTokens: 0, text: "", sessionId: "", toolUuid: "", toolUseId: "" }
+  try {
+    for await (const m of query({ prompt, options: options(maxTurns, extra) })) {
+      if (m.session_id && !out.sessionId) out.sessionId = m.session_id
+      if (m.type === "assistant") {
+        out.assistantTurns++
+        for (const b of m.message?.content ?? []) {
+          if (b.type === "tool_use") {
+            out.toolCalls.push(b.input?.file_path ?? b.id)
+            out.toolUuid = m.uuid
+            out.toolUseId = b.id
+          }
+          if (b.type === "text") out.text += b.text
+        }
+      }
+      if (m.type === "result") {
+        out.subtype = m.subtype
+        out.cost = m.total_cost_usd ?? 0
+        out.outputTokens = m.usage?.output_tokens ?? 0
+      }
+    }
+  } catch (e) {
+    out.threw = e instanceof Error ? e.message : String(e)
+  }
+  return out
+}
+
+const TOOL_PROMPT = `Read the file ${DATA} using the read tool. Use the tool, do not guess.`
+
+console.log("\n1. capped tool turn generates no digest turn")
+const capped = await drive(TOOL_PROMPT, 1)
+check(capped.toolCalls.length > 0, "the tool call still reaches the client", `${capped.toolCalls.length} call(s)`)
+check(capped.subtype === "error_max_turns", "the SDK stops at the turn cap", `subtype=${capped.subtype}`)
+check(capped.text.trim() === "", "no digest text was generated", JSON.stringify(capped.text.slice(0, 60)))
+
+console.log("\n2. capped costs materially less than uncapped")
+const uncapped = await drive(TOOL_PROMPT, 3)
+// Not an assistant-message count: the SDK splits ONE turn across several
+// assistant messages (a thinking message, then one per parallel tool call), so
+// the count moves with the model's phrasing and says nothing about turns. The
+// digest turn's signature is that it produces TEXT after the tool call — that
+// is the thing being billed and discarded.
+check(uncapped.text.trim() !== "" && capped.text.trim() === "",
+  "uncapped generates the digest text the cap removes",
+  `uncapped=${JSON.stringify(uncapped.text.slice(0, 50))} vs capped=${JSON.stringify(capped.text)}`)
+check(capped.cost < uncapped.cost,
+  "capped is cheaper on an identical prompt",
+  `$${capped.cost.toFixed(5)} vs $${uncapped.cost.toFixed(5)} (${(uncapped.cost / Math.max(capped.cost, 1e-9)).toFixed(1)}x)`)
+check(capped.outputTokens < uncapped.outputTokens,
+  "capped emits fewer output tokens",
+  `${capped.outputTokens} vs ${uncapped.outputTokens}`)
+
+console.log("\n3. the capped session resumes at its checkpoint")
+const delta = (async function* () {
+  yield {
+    type: "user",
+    session_id: capped.sessionId,
+    parent_tool_use_id: null,
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: capped.toolUseId, content: CONTENT }] },
+  }
+})()
+const resumed = await drive(delta, 1, { resume: capped.sessionId, resumeSessionAt: capped.toolUuid })
+check(!resumed.threw || resumed.subtype != null, "the resume is accepted", resumed.threw ?? "no error")
+check(resumed.text.includes(CONTENT),
+  "the model answers from the client's real tool_result",
+  JSON.stringify(resumed.text.slice(0, 80)))
+
+console.log("\n4. a text-only turn is untouched by the cap")
+const textOnly = await drive("Reply with exactly the word: pong. Nothing else.", 1)
+check(textOnly.subtype === "success", "text-only returns success, not error_max_turns", `subtype=${textOnly.subtype}`)
+check(textOnly.text.toLowerCase().includes("pong"), "the answer still arrives", JSON.stringify(textOnly.text.slice(0, 40)))
+
+console.log("\n5. parallel tool calls survive the cap")
+writeFileSync(join(WORKDIR, "a.txt"), "a\n")
+writeFileSync(join(WORKDIR, "b.txt"), "b\n")
+const parallel = await drive(
+  `Read both ${join(WORKDIR, "a.txt")} and ${join(WORKDIR, "b.txt")} using the read tool, in parallel in a single step.`,
+  1,
+)
+check(parallel.toolCalls.length >= 2,
+  "every parallel call is still forwarded",
+  `${parallel.toolCalls.length} call(s): ${JSON.stringify(parallel.toolCalls)}`)
+
+console.log(`\n${failures.length === 0 ? "OK — all checks passed" : `FAILED (${failures.length}): ${failures.join("; ")}`}`)
+process.exit(failures.length === 0 ? 0 : 1)

--- a/src/__tests__/deferred-tool-loading.test.ts
+++ b/src/__tests__/deferred-tool-loading.test.ts
@@ -258,7 +258,7 @@ describe("auto-defer — threshold-based deferral via HTTP", () => {
     expect(capturedQueryParams.options.maxTurns).toBe(4)
   })
 
-  it("sets maxTurns to 3 when no deferred tools (passthrough base budget)", async () => {
+  it("caps maxTurns at 1 when no deferred tools — nothing needs a turn past the tool handoff", async () => {
     mockMessages = [assistantMessage([{ type: "text", text: "Hello" }])]
 
     await app().fetch(new Request("http://localhost/v1/messages", {
@@ -271,7 +271,7 @@ describe("auto-defer — threshold-based deferral via HTTP", () => {
       })),
     }))
 
-    expect(capturedQueryParams.options.maxTurns).toBe(3)
+    expect(capturedQueryParams.options.maxTurns).toBe(1)
   })
 
   it("disables auto-defer when threshold is 0", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -83,6 +83,7 @@ mock.module("../mcpTools", () => ({
 const { createProxyServer } = await import("../proxy/server")
 const { clearSessionCache } = await import("../proxy/session/cache")
 const { evictSharedSession } = await import("../proxy/sessionStore")
+const { telemetryStore } = await import("../telemetry")
 
 function userDenyMessage(toolUseId: string) {
   return {
@@ -942,6 +943,263 @@ describe("Integration: passthrough early stop", () => {
     expect(second.status).toBe(200)
     expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
+  // The live SDK delivers its error result BEFORE the iterator throws — verified
+  // against the real Agent SDK, which enqueues the result then replaces the exit
+  // error with the result text. The fixture above omits that result, so it
+  // exercises sawCanonicalResult=false; this one is the shape production
+  // actually sees now that maxTurns is capped at 1.
+  it("stream: stores the checkpoint when the capped stop delivers its result before throwing", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-stream-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_capped_stream"),
+      toolUseBlockStart(0, "read", "capped-stream-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("capped-stream-tool"),
+      { type: "result", subtype: "error_max_turns", is_error: true, session_id: "test-session" },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x capped" }],
+    }, "es-capped-stream")
+    expect(first.status).toBe(200)
+    expect(await first.text()).toContain('"type":"tool_use"')
+    expect(capturedQueryParamsAll[0].options.maxTurns).toBe(1)
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says X" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x capped" },
+        { role: "assistant", content: [{ type: "tool_use", id: "capped-stream-tool", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "capped-stream-tool", content: "X" }] },
+      ],
+    }, "es-capped-stream")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
+  it("non-stream: stores the checkpoint at the capped stop so the next turn resumes", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-ns-tool", name: "read", input: { file_path: "y" } },
+    ])
+    mockMessages = [
+      toolTurn,
+      userDenyMessage("capped-ns-tool"),
+      { type: "result", subtype: "error_max_turns", is_error: true, session_id: "test-session" },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read y capped" }],
+    }, "es-capped-nonstream")
+    expect(first.status).toBe(200)
+    const firstJson = await first.json() as any
+    expect(firstJson.stop_reason).toBe("tool_use")
+    expect(firstJson.content.some((b: any) => b.type === "tool_use")).toBe(true)
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says Y" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read y capped" },
+        { role: "assistant", content: [{ type: "tool_use", id: "capped-ns-tool", name: "read", input: { file_path: "y" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "capped-ns-tool", content: "Y" }] },
+      ],
+    }, "es-capped-nonstream")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
+  // The capped stop routes every passthrough tool turn through the error
+  // recovery path. That path must still report tokens: it is now the common
+  // case, and a metric with null token columns would blind exactly the
+  // dashboards used to watch passthrough spend.
+  it("stream: records token usage for a capped tool turn", async () => {
+    telemetryStore.clear()
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-usage-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_capped_usage"),
+      toolUseBlockStart(0, "read", "capped-usage-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("capped-usage-tool"),
+      {
+        type: "result",
+        subtype: "error_max_turns",
+        is_error: true,
+        session_id: "test-session",
+        usage: {
+          input_tokens: 11,
+          output_tokens: 66,
+          cache_read_input_tokens: 4242,
+          cache_creation_input_tokens: 7,
+        },
+      },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x usage" }],
+    }, "es-capped-usage")
+    expect(res.status).toBe(200)
+    await res.text()
+
+    // The client stream closes at the tool boundary, so the response resolves
+    // before the hidden drain reaches the capped stop and records the turn.
+    // Wait for the recovery to land rather than sampling the store too early.
+    let row: any
+    for (let i = 0; i < 100 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 50 })[0]
+      if (!row) await new Promise((r) => setTimeout(r, 10))
+    }
+    expect(row).toBeDefined()
+    expect(row!.outputTokens).toBe(66)
+    expect(row!.cacheReadInputTokens).toBe(4242)
+    expect(row!.cacheCreationInputTokens).toBe(7)
+    expect(row!.inputTokens).toBe(11)
+  })
+
+  // The operator-facing usage line is how a capped tool turn's spend shows up
+  // in `tail -f` on the proxy. It is emitted on the normal completion path
+  // only, which the capped stop bypasses — so every tool turn would go quiet.
+  it("stream: logs the usage line for a capped tool turn", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-log-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_capped_log"),
+      toolUseBlockStart(0, "read", "capped-log-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("capped-log-tool"),
+      {
+        type: "result",
+        subtype: "error_max_turns",
+        is_error: true,
+        session_id: "test-session",
+        usage: { input_tokens: 11, output_tokens: 66, cache_read_input_tokens: 4242 },
+      },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const lines: string[] = []
+    const realError = console.error
+    console.error = (...args: unknown[]) => { lines.push(args.join(" ")) }
+    try {
+      const res = await post(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 400,
+        stream: true,
+        tools: [READ_TOOL],
+        messages: [{ role: "user", content: "read x logline" }],
+      }, "es-capped-logline")
+      await res.text()
+      for (let i = 0; i < 100 && !lines.some((l) => l.includes("usage:")); i++) {
+        await new Promise((r) => setTimeout(r, 10))
+      }
+    } finally {
+      console.error = realError
+    }
+
+    const usageLine = lines.find((l) => l.includes("usage:"))
+    expect(usageLine).toBeDefined()
+    expect(usageLine).toContain("output=66")
+  })
+
+  it("non-stream: logs the usage line for a capped tool turn", async () => {
+    mockMessages = [
+      assistantMessage([{ type: "tool_use", id: "capped-ns-log", name: "read", input: { file_path: "y" } }]),
+      userDenyMessage("capped-ns-log"),
+      {
+        type: "result",
+        subtype: "error_max_turns",
+        is_error: true,
+        session_id: "test-session",
+        usage: { input_tokens: 9, output_tokens: 42, cache_read_input_tokens: 1234 },
+      },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const lines: string[] = []
+    const realError = console.error
+    console.error = (...args: unknown[]) => { lines.push(args.join(" ")) }
+    let res: any
+    try {
+      res = await post(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 400,
+        stream: false,
+        tools: [READ_TOOL],
+        messages: [{ role: "user", content: "read y logline" }],
+      }, "es-capped-ns-logline")
+      await res.json()
+    } finally {
+      console.error = realError
+    }
+
+    expect(res.status).toBe(200)
+    const usageLine = lines.find((l) => l.includes("usage:"))
+    expect(usageLine).toBeDefined()
+    expect(usageLine).toContain("output=42")
+  })
+
+  // A turn that ends on its own never asks the SDK for a second turn, so the
+  // cap is invisible to it. Verified against the live SDK: text-only at
+  // maxTurns=1 returns subtype "success", not error_max_turns.
+  it("passthrough: a text-only turn completes normally under the cap", async () => {
+    mockMessages = [
+      assistantMessage([{ type: "text", text: "no tools needed" }]),
+      { type: "result", subtype: "success", is_error: false, session_id: "test-session" },
+    ]
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "just answer" }],
+    }, "es-capped-text-only")
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.stop_reason).toBe("end_turn")
+    expect(json.content[0].text).toBe("no tools needed")
+    expect(capturedQueryParamsAll[0].options.maxTurns).toBe(1)
   })
 
   it("stream: closes at turn 1 while digest and canonical result drain invisibly", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1179,6 +1179,58 @@ describe("Integration: passthrough early stop", () => {
     expect(usageLine).toContain("output=42")
   })
 
+  // ADVERSARIAL: the cap makes max_turns the ordinary terminal state, so a turn
+  // that trips it with NOTHING captured must still produce a usable envelope.
+  // This is reachable: a thinking-only turn makes the CLI take another turn for
+  // its no-visible-output nudge (audit-token-spend.mjs counts these), and under
+  // the cap that turn is refused. Before the cap it could not happen, because
+  // the SDK had budget to finish. A 500 here is a hard user-visible regression.
+  it("stream: a capped turn that captured no tool call does not fail the request", async () => {
+    mockMessages = [
+      messageStart("msg_capped_nothing"),
+      assistantMessage([{ type: "thinking", thinking: "pondering", signature: "sig" }]),
+      { type: "result", subtype: "error_max_turns", is_error: true, session_id: "test-session" },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "think only" }],
+    }, "es-capped-nothing")
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    // The streaming path already degrades honestly (#768): the turn is reported
+    // truncated, never as a clean finish. Pin that — a future change must not
+    // quietly turn this into `end_turn`, which is the silent-turn shape.
+    expect(body).toContain('"stop_reason":"max_tokens"')
+    expect(body).not.toContain('"stop_reason":"end_turn"')
+  })
+
+  it("non-stream: a capped turn that captured no tool call does not fail the request", async () => {
+    mockMessages = [
+      assistantMessage([{ type: "thinking", thinking: "pondering", signature: "sig" }]),
+      { type: "result", subtype: "error_max_turns", is_error: true, session_id: "test-session" },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "think only" }],
+    }, "es-capped-nothing-ns")
+    // Was a 500 before: a turn with content but no forwardable tool call is
+    // answerable, so it must report truncation rather than dead-ending.
+    expect(res.status).toBe(200)
+    const json = await res.json() as any
+    expect(json.stop_reason).toBe("max_tokens")
+    expect(json.stop_reason).not.toBe("end_turn")
+  })
+
   // A turn that ends on its own never asks the SDK for a second turn, so the
   // cap is invisible to it. Verified against the live SDK: text-only at
   // maxTurns=1 returns subtype "success", not error_max_turns.

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -95,17 +95,42 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).includePartialMessages).toBe(true)
   })
 
-  it("sets maxTurns to 3 in passthrough mode (thinking + tool_use + handoff fits in 3 turns)", () => {
+  it("caps maxTurns at 1 in passthrough mode so the SDK stops at the tool handoff instead of generating a billed digest turn", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true }))
-    expect(result.options.maxTurns).toBe(3)
+    expect(result.options.maxTurns).toBe(1)
   })
 
-  it("sets maxTurns to 3 in passthrough mode with resume (rehydration fits within base budget)", () => {
+  it("caps maxTurns at 1 in passthrough mode with resume (rehydration is inline and needs no extra turn)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, resumeSessionId: "sess-123" }))
+    expect(result.options.maxTurns).toBe(1)
+  })
+
+  it("restores the multi-turn budget when the early-stop kill switch is off", () => {
+    const result = buildQueryOptions(makeContext({ passthrough: true, earlyStop: false }))
     expect(result.options.maxTurns).toBe(3)
   })
 
-  it("sets maxTurns to 4 in passthrough mode with deferred tools (+1 for the ToolSearch discovery turn, #547)", () => {
+  it("keeps the multi-turn budget when a structured output contract needs internal SDK turns", () => {
+    const result = buildQueryOptions(makeContext({
+      passthrough: true,
+      outputFormat: { type: "json_schema", schema: { type: "object" } } as any,
+    }))
+    expect(result.options.maxTurns).toBe(3)
+  })
+
+  it("lets an explicit PASSTHROUGH_MAX_TURNS override win over the single-turn cap", () => {
+    const prev = process.env.MERIDIAN_PASSTHROUGH_MAX_TURNS
+    process.env.MERIDIAN_PASSTHROUGH_MAX_TURNS = "5"
+    try {
+      const result = buildQueryOptions(makeContext({ passthrough: true }))
+      expect(result.options.maxTurns).toBe(5)
+    } finally {
+      if (prev === undefined) delete process.env.MERIDIAN_PASSTHROUGH_MAX_TURNS
+      else process.env.MERIDIAN_PASSTHROUGH_MAX_TURNS = prev
+    }
+  })
+
+  it("keeps maxTurns at 4 with deferred tools — ToolSearch discovery is a real round-trip, so the cap must not apply (#547)", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, hasDeferredTools: true }))
     expect(result.options.maxTurns).toBe(4)
   })
@@ -119,7 +144,7 @@ describe("buildQueryOptions", () => {
     expect(result.options.maxTurns).toBe(4)
   })
 
-  it("sets maxTurns to 6 in passthrough mode with advisor (base 3 + 3 for advisor call/result/answer)", () => {
+  it("keeps maxTurns at 6 with advisor — the advisor executes call/result/answer, so the cap must not apply", () => {
     const result = buildQueryOptions(makeContext({ passthrough: true, advisorModel: "claude-opus-4-7" }))
     expect(result.options.maxTurns).toBe(6)
   })

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -13,9 +13,18 @@
  * checkpoint, but they are NOT a durability acknowledgement: a live PTY E2E
  * observed the assistant and deny in the iterator while neither existed in the
  * session JSONL after an immediate abort. The proxy therefore freezes the
- * assistant UUID/tool IDs at deny settlement, drains the hidden digest without
- * forwarding it, and stores the checkpoint only after the SDK's canonical
- * terminal result commits the transcript.
+ * assistant UUID/tool IDs at deny settlement and stores the checkpoint only
+ * after the SDK's canonical terminal result commits the transcript.
+ *
+ * What stops the digest turn is the maxTurns cap in query.ts, not this module:
+ * capped at 1, the SDK reaches the tool-use boundary and then declines to start
+ * another turn, so the digest never generates AND the terminal result still
+ * arrives (as `error_max_turns`) to commit the transcript. That is the
+ * combination an immediate abort could not give — it skipped the commit.
+ *
+ * This module still drains rather than aborts, because the cap is lifted for
+ * deferred tools, advisors, structured output, and the kill switch. In those
+ * configurations the digest turn does generate and is discarded here.
  *
  * Pure module — no I/O, no imports from server.ts or session/.
  */

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -9,7 +9,7 @@ import { join } from "node:path"
 import type { Options, OutputFormat, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
-import { envInt } from "../env"
+import { env, envInt } from "../env"
 import type { Effort } from "./effort"
 
 /**
@@ -87,6 +87,14 @@ export interface QueryContext {
   envOverrides?: Record<string, string | undefined>
   /** Whether any passthrough tools use deferred loading */
   hasDeferredTools: boolean
+  /**
+   * Whether passthrough early stop is active (MERIDIAN_PASSTHROUGH_EARLY_STOP
+   * != "0"). Gates the single-turn maxTurns cap: the cap is only safe when the
+   * checkpoint machinery is running to capture and store the tool boundary.
+   * Defaults to on — omitting it must not silently reintroduce the billed
+   * digest turn.
+   */
+  earlyStop?: boolean
   /** SDK session ID for resume (if continuing a session) */
   resumeSessionId?: string
   /** Whether this is an undo operation */
@@ -162,27 +170,51 @@ export interface BuildQueryResult {
 /**
  * NOTE: agent-specific (passthrough mode).
  *
- * Compute maxTurns based on which SDK features are active. Each phase the SDK
- * walks before returning control to the host costs a turn:
- *   - Base (3): turn 1 generates content (extended thinking + tool_use blocks
- *     captured by PreToolUse hook); turn 2 receives the deny and may emit a
- *     follow-up (text or further tool_use); turn 3 wraps the stream cleanly.
- *     Was 2 historically — bumped after telemetry showed opus[1m] requests with
- *     thinking + tool_use exhausting the 2-turn budget mid-handoff and returning
- *     500s on fresh (non-resume) requests. See errors.ts sdk_termination
- *     diagnostic + telemetry.
- *   - Deferred tools (+1): a ToolSearch discovery is a real model round-trip
- *     that consumes a turn before the model can emit the real tool_use. The
- *     old model wrongly assumed a lone deferred set fit in base 3, so the
- *     discovery ate into the tool-call budget — deferred sessions hit max_turns
- *     prematurely, forcing cold-cache retries and churn (#547).
- *   - Resume (+0): rehydration completes inline within turn 1, so it adds no
- *     turn — a resumed deferred session is 4, same as a fresh deferred one.
+ * Compute maxTurns based on which SDK features are active.
+ *
+ * The default is 1, and that is the whole point. In passthrough the CLIENT
+ * executes tools, so a turn that emits tool_use is already complete as far as
+ * the client is concerned. Anything the SDK generates after it — the "digest"
+ * turn where the model reacts to the PreToolUse denial — is discarded by the
+ * proxy and still billed by Anthropic. Capping at 1 makes the SDK stop at the
+ * tool-use boundary instead of generating that turn.
+ *
+ * A capped stop surfaces as `error_max_turns`, which is safe here precisely
+ * because the SDK can only report it from a `result` message it has already
+ * enqueued, and it awaits its transcript flush on `result`. So the session is
+ * durably committed at the tool boundary; server.ts stores that checkpoint and
+ * the next request resumes from it with the client's real tool_result. A turn
+ * that ends without wanting to continue (plain text, no tools) never trips the
+ * cap at all — it returns a normal success result.
+ *
+ * Measured against the live SDK (sonnet, one tool call), cap vs. the old base
+ * of 3: 66 vs 159 output tokens and 0 vs ~127k cache-read tokens, because the
+ * digest turn drags the CLI's full context along with it.
+ *
+ * The bumps below are the cases that genuinely need the SDK to keep going, and
+ * each one turns the cap off rather than adding to it:
+ *   - Deferred tools (4): a ToolSearch discovery is a real model round-trip
+ *     that consumes a turn before the model can emit the real tool_use. Capping
+ *     here would stop the query on the discovery turn and never reach the tool
+ *     call (#547).
  *   - Advisor (+3): server-side advisor executes call + result + final answer.
+ *   - Structured output: the SDK runs its internal StructuredOutput tool and
+ *     needs turns to submit the result; capping strands it (HTTP 500).
+ *   - Early-stop kill switch off: MERIDIAN_PASSTHROUGH_EARLY_STOP=0 restores
+ *     the pre-cap wire behavior wholesale, so the budget must come back too.
+ *
+ * Base for those uncapped cases stays 3: turn 1 generates content (extended
+ * thinking + tool_use blocks captured by PreToolUse hook); turn 2 receives the
+ * deny and may emit a follow-up; turn 3 wraps the stream cleanly. Was 2
+ * historically — bumped after telemetry showed opus[1m] requests with thinking
+ * + tool_use exhausting the 2-turn budget mid-handoff and returning 500s on
+ * fresh (non-resume) requests. Resume adds nothing: rehydration completes
+ * inline within turn 1.
  */
 function computePassthroughMaxTurns(
   hasDeferredTools: boolean,
   advisorModel: string | undefined,
+  singleTurnHandoff: boolean,
 ): number {
   const deferredBump = hasDeferredTools ? 1 : 0
   const defaultBase = 3 + deferredBump
@@ -195,8 +227,12 @@ function computePassthroughMaxTurns(
   // raise (or lower) the base (incl. the deferred bump); the advisor bump
   // below is added on top and is unaffected by the override.
   const configured = envInt("PASSTHROUGH_MAX_TURNS", defaultBase)
-  const base = configured > 0 ? configured : defaultBase
+  // An operator who pinned a budget gets it verbatim — the cap must not
+  // silently override a value someone set to work around a client quirk.
+  const operatorPinned = env("PASSTHROUGH_MAX_TURNS") !== undefined && configured > 0
   const advisorBump = advisorModel ? 3 : 0
+  if (singleTurnHandoff && !operatorPinned) return 1
+  const base = configured > 0 ? configured : defaultBase
   return base + advisorBump
 }
 
@@ -318,7 +354,13 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       // is not in PATH — causing subprocess spawns to fail.
       executable: "node" as const,
       maxTurns: passthrough
-        ? computePassthroughMaxTurns(hasDeferredTools, ctx.advisorModel)
+        ? computePassthroughMaxTurns(
+            hasDeferredTools,
+            ctx.advisorModel,
+            // Every condition here is one that needs the SDK to keep going
+            // past the tool boundary; see computePassthroughMaxTurns.
+            ctx.earlyStop !== false && !hasDeferredTools && !ctx.advisorModel && !outputFormat,
+          )
         : 200,
       cwd: workingDirectory,
       model,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2545,6 +2545,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // Do not rethrow — execution continues into the merge block, which
               // backfills contentBlocks from capturedToolUses and builds a clean
               // stop_reason:"tool_use" response.
+            } else if (passthrough && sdkTerm.reason === "max_turns" && contentBlocks.length > 0) {
+              // The turn hit its budget without producing a forwardable tool
+              // call, but it did produce content. Throwing here would answer a
+              // 200-able turn with a 500 — and the streaming path already does
+              // the honest thing instead, reporting the turn as truncated. Match
+              // it: `max_tokens` is the signal a client can act on (retry or
+              // continue), where a 500 is a dead end and `end_turn` would be the
+              // silent-turn lie #768 exists to prevent.
+              //
+              // Reachable before this change too (any max_turns with nothing
+              // captured), just rarer while the budget was 3. The single-turn
+              // cap makes max_turns the ordinary terminal state, so the
+              // degradation has to be honest rather than incidental.
+              lastStopReason = "max_tokens"
+              claudeLog("passthrough.capped_turn_truncated", {
+                mode: "non_stream",
+                blocks: contentBlocks.length,
+              })
+              plog(`[PROXY] ${requestMeta.requestId} capped turn produced no forwardable tool call — reporting as truncated`)
+              if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
             } else {
               claudeLog("upstream.failed", {
                 mode: "non_stream",

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2098,7 +2098,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 try {
                   for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
-                    passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                    passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                     resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
@@ -2189,7 +2189,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     yield* runSdkQueryAttempt(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
-                      passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                      passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                       resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
@@ -2239,7 +2239,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     yield* runSdkQueryAttempt(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
-                      passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                      passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                       resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
@@ -2535,6 +2535,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 reason: sdkTerm.reason,
                 captured: capturedToolUses.length,
               })
+              // The success-path logUsage sits inside the try we just threw
+              // out of, so without this a capped tool turn — now the ordinary
+              // shape of a non-streaming passthrough turn — reports its spend
+              // to telemetry but never to the operator tailing the log. Safe
+              // from double-logging for exactly the same reason: the throw
+              // means the success-path call never ran.
+              if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
               // Do not rethrow — execution continues into the merge block, which
               // backfills contentBlocks from capturedToolUses and builds a clean
               // stop_reason:"tool_use" response.
@@ -2943,7 +2950,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   try {
                     for await (const event of runSdkQueryAttempt(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
-                      passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                      passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                       resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
@@ -3013,7 +3020,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       yield* runSdkQueryAttempt(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
-                        passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                        passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                         resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
@@ -3059,7 +3066,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       yield* runSdkQueryAttempt(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
-                        passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                        passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                         resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
@@ -3728,7 +3735,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // The nudge asks for prose, but a tool call is an equally
                     // valid answer — so the tool surface has to stay identical.
                     passthrough, stream: true, sdkAgents, passthroughMcp,
-                    cleanEnv: profileEnv, envOverrides, hasDeferredTools,
+                    cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
                     resumeSessionId: currentSessionId || resumeSessionId,
                     isUndo: false,
                     // Fork rather than extend: the silent turn is now this
@@ -4248,6 +4255,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
 
                 // Record as success — the client got a usable response.
+                if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
                 const recoverTotalMs = Date.now() - requestStartAt
                 const recoverQueueWaitMs = totalQueueWaitMs(requestMeta)
                 telemetryStore.record({
@@ -4278,6 +4286,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   contentBlocks: eventsForwarded + unseenToolUses.length,
                   textEvents: textEventsForwarded,
                   error: null,
+                  // The capped tool handoff makes this the ordinary path for a
+                  // passthrough tool turn, not a rare failure. Omitting tokens
+                  // here would leave the highest-volume turn in the system
+                  // reporting nothing, and would understate passthrough spend
+                  // in exactly the dashboards used to watch it. The SDK's
+                  // terminal result carries the authoritative usage even when
+                  // it reports max_turns, so lastUsage is populated by now.
+                  // The operator-facing line comes from the same source; see
+                  // the logUsage call above this record.
+                  inputTokens: lastUsage?.input_tokens,
+                  outputTokens: lastUsage?.output_tokens,
+                  cacheReadInputTokens: lastUsage?.cache_read_input_tokens,
+                  cacheCreationInputTokens: lastUsage?.cache_creation_input_tokens,
+                  cacheHitRate: computeCacheHitRate(lastUsage),
                   ...(envelopeViolations.length > 0 ? { envelopeViolations: [...envelopeViolations] } : {}),
                 })
 


### PR DESCRIPTION
Builds on #853, which must land first — the cap depends on its checkpoint preservation.

## The problem

In passthrough the client executes tools, so a turn that emits `tool_use` is already complete for the client. The SDK nonetheless runs one more model turn to digest the PreToolUse denial. Meridian discards that turn's output; Anthropic bills it.

#609 removed it by aborting the query at the deny. #837 replaced the abort with a drain — correctly, because the abort lost the transcript — and in doing so silently reintroduced a fully billed turn per tool call. It shipped in 1.62.4 and is live in 1.62.6.

`docs/configuration.md` still claimed the digest turn "never generates", which is likely why this went unnoticed. That doc is corrected here.

## The fix

Cap `maxTurns` at 1 for passthrough turns. The SDK stops at the tool-use boundary and never starts the digest turn, while still emitting its terminal result — which is what commits the transcript, so the session stays resumable. That second half is what #837 was protecting and what makes this safe where the old abort was not.

The cap lifts for the cases that genuinely need more turns — deferred tools (ToolSearch discovery is a real round-trip), advisor, structured output — and for the `MERIDIAN_PASSTHROUGH_EARLY_STOP=0` kill switch. An explicit `MERIDIAN_PASSTHROUGH_MAX_TURNS` always wins.

## Measured against the live SDK

| one tool call | output tokens | cache read | cost |
|---|---|---|---|
| uncapped | 244 | 32k–127k | $0.0469 |
| capped | 121 | 0 | $0.0046 |

Through the proxy: output 306 → 144, cache_read 12k → 4k. The discarded digest text was captured verbatim — *"I attempted to read that file, but the tool call w…"* — content the client never sees and the account is billed for.

## Second commit: a 500 the cap would have exposed

A capped turn that produces content but no forwardable tool call returned HTTP 500 on the non-streaming path. Verified this pre-exists on `main` — the cap does not create it, it makes it reachable. Now reported as `stop_reason: "max_tokens"`, matching what the streaming path already does: a client can retry a truncated turn, where a 500 is a dead end and `end_turn` would be the silent-turn shape #768 exists to prevent.

## Verification

- New live E2E `scripts/e2e-digest-turn-cap.mjs` (E40), 11 checks: no digest text, cheaper than uncapped, **session still resumes at its checkpoint**, text-only turns still return `success`, parallel tool calls not truncated.
- Every new test was watched fail first and mutation-tested (defeating the gate fails 8 tests; reverting either checkpoint store, the telemetry fields, or the truncation branch fails its own test).
- Historical regression suites pass under the cap, including `proxy-passthrough-tool-use` and `proxy-passthrough-single-turn`, which document the original `maxTurns: 1` failure from before the recovery path existed.
- Telemetry: capped tool turns previously recorded null tokens and logged no `usage:` line, because the recovery path became the common path. Fixed and tested.

## Upgrade note

`MERIDIAN_PASSTHROUGH_MAX_TURNS` now opts out of digest-turn elimination — an explicit budget wins over the cap. Anyone who pinned it for #494 deep chains keeps paying for the digest turn until they unset it. Documented in `docs/configuration.md`.