### PR TITLE
fix: bound the per-session passthrough tool caches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,20 @@ A proxy that bridges OpenCode (Anthropic API format) to Claude Max (Agent SDK). 
 ## Commands
 
 ```bash
-npm test          # Run all tests (bun test)
+npm test          # Run all tests — ALWAYS use this, never bare `bun test`
 npm run build     # Build with tsup
 npm start         # Start the proxy server
+npm run typecheck # tsc --noEmit (CI runs this separately; tests do not typecheck)
 ```
+
+**`npm test` is not a thin wrapper around `bun test`.** Ten test files mock
+modules with `mock.module`, which is process-global in bun and leaks across
+files, so `npm test` runs each of them in its own `bun test` invocation and
+excludes them from the main pass. Running bare `bun test` puts them back in one
+process and produces ~11 failures that look pre-existing and have nothing to do
+with your change. If you see failures in `models-auth-status`, `mcpTools grep
+tool`, `models.test`, or the session-store files, check which command you ran
+before investigating anything else.
 
 ## Code Rules
 

--- a/src/__tests__/session-tool-cache-eviction.test.ts
+++ b/src/__tests__/session-tool-cache-eviction.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The per-session passthrough tool cache must be bounded.
+ *
+ * `sessionToolCache` exists so a client that intermittently omits `tools` on a
+ * continuation request keeps its cached set instead of re-rendering the prompt
+ * without it. That cache holds every session's full tool array — names,
+ * descriptions and JSON schemas — so an unbounded map grows for the life of the
+ * process. The neighbouring `sessionMcpCache` is already an LRU for exactly
+ * this reason; this one was a plain Map.
+ *
+ * That matters for cost, not just memory: the eventual OOM restart drops the
+ * in-memory session caches, and every live conversation then replays against a
+ * cold prompt cache.
+ *
+ * Eviction is asserted through observable behaviour rather than by reaching
+ * into the map — an evicted session simply stops having its tools restored.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage, makeRequest } from "./helpers"
+
+let mockMessages: any[] = []
+let capturedQueryParams: any = {}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (opts: any) => {
+    capturedQueryParams = opts
+    return (async function* () {
+      for (const msg of mockMessages) yield msg
+    })()
+  },
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "oc",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file",
+  input_schema: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+}
+
+const RUN = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`
+
+async function post(app: any, session: string, tools: any[]) {
+  mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-opencode-session": `${session}-${RUN}`,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify(makeRequest({
+      stream: false,
+      tools,
+      messages: [{ role: "user", content: "hi" }],
+    })),
+  }))
+}
+
+/** Passthrough registers the client's tools on an MCP server named `oc`;
+ *  with no tools (and none restored) there is no such server at all. */
+function toolsReachedTheSdk(): boolean {
+  return Boolean(capturedQueryParams?.options?.mcpServers?.oc)
+}
+
+describe("session tool cache is bounded", () => {
+  const saved: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    saved.passthrough = process.env.MERIDIAN_PASSTHROUGH
+    saved.maxSessions = process.env.MERIDIAN_MAX_SESSIONS
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    // Small enough that a third session must evict the first.
+    process.env.MERIDIAN_MAX_SESSIONS = "2"
+    clearSessionCache()
+    capturedQueryParams = {}
+  })
+
+  afterEach(() => {
+    if (saved.passthrough !== undefined) process.env.MERIDIAN_PASSTHROUGH = saved.passthrough
+    else delete process.env.MERIDIAN_PASSTHROUGH
+    if (saved.maxSessions !== undefined) process.env.MERIDIAN_MAX_SESSIONS = saved.maxSessions
+    else delete process.env.MERIDIAN_MAX_SESSIONS
+    clearSessionCache()
+  })
+
+  it("restores a still-cached session's tools when the client omits them", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    await post(app, "keeps-a", [READ_TOOL])
+    await post(app, "keeps-a", [])
+    // The control for the eviction test below: without eviction the cached set
+    // is restored, so the tools still reach the SDK.
+    expect(toolsReachedTheSdk()).toBe(true)
+  })
+
+  it("stops restoring tools for a session evicted past the cache limit", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    await post(app, "evicted", [READ_TOOL])
+    await post(app, "second", [READ_TOOL])
+    await post(app, "third", [READ_TOOL])
+
+    // "evicted" is now the least-recently-used of three entries in a cache of
+    // two. An unbounded Map keeps it forever and restores its tools here.
+    await post(app, "evicted", [])
+    expect(toolsReachedTheSdk()).toBe(false)
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -478,11 +478,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   restoreActiveProfile(finalConfig.profiles)
 
   // Track cumulative discovered tools per SDK session (survives across requests)
-  const sessionDiscoveredTools = new Map<string, Set<string>>()
+  // Bounded for the same reason as sessionMcpCache below: this is per-session
+  // state on a long-lived process, so an unbounded map is a slow leak whose
+  // eventual restart costs every live conversation a cold prompt cache.
+  const sessionDiscoveredTools = new LRUMap<string, Set<string>>(getMaxSessionsLimit())
 
   // Cache last-seen tool definitions per agent session to prevent prompt cache
   // invalidation when clients intermittently omit tools on continuation requests.
-  const sessionToolCache = new Map<string, any[]>()
+  const sessionToolCache = new LRUMap<string, any[]>(getMaxSessionsLimit())
   // Cache the passthrough MCP server per session. Reusing the same server
   // across turns (when the tool set is unchanged) avoids subtle prompt-cache
   // invalidation from MCP server re-creation. Key hashes tool name + schema


### PR DESCRIPTION
Closes part of the reliability sweep after #860 / #863.

## The leak

`sessionToolCache` and `sessionDiscoveredTools` were plain `Map`s with no eviction and no `delete` anywhere in the file. Both are keyed per session on a long-lived process, so both grow without bound — and the tool cache holds each session's full tool array, descriptions and JSON schemas included.

`sessionMcpCache`, declared immediately beside them, was already an `LRUMap` for exactly this reason. These two just missed it.

It matters for cost, not only memory: the eventual OOM restart drops the in-memory session caches, and every live conversation then replays against a cold prompt cache — the same failure this run has been chasing from other directions.

Both are now bounded to `MERIDIAN_MAX_SESSIONS`.

## Test

Nothing covered `sessionToolCache` at all before this. The new test asserts eviction through **observable behaviour** rather than by reaching into the map: an evicted session stops having its omitted tools restored, which is the whole point of the cache. It ships with its own control (a still-cached session *does* get them restored), and was verified to fail when the `LRUMap` is reverted to a `Map`.

## Docs: `npm test` is not `bun test`

Separately, `CLAUDE.md` said `npm test  # Run all tests (bun test)`. It is not a wrapper — ten files mock modules with `mock.module`, which is process-global in bun, so `npm test` runs each in its own invocation and excludes them from the main pass.

Running bare `bun test` puts them back in one process and produces ~11 failures that read as pre-existing and have nothing to do with the change under test. That is documented now, with the specific file names to recognise, because it is a genuinely expensive trap: it makes a green suite look permanently red and buries real regressions in the noise.

## Not included

The auto-defer threshold pinning originally proposed in #861 is **not** here — see the correction on that issue. Prompt caching invalidates the tools tier on any tool add/remove, so the tool-set change that crosses the threshold has already caused the full invalidation before deferral is consulted; pinning the decision would buy nothing. That issue is downgraded to an observability task.

## Verification

- `npm test`: 2817 passing, 0 failures, exit 0
- `npm run typecheck`: clean