### PR TITLE
Resume the session when a client only adds or drops content blocks

### DIFF
--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -643,7 +643,7 @@ describe("formatLineageMismatch", () => {
   })
 })
 
-// Shared by the two block-level suites below. Both need a session whose per-block
+// Shared by the block-level suites below, which need a session whose per-block
 // hashes were recorded — that is what makes block-granular classification
 // possible, and a session without them is expected to keep replaying.
 const toolResult = (id: string, content: string) => ({

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -643,23 +643,26 @@ describe("formatLineageMismatch", () => {
   })
 })
 
-describe("verifyLineage append-only tool-result extension", () => {
-  const toolResult = (id: string, content: string) => ({
-    type: "tool_result",
-    tool_use_id: id,
-    content,
+// Shared by the two block-level suites below. Both need a session whose per-block
+// hashes were recorded — that is what makes block-granular classification
+// possible, and a session without them is expected to keep replaying.
+const toolResult = (id: string, content: string) => ({
+  type: "tool_result",
+  tool_use_id: id,
+  content,
+})
+
+function sessionWithBlockHashes(messages: Array<{ role: string; content: any }>): SessionState {
+  return makeSession({
+    lastAccess: 0,
+    lineageHash: computeLineageHash(messages),
+    messageCount: messages.length,
+    messageHashes: computeMessageHashes(messages),
+    messageBlockHashes: computeMessageBlockHashes(messages),
   })
+}
 
-  function sessionFor(messages: Array<{ role: string; content: any }>): SessionState {
-    return makeSession({
-      lastAccess: 0,
-      lineageHash: computeLineageHash(messages),
-      messageCount: messages.length,
-      messageHashes: computeMessageHashes(messages),
-      messageBlockHashes: computeMessageBlockHashes(messages),
-    })
-  }
-
+describe("verifyLineage append-only tool-result extension", () => {
   it("resumes from only the newly appended parallel tool result", () => {
     const stored = [
       { role: "user", content: [{ type: "text", text: "run both" }] },
@@ -682,9 +685,9 @@ describe("verifyLineage append-only tool-result extension", () => {
       { role: "user", content: [toolResult("call-c", "c-result")] },
     ]
 
-    expect(verifyLineage(sessionFor(stored), incoming)).toEqual({
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming)).toEqual({
       type: "continuation",
-      session: sessionFor(stored),
+      session: sessionWithBlockHashes(stored),
       resumeFrom: 2,
       resumeContentFrom: 1,
     })
@@ -724,7 +727,7 @@ describe("verifyLineage append-only tool-result extension", () => {
     ]
     expect(incoming.length).toBe(53)
 
-    const result = verifyLineage(sessionFor(stored), incoming)
+    const result = verifyLineage(sessionWithBlockHashes(stored), incoming)
     expect(result.type).toBe("continuation")
     if (result.type === "continuation") {
       expect(result.resumeFrom).toBe(50)
@@ -780,7 +783,7 @@ describe("verifyLineage append-only tool-result extension", () => {
       { role: "assistant", content: "next" },
     ]
 
-    expect(verifyLineage(sessionFor(stored), incoming)).toMatchObject({
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming)).toMatchObject({
       type: "diverged",
       reason: "modified-history",
       prefixOverlap: 2,
@@ -799,7 +802,7 @@ describe("verifyLineage append-only tool-result extension", () => {
       { role: "assistant", content: "next" },
     ]
 
-    expect(verifyLineage(sessionFor(stored), incoming).type).toBe("diverged")
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).toBe("diverged")
   })
 
   it("still diverges when a prior tool result is appended again", () => {
@@ -814,7 +817,167 @@ describe("verifyLineage append-only tool-result extension", () => {
       { role: "assistant", content: "next" },
     ]
 
-    expect(verifyLineage(sessionFor(stored), incoming).type).toBe("diverged")
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).toBe("diverged")
+  })
+
+  // #767: OpenCode appends reminder/notification text after the tool results of
+  // a turn, so the trailing user message grows from [tool_result, ...] to
+  // [tool_result, ..., text, ...]. Before this, the appended text failed the
+  // "every appended block is a new tool_result" test and the whole turn
+  // diverged as modified-history with prefix overlap exactly messageCount - 1.
+  it("continues when the trailing tool-result turn gains appended text blocks", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "do the thing" }] },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } },
+        { type: "tool_use", id: "call-b", name: "bash", input: { command: "b" } },
+      ] },
+      { role: "user", content: [toolResult("call-a", "a-result"), toolResult("call-b", "b-result")] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("call-a", "a-result"),
+        toolResult("call-b", "b-result"),
+        { type: "text", text: "<system-reminder>agent usage</system-reminder>" },
+        { type: "text", text: "continue" },
+      ] },
+    ]
+
+    const result = verifyLineage(sessionWithBlockHashes(stored), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      expect(result.resumeFrom).toBe(2)
+      expect(result.resumeContentFrom).toBe(2)
+    }
+  })
+
+  it("does not resume when an appended tool_result repeats a stored tool_use_id", () => {
+    const stored = [
+      { role: "user", content: [{ type: "text", text: "do the thing" }] },
+      { role: "assistant", content: [{ type: "tool_use", id: "call-a", name: "bash", input: { command: "a" } }] },
+      { role: "user", content: [toolResult("call-a", "a-result")] },
+    ]
+    const incoming = [
+      stored[0]!,
+      stored[1]!,
+      { role: "user", content: [
+        toolResult("call-a", "a-result"),
+        { type: "text", text: "note" },
+        toolResult("call-a", "a-result-again"),
+      ] },
+    ]
+
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).not.toBe("continuation")
+  })
+})
+
+describe("verifyLineage dropped ephemeral blocks", () => {
+  const hookBlock = {
+    type: "text",
+    text: "<user-prompt-submit-hook>\n{\"continue\":true}\n</user-prompt-submit-hook>",
+  }
+  const userText = { type: "text", text: "Read data.txt and tell me the third line." }
+
+  // The live shape: a Claude Code UserPromptSubmit hook's stdout, bridged into
+  // OpenCode by oh-my-openagent, rides along on the submitting turn only. The
+  // next turn re-sends message[0] without it, so prefix overlap is 0 and the
+  // whole conversation reads as unrelated-history — every turn replaying
+  // against a cold cache, and a turn that also waited behind the session lease
+  // refused outright with session_turn_conflict.
+  it("continues when an injected block is dropped from the first user message", () => {
+    const stored = [{ role: "user", content: [hookBlock, userText] }]
+    const incoming = [
+      { role: "user", content: [userText] },
+      { role: "assistant", content: [{ type: "tool_use", id: "call-a", name: "read", input: {} }] },
+      { role: "user", content: [toolResult("call-a", "alpha\nbravo\ncharlie")] },
+    ]
+
+    const result = verifyLineage(sessionWithBlockHashes(stored), incoming)
+    expect(result.type).toBe("continuation")
+    if (result.type === "continuation") {
+      // The SDK session already holds message[0]; only the new turns are sent.
+      expect(result.resumeFrom).toBe(1)
+    }
+  })
+
+  it("continues when the dropped block sat between two surviving blocks", () => {
+    const before = { type: "text", text: "before" }
+    const after = { type: "text", text: "after" }
+    const stored = [{ role: "user", content: [before, hookBlock, after] }]
+    const incoming = [
+      { role: "user", content: [before, after] },
+      { role: "assistant", content: "ok" },
+    ]
+
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).toBe("continuation")
+  })
+
+  // Subtractive only. Everything below is the dangerous direction — the client
+  // claiming history the SDK session cannot prove it holds (#689, #692, #712).
+  it("does not resume when a surviving block was edited rather than dropped", () => {
+    const stored = [{ role: "user", content: [hookBlock, userText] }]
+    const incoming = [
+      { role: "user", content: [{ type: "text", text: "a different question entirely" }] },
+      { role: "assistant", content: "ok" },
+    ]
+
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).not.toBe("continuation")
+  })
+
+  it("does not resume when the survivors came back out of order", () => {
+    const first = { type: "text", text: "first" }
+    const second = { type: "text", text: "second" }
+    const stored = [{ role: "user", content: [first, second, hookBlock] }]
+    const incoming = [
+      { role: "user", content: [second, first] },
+      { role: "assistant", content: "ok" },
+    ]
+
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).not.toBe("continuation")
+  })
+
+  it("does not resume when an assistant turn lost blocks", () => {
+    const stored = [
+      { role: "user", content: [userText] },
+      { role: "assistant", content: [
+        { type: "text", text: "thinking out loud" },
+        { type: "tool_use", id: "call-a", name: "read", input: {} },
+      ] },
+    ]
+    const incoming = [
+      { role: "user", content: [userText] },
+      { role: "assistant", content: [{ type: "tool_use", id: "call-a", name: "read", input: {} }] },
+      { role: "user", content: [toolResult("call-a", "x")] },
+    ]
+
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).not.toBe("continuation")
+  })
+
+  it("does not resume when the conversation did not move forward", () => {
+    // Same length: an undo or a retype, not a continuation.
+    const stored = [{ role: "user", content: [hookBlock, userText] }]
+    const incoming = [{ role: "user", content: [userText] }]
+
+    expect(verifyLineage(sessionWithBlockHashes(stored), incoming).type).not.toBe("continuation")
+  })
+
+  it("does not resume a session stored without block hashes", () => {
+    const stored = [{ role: "user", content: [hookBlock, userText] }]
+    const legacy = makeSession({
+      lastAccess: 0,
+      lineageHash: computeLineageHash(stored),
+      messageCount: stored.length,
+      messageHashes: computeMessageHashes(stored),
+      // messageBlockHashes absent — pre-1.61.0 cache entry.
+    })
+    const incoming = [
+      { role: "user", content: [userText] },
+      { role: "assistant", content: "ok" },
+    ]
+
+    expect(verifyLineage(legacy, incoming).type).not.toBe("continuation")
   })
 })
 

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -427,7 +427,8 @@ function droppedEphemeralBlocksOnly(
 
     const hashes = blocks.map((block) => hashNormalizedContent([block]))
     // Strictly fewer blocks, every survivor byte-identical and still in order.
-    // Equal or more is growth, handled by the append-only path above.
+    // Equal or more is growth, which the append-only path in verifyLineage
+    // handles.
     if (hashes.length === 0 || hashes.length >= stored.length) return false
     if (!isOrderedSubsequence(stored, hashes)) return false
 
@@ -599,9 +600,8 @@ export function verifyLineage(
     }
   }
 
-  // Ephemeral injected blocks the client dropped. Subtractive-only, so the SDK
-  // session is a superset of the claimed history and a resume cannot skip
-  // anything the client believes it sent — see droppedEphemeralBlocksOnly.
+  // Ephemeral injected blocks the client dropped — droppedEphemeralBlocksOnly
+  // carries the shape and why resuming on it is sound.
   if (droppedEphemeralBlocksOnly(cached, messages, incomingHashes)) {
     return { type: "continuation", session: cached, resumeFrom: cached.messageCount }
   }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -361,6 +361,81 @@ function findSuffixAnchorStart(
   return anchor - suffixOverlap + 1
 }
 
+/** Is `incoming` an ordered subsequence of `stored`? */
+function isOrderedSubsequence(stored: readonly string[], incoming: readonly string[]): boolean {
+  let cursor = 0
+  for (const hash of incoming) {
+    while (cursor < stored.length && stored[cursor] !== hash) cursor++
+    if (cursor === stored.length) return false
+    cursor++
+  }
+  return true
+}
+
+/**
+ * Did the client only *drop* blocks it had previously sent, changing nothing
+ * else in the stored region?
+ *
+ * Harnesses inject per-turn context into a user message and then drop it: a
+ * Claude Code `UserPromptSubmit` hook's stdout, bridged into OpenCode by
+ * oh-my-openagent, arrives as a `<user-prompt-submit-hook>` text block on the
+ * turn that submitted the prompt and is gone on the next one. The first user
+ * message therefore goes `[text, text]` -> `[text]` mid-conversation, message
+ * hashes stop matching at index 0, and the whole conversation reads as
+ * `unrelated-history`. Every turn then replays from scratch against a cold
+ * cache, and a turn that also waited behind the session lease is refused
+ * outright with `session_turn_conflict`.
+ *
+ * Resuming is sound here precisely because the difference is subtractive: the
+ * SDK session holds a superset of what the client now claims, so nothing the
+ * client believes it sent is missing upstream. That is the opposite of the
+ * dangerous direction guarded in #689/#692 and #712, where the client's history
+ * contains turns the SDK session never saw and a resume would silently skip
+ * them.
+ */
+function droppedEphemeralBlocksOnly(
+  cached: SessionState,
+  messages: Array<{ role: string; content: any }>,
+  incomingHashes: string[]
+): boolean {
+  const blockHashes = cached.messageBlockHashes
+  if (!blockHashes || blockHashes.length !== cached.messageCount) return false
+  // Both hash arrays must cover the whole stored region: a short one would make
+  // an out-of-range `undefined` read as "changed" and send a slot into the
+  // block comparison on no evidence.
+  const messageHashes = cached.messageHashes
+  if (!messageHashes || messageHashes.length !== cached.messageCount) return false
+  // Only for a conversation that moved forward. Equal or shorter is an undo or
+  // a replay and keeps the classification it has today.
+  if (messages.length <= cached.messageCount) return false
+
+  let sawDrop = false
+  for (let index = 0; index < cached.messageCount; index++) {
+    if (messageHashes[index] === incomingHashes[index]) continue
+
+    const incoming = messages[index]
+    // Only user turns carry injected context. A changed assistant slot is a
+    // rewritten model turn and must still diverge.
+    if (incoming?.role !== "user" || !Array.isArray(incoming.content)) return false
+
+    const stored = blockHashes[index]
+    if (!stored || stored.length === 0) return false
+
+    const blocks = hashableContentBlocks(incoming.content)
+    // A block the hasher ignores would make the comparison meaningless.
+    if (blocks.length !== incoming.content.length) return false
+
+    const hashes = blocks.map((block) => hashNormalizedContent([block]))
+    // Strictly fewer blocks, every survivor byte-identical and still in order.
+    // Equal or more is growth, handled by the append-only path above.
+    if (hashes.length === 0 || hashes.length >= stored.length) return false
+    if (!isOrderedSubsequence(stored, hashes)) return false
+
+    sawDrop = true
+  }
+  return sawDrop
+}
+
 // --- Lineage verification ---
 
 /**
@@ -373,9 +448,17 @@ function findSuffixAnchorStart(
  * Decision matrix:
  *   Full prefix match (fast-path)          → continuation (resume from stored count)
  *   Suffix overlap >= MIN_SUFFIX           → compaction   (resume after matched suffix)
+ *   Trailing user slot gained blocks       → continuation (resume mid-message)
+ *   Stored user slots only lost blocks     → continuation (resume from stored count)
  *   Prefix overlap > 0, no suffix, shrank  → undo         (fork at rollback point)
  *   Cached prefix changed while growing    → diverged     (fresh full-history replay)
  *   No overlap                             → diverged     (fresh full-history replay)
+ *
+ * The two block-level continuations sit either side of one line: the SDK
+ * session must already hold everything the client still claims. Growth is
+ * admissible because the appended blocks are sent on; loss is admissible
+ * because the session is a superset. A block that *changed* satisfies neither
+ * and diverges.
  */
 export function verifyLineage(
   cached: SessionState,
@@ -459,9 +542,11 @@ export function verifyLineage(
   // slot instead of appending a new message. The SDK session already contains
   // the old blocks; resume with only the newly appended tool_result blocks.
   //
-  // This is deliberately narrow. Arbitrary text edits and changed existing
-  // blocks still diverge, preserving the stale-lineage safety fixes in #689 and
-  // #692. Legacy sessions without block hashes also keep replaying safely.
+  // This stays narrow: `preservesStoredBlocks` requires every stored block to
+  // survive byte-identical as a strict prefix, so changed existing blocks and
+  // rewritten history still diverge, preserving the stale-lineage safety fixes
+  // in #689 and #692. Legacy sessions without block hashes also keep replaying
+  // safely.
   const boundary = cached.messageCount - 1
   if (
     boundary >= 0 &&
@@ -484,13 +569,26 @@ export function verifyLineage(
           .filter((block) => block?.type === "tool_result" && typeof block.tool_use_id === "string")
           .map((block) => block.tool_use_id as string),
       )
-      const hasOnlyNewToolResults = appendedBlocks.every((block) => {
-        if (block?.type !== "tool_result" || typeof block.tool_use_id !== "string") return false
+      // Non-tool_result blocks may only be appended to a slot that is already a
+      // tool-result turn. That is the OpenCode shape — reminder text trailing
+      // the results of a turn the client is still completing. Appending text to
+      // a plain user message is a different thing: the user edited their own
+      // turn, which must still diverge.
+      const storedPrefixHasToolResult = incomingBlocks
+        .slice(0, storedBlocks.length)
+        .some((block) => block?.type === "tool_result")
+      // A tool_result must be genuinely new — repeating a tool_use_id the stored
+      // prefix already carries would replay a result the session has seen. Other
+      // block types carry no such identity and cannot collide with the stored
+      // prefix, since they sit strictly beyond it.
+      const appendedBlocksAreNew = appendedBlocks.every((block) => {
+        if (block?.type !== "tool_result") return storedPrefixHasToolResult
+        if (typeof block.tool_use_id !== "string") return false
         if (seenToolResultIds.has(block.tool_use_id)) return false
         seenToolResultIds.add(block.tool_use_id)
         return true
       })
-      if (preservesStoredBlocks && hasOnlyNewToolResults) {
+      if (preservesStoredBlocks && appendedBlocksAreNew) {
         return {
           type: "continuation",
           session: cached,
@@ -499,6 +597,13 @@ export function verifyLineage(
         }
       }
     }
+  }
+
+  // Ephemeral injected blocks the client dropped. Subtractive-only, so the SDK
+  // session is a superset of the claimed history and a resume cannot skip
+  // anything the client believes it sent — see droppedEphemeralBlocksOnly.
+  if (droppedEphemeralBlocksOnly(cached, messages, incomingHashes)) {
+    return { type: "continuation", session: cached, resumeFrom: cached.messageCount }
   }
 
   // Undo: prefix preserved (beginning intact) but suffix changed,


### PR DESCRIPTION
Two block-level mutations force a full history replay, and a replayed turn that also queued behind the session turn lease returns HTTP 400 `session_turn_conflict`.

## Appended blocks on a tool-result slot

This is #767. The append-only path required every appended block to be a new `tool_result`. OpenCode trails reminder text after the results of a turn, so its trailing user message grows from `[tool_result, tool_result]` to `[tool_result, tool_result, text, text]`. The turn then diverges as `modified-history` with prefix overlap exactly `messageCount - 1`, which is the signature reported in #767.

Appended blocks that are not `tool_result` are now accepted, but only on a slot that already carries a `tool_result`. Appended text on a plain user message is the user editing their own turn, and that still diverges. The existing test for it stays green.

## Blocks injected for one turn, then dropped

A Claude Code `UserPromptSubmit` hook writes to stdout. oh-my-openagent bridges that hook into OpenCode and injects the stdout as a `<user-prompt-submit-hook>` text block. The block rides on the turn that submits the prompt, and it is absent on the next turn.

`message[0]` therefore changes from `[text, text]` to `[text]` in the middle of a conversation. Prefix overlap is 0, so the whole conversation classifies as `unrelated-history`.

I measured this on 1.62.7 with an OpenCode client: 0 `continuation` lineages in 38 requests. The `pi` and `prime` adapters resumed normally over the same period.

`droppedEphemeralBlocksOnly()` resumes when the only differences in the stored region are blocks removed from user turns. Every surviving block must be byte-identical and in its original order.

## Why a resume is safe here

The difference is subtractive. The SDK session holds a superset of the history the client now sends, so a resume cannot skip anything the client believes it sent. That is the opposite of the direction guarded in #689, #692 and #712, where the client sends history the SDK session never saw.

Four conditions must all hold:

- The history grew. An equal or shorter history keeps the classification it has today.
- Every changed slot is a user turn. A changed assistant turn diverges.
- Every changed slot has strictly fewer blocks than the stored slot.
- Surviving blocks are byte-identical and still in their original order.

Both hash arrays must also cover the whole stored region. A short array would read an out-of-range `undefined` as "changed".

## Verification

I replayed the injected-block shape against 1.62.7 and against this branch. Turn 1 carries the injected block, turn 2 drops it and appends an exchange, turn 3 is steady state.

| Turn | 1.62.7 | This branch |
|---|---|---|
| 1, injected block present | new | new |
| 2, injected block dropped | new | continuation |
| 3, steady state | continuation | continuation |

Turn 2 is the case this PR changes. On 1.62.7 it replays the full history against a cold prompt cache.

131 tests pass across `lineage-unit`, `lineage-safety`, `session-lineage`, `lineage-thinking-blocks`, `opencode-title-agent-collision` and `proxy-concurrency-coordination`. Nine of them are new.

Every new guard has a test that fails when the guard is relaxed, and I checked that rather than assuming it. Disabling the new path fails the two positive tests. Relaxing the user-turn check and the ordered-subsequence check fails three negative tests.

## Scope

The append-only change alters an existing condition, so it can admit shapes I did not see in the field. The dropped-block path is new code and cannot change any classification that reaches it today, because every case it accepts currently returns `diverged`.

I did not touch the turn lease or the conflict response. A client that genuinely sends unrelated history still gets the 400.
