### PR TITLE
fix(passthrough): cap repeated upstream idle stalls

### DIFF
--- a/src/__tests__/idle-stall-ceiling.test.ts
+++ b/src/__tests__/idle-stall-ceiling.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for IdleStallTracker — pure, no server or clock needed.
+ */
+import { describe, it, expect } from "bun:test"
+import { IdleStallTracker } from "../proxy/idleStallCeiling"
+
+const IDLE = 150_000
+const SINCE = 150_012
+
+describe("IdleStallTracker", () => {
+  it("keeps a first stall retryable", () => {
+    const t = new IdleStallTracker(3, 10)
+    const v = t.record("sess-a", IDLE, SINCE)
+    expect(v.status).toBe(504)
+    expect(v.terminal).toBe(false)
+    expect(v.consecutive).toBe(1)
+  })
+
+  it("counts consecutive stalls on the same session", () => {
+    const t = new IdleStallTracker(3, 10)
+    expect(t.record("sess-a", IDLE, SINCE).consecutive).toBe(1)
+    expect(t.record("sess-a", IDLE, SINCE).consecutive).toBe(2)
+    expect(t.record("sess-a", IDLE, SINCE).consecutive).toBe(3)
+  })
+
+  // The whole point: a 5xx reads as "transient, try again", so a session that
+  // stalls deterministically must stop being told to retry.
+  it("turns terminal and non-retryable at the ceiling", () => {
+    const t = new IdleStallTracker(3, 10)
+    t.record("sess-a", IDLE, SINCE)
+    t.record("sess-a", IDLE, SINCE)
+    const v = t.record("sess-a", IDLE, SINCE)
+    expect(v.terminal).toBe(true)
+    expect(v.status).toBe(400)
+    expect(v.status).toBeLessThan(500)
+    expect(v.type).toBe("invalid_request_error")
+  })
+
+  it("stays terminal past the ceiling", () => {
+    const t = new IdleStallTracker(2, 10)
+    t.record("s", IDLE, SINCE)
+    expect(t.record("s", IDLE, SINCE).terminal).toBe(true)
+    expect(t.record("s", IDLE, SINCE).terminal).toBe(true)
+  })
+
+  // A stall that a retry cleared is not evidence of a stuck session.
+  it("resets the streak on a completed turn", () => {
+    const t = new IdleStallTracker(2, 10)
+    t.record("sess-a", IDLE, SINCE)
+    t.clear("sess-a")
+    const v = t.record("sess-a", IDLE, SINCE)
+    expect(v.consecutive).toBe(1)
+    expect(v.terminal).toBe(false)
+  })
+
+  it("tracks sessions independently", () => {
+    const t = new IdleStallTracker(2, 10)
+    t.record("sess-a", IDLE, SINCE)
+    expect(t.record("sess-b", IDLE, SINCE).consecutive).toBe(1)
+    expect(t.record("sess-a", IDLE, SINCE).terminal).toBe(true)
+    expect(t.record("sess-b", IDLE, SINCE).terminal).toBe(true)
+  })
+
+  // Pooling identity-less turns under a shared "" key would let unrelated
+  // sessions trip each other's ceiling.
+  it("never accumulates across turns with no session identity", () => {
+    const t = new IdleStallTracker(2, 10)
+    expect(t.record("", IDLE, SINCE).consecutive).toBe(1)
+    expect(t.record("", IDLE, SINCE).consecutive).toBe(1)
+    expect(t.record("", IDLE, SINCE).terminal).toBe(false)
+  })
+
+  it("disables the ceiling at 0, preserving the pre-ceiling 504", () => {
+    const t = new IdleStallTracker(0, 10)
+    for (let i = 0; i < 25; i++) {
+      const v = t.record("sess-a", IDLE, SINCE)
+      expect(v.status).toBe(504)
+      expect(v.terminal).toBe(false)
+    }
+  })
+
+  it("bounds its own memory", () => {
+    const t = new IdleStallTracker(3, 4)
+    for (let i = 0; i < 100; i++) t.record(`sess-${i}`, IDLE, SINCE)
+    expect(t.streak("sess-99")).toBe(1)
+    expect(t.streak("sess-0")).toBe(0)
+  })
+
+  // Evicting a live session must not carry a stale streak back in.
+  it("restarts an evicted session's streak from one", () => {
+    const t = new IdleStallTracker(3, 2)
+    t.record("sess-a", IDLE, SINCE)
+    t.record("sess-b", IDLE, SINCE)
+    t.record("sess-c", IDLE, SINCE)
+    expect(t.record("sess-a", IDLE, SINCE).consecutive).toBe(1)
+  })
+
+  it("reports the stall duration and remediation in the terminal message", () => {
+    const t = new IdleStallTracker(1, 10)
+    const v = t.record("sess-a", IDLE, SINCE)
+    expect(v.message).toContain(String(SINCE))
+    expect(v.message).toContain("MERIDIAN_UPSTREAM_IDLE_MS")
+  })
+
+  it.each([
+    [1, "1st"],
+    [2, "2nd"],
+    [3, "3rd"],
+    [4, "4th"],
+    [11, "11th"],
+    [21, "21st"],
+  ])("ordinalises %i as %s", (n, expected) => {
+    const t = new IdleStallTracker(1, 50)
+    let v = t.record("s", IDLE, SINCE)
+    for (let i = 1; i < n; i++) v = t.record("s", IDLE, SINCE)
+    expect(v.message).toContain(`the ${expected} consecutive stall`)
+  })
+})

--- a/src/__tests__/idle-stall-ceiling.test.ts
+++ b/src/__tests__/idle-stall-ceiling.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for IdleStallTracker — pure, no server or clock needed.
  */
 import { describe, it, expect } from "bun:test"
-import { IdleStallTracker } from "../proxy/idleStallCeiling"
+import { IdleStallCeilingError, IdleStallTracker } from "../proxy/idleStallCeiling"
 
 const IDLE = 150_000
 const SINCE = 150_012
@@ -34,6 +34,13 @@ describe("IdleStallTracker", () => {
     expect(v.status).toBe(400)
     expect(v.status).toBeLessThan(500)
     expect(v.type).toBe("invalid_request_error")
+  })
+
+  it("preserves its classified verdict through the non-stream error boundary", () => {
+    const verdict = new IdleStallTracker(1, 10).record("sess-a", IDLE, SINCE)
+    const error = new IdleStallCeilingError(verdict)
+    expect(error.verdict).toBe(verdict)
+    expect(error.message).toBe(verdict.message)
   })
 
   it("stays terminal past the ceiling", () => {

--- a/src/proxy/idleStallCeiling.ts
+++ b/src/proxy/idleStallCeiling.ts
@@ -1,0 +1,115 @@
+/**
+ * Consecutive upstream-idle ceiling.
+ *
+ * guardUpstreamIdle turns a stalled model stream into a 504, which is the right
+ * answer for a one-off stall: a retry usually clears it. What a 504 cannot say
+ * is that the SAME session has now stalled the same way several turns running.
+ * "Transient, try again" is what every client retry policy reads in a 5xx, so a
+ * session that stalls deterministically gets replayed forever at full upstream
+ * cost — on 2026-08-16 that ran twenty turns into a half-hour loop, each killed
+ * at exactly the idle limit, each retried, none ever completing.
+ *
+ * The proxy does not retry; the client does. So the only lever here is the
+ * status code, and past the ceiling this swaps the retryable 504 for a terminal
+ * error carrying the two things that actually resolve it — raise the idle limit
+ * above the model's real thinking pause, or shorten the turn.
+ *
+ * Counting is per session and resets on any completed turn: the ceiling is
+ * about a session that cannot make progress, not a session that has ever
+ * stalled.
+ */
+
+export interface IdleStallVerdict {
+  status: number
+  type: string
+  message: string
+  /** Consecutive stalls on this session, including the one being judged. */
+  consecutive: number
+  /** True when the ceiling fired and the client is being told to stop. */
+  terminal: boolean
+}
+
+/** Tracks consecutive idle stalls per session and rules on each one.
+ *
+ *  Bounded by construction. The session maps in server.ts that predate this are
+ *  plain unbounded Maps; a tracker keyed by session id would leak the same way,
+ *  so capacity is required rather than optional. */
+export class IdleStallTracker {
+  private readonly counts: Map<string, number> = new Map()
+
+  /** @param ceiling Consecutive stalls tolerated before the verdict turns
+   *                 terminal. 0 disables the ceiling — every stall stays a 504,
+   *                 which is the pre-ceiling behaviour.
+   *  @param capacity Maximum sessions tracked; the oldest entry is evicted
+   *                  first. */
+  constructor(
+    private readonly ceiling: number,
+    private readonly capacity: number,
+  ) {}
+
+  /** Clear a session's streak. Call on any completed turn — a turn that
+   *  finished is proof the session can still make progress. */
+  clear(sessionKey: string): void {
+    this.counts.delete(sessionKey)
+  }
+
+  /** Record a stall and rule on it.
+   *
+   *  An empty session key means the turn carries no session identity to
+   *  correlate against (a first turn that stalled before the SDK reported its
+   *  session id). Those are counted as one-offs rather than pooled under a
+   *  shared "" key, which would let unrelated sessions trip each other's
+   *  ceiling. */
+  record(sessionKey: string, idleMs: number, sinceLastMs: number): IdleStallVerdict {
+    const consecutive = sessionKey ? (this.counts.get(sessionKey) ?? 0) + 1 : 1
+    if (sessionKey) {
+      // Re-insert to refresh recency, then evict from the front (insertion
+      // order) so the map cannot outgrow capacity.
+      this.counts.delete(sessionKey)
+      this.counts.set(sessionKey, consecutive)
+      while (this.counts.size > this.capacity) {
+        const oldest = this.counts.keys().next()
+        if (oldest.done) break
+        this.counts.delete(oldest.value)
+      }
+    }
+
+    if (this.ceiling <= 0 || consecutive < this.ceiling) {
+      return {
+        status: 504,
+        type: "upstream_timeout",
+        message: `Upstream stalled: no data for ${sinceLastMs}ms`,
+        consecutive,
+        terminal: false,
+      }
+    }
+
+    return {
+      status: 400,
+      type: "invalid_request_error",
+      message: `Upstream stalled with no data for ${sinceLastMs}ms — the ${consecutive}${ordinalSuffix(consecutive)} consecutive stall on this session (limit ${idleMs}ms). Retrying has not cleared it, so this turn is failing deterministically rather than transiently. Raise MERIDIAN_UPSTREAM_IDLE_MS above the model's real thinking pause, or shorten the turn — fewer deferred tools, or compact the conversation.`,
+      consecutive,
+      terminal: true,
+    }
+  }
+
+  /** Test/telemetry accessor. */
+  streak(sessionKey: string): number {
+    return this.counts.get(sessionKey) ?? 0
+  }
+}
+
+function ordinalSuffix(n: number): string {
+  const rem100 = n % 100
+  if (rem100 >= 11 && rem100 <= 13) return "th"
+  switch (n % 10) {
+    case 1:
+      return "st"
+    case 2:
+      return "nd"
+    case 3:
+      return "rd"
+    default:
+      return "th"
+  }
+}

--- a/src/proxy/idleStallCeiling.ts
+++ b/src/proxy/idleStallCeiling.ts
@@ -29,6 +29,14 @@ export interface IdleStallVerdict {
   terminal: boolean
 }
 
+/** Carries a classified idle-stall response through the non-stream error path. */
+export class IdleStallCeilingError extends Error {
+  constructor(readonly verdict: IdleStallVerdict) {
+    super(verdict.message)
+    this.name = "IdleStallCeilingError"
+  }
+}
+
 /** Tracks consecutive idle stalls per session and rules on each one.
  *
  *  Bounded by construction. The session maps in server.ts that predate this are

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -8,6 +8,7 @@ import { join } from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
+import { IdleStallTracker } from "./idleStallCeiling"
 import { linkRequestAbort } from "./requestAbort"
 import { AbortableSemaphore, getProcessSdkSemaphore, type SemaphoreLease } from "./concurrency"
 import { closeServerWithGracePeriod, trackServerConnections } from "./shutdown"
@@ -226,6 +227,13 @@ const UPSTREAM_IDLE_MS = envInt("UPSTREAM_IDLE_MS", 90_000)
 // An override BELOW UPSTREAM_IDLE_MS deliberately re-enables that race for
 // regression tests; production defaults must remain above the upstream guard.
 const DENY_HOLD_TIMEOUT_MS = envInt("DENY_HOLD_TIMEOUT_MS", UPSTREAM_IDLE_MS + 30_000)
+// Consecutive stalls tolerated on ONE session before its 504 becomes terminal.
+// A 5xx tells every client retry policy "transient, try again", so a session
+// that stalls deterministically is replayed forever at full upstream cost. 3
+// absorbs a genuine one-off stall (and the odd second one) while capping the
+// waste at three idle windows instead of an afternoon. 0 disables the ceiling
+// and restores the pre-ceiling behaviour exactly.
+const UPSTREAM_IDLE_MAX_CONSECUTIVE = envInt("UPSTREAM_IDLE_MAX_CONSECUTIVE", 3)
 
 // Bounds how long ProxyInstance.close() waits for in-flight /v1/messages
 // requests to finish (after beginDrain() stops admitting new ones) before it
@@ -631,6 +639,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // so silently-updated tool definitions force a rebuild.
   const sessionMcpCache = new LRUMap<string, { key: string; mcp: ReturnType<typeof createPassthroughMcpServer> }>(getMaxSessionsLimit())
 
+  // Consecutive upstream-idle stalls per session, for the retry ceiling.
+  const idleStalls = new IdleStallTracker(UPSTREAM_IDLE_MAX_CONSECUTIVE, getMaxSessionsLimit())
+
+  // In-flight session stores. The streaming drain design ends the client's
+  // response at the turn boundary (fast), while deny persistence + the early
+  // stop + storeSession continue in the background for ~a second. A client
+  // that executes its tools quickly (small file reads) can send the follow-up
+  // BEFORE the store lands — its lookup misses and the conversation falls to
+  // a fresh replay. Follow-ups briefly await their session's pending store.
+  const PENDING_STORE_WAIT_MS = 3000
+  const PENDING_STORE_AUTO_RESOLVE_MS = 10000
   // A --resume spawned while the session's previous subprocess is still
   // exiting is refused, in two wordings: "currently running as a background
   // agent" (#630, a consequence of #628's CLAUDE_CODE_SESSION_KIND=bg) and
@@ -3671,6 +3690,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
             // Accumulate discovered tools into the session-level set
             const sessId = currentSessionId || resumeSessionId
+            // A turn that completed is proof the session can still make
+            // progress, so its stall streak starts over.
+            if (sessId) idleStalls.clear(sessId)
             if (sessId && discoveredTools.size > 0) {
               if (!sessionDiscoveredTools.has(sessId)) sessionDiscoveredTools.set(sessId, new Set())
               for (const t of discoveredTools) sessionDiscoveredTools.get(sessId)!.add(t)
@@ -4992,6 +5014,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
               // Accumulate discovered tools into the session-level set
               const sessId = currentSessionId || resumeSessionId
+              // A turn that completed is proof the session can still make
+              // progress, so its stall streak starts over.
+              if (sessId) idleStalls.clear(sessId)
               if (sessId && discoveredTools.size > 0) {
                 if (!sessionDiscoveredTools.has(sessId)) sessionDiscoveredTools.set(sessId, new Set())
                 for (const t of discoveredTools) sessionDiscoveredTools.get(sessId)!.add(t)
@@ -5760,13 +5785,27 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 error: errMsg,
                 ...(stderrOutput ? { stderr: stderrOutput } : {})
               })
-              const streamErr = error instanceof UpstreamIdleError
-                ? {
-                    status: 504,
-                    type: "upstream_timeout",
-                    message: `Upstream stalled: no data for ${error.sinceLastMs}ms`,
-                  }
-                : classifyError(errMsg, model)
+              let streamErr: { status: number; type: string; message: string }
+              if (error instanceof UpstreamIdleError) {
+                // A stalled stream is retryable once; the same session stalling
+                // the same way over and over is not, and only the status code
+                // can say so — the proxy does not retry, the client does.
+                const verdict = idleStalls.record(
+                  currentSessionId || resumeSessionId || "",
+                  UPSTREAM_IDLE_MS,
+                  error.sinceLastMs,
+                )
+                claudeLog("upstream.idle_streak", {
+                  model,
+                  sinceLastMs: error.sinceLastMs,
+                  consecutive: verdict.consecutive,
+                  ceiling: UPSTREAM_IDLE_MAX_CONSECUTIVE,
+                  terminal: verdict.terminal,
+                })
+                streamErr = { status: verdict.status, type: verdict.type, message: verdict.message }
+              } else {
+                streamErr = classifyError(errMsg, model)
+              }
               claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })
 
               // How long the client should wait before retrying. A streaming
@@ -5866,6 +5905,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }
 
               if (canRecoverAsToolUse) {
+                // A recovered stall delivered the client its tool calls, so the
+                // session is making progress and its streak starts over. Without
+                // this the counter climbs through stalls that were absorbed, and
+                // the first genuinely unrecoverable one reads as terminal.
+                const recoveredSessId = currentSessionId || resumeSessionId
+                if (recoveredSessId) idleStalls.clear(recoveredSessId)
+
                 // Log the recovery at session level (not error) — it's a
                 // notable flow control event but not a failure for the client.
                 diagnosticLog.session(

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -8,7 +8,7 @@ import { join } from "node:path"
 import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
-import { IdleStallTracker } from "./idleStallCeiling"
+import { IdleStallCeilingError, IdleStallTracker } from "./idleStallCeiling"
 import { linkRequestAbort } from "./requestAbort"
 import { AbortableSemaphore, getProcessSdkSemaphore, type SemaphoreLease } from "./concurrency"
 import { closeServerWithGracePeriod, trackServerConnections } from "./shutdown"
@@ -320,7 +320,6 @@ function forkAttemptMeta(meta: RequestMeta, attempt: number): RequestMeta {
     ttfbMs: undefined,
   }
 }
-
 function credentialStoreForProfile(profile: ResolvedProfile): CredentialStore | undefined {
   if (profile.type !== "claude-max") return undefined
   return createPlatformCredentialStore(
@@ -3692,7 +3691,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const sessId = currentSessionId || resumeSessionId
             // A turn that completed is proof the session can still make
             // progress, so its stall streak starts over.
-            if (sessId) idleStalls.clear(sessId)
+            idleStalls.clear(profileSessionId || sessId || "")
             if (sessId && discoveredTools.size > 0) {
               if (!sessionDiscoveredTools.has(sessId)) sessionDiscoveredTools.set(sessId, new Set())
               for (const t of discoveredTools) sessionDiscoveredTools.get(sessId)!.add(t)
@@ -3743,6 +3742,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // that never triggered the loop-break (e.g. wide parallel exceeding
             // the turn budget) land here.
             const sdkTerm = extractSdkTermination(error instanceof Error ? error.message : String(error))
+            const idleVerdict = error instanceof UpstreamIdleError
+              ? idleStalls.record(
+                  profileSessionId || currentSessionId || resumeSessionId || "",
+                  UPSTREAM_IDLE_MS,
+                  error.sinceLastMs,
+                )
+              : undefined
             const canRecoverAsToolUse = canRecoverCapturedToolUses({
               reason: sdkTerm.reason,
               passthrough,
@@ -3751,6 +3757,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               abortIsOurs: true,
             })
             if (canRecoverAsToolUse) {
+              if (idleVerdict) {
+                idleStalls.clear(profileSessionId || currentSessionId || resumeSessionId || "")
+              }
               diagnosticLog.session(
                 `${requestMeta.requestId} sdk_termination_recovered ${formatSdkTermination(sdkTerm, {
                   model, requestSource, isResume, hasDeferredTools, sdkSessionId: resumeSessionId,
@@ -3800,7 +3809,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 error: error instanceof Error ? error.message : String(error),
                 ...(stderrOutput ? { stderr: stderrOutput } : {})
               })
-              throw error
+              throw idleVerdict ? new IdleStallCeilingError(idleVerdict) : error
             }
           }
 
@@ -5016,7 +5025,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               const sessId = currentSessionId || resumeSessionId
               // A turn that completed is proof the session can still make
               // progress, so its stall streak starts over.
-              if (sessId) idleStalls.clear(sessId)
+              idleStalls.clear(profileSessionId || sessId || "")
               if (sessId && discoveredTools.size > 0) {
                 if (!sessionDiscoveredTools.has(sessId)) sessionDiscoveredTools.set(sessId, new Set())
                 for (const t of discoveredTools) sessionDiscoveredTools.get(sessId)!.add(t)
@@ -5791,7 +5800,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // the same way over and over is not, and only the status code
                 // can say so — the proxy does not retry, the client does.
                 const verdict = idleStalls.record(
-                  currentSessionId || resumeSessionId || "",
+                  profileSessionId || currentSessionId || resumeSessionId || "",
                   UPSTREAM_IDLE_MS,
                   error.sinceLastMs,
                 )
@@ -5909,7 +5918,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // session is making progress and its streak starts over. Without
                 // this the counter climbs through stalls that were absorbed, and
                 // the first genuinely unrecoverable one reads as terminal.
-                const recoveredSessId = currentSessionId || resumeSessionId
+                const recoveredSessId = profileSessionId || currentSessionId || resumeSessionId
                 if (recoveredSessId) idleStalls.clear(recoveredSessId)
 
                 // Log the recovery at session level (not error) — it's a
@@ -6271,7 +6280,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // Detect specific error types and return helpful messages
         const classified = requestAbort.controller.signal.aborted
           ? { status: 499, type: "request_cancelled", message: "The request was cancelled" }
-          : classifyError(errMsg)
+          : error instanceof IdleStallCeilingError
+            ? error.verdict
+            : classifyError(errMsg)
 
         // Non-streaming failures still own their headers here, so the hint goes
         // out as a real `Retry-After` (#901). `resolvedProfileId` is undefined

--- a/src/proxy/streamIdleGuard.ts
+++ b/src/proxy/streamIdleGuard.ts
@@ -14,9 +14,13 @@
  * COORDINATION CONTRACT (Pylon Orchestrator): this guard owns *model-stream*
  * liveness. Pylon's runtime stall watchdog is only a BACKSTOP for the
  * model-wait gap with no tool in flight, and keeps its abort threshold above
- * this guard's idle limit (default MERIDIAN_IDLE_TIMEOUT_SECONDS = 120s) so the
- * two layers never race to abort the same hung model. If this default rises,
- * re-check Pylon's STALL_ABORT_MS. See
+ * this guard's idle limit so the two layers never race to abort the same hung
+ * model. The limit is `MERIDIAN_UPSTREAM_IDLE_MS` (default 90s, set in
+ * server.ts); Pylon warns at 120s and aborts at 180s. Any override must stay
+ * BELOW Pylon's STALL_ABORT_MS; raising it past 180s requires changing Pylon
+ * first.
+ * Note `MERIDIAN_IDLE_TIMEOUT_SECONDS` is a different knob — the HTTP
+ * keep-alive timeout — and has no bearing on this contract. See
  * pylon-orchestrator/docs/circuit/specs/stall-watchdog-tool-exempt.md.
  */
 export class UpstreamIdleError extends Error {


### PR DESCRIPTION
## Summary

- track upstream idle stalls by profile session when available
- classify non-stream idle stalls as Anthropic invalid_request errors
- retain the stream terminal error event for responses that have already begun

## Verification

- bun test src/__tests__/idle-stall-ceiling.test.ts
- npm run build
- git diff --check origin/main...HEAD

## Note

The full concurrent suite has pre-existing timing flakiness in priority-routing integration tests; the affected tests pass in isolation.