### PR TITLE
fix(passthrough): rewrite forwarded denials before each resume so the model never sees them

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -93,6 +93,7 @@ kill $(lsof -ti :3456)
 | E38 | [Silent turns (#768)](#e38-silent-turns-768) | **Automated**: `bun scripts/e2e-silent-turn.mjs` — real CLI, SSE mode. Asserts four things per attempt: the client got text or a tool call; recovered content sits BEFORE the terminal `message_delta` (content behind it is dropped by a correct client); exactly one `message_delta` per message; and a third turn after a recovery still resumes. Attribution is read from `/telemetry/logs`, not stdout. Pair `MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` against `MERIDIAN_SILENT_TURN_RECOVERY=0` for the before/after. **Run before any release touching the passthrough tool loop, prompt assembly, or session resume** | 2026-08-11 |
 | E39 | [OpenCode internal-agent session key (#845)](#e39-opencode-internal-agent-session-key-845) | **Manual**, real OpenCode: its `title` agent runs under the USER'S session id, so the user's first turn used to queue behind it and then get HTTP 400 `session_turn_conflict`. Asserts the first turn succeeds, waits ~0ms on the session lease, and every later request is `lineage=continuation`. **Run after any OpenCode upgrade and before releases touching session keys or the turn coordinator** | 2026-08-19 |
 | E40 | [Passthrough digest-turn cap](#e40-passthrough-digest-turn-cap) | **Automated**: `bun scripts/e2e-digest-turn-cap.mjs` — real SDK. Asserts the capped tool turn generates no digest text, costs materially less than uncapped on an identical prompt, still RESUMES at its captured checkpoint, leaves text-only turns returning `success`, and does not truncate parallel tool calls. **Run before any release touching the passthrough tool loop, `maxTurns`, or the early-stop checkpoint** | 2026-08-20 |
+| E41 | [Passthrough multi-turn: one call, one answer](#e41-passthrough-multi-turn-one-call-one-answer) | **Automated**: `bun scripts/e2e-passthrough-turns.mjs [--stream]` — real proxy, real SDK, an OpenCode-shaped client replaying history with tool_results over a chain of dependent calls (`PROBE_PARALLEL=1`: one parallel turn). Asserts the model's final answer quotes every delivered result and never claims a call went unanswered, that no forwarded denial remains stored for a delivered id, and that every continuation turn reads the previous turn's prompt cache in full — the repaired rows must not cost a byte of prefix. **Run before any release touching passthrough resume, the deny hook, or `passthroughTranscript.ts`** | 2026-08-25 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -122,6 +123,8 @@ cat /tmp/proxy-e2e.log | strings | grep "\[PROXY\]" | tail -5
 ```
 
 **Session header.** All curl tests use `x-opencode-session` to control session identity. This is the header the OpenCode adapter reads.
+
+**Diagnostics vs gates.** `scripts/e2e-*.mjs` are gates: they assert and exit non-zero. `scripts/probe-*.mjs` are not — they drive the same real stack but print findings for a human to read, and are deliberately absent from the index above so a green run is never mistaken for a passing gate. The passthrough probes reconstruct what `resumeSessionAt` would keep by reading the session JSONL the CLI wrote, which is the one thing the mocked suites cannot check. They need Claude Max and cost real tokens.
 
 **Cleanup.** Each test section is independent. Kill the proxy and clear the session store between sections if you need isolation:
 ```bash
@@ -3525,3 +3528,63 @@ cause. Read its `digest turns` line against the corpus it scanned: a machine
 running mostly internal-mode Claude Code has almost no passthrough transcripts,
 so a `0.0%` there means "little passthrough traffic here", not "the digest turn
 is cheap". Per-turn cost is what E40 measures.
+
+## E41: Passthrough multi-turn: one call, one answer
+
+**What it proves:** that across a *chain* of forwarded tool calls the model is
+only ever shown the client's real result for each call, never the hook's
+denial that the CLI wrote for it at the time of the call.
+
+**Why it needs a live SDK and several turns:** `resumeSessionAt` cuts a suffix,
+so it removes the current turn's denial and never a previous turn's; on the
+resume after that the CLI's loader splices the stale denial back beside the
+real result and keeps the first one. Nothing is wrong until the third turn,
+which is why every single-turn check passed while a live OpenCode session was
+telling the user its tools returned nothing. The mocked suites cannot see any
+of this — it lives in the CLI's transcript loader.
+
+```bash
+bun scripts/e2e-passthrough-turns.mjs            # non-stream
+bun scripts/e2e-passthrough-turns.mjs --stream   # stream
+```
+
+An OpenCode-shaped client asks for three files to be read one after another,
+executes each forwarded call itself, and replays the full history with the
+`tool_result` on the next request, until the model answers in text.
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- The final answer quotes all three delivered results and does not say a call
+  went unanswered
+- Every continuation turn, including a follow-up turn sent after the final
+  answer, reports `cache_read_input_tokens` of at least 95% of what the previous
+  turn had cached (`cache_read + cache_creation`). The follow-up turn is the one
+  whose prompt the CLI's loader builds *through* the repaired rows, so this is
+  where a repair that wrote anything other than what turn N+1 sent would show
+  up as a lost prefix. Measured 2026-08-25 on all four combinations
+  (chain/parallel x stream/non-stream): equal to the token, every turn
+- The session JSONL of every session the proxy **resumed** (`lineage=continuation`
+  in the per-turn readout) holds **no** forwarded denial for an id whose real
+  result was delivered (the denial was rewritten in place by
+  `passthroughTranscript.ts`). Sessions the proxy abandoned are not counted: a
+  passthrough tool turn without a checkpoint is evicted, so its transcript is
+  never loaded again and a denial left in it is dead, not stale. A run in which
+  no turn resumed (e.g. `MERIDIAN_PASSTHROUGH_EARLY_STOP=0`, where every turn is
+  `lineage=new`) says so and fails as inconclusive rather than passing vacuously
+
+**Proving the gate bites:** `git stash push src/proxy/server.ts`, run it, `git
+stash pop`. Unfixed it fails on both counts by the third turn — the model
+answers *"[Error: tool call forwarded to client, no content returned]"* for the
+first two files.
+
+`PROBE_PARALLEL=1` asks for the three reads in one turn instead of a chain, so
+the hook's denies arrive mid-generation and are held.
+
+**Mechanism at the SDK level:** `bun scripts/probe-passthrough-accumulation.mjs`
+drives the raw SDK the same way behind a recording proxy on
+`ANTHROPIC_BASE_URL`, so it shows the actual request bodies the model received
+— the denial winning and the real result gone — and with `--rewrite` applies
+the shipped repair before each resume. It is the reproduction; E41 is the gate.
+
+**Verified:** 2026-08-25, sonnet, both paths. Fixed: 4 turns, 3/3 quoted, 0
+stale denials. Stashed: 3 turns, 0/3 quoted, 2 stale denials.

--- a/scripts/e2e-passthrough-turns.mjs
+++ b/scripts/e2e-passthrough-turns.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env bun
+/**
+ * Multi-turn passthrough conversation through the REAL proxy.
+ *
+ * probe-passthrough-accumulation.mjs proves the defect and the repair at the
+ * SDK level. This drives Meridian itself the way OpenCode does: send a
+ * request with tools, execute the tool_use blocks it returns, replay the
+ * whole history plus tool_results as the next request, repeat until the
+ * model answers in text. The proxy strips ANTHROPIC_BASE_URL from the SDK
+ * subprocess, so the wire is not observable here; the verdict rests on two
+ * things that are:
+ *
+ *   - the model's final answer quotes every file it was handed, and it never
+ *     says a call went unanswered
+ *   - the session JSONL holds no forwarded denial for an id whose real result
+ *     was delivered
+ *
+ * Run it against the fix and it passes; stash src/proxy/server.ts and it
+ * fails on both counts by the third turn.
+ *
+ *   bun scripts/e2e-passthrough-turns.mjs [--stream]
+ */
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { snapshotSessionFiles as snapshot, readRows, blocksOf } from "./lib/passthrough-jsonl.mjs"
+import { isForwardedDenial } from "../src/proxy/passthroughTranscript.ts"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+process.env.OPENCODE_CLAUDE_PROVIDER_DEBUG = "1"
+const { startProxyServer } = await import("../src/proxy/server.ts")
+
+const STREAM = process.argv.includes("--stream")
+const PORT = Number(process.env.PROBE_PORT ?? 3522)
+const MODEL = process.env.PROBE_MODEL ?? "claude-sonnet-5"
+const MAX_TURNS = Number(process.env.PROBE_TURNS ?? 6)
+
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-proxy-"))
+const CONTENT = { "a.txt": "alpha", "b.txt": "bravo", "c.txt": "charlie" }
+const FILES = Object.keys(CONTENT).map(f => join(WORKDIR, f))
+for (const f of FILES) writeFileSync(f, CONTENT[f.slice(-5)] + "\n")
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file from disk",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string", description: "Absolute path" } },
+    required: ["file_path"],
+  },
+}
+
+// The proxy logs on stdout and stderr; keep both out of the probe's own
+// output and readable for the per-turn repair line.
+const say = console.log.bind(console)
+const proxyLog = []
+// claudeLog events go through console.debug, plog through console.error;
+// both must be captured or the repair readout below can never see its event.
+for (const k of ["log", "error", "debug"]) console[k] = (...args) => { proxyLog.push(args.map(String).join(" ")) }
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1" })
+const short = s => (typeof s === "string" && s.length > 10 ? s.slice(-8) : String(s))
+
+/** Parse either response shape into assistant content blocks plus usage. */
+async function assistantBlocks(res) {
+  const text = await res.text()
+  if (!STREAM) { const body = JSON.parse(text); return { blocks: body.content ?? [], usage: body.usage ?? {} } }
+  const blocks = []
+  let usage = {}
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data:")) continue
+    let ev
+    try { ev = JSON.parse(line.slice(5)) } catch { continue }
+    if (ev.type === "message_start") usage = { ...usage, ...(ev.message?.usage ?? {}) }
+    if (ev.type === "message_delta" && ev.usage) usage = { ...usage, ...ev.usage }
+    if (ev.type === "content_block_start") blocks[ev.index] = { ...ev.content_block, ...(ev.content_block.type === "tool_use" ? { _json: "" } : {}) }
+    if (ev.type === "content_block_delta") {
+      const b = blocks[ev.index]
+      if (ev.delta.type === "text_delta") b.text = (b.text ?? "") + ev.delta.text
+      if (ev.delta.type === "input_json_delta") b._json += ev.delta.partial_json
+    }
+  }
+  return { usage, blocks: blocks.filter(Boolean).map(b => {
+    if (b.type === "tool_use") { const { _json, ...rest } = b; return { ...rest, input: _json ? JSON.parse(_json) : (b.input ?? {}) } }
+    return b
+  }) }
+}
+
+/** One line of prompt-cache accounting: what was read from cache vs paid for. */
+const usageLine = u => {
+  const read = u.cache_read_input_tokens ?? 0, created = u.cache_creation_input_tokens ?? 0, fresh = u.input_tokens ?? 0
+  const total = read + created + fresh
+  return `cache_read=${read} cache_create=${created} input=${fresh} (${total ? Math.round(100 * read / total) : 0}% of ${total} input read from cache)`
+}
+
+// Prompt-cache continuity across resumes. Every continuation turn's prompt is
+// the previous turn's prompt plus a delta, so its cache_read must cover what
+// the previous turn had in cache (cache_read + cache_create). Measured, the
+// two are equal to the token; a shortfall means the resumed transcript no
+// longer matches what was sent — which is exactly what a repair that wrote a
+// different byte than the client delivered would cause.
+const CACHE_FLOOR = 0.95
+let priorCached = 0
+const cacheMisses = []
+function checkCache(label, usage, lineage) {
+  const read = usage.cache_read_input_tokens ?? 0
+  if (lineage.includes("continuation") && priorCached > 0 && read < CACHE_FLOOR * priorCached) {
+    cacheMisses.push(`${label}: cache_read=${read} < ${CACHE_FLOOR} x prior cached ${priorCached}`)
+  }
+  priorCached = read + (usage.cache_creation_input_tokens ?? 0)
+}
+
+async function send(messages) {
+  return fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": "dummy", "x-opencode-session": sessionId, "user-agent": "opencode/1.0.0" },
+    body: JSON.stringify({ model: MODEL, max_tokens: 2048, stream: STREAM, tools: [READ_TOOL], messages }),
+  })
+}
+
+const sessionId = `probe-turns-${STREAM ? "stream" : "nonstream"}-${process.pid}`
+// PROBE_PARALLEL=1 asks for all three reads in one turn, so the hook's denies
+// arrive while the turn is still generating and are HELD. Pair it with
+// DENY_HOLD_TIMEOUT_MS=1 to make the hold expire, which refuses the checkpoint
+// and forces the next turn through the text-path resume — the one way to
+// exercise that path from outside the proxy.
+const PARALLEL = process.env.PROBE_PARALLEL === "1"
+const messages = [{
+  role: "user",
+  content: PARALLEL
+    ? `Use the read tool to read ${FILES.join(", ")} — all three in a single turn, in parallel. ` +
+      `Once you have all three contents reply with them on one line and nothing else.`
+    : `Use the read tool to read ${FILES[0]}. Only after its content has been returned to you, ` +
+      `read ${FILES[1]}. Only after that content has been returned, read ${FILES[2]}. ` +
+      `Make exactly one read call per step, never in parallel, and once you have all three ` +
+      `reply with the three contents on one line and nothing else.`,
+}]
+
+const before = snapshot()
+const delivered = new Set()
+// Session-id prefixes the proxy actually RESUMED. Only their transcripts are
+// ever loaded again, so only they can replay a stale denial; a session the
+// proxy abandoned (lineage=new on the next turn) is dead and irrelevant.
+const resumedSessions = new Set()
+let finalText = ""
+
+for (let turn = 1; turn <= MAX_TURNS; turn++) {
+  const logFrom = proxyLog.length
+  const res = await send(messages)
+  const { blocks, usage } = await assistantBlocks(res)
+  const calls = blocks.filter(b => b.type === "tool_use")
+  const text = blocks.filter(b => b.type === "text").map(b => b.text).join("")
+  const turnLog = proxyLog.slice(logFrom)
+  const repaired = turnLog.filter(l => l.includes("denials_rewrit"))
+  const lineage = turnLog.map(l => l.match(/lineage=\S+ session=\S+/)?.[0]).find(Boolean) ?? "?"
+  const resumedPrefix = lineage.match(/lineage=continuation session=(\S+)/)?.[1]
+  if (resumedPrefix) resumedSessions.add(resumedPrefix)
+  say(`\n=== turn ${turn} (stream=${STREAM}) http ${res.status} ===`)
+  say(`  calls: ${calls.map(c => `${c.name}(${String(c.input?.file_path ?? "").slice(-5)})#${short(c.id)}`).join(", ") || "none"}`)
+  if (text) say(`  text: ${JSON.stringify(text.slice(0, 200))}`)
+  say(`  lineage: ${lineage}`)
+  say(`  usage: ${usageLine(usage)}`)
+  checkCache(`turn ${turn}`, usage, lineage)
+  say(`  proxy repair log: ${repaired.length ? repaired.map(l => l.replace(/^.*denials_rewrit/, "denials_rewrit").slice(0, 220)).join(" | ") : "none"}`)
+  if (res.status !== 200) { say(`  body: ${JSON.stringify(blocks).slice(0, 300)}`); break }
+
+  messages.push({ role: "assistant", content: blocks.map(({ type, id, name, input, text }) => type === "tool_use" ? { type, id, name, input } : { type, text }) })
+  if (calls.length === 0) { finalText = text; break }
+
+  // Execute the forwarded calls like a client would.
+  const results = calls.map(c => {
+    const p = String(c.input?.file_path ?? "")
+    let content
+    try { content = readFileSync(p, "utf8").trim() } catch (e) { content = `ERROR: ${e.message}` }
+    delivered.add(c.id)
+    return { type: "tool_result", tool_use_id: c.id, content: `REALOUTPUT[${content}]` }
+  })
+  messages.push({ role: "user", content: results })
+}
+
+// One more turn after the answer. Its prompt runs THROUGH the repaired rows —
+// the CLI's loader now splices them back beside the real results — so this is
+// where a byte of difference between what turn N+1 sent and what the repair
+// wrote would show up as a cache miss. Expect cache_read to cover the prior turn.
+if (finalText) {
+  const logFrom = proxyLog.length
+  const res = await send([...messages, { role: "user", content: "Reply with the single word OK." }])
+  const { usage } = await assistantBlocks(res)
+  const lineage = proxyLog.slice(logFrom).map(l => l.match(/lineage=\S+ session=\S+/)?.[0]).find(Boolean) ?? "?"
+  say(`\n=== follow-up turn (stream=${STREAM}) http ${res.status} ===`)
+  say(`  lineage: ${lineage}`)
+  say(`  usage: ${usageLine(usage)}`)
+  checkCache("follow-up", usage, lineage)
+}
+
+// The CLI flushes the transcript as the query settles; give it a beat.
+await new Promise(r => setTimeout(r, 1500))
+const touched = [...snapshot().entries()].filter(([p, m]) => !before.has(p) || before.get(p) !== m).map(([p]) => p)
+
+say(`\n=== verdict (stream=${STREAM}) ===`)
+const quotes = Object.values(CONTENT).filter(w => finalText.includes(w))
+const claimsUnanswered = /forwarded|no content|not returned|never returned|no result/i.test(finalText)
+say(`  turns used: ${messages.filter(m => m.role === "assistant").length}, calls delivered: ${delivered.size}`)
+say(`  final reply quotes ${quotes.length}/3 contents: ${quotes.join(",") || "none"}${claimsUnanswered ? "   <-- and claims a call went unanswered" : ""}`)
+const resumedFiles = touched.filter(f => [...resumedSessions].some(p => f.includes(`${p}`)))
+let staleDenials = 0
+for (const f of resumedFiles) {
+  const denials = readRows(f).flatMap(r => blocksOf(r).filter(b => isForwardedDenial(b) && delivered.has(b.tool_use_id)))
+  staleDenials += denials.length
+  say(`  ${f}\n    forwarded denials still stored for delivered ids: ${denials.length}${denials.length ? "   <-- REPLAYED ON THE NEXT RESUME" : "   (clean)"}`)
+}
+say(`  prompt cache across resumes: ${cacheMisses.length ? cacheMisses.join("; ") + "   <-- PREFIX LOST" : "every continuation read the prior turn's cache in full"}`)
+if (touched.length === 0) say("  no session JSONL was written — inconclusive")
+else if (resumedFiles.length === 0) say(`  no turn resumed a session (${touched.length} file(s) touched, all abandoned) — the stale-denial check cannot apply; the defect needs a resume`)
+const pass = quotes.length === 3 && !claimsUnanswered && staleDenials === 0 && resumedFiles.length > 0 && cacheMisses.length === 0
+say(`  ${pass ? "PASS" : "FAIL"}: one call, one answer, the real one`)
+
+await inst.stop?.()
+process.exit(pass ? 0 : 1)

--- a/scripts/lib/passthrough-jsonl.mjs
+++ b/scripts/lib/passthrough-jsonl.mjs
@@ -1,0 +1,78 @@
+/**
+ * Shared reader for the session JSONL the CLI writes behind Meridian.
+ *
+ * The passthrough probes all answer the same question — what would
+ * resumeSessionAt keep? — so they read the transcript the same way, from one
+ * copy.
+ *
+ * A denial is whatever src/proxy/passthroughTranscript.ts says it is: the
+ * proxy's own detector, imported rather than restated, so the probes and the
+ * repair can never disagree about which rows are the hook's denials. That
+ * matters after a repair: a delivered result that was itself an error is
+ * rewritten in place with is_error still set, and a reader keyed on is_error
+ * alone would count it as a surviving denial.
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { isForwardedDenial } from "../../src/proxy/passthroughTranscript.ts"
+
+const PROJECTS_ROOT = join(homedir(), ".claude", "projects")
+
+/** Locate the session JSONL the CLI wrote for a session id, whatever the cwd slug. */
+export function findSessionFile(sessionId) {
+  if (!existsSync(PROJECTS_ROOT)) return null
+  for (const dir of readdirSync(PROJECTS_ROOT)) {
+    const candidate = join(PROJECTS_ROOT, dir, `${sessionId}.jsonl`)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+/** Every session JSONL on disk with its mtime, for before/after diffing. */
+export function snapshotSessionFiles() {
+  const seen = new Map()
+  if (!existsSync(PROJECTS_ROOT)) return seen
+  for (const dir of readdirSync(PROJECTS_ROOT)) {
+    const full = join(PROJECTS_ROOT, dir)
+    let entries
+    try { entries = readdirSync(full) } catch { continue }
+    for (const f of entries) {
+      if (!f.endsWith(".jsonl")) continue
+      const p = join(full, f)
+      try { seen.set(p, statSync(p).mtimeMs) } catch { /* raced with a write */ }
+    }
+  }
+  return seen
+}
+
+export function readRows(file) {
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter(l => l.trim().length > 0)
+    .map(l => { try { return JSON.parse(l) } catch { return null } })
+    .filter(Boolean)
+}
+
+export const blocksOf = row => (Array.isArray(row?.message?.content) ? row.message.content : [])
+
+/** Flatten a tool_result's content to text, whichever shape it arrived in. */
+export function toolResultText(block) {
+  if (typeof block?.content === "string") return block.content
+  if (Array.isArray(block?.content)) return block.content.map(c => c?.text ?? "").join("")
+  return ""
+}
+
+/** A synthetic denial: the CLI's answer to a call the hook refused. */
+export const isDenyResult = isForwardedDenial
+
+/**
+ * Guard against a silent detection failure: a turn that forwarded calls must
+ * have produced denials, so finding none means the reader is broken, not that
+ * the transcript is clean. Returns a warning string, or null when all is well.
+ */
+export function denyDetectionWarning({ forwardedCalls, denyResults }) {
+  if (forwardedCalls === 0 || denyResults.length > 0) return null
+  return `${forwardedCalls} call(s) were forwarded but NO deny tool_result was found — ` +
+    `treat every "clean" result below as unproven; the reader, not the transcript, is probably wrong`
+}

--- a/scripts/probe-passthrough-accumulation.mjs
+++ b/scripts/probe-passthrough-accumulation.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+/**
+ * Multi-turn probe for the passthrough synthetic-denial defect.
+ * See ~/ss/claude/meridian-passthrough-spec.md — *Phase 3 field test*.
+ *
+ * A single-turn probe cannot see this defect: `resumeSessionAt` cuts a suffix,
+ * so it removes the current turn's denials and never a previous turn's. This
+ * one drives the raw Agent SDK through a chain of dependent tool calls, one
+ * per turn, resuming at the checkpoint each time exactly as Meridian does, and
+ * records WHAT THE MODEL WAS SENT via a recording proxy on ANTHROPIC_BASE_URL.
+ * The transcript on disk is shown too, with its parentUuid topology, because
+ * the CLI loads by walking that chain and then splicing back "orphaned"
+ * tool_results — which is how a logically truncated denial comes back.
+ *
+ * The one assertion that matters: on the wire, every call whose real result
+ * was delivered is answered exactly once, by that real result. "Answered more
+ * than once" is not enough — the CLI dedups tool_results per id and keeps the
+ * FIRST, so the observed failure is the denial winning and the real result
+ * vanishing.
+ *
+ *   bun scripts/probe-passthrough-accumulation.mjs            # measure: FAILs
+ *   bun scripts/probe-passthrough-accumulation.mjs --rewrite  # with the
+ *       shipped repair (src/proxy/passthroughTranscript.ts) applied before
+ *       each resume, exactly where server.ts applies it: PASSes
+ *
+ * Deleting the denial rows instead is not an option: the loader starts its
+ * chain walk from the `last-prompt` leaf hint, which points at the deleted
+ * row, and the resume fails with "No message found with message.uuid".
+ *
+ * Costs a few cents of real tokens and needs Claude Max.
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import http from "node:http"
+import https from "node:https"
+import { findSessionFile, readRows, blocksOf, toolResultText, isDenyResult } from "./lib/passthrough-jsonl.mjs"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+import { PASSTHROUGH_DENY_REASON, repairForwardedDenials, transcriptConfigDirs } from "../src/proxy/passthroughTranscript.ts"
+
+const FIX = process.argv.includes("--rewrite") ? "rewrite" : "none"
+const MODEL = process.env.PROBE_MODEL ?? "sonnet"
+const MAX_TURNS = Number(process.env.PROBE_TURNS ?? 5)
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-acc-"))
+const FILES = ["a.txt", "b.txt", "c.txt"].map(f => join(WORKDIR, f))
+const CONTENT = { "a.txt": "alpha", "b.txt": "bravo", "c.txt": "charlie" }
+for (const f of FILES) writeFileSync(f, CONTENT[f.slice(-5)] + "\n")
+
+const short = s => (typeof s === "string" && s.length > 10 ? s.slice(-8) : String(s))
+
+// ---------------------------------------------------------------- wire tap
+/**
+ * Minimal recording proxy: the CLI talks to it as ANTHROPIC_BASE_URL, it
+ * forwards to the real API and keeps every request body, labelled with the
+ * probe turn that produced it. Responses stream straight through.
+ */
+const wire = []
+let currentTurn = 0
+const UPSTREAM = new URL(process.env.PROBE_UPSTREAM ?? "https://api.anthropic.com")
+const tap = http.createServer((req, res) => {
+  const chunks = []
+  req.on("data", c => chunks.push(c))
+  req.on("end", () => {
+    const raw = Buffer.concat(chunks)
+    let body = null
+    try { body = JSON.parse(raw.toString("utf8")) } catch { /* not JSON */ }
+    if (body?.messages) wire.push({ turn: currentTurn, path: req.url, body })
+    const client = UPSTREAM.protocol === "https:" ? https : http
+    const up = client.request(
+      { hostname: UPSTREAM.hostname, port: UPSTREAM.port || undefined, path: req.url, method: req.method,
+        headers: { ...req.headers, host: UPSTREAM.host } },
+      u => { res.writeHead(u.statusCode ?? 502, u.headers); u.pipe(res) },
+    )
+    up.on("error", e => { res.writeHead(502); res.end(String(e)) })
+    up.end(raw)
+  })
+})
+await new Promise(r => tap.listen(0, "127.0.0.1", r))
+const TAP_URL = `http://127.0.0.1:${tap.address().port}`
+
+// ---------------------------------------------------------------- SDK drive
+const claudeExecutable = await resolveClaudeExecutableAsync()
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/** Mirrors the passthrough shape buildQueryOptions produces. */
+function options(extra = {}) {
+  return {
+    executable: "node",
+    maxTurns: 1,
+    cwd: WORKDIR,
+    model: MODEL,
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    env: { ...process.env, ANTHROPIC_BASE_URL: TAP_URL },
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          return { decision: "block", reason: PASSTHROUGH_DENY_REASON }
+        }],
+      }],
+    },
+    ...extra,
+  }
+}
+
+async function drive(prompt, extra) {
+  const out = { sessionId: "", subtype: null, text: "", calls: [], checkpointUuid: "", threw: undefined }
+  try {
+    for await (const m of query({ prompt, options: options(extra) })) {
+      if (m.session_id && !out.sessionId) out.sessionId = m.session_id
+      if (m.type === "assistant") {
+        let armed = false
+        for (const b of m.message?.content ?? []) {
+          if (b.type === "tool_use") { out.calls.push({ id: b.id, name: b.name, input: b.input }); armed = true }
+          if (b.type === "text") out.text += b.text
+        }
+        if (armed) out.checkpointUuid = m.uuid ?? ""
+      }
+      if (m.type === "result") out.subtype = m.subtype
+    }
+  } catch (e) {
+    out.threw = e instanceof Error ? e.message : String(e)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------- reporting
+function describeRow(row, index) {
+  const blocks = blocksOf(row).map(b => {
+    if (b.type === "tool_use") return `tool_use:${short(b.id)}(${b.name})`
+    if (b.type === "tool_result") return `tool_result:${short(b.tool_use_id)}=${isDenyResult(b) ? "DENY" : JSON.stringify(toolResultText(b).slice(0, 20))}`
+    return b.type
+  })
+  const content = typeof row.message?.content === "string" ? JSON.stringify(row.message.content.slice(0, 30)) : blocks.join(",")
+  return `[${String(index).padStart(2)}] ${(row.type ?? "?").padEnd(9)} uuid=${short(row.uuid)} parent=${short(row.parentUuid) ?? "-"}  ${content}`
+}
+
+function dumpTranscript(label, file) {
+  const rows = readRows(file)
+  console.log(`  --- ${label}: ${rows.length} rows on disk`)
+  rows.forEach((r, i) => console.log("    " + describeRow(r, i)))
+  return rows
+}
+
+/** tool_use_id -> list of answers, from a request body's messages. */
+function answersOnWire(body) {
+  const byId = new Map()
+  for (const m of body.messages ?? []) {
+    if (m.role !== "user" || !Array.isArray(m.content)) continue
+    for (const b of m.content) {
+      if (b?.type !== "tool_result") continue
+      const list = byId.get(b.tool_use_id) ?? []
+      list.push(isDenyResult(b) ? "DENY" : "REAL")
+      byId.set(b.tool_use_id, list)
+    }
+  }
+  return byId
+}
+
+/**
+ * The wire report for one probe turn: what the model saw for every id.
+ * Returns how many DELIVERED ids were misanswered — anything other than a
+ * single REAL result.
+ */
+function reportWire(turn, delivered) {
+  // The first turn also fires side requests (title generation); only the
+  // conversation requests carry history worth reading.
+  const reqs = wire.filter(w => w.turn === turn && w.body.messages.length > 1)
+  if (reqs.length === 0) { console.log(`  wire: ${delivered.size === 0 ? "first turn, nothing to check" : "NO REQUEST RECORDED (is ANTHROPIC_BASE_URL honoured?)"}`); return 0 }
+  let bad = 0
+  for (const [i, r] of reqs.entries()) {
+    const byId = answersOnWire(r.body)
+    const wrong = [...delivered].filter(id => (byId.get(id) ?? []).join() !== "REAL")
+    bad += wrong.length
+    const denialTexts = JSON.stringify(r.body).split(PASSTHROUGH_DENY_REASON.slice(0, 40)).length - 1
+    console.log(`  wire request ${i + 1}/${reqs.length}: ${r.body.messages.length} messages, ` +
+      `${byId.size} id(s) answered, ${wrong.length} delivered id(s) MISANSWERED, denial text present ${denialTexts}x`)
+    for (const [id, answers] of byId) {
+      const verdict = !delivered.has(id) ? "" : answers.join() === "REAL" ? "  ok" : "  <-- WRONG (real result was delivered)"
+      console.log(`    ${short(id)}: ${answers.join(" then ")}${verdict}`)
+    }
+  }
+  return bad
+}
+
+// ---------------------------------------------------------------- run
+console.log(`model=${MODEL} fix=${FIX} workdir=${WORKDIR} tap=${TAP_URL}`)
+
+const prompt =
+  `Use the read tool to read ${FILES[0]}. Only after its content has been returned to you, ` +
+  `read ${FILES[1]}. Only after that content has been returned, read ${FILES[2]}. ` +
+  `Make exactly one read call per step, never in parallel, and once you have all three ` +
+  `reply with the three contents on one line and nothing else.`
+
+let sessionId = ""
+let checkpoint = ""
+let pendingCalls = []
+let file = null
+let totalBad = 0
+let lastText = ""
+const delivered = new Set()
+
+for (let turn = 1; turn <= MAX_TURNS; turn++) {
+  currentTurn = turn
+  console.log(`\n=== turn ${turn} ${turn === 1 ? "(first)" : `(resume at ${short(checkpoint)}, answering ${pendingCalls.map(c => short(c.id)).join(",")})`} ===`)
+
+  let result
+  if (turn === 1) {
+    result = await drive(prompt)
+  } else {
+    const realResults = pendingCalls.map(c => ({
+      type: "tool_result",
+      tool_use_id: c.id,
+      content: `REALOUTPUT[${CONTENT[String(c.input?.file_path ?? "").slice(-5)] ?? "?"}]`,
+    }))
+    if (FIX === "rewrite") {
+      const repair = repairForwardedDenials({ sessionId, configDirs: transcriptConfigDirs(process.env), results: realResults })
+      console.log(`  repair: rewrote ${repair.rewritten} denial(s) in ${repair.file ?? "(no transcript found)"}`)
+    }
+    for (const c of pendingCalls) delivered.add(c.id)
+    const delta = (async function* () {
+      yield { type: "user", session_id: sessionId, parent_tool_use_id: null, message: { role: "user", content: realResults } }
+    })()
+    result = await drive(delta, { resume: sessionId, resumeSessionAt: checkpoint })
+  }
+
+  if (turn === 1) sessionId = result.sessionId
+  console.log(`  subtype=${result.subtype} threw=${result.threw ?? "no"} calls=${result.calls.map(c => `${c.name}(${String(c.input?.file_path ?? "").slice(-5)})`).join(",") || "none"}`)
+  if (result.text) console.log(`  text=${JSON.stringify(result.text.slice(0, 160))}`)
+  lastText = result.text
+
+  file ??= findSessionFile(sessionId)
+  if (!file) { console.log("FAIL: no session JSONL found"); process.exit(1) }
+  dumpTranscript(`transcript after turn ${turn}`, file)
+  totalBad += reportWire(turn, delivered)
+
+  if (result.calls.length === 0) break
+  pendingCalls = result.calls
+  checkpoint = result.checkpointUuid
+}
+
+console.log(`\n=== verdict (fix=${FIX}) ===`)
+const quotes = ["alpha", "bravo", "charlie"].filter(w => lastText.includes(w))
+console.log(`  delivered ids misanswered on the wire, summed over turns: ${totalBad}`)
+console.log(`  final reply quotes ${quotes.length}/3 contents: ${quotes.join(",") || "none"}`)
+const pass = totalBad === 0 && quotes.length === 3
+console.log(`  ${pass ? "PASS" : "FAIL"}: one call, one answer, the real one`)
+console.log(`\nsession file: ${file}`)
+tap.close()
+process.exit(pass ? 0 : 1)

--- a/scripts/probe-passthrough-ordering.mjs
+++ b/scripts/probe-passthrough-ordering.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * Phase 1 follow-up: WHY does a deny survive resumeSessionAt truncation?
+ *
+ * probe-passthrough-transcript.mjs showed the mechanism is positional, not
+ * random. The CLI writes per-block assistant rows and dispatches each block's
+ * PreToolUse hook as soon as that block finishes streaming, so a 2-call turn
+ * lands on disk interleaved:
+ *
+ *     [6] assistant tool_use #1
+ *     [7] user      tool_result #1 = DENY      <-- inside the slice
+ *     [8] assistant tool_use #2                <-- checkpoint (last tool-bearing)
+ *     [9] user      tool_result #2 = DENY      <-- sliced away
+ *
+ * resumeSessionAt slices to (0, checkpointIndex + 1), so the first N-1 denies
+ * of an N-call turn are replayed to the model and the Nth is not. Picking the
+ * FIRST assistant row instead would drop forwarded tool_use blocks, which
+ * dangles the client's results — so no single index is clean while the denies
+ * interleave.
+ *
+ * This probe tests the two predictions that follow, and the one lever that
+ * could already be doing the job in production:
+ *
+ *   A. N=1 leaves ZERO survivors (the defect needs parallelism).
+ *   B. N=3 leaves TWO survivors (survivors == N-1).
+ *   C. Holding the deny until the turn finishes generating — what Meridian's
+ *      holdDenyUntilTurnEnd already does — reorders the log to A1,A2,U1,U2 and
+ *      leaves zero survivors.
+ *
+ * If C holds, the production defect is confined to the paths where the hold
+ * does NOT apply, and the fix is to close those gaps rather than to redesign
+ * the boundary.
+ *
+ * Costs real tokens and needs Claude Max.
+ *
+ *   bun scripts/probe-passthrough-ordering.mjs
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { findSessionFile, readRows, blocksOf, isDenyResult as isDeny } from "./lib/passthrough-jsonl.mjs"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+
+const MODEL = process.env.PROBE_MODEL ?? "sonnet"
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-order-"))
+const FILES = ["a.txt", "b.txt", "c.txt"].map(n => join(WORKDIR, n))
+for (const [i, f] of FILES.entries()) writeFileSync(f, `content-${i}\n`)
+
+const DENY_REASON =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+const claudeExecutable = await resolveClaudeExecutableAsync()
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/**
+ * @param holdMs 0 = answer the hook immediately (today's raw shape).
+ *               >0 = stall every deny, standing in for holdDenyUntilTurnEnd.
+ */
+function options(holdMs) {
+  return {
+    executable: "node",
+    maxTurns: 1,
+    cwd: WORKDIR,
+    model: MODEL,
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          if (holdMs > 0) await sleep(holdMs)
+          return { decision: "block", reason: DENY_REASON }
+        }],
+      }],
+    },
+  }
+}
+
+async function run(label, fileCount, holdMs) {
+  const targets = FILES.slice(0, fileCount)
+  const prompt = fileCount === 1
+    ? `Read ${targets[0]} using the read tool. Use the tool, do not guess.`
+    : `Read all of ${targets.join(" and ")} using the read tool, in parallel in a single step.`
+
+  let sessionId = ""
+  let checkpointUuid = ""
+  const callIds = new Set()
+  // The SDK throws on the terminal error_max_turns result rather than yielding
+  // it, so the cap is a normal outcome here and not a failure.
+  try {
+    for await (const m of query({ prompt, options: options(holdMs) })) {
+      if (m.session_id && !sessionId) sessionId = m.session_id
+      if (m.type === "assistant") {
+        let armed = false
+        for (const b of m.message?.content ?? []) {
+          if (b.type === "tool_use") { callIds.add(b.id); armed = true }
+        }
+        if (armed) checkpointUuid = m.uuid ?? ""
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    if (!msg.includes("maximum number of turns")) throw e
+  }
+
+  const file = findSessionFile(sessionId)
+  if (!file) return console.log(`  ${label}: no session file`), null
+
+  const rows = readRows(file)
+  // Only the conversation rows matter — the CLI also writes queue/attachment
+  // bookkeeping rows that carry no content blocks.
+  const shape = rows
+    .map((r, i) => {
+      const bs = blocksOf(r)
+      if (r.type === "assistant" && bs.some(b => b.type === "tool_use")) return { i, tag: "A" }
+      if (r.type === "user" && bs.some(b => b.type === "tool_result" && isDeny(b))) return { i, tag: "U" }
+      return null
+    })
+    .filter(Boolean)
+
+  const checkpointIndex = rows.findIndex(r => r.uuid === checkpointUuid)
+  const kept = checkpointIndex >= 0 ? rows.slice(0, checkpointIndex + 1) : []
+  const survivors = kept.flatMap(r => blocksOf(r).filter(b => b.type === "tool_result" && isDeny(b)))
+  const keptCalls = kept.flatMap(r => blocksOf(r).filter(b => b.type === "tool_use" && callIds.has(b.id)))
+
+  console.log(`  ${label}`)
+  console.log(`    calls=${callIds.size}  log order: ${shape.map(s => s.tag).join("")}  checkpoint=row ${checkpointIndex}`)
+  console.log(`    denies surviving the slice: ${survivors.length}   (expected N-1 = ${callIds.size - 1} when interleaved)`)
+  console.log(`    forwarded tool_use kept:    ${keptCalls.length} of ${callIds.size}${keptCalls.length < callIds.size ? "   <-- DANGLING client result" : ""}`)
+  return { calls: callIds.size, survivors: survivors.length, shape: shape.map(s => s.tag).join("") }
+}
+
+console.log(`model=${MODEL}  workdir=${WORKDIR}\n`)
+console.log("A. single call, no hold — does the defect need parallelism?")
+const a = await run("N=1, hold=0", 1, 0)
+console.log("\nB. three calls, no hold — do survivors track N-1?")
+const b = await run("N=3, hold=0", 3, 0)
+console.log("\nC. three calls, deny held past generation — does the hold reorder the log?")
+const c = await run("N=3, hold=2500ms", 3, 2500)
+
+console.log("\n=== verdict ===")
+if (a) console.log(`  A  N=1 survivors=${a.survivors}  ${a.survivors === 0 ? "OK — a lone call is clean" : "UNEXPECTED — the defect is not positional"}`)
+if (b) console.log(`  B  N=${b.calls} survivors=${b.survivors}  ${b.survivors === b.calls - 1 ? "OK — survivors == N-1" : "UNEXPECTED"}`)
+if (c) console.log(`  C  N=${c.calls} survivors=${c.survivors} order=${c.shape}  ${c.survivors === 0 ? "the hold ALREADY fixes the ordering" : "the hold does NOT fix it"}`)
+console.log(`\nworkdir: ${WORKDIR}`)

--- a/scripts/probe-passthrough-proxy.mjs
+++ b/scripts/probe-passthrough-proxy.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+/**
+ * Phase 3 measurement: does the REAL proxy produce a clean transcript ordering?
+ *
+ * probe-passthrough-ordering.mjs proved the rule against the raw SDK: with N
+ * parallel calls the session JSONL interleaves (A U A U A U) and resumeSessionAt
+ * replays the first N-1 denials to the model, unless the denials are held until
+ * generation ends, which reorders it to A A A U U U.
+ *
+ * Meridian holds denials already (holdDenyUntilTurnEnd), but only the streaming
+ * path releases on the turn boundary. Non-stream releases on the FIRST assistant
+ * message and clears turnGenerating with it, so every later parallel block skips
+ * the hold. This drives the actual proxy on both paths and reads the SDK session
+ * JSONL it produced, so the answer is measured rather than reasoned about.
+ *
+ *   bun scripts/probe-passthrough-proxy.mjs
+ */
+import {
+  snapshotSessionFiles as snapshot,
+  readRows,
+  blocksOf,
+  isDenyResult as isDeny,
+  denyDetectionWarning,
+} from "./lib/passthrough-jsonl.mjs"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+const { startProxyServer } = await import("../src/proxy/server.ts")
+
+const PORT = Number(process.env.PROBE_PORT ?? 3521)
+const MODEL = process.env.PROBE_MODEL ?? "claude-sonnet-5"
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file from disk",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string", description: "Absolute path" } },
+    required: ["file_path"],
+  },
+}
+
+// plog is the only place the checkpoint decision is observable, and it is
+// gated by `silent`, so run the server loud and divert its output here.
+const proxyLog = []
+console.error = (...args) => { proxyLog.push(args.map(String).join(" ")) }
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1" })
+
+/**
+ * Replay the tracker's own checkpoint rule over the log.
+ *
+ * NOT "the last assistant row with a tool_use": shouldEarlyStop freezes the
+ * checkpoint the moment every CURRENTLY known call is resolved, and after that
+ * noteAssistantMessage is no longer called. A later parallel call therefore
+ * lands past the checkpoint and is dropped from the client-facing set rather
+ * than replayed. Both failures matter and they are different:
+ *
+ *   survivors > 0  a deny sits inside the slice and is replayed to the model
+ *   dropped   > 0  the model called N tools and the client was handed fewer
+ */
+function analyze(file) {
+  const rows = readRows(file)
+  const shape = []
+  const expected = new Set()
+  const resolved = new Set()
+  const turnOfCall = new Map()
+  let checkpointIndex = -1
+  let checkpointTurnId
+  let frozen = false
+  let dropped = 0
+
+  for (const [i, r] of rows.entries()) {
+    const bs = blocksOf(r)
+    const calls = bs.filter(b => b.type === "tool_use" && String(b.name ?? "").startsWith("mcp__oc__"))
+    const denies = bs.filter(b => b.type === "tool_result" && isDeny(b))
+    if (r.type === "assistant" && calls.length > 0) {
+      shape.push("A")
+      const fresh = calls.filter(b => !expected.has(b.id))
+      // Calls of ONE model turn share an API message id. A call carrying a
+      // different id belongs to a later turn, so excluding it is correct, not a
+      // drop — without this the two are indistinguishable in the totals.
+      const msgId = r.message?.id
+      for (const b of fresh) turnOfCall.set(b.id, msgId)
+      if (frozen) { dropped += fresh.length; continue }
+      for (const b of fresh) expected.add(b.id)
+      if (fresh.length > 0) { checkpointIndex = i; checkpointTurnId = msgId }
+    } else if (r.type === "user" && denies.length > 0) {
+      shape.push("U")
+      if (frozen) continue
+      for (const b of denies) resolved.add(b.tool_use_id)
+      if (expected.size > 0 && [...expected].every(id => resolved.has(id))) frozen = true
+    }
+  }
+  if (expected.size === 0 && dropped === 0) return null
+
+  const kept = checkpointIndex >= 0 ? rows.slice(0, checkpointIndex + 1) : []
+  const survivors = kept.flatMap(r => blocksOf(r).filter(b => b.type === "tool_result" && isDeny(b)))
+  // Of the calls left out, how many belonged to the checkpoint's own turn?
+  // Those are the real drops; the rest are later-turn calls, correctly excluded.
+  const sameTurnDropped = [...turnOfCall.entries()]
+    .filter(([id, mid]) => !expected.has(id) && mid !== undefined && mid === checkpointTurnId)
+    .length
+  const turnIds = new Set([...turnOfCall.values()].filter(Boolean))
+  const allDenies = rows.flatMap(r => blocksOf(r).filter(isDeny))
+  return {
+    warning: denyDetectionWarning({ forwardedCalls: expected.size + dropped, denyResults: allDenies }),
+    file,
+    calls: expected.size + dropped,
+    delivered: expected.size,
+    dropped,
+    sameTurnDropped,
+    turns: turnIds.size,
+    shape: shape.join(""),
+    checkpointIndex,
+    survivors: survivors.length,
+  }
+}
+
+async function drive(label, stream) {
+  const before = snapshot()
+  const sessionId = `probe-${stream ? "stream" : "nonstream"}-${process.pid}`
+  const body = {
+    model: MODEL,
+    max_tokens: 2048,
+    stream,
+    tools: [READ_TOOL],
+    messages: [{
+      role: "user",
+      content:
+        "Read all three of /tmp/a.txt, /tmp/b.txt and /tmp/c.txt using the read tool, " +
+        "in parallel in a single step. Use the tool, do not guess.",
+    }],
+  }
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": sessionId,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const toolCalls = (text.match(/"type":"tool_use"/g) ?? []).length
+
+  // The CLI flushes the transcript as the query settles; give it a beat.
+  await new Promise(r => setTimeout(r, 1500))
+  const after = snapshot()
+  const touched = [...after.entries()]
+    .filter(([p, m]) => !before.has(p) || before.get(p) !== m)
+    .map(([p]) => p)
+
+  console.log(`\n=== ${label} (stream=${stream}) ===`)
+  console.log(`  http ${res.status}  tool_use blocks in response: ${toolCalls}`)
+  if (touched.length === 0) console.log("  no session JSONL was written or updated")
+  const results = []
+  for (const f of touched) {
+    const a = analyze(f)
+    if (!a) continue
+    results.push(a)
+    console.log(`  ${a.file}`)
+    console.log(`    model called ${a.calls}  order=${a.shape}  checkpoint=row ${a.checkpointIndex}`)
+    if (a.warning) console.log(`    !! ${a.warning}`)
+    console.log(`    denials surviving the slice: ${a.survivors}${a.survivors > 0 ? "   <-- REPLAYED TO THE MODEL" : a.warning ? "   (UNPROVEN)" : "   (clean)"}`)
+    console.log(`    calls delivered to client:  ${a.delivered} of ${a.calls} across ${a.turns} model turn(s)`)
+    if (a.dropped > 0) {
+      console.log(`      left out: ${a.dropped} (${a.sameTurnDropped} from the checkpoint's OWN turn${a.sameTurnDropped > 0 ? " <-- REAL DROP" : ", i.e. none — the rest are later-turn calls, correctly excluded"})`)
+    }
+  }
+  return results
+}
+
+const streamed = await drive("streaming path", true)
+const nonStreamed = await drive("non-streaming path", false)
+
+console.log("\n=== verdict ===")
+const worst = rs => rs.reduce((n, r) => Math.max(n, r.survivors), 0)
+const parallel = rs => rs.some(r => r.calls > 1)
+for (const [label, rs] of [["stream    ", streamed], ["non-stream", nonStreamed]]) {
+  if (rs.length === 0) { console.log(`  ${label}  no forwarded calls captured — inconclusive`); continue }
+  if (!parallel(rs)) { console.log(`  ${label}  only ${rs[0].calls} call(s) — the defect needs parallelism, inconclusive`); continue }
+  const drops = rs.reduce((n, r) => n + r.sameTurnDropped, 0)
+  const issues = []
+  if (worst(rs) > 0) issues.push(`${worst(rs)} denial(s) replayed`)
+  if (drops > 0) issues.push(`${drops} same-turn call(s) dropped`)
+  console.log(`  ${label}  ${issues.length === 0 ? "CLEAN" : "LEAKS — " + issues.join(", ")}`)
+}
+
+await inst.stop?.()
+process.exit(0)

--- a/scripts/probe-passthrough-transcript.mjs
+++ b/scripts/probe-passthrough-transcript.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env bun
+/**
+ * Phase 1 ground-truth probe for the passthrough synthetic-denial defect.
+ * See ~/ss/claude/meridian-passthrough-spec.md — this answers questions 1-4
+ * by reading the session JSONL the SDK actually writes, not by reasoning
+ * about Meridian's code.
+ *
+ * It drives the raw Agent SDK in the exact passthrough shape (deny hook +
+ * maxTurns 1), then dumps every JSONL row so the answers are observed:
+ *
+ *   Q3  Is the deny stored as the call's tool_result?
+ *   Q3b Does it survive `resumeSessionAt` truncation, which slices the loaded
+ *       transcript to (0, checkpointIndex + 1)?  Interleaved per-block
+ *       assistant messages would leave earlier denies INSIDE the slice.
+ *   Q4  What happens when the resumed turn supplies a real tool_result for a
+ *       tool_use_id the session already answered?
+ *
+ * Costs a few cents of real tokens and needs Claude Max.
+ *
+ *   bun scripts/probe-passthrough-transcript.mjs
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { findSessionFile, readRows, toolResultText, isDenyResult } from "./lib/passthrough-jsonl.mjs"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+
+const MODEL = process.env.PROBE_MODEL ?? "sonnet"
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-"))
+const A = join(WORKDIR, "a.txt")
+const B = join(WORKDIR, "b.txt")
+writeFileSync(A, "alpha\n")
+writeFileSync(B, "bravo\n")
+
+const DENY_REASON =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+const claudeExecutable = await resolveClaudeExecutableAsync()
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/** Mirrors the passthrough shape buildQueryOptions produces. */
+function options(maxTurns, extra = {}) {
+  return {
+    executable: "node",
+    maxTurns,
+    cwd: WORKDIR,
+    model: MODEL,
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          return { decision: "block", reason: DENY_REASON }
+        }],
+      }],
+    },
+    ...extra,
+  }
+}
+
+/** Drive one query, recording the iterator's view of the turn. */
+async function drive(prompt, maxTurns, extra) {
+  const out = {
+    sessionId: "",
+    subtype: null,
+    text: "",
+    /** every forwarded tool_use, in iterator order */
+    calls: [],
+    /** the assistant UUID Meridian would freeze as the checkpoint */
+    checkpointUuid: "",
+    /** iterator-order log of assistant/user messages */
+    iterator: [],
+  }
+  try {
+    for await (const m of query({ prompt, options: options(maxTurns, extra) })) {
+      if (m.session_id && !out.sessionId) out.sessionId = m.session_id
+      if (m.type === "assistant") {
+        const blocks = m.message?.content ?? []
+        out.iterator.push(`assistant[${blocks.map(b => b.type).join(",")}] uuid=${short(m.uuid)}`)
+        let armed = false
+        for (const b of blocks) {
+          if (b.type === "tool_use") {
+            out.calls.push({ id: b.id, name: b.name, input: b.input })
+            armed = true
+          }
+          if (b.type === "text") out.text += b.text
+        }
+        // noteAssistantMessage: a newer tool-bearing message supersedes the
+        // older checkpoint.
+        if (armed) out.checkpointUuid = m.uuid ?? ""
+      }
+      if (m.type === "user") {
+        const blocks = Array.isArray(m.message?.content) ? m.message.content : []
+        out.iterator.push(
+          `user[${blocks.map(b => b.type + (b.tool_use_id ? `:${short(b.tool_use_id)}` : "")).join(",")}]`,
+        )
+      }
+      if (m.type === "result") out.subtype = m.subtype
+    }
+  } catch (e) {
+    out.threw = e instanceof Error ? e.message : String(e)
+  }
+  return out
+}
+
+const short = s => (typeof s === "string" && s.length > 10 ? s.slice(-8) : String(s))
+
+/** One-line summary of a JSONL row: what it is and what it answers. */
+function describe(row) {
+  const kind = row.type ?? "?"
+  const content = row.message?.content
+  let blocks = ""
+  if (Array.isArray(content)) {
+    blocks = content
+      .map(b => {
+        if (b.type === "tool_use") return `tool_use:${short(b.id)}(${b.name})`
+        if (b.type === "tool_result") {
+          const text = toolResultText(b)
+          return `tool_result:${short(b.tool_use_id)}${b.is_error ? "!err" : ""}=${isDenyResult(b) ? "DENY" : JSON.stringify(text.slice(0, 24))}`
+        }
+        return b.type
+      })
+      .join(",")
+  } else if (typeof content === "string") {
+    blocks = JSON.stringify(content.slice(0, 40))
+  }
+  return `${kind}${row.isMeta ? "/meta" : ""}${row.subtype ? `/${row.subtype}` : ""} uuid=${short(row.uuid)} [${blocks}]`
+}
+
+/** Every tool_result id carried by a row, with whether it is a deny. */
+function toolResultsIn(row) {
+  const content = row.message?.content
+  if (!Array.isArray(content)) return []
+  const out = []
+  for (const b of content) {
+    if (b?.type !== "tool_result") continue
+    out.push({ id: b.tool_use_id, deny: isDenyResult(b), text: toolResultText(b) })
+  }
+  return out
+}
+
+function dump(label, file) {
+  const rows = readRows(file)
+  console.log(`\n--- ${label}: ${rows.length} rows — ${file}`)
+  rows.forEach((r, i) => console.log(`  [${String(i).padStart(2)}] ${describe(r)}`))
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+
+console.log(`model=${MODEL}  workdir=${WORKDIR}`)
+
+console.log("\n=== 1. capped passthrough turn with PARALLEL calls ===")
+const turn = await drive(
+  `Read both ${A} and ${B} using the read tool, in parallel in a single step.`,
+  1,
+)
+console.log(`  session=${turn.sessionId} subtype=${turn.subtype} calls=${turn.calls.length}`)
+console.log(`  checkpoint(assistant uuid)=${short(turn.checkpointUuid)}`)
+console.log("  iterator order:")
+for (const line of turn.iterator) console.log(`    ${line}`)
+
+const file = findSessionFile(turn.sessionId)
+if (!file) {
+  console.log("\nFAIL: no session JSONL found — cannot answer Q3/Q4.")
+  process.exit(1)
+}
+const rows = dump("JSONL after the capped turn", file)
+
+// Q3 — is the deny stored as the call's tool_result?
+const denies = rows.flatMap((r, i) => toolResultsIn(r).filter(t => t.deny).map(t => ({ ...t, index: i })))
+console.log("\n=== Q3: is the deny persisted as the call's tool_result? ===")
+console.log(`  ${denies.length > 0 ? "YES" : "NO"} — ${denies.length} deny tool_result(s) on disk`)
+for (const d of denies) console.log(`    row ${d.index}  tool_use_id=${short(d.id)}`)
+
+// Q3b — does it survive resumeSessionAt truncation?
+const checkpointIndex = rows.findIndex(r => r.uuid === turn.checkpointUuid)
+console.log("\n=== Q3b: does the deny survive resumeSessionAt truncation? ===")
+console.log(`  checkpoint row index = ${checkpointIndex} of ${rows.length - 1}`)
+if (checkpointIndex < 0) {
+  console.log("  the checkpoint UUID is NOT in the JSONL — resume would fail with missing-message")
+} else {
+  const kept = rows.slice(0, checkpointIndex + 1)
+  const survivors = kept.flatMap((r, i) => toolResultsIn(r).filter(t => t.deny).map(t => ({ ...t, index: i })))
+  console.log(`  slice(0, ${checkpointIndex + 1}) keeps ${kept.length} rows`)
+  console.log(`  deny tool_results INSIDE the slice: ${survivors.length}`)
+  for (const s of survivors) console.log(`    row ${s.index}  tool_use_id=${short(s.id)}  <-- REPLAYED TO THE MODEL`)
+  if (survivors.length === 0) {
+    console.log("  => the truncation removes every deny; the resumed history is clean")
+  }
+  const callIds = new Set(turn.calls.map(c => c.id))
+  const keptCalls = kept.flatMap(r =>
+    (Array.isArray(r.message?.content) ? r.message.content : [])
+      .filter(b => b?.type === "tool_use" && callIds.has(b.id))
+      .map(b => b.id))
+  console.log(`  forwarded tool_use blocks inside the slice: ${keptCalls.length} of ${callIds.size}`)
+  const missing = [...callIds].filter(id => !keptCalls.includes(id))
+  if (missing.length) console.log(`    MISSING from the slice: ${missing.map(short).join(", ")} <-- dangling client result`)
+}
+
+// Q4 — resume with a real tool_result for an already-answered id.
+console.log("\n=== 2. resume at the checkpoint with REAL tool_results ===")
+const realResults = turn.calls.map(c => ({
+  type: "tool_result",
+  tool_use_id: c.id,
+  content: `REALOUTPUT[${c.input?.file_path?.endsWith("a.txt") ? "alpha" : "bravo"}]`,
+}))
+const delta = (async function* () {
+  yield {
+    type: "user",
+    session_id: turn.sessionId,
+    parent_tool_use_id: null,
+    message: { role: "user", content: realResults },
+  }
+})()
+const resumed = await drive(delta, 1, { resume: turn.sessionId, resumeSessionAt: turn.checkpointUuid })
+console.log(`  subtype=${resumed.subtype} threw=${resumed.threw ?? "no"}`)
+console.log(`  text=${JSON.stringify(resumed.text.slice(0, 200))}`)
+console.log(`  quotes the real output: ${resumed.text.includes("alpha") || resumed.text.includes("bravo") || resumed.text.includes("REALOUTPUT")}`)
+console.log(`  re-called the tool: ${resumed.calls.length > 0} (${resumed.calls.length} call(s))`)
+
+const resumedFile = findSessionFile(resumed.sessionId) ?? file
+const rows2 = dump("JSONL after the resume", resumedFile)
+console.log(`  resumed session id ${resumed.sessionId === turn.sessionId ? "REUSED" : `FORKED (${resumed.sessionId})`}`)
+
+console.log("\n=== Q4: two results for one tool_use_id? ===")
+const byId = new Map()
+for (const [i, r] of rows2.entries()) {
+  for (const t of toolResultsIn(r)) {
+    if (!byId.has(t.id)) byId.set(t.id, [])
+    byId.get(t.id).push({ index: i, deny: t.deny, text: t.text.slice(0, 40) })
+  }
+}
+for (const [id, hits] of byId) {
+  console.log(`  ${short(id)}: ${hits.length} result(s) — ${hits.map(h => `row ${h.index}:${h.deny ? "DENY" : "REAL"}`).join(", ")}`)
+}
+const dupes = [...byId.values()].filter(h => h.length > 1)
+console.log(`  ids answered more than once: ${dupes.length}`)
+
+console.log(`\nworkdir kept for inspection: ${WORKDIR}`)
+console.log(`session file: ${file}`)

--- a/src/__tests__/messages.test.ts
+++ b/src/__tests__/messages.test.ts
@@ -514,7 +514,10 @@ describe("frameReplayTurns (#619)", () => {
     expect(out).toContain("[Assistant: I read it, it contains X]")
     expect(out).toContain("</conversation_history>")
     // Anti-imitation instruction between envelope and live message
-    expect(out).toContain("context only")
+    expect(out).toContain("imitate its transcript format")
+    // ...and it must vouch for the content first, or the model discards real
+    // tool results it received and retracts findings drawn from them.
+    expect(out).toContain("the tool results are genuine output")
     // The live user message is terminal, outside the envelope
     expect(out).toEndWith("now update the port")
     expect(out.indexOf("</conversation_history>")).toBeLessThan(out.indexOf("now update the port"))

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -710,6 +710,85 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(finalFragment.uuid)
   })
 
+  // The non-stream counterpart of the late-parallel-metadata case above.
+  // Passthrough asks for partial messages on both paths, so non-stream has the
+  // same turn boundary AND the same hazard: after message_delta the tracker
+  // knows only the calls whose assistant fragments it has consumed, and a deny
+  // arriving before the final fragment settles that partial set. Freezing there
+  // hands the client a SUBSET of what the model called — the calls past the
+  // checkpoint are dropped, not replayed, so nothing on the wire looks wrong.
+  it("non-stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
+    const firstFragment = assistantMessage([
+      { type: "tool_use", id: "ns-late-1", name: "read", input: { file_path: "a" } },
+    ])
+    const finalFragment = assistantMessage([
+      { type: "tool_use", id: "ns-late-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [
+      messageStart("msg_ns_late_parallel"),
+      toolUseBlockStart(0, "read", "ns-late-1"),
+      inputJsonDelta(0, '{"file_path":"a"}'),
+      blockStop(0),
+      toolUseBlockStart(1, "read", "ns-late-2"),
+      inputJsonDelta(1, '{"file_path":"b"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      firstFragment,
+      userDenyMessage("ns-late-1"),
+      finalFragment,
+      userDenyMessage("ns-late-2"),
+    ]
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a and b" }],
+    }, "es-ns-late-parallel")
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.map((t: any) => t.id).sort()).toEqual(["ns-late-1", "ns-late-2"])
+  })
+
+  // The other half of the same gate. Above, the tracker lags the wire; here it
+  // matches it exactly — but only because the turn has not finished emitting.
+  // Settling on that agreement mid-generation freezes the checkpoint before the
+  // remaining blocks exist, so the completeness oracle alone is not sufficient:
+  // generation must also have ended.
+  it("non-stream: does not freeze when the tracker matches the wire mid-generation", async () => {
+    mockMessages = [
+      messageStart("msg_ns_midgen"),
+      toolUseBlockStart(0, "read", "ns-mid-1"),
+      inputJsonDelta(0, '{"file_path":"a"}'),
+      blockStop(0),
+      // Armed and settled while the turn is still generating: at this point
+      // expected and the streamed set agree on exactly {ns-mid-1}.
+      assistantMessage([{ type: "tool_use", id: "ns-mid-1", name: "read", input: { file_path: "a" } }]),
+      userDenyMessage("ns-mid-1"),
+      // ...and only now does the second call reach the wire.
+      toolUseBlockStart(1, "read", "ns-mid-2"),
+      inputJsonDelta(1, '{"file_path":"b"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      assistantMessage([{ type: "tool_use", id: "ns-mid-2", name: "read", input: { file_path: "b" } }]),
+      userDenyMessage("ns-mid-2"),
+    ]
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a and b" }],
+    }, "es-ns-midgen")
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.map((t: any) => t.id).sort()).toEqual(["ns-mid-1", "ns-mid-2"])
+  })
+
   // #742: a deny can become iterator-visible while a later tool_use block is
   // still mid-input_json_delta. Freezing or closing solely from the tracker's
   // currently-known set can force-emit that block's content_block_stop, so the client

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -22,6 +22,7 @@ import {
   noteUserContent,
   settledToolCallAssistantUuid,
   shouldEarlyStop,
+  trackerCoversStreamedCalls,
 } from "../proxy/passthroughEarlyStop"
 
 import { PASSTHROUGH_MCP_PREFIX } from "../proxy/passthroughTools"
@@ -175,6 +176,35 @@ describe("assistant resume checkpoint", () => {
     noteUserContent(tracker, [toolResult("t1"), toolResult("t2")])
     expect(settledToolCallAssistantUuid(tracker)).toBeUndefined()
     expect(shouldEarlyStop(tracker)).toBe(false)
+  })
+})
+
+describe("trackerCoversStreamedCalls", () => {
+  it("is false while an assistant fragment is still in flight", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, sdkAssistant("a1", [toolUse("t1", "read")]))
+    // The wire carried two calls; only one has been armed so far.
+    expect(trackerCoversStreamedCalls(tracker, new Set(["t1", "t2"]))).toBe(false)
+  })
+
+  it("is true once every streamed call is armed", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, sdkAssistant("a1", [toolUse("t1", "read")]))
+    noteAssistantMessage(tracker, sdkAssistant("a2", [toolUse("t2", "read")]))
+    expect(trackerCoversStreamedCalls(tracker, new Set(["t1", "t2"]))).toBe(true)
+  })
+
+  it("is false when nothing was streamed, so an empty turn cannot settle", () => {
+    const tracker = createEarlyStopTracker()
+    expect(trackerCoversStreamedCalls(tracker, new Set())).toBe(false)
+  })
+
+  it("is false when the sets are the same size but disagree", () => {
+    // Equal sizes must not be mistaken for equal sets — a regenerated call
+    // carries a fresh id, so a stale id would otherwise pass the count check.
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, sdkAssistant("a1", [toolUse("t1", "read")]))
+    expect(trackerCoversStreamedCalls(tracker, new Set(["t-other"]))).toBe(false)
   })
 })
 

--- a/src/__tests__/passthrough-transcript-integration.test.ts
+++ b/src/__tests__/passthrough-transcript-integration.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Transcript repair at the call site — full HTTP layer, mocked SDK, real file.
+ *
+ * The unit suite proves the rewrite; this proves server.ts invokes it on the
+ * checkpoint resume (resumeSessionAt set), where the CLI's loader would
+ * otherwise splice the stale denial back beside the real result on the
+ * following resume.
+ *
+ * The repair is gated on a checkpoint because that is the only resume a
+ * passthrough tool turn can have: a turn without one — early stop off, or its
+ * checkpoint refused — is evicted, never stored, so the next turn starts a
+ * fresh session and the denial sits in a file that is never loaded again. The
+ * second test pins that invariant; if a no-checkpoint tool turn ever becomes
+ * resumable, the repair's gate has to widen with it.
+ *
+ * The fixture transcript lives under a temp CLAUDE_CONFIG_DIR, which is what
+ * transcriptConfigDirs reads first, so no real session file is touched.
+ */
+import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const SDK_SESSION = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+let mockMessages: any[] = []
+let capturedQueryParamsAll: any[] = []
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    capturedQueryParamsAll.push(params)
+    const preHook = params?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+    return (async function* () {
+      let sawDeny = false
+      for (const msg of mockMessages) {
+        if (msg?.type === "user" && msg?.message?.content?.some((b: any) => b?.type === "tool_result")) sawDeny = true
+        yield msg
+        if (preHook && msg?.type === "assistant" && Array.isArray(msg?.message?.content)) {
+          for (const block of msg.message.content) {
+            if (block?.type !== "tool_use") continue
+            void Promise.resolve(preHook({ tool_name: block.name, tool_use_id: block.id, tool_input: block.input }, undefined, { signal: new AbortController().signal }))
+          }
+        }
+      }
+      if (sawDeny) yield { type: "result", subtype: "success", is_error: false, session_id: SDK_SESSION }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
+}))
+
+const { createProxyServer } = await import("../proxy/server")
+const { clearSessionCache } = await import("../proxy/session/cache")
+const { evictSharedSession } = await import("../proxy/sessionStore")
+const { PASSTHROUGH_DENY_REASON } = await import("../proxy/passthroughTranscript")
+
+const TEST_RUN_ID = crypto.randomUUID()
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file",
+  input_schema: { type: "object", properties: { file_path: { type: "string" } }, required: ["file_path"] },
+}
+
+function sdkAssistant(content: any[]) {
+  return {
+    type: "assistant",
+    uuid: crypto.randomUUID(),
+    session_id: SDK_SESSION,
+    parent_tool_use_id: null,
+    message: { id: `msg_${crypto.randomUUID().slice(0, 8)}`, type: "message", role: "assistant", model: "claude-sonnet-5", content, stop_reason: content.some(b => b.type === "tool_use") ? "tool_use" : "end_turn", usage: { input_tokens: 1, output_tokens: 1 } },
+  }
+}
+
+function sdkDeny(toolUseId: string) {
+  return {
+    type: "user",
+    uuid: crypto.randomUUID(),
+    session_id: SDK_SESSION,
+    parent_tool_use_id: null,
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: toolUseId, content: PASSTHROUGH_DENY_REASON, is_error: true }] },
+  }
+}
+
+/** The JSONL the CLI would have written for the turn above: A(tool_use) U(denial). */
+function writeFixture(configDir: string, toolUseId: string): string {
+  const project = join(configDir, "projects", "C--some-cwd")
+  mkdirSync(project, { recursive: true })
+  const file = join(project, `${SDK_SESSION}.jsonl`)
+  const rows = [
+    { type: "user", uuid: "u1", parentUuid: null, message: { role: "user", content: "read a" } },
+    { type: "assistant", uuid: "a1", parentUuid: "u1", message: { id: "msg_1", content: [{ type: "tool_use", id: toolUseId, name: "read", input: { file_path: "a" } }] } },
+    { type: "user", uuid: "d1", parentUuid: "a1", message: { role: "user", content: [{ type: "tool_result", tool_use_id: toolUseId, is_error: true, content: PASSTHROUGH_DENY_REASON }] } },
+    { type: "last-prompt", leafUuid: "d1", explicit: true },
+  ]
+  writeFileSync(file, rows.map(r => JSON.stringify(r)).join("\n") + "\n")
+  return file
+}
+
+function storedResult(file: string, toolUseId: string) {
+  return readFileSync(file, "utf8").split("\n").filter(Boolean).map(l => JSON.parse(l))
+    .flatMap((r: any) => (Array.isArray(r.message?.content) ? r.message.content : []))
+    .find((b: any) => b.type === "tool_result" && b.tool_use_id === toolUseId)
+}
+
+const usedSessionKeys = new Set<string>()
+async function post(app: any, body: any, sessionHeader: string) {
+  const sessionKey = `${sessionHeader}-${TEST_RUN_ID}`
+  usedSessionKeys.add(sessionKey)
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": "dummy", "x-opencode-session": sessionKey, "user-agent": "opencode/1.0.0" },
+    body: JSON.stringify(body),
+  }))
+}
+
+/** Turn 1 (one forwarded call, denied) then turn 2 delivering its result. */
+async function twoTurns(app: any, sessionHeader: string, toolUseId: string) {
+  mockMessages = [
+    sdkAssistant([{ type: "tool_use", id: toolUseId, name: "read", input: { file_path: "a" } }]),
+    sdkDeny(toolUseId),
+  ]
+  const first = await post(app, { model: "claude-sonnet-4-5", max_tokens: 400, stream: false, tools: [READ_TOOL], messages: [{ role: "user", content: "read a" }] }, sessionHeader)
+  expect(first.status).toBe(200)
+  await first.text()
+
+  mockMessages = [sdkAssistant([{ type: "text", text: "done" }])]
+  const second = await post(app, {
+    model: "claude-sonnet-4-5", max_tokens: 400, stream: false, tools: [READ_TOOL],
+    messages: [
+      { role: "user", content: "read a" },
+      { role: "assistant", content: [{ type: "tool_use", id: toolUseId, name: "read", input: { file_path: "a" } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: toolUseId, content: "REAL[alpha]" }] },
+    ],
+  }, sessionHeader)
+  expect(second.status).toBe(200)
+  await second.text()
+  return capturedQueryParamsAll[1]
+}
+
+describe("Integration: transcript repair on resume", () => {
+  let app: any
+  const saved: Record<string, string | undefined> = {}
+  let configDir: string
+
+  beforeAll(() => {
+    app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+  })
+
+  beforeEach(() => {
+    for (const k of ["MERIDIAN_PASSTHROUGH", "MERIDIAN_PASSTHROUGH_EARLY_STOP", "CLAUDE_CONFIG_DIR"]) saved[k] = process.env[k]
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    configDir = mkdtempSync(join(tmpdir(), "meridian-repair-"))
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    mockMessages = []
+    capturedQueryParamsAll = []
+  })
+
+  afterEach(() => {
+    for (const key of usedSessionKeys) evictSharedSession(key)
+    usedSessionKeys.clear()
+    clearSessionCache()
+    for (const [k, v] of Object.entries(saved)) {
+      if (v !== undefined) process.env[k] = v
+      else delete process.env[k]
+    }
+  })
+
+  it("checkpoint resume: the stored denial is rewritten before the structured resume", async () => {
+    const file = writeFixture(configDir, "cp-1")
+    const resumed = await twoTurns(app, "repair-checkpoint", "cp-1")
+    expect(resumed.options.resume).toBe(SDK_SESSION)
+    expect(resumed.options.resumeSessionAt).toBeDefined()
+    expect(storedResult(file, "cp-1")).toEqual({ type: "tool_result", tool_use_id: "cp-1", content: "REAL[alpha]" })
+  })
+
+  it("no checkpoint (early stop off): the tool turn is not resumed at all, so its denial is dead, not stale", async () => {
+    process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = "0"
+    const file = writeFixture(configDir, "nc-1")
+    const next = await twoTurns(app, "repair-nocheckpoint", "nc-1")
+    expect(next.options.resume).toBeUndefined()
+    expect(next.options.resumeSessionAt).toBeUndefined()
+    // Nothing loads this transcript again; the repair has no reason to run.
+    expect(storedResult(file, "nc-1")?.is_error).toBe(true)
+  })
+})

--- a/src/__tests__/passthrough-transcript.test.ts
+++ b/src/__tests__/passthrough-transcript.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Passthrough transcript repair — rewriting forwarded denials in place.
+ *
+ * The fixture mirrors the session JSONL the CLI writes behind a capped
+ * passthrough turn, as observed by scripts/probe-passthrough-accumulation.mjs:
+ * an assistant tool_use row, then a user row holding the hook's denial as the
+ * call's tool_result, chained by parentUuid.
+ */
+import { describe, expect, test } from "bun:test"
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  PASSTHROUGH_DENY_REASON,
+  deliveredToolResults,
+  isForwardedDenial,
+  locateSessionTranscript,
+  repairForwardedDenials,
+  rewriteDenialRows,
+  transcriptConfigDirs,
+} from "../proxy/passthroughTranscript"
+
+const SESSION = "11111111-2222-4333-8444-555555555555"
+
+function denialBlock(id: string) {
+  return { type: "tool_result", tool_use_id: id, is_error: true, content: PASSTHROUGH_DENY_REASON }
+}
+
+/** The row-level stamps the CLI puts beside a denial and not beside a real result. */
+const denialStamps = { toolDenialKind: "permission-rule", toolUseResult: `Error: ${PASSTHROUGH_DENY_REASON}` }
+
+function rows() {
+  return [
+    { type: "user", uuid: "u1", parentUuid: null, message: { role: "user", content: "read a and b" } },
+    { type: "assistant", uuid: "a1", parentUuid: "u1", message: { id: "msg_1", content: [
+      { type: "tool_use", id: "call_a", name: "read", input: { file_path: "a" } },
+      { type: "tool_use", id: "call_b", name: "read", input: { file_path: "b" } },
+    ] } },
+    { type: "user", uuid: "d1", parentUuid: "a1", ...denialStamps, message: { role: "user", content: [denialBlock("call_a")] } },
+    { type: "user", uuid: "d2", parentUuid: "a1", ...denialStamps, message: { role: "user", content: [denialBlock("call_b")] } },
+    { type: "attachment", uuid: "t1", parentUuid: "d2", attachment: {} },
+    { type: "last-prompt", leafUuid: "d2", explicit: true },
+  ]
+}
+
+describe("isForwardedDenial", () => {
+  test("recognises the hook's denial and nothing else", () => {
+    expect(isForwardedDenial(denialBlock("x"))).toBe(true)
+    expect(isForwardedDenial({ type: "tool_result", tool_use_id: "x", is_error: true, content: [{ type: "text", text: PASSTHROUGH_DENY_REASON }] })).toBe(true)
+    // A client's real result that failed is an error too, but not a denial.
+    expect(isForwardedDenial({ type: "tool_result", tool_use_id: "x", is_error: true, content: "ENOENT" })).toBe(false)
+    expect(isForwardedDenial({ type: "tool_result", tool_use_id: "x", content: PASSTHROUGH_DENY_REASON })).toBe(false)
+    expect(isForwardedDenial({ type: "text", text: PASSTHROUGH_DENY_REASON })).toBe(false)
+    expect(isForwardedDenial(undefined)).toBe(false)
+  })
+})
+
+describe("deliveredToolResults", () => {
+  test("collects tool_result blocks from user messages, keeping is_error only when set", () => {
+    const out = deliveredToolResults([
+      { role: "assistant", content: [{ type: "tool_use", id: "call_a" }] },
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "call_a", content: "alpha" },
+        { type: "tool_result", tool_use_id: "call_b", content: [{ type: "text", text: "bravo" }], is_error: true },
+        { type: "text", text: "and now continue" },
+      ] },
+      { role: "user", content: "plain text" },
+    ])
+    expect(out).toEqual([
+      { tool_use_id: "call_a", content: "alpha" },
+      { tool_use_id: "call_b", content: [{ type: "text", text: "bravo" }], is_error: true },
+    ])
+  })
+})
+
+describe("rewriteDenialRows", () => {
+  test("replaces the denial with the real result and touches nothing else", () => {
+    const rs = rows()
+    const before = JSON.parse(JSON.stringify(rs))
+    const changed = rewriteDenialRows(rs, [{ tool_use_id: "call_a", content: "REAL[alpha]" }])
+    expect([...changed]).toEqual([rs[2]!])
+    const rewritten = (rs[2] as any).message.content[0]
+    expect(rewritten).toEqual({ type: "tool_result", tool_use_id: "call_a", content: "REAL[alpha]" })
+    // The rewritten row loses the denial stamps; an untouched one keeps them.
+    expect("toolDenialKind" in rs[2]!).toBe(false)
+    expect("toolUseResult" in rs[2]!).toBe(false)
+    expect((rs[3] as any).toolDenialKind).toBe("permission-rule")
+    // call_b was not delivered: its denial stays.
+    expect((rs[3] as any).message.content[0]).toEqual(denialBlock("call_b"))
+    // Topology is untouched: every uuid, parentUuid and leaf hint as before.
+    for (const [i, r] of rs.entries()) {
+      expect((r as any).uuid).toBe(before[i].uuid)
+      expect((r as any).parentUuid).toBe(before[i].parentUuid)
+      expect((r as any).leafUuid).toBe(before[i].leafUuid)
+    }
+    expect(rs.length).toBe(before.length)
+  })
+
+  test("a delivered result that is itself an error keeps is_error", () => {
+    const rs = rows()
+    rewriteDenialRows(rs, [{ tool_use_id: "call_b", content: "ENOENT", is_error: true }])
+    expect((rs[3] as any).message.content[0]).toEqual({ type: "tool_result", tool_use_id: "call_b", is_error: true, content: "ENOENT" })
+  })
+
+  test("an already rewritten denial is not rewritten again, and unknown ids are ignored", () => {
+    const rs = rows()
+    expect(rewriteDenialRows(rs, [{ tool_use_id: "call_a", content: "first" }]).size).toBe(1)
+    expect(rewriteDenialRows(rs, [{ tool_use_id: "call_a", content: "second" }, { tool_use_id: "nope", content: "x" }]).size).toBe(0)
+    expect((rs[2] as any).message.content[0].content).toBe("first")
+  })
+})
+
+describe("locate + repair on disk", () => {
+  function fixtureSession() {
+    const configDir = mkdtempSync(join(tmpdir(), "meridian-transcript-"))
+    const project = join(configDir, "projects", "C--some-cwd-slug")
+    mkdirSync(project, { recursive: true })
+    const file = join(project, `${SESSION}.jsonl`)
+    // A blank line, an unparsable line, and a parsable line the CLI did not
+    // write canonically (spaces, escaped unicode, a float), all of which must
+    // survive verbatim. The last one is the real check: JSON.parse followed by
+    // JSON.stringify would silently normalise it.
+    const lines = rows().map(r => JSON.stringify(r))
+    lines.splice(2, 0, "")
+    lines.push('{ "type": "summary", "summary": "caf\\u00e9", "n": 1.0 }')
+    lines.push("{not json")
+    writeFileSync(file, lines.join("\n") + "\n")
+    return { configDir, file }
+  }
+
+  test("locateSessionTranscript scans project dirs without knowing the cwd slug", () => {
+    const { configDir, file } = fixtureSession()
+    expect(locateSessionTranscript(SESSION, [join(configDir, "missing"), configDir])).toBe(file)
+    expect(locateSessionTranscript("00000000-0000-4000-8000-000000000000", [configDir])).toBeUndefined()
+    // Never treats a session id as a path component.
+    expect(locateSessionTranscript("../../etc/passwd", [configDir])).toBeUndefined()
+  })
+
+  test("repairForwardedDenials rewrites on disk and preserves every other line byte for byte", () => {
+    const { configDir, file } = fixtureSession()
+    const before = readFileSync(file, "utf8").split("\n")
+    const outcome = repairForwardedDenials({
+      sessionId: SESSION,
+      configDirs: [configDir],
+      results: [{ tool_use_id: "call_a", content: "REAL[alpha]" }, { tool_use_id: "call_b", content: [{ type: "text", text: "REAL[bravo]" }] }],
+    })
+    expect(outcome).toEqual({ file, rewritten: 2 })
+    const after = readFileSync(file, "utf8").split("\n")
+    expect(after.length).toBe(before.length)
+    for (const [i, line] of after.entries()) {
+      if (i === 3 || i === 4) continue // the two denial rows
+      // Every other line, canonical or not, is the same bytes.
+      expect(line).toBe(before[i]!)
+    }
+    expect(JSON.parse(after[3]!).message.content[0]).toEqual({ type: "tool_result", tool_use_id: "call_a", content: "REAL[alpha]" })
+    expect(JSON.parse(after[4]!).message.content[0]).toEqual({ type: "tool_result", tool_use_id: "call_b", content: [{ type: "text", text: "REAL[bravo]" }] })
+    expect(after.filter(l => l.includes(PASSTHROUGH_DENY_REASON)).length).toBe(0)
+  })
+
+  test("nothing to rewrite leaves the file untouched", () => {
+    const { configDir, file } = fixtureSession()
+    const before = readFileSync(file, "utf8")
+    expect(repairForwardedDenials({ sessionId: SESSION, configDirs: [configDir], results: [] })).toEqual({ rewritten: 0 })
+    expect(repairForwardedDenials({ sessionId: SESSION, configDirs: [configDir], results: [{ tool_use_id: "nope", content: "x" }] })).toEqual({ file, rewritten: 0 })
+    expect(repairForwardedDenials({ sessionId: SESSION, configDirs: [join(configDir, "elsewhere")], results: [{ tool_use_id: "call_a", content: "x" }] })).toEqual({ rewritten: 0 })
+    expect(readFileSync(file, "utf8")).toBe(before)
+  })
+})
+
+describe("transcriptConfigDirs", () => {
+  test("profile config dir first, CLI default always, no duplicates", () => {
+    const [dflt, ...rest] = transcriptConfigDirs({})
+    expect(rest).toEqual([])
+    expect(dflt!.endsWith(".claude")).toBe(true)
+    expect(transcriptConfigDirs({ CLAUDE_CONFIG_DIR: "/profiles/work" })).toEqual(["/profiles/work", dflt!])
+    expect(transcriptConfigDirs({ CLAUDE_CONFIG_DIR: dflt })).toEqual([dflt!])
+  })
+})

--- a/src/__tests__/proxy-nonstream-deny-hold.test.ts
+++ b/src/__tests__/proxy-nonstream-deny-hold.test.ts
@@ -28,14 +28,17 @@ const denyMsg = (ids: string[]) => ({
   },
 })
 
+const boundary = (type: string) => ({
+  type: "stream_event", session_id: "sdk-ns-1", event: { type },
+})
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
-    const isStreaming = opts.options?.includePartialMessages === true
     return (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
       yield { type: "system", subtype: "init", session_id: "sdk-ns-1" }
-      if (isStreaming || !preHook) {
-        // Streaming path not under test here
+      if (!preHook) {
+        // No passthrough hooks — nothing to hold, so answer and stop.
         yield {
           type: "assistant", uuid: "u1",
           message: { id: "m1", type: "message", role: "assistant", content: [{ type: "text", text: "ok" }], model: "claude-sonnet-5", stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 } },
@@ -44,8 +47,13 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         return
       }
 
-      // Turn 1 generation begins. The CLI dispatches block 1's hook while
-      // block 2 is still generating.
+      // Turn 1 generation begins. `message_start`/`message_delta` bracket it on
+      // both paths — passthrough asks for partial messages regardless of whether
+      // the client streams, because they are the only turn-boundary signal and
+      // the deny-hold and the checkpoint both key off it.
+      yield boundary("message_start")
+
+      // The CLI dispatches block 1's hook while block 2 is still generating.
       let settled = false
       const deny1 = preHook({ tool_name: "read", tool_use_id: "tu1", tool_input: { filePath: "/tmp/a.txt" } })
         .then((r: any) => { settled = true; return r })
@@ -56,6 +64,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
 
       if (settled) {
         // Cancel-on-deny: block 2 is beheaded; only block 1 exists.
+        yield boundary("message_delta")
         yield {
           type: "assistant", uuid: "u1",
           message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },
@@ -67,6 +76,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       }
 
       // Deny held → generation completed with BOTH blocks.
+      yield boundary("message_delta")
       yield {
         type: "assistant", uuid: "u1",
         message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt"), tu("tu2", "/tmp/b.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },

--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -79,7 +79,8 @@ describe("fresh-session replay envelope (#619)", () => {
     expect(typeof prompt).toBe("string")
     expect(prompt).toContain("<conversation_history>")
     expect(prompt).toContain("</conversation_history>")
-    expect(prompt).toContain("context only")
+    expect(prompt).toContain("imitate its transcript format")
+    expect(prompt).toContain("the tool results are genuine output")
     // Live message is terminal, outside the envelope
     expect(prompt.trimEnd()).toEndWith("now change the port to 4000")
     expect(prompt.indexOf("</conversation_history>")).toBeLessThan(prompt.indexOf("now change the port to 4000"))

--- a/src/proxy/messages.ts
+++ b/src/proxy/messages.ts
@@ -156,11 +156,19 @@ export function getLastUserMessage(messages: Array<{ role: string; content: any 
  * rather than answer the user: self-played turns, confabulated tool output.
  *
  * This wraps everything before the final user turn in an explicit
- * `<conversation_history>` envelope with a context-only instruction, and
- * presents the final user message separately as the live prompt — mirroring
- * the structure the OpenAI-compat path has always used. Single-turn prompts
- * and histories that don't end with a user turn are returned as a plain
- * join (nothing to separate).
+ * `<conversation_history>` envelope, and presents the final user message
+ * separately as the live prompt — mirroring the structure the OpenAI-compat
+ * path has always used. Single-turn prompts and histories that don't end with
+ * a user turn are returned as a plain join (nothing to separate).
+ *
+ * The envelope asserts the history is true before it forbids imitating it.
+ * Wording that only says "context only" and "never invent tool output" reads
+ * as a warning that the transcript itself may be invented: models then discard
+ * tool results they really received and retract correct findings drawn from
+ * them. The instruction has to separate the format (do not imitate) from the
+ * content (real, and safe to quote). A replayed turn is also inherited by
+ * every later resumed turn, so a frame that induces distrust poisons the whole
+ * session, not just the turn that replayed.
  */
 export function frameReplayTurns(turns: Array<{ role: string; text: string }>): string {
   const nonEmpty = turns.filter((t) => t.text)
@@ -171,9 +179,11 @@ export function frameReplayTurns(turns: Array<{ role: string; text: string }>): 
   const history = nonEmpty.slice(0, -1).map((t) => t.text).join("\n\n")
   return (
     `<conversation_history>\n${history}\n</conversation_history>\n\n` +
-    `The above is a replay of your prior conversation with this user — the original session could not be resumed. ` +
-    `It is context only: do not continue or imitate its transcript format, do not write "[Assistant: ...]" markers, ` +
-    `and never invent tool output — use your actual tools when action is needed. ` +
+    `The above is your prior conversation with this user, replayed because the original session could not be ` +
+    `resumed. Everything in it happened: the user's messages are real, and the tool results are genuine output ` +
+    `from tools that ran. Rely on it and quote from it. ` +
+    `Do not continue or imitate its transcript format, do not write "[Assistant: ...]" markers, and do not write ` +
+    `tool output yourself — call your tools when you need something not already in the history. ` +
     `Respond only as the assistant to the user's message below.\n\n` +
     last.text
   )

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -26,6 +26,18 @@
  * deferred tools, advisors, structured output, and the kill switch. In those
  * configurations the digest turn does generate and is discarded here.
  *
+ * Settlement is necessary but NOT sufficient to freeze the checkpoint. Two
+ * further conditions belong to the caller, which owns the wire:
+ *
+ *   - the turn has stopped generating, so no further call can appear, and
+ *   - trackerCoversStreamedCalls agrees the tracker has caught up with every
+ *     forwarded call the wire carried.
+ *
+ * Both exist because `expected` is armed from assistant messages, which the SDK
+ * can surface after the deny that settles them — so "everything I know about is
+ * answered" is true long before "everything is answered". Freezing on the
+ * former drops the calls still in flight, silently, from the client's set.
+ *
  * Pure module — no I/O, no imports from server.ts or session/.
  */
 
@@ -188,6 +200,33 @@ export function isCompleteToolResultContinuation(
 
   return actual.size === expected.size &&
     (echoedCalls.size === 0 || echoedCalls.size === expected.size)
+}
+
+/**
+ * Has the tracker caught up with every forwarded call the wire actually
+ * carried?
+ *
+ * `expected` is armed from assistant messages, which the SDK can surface AFTER
+ * the deny that settles them. Settlement alone therefore proves only that the
+ * calls seen SO FAR are answered — freeze on that and any call whose assistant
+ * fragment is still in flight lands past the checkpoint and is dropped from the
+ * client-facing set. Silently: a dropped call is not a malformed envelope, so
+ * nothing downstream looks wrong.
+ *
+ * `streamedToolUseIds` comes from content_block_start, which cannot lag, so it
+ * is the completeness oracle both paths gate on. Callers build it with
+ * isClientForwardedToolUse so the two sets are comparable by construction.
+ */
+export function trackerCoversStreamedCalls(
+  tracker: EarlyStopTracker,
+  streamedToolUseIds: ReadonlySet<string>
+): boolean {
+  if (streamedToolUseIds.size === 0) return false
+  if (tracker.expected.size !== streamedToolUseIds.size) return false
+  for (const id of streamedToolUseIds) {
+    if (!tracker.expected.has(id)) return false
+  }
+  return true
 }
 
 /** The cache-stable assistant boundary after every forwarded call settled. */

--- a/src/proxy/passthroughTranscript.ts
+++ b/src/proxy/passthroughTranscript.ts
@@ -1,0 +1,175 @@
+/**
+ * Passthrough transcript repair — one call, one answer, the real one.
+ *
+ * In passthrough the CLIENT executes tools. The PreToolUse hook denies every
+ * forwarded call, and the CLI writes that denial into the session JSONL as
+ * the call's `tool_result`. The client's real result arrives on the next
+ * request and is appended as a second answer for the same `tool_use_id`.
+ *
+ * `resumeSessionAt` does not remove the denial: it cuts a suffix, so it only
+ * ever drops the CURRENT turn's rows. On the resume after that the CLI loads
+ * the transcript by walking the parentUuid chain from the newest leaf and
+ * then splices back any tool_result whose parent is an on-chain assistant —
+ * a recovery pass written for parallel siblings that cannot tell a stale
+ * denial from one. Both answers are now in the loaded history, the CLI keeps
+ * the FIRST tool_result per id, and the model is sent the denial with the
+ * real result gone. Measured with scripts/probe-passthrough-accumulation.mjs:
+ * by the third turn the model reports "forwarded to client, no content
+ * returned" for calls whose output it was handed a turn earlier.
+ *
+ * The repair rewrites each denial IN PLACE with the real result before the
+ * resume starts. No row is added or removed and no uuid, parentUuid or leaf
+ * hint changes, so none of the loader's topology handling is exercised —
+ * deleting the row instead breaks the resume, because the `last-prompt`
+ * leaf hint the loader starts from points at it. After the rewrite the
+ * transcript has the plain-API shape: tool_use, then its real result.
+ */
+import { existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+/** The hook's reason for a forwarded call. Also the marker a denial row carries. */
+export const PASSTHROUGH_DENY_REASON =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+/** A client-supplied real result for a forwarded call. */
+export interface DeliveredToolResult {
+  tool_use_id: string
+  content: unknown
+  is_error?: boolean
+}
+
+type Block = { type?: string; tool_use_id?: string; content?: unknown; is_error?: boolean; [k: string]: unknown }
+/**
+ * A transcript row. Beside the message, the CLI stamps a denial row with
+ * `toolDenialKind` and mirrors the denial text into `toolUseResult`; a row it
+ * writes for a real result carries neither.
+ */
+type Row = { type?: string; message?: { content?: unknown }; toolDenialKind?: unknown; toolUseResult?: unknown; [k: string]: unknown }
+
+function blockText(block: Block): string {
+  if (typeof block.content === "string") return block.content
+  if (Array.isArray(block.content)) {
+    return block.content.map((c: any) => (typeof c?.text === "string" ? c.text : "")).join("")
+  }
+  return ""
+}
+
+/**
+ * The CLI's answer to a call the hook refused: an error tool_result carrying
+ * the hook's reason. A client's real result that happens to be an error does
+ * not carry the reason and is left alone.
+ */
+export function isForwardedDenial(block: Block | undefined): boolean {
+  return block?.type === "tool_result" && block.is_error === true && blockText(block).includes(PASSTHROUGH_DENY_REASON)
+}
+
+/** Every tool_result block in a set of client messages, in order. */
+export function deliveredToolResults(messages: ReadonlyArray<{ role?: string; content?: unknown }> | undefined): DeliveredToolResult[] {
+  const out: DeliveredToolResult[] = []
+  for (const m of messages ?? []) {
+    if (m.role !== "user" || !Array.isArray(m.content)) continue
+    for (const b of m.content as Block[]) {
+      if (b?.type !== "tool_result" || typeof b.tool_use_id !== "string") continue
+      out.push({ tool_use_id: b.tool_use_id, content: b.content, ...(b.is_error === true ? { is_error: true } : {}) })
+    }
+  }
+  return out
+}
+
+/**
+ * Rewrite, in place, every forwarded denial whose id has a delivered result.
+ * Pure over the parsed rows; returns the rows that changed, so a caller
+ * re-serializes those and nothing else.
+ */
+export function rewriteDenialRows(rows: ReadonlyArray<Row>, results: ReadonlyArray<DeliveredToolResult>): Set<Row> {
+  const changed = new Set<Row>()
+  if (results.length === 0) return changed
+  const byId = new Map(results.map(r => [r.tool_use_id, r]))
+  for (const row of rows) {
+    if (row.type !== "user") continue
+    const content = row.message?.content
+    if (!Array.isArray(content)) continue
+    for (const block of content as Block[]) {
+      if (!isForwardedDenial(block)) continue
+      const real = byId.get(block.tool_use_id as string)
+      if (!real) continue
+      block.content = real.content
+      if (real.is_error) block.is_error = true
+      else delete block.is_error
+      // The row-level denial stamps go too, so the row is what the CLI would
+      // have written for a real result and nothing keyed on them sees a denial.
+      delete row.toolDenialKind
+      delete row.toolUseResult
+      changed.add(row)
+    }
+  }
+  return changed
+}
+
+/**
+ * Config dirs whose `projects/` tree may hold the session: the profile's
+ * CLAUDE_CONFIG_DIR if any, then the CLI's default.
+ */
+export function transcriptConfigDirs(env: Record<string, string | undefined>): string[] {
+  const dirs = [env.CLAUDE_CONFIG_DIR, join(homedir(), ".claude")].filter((d): d is string => Boolean(d))
+  return [...new Set(dirs)]
+}
+
+/**
+ * The session JSONL for a CLI session id. The project sub-directory is a
+ * slug of the cwd the CLI was launched in; scanning for the id avoids
+ * re-implementing that slug and survives it changing.
+ */
+export function locateSessionTranscript(sessionId: string, configDirs: ReadonlyArray<string>): string | undefined {
+  if (!/^[0-9a-f-]{36}$/i.test(sessionId)) return undefined
+  for (const dir of configDirs) {
+    const projects = join(dir, "projects")
+    if (!existsSync(projects)) continue
+    let entries: string[]
+    try { entries = readdirSync(projects) } catch { continue }
+    for (const project of entries) {
+      const candidate = join(projects, project, `${sessionId}.jsonl`)
+      if (existsSync(candidate)) return candidate
+    }
+  }
+  return undefined
+}
+
+export interface RepairOutcome {
+  file?: string
+  rewritten: number
+}
+
+/**
+ * Rewrite the session's forwarded denials with the delivered results. Reads
+ * the JSONL, rewrites the matching blocks, writes it back through a rename so
+ * the CLI never observes a half-written file. Only the lines that changed are
+ * re-serialized: every other line, parsable or not, goes back verbatim, so
+ * the CLI's own formatting is never touched. A session with nothing to
+ * rewrite is left untouched.
+ */
+export function repairForwardedDenials(opts: {
+  sessionId: string
+  configDirs: ReadonlyArray<string>
+  results: ReadonlyArray<DeliveredToolResult>
+}): RepairOutcome {
+  if (opts.results.length === 0) return { rewritten: 0 }
+  const file = locateSessionTranscript(opts.sessionId, opts.configDirs)
+  if (!file) return { rewritten: 0 }
+  const lines = readFileSync(file, "utf8").split("\n")
+  const rows: Array<Row | null> = lines.map(l => {
+    if (l.trim().length === 0) return null
+    try { return JSON.parse(l) as Row } catch { return null }
+  })
+  const changed = rewriteDenialRows(rows.filter((r): r is Row => r !== null), opts.results)
+  const rewritten = changed.size
+  if (rewritten === 0) return { file, rewritten }
+  const out = lines.map((l, i) => (rows[i] && changed.has(rows[i]) ? JSON.stringify(rows[i]) : l)).join("\n")
+  const tmp = `${file}.meridian-tmp`
+  writeFileSync(tmp, out)
+  renameSync(tmp, file)
+  return { file, rewritten }
+}

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -366,7 +366,13 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       model,
       pathToClaudeCodeExecutable: claudeExecutable,
       ...(abortController ? { abortController } : {}),
-      ...(stream ? { includePartialMessages: true } : {}),
+      // Passthrough needs them on BOTH paths, not just streaming: the deny-hold
+      // and the early-stop checkpoint both key off the turn-generation boundary,
+      // and `message_start`/`message_delta` are the only place it is observable.
+      // Without them non-stream releases its holds on the first assistant
+      // message and freezes the checkpoint there, so a parallel turn hands the
+      // client the first call and silently drops the rest (measured 1 of 3).
+      ...(stream || passthrough ? { includePartialMessages: true } : {}),
       permissionMode: "bypassPermissions" as const,
       allowDangerouslySkipPermissions: true,
       ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt, cwdNote),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -38,13 +38,14 @@ export type {
 // transforms through the same runner meridian uses internally.
 export { runTransformHook, runObserveHook, buildPipeline, createRequestContext } from "./transform"
 import { claudeLog } from "../logger"
+import { PASSTHROUGH_DENY_REASON, deliveredToolResults, repairForwardedDenials, transcriptConfigDirs } from "./passthroughTranscript"
 import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, createEarlyStopTracker, isCompleteToolResultContinuation, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { clientAbortDisposition, createEarlyStopTracker, isClientForwardedToolUse, isCompleteToolResultContinuation, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -140,6 +141,24 @@ let claudeExecutable = ""
 // to abort the same hung model — see the coordination contract in
 // streamIdleGuard.ts.
 const UPSTREAM_IDLE_MS = envInt("UPSTREAM_IDLE_MS", 90_000)
+
+// How long a passthrough deny may be held waiting for the turn-generation
+// boundary. Derived from UPSTREAM_IDLE_MS, never a standalone number, because
+// this is the same coordination contract: guardUpstreamIdle owns model-stream
+// liveness, so every other timer must sit ABOVE it and let it decide.
+//
+// The hazard this guards is a CLI version that serialises hook-then-stream, in
+// which case a held deny blocks generation forever. That case is already
+// covered by the layer that owns it: no upstream messages flow, so
+// guardUpstreamIdle throws UpstreamIdleError and the turn fails loudly. A
+// shorter timer here would only pre-empt that with a WORSE outcome — releasing
+// mid-generation lets the CLI cancel the in-flight request, which beheads every
+// parallel call still generating and hands the client a truncated tool set
+// under a 200 (measured: 1 of 3 calls delivered).
+//
+// An override BELOW UPSTREAM_IDLE_MS deliberately re-enables that race; that is
+// how scripts/probe-passthrough-proxy.mjs reproduces the leak on demand.
+const DENY_HOLD_TIMEOUT_MS = envInt("DENY_HOLD_TIMEOUT_MS", UPSTREAM_IDLE_MS + 30_000)
 
 // Bounds how long ProxyInstance.close() waits for in-flight /v1/messages
 // requests to finish (after beginDrain() stops admitting new ones) before it
@@ -1616,6 +1635,27 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               })
             }
           }
+          // The session already answered these calls with the hook's denial,
+          // and resumeSessionAt never removes it — the CLI's loader splices
+          // it back on the next resume and keeps it over the real result. So
+          // the denial is rewritten with the real result before the resume
+          // starts. See passthroughTranscript.ts.
+          if (resumeSessionId && passthroughToolCallAssistantUuid) {
+            const results = deliveredToolResults(messagesToConvert)
+            try {
+              const repair = repairForwardedDenials({ sessionId: resumeSessionId, configDirs: transcriptConfigDirs(profileEnv), results })
+              claudeLog("passthrough.denials_rewritten", {
+                sessionId: resumeSessionId, delivered: results.length, rewritten: repair.rewritten, file: repair.file,
+              })
+            } catch (err) {
+              // The resume is still valid without the repair; the denial then
+              // survives for the model to see, which is the un-repaired
+              // outcome, not a failed turn. Say so and carry on.
+              claudeLog("passthrough.denials_rewrite_failed", {
+                sessionId: resumeSessionId, delivered: results.length, error: err instanceof Error ? err.message : String(err),
+              })
+            }
+          }
         } else {
           // First request: all messages (system context now passed via appendSystemPrompt)
           for (const m of messagesToConvert) {
@@ -1740,8 +1780,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // beheads trailing parallel calls (#552 red reads: `glob {}` aborted)
       // and re-loops the model. Fix: hold every deny response until turn-1
       // generation completes (message_delta observed), so the cancel can
-      // never land mid-generation. Timeout is a deadlock backstop in case a
-      // CLI version serializes hook-then-stream.
+      // never land mid-generation. The hold defers to guardUpstreamIdle for
+      // liveness — see DENY_HOLD_TIMEOUT_MS — so its own timer sits above that
+      // limit and is a last-ditch backstop, not the thing that decides.
       // Envelope integrity: violations of the proxy's own output contract
       // (dangling blocks, undelivered captured calls, empty required tool
       // inputs). Logged loudly + counted on /telemetry so #552-family
@@ -1754,7 +1795,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           diagnosticLog.error(`${requestMeta.requestId} ENVELOPE VIOLATION [${v.type}] ${v.detail}`, requestMeta.requestId)
         }
       }
-      const DENY_HOLD_TIMEOUT_MS = 8000
       const pendingDenyReleases: Array<() => void> = []
       // True while a model turn is actively generating (message_start seen,
       // no message_delta/message_stop yet). Hooks dispatched AFTER generation
@@ -1762,6 +1802,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // hooks can fire post-turn) must NOT hold — there is no in-flight
       // request left to protect, and holding would only add dead time.
       let turnGenerating = false
+      // Whether this request ever saw a raw turn-boundary event. Partial
+      // messages are requested for passthrough on both paths, but if they are
+      // ever absent (an older CLI, a mocked SDK) the gates below must fall back
+      // to releasing on the assistant message rather than wedge waiting for a
+      // boundary that never arrives.
+      let sawTurnBoundarySignal = false
       const releaseHeldDenies = (reason: string): void => {
         turnGenerating = false
         if (pendingDenyReleases.length === 0) return
@@ -1772,6 +1818,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         new Promise<void>((resolve) => {
           const timer = setTimeout(() => {
             claudeLog("passthrough.deny_hold_timeout", { afterMs: DENY_HOLD_TIMEOUT_MS })
+            // The deny lands while the turn may still be emitting per-block
+            // assistant rows, so it can end up INSIDE the checkpoint slice. The
+            // checkpoint stays valid regardless: the transcript repair rewrites
+            // every delivered call's denial before the resume, wherever the row
+            // sits (passthroughTranscript.ts). Refusing it here would cost a
+            // digest turn and a cold replay to avoid a row that gets fixed.
             resolve()
           }, DENY_HOLD_TIMEOUT_MS)
           pendingDenyReleases.push(() => {
@@ -2009,10 +2061,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
                 return {
                   decision: "block" as const,
-                  reason:
-                    "This tool call has been forwarded to the client for execution. " +
-                    "The result will be delivered in a future turn. " +
-                    "Do not retry, do not call additional tools, and do not generate further text — end your turn now.",
+                  reason: PASSTHROUGH_DENY_REASON,
                 }
               }],
             }],
@@ -2057,6 +2106,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
           let lastStopReason: string | undefined
+          // Completeness oracle, the non-stream twin of the streaming path's
+          // `streamedToolUseIds`. Built from content_block_start, so it names
+          // every tool_use the turn actually produced — including calls whose
+          // assistant fragment the iterator has not surfaced yet. Without it the
+          // checkpoint can freeze on the fragments consumed so far and silently
+          // drop the rest from the client-facing set.
+          const streamedToolUseIds = new Set<string>()
           let nextPassthroughToolCallAssistantUuid: string | undefined
           let nextPassthroughToolCallIds: string[] | undefined
           let sawCanonicalResult = false
@@ -2358,7 +2414,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
               } else if (passthrough && message.type === "user" && !earlyStopFired) {
                 noteUserContent(earlyStop, (message as any).message?.content)
-                if (earlyStopEnabled && shouldEarlyStop(earlyStop)) {
+                // The completeness gate the streaming path already applies:
+                // generation has ended AND the tracker has caught up with every
+                // tool_use the wire actually carried. Either half alone is not
+                // enough — a deny can settle the calls known so far while a
+                // later assistant fragment is still to come, and freezing there
+                // drops it.
+                const turnComplete = sawTurnBoundarySignal
+                  ? !turnGenerating && trackerCoversStreamedCalls(earlyStop, streamedToolUseIds)
+                  : true // nothing to gate on — settle on the tracker alone
+                if (earlyStopEnabled && turnComplete && shouldEarlyStop(earlyStop)) {
                   nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
                   nextPassthroughToolCallIds = [...earlyStop.expected]
                   earlyStopFired = true
@@ -2378,10 +2443,31 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   })
                 }
               }
+              // #592/#625: the turn-generation boundary, observable here because
+              // passthrough requests partial messages on both paths. An assistant
+              // message is NOT this boundary: the CLI emits one per tool-use
+              // block, so releasing there frees the denies while later parallel
+              // blocks are still generating, and those denies cancel the
+              // in-flight request — beheading calls 2..N and freezing the
+              // checkpoint on call 1.
+              if (message.type === "stream_event") {
+                const event = (message as any).event as any
+                const eventType = event?.type
+                if (eventType === "message_delta" || eventType === "message_stop") {
+                  sawTurnBoundarySignal = true
+                  releaseHeldDenies(eventType)
+                } else if (eventType === "message_start") {
+                  sawTurnBoundarySignal = true
+                  turnGenerating = true
+                } else if (passthrough && eventType === "content_block_start") {
+                  // The predicate the tracker arms `expected` with, so the two
+                  // sets are comparable by construction.
+                  const block = event.content_block
+                  if (isClientForwardedToolUse(block)) streamedToolUseIds.add(block.id)
+                }
+              }
               if (message.type === "assistant") {
-                // #592: the turn's generation is complete — held denies can
-                // return without the CLI cancelling anything in flight.
-                releaseHeldDenies("assistant_message")
+                if (!sawTurnBoundarySignal) releaseHeldDenies("assistant_message")
                 assistantMessages += 1
                 // One Anthropic assistant response may combine several SDK
                 // assistant fragments (for example parallel tool calls).
@@ -3243,14 +3329,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // until generation ended, every block closed, and metadata
                     // names exactly the full forwarded ID set. Recheck on both
                     // assistant and user messages so either ordering can settle.
-                    const hasCompleteStreamedSet =
-                      streamedToolUseIds.size > 0 &&
-                      earlyStop.expected.size === streamedToolUseIds.size &&
-                      [...streamedToolUseIds].every((id) => earlyStop.expected.has(id))
                     if (
                       !turnGenerating &&
                       openClientBlocks.size === 0 &&
-                      hasCompleteStreamedSet &&
+                      trackerCoversStreamedCalls(earlyStop, streamedToolUseIds) &&
                       shouldEarlyStop(earlyStop)
                     ) {
                       nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)


### PR DESCRIPTION
In passthrough mode, from the third turn of a session, the model is sent the hook's denial instead of the client's real result. This happens for every tool call made in an earlier turn. This PR rewrites that denial in the session transcript before each resume, so the model only sees the real result.

## What the model sees today

Passthrough forwards each tool call to the client. The PreToolUse hook denies the call inside the SDK. The CLI stores that denial in the session JSONL as the call's `tool_result` ("This tool call has been forwarded to the client for execution..."). The client runs the tool and sends the real result on its next request, which Meridian resumes at the assistant checkpoint (`resumeSessionAt`).

That resume cuts a suffix of the transcript. It removes the current turn's denial and never an earlier turn's. On the following resume the CLI's loader walks the `parentUuid` chain, then splices back every `tool_result` whose parent assistant is on the chain. That pass exists for parallel siblings and cannot tell a stale denial from one. The loader keeps the first `tool_result` per id, and the denial is older than the real result. The request body the model receives now carries the denial, and the real result is gone.

I measured this with a recording proxy on `ANTHROPIC_BASE_URL` (`scripts/probe-passthrough-accumulation.mjs`). On turn 3 of a three-call chain, the request body contained the denial for call 1 and no real result for it. Every single-turn probe measured clean, which is why the defect survived the existing suites: it needs three turns to appear.

I also observed it in OpenCode after a turn with parallel `grep`, `glob` and `read` calls. The model reported the results as fabricated, refused to quote output it had received, re-ran the calls, and retracted findings drawn from them. With this PR applied, OpenCode reports every result correctly across the same session.

## Issues that patched the symptom

The following reports describe this defect from the model's side. Each was answered by changing what the model is told, and the denial stayed in the transcript.

- #496: "tool invocations return empty", the model asks the user to paste file contents or run grep by hand.
- #552: the model is confused about which calls ran and reports "a file I never created". PR #580 answered it by rewording the deny text for dropped calls.
- #768: "the persisted `end your turn now` deny sits immediately before the continuation's user turn, and the model obeys it". PR #793 captured the boundary and added `SILENT_TURN_NUDGE`, which tells the model that the earlier deny is discharged.
- #689: the same "results never came back to me" report on the internal-mode resume path.
- #619, #111, #386: the replay envelope and the anti-imitation instruction. Related because the envelope's wording ("context only", "never invent tool output") made the model discard tool results it really received. The second commit here changes that wording.

`server.ts`, `messages.ts`, `passthroughEarlyStop.ts` and `envelopeIntegrity.ts` cite 43 distinct issue numbers. Their comments describe one family: the model denies making calls it made, misattributes results, invents tool output, imitates replayed transcripts. This PR removes the cause and touches none of those workarounds. Which of them are now unnecessary is a separate pass.

## What changes

`src/proxy/passthroughTranscript.ts` (new). Before a checkpoint resume that delivers real results, every forwarded denial whose id has a delivered result is rewritten in place with that result. No row is added or removed. No `uuid`, `parentUuid` or `last-prompt` leaf hint changes, because the loader starts its chain walk from that hint and deleting the row breaks the resume. Only the changed lines are re-serialized; every other line goes back byte for byte. The rewritten row also loses the CLI's row-level denial stamps (`toolDenialKind`, `toolUseResult`). A denial row is recognised as an error `tool_result` carrying `PASSTHROUGH_DENY_REASON`, which is now the single owner of that text. A client result that is itself an error is left alone. If the repair throws, the resume proceeds un-repaired and the turn does not fail.

A repair is only needed on a checkpoint resume. A passthrough tool turn with no checkpoint (early stop off, or its checkpoint refused) is evicted, never stored. The next turn is `lineage=new`, and the old transcript is never loaded again. `passthrough-transcript-integration.test.ts` pins both facts.

`src/proxy/server.ts`, `src/proxy/query.ts`, `src/proxy/passthroughEarlyStop.ts`. The non-stream path had no turn boundary. It released held denies on the first assistant message and froze the checkpoint there, which delivered 1 of 3 parallel calls against the real proxy. Passthrough now requests `includePartialMessages` on both paths and releases denies on `message_delta`. The checkpoint is gated on the completeness oracle the streaming path already used, `trackerCoversStreamedCalls`, which now has one owner instead of two copies. Both paths deliver 3 of 3. `DENY_HOLD_TIMEOUT_MS` is derived from `UPSTREAM_IDLE_MS` instead of a standalone 8 s. `guardUpstreamIdle` owns model-stream liveness, and the shorter timer released mid-generation and truncated the tool set.

`src/proxy/messages.ts` (second commit, independent). The fresh-session envelope now states that the replayed history happened and the tool results are genuine, before it forbids imitating the format. On a live OpenCode session the old wording made the model retract a pytest run, a file read, a glob and a grep as fabrications. It cited the warning as its reason.

## Evidence

`bun scripts/e2e-passthrough-turns.mjs [--stream]` (E41) runs an OpenCode-shaped client through the real proxy and the real SDK. The client makes three dependent reads, or three parallel reads with `PROBE_PARALLEL=1`, then one follow-up turn. The gate asserts three things. The final answer quotes all three results. No forwarded denial remains stored for a delivered id in any resumed session. Every continuation turn reads at least 95% of the previous turn's prompt cache. It needs Claude Max and costs real tokens.

Results on sonnet, 2026-08-25, all four combinations:

| Run | Turns | Quoted | Stale denials | Cache read per continuation |
|---|---|---|---|---|
| chain, non-stream | 4 + follow-up | 3/3 | 0 | 5859 = 3703+2156, 6053 = 5859+194, 6216 = 6053+163, 6369 = 6216+153 |
| chain, stream | 4 + follow-up | 3/3 | 0 | 5795 = 3703+2092, 5978 = 5795+183, 6207 = 5978+229, 6368 = 6207+161 |
| parallel, non-stream | 2 + follow-up | 3/3 | 0 | 5830 = 5355+475, 6299 = 5830+469 |
| parallel, stream | 2 + follow-up | 3/3 | 0 | 5772 = 5294+478, 6244 = 5772+472 |

Each continuation's `cache_read_input_tokens` equals the previous turn's `cache_read + cache_creation` to the token. That includes the follow-up turn, whose prompt the loader builds through the repaired rows. The repair costs no prompt cache. A mutation that writes one extra byte into the rewritten content freezes the follow-up's cache read at 5838, against an expected 6307. The assertion catches that defect.

Without the fix (`git stash push src/proxy/server.ts`), the chain run fails by the third turn: 0/3 quoted, 2 stale denials. The model answers "[Error: tool call forwarded to client, no content returned]" for the first two files.

Unit and integration suites: `passthrough-transcript`, `passthrough-transcript-integration`, `passthrough-early-stop`, `passthrough-early-stop-integration`, `proxy-nonstream-deny-hold`, `messages`, `proxy-replay-envelope`. 152 pass on this branch. `tsc --noEmit` is clean.

## Not in this PR

- Removal of the workarounds cited above. Candidates only; none is removed here.
- Runs on haiku and opus. All measurements are on sonnet.
- The `scripts/probe-passthrough-*.mjs` files print findings and never assert. They are the diagnostics that found the mechanism and are documented in E2E.md as such, separate from the gate.
