### PR TITLE
fix(passthrough): preserve checkpoint resume continuity

### DIFF
--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -15,6 +15,7 @@ import {
   verifyLineage,
   normalizeContextUsage,
   withClientAssistantUuid,
+  reconcileReturnedSessionUuids,
   MIN_SUFFIX_FOR_COMPACTION,
   type SessionState,
 } from "../proxy/session/lineage"
@@ -941,5 +942,67 @@ describe("withClientAssistantUuid", () => {
   it("pads missing client user slots without shifting the assistant UUID", () => {
     expect(withClientAssistantUuid([null, "prior-assistant"], 3, "next-assistant"))
       .toEqual([null, "prior-assistant", null, "next-assistant"])
+  })
+})
+
+describe("reconcileReturnedSessionUuids", () => {
+  it("clears copied UUIDs after an observed session change and keeps the current output", () => {
+    expect(reconcileReturnedSessionUuids(
+      [null, "copied-assistant", null, "current-assistant"],
+      3,
+      "current-assistant",
+      "source-session",
+      "fork-session",
+    )).toEqual([null, null, null, "current-assistant"])
+  })
+
+  it("keeps the UUID map when the SDK returns the resumed session", () => {
+    const map = [null, "existing-assistant", null, "current-assistant"]
+    expect(reconcileReturnedSessionUuids(map, 3, "current-assistant", "same-session", "same-session"))
+      .toBe(map)
+  })
+
+  it("does not discard fresh-request UUIDs", () => {
+    const map = [null, "fresh-assistant"]
+    expect(reconcileReturnedSessionUuids(map, 1, "fresh-assistant", undefined, "fresh-session"))
+      .toBe(map)
+  })
+})
+
+describe("fork-remapped undo boundaries", () => {
+  const stored = [
+    msg("user", "one"),
+    msg("assistant", "reply one"),
+    msg("user", "two"),
+    msg("assistant", "reply two"),
+    msg("user", "three"),
+    msg("assistant", "new fork output"),
+    msg("user", "four"),
+  ]
+  const session = makeSession({
+    messageCount: stored.length,
+    lineageHash: computeLineageHash(stored),
+    messageHashes: computeMessageHashes(stored),
+    sdkMessageUuids: [null, null, null, null, null, "new-fork-output-uuid", null],
+  })
+
+  it("leaves an undo boundary empty when the preserved prefix has only remapped UUIDs", () => {
+    const result = verifyLineage(session, [
+      ...stored.slice(0, 2),
+      msg("user", "branch before the new fork output"),
+    ])
+    expect(result).toMatchObject({ type: "undo", prefixOverlap: 2, rollbackUuid: undefined })
+  })
+
+  it("uses the newly observed fork output UUID when the undo preserves it", () => {
+    const result = verifyLineage(session, [
+      ...stored.slice(0, 6),
+      msg("user", "branch after the new fork output"),
+    ])
+    expect(result).toMatchObject({
+      type: "undo",
+      prefixOverlap: 6,
+      rollbackUuid: "new-fork-output-uuid",
+    })
   })
 })

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -307,6 +307,65 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
+  it("stream: keeps the checkpoint when queued user text follows tool results", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "queued-stream-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_queued_stream"),
+      toolUseBlockStart(0, "read", "queued-stream-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("queued-stream-tool"),
+    ]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-queued-stream-user")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockMessages = [
+      messageStart("msg_queued_stream_reply"),
+      textBlockStart(0),
+      textDelta(0, "the file says X"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "the file says X" }]),
+    ]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "queued-stream-tool", content: "X" }] },
+        { role: "user", content: "also summarize it" },
+      ],
+    }, "es-queued-stream-user")
+    expect(second.status).toBe(200)
+    await second.text()
+
+    const resumed = capturedQueryParamsAll[1]
+    expect(resumed.options.resume).toBe("test-session")
+    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+    const promptMessages: any[] = []
+    for await (const message of resumed.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "queued-stream-tool", content: "X" },
+      { type: "text", text: "also summarize it" },
+    ])
+  })
+
   it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
     const firstToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },
@@ -399,6 +458,39 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resume).toBeUndefined()
     expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
     expect(typeof capturedQueryParams.prompt).toBe("string")
+  })
+
+  it("non-stream: preserves queued user text when partial results force a fresh replay", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "partial-queued-1", name: "read", input: { file_path: "a" } },
+      { type: "tool_use", id: "partial-queued-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("partial-queued-1"), userDenyMessage("partial-queued-2")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read both" }],
+    }, "es-partial-queued-results")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "safe replay" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read both" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "partial-queued-1", content: "A" }] },
+        { role: "user", content: "keep this queued" },
+      ],
+    }, "es-partial-queued-results")).status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(typeof capturedQueryParams.prompt).toBe("string")
+    expect(capturedQueryParams.prompt).toContain("keep this queued")
   })
 
   it("non-stream: preserves a nested multimodal tool_result wrapper", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -14,6 +14,7 @@ let yieldedCount = 0
 let capturedQueryParams: any = null
 let capturedQueryParamsAll: any[] = []
 let mockTerminalError: Error | undefined
+let forkSessionSequence = 0
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
@@ -21,6 +22,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedQueryParamsAll.push(params)
     const terminalError = mockTerminalError
     const preHook = params?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+    const returnedSessionId = params?.options?.forkSession
+      ? `test-session-fork-${++forkSessionSequence}`
+      : params?.options?.resume ?? "test-session"
     return (async function* () {
       let sawSyntheticDeny = false
       let sawResult = false
@@ -36,13 +40,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           }
           continue
         }
-        if (msg?.type === "user" && msg?.message?.content?.some((b: any) => b?.type === "tool_result")) {
+        const delivered = { ...msg, session_id: returnedSessionId }
+        if (delivered?.type === "user" && delivered?.message?.content?.some((b: any) => b?.type === "tool_result")) {
           sawSyntheticDeny = true
         }
-        if (msg?.type === "result") sawResult = true
-        yield msg
-        if (preHook && msg?.type === "assistant" && Array.isArray(msg?.message?.content)) {
-          for (const block of msg.message.content) {
+        if (delivered?.type === "result") sawResult = true
+        yield delivered
+        if (preHook && delivered?.type === "assistant" && Array.isArray(delivered?.message?.content)) {
+          for (const block of delivered.message.content) {
             if (block?.type !== "tool_use") continue
             void Promise.resolve(preHook({
               tool_name: block.name,
@@ -59,7 +64,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       // after tool-deny flows unless a fixture provided one explicitly.
       if (sawSyntheticDeny && !sawResult) {
         yieldedCount++
-        yield { type: "result", subtype: "success", is_error: false, session_id: "test-session" }
+        yield { type: "result", subtype: "success", is_error: false, session_id: returnedSessionId }
       }
     })()
   },
@@ -144,6 +149,7 @@ describe("Integration: passthrough early stop", () => {
     capturedQueryParams = null
     capturedQueryParamsAll = []
     mockTerminalError = undefined
+    forkSessionSequence = 0
   })
 
   afterEach(() => {
@@ -255,9 +261,9 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resume).toBe("test-session")
     expect(capturedQueryParams.options.resumeSessionAt).toBe(assistantForkUuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(syntheticDeny.uuid)
-    // Normal passthrough continuation reuses the session ID. Forking is for
-    // semantic branches (undo) or the bounded busy-session fallback only.
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    // The fork makes this rewind durable, replacing the persisted synthetic
+    // denial tail with the client's real result in the new transcript.
+    expect(capturedQueryParams.options.forkSession).toBe(true)
 
     const promptMessages: any[] = []
     for await (const message of capturedQueryParams.prompt) promptMessages.push(message)
@@ -366,7 +372,7 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
-  it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
+  it("non-stream: forks every repeated checkpoint resume so delivered results replace deny tails", async () => {
     const firstToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },
     ])
@@ -397,14 +403,22 @@ describe("Integration: passthrough early stop", () => {
     const secondQuery = capturedQueryParamsAll[1]
     expect(secondQuery.options.resume).toBe("test-session")
     expect(secondQuery.options.resumeSessionAt).toBe(firstToolTurn.uuid)
-    expect(secondQuery.options.forkSession).toBeUndefined()
+    // resumeSessionAt alone rewinds only for this query. The source transcript
+    // still ends in the persisted PreToolUse denial, so a later resume from the
+    // newly produced assistant UUID serializes that marker in place of result A.
+    // Forking makes the rewind durable: the new transcript appends result A and
+    // subsequent assistant turns descend from the real client result.
+    expect(secondQuery.options.forkSession).toBe(true)
     const secondPrompt: any[] = []
     for await (const message of secondQuery.prompt) secondPrompt.push(message)
     expect(secondPrompt[0].message.content).toEqual([
       { type: "tool_result", tool_use_id: "tu-round-1", content: "A" },
     ])
 
-    mockMessages = [assistantMessage([{ type: "text", text: "done" }])]
+    const thirdToolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-round-3", name: "read", input: { file_path: "c" } },
+    ])
+    mockMessages = [thirdToolTurn, userDenyMessage("tu-round-3")]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
@@ -419,13 +433,41 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-repeated-boundary")).status).toBe(200)
     const thirdQuery = capturedQueryParamsAll[2]
-    expect(thirdQuery.options.resume).toBe("test-session")
+    expect(thirdQuery.options.resume).toBe("test-session-fork-1")
     expect(thirdQuery.options.resumeSessionAt).toBe(secondToolTurn.uuid)
-    expect(thirdQuery.options.forkSession).toBeUndefined()
+    // Every tool boundary has its own synthetic denial tail. Repeating the fork
+    // is what keeps result B durable as the chain grows beyond three resumes.
+    expect(thirdQuery.options.forkSession).toBe(true)
     const thirdPrompt: any[] = []
     for await (const message of thirdQuery.prompt) thirdPrompt.push(message)
     expect(thirdPrompt[0].message.content).toEqual([
       { type: "tool_result", tool_use_id: "tu-round-2", content: "B" },
+    ])
+
+    mockMessages = [assistantMessage([{ type: "text", text: "done" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read a" },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-1", content: "A" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-2", name: "read", input: { file_path: "b" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-2", content: "B" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-3", name: "read", input: { file_path: "c" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-3", content: "C" }] },
+      ],
+    }, "es-repeated-boundary")).status).toBe(200)
+    const fourthQuery = capturedQueryParamsAll[3]
+    expect(fourthQuery.options.resume).toBe("test-session-fork-2")
+    expect(fourthQuery.options.resumeSessionAt).toBe(thirdToolTurn.uuid)
+    expect(fourthQuery.options.forkSession).toBe(true)
+    const fourthPrompt: any[] = []
+    for await (const message of fourthQuery.prompt) fourthPrompt.push(message)
+    expect(fourthPrompt[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tu-round-3", content: "C" },
     ])
   })
 
@@ -530,7 +572,7 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
-  it("non-stream: maps parallel SDK fragments to one final undo UUID", async () => {
+  it("non-stream: drops copied rollback UUIDs after a checkpoint fork", async () => {
     const firstFragment = assistantMessage([
       { type: "tool_use", id: "undo-parallel-1", name: "read", input: { file_path: "a" } },
     ])
@@ -552,7 +594,8 @@ describe("Integration: passthrough early stop", () => {
       messages: [{ role: "user", content: "read both for undo" }],
     }, "es-parallel-undo")).status).toBe(200)
 
-    mockMessages = [assistantMessage([{ type: "text", text: "both read" }])]
+    const forkOutput = assistantMessage([{ type: "text", text: "both read" }])
+    mockMessages = [forkOutput]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
@@ -568,9 +611,9 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-parallel-undo")).status).toBe(200)
     expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBe(true)
 
-    mockMessages = [assistantMessage([{ type: "text", text: "changed direction" }])]
+    mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
@@ -579,14 +622,39 @@ describe("Integration: passthrough early stop", () => {
       messages: [
         { role: "user", content: "read both for undo" },
         { role: "assistant", content: combinedToolTurn },
-        { role: "user", content: "instead, take a different direction" },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "undo-parallel-1", content: "A" },
+          { type: "tool_result", tool_use_id: "undo-parallel-2", content: "B" },
+        ] },
+        { role: "assistant", content: forkOutput.message.content },
+        { role: "user", content: "continue after the fork" },
       ],
     }, "es-parallel-undo")).status).toBe(200)
-    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
-    expect(capturedQueryParams.options.forkSession).toBe(true)
+    expect(capturedQueryParams.options.resume).toBe("test-session-fork-1")
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
 
-    // The first undo must retain UUIDs for the preserved prefix so another
-    // branch from that prefix still rolls back to the final parallel fragment.
+    const rewrittenBranch = [
+      { role: "user", content: "read both for undo" },
+      { role: "assistant", content: combinedToolTurn },
+      { role: "user", content: "instead, take a different direction" },
+      { role: "assistant", content: [{ type: "text", text: "branch draft" }] },
+      { role: "user", content: "rewrite this branch" },
+    ]
+    mockMessages = [assistantMessage([{ type: "text", text: "changed direction" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: rewrittenBranch,
+    }, "es-parallel-undo")).status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+
+    // The fresh replay above has the same message count as the cached fork
+    // continuation. It must not inherit forkOutput.uuid from the older slot.
     mockMessages = [assistantMessage([{ type: "text", text: "changed again" }])]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
@@ -594,13 +662,13 @@ describe("Integration: passthrough early stop", () => {
       stream: false,
       tools: [READ_TOOL],
       messages: [
-        { role: "user", content: "read both for undo" },
-        { role: "assistant", content: combinedToolTurn },
-        { role: "user", content: "take yet another direction" },
+        ...rewrittenBranch.slice(0, 4),
+        { role: "user", content: "rewrite this branch again" },
       ],
     }, "es-parallel-undo")).status).toBe(200)
-    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
-    expect(capturedQueryParams.options.forkSession).toBe(true)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
   })
 
   it("non-stream: a plain resume with no deny boundary stays bare", async () => {
@@ -781,7 +849,7 @@ describe("Integration: passthrough early stop", () => {
     }, "es-kill-switch-undo")).status).toBe(200)
     expect(capturedQueryParams.options.resumeSessionAt).toBe(visibleToolTurn.uuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(hiddenDigestTurn.uuid)
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
@@ -1125,6 +1193,77 @@ describe("Integration: passthrough early stop", () => {
     expect(second.status).toBe(200)
     expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
+  it("stream: a capped checkpoint fork does not store parent rollback UUIDs", async () => {
+    const parentToolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-fork-parent", name: "read", input: { file_path: "parent" } },
+    ])
+    mockMessages = [parentToolTurn, userDenyMessage("capped-fork-parent")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read parent then child" }],
+    }, "es-capped-fork-map")).status).toBe(200)
+
+    const forkToolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-fork-child", name: "read", input: { file_path: "child" } },
+    ])
+    mockMessages = [
+      messageStart("msg_capped_fork_child"),
+      toolUseBlockStart(0, "read", "capped-fork-child"),
+      inputJsonDelta(0, '{"file_path":"child"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      forkToolTurn,
+      userDenyMessage("capped-fork-child"),
+      { type: "result", subtype: "error_max_turns", is_error: true },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+    const forkRequestId = `capped-fork-map-${TEST_RUN_ID}`
+    const forked = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read parent then child" },
+        { role: "assistant", content: parentToolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "capped-fork-parent", content: "P" }] },
+      ],
+    }, "es-capped-fork-map", { "x-request-id": forkRequestId })
+    expect(forked.status).toBe(200)
+    expect(await forked.text()).toContain('"type":"tool_use"')
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(parentToolTurn.uuid)
+    expect(capturedQueryParamsAll[1].options.forkSession).toBe(true)
+    let forkRow: any
+    for (let i = 0; i < 500 && !forkRow; i++) {
+      forkRow = telemetryStore.getRecent({ limit: 200 }).find((row: any) => row.requestId === forkRequestId)
+      if (!forkRow) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(forkRow).toBeDefined()
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "fresh branch" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read parent then child" },
+        { role: "assistant", content: parentToolTurn.message.content },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "capped-fork-parent", content: "different parent result" },
+        ] },
+      ],
+    }, "es-capped-fork-map")).status).toBe(200)
+    expect(capturedQueryParamsAll[2].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[2].options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParamsAll[2].options.forkSession).toBeUndefined()
   })
 
   it("non-stream: stores the checkpoint at the capped stop so the next turn resumes", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -268,6 +268,45 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
+  it("non-stream: keeps the checkpoint when queued user text follows tool results", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "queued-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("queued-tool")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-queued-user")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says X" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "queued-tool", content: "X" }] },
+        { role: "user", content: "also summarize it" },
+      ],
+    }, "es-queued-user")).status).toBe(200)
+
+    const resumed = capturedQueryParamsAll[1]
+    expect(resumed.options.resume).toBe("test-session")
+    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+    const promptMessages: any[] = []
+    for await (const message of resumed.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "queued-tool", content: "X" },
+      { type: "text", text: "also summarize it" },
+    ])
+  })
+
   it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
     const firstToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -259,6 +259,14 @@ describe("coalesceCompleteToolResultContinuation", () => {
     ], ["t1", "t2"])).toEqual([{ role: "user", content: results }])
   })
 
+  it("accepts a parallel result batch in a different order", () => {
+    // Anthropic protocol matches tool_result by tool_use_id, not by position.
+    const results = [result("t2"), result("t1")]
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: results },
+    ], ["t1", "t2"])).toEqual([{ role: "user", content: results }])
+  })
+
   it("rejects a partial batch and an unknown result id", () => {
     expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1")] },
@@ -286,6 +294,28 @@ describe("coalesceCompleteToolResultContinuation", () => {
     expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1"), { type: "text", text: "then continue" }] },
     ], ["t1"])).toBeDefined()
+  })
+
+  it("rejects a text-only assistant message before user results", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "assistant", content: [{ type: "text", text: "intervening turn" }] },
+      { role: "user", content: [result("t1")] },
+    ], ["t1"])).toBeUndefined()
+  })
+
+  it("rejects an extra text-only assistant message after the complete echo", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "read", input: {} }] },
+      { role: "assistant", content: [{ type: "text", text: "intervening turn" }] },
+      { role: "user", content: [result("t1")] },
+    ], ["t1"])).toBeUndefined()
+  })
+
+  it("rejects tool results in a turn after queued user text", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "user", content: [result("t1")] },
+    ], ["t1"])).toBeUndefined()
   })
 
   it("rejects results split across turns, duplicated, or sent after queued content", () => {

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -13,10 +13,10 @@
 import { describe, it, expect } from "bun:test"
 import {
   clientAbortDisposition,
+  coalesceCompleteToolResultContinuation,
   createEarlyStopTracker,
   allForwardedCallsResolved,
   isClientForwardedToolUse,
-  isCompleteToolResultContinuation,
   noteAssistantContent,
   noteAssistantMessage,
   noteUserContent,
@@ -249,37 +249,60 @@ describe("early-stop tracking", () => {
 })
 
 
-describe("isCompleteToolResultContinuation", () => {
+describe("coalesceCompleteToolResultContinuation", () => {
   const result = (id: string, content: unknown = "ok") => ({ type: "tool_result", tool_use_id: id, content })
 
   it("accepts one complete parallel result batch", () => {
-    expect(isCompleteToolResultContinuation([
-      { role: "user", content: [result("t1"), result("t2")] },
-    ], ["t1", "t2"])).toBe(true)
+    const results = [result("t1"), result("t2")]
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: results },
+    ], ["t1", "t2"])).toEqual([{ role: "user", content: results }])
   })
 
   it("rejects a partial batch and an unknown result id", () => {
-    expect(isCompleteToolResultContinuation([
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1")] },
-    ], ["t1", "t2"])).toBe(false)
-    expect(isCompleteToolResultContinuation([
+    ], ["t1", "t2"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("unknown")] },
-    ], ["t1"])).toBe(false)
+    ], ["t1"])).toBeUndefined()
   })
 
-  it("rejects multiple user messages so multimodal results stay on the final SDK input", () => {
-    expect(isCompleteToolResultContinuation([
-      { role: "user", content: [result("t1")] },
-      { role: "user", content: [{ type: "text", text: "continue" }] },
-    ], ["t1"])).toBe(false)
+  it("coalesces queued user messages so results stay on the final SDK input", () => {
+    const toolResult = result("t1")
+    const queuedText = { type: "text", text: "continue" }
+    const queuedImage = { type: "image", source: { type: "base64", data: "abc" } }
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [toolResult] },
+      { role: "user", content: "continue" },
+      { role: "user", content: [queuedImage] },
+    ], ["t1"])).toEqual([{ role: "user", content: [toolResult, queuedText, queuedImage] }])
   })
 
   it("requires tool results before ordinary user content", () => {
-    expect(isCompleteToolResultContinuation([
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [{ type: "text", text: "first" }, result("t1")] },
-    ], ["t1"])).toBe(false)
-    expect(isCompleteToolResultContinuation([
+    ], ["t1"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1"), { type: "text", text: "then continue" }] },
-    ], ["t1"])).toBe(true)
+    ], ["t1"])).toBeDefined()
+  })
+
+  it("rejects results split across turns, duplicated, or sent after queued content", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "user", content: [result("t2")] },
+    ], ["t1", "t2"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1"), result("t1")] },
+    ], ["t1"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "user", content: [{ type: "text", text: "continue" }, result("t1")] },
+    ], ["t1"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "assistant", content: [{ type: "text", text: "late" }] },
+    ], ["t1"])).toBeUndefined()
   })
 })

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -267,6 +267,6 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     expect(capturedResume ?? "(fresh)").toBe("test-session")
     expect(capturedResumeSessionAt).toBe(resumeBoundary)
     expect(denyUuids).not.toContain(capturedResumeSessionAt)
-    expect(capturedForkSession).toBeUndefined()
+    expect(capturedForkSession).toBe(true)
   })
 })

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -214,14 +214,15 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).resumeSessionAt).toBe("uuid-abc")
   })
 
-  it("resumes passthrough at an assistant boundary without creating a new session", () => {
+  it("forks a passthrough assistant-boundary resume so its replacement tail is durable", () => {
     const result = buildQueryOptions(makeContext({
+      passthrough: true,
       resumeSessionId: "sdk-123",
       resumeSessionAtUuid: "assistant-uuid",
     }))
     expect((result.options as any).resume).toBe("sdk-123")
     expect((result.options as any).resumeSessionAt).toBe("assistant-uuid")
-    expect((result.options as any).forkSession).toBeUndefined()
+    expect((result.options as any).forkSession).toBe(true)
   })
 
   it("includes agents when provided", () => {

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -143,17 +143,19 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
 
 /**
  * Verify that a resumed tool-result delta settles exactly the tool calls at the
- * stored assistant checkpoint. Tool results must precede any ordinary user
- * content, matching the Anthropic Messages protocol.
+ * stored assistant checkpoint, then coalesce queued user turns into one SDK
+ * input. Tool results must precede any ordinary user content, matching the
+ * Anthropic Messages protocol.
  */
-export function isCompleteToolResultContinuation(
+export function coalesceCompleteToolResultContinuation(
   messages: Array<{ role?: unknown; content?: unknown }>,
   expectedIds: readonly string[]
-): boolean {
-  if (expectedIds.length === 0 || messages.length === 0) return false
+): Array<{ role: "user"; content: unknown[] }> | undefined {
+  if (expectedIds.length === 0 || messages.length === 0) return undefined
   const expected = new Set(expectedIds)
   const actual = new Set<string>()
   const echoedCalls = new Set<string>()
+  const content: unknown[] = []
   let sawUser = false
   let sawNonToolResult = false
 
@@ -166,28 +168,41 @@ export function isCompleteToolResultContinuation(
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; id?: unknown } | null | undefined
           if (block?.type !== "tool_use") continue
-          if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return false
+          if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return undefined
           echoedCalls.add(block.id)
         }
       }
       continue
     }
-    if (message.role !== "user" || !Array.isArray(message.content) || sawUser) return false
+    if (message.role !== "user") return undefined
+    // A queued user turn may follow only after the first turn settled the full
+    // checkpoint batch. Splitting results across turns is not a valid resume.
+    if (sawUser && actual.size !== expected.size) return undefined
+    const userContent = Array.isArray(message.content)
+      ? message.content
+      : typeof message.content === "string"
+        ? [{ type: "text", text: message.content }]
+        : undefined
+    if (!userContent) return undefined
     sawUser = true
-    for (const rawBlock of message.content) {
+    for (const rawBlock of userContent) {
       const block = rawBlock as { type?: unknown; tool_use_id?: unknown } | null | undefined
       if (block?.type === "tool_result") {
-        if (sawNonToolResult || typeof block.tool_use_id !== "string") return false
-        if (!expected.has(block.tool_use_id) || actual.has(block.tool_use_id)) return false
+        if (sawNonToolResult || typeof block.tool_use_id !== "string") return undefined
+        if (!expected.has(block.tool_use_id) || actual.has(block.tool_use_id)) return undefined
         actual.add(block.tool_use_id)
       } else {
         sawNonToolResult = true
       }
+      content.push(rawBlock)
     }
   }
 
-  return actual.size === expected.size &&
-    (echoedCalls.size === 0 || echoedCalls.size === expected.size)
+  if (
+    actual.size !== expected.size ||
+    (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
+  ) return undefined
+  return [{ role: "user", content }]
 }
 
 /** The cache-stable assistant boundary after every forwarded call settled. */

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,14 +164,17 @@ export function coalesceCompleteToolResultContinuation(
     // result. That assistant turn already exists at resumeSessionAt, so the
     // structured SDK delta below intentionally filters it out.
     if (message.role === "assistant" && !sawUser) {
+      let sawToolUse = false
       if (Array.isArray(message.content)) {
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; id?: unknown } | null | undefined
           if (block?.type !== "tool_use") continue
+          sawToolUse = true
           if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return undefined
           echoedCalls.add(block.id)
         }
       }
+      if (!sawToolUse) return undefined
       continue
     }
     if (message.role !== "user") return undefined

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -471,7 +471,11 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       },
       ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
-      ...(isUndo || forkSession ? { forkSession: true } : {}),
+      // A passthrough checkpoint sits immediately before a persisted
+      // PreToolUse denial. resumeSessionAt rewinds that tail for one query but
+      // does not replace it in the source transcript; forking makes the rewind
+      // durable so the client's real tool_result becomes the new ancestry.
+      ...(isUndo || forkSession || (passthrough && resumeSessionAtUuid) ? { forkSession: true } : {}),
       ...(resumeSessionAtUuid ? { resumeSessionAt: resumeSessionAtUuid } : {}),
       ...(sdkHooks ? { hooks: sdkHooks } : {}),
       ...(effort ? { effort } : {}),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -96,6 +96,7 @@ import {
   computeMessageHashes,
   normalizeContextUsage,
   withClientAssistantUuid,
+  reconcileReturnedSessionUuids,
   type LineageResult,
   type TokenUsageIteration,
   type TokenUsage,
@@ -1465,6 +1466,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
+        const sdkUndo = isUndo && Boolean(undoRollbackUuid)
+        if (isUndo && !undoRollbackUuid) {
+          // Forks remap copied-history UUIDs. Without a valid boundary in the
+          // preserved prefix, replay fresh rather than first attempting a
+          // deterministic missing-message resume against the returned session.
+          resumeSessionId = undefined
+        }
         // Early-stopped sessions resume at the assistant tool-use turn, before synthetic denials.
         let passthroughToolCallAssistantUuid = passthrough && isResume ? cachedSession?.passthroughToolCallAssistantUuid : undefined
         const passthroughToolCallIds = passthrough && isResume ? cachedSession?.passthroughToolCallIds : undefined
@@ -1557,9 +1565,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             messagesToConvert = getLastUserMessage(allMessages)
           }
         } else {
-          // Undo without UUID (legacy session) — fall back to last user message
-          // to avoid the catastrophic flat text replay.
-          messagesToConvert = getLastUserMessage(allMessages)
+          // Undo without a valid SDK boundary is a fresh structured replay.
+          messagesToConvert = allMessages
         }
       } else {
         messagesToConvert = allMessages
@@ -2055,11 +2062,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // RangeError when allMessages.length was 0. Cold-start requests
           // are now also rejected at the entrypoint (#450) but the defensive
           // initializer keeps any future reentry safe.
-          let sdkUuidMap: Array<string | null> = (isResume || isUndo) && cachedSession?.sdkMessageUuids
+          let sdkUuidMap: Array<string | null> = (isResume || sdkUndo) && cachedSession?.sdkMessageUuids
             ? [...cachedSession.sdkMessageUuids]
             : []
           // Pad to current message count (the last user message has no UUID yet)
           while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
+          let currentClientAssistantUuid: string | null = null
 
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
@@ -2117,7 +2125,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                    resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2398,6 +2406,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     allMessages.length,
                     (message as any).uuid
                   )
+                  currentClientAssistantUuid = sdkUuidMap[allMessages.length] ?? null
                 }
                 if (!firstChunkAt) {
                   firstChunkAt = Date.now()
@@ -2782,7 +2791,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     body.messages || [],
                     currentSessionId,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    reconcileReturnedSessionUuids(
+                      sdkUuidMap,
+                      allMessages.length,
+                      currentClientAssistantUuid,
+                      resumeSessionId,
+                      currentSessionId,
+                    ),
                     lastUsage,
                     earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
                     earlyStopFired ? nextPassthroughToolCallIds : null
@@ -2871,10 +2886,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // Defensive: start empty so allMessages.length === 0 doesn't crash the
             // ReadableStream's start() with `RangeError: Invalid array length`.
             // Cold-start requests with no messages are also rejected upstream now (#450).
-            let sdkUuidMap: Array<string | null> = (isResume || isUndo) && cachedSession?.sdkMessageUuids
+            let sdkUuidMap: Array<string | null> = (isResume || sdkUndo) && cachedSession?.sdkMessageUuids
               ? [...cachedSession.sdkMessageUuids]
               : []
             while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
+            let currentClientAssistantUuid: string | null = null
 
             let messageStartEmitted = false
             let lastUsage: TokenUsage | undefined
@@ -2994,7 +3010,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     for await (const event of runSdkQueryAttempt(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                      resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -3282,6 +3298,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       allMessages.length,
                       (message as any).uuid
                     )
+                    currentClientAssistantUuid = sdkUuidMap[allMessages.length] ?? null
                   }
                   if (message.type === "result") {
                     sawCanonicalResult = true
@@ -3707,7 +3724,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     body.messages || [],
                     currentSessionId,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    reconcileReturnedSessionUuids(
+                      sdkUuidMap,
+                      allMessages.length,
+                      currentClientAssistantUuid,
+                      resumeSessionId,
+                      currentSessionId,
+                    ),
                     lastUsage,
                     earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
                     earlyStopFired ? nextPassthroughToolCallIds : null
@@ -4289,7 +4312,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     body.messages || [],
                     currentSessionId!,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    reconcileReturnedSessionUuids(
+                      sdkUuidMap,
+                      allMessages.length,
+                      currentClientAssistantUuid,
+                      resumeSessionId,
+                      currentSessionId,
+                    ),
                     lastUsage,
                     nextPassthroughToolCallAssistantUuid!,
                     nextPassthroughToolCallIds!,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, createEarlyStopTracker, isCompleteToolResultContinuation, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -1565,21 +1565,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         messagesToConvert = allMessages
       }
 
-      // Rewinding to a tool-use checkpoint is valid only when the immediate
-      // delta settles that exact batch. Partial, late, duplicate, or unknown
-      // results get one safe fresh replay rather than an invalid SDK resume.
-      if (
-        passthroughToolCallAssistantUuid &&
-        !isCompleteToolResultContinuation(messagesToConvert, passthroughToolCallIds ?? [])
-      ) {
-        claudeLog("passthrough.checkpoint_replay", {
-          expectedToolIds: passthroughToolCallIds?.length ?? 0,
-          reason: "incomplete_or_mismatched_results",
-        })
-        isResume = false
-        resumeSessionId = undefined
-        passthroughToolCallAssistantUuid = undefined
-        messagesToConvert = allMessages
+      if (passthroughToolCallAssistantUuid) {
+        // Rewinding to a tool-use checkpoint is valid only when the immediate
+        // delta settles that exact batch. Coalesce any subsequent queued user
+        // turns so multimodal tool results remain on the final SDK input.
+        const checkpointContinuation = coalesceCompleteToolResultContinuation(
+          messagesToConvert,
+          passthroughToolCallIds ?? []
+        )
+        if (checkpointContinuation) {
+          messagesToConvert = checkpointContinuation
+        } else {
+          // Partial, late, duplicate, or unknown results get one safe fresh
+          // replay rather than an invalid SDK resume.
+          claudeLog("passthrough.checkpoint_replay", {
+            expectedToolIds: passthroughToolCallIds?.length ?? 0,
+            reason: "incomplete_or_mismatched_results",
+          })
+          isResume = false
+          resumeSessionId = undefined
+          passthroughToolCallAssistantUuid = undefined
+          messagesToConvert = allMessages
+        }
       }
 
       // Multimodal blocks and passthrough tool results must remain structured.

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -85,6 +85,27 @@ export function withClientAssistantUuid(
 }
 
 /**
+ * Reconcile rollback UUIDs with the session the SDK actually returned.
+ *
+ * A fork remaps every copied transcript UUID, so UUIDs inherited from the
+ * resumed session are invalid in the returned session. The one UUID observed
+ * for this request's new client-visible assistant remains valid and occupies
+ * its future client message slot.
+ */
+export function reconcileReturnedSessionUuids(
+  existing: Array<string | null>,
+  clientMessageCount: number,
+  currentAssistantUuid: string | null,
+  resumeSessionId: string | undefined,
+  returnedSessionId: string | undefined,
+): Array<string | null> {
+  if (!resumeSessionId || !returnedSessionId || returnedSessionId === resumeSessionId) return existing
+  const next = new Array<string | null>(clientMessageCount + 1).fill(null)
+  next[clientMessageCount] = currentAssistantUuid
+  return next
+}
+
+/**
  * Result of lineage verification — classifies the mutation and provides
  * the information needed to take the correct SDK action.
  */


### PR DESCRIPTION
## Summary

- preserve the assistant checkpoint when a complete tool-result batch is followed by queued user input
- make every passthrough checkpoint rewind durable, so delivered client `tool_result` blocks remain in later resume history instead of reverting to the persisted PreToolUse denial
- discard copied rollback UUIDs when the SDK returns a forked session, while retaining the newly observed assistant UUID
- fail closed to structured fresh replay for partial, unknown, duplicate, split, or late results, stray assistant turns, and undo prefixes whose UUIDs were remapped by a fork

## Root causes

### Queued user input forced a fresh replay

OpenCode can append a queued user message while a passthrough tool loop is in progress, producing `user[tool_result] -> user[text]`. The continuation validator rejected every second user message, so the proxy cleared `resumeSessionAt` and replayed the full history in a fresh SDK session.

The validator now coalesces consecutive user turns only after proving that the first turn settles the exact checkpoint batch. Queued string, text-block, and image-block content remains ordered; invalid result sequences still fail closed. Parallel results are matched by `tool_use_id`, as required by the Anthropic protocol.

### A successful resume rewrote an older result

The PreToolUse denial that prevents server-side execution is persisted in the Claude Code transcript. `resumeSessionAt` rewound that denial for one query, but the source transcript retained it. On the next resume, Claude Code serialized the old call as Meridian's 209-byte forwarding marker instead of the client result, invalidating the prompt-cache prefix.

Passthrough checkpoint resumes now use `forkSession: true`. The fork makes the replacement tail durable: the client result becomes ancestry in the returned session, while the denial remains only on the current unresolved tool boundary.

Forking remaps every copied message UUID. Session storage therefore reconciles rollback UUIDs against the session ID actually returned by the SDK: copied UUIDs are cleared on a session change, the current output UUID is retained, and an older undo prefix with no valid boundary goes directly to a structured fresh replay instead of first failing with `missing-message`. This applies to normal stream/non-stream completion and the recoverable streaming `error_max_turns` checkpoint path.

## Production impact

In one live passthrough session before the fixes:

| turn type | n | avg cache hit rate | cache write |
|---|---:|---:|---:|
| resumed | 355 | 0.88 | ~24k/turn |
| checkpoint replay | 44 | 0.36 | ~77k/turn |

That produced 3.4M avoidable cache-write tokens at the 1.25x rate. After queued-message resume was restored, a separate successful continuation still collapsed from a 93.5% cache hit to 30.1% because an older delivered result reverted to the forwarding marker; this PR now addresses both causes.

Related: #767, #861, #869.

## Verification

- `npm test`: 2727 passed, 1 skipped, 0 failed, plus all process-isolated suites
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- focused HTTP regressions cover queued string/multimodal input, repeated and parallel tool rounds, changed fork session IDs, rollback UUID reconciliation, direct fresh undo, and streaming capped-turn checkpoint persistence
- isolated end-to-end HTTP audit against the freshly built CLI with Claude Code 2.1.221 / Agent SDK 0.2.141:
  - four passthrough turns returned four distinct chained session IDs
  - intercepted historical `tool_result` payloads stayed byte-stable; the only prefix change was expected `cache_control` movement
  - the forwarding marker did not reappear in subsequent API request bodies
  - a server-side `bash` sentinel was not executed
  - undo to a remapped old prefix made one fresh request with no `missing-message` attempt

The end-to-end audit used a dummy key in an isolated network namespace with only a loopback interceptor; no external Anthropic request was possible.
