### PR TITLE
fix: bench [1m] per profile after a rate limit instead of flapping back

### DIFF
--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterEach, beforeEach, describe, it, expect, mock } from "bun:test"
 
-import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resetWarnedTierOverrides, resolveSdkModelDefaults, subscriptionIncludesExtendedContext, CANONICAL_FABLE_MODEL, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
+import { mapModelToClaudeModel, isClosedControllerError, resetCachedClaudeAuthStatus, stripExtendedContext, hasExtendedContext, recordExtendedContextUnavailable, recordExtendedContextRateLimited, isExtendedContextKnownUnavailable, resetExtendedContextUnavailable, resetWarnedTierOverrides, resolveSdkModelDefaults, subscriptionIncludesExtendedContext, CANONICAL_FABLE_MODEL, CANONICAL_OPUS_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_HAIKU_MODEL } from "../proxy/models"
 
 describe("mapModelToClaudeModel", () => {
   const originalSonnetModel = process.env.CLAUDE_PROXY_SONNET_MODEL
@@ -569,5 +569,42 @@ describe("resolveSdkModelDefaults", () => {
     expect(typeof pins.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("string")
     expect(typeof pins.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("string")
     expect(typeof pins.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("string")
+  })
+})
+
+describe("extended-context bench is per profile (#862)", () => {
+  afterEach(() => {
+    resetExtendedContextUnavailable()
+  })
+
+  it("keeps one account's Extra Usage failure from benching [1m] on another", () => {
+    recordExtendedContextUnavailable("work")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work")).toBe("opus")
+    // "personal" may well include the 1M window; benching it because a
+    // different account ran out of Extra Usage costs it the window for an hour.
+    expect(mapModelToClaudeModel("opus", "max", undefined, "personal")).toBe("opus[1m]")
+  })
+
+  it("benches [1m] until the supplied rate-limit reset", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000)
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work")).toBe("opus")
+  })
+
+  it("does not bench when the supplied reset has already passed", () => {
+    recordExtendedContextRateLimited("work", Date.now() - 1_000)
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work")).toBe("opus[1m]")
+  })
+
+  it("lets a later bench extend an earlier one, but never lets an earlier shorten it", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000)
+    recordExtendedContextRateLimited("work", Date.now() + 1)
+    // The near-term mark must not un-bench the profile.
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work")).toBe("opus")
+  })
+
+  it("reports the bench through isExtendedContextKnownUnavailable per profile", () => {
+    recordExtendedContextUnavailable("work")
+    expect(isExtendedContextKnownUnavailable("work")).toBe(true)
+    expect(isExtendedContextKnownUnavailable("personal")).toBe(false)
   })
 })

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -108,7 +108,7 @@ const READ_TOOL = {
 
 const usedSessionKeys = new Set<string>()
 
-async function post(app: any, body: any, sessionHeader = "es-session") {
+async function post(app: any, body: any, sessionHeader = "es-session", extraHeaders: Record<string, string> = {}) {
   const sessionKey = `${sessionHeader}-${TEST_RUN_ID}`
   usedSessionKeys.add(sessionKey)
   return app.fetch(new Request("http://localhost/v1/messages", {
@@ -118,6 +118,7 @@ async function post(app: any, body: any, sessionHeader = "es-session") {
       "x-api-key": "dummy",
       "x-opencode-session": sessionKey,
       "user-agent": "opencode/1.0.0",
+      ...extraHeaders,
     },
     body: JSON.stringify(body),
   }))
@@ -1068,22 +1069,27 @@ describe("Integration: passthrough early stop", () => {
     ]
     mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
 
+    // Correlate by request id. Ordering is NOT safe here: the capped turn drains
+    // asynchronously after its stream closes, so an earlier test's drain can
+    // land a row after this one starts — reading getRecent()[0] then picks up
+    // the straggler and compares against the wrong turn's tokens.
+    const requestId = `capped-usage-${TEST_RUN_ID}`
     const res = await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
       stream: true,
       tools: [READ_TOOL],
       messages: [{ role: "user", content: "read x usage" }],
-    }, "es-capped-usage")
+    }, "es-capped-usage", { "x-request-id": requestId })
     expect(res.status).toBe(200)
     await res.text()
 
     // The client stream closes at the tool boundary, so the response resolves
     // before the hidden drain reaches the capped stop and records the turn.
-    // Wait for the recovery to land rather than sampling the store too early.
+    // Wait for THIS turn's row rather than sampling the store too early.
     let row: any
-    for (let i = 0; i < 100 && !row; i++) {
-      row = telemetryStore.getRecent({ limit: 50 })[0]
+    for (let i = 0; i < 500 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
       if (!row) await new Promise((r) => setTimeout(r, 10))
     }
     expect(row).toBeDefined()
@@ -1118,6 +1124,11 @@ describe("Integration: passthrough early stop", () => {
     ]
     mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
 
+    // Match on this turn's request id: a concurrently-draining turn from an
+    // earlier test logs its own `usage:` line, and a bare substring search
+    // would assert against whichever landed first.
+    const requestId = `capped-logline-${TEST_RUN_ID}`
+    const isMine = (l: string) => l.includes("usage:") && l.includes(requestId)
     const lines: string[] = []
     const realError = console.error
     console.error = (...args: unknown[]) => { lines.push(args.join(" ")) }
@@ -1128,16 +1139,16 @@ describe("Integration: passthrough early stop", () => {
         stream: true,
         tools: [READ_TOOL],
         messages: [{ role: "user", content: "read x logline" }],
-      }, "es-capped-logline")
+      }, "es-capped-logline", { "x-request-id": requestId })
       await res.text()
-      for (let i = 0; i < 100 && !lines.some((l) => l.includes("usage:")); i++) {
+      for (let i = 0; i < 500 && !lines.some(isMine); i++) {
         await new Promise((r) => setTimeout(r, 10))
       }
     } finally {
       console.error = realError
     }
 
-    const usageLine = lines.find((l) => l.includes("usage:"))
+    const usageLine = lines.find(isMine)
     expect(usageLine).toBeDefined()
     expect(usageLine).toContain("output=66")
   })
@@ -1156,6 +1167,8 @@ describe("Integration: passthrough early stop", () => {
     ]
     mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
 
+    const requestId = `capped-ns-logline-${TEST_RUN_ID}`
+    const isMine = (l: string) => l.includes("usage:") && l.includes(requestId)
     const lines: string[] = []
     const realError = console.error
     console.error = (...args: unknown[]) => { lines.push(args.join(" ")) }
@@ -1167,14 +1180,14 @@ describe("Integration: passthrough early stop", () => {
         stream: false,
         tools: [READ_TOOL],
         messages: [{ role: "user", content: "read y logline" }],
-      }, "es-capped-ns-logline")
+      }, "es-capped-ns-logline", { "x-request-id": requestId })
       await res.json()
     } finally {
       console.error = realError
     }
 
     expect(res.status).toBe(200)
-    const usageLine = lines.find((l) => l.includes("usage:"))
+    const usageLine = lines.find(isMine)
     expect(usageLine).toBeDefined()
     expect(usageLine).toContain("output=42")
   })

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -21,6 +21,8 @@ import {
 // Track query calls to verify retry behavior
 let queryCalls: Array<{ model: string; callIndex: number; resume?: string }> = []
 let queryCallCount = 0
+/** Benches recorded when a [1m] model is stripped after a rate limit (#862). */
+let rateLimitBenches: Array<{ profileId: string | undefined; until: number }> = []
 
 // Control what the mock does
 let mockBehavior: "extra_usage_then_succeed" | "always_extra_usage" | "out_of_extra_usage_then_succeed" | "resume_extra_usage_then_succeed" | "succeed" | "error_assistant_then_ratelimit" = "succeed"
@@ -42,6 +44,9 @@ mock.module("../proxy/models", () => ({
   stripExtendedContext: (model: string) => model.replace("[1m]", ""),
   isClosedControllerError: () => false,
   recordExtendedContextUnavailable: () => {},
+  recordExtendedContextRateLimited: (profileId: string | undefined, until: number) => {
+    rateLimitBenches.push({ profileId, until })
+  },
   isExtendedContextKnownUnavailable: () => false,
   getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
 }))
@@ -157,6 +162,7 @@ describe("Extra usage required fallback", () => {
   beforeEach(() => {
     clearSessionCache()
     queryCalls = []
+    rateLimitBenches = []
     queryCallCount = 0
     mockBehavior = "succeed"
   })
@@ -322,6 +328,24 @@ describe("Extra usage required fallback", () => {
       expect(queryCalls.length).toBe(2)
       expect(queryCalls[0]!.model).toBe("sonnet[1m]")
       expect(queryCalls[1]!.model).toBe("sonnet")
+    })
+
+    it("benches [1m] after a rate-limit strip so the next request does not flap back (#862)", async () => {
+      // Stripping [1m] without recording anything means the NEXT request maps
+      // straight back to [1m] — two model switches, and a cold prompt cache in
+      // both directions, for one rate-limit event.
+      mockBehavior = "error_assistant_then_ratelimit"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })
+      expect(response.status).toBe(200)
+
+      expect(rateLimitBenches.length).toBe(1)
+      expect(rateLimitBenches[0]!.until).toBeGreaterThan(Date.now())
     })
   })
 })

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -150,7 +150,7 @@ function supports1mContext(model: string): boolean {
   return true
 }
 
-export function mapModelToClaudeModel(model: string, subscriptionType?: string | null, agentMode?: string | null): ClaudeModel {
+export function mapModelToClaudeModel(model: string, subscriptionType?: string | null, agentMode?: string | null, profileId?: string): ClaudeModel {
   if (model.includes("haiku")) return "haiku"
 
   const use1m = supports1mContext(model)
@@ -186,7 +186,7 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
     if (fableOverrideRaw && fableOverride !== "fable[1m]") {
       warnUnrecognizedTierOverride("FABLE_MODEL", fableOverrideRaw, "fable")
     }
-    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable()) return "fable[1m]"
+    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable(profileId)) return "fable[1m]"
     return "fable"
   }
 
@@ -209,7 +209,7 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
     if (opusOverrideRaw && opusOverride !== "opus[1m]") {
       warnUnrecognizedTierOverride("OPUS_MODEL", opusOverrideRaw, "opus")
     }
-    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable()) return "opus[1m]"
+    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable(profileId)) return "opus[1m]"
     return "opus"
   }
 
@@ -219,7 +219,7 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
   // avoid unexpected charges. Users opt in via MERIDIAN_SONNET_MODEL=sonnet[1m].
   const sonnetOverride = process.env.MERIDIAN_SONNET_MODEL ?? process.env.CLAUDE_PROXY_SONNET_MODEL
   if (sonnetOverride === "sonnet[1m]") {
-    if (!use1m || isSubagent || isExtendedContextKnownUnavailable()) return "sonnet"
+    if (!use1m || isSubagent || isExtendedContextKnownUnavailable(profileId)) return "sonnet"
     return "sonnet[1m]"
   }
 
@@ -233,7 +233,36 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
 /** How long to skip [1m] models after confirming Extra Usage is not enabled. */
 const EXTRA_USAGE_RETRY_MS = 60 * 60 * 1000 // 1 hour
 
-let extraUsageUnavailableAt = 0
+/**
+ * Per-profile "[1m] is benched until" timestamps.
+ *
+ * Keyed by profile because both reasons to bench are account-scoped: Extra
+ * Usage is a subscription setting, and a rate limit is charged against one
+ * account's window. This was a single process-global timestamp, which benched
+ * [1m] for EVERY profile the moment any one of them failed — so an account
+ * whose plan includes the 1M window lost it for an hour because an unrelated
+ * account ran out of Extra Usage (#862).
+ *
+ * Requests carrying no profile share one default bucket, which leaves the
+ * single-profile case behaving exactly as it did.
+ */
+const DEFAULT_BENCH_KEY = "__default__"
+const extendedContextBenchedUntil = new Map<string, number>()
+
+/**
+ * Bench a profile's [1m] access until `until`.
+ *
+ * A later mark extends an earlier one; an earlier mark never shortens a longer
+ * bench. Two concurrent failures must not un-learn the longer reset — the same
+ * rule `ProfileExhaustion.mark` follows, and for the same reason.
+ */
+function benchExtendedContext(profileId: string | undefined, until: number): void {
+  if (until <= Date.now()) return
+  const key = profileId || DEFAULT_BENCH_KEY
+  const existing = extendedContextBenchedUntil.get(key)
+  if (existing !== undefined && existing >= until) return
+  extendedContextBenchedUntil.set(key, until)
+}
 
 /**
  * Record that Extra Usage is not enabled on this subscription.
@@ -242,23 +271,44 @@ let extraUsageUnavailableAt = 0
  * the next request probes [1m] once; if Extra Usage was enabled in the
  * meantime it succeeds and the flag is never set again.
  */
-export function recordExtendedContextUnavailable(): void {
-  extraUsageUnavailableAt = Date.now()
+export function recordExtendedContextUnavailable(profileId?: string): void {
+  benchExtendedContext(profileId, Date.now() + EXTRA_USAGE_RETRY_MS)
 }
 
 /**
- * Returns true while within the cooldown window after a confirmed
- * Extra Usage failure. After the window expires this returns false,
- * allowing one probe to check whether Extra Usage has been enabled.
+ * Record that a [1m] request was rate-limited, benching it until `until`.
+ *
+ * Callers derive `until` from the account's own observed reset rather than a
+ * constant. Stripping [1m] on a rate limit while recording nothing is what
+ * makes the next request map straight back to [1m]: the conversation then
+ * flaps between two models and pays a cold prompt cache in BOTH directions,
+ * which routinely costs more than the rate limit it was routing around (#862).
  */
-export function isExtendedContextKnownUnavailable(): boolean {
-  return extraUsageUnavailableAt > 0 &&
-    Date.now() - extraUsageUnavailableAt < EXTRA_USAGE_RETRY_MS
+export function recordExtendedContextRateLimited(profileId: string | undefined, until: number): void {
+  benchExtendedContext(profileId, until)
 }
 
-/** Reset the Extended Context unavailability timer — for testing only. */
-export function resetExtendedContextUnavailable(): void {
-  extraUsageUnavailableAt = 0
+/**
+ * Returns true while this profile's [1m] access is benched. Expired marks are
+ * dropped on read, so the next request probes [1m] once — and if the window
+ * has genuinely reset, it simply succeeds.
+ */
+export function isExtendedContextKnownUnavailable(profileId?: string): boolean {
+  const key = profileId || DEFAULT_BENCH_KEY
+  const until = extendedContextBenchedUntil.get(key)
+  if (until === undefined) return false
+  if (until <= Date.now()) {
+    extendedContextBenchedUntil.delete(key)
+    return false
+  }
+  return true
+}
+
+/** Clear extended-context benches — for testing only. Clears every profile
+ *  when no id is given. */
+export function resetExtendedContextUnavailable(profileId?: string): void {
+  if (profileId) extendedContextBenchedUntil.delete(profileId)
+  else extendedContextBenchedUntil.clear()
 }
 
 /**

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -65,7 +65,7 @@ import {
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
 import { checkPluginConfigured, notePluginlessOpenCodeRequest } from "./setup"
-import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, subscriptionIncludesExtendedContext } from "./models"
+import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, recordExtendedContextRateLimited, subscriptionIncludesExtendedContext } from "./models"
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
@@ -1040,7 +1040,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           declaredAgentMode === "subagent" || requestSource?.startsWith("subagent-") === true
         const agentMode = isSubagentRequest ? "subagent" : declaredAgentMode
         const requestedModel = typeof body.model === "string" ? body.model : "sonnet"
-        let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode)
+        let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode, profile.id)
         // Explicitly versioned ids override their tier's canonical pin for
         // this request (spread last in query.ts env, so they also beat
         // operator env) — a proxy must never substitute models. Bare aliases
@@ -2214,7 +2214,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   if (isExtraUsageRequiredError(errMsg) && hasExtendedContext(model)) {
                     const from = model
                     model = stripExtendedContext(model)
-                    recordExtendedContextUnavailable()
+                    recordExtendedContextUnavailable(profile.id)
                     claudeLog("upstream.context_fallback", {
                       mode: "non_stream",
                       from,
@@ -2275,6 +2275,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     if (hasExtendedContext(model)) {
                       const from = model
                       model = stripExtendedContext(model)
+                      // Bench [1m] for this profile until its window resets. Without
+                      // this the next request maps straight back to [1m], so one rate
+                      // limit costs TWO model switches and a cold prompt cache in both
+                      // directions — routinely more than the rate limit itself (#862).
+                      recordExtendedContextRateLimited(profile.id, priorityCooldownUntil(profile.id, Date.now()))
                       claudeLog("upstream.context_fallback", {
                         mode: "non_stream",
                         from,
@@ -3061,7 +3066,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     if (isExtraUsageRequiredError(errMsg) && hasExtendedContext(model)) {
                       const from = model
                       model = stripExtendedContext(model)
-                      recordExtendedContextUnavailable()
+                      recordExtendedContextUnavailable(profile.id)
                       claudeLog("upstream.context_fallback", {
                         mode: "stream",
                         from,
@@ -3122,6 +3127,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       if (hasExtendedContext(model)) {
                         const from = model
                         model = stripExtendedContext(model)
+                        // Bench [1m] for this profile until its window resets. Without
+                        // this the next request maps straight back to [1m], so one rate
+                        // limit costs TWO model switches and a cold prompt cache in both
+                        // directions — routinely more than the rate limit itself (#862).
+                        recordExtendedContextRateLimited(profile.id, priorityCooldownUntil(profile.id, Date.now()))
                         claudeLog("upstream.context_fallback", {
                           mode: "stream",
                           from,


### PR DESCRIPTION
Closes #862.

## The flap

A rate limit on a `[1m]` model strips the suffix and retries (`server.ts` non-stream + stream), but records nothing. `mapModelToClaudeModel` then maps straight back to `[1m]` on the next request:

```
opus[1m]  --rate limited-->  opus  --next request-->  opus[1m]
```

Prompt caches are model-scoped, so that is **two** invalidations per rate-limit event — one on the way down, one on the way back — each a full-price re-read of the conversation. On a long session that costs more than the rate limit it was routing around.

The Extra-Usage path already recognised this and records a cooldown so subsequent requests skip `[1m]` rather than re-probing every time. The rate-limit path never got the same treatment.

## The fix

Bench `[1m]` until the account's **own observed reset**, derived through the existing `priorityCooldownUntil` → `rateLimitStore` → `resolveCooldownUntil` path rather than a constant. A fixed window would repeat the mistake #790 fixed: a too-short cooldown just re-probes on a slower interval instead of waiting for the real reset. When no exhausted account-wide window is known it falls back to the same conservative 10-minute default the priority pool uses.

## Why the store had to change with it

The bench was a single process-global timestamp:

```ts
let extraUsageUnavailableAt = 0
export function recordExtendedContextUnavailable(): void { extraUsageUnavailableAt = Date.now() }
```

So one account hitting "Extra Usage required" benched `[1m]` for **every** profile for an hour — including accounts whose plan includes the 1M window at no cost. Building a second bench reason on top of that global would have widened the bug, so both are now keyed by profile.

Semantics match `ProfileExhaustion.mark`: a later mark extends an earlier one, an earlier mark never shortens a longer bench, and expired marks are dropped on read so the next request probes once. Callers that pass no profile share a single default bucket, leaving single-profile setups byte-identical.

## Tests

- Unit (`models.test.ts`): per-profile isolation, bench until a supplied reset, no bench for an already-passed reset, extend-not-shorten, and the `isExtendedContextKnownUnavailable` read path. Mutation-verified — collapsing the key back to a global fails the isolation tests.
- Wiring (`proxy-extra-usage-fallback.test.ts`): a rate-limit strip records exactly one bench with a future `until`. Mutation-verified — removing the call fails it.
- Full suite: 2804 pass, no new failures (the 11 failing locally are pre-existing environment/suite-ordering artifacts and pass in CI).
- `tsc --noEmit` clean.

## Not covered

`resolveCooldownUntil` only honours account-wide windows (`five_hour`, `seven_day`). A `[1m]` rate limit reported against a per-model window (`seven_day_opus`) falls through to the conservative default — deliberate, and the same known remainder documented in #790.