### PR TITLE
fix: downgrade modified-history turn conflict to fresh replay instead of 409

### DIFF
--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -360,6 +360,30 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resume).toBeUndefined()
     expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
     expect(typeof capturedQueryParams.prompt).toBe("string")
+    // The fresh replay should carry the checkpoint-incomplete replay degradation note
+    const sp = capturedQueryParams.options.systemPrompt
+    const append = typeof sp === "object" && sp !== null ? sp.append : sp
+    expect(append).toContain("parallel tool-call batch")
+    expect(append).toContain("<meridian-note>")
+  })
+
+  it("non-stream: first-ever request does NOT set replayDegradationReason", async () => {
+    // A normal first request with no prior session must not carry the reason.
+    capturedQueryParams = null
+    mockMessages = [
+      assistantMessage([{ type: "text", text: "First response." }]),
+    ]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "hello" }],
+    }, "es-first-ever")).status).toBe(200)
+    const sp = capturedQueryParams.options.systemPrompt
+    const append = typeof sp === "object" && sp !== null ? sp.append : sp
+    expect(append).not.toContain("full conversation replay")
+    expect(append).not.toContain("This turn required a full conversation replay")
   })
 
   it("non-stream: preserves a nested multimodal tool_result wrapper", async () => {

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -690,3 +690,101 @@ describe("envelope integrity tripwire", () => {
     expect(after - before).toBe(0)
   })
 })
+
+describe("dropped duplicate tool_use is excluded from persisted checkpoint", () => {
+  let origEnv: string | undefined
+  let origEarlyStop: string | undefined
+
+  beforeEach(() => {
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP // early stop ON (default)
+    mockTurns = []
+    capturedController = undefined
+    capturedResume = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origEnv
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+  })
+
+  function duplicateTurn() {
+    // Two tool_use blocks: same name + same input → second is an exact duplicate
+    const turn = toolTurn("toolu_d1", "read", { filePath: "a.txt" })
+    ;(turn as any).message.content = [
+      { type: "tool_use", id: "toolu_d1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      { type: "tool_use", id: "toolu_d2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+    ]
+    return turn
+  }
+
+  function denyUser(ids: string[]) {
+    return {
+      type: "user",
+      message: {
+        role: "user",
+        content: ids.map((id) => ({
+          type: "tool_result",
+          tool_use_id: id,
+          is_error: true,
+          content: "This tool call has been forwarded to the client for execution. " +
+            "The result will be delivered in a future turn. " +
+            "Do not retry, do not call additional tools, and do not generate further text — end your turn now.",
+        })),
+      },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: "test-session",
+    }
+  }
+
+  it("checkpoint excludes the dropped duplicate id — follow-up resumes instead of fresh-replaying", async () => {
+    // First turn: model emits two reads, second is an exact duplicate.
+    // The hook drops toolu_d2 (isExactDuplicate) → added to droppedToolUseIds.
+    // The checkpoint must contain only toolu_d1.
+    mockTurns = [
+      duplicateTurn(),
+      denyUser(["toolu_d1", "toolu_d2"]),
+      { type: "assistant", message: {
+        id: "msg_digest", type: "message", role: "assistant",
+        content: [{ type: "text", text: "hidden digest" }],
+        model: "claude-sonnet-4-5-20250929", stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 10 },
+      }, parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session" },
+      { type: "result", subtype: "success", is_error: false, session_id: "test-session" },
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const first = await post(app, false)
+    expect(first.status).toBe(200)
+
+    // Follow-up: client sends back the real result for toolu_d1 only.
+    // If the checkpoint incorrectly included toolu_d2, isCompleteToolResultContinuation
+    // would fail (expected size 2, actual size 1) and the request would fresh-replay.
+    mockTurns = [
+      { type: "assistant", message: {
+        id: "msg_final", type: "message", role: "assistant",
+        content: [{ type: "text", text: "File read successfully." }],
+        model: "claude-sonnet-4-5-20250929", stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 10 },
+      }, parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session" },
+    ]
+    capturedResume = undefined
+    const second = await post(app, false, [
+      { role: "user", content: "Do the thing." },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "toolu_d1", name: "read", input: { filePath: "a.txt" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_d1", content: "contents of a.txt" },
+      ]},
+    ])
+    expect(second.status).toBe(200)
+    // Must resume — if the checkpoint included toolu_d2, this would fresh-replay
+    expect(capturedResume ?? "(not resumed)").toBe("test-session")
+  })
+})

--- a/src/__tests__/proxy-passthrough-settlement.test.ts
+++ b/src/__tests__/proxy-passthrough-settlement.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for passthrough settlement in lineage verification.
+ *
+ * In passthrough mode the PreToolUse hook denies every tool call with a
+ * placeholder reason string. The SDK records a synthetic `user` message whose
+ * `tool_result` content is that placeholder. When the client sends back the
+ * real tool_result, verifyLineage must classify this as a continuation
+ * (passthrough settlement) rather than modified-history, which would re-fire
+ * the deny hook and loop.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  isPassthroughDenyToolResult,
+  FORWARDED_TOOL_DENY,
+  EXACT_DUPLICATE_DENY,
+  SAME_TOOL_REPEAT_DENY,
+} from "../proxy/denyReasons"
+import {
+  verifyLineage,
+  computeLineageHash,
+  computeMessageHashes,
+  computeMessageBlockHashes,
+  type SessionState,
+} from "../proxy/session/lineage"
+
+function makeSession(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    claudeSessionId: "sdk-1",
+    lastAccess: Date.now(),
+    messageCount: 0,
+    lineageHash: "",
+    ...overrides,
+  }
+}
+
+function msg(role: string, content: any) {
+  return { role, content }
+}
+
+function toolResult(id: string, content: string) {
+  return { type: "tool_result", tool_use_id: id, content }
+}
+
+function toolUse(id: string, name: string) {
+  return { type: "tool_use", id, name, input: {} }
+}
+
+// --- isPassthroughDenyToolResult ---
+
+describe("isPassthroughDenyToolResult", () => {
+  it("matches FORWARDED_TOOL_DENY", () => {
+    expect(isPassthroughDenyToolResult(FORWARDED_TOOL_DENY)).toBe(true)
+  })
+
+  it("matches EXACT_DUPLICATE_DENY", () => {
+    expect(isPassthroughDenyToolResult(EXACT_DUPLICATE_DENY)).toBe(true)
+  })
+
+  it("matches SAME_TOOL_REPEAT_DENY", () => {
+    expect(isPassthroughDenyToolResult(SAME_TOOL_REPEAT_DENY)).toBe(true)
+  })
+
+  it("rejects a normal tool_result payload", () => {
+    expect(isPassthroughDenyToolResult("contents of a.txt")).toBe(false)
+  })
+
+  it("rejects empty string", () => {
+    expect(isPassthroughDenyToolResult("")).toBe(false)
+  })
+
+  it("rejects non-string content (e.g. array)", () => {
+    expect(isPassthroughDenyToolResult(["not a string"])).toBe(false)
+  })
+
+  it("rejects null/undefined", () => {
+    expect(isPassthroughDenyToolResult(null)).toBe(false)
+    expect(isPassthroughDenyToolResult(undefined)).toBe(false)
+  })
+
+  it("rejects a string that merely CONTAINS a deny reason (not exact match)", () => {
+    expect(isPassthroughDenyToolResult("prefix " + FORWARDED_TOOL_DENY + " suffix")).toBe(false)
+  })
+})
+
+// --- verifyLineage passthrough settlement ---
+
+describe("verifyLineage passthrough settlement", () => {
+  function sessionFor(messages: Array<{ role: string; content: any }>, overrides: Partial<SessionState> = {}): SessionState {
+    return makeSession({
+      lastAccess: 0,
+      lineageHash: computeLineageHash(messages),
+      messageCount: messages.length,
+      messageHashes: computeMessageHashes(messages),
+      messageBlockHashes: computeMessageBlockHashes(messages),
+      passthroughToolCallIds: ["toolu_1"],
+      passthroughToolCallAssistantUuid: "uuid-assistant",
+      ...overrides,
+    })
+  }
+
+  it("returns continuation when trailing placeholder is replaced by real tool_result", () => {
+    // Stored: user asks, assistant calls tool, user gets deny placeholder
+    const stored = [
+      msg("user", "read file a.txt"),
+      { role: "assistant", content: [toolUse("toolu_1", "read")] },
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+    ]
+    // Incoming: same prefix, but the last user message has the REAL result
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [toolResult("toolu_1", "contents of a.txt")] },
+    ]
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(2)
+      expect(result.resumeContentFrom).toBe(0)
+    }
+  })
+
+  it("returns continuation when placeholder is replaced AND new messages follow", () => {
+    const stored = [
+      msg("user", "read file a.txt"),
+      { role: "assistant", content: [toolUse("toolu_1", "read")] },
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [toolResult("toolu_1", "contents of a.txt")] },
+      { role: "assistant", content: "Here are the contents." },
+      msg("user", "thanks"),
+    ]
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(2)
+      expect(result.resumeContentFrom).toBe(0)
+    }
+  })
+
+  it("returns continuation with multiple parallel forwarded tool IDs", () => {
+    const stored = [
+      msg("user", "run both"),
+      { role: "assistant", content: [
+        toolUse("toolu_a", "read"),
+        toolUse("toolu_b", "bash"),
+      ]},
+      { role: "user", content: [
+        toolResult("toolu_a", FORWARDED_TOOL_DENY),
+        toolResult("toolu_b", FORWARDED_TOOL_DENY),
+      ]},
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("toolu_a", "file contents"),
+        toolResult("toolu_b", "command output"),
+      ]},
+      { role: "assistant", content: "Both done." },
+    ]
+
+    const result = verifyLineage(sessionFor(stored, {
+      passthroughToolCallIds: ["toolu_a", "toolu_b"],
+    }), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(2)
+      expect(result.resumeContentFrom).toBe(0)
+    }
+  })
+
+  it("still returns modified-history when passthroughToolCallIds is absent", () => {
+    // Same shape but no checkpoint — this is a genuine content rewrite
+    const stored = [
+      msg("user", "read file a.txt"),
+      { role: "assistant", content: [toolUse("toolu_1", "read")] },
+      { role: "user", content: [toolResult("toolu_1", "old content")] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [toolResult("toolu_1", "new content")] },
+      msg("assistant", "next"),
+    ]
+
+    const session = sessionFor(stored, { passthroughToolCallIds: undefined })
+    const result = verifyLineage(session, incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
+  })
+
+  it("still returns modified-history when tool_use_id does not match forwarded ids", () => {
+    const stored = [
+      msg("user", "read file a.txt"),
+      { role: "assistant", content: [toolUse("toolu_1", "read")] },
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+    ]
+    // Incoming has a DIFFERENT tool_use_id than what was forwarded
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [toolResult("toolu_WRONG", "contents")] },
+      msg("assistant", "next"),
+    ]
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
+  })
+
+  it("returns continuation when incoming tool_result is still a placeholder (fast-path match)", () => {
+    // Client re-sends the same placeholder — the fast path catches this as
+    // a strict prefix match (continuation), not a divergence. This is correct:
+    // the SDK resumes at the assistant UUID and the delta is the same deny
+    // result the SDK already has, so the hook re-fires harmlessly.
+    const stored = [
+      msg("user", "read file a.txt"),
+      { role: "assistant", content: [toolUse("toolu_1", "read")] },
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+      msg("assistant", "next"),
+    ]
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    // Fast path: prefix hash matches exactly, so this is a continuation
+    expect(result.type).toBe("continuation")
+  })
+
+  it("returns replayed-request when incoming is identical to stored (same placeholder, no new messages)", () => {
+    const stored = [
+      msg("user", "read file a.txt"),
+      { role: "assistant", content: [toolUse("toolu_1", "read")] },
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+    ]
+    const incoming = [...stored]
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("replayed-request")
+  })
+
+  it("still returns modified-history for a mid-history content rewrite", () => {
+    // Genuine modified-history: a message in the middle changed, not the last one
+    const stored = [
+      msg("user", "hello"),
+      msg("assistant", "hi"),
+      msg("user", "how are you?"),
+    ]
+    const incoming = [
+      msg("user", "hello"),
+      msg("assistant", "hi"),
+      msg("user", "how are you? EDITED"),
+      msg("assistant", "good"),
+    ]
+
+    const result = verifyLineage(sessionFor(stored, { passthroughToolCallIds: undefined }), incoming)
+    expect(result.type).toBe("diverged")
+    if (result.type === "diverged") expect(result.reason).toBe("modified-history")
+  })
+
+  it("append-only parallel tool results still work (existing branch not disturbed)", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "run both" }] },
+      { role: "assistant", content: [
+        toolUse("call-a", "bash"),
+        toolUse("call-b", "bash"),
+      ]},
+      { role: "user", content: [toolResult("call-a", "a-result")] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("call-a", "a-result"),
+        toolResult("call-b", "b-result"),
+      ]},
+      { role: "assistant", content: [toolUse("call-c", "bash")] },
+      { role: "user", content: [toolResult("call-c", "c-result")] },
+    ]
+
+    const result = verifyLineage(sessionFor(stored, { passthroughToolCallIds: undefined }), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(2)
+      expect(result.resumeContentFrom).toBe(1)
+    }
+  })
+
+  it("does not fire when prefixOverlap is less than messageCount - 1 (mid-history change)", () => {
+    const stored = [
+      msg("user", "a"),
+      msg("assistant", "b"),
+      msg("user", "c"),
+      { role: "user", content: [toolResult("toolu_1", FORWARDED_TOOL_DENY)] },
+    ]
+    // Message at index 1 changed — not trailing-only
+    const incoming = [
+      msg("user", "a"),
+      msg("assistant", "b CHANGED"),
+      msg("user", "c"),
+      { role: "user", content: [toolResult("toolu_1", "real result")] },
+      msg("assistant", "next"),
+    ]
+
+    const result = verifyLineage(sessionFor(stored), incoming)
+    expect(result.type).toBe("diverged")
+  })
+})

--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -45,7 +45,7 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
-const { storeSession } = await import("../proxy/session/cache")
+const { storeSession, getSessionByClaudeId } = await import("../proxy/session/cache")
 
 function post(app: any, messages: any[], headers: Record<string, string> = {}) {
   return app.fetch(
@@ -345,5 +345,70 @@ describe("MERIDIAN_STRIP_THINKING env escape hatch", () => {
     const prompt = capturedPrompts[0] as string
     expect(prompt).not.toContain("<thinking>")
     expect(prompt).toContain("the question")
+  })
+})
+
+describe("passthrough checkpoint preservation across storeSession calls", () => {
+  beforeEach(() => {
+    clearSessionCache()
+  })
+
+  it("preserves checkpoint when storeSession is called with undefined passthrough fields", () => {
+    const messages = [{ role: "user", content: "hello" }]
+    // First call: store a checkpoint
+    storeSession(
+      "checkpoint-preserve-test",
+      messages,
+      "sdk-checkpoint",
+      undefined,
+      [null],
+      undefined,
+      "uuid-123",
+      ["toolA", "toolB"]
+    )
+    // Second call: no checkpoint (undefined passthrough fields) — must preserve
+    storeSession(
+      "checkpoint-preserve-test",
+      messages,
+      "sdk-checkpoint",
+      undefined,
+      [null],
+      undefined,
+      undefined,
+      undefined
+    )
+    // Verify checkpoint is still intact
+    const state = getSessionByClaudeId("sdk-checkpoint")
+    expect(state?.passthroughToolCallAssistantUuid).toBe("uuid-123")
+    expect(state?.passthroughToolCallIds).toEqual(["toolA", "toolB"])
+  })
+
+  it("clears checkpoint when storeSession is called with null passthrough fields", () => {
+    const messages = [{ role: "user", content: "hello" }]
+    // First call: store a checkpoint
+    storeSession(
+      "checkpoint-clear-test",
+      messages,
+      "sdk-clear",
+      undefined,
+      [null],
+      undefined,
+      "uuid-456",
+      ["toolC"]
+    )
+    // Second call: explicit null — must clear
+    storeSession(
+      "checkpoint-clear-test",
+      messages,
+      "sdk-clear",
+      undefined,
+      [null],
+      undefined,
+      null,
+      null
+    )
+    const state = getSessionByClaudeId("sdk-clear")
+    expect(state?.passthroughToolCallAssistantUuid).toBeUndefined()
+    expect(state?.passthroughToolCallIds).toBeUndefined()
   })
 })

--- a/src/__tests__/proxy-turn-conflict-downgrade.test.ts
+++ b/src/__tests__/proxy-turn-conflict-downgrade.test.ts
@@ -102,6 +102,7 @@ async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptC
 describe("modified-history conflict downgrade", () => {
   const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
   const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+  const originalPassthrough = process.env.MERIDIAN_PASSTHROUGH
 
   beforeEach(() => {
     process.env.MERIDIAN_MAX_CONCURRENT = "1"
@@ -121,9 +122,12 @@ describe("modified-history conflict downgrade", () => {
     else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
     if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
     else process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = originalHold
+    if (originalPassthrough === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = originalPassthrough
   })
 
-  it("downgrades modified-history conflict to fresh replay", async () => {
+  it("downgrades modified-history conflict to fresh replay (passthrough mode)", async () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
     // Request A: 3 messages — acquires lease, commits turn.
     // Request B: 5 messages, same session, trailing tool_result content revised.
     //   Queued during A → should get fresh replay (200), NOT 409.
@@ -182,5 +186,39 @@ describe("modified-history conflict downgrade", () => {
     expect(body.error.message).toContain("session advanced")
     // Only one SDK query — the second request is refused
     expect(queryCalls).toBe(1)
+  })
+
+  it("does not downgrade modified-history conflict in non-passthrough mode", async () => {
+    // Without MERIDIAN_PASSTHROUGH, the downgrade must NOT fire.
+    // The request proceeds as a fresh session rather than being downgraded
+    // or getting a 409 (the turn lease mechanism determines conflict handling).
+    delete process.env.MERIDIAN_PASSTHROUGH
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
+    ]
+    const superseding = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
+      { role: "user", content: "extra turn" },
+      { role: "assistant", content: "and response" },
+    ]
+    const firstP = app.fetch(request(opening, "non-passthrough-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(superseding, "non-passthrough-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    // B proceeds as a fresh session (not downgraded, not 409'd).
+    // Release B's SDK query if one started.
+    try {
+      const secondControl = await waitForControl(1, 500)
+      secondControl.release()
+    } catch { /* B may not start an SDK query */ }
+    const second = await secondP
+    expect(second.status).toBe(200)
   })
 })

--- a/src/__tests__/proxy-turn-conflict-downgrade.test.ts
+++ b/src/__tests__/proxy-turn-conflict-downgrade.test.ts
@@ -221,4 +221,41 @@ describe("modified-history conflict downgrade", () => {
     const second = await secondP
     expect(second.status).toBe(200)
   })
+
+  it("sets replayDegradationReason on the downgraded SDK query in passthrough mode", async () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
+    ]
+    const superseding = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
+      { role: "user", content: "extra turn" },
+      { role: "assistant", content: "and response" },
+    ]
+    const firstP = app.fetch(request(opening, "replay-reason-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(superseding, "replay-reason-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    const second = await secondP
+    expect(second.status).toBe(200)
+
+    // The second SDK query (index 1) is the fresh replay — its system prompt
+    // should contain the concurrent-modified-history replay degradation note.
+    const replayQuery = capturedParams[1] as any
+    expect(replayQuery).toBeDefined()
+    const sp = replayQuery.options?.systemPrompt
+    const append = typeof sp === "object" && sp !== null ? (sp as { append?: string }).append : sp
+    expect(append).toContain("another request")
+    expect(append).toContain("in flight")
+    expect(append).toContain("<meridian-note>")
+  })
 })

--- a/src/__tests__/proxy-turn-conflict-downgrade.test.ts
+++ b/src/__tests__/proxy-turn-conflict-downgrade.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import {
+  assistantMessage,
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+interface AttemptControl {
+  release: () => void
+  started: Promise<void>
+}
+
+let activeQueries = 0
+let maxActiveQueries = 0
+let queryCalls = 0
+let controls: AttemptControl[] = []
+let capturedParams: Array<{ options?: { resume?: string } }> = []
+
+function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
+  let release = () => {}
+  let markStarted = () => {}
+  const wait = new Promise<void>(resolve => { release = resolve })
+  const started = new Promise<void>(resolve => { markStarted = resolve })
+  return { release, started, wait, markStarted }
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { options?: { resume?: string } }) => {
+    capturedParams.push(params)
+    queryCalls++
+    const control = deferredAttempt()
+    controls.push(control)
+    const sessionId = `sdk-downgrade-${queryCalls}`
+    const generator = (async function* () {
+      activeQueries++
+      maxActiveQueries = Math.max(maxActiveQueries, activeQueries)
+      control.markStarted()
+      try {
+        yield { ...messageStart(), session_id: sessionId }
+        await control.wait
+        yield { ...textBlockStart(0), session_id: sessionId }
+        yield { ...textDelta(0, "ok"), session_id: sessionId }
+        yield { ...blockStop(0), session_id: sessionId }
+        yield { ...messageDelta("end_turn"), session_id: sessionId }
+        yield { ...messageStop(), session_id: sessionId }
+        yield { ...assistantMessage([{ type: "text", text: "ok" }]), session_id: sessionId }
+      } finally {
+        activeQueries--
+      }
+    })()
+    return Object.assign(generator, { close: () => {} })
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { telemetryStore } = await import("../telemetry")
+
+function request(
+  messages: Array<{ role: string; content: unknown }>,
+  sessionId: string,
+  stream = false,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-opencode-session": sessionId,
+      ...extraHeaders,
+    },
+    body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 128, stream, messages }),
+  })
+}
+
+async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptControl> {
+  const deadline = Date.now() + timeoutMs
+  while (!controls[index]) {
+    if (Date.now() > deadline) throw new Error(`SDK attempt #${index} never started`)
+    await Bun.sleep(1)
+  }
+  const control = controls[index]!
+  await control.started
+  return control
+}
+
+describe("modified-history conflict downgrade", () => {
+  const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
+  const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+
+  beforeEach(() => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "1"
+    activeQueries = 0
+    maxActiveQueries = 0
+    queryCalls = 0
+    controls = []
+    capturedParams = []
+    clearSessionCache()
+    resetProcessSdkSemaphoreForTests()
+    telemetryStore.clear()
+  })
+
+  afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    if (originalMax === undefined) delete process.env.MERIDIAN_MAX_CONCURRENT
+    else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
+    if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+    else process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = originalHold
+  })
+
+  it("downgrades modified-history conflict to fresh replay", async () => {
+    // Request A: 3 messages — acquires lease, commits turn.
+    // Request B: 5 messages, same session, trailing tool_result content revised.
+    //   Queued during A → should get fresh replay (200), NOT 409.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
+    ]
+    const superseding = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      // Same position, revised content — triggers modified-history
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
+      // Extra messages — makes incoming longer than stored
+      { role: "user", content: "extra turn" },
+      { role: "assistant", content: "and response" },
+    ]
+    const firstP = app.fetch(request(opening, "downgrade-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(superseding, "downgrade-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    // B gets the turn lease, does its lookup, and starts a fresh replay SDK query.
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    const second = await secondP
+    // modified-history should be downgraded to fresh replay, not 409
+    expect(second.status).toBe(200)
+    // Two distinct SDK queries — B does a fresh replay
+    expect(queryCalls).toBe(2)
+  })
+
+  it("still returns 409 for undo conflict (stale racer)", async () => {
+    // Control: a request shorter than stored history → still 409/undo.
+    // This mirrors the existing concurrency-coordination test's stale-branch case.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "set up" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "more context" },
+    ]
+    // Shorter request (1 msg) — undo when found in cache with 3 msgs
+    const stale = [{ role: "user", content: "set up" }]
+    const firstP = app.fetch(request(opening, "undo-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(stale, "undo-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    const second = await secondP
+    expect(second.status).toBe(400)
+    const body = await second.json()
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.message).toContain("session advanced")
+    // Only one SDK query — the second request is refused
+    expect(queryCalls).toBe(1)
+  })
+})

--- a/src/__tests__/query-replay-degradation-note.test.ts
+++ b/src/__tests__/query-replay-degradation-note.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for buildReplayDegradationNote — the addendum that tells the model
+ * why this turn required a full conversation replay instead of a fast
+ * incremental resume.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  buildQueryOptions,
+  buildReplayDegradationNote,
+  GIT_STATUS_PROVENANCE_NOTE,
+  type QueryContext,
+  type ReplayDegradationReason,
+} from "../proxy/query"
+import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../proxy/tools"
+
+/** Mirrors the shared context helper in query.test.ts and query-git-status-note.test.ts. */
+function ctx(overrides: Partial<QueryContext> = {}): QueryContext {
+  return {
+    prompt: "Hello",
+    model: "sonnet[1m]",
+    workingDirectory: "/tmp/test",
+    systemContext: "",
+    claudeExecutable: "/usr/bin/claude",
+    passthrough: false,
+    stream: false,
+    sdkAgents: {},
+    cleanEnv: {},
+    envOverrides: undefined,
+    hasDeferredTools: false,
+    isUndo: false,
+    blockedTools: BLOCKED_BUILTIN_TOOLS,
+    incompatibleTools: CLAUDE_CODE_ONLY_TOOLS,
+    mcpServerName: MCP_SERVER_NAME,
+    allowedMcpTools: ALLOWED_MCP_TOOLS,
+    ...overrides,
+  }
+}
+
+/** The append string for a request that resolves to the preset. */
+function presetAppend(overrides: Partial<QueryContext> = {}): string {
+  const { options } = buildQueryOptions(ctx(overrides))
+  const sp = options.systemPrompt
+  if (typeof sp !== "object" || sp === null) {
+    throw new Error(`expected preset object, got ${JSON.stringify(sp)}`)
+  }
+  return (sp as { append?: string }).append ?? ""
+}
+
+describe("buildReplayDegradationNote", () => {
+  it("returns empty string for undefined reason", () => {
+    expect(buildReplayDegradationNote(undefined)).toBe("")
+  })
+
+  it("returns empty string for nullish reason", () => {
+    // @ts-expect-error testing undefined input
+    expect(buildReplayDegradationNote(null)).toBe("")
+  })
+
+  it("contains meridian-note tags for checkpoint-incomplete", () => {
+    const note = buildReplayDegradationNote("checkpoint-incomplete")
+    expect(note).toContain("<meridian-note>")
+    expect(note).toContain("</meridian-note>")
+  })
+
+  it("mentions parallel tool-call batch for checkpoint-incomplete", () => {
+    const note = buildReplayDegradationNote("checkpoint-incomplete")
+    expect(note).toContain("parallel tool-call batch")
+  })
+
+  it("contains meridian-note tags for concurrent-modified-history", () => {
+    const note = buildReplayDegradationNote("concurrent-modified-history")
+    expect(note).toContain("<meridian-note>")
+    expect(note).toContain("</meridian-note>")
+  })
+
+  it("mentions another request in flight for concurrent-modified-history", () => {
+    const note = buildReplayDegradationNote("concurrent-modified-history")
+    expect(note).toContain("another request")
+    expect(note).toContain("in flight")
+  })
+})
+
+describe("buildQueryOptions — replay degradation note placement", () => {
+  it("appends the note when the preset is used with checkpoint-incomplete reason", () => {
+    const append = presetAppend({
+      codeSystemPrompt: true,
+      replayDegradationReason: "checkpoint-incomplete",
+    })
+    expect(append).toContain("parallel tool-call batch")
+    expect(append).toContain("<meridian-note>")
+  })
+
+  it("appends the note when the preset is used with concurrent-modified-history reason", () => {
+    const append = presetAppend({
+      codeSystemPrompt: true,
+      replayDegradationReason: "concurrent-modified-history",
+    })
+    expect(append).toContain("another request")
+    expect(append).toContain("in flight")
+  })
+
+  it("includes the note in the non-preset branch when systemContext is present", () => {
+    const { options } = buildQueryOptions(ctx({
+      codeSystemPrompt: false,
+      systemContext: "You are helpful.",
+      replayDegradationReason: "checkpoint-incomplete",
+    }))
+    expect(options.systemPrompt).toContain("parallel tool-call batch")
+    expect(options.systemPrompt).toContain("You are helpful.")
+  })
+
+  it("omits the note when replayDegradationReason is undefined", () => {
+    const append = presetAppend({ codeSystemPrompt: true })
+    expect(append).not.toContain("full conversation replay")
+  })
+
+  it("places the note after cwdNote and before GIT_STATUS_PROVENANCE_NOTE in the preset branch", () => {
+    const append = presetAppend({
+      codeSystemPrompt: true,
+      workingDirectory: "/srv/proxy",
+      clientWorkingDirectory: "/Users/alice/app",
+      replayDegradationReason: "checkpoint-incomplete",
+    })
+    expect(append.indexOf("<env>")).toBeLessThan(append.indexOf("full conversation replay"))
+    expect(append.indexOf("full conversation replay")).toBeLessThan(append.indexOf("gitStatus"))
+  })
+
+  it("includes both cwdNote and replayNote when both are present", () => {
+    const append = presetAppend({
+      codeSystemPrompt: true,
+      workingDirectory: "/srv/proxy",
+      clientWorkingDirectory: "/Users/alice/app",
+      replayDegradationReason: "concurrent-modified-history",
+    })
+    expect(append).toContain("Working directory")
+    expect(append).toContain("another request")
+    expect(append).toContain(GIT_STATUS_PROVENANCE_NOTE.trim())
+  })
+})

--- a/src/proxy/denyReasons.ts
+++ b/src/proxy/denyReasons.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared passthrough deny reason strings.
+ *
+ * In passthrough mode the PreToolUse hook denies every client tool call with
+ * one of these reasons. The SDK records a synthetic `user` message whose
+ * `tool_result` content is the deny string. When the client sends back the
+ * real tool_result, the lineage verifier must recognise the placeholder and
+ * classify the divergence as a passthrough settlement rather than a
+ * modified-history rewrite.
+ *
+ * Single source of truth: both server.ts (the hook) and lineage.ts (the
+ * verifier) reference these strings through this module. Never copy them.
+ */
+
+/** A forwarded tool call that was NOT a duplicate or forced-single overflow. */
+export const FORWARDED_TOOL_DENY =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+/** An exact-duplicate or post-checkpoint tool call the model must not repeat. */
+export const EXACT_DUPLICATE_DENY =
+  "This tool call has already been handled by the client-facing turn — do not repeat it. " +
+  "Do not call additional tools and do not generate further text — end your turn now."
+
+/** A same-tool-repeat or forced-single overflow that was NOT forwarded. */
+export const SAME_TOOL_REPEAT_DENY =
+  "This tool call was NOT executed and was not forwarded. Your earlier tool call(s) " +
+  "are being returned to the client now; their results arrive next turn. Re-issue this " +
+  "call after that if it is still needed. Do not call additional tools and do not " +
+  "generate further text — end your turn now."
+
+/** All deny reason strings, for matching against tool_result content. */
+export const ALL_DENY_REASONS = [
+  FORWARDED_TOOL_DENY,
+  EXACT_DUPLICATE_DENY,
+  SAME_TOOL_REPEAT_DENY,
+] as const
+
+/**
+ * True when a tool_result block's content (string form) is one of the
+ * passthrough deny placeholder strings. Used by lineage verification to
+ * detect that a stored user message is a synthetic denial rather than a
+ * genuine tool result.
+ *
+ * Only matches exact deny strings — never matches arbitrary tool_result
+ * payloads.
+ */
+export function isPassthroughDenyToolResult(content: unknown): boolean {
+  if (typeof content !== "string") return false
+  return ALL_DENY_REASONS.includes(content as typeof ALL_DENY_REASONS[number])
+}

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -155,6 +155,9 @@ export interface QueryContext {
   additionalDirectories?: string[]
   /** Advisor model for server-side advisor tool support */
   advisorModel?: string
+  /** Set when this request had to fall back to a full replay instead of an
+   *  incremental resume — surfaces a one-turn note explaining why. */
+  replayDegradationReason?: ReplayDegradationReason
 }
 
 /**
@@ -264,6 +267,37 @@ export function buildCwdNote(sdkCwd: string, clientCwd?: string): string {
   )
 }
 
+export type ReplayDegradationReason =
+  | "checkpoint-incomplete"        // trigger (a): passthrough tool results incomplete/mismatched
+  | "concurrent-modified-history"  // trigger (b): modified-history conflict downgraded to fresh replay
+
+/**
+ * Build an addendum that tells the model why this turn required a full
+ * conversation replay instead of a fast incremental resume. Applied when
+ * either the passthrough checkpoint-replay path fires (trigger a) or the
+ * modified-history concurrent-conflict downgrade fires (trigger b).
+ *
+ * These two triggers are mutually exclusive within a single request by
+ * construction, so a single local variable is sufficient.
+ */
+export function buildReplayDegradationNote(reason: ReplayDegradationReason | undefined): string {
+  if (!reason) return ""
+  const explanation = reason === "checkpoint-incomplete"
+    ? "the client's tool results for a parallel tool-call batch arrived incomplete or in a shape that didn't match what was expected"
+    : "another request for this same session was still in flight when this one arrived"
+  return (
+    `\n\n<meridian-note>\n` +
+    `This turn required a full conversation replay instead of a fast incremental ` +
+    `resume, because ${explanation}. This does not affect correctness or the ` +
+    `content of your answer — it only means this turn re-sent more context than ` +
+    `usual, so it may be slightly slower or larger than a typical turn. Nothing ` +
+    `for the user to fix. Mention this in one short, low-key sentence at the end ` +
+    `of your response (for example: "Note: this turn needed a full context ` +
+    `replay — nothing wrong on your end.") and then continue normally.\n` +
+    `</meridian-note>`
+  )
+}
+
 /**
  * Correct the provenance claim on the preset's `gitStatus` block.
  *
@@ -308,6 +342,7 @@ function resolveSystemPrompt(
   codeSystemPrompt: boolean | undefined,
   clientSystemPrompt: boolean | undefined,
   cwdNote: string,
+  replayNote: string,
 ): { systemPrompt?: string | { type: "preset"; preset: "claude_code"; append?: string } } {
   const hasSettings = settingSources != null && settingSources.length > 0
   const usePreset = codeSystemPrompt ?? (hasSettings || (!passthrough && !!systemContext))
@@ -317,10 +352,10 @@ function resolveSystemPrompt(
   if (usePreset) {
     // Always non-empty: the gitStatus correction applies to every preset
     // request, whether or not the client sent a system prompt.
-    const append = [clientContext, cwdNote, GIT_STATUS_PROVENANCE_NOTE].filter(Boolean).join("")
+    const append = [clientContext, cwdNote, replayNote, GIT_STATUS_PROVENANCE_NOTE].filter(Boolean).join("")
     return { systemPrompt: { type: "preset" as const, preset: "claude_code" as const, append } }
   }
-  const append = [clientContext, cwdNote].filter(Boolean).join("") || undefined
+  const append = [clientContext, cwdNote, replayNote].filter(Boolean).join("") || undefined
   if (append) return { systemPrompt: append }
   // Defensive: when `codeSystemPrompt: false` is explicit and there's
   // nothing to append, force an empty-string system prompt so the SDK
@@ -342,6 +377,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
     memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
   } = ctx
   const cwdNote = buildCwdNote(workingDirectory, clientWorkingDirectory)
+  const replayNote = buildReplayDegradationNote(ctx.replayDegradationReason)
 
   const allBlockedTools = [...blockedTools, ...incompatibleTools]
 
@@ -369,7 +405,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       ...(stream ? { includePartialMessages: true } : {}),
       permissionMode: "bypassPermissions" as const,
       allowDangerouslySkipPermissions: true,
-      ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt, cwdNote),
+      ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt, cwdNote, replayNote),
       ...(passthrough
         ? {
             // Strip the SDK's ~25k-token built-in tool catalog from the

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2372,7 +2372,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 noteUserContent(earlyStop, (message as any).message?.content)
                 if (earlyStopEnabled && shouldEarlyStop(earlyStop)) {
                   nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
-                  nextPassthroughToolCallIds = [...earlyStop.expected]
+                  nextPassthroughToolCallIds = [...earlyStop.expected].filter(id => !droppedToolUseIds.has(id))
                   earlyStopFired = true
                   // A digest hook can race just ahead of iterator consumption.
                   // Retain only calls proven to belong to the visible assistant
@@ -3269,7 +3269,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       shouldEarlyStop(earlyStop)
                     ) {
                       nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
-                      nextPassthroughToolCallIds = [...earlyStop.expected]
+                      nextPassthroughToolCallIds = [...earlyStop.expected].filter(id => !droppedToolUseIds.has(id))
                       earlyStopFired = true
                       for (let i = capturedToolUses.length - 1; i >= 0; i--) {
                         if (!earlyStop.expected.has(capturedToolUses[i]!.id)) capturedToolUses.splice(i, 1)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -45,6 +45,7 @@ import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, createEarlyStopTracker, isCompleteToolResultContinuation, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { FORWARDED_TOOL_DENY, EXACT_DUPLICATE_DENY, SAME_TOOL_REPEAT_DENY } from "./denyReasons"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -2005,27 +2006,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (isExactDuplicate || isPostCheckpointCall) {
                   return {
                     decision: "block" as const,
-                    reason:
-                      "This tool call has already been handled by the client-facing turn — do not repeat it. " +
-                      "Do not call additional tools and do not generate further text — end your turn now.",
+                    reason: EXACT_DUPLICATE_DENY,
                   }
                 }
                 if (isSameToolRepeat || exceedsForcedSingle) {
                   return {
                     decision: "block" as const,
-                    reason:
-                      "This tool call was NOT executed and was not forwarded. Your earlier tool call(s) " +
-                      "are being returned to the client now; their results arrive next turn. Re-issue this " +
-                      "call after that if it is still needed. Do not call additional tools and do not " +
-                      "generate further text — end your turn now.",
+                    reason: SAME_TOOL_REPEAT_DENY,
                   }
                 }
                 return {
                   decision: "block" as const,
-                  reason:
-                    "This tool call has been forwarded to the client for execution. " +
-                    "The result will be delivered in a future turn. " +
-                    "Do not retry, do not call additional tools, and do not generate further text — end your turn now.",
+                  reason: FORWARDED_TOOL_DENY,
                 }
               }],
             }],

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1341,13 +1341,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // would break flows that worked before turn coordination existed.
         const declaresConcurrentFlow =
           requestSource?.startsWith("fork-") === true || isSubagentRequest
+        // Passthrough mode — resolved early so the concurrent-conflict guards
+        // below can gate on passthrough status. When enabled, ALL tool execution
+        // is forwarded to OpenCode instead of being handled internally.
+        // Adapter can override the global passthrough env var per-agent.
+        // Instance passthrough override (#476) beats the adapter transform's
+        // default, which beats the global env var.
+        const passthrough = adapter.instancePassthrough !== undefined
+          ? adapter.instancePassthrough
+          : pipelineCtx.passthrough !== undefined
+            ? pipelineCtx.passthrough
+            : envBool("PASSTHROUGH")
         if (
           profileSessionId &&
           !declaresConcurrentFlow &&
           requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
           lineageResult.type !== "continuation" &&
           lineageResult.type !== "compaction" &&
-          !(lineageResult.type === "diverged" && lineageResult.reason === "modified-history")
+          !(passthrough && lineageResult.type === "diverged" && lineageResult.reason === "modified-history")
         ) {
           const reason = lineageResult.type === "diverged" ? lineageResult.reason : lineageResult.type
           const message = "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
@@ -1410,8 +1421,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // concurrent turn lease falls through to fresh-replay instead of 409.
         // Safe: it is only produced when the history strictly grows
         // (messages.length > cached.messageCount), so undo / replayed-request /
-        // unrelated-history still 409.
+        // unrelated-history still 409. Only applies to passthrough sessions —
+        // non-passthrough (internal) sessions must surface a loud 409 so the
+        // concurrent-request race is visible to operators.
         if (
+          passthrough &&
           profileSessionId &&
           requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
           lineageResult.type === "diverged" &&
@@ -1458,19 +1472,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         let resumeSessionId = cachedSession?.claudeSessionId
-        // --- Passthrough mode ---
-        // When enabled, ALL tool execution is forwarded to OpenCode instead of
-        // being handled internally. This enables multi-model agent delegation
-        // (e.g., oracle on GPT-5.2, explore on Gemini via oh-my-opencode).
-        // Adapter can override the global passthrough env var per-agent.
-        // Droid always uses internal mode; OpenCode defers to the env var.
-        // Instance passthrough override (#476) beats the adapter transform's
-        // default, which beats the global env var.
-        const passthrough = adapter.instancePassthrough !== undefined
-          ? adapter.instancePassthrough
-          : pipelineCtx.passthrough !== undefined
-            ? pipelineCtx.passthrough
-            : envBool("PASSTHROUGH")
         const resumeFrom = lineageResult.type === "continuation" || lineageResult.type === "compaction"
           ? lineageResult.resumeFrom
           : undefined

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2782,8 +2782,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     profileScopedCwd,
                     sdkUuidMap,
                     lastUsage,
-                    earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
-                    earlyStopFired ? nextPassthroughToolCallIds : null
+                    earlyStopFired ? nextPassthroughToolCallAssistantUuid : undefined,
+                    earlyStopFired ? nextPassthroughToolCallIds : undefined
                   )
                   commitSessionTurn()
                 }
@@ -3707,8 +3707,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     profileScopedCwd,
                     sdkUuidMap,
                     lastUsage,
-                    earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
-                    earlyStopFired ? nextPassthroughToolCallIds : null
+                    earlyStopFired ? nextPassthroughToolCallAssistantUuid : undefined,
+                    earlyStopFired ? nextPassthroughToolCallIds : undefined
                   )
                   commitSessionTurn()
                 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1345,7 +1345,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           !declaresConcurrentFlow &&
           requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
           lineageResult.type !== "continuation" &&
-          lineageResult.type !== "compaction"
+          lineageResult.type !== "compaction" &&
+          !(lineageResult.type === "diverged" && lineageResult.reason === "modified-history")
         ) {
           const reason = lineageResult.type === "diverged" ? lineageResult.reason : lineageResult.type
           const message = "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
@@ -1402,6 +1403,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               status: 400,
               headers: { "Content-Type": "application/json" },
             },
+          )
+        }
+        // A modified-history request (superseding, revised in place) under a
+        // concurrent turn lease falls through to fresh-replay instead of 409.
+        // Safe: it is only produced when the history strictly grows
+        // (messages.length > cached.messageCount), so undo / replayed-request /
+        // unrelated-history still 409.
+        if (
+          profileSessionId &&
+          requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
+          lineageResult.type === "diverged" &&
+          lineageResult.reason === "modified-history"
+        ) {
+          claudeLog("session.concurrent_conflict", {
+            reason: "downgraded=fresh-replay",
+            sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+          })
+          diagnosticLog.session(
+            `${requestMeta.requestId} session.concurrent_conflict reason=downgraded=fresh-replay wait=${requestMeta.sessionQueueWaitMs}ms`,
+            requestMeta.requestId,
           )
         }
         // Publish the decision to plugins. Core has always known WHICH message

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -74,7 +74,7 @@ import { translateResponsesToAnthropic, translateAnthropicToResponses, createRes
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
-import { buildQueryOptions, type QueryContext } from "./query"
+import { buildQueryOptions, type QueryContext, type ReplayDegradationReason } from "./query"
 import { normalizeEffort } from "./effort"
 import { parseOutputFormat, structuredOutputText } from "./structuredOutput"
 import { runTransformHook, buildPipeline, createRequestContext } from "./transform"
@@ -1352,6 +1352,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           : pipelineCtx.passthrough !== undefined
             ? pipelineCtx.passthrough
             : envBool("PASSTHROUGH")
+        let replayDegradationReason: ReplayDegradationReason | undefined
         if (
           profileSessionId &&
           !declaresConcurrentFlow &&
@@ -1431,6 +1432,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           lineageResult.type === "diverged" &&
           lineageResult.reason === "modified-history"
         ) {
+          replayDegradationReason = "concurrent-modified-history"
           claudeLog("session.concurrent_conflict", {
             reason: "downgraded=fresh-replay",
             sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
@@ -1587,6 +1589,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         passthroughToolCallAssistantUuid &&
         !isCompleteToolResultContinuation(messagesToConvert, passthroughToolCallIds ?? [])
       ) {
+        replayDegradationReason = "checkpoint-incomplete"
         claudeLog("passthrough.checkpoint_replay", {
           expectedToolIds: passthroughToolCallIds?.length ?? 0,
           reason: "incomplete_or_mismatched_results",
@@ -2128,6 +2131,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
+                    replayDegradationReason,
                   }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream")) {
                     // Capture Claude Max subscription quota updates emitted by
                     // the SDK as rate_limit_event. We snapshot them in this
@@ -2219,6 +2223,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
+                      replayDegradationReason,
                     }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh")
                     return
                   }
@@ -2269,6 +2274,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
+                      replayDegradationReason,
                     }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh")
                     return
                   }
@@ -3005,6 +3011,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
+                      replayDegradationReason,
                     }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream")) {
                       // Same SDK rate-limit capture as the non-stream path.
                       if ((event as any).type === "rate_limit_event") {
@@ -3075,6 +3082,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
+                        replayDegradationReason,
                       }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh")
                       return
                     }
@@ -3121,6 +3129,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
+                        replayDegradationReason,
                       }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh")
                       return
                     }
@@ -3808,6 +3817,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
+                    replayDegradationReason,
                   }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "silent_recovery")) {
                     const recoveryMessage = event as any
                     if (recoveryMessage.session_id) recoverySessionId = recoveryMessage.session_id

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -285,6 +285,7 @@ export function storeSession(
   const lineageHash = computeLineageHash(messages)
   const messageHashes = computeMessageHashes(messages)
   const messageBlockHashes = computeMessageBlockHashes(messages)
+  const existing: SessionState | undefined = sessionId ? sessionCache.get(sessionId) : undefined
   const state: SessionState = {
     claudeSessionId,
     lastAccess: Date.now(),
@@ -293,8 +294,14 @@ export function storeSession(
     messageHashes,
     messageBlockHashes,
     sdkMessageUuids,
-    ...(passthroughToolCallAssistantUuid ? { passthroughToolCallAssistantUuid } : {}),
-    ...(passthroughToolCallIds ? { passthroughToolCallIds } : {}),
+    // Three-state merge for checkpoint fields: undefined preserves existing,
+    // null clears, a value sets. Mirrors the contract in sessionStore.ts.
+    passthroughToolCallAssistantUuid: passthroughToolCallAssistantUuid === undefined
+      ? existing?.passthroughToolCallAssistantUuid
+      : passthroughToolCallAssistantUuid ?? undefined,
+    passthroughToolCallIds: passthroughToolCallIds === undefined
+      ? existing?.passthroughToolCallIds
+      : passthroughToolCallIds ?? undefined,
     ...(contextUsage ? { contextUsage } : {}),
   }
   // In-memory cache
@@ -318,9 +325,9 @@ export function storeSession(
       sdkMessageUuids,
       contextUsage,
       messageBlockHashes,
-      // undefined would preserve the stored checkpoint; a full store must rewrite it.
-      passthroughToolCallAssistantUuid ?? null,
-      passthroughToolCallIds ?? null
+      // undefined preserves a checkpoint set by an earlier turn; only null clears it.
+      passthroughToolCallAssistantUuid,
+      passthroughToolCallIds
     )
   }
 }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -7,6 +7,7 @@
 
 import { createHash } from "crypto"
 import { HASH_IGNORED_BLOCK_TYPES, normalizeContent } from "../messages"
+import { isPassthroughDenyToolResult } from "../denyReasons"
 
 // --- Types ---
 
@@ -501,7 +502,49 @@ export function verifyLineage(
     }
   }
 
-  // Undo: prefix preserved (beginning intact) but suffix changed,
+  // Passthrough settlement: the stored session ends with a synthetic user
+  // message whose tool_result content is a deny placeholder (the PreToolUse
+  // hook blocked the call). The client executed the tool and now sends back
+  // the real tool_result at the same position. Classify this as a continuation
+  // so the existing resumeSessionAtUuid + isCompleteToolResultContinuation
+  // wiring in server.ts takes over, instead of modified-history (which would
+  // re-fire the deny hook and loop).
+  //
+  // Conditions:
+  //   - prefixOverlap is exactly messageCount - 1 (trailing-only mismatch)
+  //   - cached.passthroughToolCallIds is present (checkpoint exists)
+  //   - incoming has at least as many messages as stored
+  //   - the incoming message at the boundary is a user message with tool_result
+  //     blocks whose content is NOT a deny placeholder
+  //   - every tool_use_id in those blocks matches a forwarded id
+  const settlementBoundary = cached.messageCount - 1
+  if (
+    settlementBoundary >= 0 &&
+    prefixOverlap === settlementBoundary &&
+    messages.length >= cached.messageCount &&
+    cached.passthroughToolCallIds?.length
+  ) {
+    const incomingBoundary = messages[settlementBoundary]
+    if (incomingBoundary?.role === "user" && Array.isArray(incomingBoundary.content)) {
+      const toolResultIds = new Set(cached.passthroughToolCallIds)
+      let matchedAll = true
+      let hasRealResult = false
+      for (const block of incomingBoundary.content) {
+        if (block?.type === "tool_result" && typeof block.tool_use_id === "string") {
+          if (!toolResultIds.has(block.tool_use_id)) { matchedAll = false; break }
+          if (!isPassthroughDenyToolResult(block.content)) hasRealResult = true
+        }
+      }
+      if (matchedAll && hasRealResult) {
+        return {
+          type: "continuation",
+          session: cached,
+          resumeFrom: settlementBoundary,
+          resumeContentFrom: 0,
+        }
+      }
+    }
+  }
   // AND the conversation shrank (fewer messages). If the conversation grew
   // after a cached message changed, the old SDK session cannot prove it has
   // the intervening history; that case is handled as divergence below.


### PR DESCRIPTION
When a session-turn lease advances while a request waits and the lineage result is `diverged` with `reason: "modified-history"`, the turn coordinator returns a 409 ("This session advanced while the request was waiting"). This downgrades that case to the existing fresh-replay path instead.

**Why it's safe**

- `modified-history` is produced only when `prefixOverlap > 0 && messages.length > cached.messageCount` — the incoming request strictly extends the stored history. A genuinely stale racer classifies as `undo` or `replayed-request` (both require `messages.length <= cached.messageCount`) and still returns the 409, so the turn coordinator's stale-racer protection is unchanged.
- The identical revision already recovers cleanly through the fresh-replay path whenever `advancedWhileWaiting` is false; this removes the timing-dependent 409 for the superseding-but-revised case.

**Context**

This is the "mid-history rewriting / different bug" branch of #767. We traced the rewriting party to client-side prompt-transform hooks (oh-my-openagent's `directory-*` injectors and `category-skill-reminder`, plus DCP's context-limit nudges) that revise already-sent history between request builds. Each mutator produces a different mismatch signature, so the client-side chase does not converge — the proxy-side downgrade neutralizes the class while preserving stale-racer protection.

Diagnostic telemetry is preserved: the `session.concurrent_conflict` log line reports `reason=downgraded=fresh-replay` for the downgraded case.

**Tests**

`src/__tests__/proxy-turn-conflict-downgrade.test.ts`: a superseding request with a revised trailing tool_result queued behind a committed turn gets a 200 fresh replay (new SDK session) rather than a 409, plus a control asserting a stale racer (`undo`) still 409s. Full suite: 2669 passing.

Happy to adjust.