### PR TITLE
fix(cwd): disown the CLI's own environment lines, not only the path

### DIFF
--- a/src/__tests__/query-cwd-note.test.ts
+++ b/src/__tests__/query-cwd-note.test.ts
@@ -31,6 +31,19 @@ describe("buildCwdNote", () => {
     expect(note).toContain("</meridian-note>")
   })
 
+  // The CLI always emits its own environment block from the subprocess cwd,
+  // so the note must disown BOTH of its lines by name, not only the path:
+  // left unmentioned, "Is a git repository: false" is taken as true and the
+  // model reports the contradiction to the user.
+  it("names the CLI's own working-directory and git-repository lines as proxy-host facts", () => {
+    const note = buildCwdNote("/app", "C:\\projects\\example-app")
+    expect(note).toContain('"Primary working directory: /app"')
+    expect(note).toContain('"Is a git repository: ..."')
+    expect(note).toContain("describes that host, not the user's machine")
+    expect(note).toContain("client's own environment block")
+    expect(note).toContain("two different machines")
+  })
+
   it("places the <env> override before the meridian-note so the subprocess sees it first", () => {
     const note = buildCwdNote("/srv/proxy", "/Users/alice/app")
     const envIdx = note.indexOf("<env>")

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -240,26 +240,33 @@ function computePassthroughMaxTurns(
  * Build an addendum that tells the model which path belongs to the real user.
  * Applied when the SDK subprocess runs in one directory on the proxy host but
  * the client is working in a different directory on their own machine
- * (typical of a remote Claude Code → network-proxy setup). Without this note
- * the SDK's env block leaks `sdkCwd` into the model's context and Claude
- * reports that as its working directory.
+ * (typical of a remote Claude Code → network-proxy setup).
+ *
+ * The CLI computes its own environment block from the subprocess cwd and
+ * always emits it, whatever the system prompt already contains: "Primary
+ * working directory: <sdkCwd>" and "Is a git repository: <bool>" describe the
+ * proxy host, and nothing the proxy appends suppresses them. The note has to
+ * name both lines, or the model accepts the git-status line as true, reports
+ * the contradiction to the user, and reasons about the wrong tree.
  */
 export function buildCwdNote(sdkCwd: string, clientCwd?: string): string {
   if (!clientCwd || clientCwd === sdkCwd) return ""
-  // Emit in the `<env>Working directory: …</env>` shape the Claude Code
-  // subprocess uses itself, so it doesn't auto-inject a second env block
-  // pointing at its own process.cwd() (which would be the proxy host path).
-  // Placed at the top of the append so it's the first env block the model
-  // sees. The subsequent notice tells the model to prefer this over any
-  // contradictory path that might slip through later in the context.
+  // The `<env>` block is the client's working directory in the shape the
+  // client itself uses, first in the append so it precedes the note that
+  // explains it. The note then names the CLI's own lines as proxy-host facts.
   return (
     `\n\n<env>\n` +
     `Working directory: ${clientCwd}\n` +
     `</env>\n` +
     `<meridian-note>\n` +
     `You are reached through a proxy. The subprocess running you resides at ` +
-    `"${sdkCwd}" on the proxy host, but that is not the user's working directory. ` +
-    `Always treat "${clientCwd}" as the working directory when referring to files or paths.\n` +
+    `"${sdkCwd}" on the proxy host, and the environment block it generated ` +
+    `("Primary working directory: ${sdkCwd}", "Is a git repository: ...") describes ` +
+    `that host, not the user's machine. The user's working directory is "${clientCwd}"; ` +
+    `always treat it as the working directory when referring to files or paths. ` +
+    `Whether it is a git repository is stated by the client's own environment block ` +
+    `when one is present; otherwise \`git status\` tells you. The two blocks describe ` +
+    `two different machines.\n` +
     `</meridian-note>`
   )
 }


### PR DESCRIPTION
When the SDK subprocess and the client run in different directories, the model gets two environment blocks. Only one line of the stale block is disowned. The model reads "Is a git repository: false" from the proxy host as true of the user's machine. It then reports the mismatch to the user as a contradiction.

## What the model sees

The CLI builds its own environment block from the subprocess cwd and emits it on every request, whatever the system prompt already contains:

```
Primary working directory: /app
Is a git repository: false
```

`buildCwdNote` (#744, PR #746) appends an `<env>` block with the client's directory, plus a note that disputes the path. Its comment says the appended block stops the CLI from injecting its own. It does not. The CLI builds that block in `computeEnvInfo` from `getCwd()` and `getIsGit()`, and it reaches the model anyway, as the transcript below shows.

So the model receives both, and the note names only one of the two lines. Measured against a proxy running in `/app` with a client in `C:\projects\example-app`, asked to quote every environment line it can see:

```
[Environment block]
"Primary working directory: /app"
"Is a git repository: false"

[env block]
"Working directory: C:\projects\example-app"

[meridian-note]
"... resides at "/app" on the proxy host, but that is not the user's working directory."
```

The model picked the client directory for paths, which is what the note asks for. It then told the user that the environment block reports `/app` and no git repository, while the real directory is a repository. That second claim comes from a line no one had disowned.

This matters beyond the confusing message. `Is a git repository: false` gates behaviour. A model that believes it is outside a repository does not offer to commit, and does not run `git status` before a destructive command.

## The change

The note now names both of the CLI's lines as proxy-host facts and states the client's directory. It also says where the git answer comes from: the client's own environment block when it sends one, otherwise `git status`. One test covers that.

After the change, the same probe on the same proxy:

```
1. Working directory: C:\projects\example-app
2. Yes, it's a git repository
3. I'm reached through a proxy - the subprocess backing me runs at /app on the
   proxy host, but that's irrelevant to you; all file/path operations refer to
   your machine above.
```

## One wording constraint

An earlier revision of this note ended with "so there is no discrepancy to resolve or report". The model then treated the whole `<meridian-note>` as injected content and said so to the user. It read that sentence as an instruction to explain away a mismatch. The shipped wording states that the two blocks describe two different machines, and stops there. A note that tells the model what not to say to the user reads as manipulation, whoever wrote it.

## Scope

`buildCwdNote` returns an empty string when the client directory is absent or equals the SDK cwd, so a same-host client is unaffected. Only the note text changes; no call site, no control flow.

Verified on the prod image with the plugins mount: 9 of 9 harness cases pass, and the probe above is the deployed behaviour. Unit suites `query-cwd-note`, `opencode-cwd-note`, `claude-code-cwd-note`, `query-git-status-note` and `pi-adapter`: 80 pass. `tsc --noEmit` is clean.
