### PR TITLE
fix(passthrough): make durable resume crash safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
       - run: bun test src/__tests__/claude-executable-resolver.test.ts
         shell: bash
 
+      # Exercise the real Windows SDK process wrapper, PowerShell incarnation
+      # capture, abort handling, stderr draining, and exact join semantics.
+      - run: bun test src/__tests__/sdk-process-gate.test.ts src/__tests__/process-incarnation.test.ts
+        shell: bash
+
       # Plugin loader exercises `await import(absolutePath)` which on Windows
       # rejects raw backslash paths with `Received protocol c:`. The test
       # writes a real plugin file to a tempdir and loads it, so it actually

--- a/E2E.md
+++ b/E2E.md
@@ -93,6 +93,7 @@ kill $(lsof -ti :3456)
 | E38 | [Silent turns (#768)](#e38-silent-turns-768) | **Automated**: `bun scripts/e2e-silent-turn.mjs` — real CLI, SSE mode. Asserts four things per attempt: the client got text or a tool call; recovered content sits BEFORE the terminal `message_delta` (content behind it is dropped by a correct client); exactly one `message_delta` per message; and a third turn after a recovery still resumes. Attribution is read from `/telemetry/logs`, not stdout. Pair `MERIDIAN_DEBUG_FORCE_SILENT_TURN=1` against `MERIDIAN_SILENT_TURN_RECOVERY=0` for the before/after. **Run before any release touching the passthrough tool loop, prompt assembly, or session resume** | 2026-08-11 |
 | E39 | [OpenCode internal-agent session key (#845)](#e39-opencode-internal-agent-session-key-845) | **Manual**, real OpenCode: its `title` agent runs under the USER'S session id, so the user's first turn used to queue behind it and then get HTTP 400 `session_turn_conflict`. Asserts the first turn succeeds, waits ~0ms on the session lease, and every later request is `lineage=continuation`. **Run after any OpenCode upgrade and before releases touching session keys or the turn coordinator** | 2026-08-19 |
 | E40 | [Passthrough digest-turn cap](#e40-passthrough-digest-turn-cap) | **Automated**: `bun scripts/e2e-digest-turn-cap.mjs` — real SDK. Asserts the capped tool turn generates no digest text, costs materially less than uncapped on an identical prompt, still RESUMES at its captured checkpoint, leaves text-only turns returning `success`, and does not truncate parallel tool calls. **Run before any release touching the passthrough tool loop, `maxTurns`, or the early-stop checkpoint** | 2026-08-20 |
+| E41 | [Passthrough multi-turn: one call, one answer](#e41-passthrough-multi-turn-one-call-one-answer) | **Automated**: `bun scripts/e2e-passthrough-turns.mjs [--stream]` — real proxy + SDK + Claude Max. Chain and `PROBE_PARALLEL=1` modes assert exact tool-call batching, a distinct durable fork per result round, one real answer per delivered call in the active transcript, and full prompt-cache continuity. **Run all four chain/parallel × stream/non-stream combinations before releases touching passthrough resume or the deny hook** | 2026-08-26 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -122,6 +123,8 @@ cat /tmp/proxy-e2e.log | strings | grep "\[PROXY\]" | tail -5
 ```
 
 **Session header.** All curl tests use `x-opencode-session` to control session identity. This is the header the OpenCode adapter reads.
+
+**Diagnostics vs gates.** `scripts/e2e-*.mjs` are gates: they assert and exit non-zero. `scripts/probe-*.mjs` are not — they drive the same real stack but print findings for a human to read, and are deliberately absent from the index above so a green run is never mistaken for a passing gate. The passthrough probes reconstruct what `resumeSessionAt` would keep by reading the session JSONL the CLI wrote, which is the one thing the mocked suites cannot check. They need Claude Max and cost real tokens.
 
 **Cleanup.** Each test section is independent. Kill the proxy and clear the session store between sections if you need isolation:
 ```bash
@@ -3525,3 +3528,58 @@ cause. Read its `digest turns` line against the corpus it scanned: a machine
 running mostly internal-mode Claude Code has almost no passthrough transcripts,
 so a `0.0%` there means "little passthrough traffic here", not "the digest turn
 is cheap". Per-turn cost is what E40 measures.
+
+## E41: Passthrough multi-turn: one call, one answer
+
+**What it proves:** across dependent and parallel forwarded tool calls, the active
+SDK session contains exactly one answer per delivered call — the client's real
+result — and never replays the forwarding hook's denial.
+
+**Why it needs the real SDK and several turns:** `resumeSessionAt` only trims a
+suffix of the source transcript. A plain resume leaves the denial in that source,
+and the CLI loader can splice it back on a later turn. Meridian therefore resumes
+the assistant checkpoint with the supported `forkSession` option. The child fork
+makes the replacement tail durable while the superseded source becomes dead
+history. Mocked tests cannot prove the CLI loader or prompt-cache behavior.
+
+Run the full matrix:
+
+```bash
+bun scripts/e2e-passthrough-turns.mjs
+bun scripts/e2e-passthrough-turns.mjs --stream
+PROBE_PARALLEL=1 bun scripts/e2e-passthrough-turns.mjs
+PROBE_PARALLEL=1 bun scripts/e2e-passthrough-turns.mjs --stream
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- Chain mode returns three batches of one call; parallel mode returns one batch
+  of all three calls. Eventually returning three serial calls does not pass the
+  parallel gate.
+- The final answer quotes all three delivered results and never claims a call
+  went unanswered.
+- Every result round advances to a distinct continuation session, proving the
+  replacement tail was committed to a fork rather than only rewound for one
+  query.
+- A follow-up resumes the active fork. Its JSONL contains exactly one real
+  `tool_result` for every delivered id and no forwarding denial for those ids.
+  Superseded parent files may retain the deny tail that was cut; they are not
+  live history and are reported separately for retention accounting.
+- Every continuation, including the follow-up, reads at least 95% of the prior
+  turn's `cache_read_input_tokens + cache_creation_input_tokens`.
+
+**Mechanism-level A/B:**
+
+```bash
+bun scripts/probe-passthrough-accumulation.mjs
+bun scripts/probe-passthrough-accumulation.mjs --fork
+```
+
+The raw-SDK probe records the actual Anthropic request bodies through a local
+`ANTHROPIC_BASE_URL` tap. The first command demonstrates the stale denial winning;
+`--fork` proves the supported replacement branch sends only the real result.
+
+**Verified:** 2026-08-26, sonnet, chain and parallel, stream and non-stream.
+The active fork held one real answer per delivered call and every continuation
+read the prior cached prefix in full.
+

--- a/scripts/e2e-passthrough-turns.mjs
+++ b/scripts/e2e-passthrough-turns.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env bun
+/**
+ * Multi-turn passthrough conversation through the REAL proxy.
+ *
+ * probe-passthrough-accumulation.mjs proves the defect and the supported
+ * forkSession repair at the SDK level. This drives Meridian itself the way
+ * OpenCode does: send a request with tools, execute the returned calls, replay
+ * the history plus tool_results, and continue until the model answers.
+ *
+ * The gate asserts behavior, cache continuity, exact tool-call batching, and
+ * the ACTIVE fork's transcript. Superseded source sessions may retain the deny
+ * tail that forkSession cut; they are not live history and are reported only
+ * for retention accounting.
+ *
+ *   bun scripts/e2e-passthrough-turns.mjs [--stream]
+ */
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { snapshotSessionFiles as snapshot, readRows, blocksOf } from "./lib/passthrough-jsonl.mjs"
+import { isForwardedDenial } from "../src/proxy/passthroughDenial.ts"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+process.env.OPENCODE_CLAUDE_PROVIDER_DEBUG = "1"
+const { startProxyServer } = await import("../src/proxy/server.ts")
+
+const STREAM = process.argv.includes("--stream")
+const PORT = Number(process.env.PROBE_PORT ?? 3522)
+const MODEL = process.env.PROBE_MODEL ?? "claude-sonnet-5"
+const MAX_TURNS = Number(process.env.PROBE_TURNS ?? 6)
+
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-proxy-"))
+const CONTENT = { "a.txt": "alpha", "b.txt": "bravo", "c.txt": "charlie" }
+const FILES = Object.keys(CONTENT).map(f => join(WORKDIR, f))
+for (const f of FILES) writeFileSync(f, CONTENT[f.slice(-5)] + "\n")
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file from disk",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string", description: "Absolute path" } },
+    required: ["file_path"],
+  },
+}
+
+// Keep proxy logs out of the probe's verdict while retaining lineage events.
+const say = console.log.bind(console)
+const proxyLog = []
+// claudeLog events use console.debug and request lines use console.error.
+for (const k of ["log", "error", "debug"]) console[k] = (...args) => { proxyLog.push(args.map(String).join(" ")) }
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1" })
+const short = s => (typeof s === "string" && s.length > 10 ? s.slice(-8) : String(s))
+
+/** Parse either response shape into assistant content blocks plus usage. */
+async function assistantBlocks(res) {
+  const text = await res.text()
+  if (!STREAM) { const body = JSON.parse(text); return { blocks: body.content ?? [], usage: body.usage ?? {} } }
+  const blocks = []
+  let usage = {}
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data:")) continue
+    let ev
+    try { ev = JSON.parse(line.slice(5)) } catch { continue }
+    if (ev.type === "message_start") usage = { ...usage, ...(ev.message?.usage ?? {}) }
+    if (ev.type === "message_delta" && ev.usage) usage = { ...usage, ...ev.usage }
+    if (ev.type === "content_block_start") blocks[ev.index] = { ...ev.content_block, ...(ev.content_block.type === "tool_use" ? { _json: "" } : {}) }
+    if (ev.type === "content_block_delta") {
+      const b = blocks[ev.index]
+      if (ev.delta.type === "text_delta") b.text = (b.text ?? "") + ev.delta.text
+      if (ev.delta.type === "input_json_delta") b._json += ev.delta.partial_json
+    }
+  }
+  return { usage, blocks: blocks.filter(Boolean).map(b => {
+    if (b.type === "tool_use") { const { _json, ...rest } = b; return { ...rest, input: _json ? JSON.parse(_json) : (b.input ?? {}) } }
+    return b
+  }) }
+}
+
+/** One line of prompt-cache accounting: what was read from cache vs paid for. */
+const usageLine = u => {
+  const read = u.cache_read_input_tokens ?? 0, created = u.cache_creation_input_tokens ?? 0, fresh = u.input_tokens ?? 0
+  const total = read + created + fresh
+  return `cache_read=${read} cache_create=${created} input=${fresh} (${total ? Math.round(100 * read / total) : 0}% of ${total} input read from cache)`
+}
+
+// Prompt-cache continuity across resumes. Forking changes session/message
+// metadata, not Anthropic prompt content, so each continuation must read the
+// previous turn's full cached prefix.
+const CACHE_FLOOR = 0.95
+let priorCached = 0
+const cacheMisses = []
+function checkCache(label, usage, lineage) {
+  const read = usage.cache_read_input_tokens ?? 0
+  if (lineage.includes("continuation") && priorCached > 0 && read < CACHE_FLOOR * priorCached) {
+    cacheMisses.push(`${label}: cache_read=${read} < ${CACHE_FLOOR} x prior cached ${priorCached}`)
+  }
+  priorCached = read + (usage.cache_creation_input_tokens ?? 0)
+}
+
+async function send(messages) {
+  return fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-api-key": "dummy", "x-opencode-session": sessionId, "user-agent": "opencode/1.0.0" },
+    body: JSON.stringify({ model: MODEL, max_tokens: 2048, stream: STREAM, tools: [READ_TOOL], messages }),
+  })
+}
+
+const sessionId = `probe-turns-${STREAM ? "stream" : "nonstream"}-${process.pid}`
+// PROBE_PARALLEL=1 asks for all three reads in one turn, so the hook's denies
+// arrive while the turn is still generating and are HELD. Pair it with
+// DENY_HOLD_TIMEOUT_MS=1 to make the hold expire, which refuses the checkpoint
+// and forces the next turn through the text-path resume — the one way to
+// exercise that path from outside the proxy.
+const PARALLEL = process.env.PROBE_PARALLEL === "1"
+const messages = [{
+  role: "user",
+  content: PARALLEL
+    ? `Use the read tool to read ${FILES.join(", ")} — all three in a single turn, in parallel. ` +
+      `Once you have all three contents reply with them on one line and nothing else.`
+    : `Use the read tool to read ${FILES[0]}. Only after its content has been returned to you, ` +
+      `read ${FILES[1]}. Only after that content has been returned, read ${FILES[2]}. ` +
+      `Make exactly one read call per step, never in parallel, and once you have all three ` +
+      `reply with the three contents on one line and nothing else.`,
+}]
+
+const before = snapshot()
+const delivered = new Set()
+const continuationPrefixes = []
+const toolCallBatchSizes = []
+let liveSessionPrefix
+let finalText = ""
+
+for (let turn = 1; turn <= MAX_TURNS; turn++) {
+  const logFrom = proxyLog.length
+  const res = await send(messages)
+  const { blocks, usage } = await assistantBlocks(res)
+  const calls = blocks.filter(b => b.type === "tool_use")
+  const text = blocks.filter(b => b.type === "text").map(b => b.text).join("")
+  const turnLog = proxyLog.slice(logFrom)
+  const lineage = turnLog.map(l => l.match(/lineage=\S+ session=\S+/)?.[0]).find(Boolean) ?? "?"
+  const resumedPrefix = lineage.match(/lineage=continuation session=(\S+)/)?.[1]
+  if (resumedPrefix) {
+    continuationPrefixes.push(resumedPrefix)
+    liveSessionPrefix = resumedPrefix
+  }
+  say(`\n=== turn ${turn} (stream=${STREAM}) http ${res.status} ===`)
+  say(`  calls: ${calls.map(c => `${c.name}(${String(c.input?.file_path ?? "").slice(-5)})#${short(c.id)}`).join(", ") || "none"}`)
+  if (text) say(`  text: ${JSON.stringify(text.slice(0, 200))}`)
+  say(`  lineage: ${lineage}`)
+  say(`  usage: ${usageLine(usage)}`)
+  checkCache(`turn ${turn}`, usage, lineage)
+  if (res.status !== 200) { say(`  body: ${JSON.stringify(blocks).slice(0, 300)}`); break }
+
+  messages.push({ role: "assistant", content: blocks.map(({ type, id, name, input, text }) => type === "tool_use" ? { type, id, name, input } : { type, text }) })
+  if (calls.length === 0) { finalText = text; break }
+  toolCallBatchSizes.push(calls.length)
+
+  // Execute the forwarded calls like a client would.
+  const results = calls.map(c => {
+    const p = String(c.input?.file_path ?? "")
+    let content
+    try { content = readFileSync(p, "utf8").trim() } catch (e) { content = `ERROR: ${e.message}` }
+    delivered.add(c.id)
+    return { type: "tool_result", tool_use_id: c.id, content: `REALOUTPUT[${content}]` }
+  })
+  messages.push({ role: "user", content: results })
+}
+
+// One more turn after the answer. This resumes the final live fork through all
+// delivered results and proves both the active transcript and its cache prefix.
+if (finalText) {
+  const logFrom = proxyLog.length
+  const res = await send([...messages, { role: "user", content: "Reply with the single word OK." }])
+  const { usage } = await assistantBlocks(res)
+  const lineage = proxyLog.slice(logFrom).map(l => l.match(/lineage=\S+ session=\S+/)?.[0]).find(Boolean) ?? "?"
+  const resumedPrefix = lineage.match(/lineage=continuation session=(\S+)/)?.[1]
+  if (resumedPrefix) {
+    continuationPrefixes.push(resumedPrefix)
+    liveSessionPrefix = resumedPrefix
+  }
+  say(`\n=== follow-up turn (stream=${STREAM}) http ${res.status} ===`)
+  say(`  lineage: ${lineage}`)
+  say(`  usage: ${usageLine(usage)}`)
+  checkCache("follow-up", usage, lineage)
+}
+
+// The CLI flushes the transcript as the query settles; give it a beat.
+await new Promise(r => setTimeout(r, 1500))
+const touched = [...snapshot().entries()].filter(([p, m]) => !before.has(p) || before.get(p) !== m).map(([p]) => p)
+
+say(`\n=== verdict (stream=${STREAM}, parallel=${PARALLEL}) ===`)
+const quotes = Object.values(CONTENT).filter(w => finalText.includes(w))
+const claimsUnanswered = /forwarded|no content|not returned|never returned|no result/i.test(finalText)
+const toolShapeOk = PARALLEL
+  ? toolCallBatchSizes.length === 1 && toolCallBatchSizes[0] === 3
+  : toolCallBatchSizes.length === 3 && toolCallBatchSizes.every(n => n === 1)
+const uniqueContinuations = new Set(continuationPrefixes)
+const forkShapeOk = uniqueContinuations.size === toolCallBatchSizes.length + 1
+say(`  tool-call batches: ${toolCallBatchSizes.join(" + ") || "none"}${toolShapeOk ? "" : "   <-- WRONG TURN SHAPE"}`)
+say(`  continuation session prefixes: ${[...uniqueContinuations].join(" -> ") || "none"}${forkShapeOk ? "" : "   <-- FORK CHAIN NOT DURABLE"}`)
+say(`  final reply quotes ${quotes.length}/3 contents: ${quotes.join(",") || "none"}${claimsUnanswered ? "   <-- claims a call went unanswered" : ""}`)
+
+const activeFiles = liveSessionPrefix
+  ? touched.filter(file => file.split("/").at(-1)?.startsWith(liveSessionPrefix))
+  : []
+const supersededFiles = touched.filter(file => !activeFiles.includes(file))
+const activeAnswerProblems = []
+for (const file of activeFiles) {
+  const answerBlocks = readRows(file).flatMap(row => blocksOf(row).filter(block =>
+    block?.type === "tool_result" && delivered.has(block.tool_use_id)
+  ))
+  for (const id of delivered) {
+    const answers = answerBlocks.filter(block => block.tool_use_id === id)
+    const denials = answers.filter(isForwardedDenial)
+    const real = answers.filter(block => !isForwardedDenial(block))
+    if (denials.length !== 0 || real.length !== 1) {
+      activeAnswerProblems.push(`${short(id)}: real=${real.length} denial=${denials.length}`)
+    }
+  }
+  say(`  active fork ${file}: ${activeAnswerProblems.length ? activeAnswerProblems.join(", ") : "exactly one real answer per delivered call"}`)
+}
+say(`  superseded fork files still present: ${supersededFiles.length}`)
+say(`  prompt cache: ${cacheMisses.length ? cacheMisses.join("; ") + "   <-- PREFIX LOST" : "every continuation read the prior cached prefix"}`)
+if (touched.length === 0) say("  no session JSONL was written — inconclusive")
+if (activeFiles.length !== 1) say(`  expected one active fork, found ${activeFiles.length}`)
+const pass = quotes.length === 3 &&
+  !claimsUnanswered &&
+  delivered.size === 3 &&
+  toolShapeOk &&
+  forkShapeOk &&
+  activeFiles.length === 1 &&
+  activeAnswerProblems.length === 0 &&
+  cacheMisses.length === 0
+say(`  ${pass ? "PASS" : "FAIL"}: active history has one call, one real answer`)
+
+await inst.stop?.()
+process.exit(pass ? 0 : 1)

--- a/scripts/lib/passthrough-jsonl.mjs
+++ b/scripts/lib/passthrough-jsonl.mjs
@@ -1,0 +1,76 @@
+/**
+ * Shared reader for the session JSONL the CLI writes behind Meridian.
+ *
+ * The passthrough probes all answer the same question — what would
+ * resumeSessionAt keep? — so they read the transcript the same way, from one
+ * copy.
+ *
+ * A denial is whatever src/proxy/passthroughDenial.ts says it is: the
+ * proxy's own detector, imported rather than restated, so runtime and E2E
+ * checks cannot disagree about which rows are the hook's denials. A client
+ * result can itself be an error, so `is_error` alone is never sufficient.
+ */
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { isForwardedDenial } from "../../src/proxy/passthroughDenial.ts"
+
+const PROJECTS_ROOT = join(homedir(), ".claude", "projects")
+
+/** Locate the session JSONL the CLI wrote for a session id, whatever the cwd slug. */
+export function findSessionFile(sessionId) {
+  if (!existsSync(PROJECTS_ROOT)) return null
+  for (const dir of readdirSync(PROJECTS_ROOT)) {
+    const candidate = join(PROJECTS_ROOT, dir, `${sessionId}.jsonl`)
+    if (existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+/** Every session JSONL on disk with its mtime, for before/after diffing. */
+export function snapshotSessionFiles() {
+  const seen = new Map()
+  if (!existsSync(PROJECTS_ROOT)) return seen
+  for (const dir of readdirSync(PROJECTS_ROOT)) {
+    const full = join(PROJECTS_ROOT, dir)
+    let entries
+    try { entries = readdirSync(full) } catch { continue }
+    for (const f of entries) {
+      if (!f.endsWith(".jsonl")) continue
+      const p = join(full, f)
+      try { seen.set(p, statSync(p).mtimeMs) } catch { /* raced with a write */ }
+    }
+  }
+  return seen
+}
+
+export function readRows(file) {
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter(l => l.trim().length > 0)
+    .map(l => { try { return JSON.parse(l) } catch { return null } })
+    .filter(Boolean)
+}
+
+export const blocksOf = row => (Array.isArray(row?.message?.content) ? row.message.content : [])
+
+/** Flatten a tool_result's content to text, whichever shape it arrived in. */
+export function toolResultText(block) {
+  if (typeof block?.content === "string") return block.content
+  if (Array.isArray(block?.content)) return block.content.map(c => c?.text ?? "").join("")
+  return ""
+}
+
+/** A synthetic denial: the CLI's answer to a call the hook refused. */
+export const isDenyResult = isForwardedDenial
+
+/**
+ * Guard against a silent detection failure: a turn that forwarded calls must
+ * have produced denials, so finding none means the reader is broken, not that
+ * the transcript is clean. Returns a warning string, or null when all is well.
+ */
+export function denyDetectionWarning({ forwardedCalls, denyResults }) {
+  if (forwardedCalls === 0 || denyResults.length > 0) return null
+  return `${forwardedCalls} call(s) were forwarded but NO deny tool_result was found — ` +
+    `treat every "clean" result below as unproven; the reader, not the transcript, is probably wrong`
+}

--- a/scripts/probe-passthrough-accumulation.mjs
+++ b/scripts/probe-passthrough-accumulation.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env bun
+/**
+ * Multi-turn probe for the passthrough synthetic-denial defect.
+ * See ~/ss/claude/meridian-passthrough-spec.md — *Phase 3 field test*.
+ *
+ * A single-turn probe cannot see this defect: `resumeSessionAt` cuts a suffix,
+ * so it removes the current turn's denials and never a previous turn's. This
+ * one drives the raw Agent SDK through a chain of dependent tool calls, one
+ * per turn, resuming at the checkpoint each time exactly as Meridian does, and
+ * records WHAT THE MODEL WAS SENT via a recording proxy on ANTHROPIC_BASE_URL.
+ * The transcript on disk is shown too, with its parentUuid topology, because
+ * the CLI loads by walking that chain and then splicing back "orphaned"
+ * tool_results — which is how a logically truncated denial comes back.
+ *
+ * The one assertion that matters: on the wire, every call whose real result
+ * was delivered is answered exactly once, by that real result. "Answered more
+ * than once" is not enough — the CLI dedups tool_results per id and keeps the
+ * FIRST, so the observed failure is the denial winning and the real result
+ * vanishing.
+ *
+ *   bun scripts/probe-passthrough-accumulation.mjs         # source resume: FAILs
+ *   bun scripts/probe-passthrough-accumulation.mjs --fork  # durable replacement
+ *       branch through the Agent SDK's supported forkSession option: PASSes
+ *
+ * Deleting the denial rows instead is not an option: the loader starts its
+ * chain walk from the `last-prompt` leaf hint, which points at the deleted
+ * row, and the resume fails with "No message found with message.uuid".
+ *
+ * Costs a few cents of real tokens and needs Claude Max.
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import http from "node:http"
+import https from "node:https"
+import { findSessionFile, readRows, blocksOf, toolResultText, isDenyResult } from "./lib/passthrough-jsonl.mjs"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+import { PASSTHROUGH_DENY_REASON } from "../src/proxy/passthroughDenial.ts"
+
+const FIX = process.argv.includes("--fork") ? "fork" : "none"
+const MODEL = process.env.PROBE_MODEL ?? "sonnet"
+const MAX_TURNS = Number(process.env.PROBE_TURNS ?? 5)
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-acc-"))
+const FILES = ["a.txt", "b.txt", "c.txt"].map(f => join(WORKDIR, f))
+const CONTENT = { "a.txt": "alpha", "b.txt": "bravo", "c.txt": "charlie" }
+for (const f of FILES) writeFileSync(f, CONTENT[f.slice(-5)] + "\n")
+
+const short = s => (typeof s === "string" && s.length > 10 ? s.slice(-8) : String(s))
+
+// ---------------------------------------------------------------- wire tap
+/**
+ * Minimal recording proxy: the CLI talks to it as ANTHROPIC_BASE_URL, it
+ * forwards to the real API and keeps every request body, labelled with the
+ * probe turn that produced it. Responses stream straight through.
+ */
+const wire = []
+let currentTurn = 0
+const UPSTREAM = new URL(process.env.PROBE_UPSTREAM ?? "https://api.anthropic.com")
+const tap = http.createServer((req, res) => {
+  const chunks = []
+  req.on("data", c => chunks.push(c))
+  req.on("end", () => {
+    const raw = Buffer.concat(chunks)
+    let body = null
+    try { body = JSON.parse(raw.toString("utf8")) } catch { /* not JSON */ }
+    if (body?.messages) wire.push({ turn: currentTurn, path: req.url, body })
+    const client = UPSTREAM.protocol === "https:" ? https : http
+    const up = client.request(
+      { hostname: UPSTREAM.hostname, port: UPSTREAM.port || undefined, path: req.url, method: req.method,
+        headers: { ...req.headers, host: UPSTREAM.host } },
+      u => { res.writeHead(u.statusCode ?? 502, u.headers); u.pipe(res) },
+    )
+    up.on("error", e => { res.writeHead(502); res.end(String(e)) })
+    up.end(raw)
+  })
+})
+await new Promise(r => tap.listen(0, "127.0.0.1", r))
+const TAP_URL = `http://127.0.0.1:${tap.address().port}`
+
+// ---------------------------------------------------------------- SDK drive
+const claudeExecutable = await resolveClaudeExecutableAsync()
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/** Mirrors the passthrough shape buildQueryOptions produces. */
+function options(extra = {}) {
+  return {
+    executable: "node",
+    maxTurns: 1,
+    cwd: WORKDIR,
+    model: MODEL,
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    env: { ...process.env, ANTHROPIC_BASE_URL: TAP_URL },
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          return { decision: "block", reason: PASSTHROUGH_DENY_REASON }
+        }],
+      }],
+    },
+    ...extra,
+  }
+}
+
+async function drive(prompt, extra) {
+  const out = { sessionId: "", subtype: null, text: "", calls: [], checkpointUuid: "", threw: undefined }
+  try {
+    for await (const m of query({ prompt, options: options(extra) })) {
+      if (m.session_id && !out.sessionId) out.sessionId = m.session_id
+      if (m.type === "assistant") {
+        let armed = false
+        for (const b of m.message?.content ?? []) {
+          if (b.type === "tool_use") { out.calls.push({ id: b.id, name: b.name, input: b.input }); armed = true }
+          if (b.type === "text") out.text += b.text
+        }
+        if (armed) out.checkpointUuid = m.uuid ?? ""
+      }
+      if (m.type === "result") out.subtype = m.subtype
+    }
+  } catch (e) {
+    out.threw = e instanceof Error ? e.message : String(e)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------- reporting
+function describeRow(row, index) {
+  const blocks = blocksOf(row).map(b => {
+    if (b.type === "tool_use") return `tool_use:${short(b.id)}(${b.name})`
+    if (b.type === "tool_result") return `tool_result:${short(b.tool_use_id)}=${isDenyResult(b) ? "DENY" : JSON.stringify(toolResultText(b).slice(0, 20))}`
+    return b.type
+  })
+  const content = typeof row.message?.content === "string" ? JSON.stringify(row.message.content.slice(0, 30)) : blocks.join(",")
+  return `[${String(index).padStart(2)}] ${(row.type ?? "?").padEnd(9)} uuid=${short(row.uuid)} parent=${short(row.parentUuid) ?? "-"}  ${content}`
+}
+
+function dumpTranscript(label, file) {
+  const rows = readRows(file)
+  console.log(`  --- ${label}: ${rows.length} rows on disk`)
+  rows.forEach((r, i) => console.log("    " + describeRow(r, i)))
+  return rows
+}
+
+/** tool_use_id -> list of answers, from a request body's messages. */
+function answersOnWire(body) {
+  const byId = new Map()
+  for (const m of body.messages ?? []) {
+    if (m.role !== "user" || !Array.isArray(m.content)) continue
+    for (const b of m.content) {
+      if (b?.type !== "tool_result") continue
+      const list = byId.get(b.tool_use_id) ?? []
+      list.push(isDenyResult(b) ? "DENY" : "REAL")
+      byId.set(b.tool_use_id, list)
+    }
+  }
+  return byId
+}
+
+/**
+ * The wire report for one probe turn: what the model saw for every id.
+ * Returns how many DELIVERED ids were misanswered — anything other than a
+ * single REAL result.
+ */
+function reportWire(turn, delivered) {
+  // The first turn also fires side requests (title generation); only the
+  // conversation requests carry history worth reading.
+  const reqs = wire.filter(w => w.turn === turn && w.body.messages.length > 1)
+  if (reqs.length === 0) { console.log(`  wire: ${delivered.size === 0 ? "first turn, nothing to check" : "NO REQUEST RECORDED (is ANTHROPIC_BASE_URL honoured?)"}`); return 0 }
+  let bad = 0
+  for (const [i, r] of reqs.entries()) {
+    const byId = answersOnWire(r.body)
+    const wrong = [...delivered].filter(id => (byId.get(id) ?? []).join() !== "REAL")
+    bad += wrong.length
+    const denialTexts = JSON.stringify(r.body).split(PASSTHROUGH_DENY_REASON.slice(0, 40)).length - 1
+    console.log(`  wire request ${i + 1}/${reqs.length}: ${r.body.messages.length} messages, ` +
+      `${byId.size} id(s) answered, ${wrong.length} delivered id(s) MISANSWERED, denial text present ${denialTexts}x`)
+    for (const [id, answers] of byId) {
+      const verdict = !delivered.has(id) ? "" : answers.join() === "REAL" ? "  ok" : "  <-- WRONG (real result was delivered)"
+      console.log(`    ${short(id)}: ${answers.join(" then ")}${verdict}`)
+    }
+  }
+  return bad
+}
+
+// ---------------------------------------------------------------- run
+console.log(`model=${MODEL} fix=${FIX} workdir=${WORKDIR} tap=${TAP_URL}`)
+
+const prompt =
+  `Use the read tool to read ${FILES[0]}. Only after its content has been returned to you, ` +
+  `read ${FILES[1]}. Only after that content has been returned, read ${FILES[2]}. ` +
+  `Make exactly one read call per step, never in parallel, and once you have all three ` +
+  `reply with the three contents on one line and nothing else.`
+
+let sessionId = ""
+let checkpoint = ""
+let pendingCalls = []
+let file = null
+let totalBad = 0
+let lastText = ""
+const delivered = new Set()
+
+for (let turn = 1; turn <= MAX_TURNS; turn++) {
+  currentTurn = turn
+  console.log(`\n=== turn ${turn} ${turn === 1 ? "(first)" : `(resume at ${short(checkpoint)}, answering ${pendingCalls.map(c => short(c.id)).join(",")})`} ===`)
+
+  let result
+  if (turn === 1) {
+    result = await drive(prompt)
+  } else {
+    const realResults = pendingCalls.map(c => ({
+      type: "tool_result",
+      tool_use_id: c.id,
+      content: `REALOUTPUT[${CONTENT[String(c.input?.file_path ?? "").slice(-5)] ?? "?"}]`,
+    }))
+    for (const c of pendingCalls) delivered.add(c.id)
+    const delta = (async function* () {
+      yield { type: "user", session_id: sessionId, parent_tool_use_id: null, message: { role: "user", content: realResults } }
+    })()
+    result = await drive(delta, {
+      resume: sessionId,
+      resumeSessionAt: checkpoint,
+      ...(FIX === "fork" ? { forkSession: true } : {}),
+    })
+  }
+
+  if (result.sessionId) sessionId = result.sessionId
+  console.log(`  subtype=${result.subtype} threw=${result.threw ?? "no"} calls=${result.calls.map(c => `${c.name}(${String(c.input?.file_path ?? "").slice(-5)})`).join(",") || "none"}`)
+  if (result.text) console.log(`  text=${JSON.stringify(result.text.slice(0, 160))}`)
+  lastText = result.text
+
+  file = findSessionFile(sessionId)
+  if (!file) { console.log("FAIL: no session JSONL found"); process.exit(1) }
+  dumpTranscript(`transcript after turn ${turn}`, file)
+  totalBad += reportWire(turn, delivered)
+
+  if (result.calls.length === 0) break
+  pendingCalls = result.calls
+  checkpoint = result.checkpointUuid
+}
+
+console.log(`\n=== verdict (fix=${FIX}) ===`)
+const quotes = ["alpha", "bravo", "charlie"].filter(w => lastText.includes(w))
+console.log(`  delivered ids misanswered on the wire, summed over turns: ${totalBad}`)
+console.log(`  final reply quotes ${quotes.length}/3 contents: ${quotes.join(",") || "none"}`)
+const pass = totalBad === 0 && quotes.length === 3
+console.log(`  ${pass ? "PASS" : "FAIL"}: one call, one answer, the real one`)
+console.log(`\nsession file: ${file}`)
+tap.close()
+process.exit(pass ? 0 : 1)

--- a/scripts/probe-passthrough-ordering.mjs
+++ b/scripts/probe-passthrough-ordering.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env bun
+/**
+ * Phase 1 follow-up: WHY does a deny survive resumeSessionAt truncation?
+ *
+ * probe-passthrough-transcript.mjs showed the mechanism is positional, not
+ * random. The CLI writes per-block assistant rows and dispatches each block's
+ * PreToolUse hook as soon as that block finishes streaming, so a 2-call turn
+ * lands on disk interleaved:
+ *
+ *     [6] assistant tool_use #1
+ *     [7] user      tool_result #1 = DENY      <-- inside the slice
+ *     [8] assistant tool_use #2                <-- checkpoint (last tool-bearing)
+ *     [9] user      tool_result #2 = DENY      <-- sliced away
+ *
+ * resumeSessionAt slices to (0, checkpointIndex + 1), so the first N-1 denies
+ * of an N-call turn are replayed to the model and the Nth is not. Picking the
+ * FIRST assistant row instead would drop forwarded tool_use blocks, which
+ * dangles the client's results — so no single index is clean while the denies
+ * interleave.
+ *
+ * This probe tests the two predictions that follow, and the one lever that
+ * could already be doing the job in production:
+ *
+ *   A. N=1 leaves ZERO survivors (the defect needs parallelism).
+ *   B. N=3 leaves TWO survivors (survivors == N-1).
+ *   C. Holding the deny until the turn finishes generating — what Meridian's
+ *      holdDenyUntilTurnEnd already does — reorders the log to A1,A2,U1,U2 and
+ *      leaves zero survivors.
+ *
+ * If C holds, the production defect is confined to the paths where the hold
+ * does NOT apply, and the fix is to close those gaps rather than to redesign
+ * the boundary.
+ *
+ * Costs real tokens and needs Claude Max.
+ *
+ *   bun scripts/probe-passthrough-ordering.mjs
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { findSessionFile, readRows, blocksOf, isDenyResult as isDeny } from "./lib/passthrough-jsonl.mjs"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+
+const MODEL = process.env.PROBE_MODEL ?? "sonnet"
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-order-"))
+const FILES = ["a.txt", "b.txt", "c.txt"].map(n => join(WORKDIR, n))
+for (const [i, f] of FILES.entries()) writeFileSync(f, `content-${i}\n`)
+
+const DENY_REASON =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+const claudeExecutable = await resolveClaudeExecutableAsync()
+const sleep = ms => new Promise(r => setTimeout(r, ms))
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/**
+ * @param holdMs 0 = answer the hook immediately (today's raw shape).
+ *               >0 = stall every deny, standing in for holdDenyUntilTurnEnd.
+ */
+function options(holdMs) {
+  return {
+    executable: "node",
+    maxTurns: 1,
+    cwd: WORKDIR,
+    model: MODEL,
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          if (holdMs > 0) await sleep(holdMs)
+          return { decision: "block", reason: DENY_REASON }
+        }],
+      }],
+    },
+  }
+}
+
+async function run(label, fileCount, holdMs) {
+  const targets = FILES.slice(0, fileCount)
+  const prompt = fileCount === 1
+    ? `Read ${targets[0]} using the read tool. Use the tool, do not guess.`
+    : `Read all of ${targets.join(" and ")} using the read tool, in parallel in a single step.`
+
+  let sessionId = ""
+  let checkpointUuid = ""
+  const callIds = new Set()
+  // The SDK throws on the terminal error_max_turns result rather than yielding
+  // it, so the cap is a normal outcome here and not a failure.
+  try {
+    for await (const m of query({ prompt, options: options(holdMs) })) {
+      if (m.session_id && !sessionId) sessionId = m.session_id
+      if (m.type === "assistant") {
+        let armed = false
+        for (const b of m.message?.content ?? []) {
+          if (b.type === "tool_use") { callIds.add(b.id); armed = true }
+        }
+        if (armed) checkpointUuid = m.uuid ?? ""
+      }
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    if (!msg.includes("maximum number of turns")) throw e
+  }
+
+  const file = findSessionFile(sessionId)
+  if (!file) return console.log(`  ${label}: no session file`), null
+
+  const rows = readRows(file)
+  // Only the conversation rows matter — the CLI also writes queue/attachment
+  // bookkeeping rows that carry no content blocks.
+  const shape = rows
+    .map((r, i) => {
+      const bs = blocksOf(r)
+      if (r.type === "assistant" && bs.some(b => b.type === "tool_use")) return { i, tag: "A" }
+      if (r.type === "user" && bs.some(b => b.type === "tool_result" && isDeny(b))) return { i, tag: "U" }
+      return null
+    })
+    .filter(Boolean)
+
+  const checkpointIndex = rows.findIndex(r => r.uuid === checkpointUuid)
+  const kept = checkpointIndex >= 0 ? rows.slice(0, checkpointIndex + 1) : []
+  const survivors = kept.flatMap(r => blocksOf(r).filter(b => b.type === "tool_result" && isDeny(b)))
+  const keptCalls = kept.flatMap(r => blocksOf(r).filter(b => b.type === "tool_use" && callIds.has(b.id)))
+
+  console.log(`  ${label}`)
+  console.log(`    calls=${callIds.size}  log order: ${shape.map(s => s.tag).join("")}  checkpoint=row ${checkpointIndex}`)
+  console.log(`    denies surviving the slice: ${survivors.length}   (expected N-1 = ${callIds.size - 1} when interleaved)`)
+  console.log(`    forwarded tool_use kept:    ${keptCalls.length} of ${callIds.size}${keptCalls.length < callIds.size ? "   <-- DANGLING client result" : ""}`)
+  return { calls: callIds.size, survivors: survivors.length, shape: shape.map(s => s.tag).join("") }
+}
+
+console.log(`model=${MODEL}  workdir=${WORKDIR}\n`)
+console.log("A. single call, no hold — does the defect need parallelism?")
+const a = await run("N=1, hold=0", 1, 0)
+console.log("\nB. three calls, no hold — do survivors track N-1?")
+const b = await run("N=3, hold=0", 3, 0)
+console.log("\nC. three calls, deny held past generation — does the hold reorder the log?")
+const c = await run("N=3, hold=2500ms", 3, 2500)
+
+console.log("\n=== verdict ===")
+if (a) console.log(`  A  N=1 survivors=${a.survivors}  ${a.survivors === 0 ? "OK — a lone call is clean" : "UNEXPECTED — the defect is not positional"}`)
+if (b) console.log(`  B  N=${b.calls} survivors=${b.survivors}  ${b.survivors === b.calls - 1 ? "OK — survivors == N-1" : "UNEXPECTED"}`)
+if (c) console.log(`  C  N=${c.calls} survivors=${c.survivors} order=${c.shape}  ${c.survivors === 0 ? "the hold ALREADY fixes the ordering" : "the hold does NOT fix it"}`)
+console.log(`\nworkdir: ${WORKDIR}`)

--- a/scripts/probe-passthrough-proxy.mjs
+++ b/scripts/probe-passthrough-proxy.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+/**
+ * Phase 3 measurement: does the REAL proxy produce a clean transcript ordering?
+ *
+ * probe-passthrough-ordering.mjs proved the rule against the raw SDK: with N
+ * parallel calls the session JSONL interleaves (A U A U A U) and resumeSessionAt
+ * replays the first N-1 denials to the model, unless the denials are held until
+ * generation ends, which reorders it to A A A U U U.
+ *
+ * Meridian holds denials already (holdDenyUntilTurnEnd), but only the streaming
+ * path releases on the turn boundary. Non-stream releases on the FIRST assistant
+ * message and clears turnGenerating with it, so every later parallel block skips
+ * the hold. This drives the actual proxy on both paths and reads the SDK session
+ * JSONL it produced, so the answer is measured rather than reasoned about.
+ *
+ *   bun scripts/probe-passthrough-proxy.mjs
+ */
+import {
+  snapshotSessionFiles as snapshot,
+  readRows,
+  blocksOf,
+  isDenyResult as isDeny,
+  denyDetectionWarning,
+} from "./lib/passthrough-jsonl.mjs"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+const { startProxyServer } = await import("../src/proxy/server.ts")
+
+const PORT = Number(process.env.PROBE_PORT ?? 3521)
+const MODEL = process.env.PROBE_MODEL ?? "claude-sonnet-5"
+
+const READ_TOOL = {
+  name: "read",
+  description: "Read a file from disk",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string", description: "Absolute path" } },
+    required: ["file_path"],
+  },
+}
+
+// plog is the only place the checkpoint decision is observable, and it is
+// gated by `silent`, so run the server loud and divert its output here.
+const proxyLog = []
+console.error = (...args) => { proxyLog.push(args.map(String).join(" ")) }
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1" })
+
+/**
+ * Replay the tracker's own checkpoint rule over the log.
+ *
+ * NOT "the last assistant row with a tool_use": shouldEarlyStop freezes the
+ * checkpoint the moment every CURRENTLY known call is resolved, and after that
+ * noteAssistantMessage is no longer called. A later parallel call therefore
+ * lands past the checkpoint and is dropped from the client-facing set rather
+ * than replayed. Both failures matter and they are different:
+ *
+ *   survivors > 0  a deny sits inside the slice and is replayed to the model
+ *   dropped   > 0  the model called N tools and the client was handed fewer
+ */
+function analyze(file) {
+  const rows = readRows(file)
+  const shape = []
+  const expected = new Set()
+  const resolved = new Set()
+  const turnOfCall = new Map()
+  let checkpointIndex = -1
+  let checkpointTurnId
+  let frozen = false
+  let dropped = 0
+
+  for (const [i, r] of rows.entries()) {
+    const bs = blocksOf(r)
+    const calls = bs.filter(b => b.type === "tool_use" && String(b.name ?? "").startsWith("mcp__oc__"))
+    const denies = bs.filter(b => b.type === "tool_result" && isDeny(b))
+    if (r.type === "assistant" && calls.length > 0) {
+      shape.push("A")
+      const fresh = calls.filter(b => !expected.has(b.id))
+      // Calls of ONE model turn share an API message id. A call carrying a
+      // different id belongs to a later turn, so excluding it is correct, not a
+      // drop — without this the two are indistinguishable in the totals.
+      const msgId = r.message?.id
+      for (const b of fresh) turnOfCall.set(b.id, msgId)
+      if (frozen) { dropped += fresh.length; continue }
+      for (const b of fresh) expected.add(b.id)
+      if (fresh.length > 0) { checkpointIndex = i; checkpointTurnId = msgId }
+    } else if (r.type === "user" && denies.length > 0) {
+      shape.push("U")
+      if (frozen) continue
+      for (const b of denies) resolved.add(b.tool_use_id)
+      if (expected.size > 0 && [...expected].every(id => resolved.has(id))) frozen = true
+    }
+  }
+  if (expected.size === 0 && dropped === 0) return null
+
+  const kept = checkpointIndex >= 0 ? rows.slice(0, checkpointIndex + 1) : []
+  const survivors = kept.flatMap(r => blocksOf(r).filter(b => b.type === "tool_result" && isDeny(b)))
+  // Of the calls left out, how many belonged to the checkpoint's own turn?
+  // Those are the real drops; the rest are later-turn calls, correctly excluded.
+  const sameTurnDropped = [...turnOfCall.entries()]
+    .filter(([id, mid]) => !expected.has(id) && mid !== undefined && mid === checkpointTurnId)
+    .length
+  const turnIds = new Set([...turnOfCall.values()].filter(Boolean))
+  const allDenies = rows.flatMap(r => blocksOf(r).filter(isDeny))
+  return {
+    warning: denyDetectionWarning({ forwardedCalls: expected.size + dropped, denyResults: allDenies }),
+    file,
+    calls: expected.size + dropped,
+    delivered: expected.size,
+    dropped,
+    sameTurnDropped,
+    turns: turnIds.size,
+    shape: shape.join(""),
+    checkpointIndex,
+    survivors: survivors.length,
+  }
+}
+
+async function drive(label, stream) {
+  const before = snapshot()
+  const sessionId = `probe-${stream ? "stream" : "nonstream"}-${process.pid}`
+  const body = {
+    model: MODEL,
+    max_tokens: 2048,
+    stream,
+    tools: [READ_TOOL],
+    messages: [{
+      role: "user",
+      content:
+        "Read all three of /tmp/a.txt, /tmp/b.txt and /tmp/c.txt using the read tool, " +
+        "in parallel in a single step. Use the tool, do not guess.",
+    }],
+  }
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": sessionId,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify(body),
+  })
+  const text = await res.text()
+  const toolCalls = (text.match(/"type":"tool_use"/g) ?? []).length
+
+  // The CLI flushes the transcript as the query settles; give it a beat.
+  await new Promise(r => setTimeout(r, 1500))
+  const after = snapshot()
+  const touched = [...after.entries()]
+    .filter(([p, m]) => !before.has(p) || before.get(p) !== m)
+    .map(([p]) => p)
+
+  console.log(`\n=== ${label} (stream=${stream}) ===`)
+  console.log(`  http ${res.status}  tool_use blocks in response: ${toolCalls}`)
+  if (touched.length === 0) console.log("  no session JSONL was written or updated")
+  const results = []
+  for (const f of touched) {
+    const a = analyze(f)
+    if (!a) continue
+    results.push(a)
+    console.log(`  ${a.file}`)
+    console.log(`    model called ${a.calls}  order=${a.shape}  checkpoint=row ${a.checkpointIndex}`)
+    if (a.warning) console.log(`    !! ${a.warning}`)
+    console.log(`    denials surviving the slice: ${a.survivors}${a.survivors > 0 ? "   <-- REPLAYED TO THE MODEL" : a.warning ? "   (UNPROVEN)" : "   (clean)"}`)
+    console.log(`    calls delivered to client:  ${a.delivered} of ${a.calls} across ${a.turns} model turn(s)`)
+    if (a.dropped > 0) {
+      console.log(`      left out: ${a.dropped} (${a.sameTurnDropped} from the checkpoint's OWN turn${a.sameTurnDropped > 0 ? " <-- REAL DROP" : ", i.e. none — the rest are later-turn calls, correctly excluded"})`)
+    }
+  }
+  return results
+}
+
+const streamed = await drive("streaming path", true)
+const nonStreamed = await drive("non-streaming path", false)
+
+console.log("\n=== verdict ===")
+const worst = rs => rs.reduce((n, r) => Math.max(n, r.survivors), 0)
+const parallel = rs => rs.some(r => r.calls > 1)
+for (const [label, rs] of [["stream    ", streamed], ["non-stream", nonStreamed]]) {
+  if (rs.length === 0) { console.log(`  ${label}  no forwarded calls captured — inconclusive`); continue }
+  if (!parallel(rs)) { console.log(`  ${label}  only ${rs[0].calls} call(s) — the defect needs parallelism, inconclusive`); continue }
+  const drops = rs.reduce((n, r) => n + r.sameTurnDropped, 0)
+  const issues = []
+  if (worst(rs) > 0) issues.push(`${worst(rs)} denial(s) replayed`)
+  if (drops > 0) issues.push(`${drops} same-turn call(s) dropped`)
+  console.log(`  ${label}  ${issues.length === 0 ? "CLEAN" : "LEAKS — " + issues.join(", ")}`)
+}
+
+await inst.stop?.()
+process.exit(0)

--- a/scripts/probe-passthrough-transcript.mjs
+++ b/scripts/probe-passthrough-transcript.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env bun
+/**
+ * Phase 1 ground-truth probe for the passthrough synthetic-denial defect.
+ * See ~/ss/claude/meridian-passthrough-spec.md — this answers questions 1-4
+ * by reading the session JSONL the SDK actually writes, not by reasoning
+ * about Meridian's code.
+ *
+ * It drives the raw Agent SDK in the exact passthrough shape (deny hook +
+ * maxTurns 1), then dumps every JSONL row so the answers are observed:
+ *
+ *   Q3  Is the deny stored as the call's tool_result?
+ *   Q3b Does it survive `resumeSessionAt` truncation, which slices the loaded
+ *       transcript to (0, checkpointIndex + 1)?  Interleaved per-block
+ *       assistant messages would leave earlier denies INSIDE the slice.
+ *   Q4  What happens when the resumed turn supplies a real tool_result for a
+ *       tool_use_id the session already answered?
+ *
+ * Costs a few cents of real tokens and needs Claude Max.
+ *
+ *   bun scripts/probe-passthrough-transcript.mjs
+ */
+import { query, createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { z } from "zod"
+import { mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { findSessionFile, readRows, toolResultText, isDenyResult } from "./lib/passthrough-jsonl.mjs"
+import { resolveClaudeExecutableAsync } from "../src/proxy/models.ts"
+
+const MODEL = process.env.PROBE_MODEL ?? "sonnet"
+const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-"))
+const A = join(WORKDIR, "a.txt")
+const B = join(WORKDIR, "b.txt")
+writeFileSync(A, "alpha\n")
+writeFileSync(B, "bravo\n")
+
+const DENY_REASON =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+const claudeExecutable = await resolveClaudeExecutableAsync()
+
+function mkServer() {
+  const server = createSdkMcpServer({ name: "oc" })
+  server.instance.registerTool(
+    "read",
+    { description: "Read a file from disk", inputSchema: { file_path: z.string() } },
+    async () => ({ content: [{ type: "text", text: "passthrough" }] }),
+  )
+  return server
+}
+
+/** Mirrors the passthrough shape buildQueryOptions produces. */
+function options(maxTurns, extra = {}) {
+  return {
+    executable: "node",
+    maxTurns,
+    cwd: WORKDIR,
+    model: MODEL,
+    pathToClaudeCodeExecutable: claudeExecutable,
+    permissionMode: "bypassPermissions",
+    allowDangerouslySkipPermissions: true,
+    tools: [],
+    allowedTools: ["mcp__oc__read"],
+    mcpServers: { oc: mkServer() },
+    settingSources: [],
+    plugins: [],
+    systemPrompt: "",
+    hooks: {
+      PreToolUse: [{
+        matcher: "",
+        hooks: [async (input) => {
+          if (input.tool_name === "ToolSearch" || input.tool_name === "StructuredOutput") return {}
+          return { decision: "block", reason: DENY_REASON }
+        }],
+      }],
+    },
+    ...extra,
+  }
+}
+
+/** Drive one query, recording the iterator's view of the turn. */
+async function drive(prompt, maxTurns, extra) {
+  const out = {
+    sessionId: "",
+    subtype: null,
+    text: "",
+    /** every forwarded tool_use, in iterator order */
+    calls: [],
+    /** the assistant UUID Meridian would freeze as the checkpoint */
+    checkpointUuid: "",
+    /** iterator-order log of assistant/user messages */
+    iterator: [],
+  }
+  try {
+    for await (const m of query({ prompt, options: options(maxTurns, extra) })) {
+      if (m.session_id && !out.sessionId) out.sessionId = m.session_id
+      if (m.type === "assistant") {
+        const blocks = m.message?.content ?? []
+        out.iterator.push(`assistant[${blocks.map(b => b.type).join(",")}] uuid=${short(m.uuid)}`)
+        let armed = false
+        for (const b of blocks) {
+          if (b.type === "tool_use") {
+            out.calls.push({ id: b.id, name: b.name, input: b.input })
+            armed = true
+          }
+          if (b.type === "text") out.text += b.text
+        }
+        // noteAssistantMessage: a newer tool-bearing message supersedes the
+        // older checkpoint.
+        if (armed) out.checkpointUuid = m.uuid ?? ""
+      }
+      if (m.type === "user") {
+        const blocks = Array.isArray(m.message?.content) ? m.message.content : []
+        out.iterator.push(
+          `user[${blocks.map(b => b.type + (b.tool_use_id ? `:${short(b.tool_use_id)}` : "")).join(",")}]`,
+        )
+      }
+      if (m.type === "result") out.subtype = m.subtype
+    }
+  } catch (e) {
+    out.threw = e instanceof Error ? e.message : String(e)
+  }
+  return out
+}
+
+const short = s => (typeof s === "string" && s.length > 10 ? s.slice(-8) : String(s))
+
+/** One-line summary of a JSONL row: what it is and what it answers. */
+function describe(row) {
+  const kind = row.type ?? "?"
+  const content = row.message?.content
+  let blocks = ""
+  if (Array.isArray(content)) {
+    blocks = content
+      .map(b => {
+        if (b.type === "tool_use") return `tool_use:${short(b.id)}(${b.name})`
+        if (b.type === "tool_result") {
+          const text = toolResultText(b)
+          return `tool_result:${short(b.tool_use_id)}${b.is_error ? "!err" : ""}=${isDenyResult(b) ? "DENY" : JSON.stringify(text.slice(0, 24))}`
+        }
+        return b.type
+      })
+      .join(",")
+  } else if (typeof content === "string") {
+    blocks = JSON.stringify(content.slice(0, 40))
+  }
+  return `${kind}${row.isMeta ? "/meta" : ""}${row.subtype ? `/${row.subtype}` : ""} uuid=${short(row.uuid)} [${blocks}]`
+}
+
+/** Every tool_result id carried by a row, with whether it is a deny. */
+function toolResultsIn(row) {
+  const content = row.message?.content
+  if (!Array.isArray(content)) return []
+  const out = []
+  for (const b of content) {
+    if (b?.type !== "tool_result") continue
+    out.push({ id: b.tool_use_id, deny: isDenyResult(b), text: toolResultText(b) })
+  }
+  return out
+}
+
+function dump(label, file) {
+  const rows = readRows(file)
+  console.log(`\n--- ${label}: ${rows.length} rows — ${file}`)
+  rows.forEach((r, i) => console.log(`  [${String(i).padStart(2)}] ${describe(r)}`))
+  return rows
+}
+
+// ---------------------------------------------------------------------------
+
+console.log(`model=${MODEL}  workdir=${WORKDIR}`)
+
+console.log("\n=== 1. capped passthrough turn with PARALLEL calls ===")
+const turn = await drive(
+  `Read both ${A} and ${B} using the read tool, in parallel in a single step.`,
+  1,
+)
+console.log(`  session=${turn.sessionId} subtype=${turn.subtype} calls=${turn.calls.length}`)
+console.log(`  checkpoint(assistant uuid)=${short(turn.checkpointUuid)}`)
+console.log("  iterator order:")
+for (const line of turn.iterator) console.log(`    ${line}`)
+
+const file = findSessionFile(turn.sessionId)
+if (!file) {
+  console.log("\nFAIL: no session JSONL found — cannot answer Q3/Q4.")
+  process.exit(1)
+}
+const rows = dump("JSONL after the capped turn", file)
+
+// Q3 — is the deny stored as the call's tool_result?
+const denies = rows.flatMap((r, i) => toolResultsIn(r).filter(t => t.deny).map(t => ({ ...t, index: i })))
+console.log("\n=== Q3: is the deny persisted as the call's tool_result? ===")
+console.log(`  ${denies.length > 0 ? "YES" : "NO"} — ${denies.length} deny tool_result(s) on disk`)
+for (const d of denies) console.log(`    row ${d.index}  tool_use_id=${short(d.id)}`)
+
+// Q3b — does it survive resumeSessionAt truncation?
+const checkpointIndex = rows.findIndex(r => r.uuid === turn.checkpointUuid)
+console.log("\n=== Q3b: does the deny survive resumeSessionAt truncation? ===")
+console.log(`  checkpoint row index = ${checkpointIndex} of ${rows.length - 1}`)
+if (checkpointIndex < 0) {
+  console.log("  the checkpoint UUID is NOT in the JSONL — resume would fail with missing-message")
+} else {
+  const kept = rows.slice(0, checkpointIndex + 1)
+  const survivors = kept.flatMap((r, i) => toolResultsIn(r).filter(t => t.deny).map(t => ({ ...t, index: i })))
+  console.log(`  slice(0, ${checkpointIndex + 1}) keeps ${kept.length} rows`)
+  console.log(`  deny tool_results INSIDE the slice: ${survivors.length}`)
+  for (const s of survivors) console.log(`    row ${s.index}  tool_use_id=${short(s.id)}  <-- REPLAYED TO THE MODEL`)
+  if (survivors.length === 0) {
+    console.log("  => the truncation removes every deny; the resumed history is clean")
+  }
+  const callIds = new Set(turn.calls.map(c => c.id))
+  const keptCalls = kept.flatMap(r =>
+    (Array.isArray(r.message?.content) ? r.message.content : [])
+      .filter(b => b?.type === "tool_use" && callIds.has(b.id))
+      .map(b => b.id))
+  console.log(`  forwarded tool_use blocks inside the slice: ${keptCalls.length} of ${callIds.size}`)
+  const missing = [...callIds].filter(id => !keptCalls.includes(id))
+  if (missing.length) console.log(`    MISSING from the slice: ${missing.map(short).join(", ")} <-- dangling client result`)
+}
+
+// Q4 — resume with a real tool_result for an already-answered id.
+console.log("\n=== 2. resume at the checkpoint with REAL tool_results ===")
+const realResults = turn.calls.map(c => ({
+  type: "tool_result",
+  tool_use_id: c.id,
+  content: `REALOUTPUT[${c.input?.file_path?.endsWith("a.txt") ? "alpha" : "bravo"}]`,
+}))
+const delta = (async function* () {
+  yield {
+    type: "user",
+    session_id: turn.sessionId,
+    parent_tool_use_id: null,
+    message: { role: "user", content: realResults },
+  }
+})()
+const resumed = await drive(delta, 1, { resume: turn.sessionId, resumeSessionAt: turn.checkpointUuid })
+console.log(`  subtype=${resumed.subtype} threw=${resumed.threw ?? "no"}`)
+console.log(`  text=${JSON.stringify(resumed.text.slice(0, 200))}`)
+console.log(`  quotes the real output: ${resumed.text.includes("alpha") || resumed.text.includes("bravo") || resumed.text.includes("REALOUTPUT")}`)
+console.log(`  re-called the tool: ${resumed.calls.length > 0} (${resumed.calls.length} call(s))`)
+
+const resumedFile = findSessionFile(resumed.sessionId) ?? file
+const rows2 = dump("JSONL after the resume", resumedFile)
+console.log(`  resumed session id ${resumed.sessionId === turn.sessionId ? "REUSED" : `FORKED (${resumed.sessionId})`}`)
+
+console.log("\n=== Q4: two results for one tool_use_id? ===")
+const byId = new Map()
+for (const [i, r] of rows2.entries()) {
+  for (const t of toolResultsIn(r)) {
+    if (!byId.has(t.id)) byId.set(t.id, [])
+    byId.get(t.id).push({ index: i, deny: t.deny, text: t.text.slice(0, 40) })
+  }
+}
+for (const [id, hits] of byId) {
+  console.log(`  ${short(id)}: ${hits.length} result(s) — ${hits.map(h => `row ${h.index}:${h.deny ? "DENY" : "REAL"}`).join(", ")}`)
+}
+const dupes = [...byId.values()].filter(h => h.length > 1)
+console.log(`  ids answered more than once: ${dupes.length}`)
+
+console.log(`\nworkdir kept for inspection: ${WORKDIR}`)
+console.log(`session file: ${file}`)

--- a/src/__tests__/adapter-instances-integration.test.ts
+++ b/src/__tests__/adapter-instances-integration.test.ts
@@ -7,7 +7,7 @@
  *   - PASSTHROUGH override comes from the instance
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -16,7 +16,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),

--- a/src/__tests__/concurrency-hardening.test.ts
+++ b/src/__tests__/concurrency-hardening.test.ts
@@ -7,6 +7,7 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 /**
@@ -32,11 +33,11 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
 }
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     queryCalls++
     const control = deferredAttempt()
     controls.push(control)
-    const sessionId = `sdk-harden-${queryCalls}`
+    const sessionId = resolveMockSdkSessionId(params.options, `sdk-harden-${queryCalls}`)
     const generator = (async function* () {
       control.markStarted()
       yield { ...messageStart(), session_id: sessionId }

--- a/src/__tests__/cross-process-turn-coordinator.test.ts
+++ b/src/__tests__/cross-process-turn-coordinator.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, readFile, readdir, rm, utimes, writeFile } from "node:fs/promises"
+import { hostname, tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { captureProcessIncarnation } from "../proxy/session/processIncarnation"
+
+const coordinatorModule = pathToFileURL(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../proxy/session/crossProcessTurnCoordinator.ts"),
+).href
+const processIncarnationModule = pathToFileURL(
+  resolve(dirname(fileURLToPath(import.meta.url)), "../proxy/session/processIncarnation.ts"),
+).href
+
+const workerSource = String.raw`
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
+import { createHash } from "node:crypto"
+import { join } from "node:path"
+import { hostname } from "node:os"
+const { CrossProcessTurnCoordinator } = await import(process.env.COORDINATOR_MODULE)
+const { captureProcessIncarnation } = await import(process.env.PROCESS_INCARNATION_MODULE)
+const currentIncarnation = captureProcessIncarnation()
+if (!currentIncarnation) throw new Error("worker process incarnation unavailable")
+const deadIncarnation = (pid) => ({
+  ...currentIncarnation,
+  pid,
+  bootId: "00000000-0000-4000-8000-000000000000",
+})
+const root = process.env.LOCK_ROOT
+const eventFile = process.env.EVENT_FILE
+const key = process.env.LOCK_KEY
+const action = process.env.ACTION
+const options = JSON.parse(process.env.OPTIONS)
+const event = async (name, extra = {}) => {
+  await appendFile(eventFile, JSON.stringify({ name, at: Date.now(), pid: process.pid, ...extra }) + "\n")
+}
+const keepAlive = setInterval(() => {}, 1_000)
+try {
+  if (action === "seed-stale") {
+    const hash = createHash("sha256").update(key).digest("hex")
+    const lockPath = join(root, hash + ".lock")
+    await mkdir(lockPath, { recursive: true })
+    await writeFile(join(lockPath, "owner.json"), JSON.stringify({
+      token: "stale-seed", pid: 999_999_999, hostname: hostname(), createdAt: 1,
+      incarnation: deadIncarnation(999_999_999),
+    }))
+    const heartbeat = join(lockPath, "heartbeat-stale-seed")
+    await writeFile(heartbeat, "")
+    const old = new Date(1)
+    await Bun.file(heartbeat).exists()
+    const { utimes } = await import("node:fs/promises")
+    await utimes(heartbeat, old, old)
+    await event("seeded")
+  } else if (action === "seed-orphan-claim") {
+    const hash = createHash("sha256").update(key).digest("hex")
+    const lockPath = join(root, hash + ".lock")
+    await mkdir(lockPath, { recursive: true })
+    const staleToken = "stale-with-orphan-claim"
+    await writeFile(join(lockPath, "owner.json"), JSON.stringify({
+      token: staleToken, pid: 999_999_999, hostname: hostname(), createdAt: 1,
+      incarnation: deadIncarnation(999_999_999),
+    }))
+    const heartbeat = join(lockPath, "heartbeat-" + staleToken)
+    await writeFile(heartbeat, "")
+    const claimIdentity = createHash("sha256").update(staleToken).digest("hex")
+    const claimPath = lockPath + ".recover-" + claimIdentity
+    const firstClaimToken = "first-dead-recovery-claim"
+    const firstTombstone = claimPath + ".orphan-"
+      + createHash("sha256").update(firstClaimToken).digest("hex")
+    await mkdir(firstTombstone, { recursive: true })
+    await writeFile(join(firstTombstone, "owner.json"), JSON.stringify({
+      version: 2, generation: staleToken, token: firstClaimToken,
+      pid: 999_999_998, hostname: hostname(), createdAt: 1,
+      incarnation: deadIncarnation(999_999_998),
+    }))
+    await mkdir(claimPath, { recursive: true })
+    const claimToken = "second-dead-recovery-claim"
+    await writeFile(join(claimPath, "owner.json"), JSON.stringify({
+      version: 2, generation: staleToken, token: claimToken,
+      pid: 999_999_999, hostname: hostname(), createdAt: 1,
+      incarnation: deadIncarnation(999_999_999),
+    }))
+    const { utimes } = await import("node:fs/promises")
+    const old = new Date(1)
+    await utimes(heartbeat, old, old)
+    await event("seeded-orphan-claim")
+  } else {
+    const coordinator = new CrossProcessTurnCoordinator(root, options)
+    if (action === "abort") {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), Number(process.env.ABORT_AFTER_MS))
+      try {
+        await coordinator.acquire(key, controller.signal)
+        await event("unexpected-acquire")
+      } catch (error) {
+        await event("acquire-error", { errorName: error.name })
+      } finally {
+        clearTimeout(timer)
+      }
+    } else if (action === "timeout") {
+      try {
+        const lease = await coordinator.acquire(key)
+        await event("unexpected-acquire")
+        await lease.release()
+      } catch (error) {
+        await event("acquire-error", { errorName: error.name })
+      }
+    } else {
+      const lease = await coordinator.acquire(key)
+      await event("acquired", { waitedMs: lease.waitedMs })
+      if (action === "crash") {
+        clearInterval(keepAlive)
+        process.exit(0)
+      }
+      if (action === "tamper-release") {
+        const hash = createHash("sha256").update(key).digest("hex")
+        const ownerPath = join(root, hash + ".lock", "owner.json")
+        const owner = JSON.parse(await readFile(ownerPath, "utf8"))
+        owner.token = "not-the-lease-token"
+        await writeFile(ownerPath, JSON.stringify(owner))
+        try {
+          await lease.release()
+          await event("unexpected-release")
+        } catch (error) {
+          await event("release-refused", { errorName: error.name })
+        }
+        await Bun.sleep(Number(process.env.HOLD_MS))
+      } else {
+        await Bun.sleep(Number(process.env.HOLD_MS || 0))
+        await event("leaving")
+        await lease.release()
+        await lease.release()
+        await event("released")
+      }
+    }
+  }
+} finally {
+  clearInterval(keepAlive)
+}
+`
+
+type WorkerAction = "hold" | "abort" | "timeout" | "crash" | "seed-stale" | "seed-orphan-claim" | "tamper-release"
+interface WorkerEvent {
+  name: string
+  at: number
+  pid: number
+  waitedMs?: number
+  errorName?: string
+}
+
+const tempRoots: string[] = []
+const children = new Set<ReturnType<typeof Bun.spawn>>()
+
+afterEach(async () => {
+  for (const child of children) child.kill()
+  children.clear()
+  await Promise.all(tempRoots.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+async function makeFiles(): Promise<{ base: string, locks: string, events: string }> {
+  const base = await mkdtemp(join(tmpdir(), "meridian-cross-process-turn-"))
+  tempRoots.push(base)
+  return { base, locks: join(base, "locks"), events: join(base, "events.jsonl") }
+}
+
+function spawnWorker(
+  action: WorkerAction,
+  paths: { locks: string, events: string },
+  overrides: Record<string, string> = {},
+): ReturnType<typeof Bun.spawn> {
+  const child = Bun.spawn([process.execPath, "-e", workerSource], {
+    env: {
+      ...process.env,
+      COORDINATOR_MODULE: coordinatorModule,
+      PROCESS_INCARNATION_MODULE: processIncarnationModule,
+      LOCK_ROOT: paths.locks,
+      EVENT_FILE: paths.events,
+      LOCK_KEY: "logical-session",
+      ACTION: action,
+      HOLD_MS: "0",
+      OPTIONS: JSON.stringify({
+        acquireTimeoutMs: 2_000,
+        staleAfterMs: 800,
+        heartbeatIntervalMs: 100,
+        retryDelayMs: 10,
+      }),
+      ...overrides,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  children.add(child)
+  void child.exited.then(() => children.delete(child))
+  return child
+}
+
+async function events(path: string): Promise<WorkerEvent[]> {
+  try {
+    const text = await readFile(path, "utf8")
+    return text.trim().split("\n").filter(Boolean).map(line => JSON.parse(line) as WorkerEvent)
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return []
+    throw error
+  }
+}
+
+async function waitForEvent(path: string, name: string, timeoutMs = 5_000): Promise<WorkerEvent> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const found = (await events(path)).find(item => item.name === name)
+    if (found) return found
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for worker event ${name}`)
+}
+
+async function expectSuccess(child: ReturnType<typeof Bun.spawn>): Promise<void> {
+  const exitCode = await child.exited
+  if (exitCode === 0) return
+  const stderr = child.stderr instanceof ReadableStream
+    ? await new Response(child.stderr).text()
+    : String(child.stderr ?? "")
+  throw new Error(`Worker exited ${exitCode}: ${stderr}`)
+}
+
+describe("cross-process turn coordinator", () => {
+  test("serializes the same logical key in independent processes", async () => {
+    const paths = await makeFiles()
+    const heartbeatOptions = JSON.stringify({
+      acquireTimeoutMs: 2_000,
+      staleAfterMs: 120,
+      heartbeatIntervalMs: 25,
+      retryDelayMs: 10,
+    })
+    const first = spawnWorker("hold", paths, { HOLD_MS: "500", OPTIONS: heartbeatOptions })
+    const firstAcquired = await waitForEvent(paths.events, "acquired")
+    const second = spawnWorker("hold", paths, { HOLD_MS: "0", OPTIONS: heartbeatOptions })
+
+    await Promise.all([expectSuccess(first), expectSuccess(second)])
+    const all = await events(paths.events)
+    const firstLeaving = all.find(item => item.name === "leaving" && item.pid === firstAcquired.pid)!
+    const secondAcquired = all.find(item => item.name === "acquired" && item.pid !== firstAcquired.pid)!
+    expect(firstLeaving.at).toBeLessThanOrEqual(secondAcquired.at)
+    expect(secondAcquired.waitedMs).toBeGreaterThanOrEqual(0)
+  })
+
+  test("aborts a bounded cross-process acquire without entering the turn", async () => {
+    const paths = await makeFiles()
+    const holder = spawnWorker("hold", paths, { HOLD_MS: "400" })
+    const held = await waitForEvent(paths.events, "acquired")
+    const waiter = spawnWorker("abort", paths, { ABORT_AFTER_MS: "60" })
+
+    await expectSuccess(waiter)
+    const all = await events(paths.events)
+    const failure = all.find(item => item.name === "acquire-error" && item.pid !== held.pid)
+    expect(failure?.errorName).toBe("AbortError")
+    expect(all.some(item => item.name === "unexpected-acquire")).toBe(false)
+    await expectSuccess(holder)
+  })
+
+  test("atomically recovers locks left by dead and stale owners", async () => {
+    const deadPaths = await makeFiles()
+    const deadOwner = spawnWorker("crash", deadPaths)
+    await waitForEvent(deadPaths.events, "acquired")
+    await expectSuccess(deadOwner)
+    const deadSuccessor = spawnWorker("hold", deadPaths)
+    await expectSuccess(deadSuccessor)
+    const deadAcquisitions = (await events(deadPaths.events)).filter(item => item.name === "acquired")
+    expect(deadAcquisitions).toHaveLength(2)
+    // Parent death is necessary but not sufficient: quarantine the last fresh
+    // heartbeat so an orphan SDK child cannot overlap its successor.
+    expect(deadAcquisitions[1]!.waitedMs).toBeGreaterThanOrEqual(500)
+
+    const stalePaths = await makeFiles()
+    const seeder = spawnWorker("seed-stale", stalePaths)
+    await expectSuccess(seeder)
+    const staleSuccessor = spawnWorker("hold", stalePaths)
+    await expectSuccess(staleSuccessor)
+    expect((await events(stalePaths.events)).some(item => item.name === "released")).toBe(true)
+  })
+
+  test("repeatedly adopts dead recovery claims and cleans resolved tombstones", async () => {
+    const paths = await makeFiles()
+    const seeder = spawnWorker("seed-orphan-claim", paths)
+    await expectSuccess(seeder)
+    const recoveryOptions = {
+      OPTIONS: JSON.stringify({
+        acquireTimeoutMs: 2_000,
+        staleAfterMs: 100,
+        heartbeatIntervalMs: 25,
+        retryDelayMs: 10,
+      }),
+    }
+    const successors = [
+      spawnWorker("hold", paths, recoveryOptions),
+      spawnWorker("hold", paths, recoveryOptions),
+    ]
+    await Promise.all(successors.map(expectSuccess))
+    const all = await events(paths.events)
+    expect(all.filter((item) => item.name === "acquired")).toHaveLength(2)
+    expect(all.filter((item) => item.name === "released")).toHaveLength(2)
+    expect((await readdir(paths.locks)).some((name) => name.includes(".recover-"))).toBe(false)
+  })
+
+  test("fails closed for live and remote recovery claim owners", async () => {
+    for (const [claimHostname, claimPid] of [[hostname(), process.pid], ["remote.example", 999_999_999]] as const) {
+      const paths = await makeFiles()
+      const key = "logical-session"
+      const lockPath = join(paths.locks, `${createHash("sha256").update(key).digest("hex")}.lock`)
+      const generation = `blocked-${claimHostname}`
+      await mkdir(lockPath, { recursive: true })
+      await writeFile(join(lockPath, "owner.json"), JSON.stringify({
+        token: generation,
+        pid: 999_999_999,
+        hostname: hostname(),
+        createdAt: 1,
+      }))
+      const heartbeat = join(lockPath, `heartbeat-${generation}`)
+      await writeFile(heartbeat, "")
+      await utimes(heartbeat, new Date(1), new Date(1))
+
+      const claimPath = `${lockPath}.recover-${createHash("sha256").update(generation).digest("hex")}`
+      await mkdir(claimPath, { recursive: true })
+      await writeFile(join(claimPath, "owner.json"), JSON.stringify({
+        version: 2,
+        generation,
+        token: `claim-${claimHostname}`,
+        pid: claimPid,
+        hostname: claimHostname,
+        createdAt: 1,
+        incarnation: claimHostname !== hostname()
+          ? { ...captureProcessIncarnation()!, pid: claimPid, hostId: "b".repeat(64) }
+          : claimPid === process.pid
+            ? captureProcessIncarnation()
+            : {
+              ...captureProcessIncarnation()!,
+              pid: claimPid,
+              bootId: "00000000-0000-4000-8000-000000000000",
+            },
+      }))
+
+      const contender = spawnWorker("timeout", paths, {
+        OPTIONS: JSON.stringify({
+          acquireTimeoutMs: 120,
+          staleAfterMs: 20,
+          heartbeatIntervalMs: 5,
+          retryDelayMs: 5,
+        }),
+      })
+      await expectSuccess(contender)
+      const failure = (await events(paths.events)).find((item) => item.name === "acquire-error")
+      expect(failure?.errorName).toBe("CrossProcessTurnAcquireTimeoutError")
+      expect(await readFile(join(claimPath, "owner.json"), "utf8")).toContain(`claim-${claimHostname}`)
+    }
+  })
+
+  test("a lease cannot release a directory whose owner token changed", async () => {
+    const paths = await makeFiles()
+    const owner = spawnWorker("tamper-release", paths, {
+      HOLD_MS: "450",
+      OPTIONS: JSON.stringify({
+        acquireTimeoutMs: 2_000,
+        staleAfterMs: 2_000,
+        heartbeatIntervalMs: 100,
+        retryDelayMs: 10,
+      }),
+    })
+    await waitForEvent(paths.events, "release-refused")
+
+    const contender = spawnWorker("timeout", paths, {
+      OPTIONS: JSON.stringify({
+        acquireTimeoutMs: 120,
+        staleAfterMs: 2_000,
+        heartbeatIntervalMs: 100,
+        retryDelayMs: 10,
+      }),
+    })
+    await expectSuccess(contender)
+    const failure = (await events(paths.events)).find(
+      item => item.name === "acquire-error" && item.pid !== owner.pid,
+    )
+    expect(failure?.errorName).toBe("CrossProcessTurnAcquireTimeoutError")
+
+    await expectSuccess(owner)
+    const hash = createHash("sha256").update("logical-session").digest("hex")
+    expect(await Bun.file(join(paths.locks, `${hash}.lock`, "owner.json")).exists()).toBe(true)
+  })
+})

--- a/src/__tests__/cwd.test.ts
+++ b/src/__tests__/cwd.test.ts
@@ -92,4 +92,16 @@ describe("resolveSdkWorkingDirectory", () => {
     })
     expect(r.workingDirectory).toBe("/adapter/path")
   })
+
+  it("normalizes relative SDK directories to absolute paths", () => {
+    const result = resolveSdkWorkingDirectory({
+      envOverride: ".",
+      adapterCwd: undefined,
+      fallback: ".",
+      exists: () => true,
+    })
+    expect(result.workingDirectory.startsWith("/")).toBe(true)
+    expect(result.claimedWorkingDirectory.startsWith("/")).toBe(true)
+  })
+
 })

--- a/src/__tests__/deferred-tool-loading.test.ts
+++ b/src/__tests__/deferred-tool-loading.test.ts
@@ -17,6 +17,7 @@ import {
   parseSSE,
   assistantMessage,
   makeRequest,
+  withMockSdkSessionId,
 } from "./helpers"
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk"
 
@@ -28,7 +29,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedQueryParams = opts
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, opts.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({

--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -62,6 +62,8 @@ describe("canonical opus pin", () => {
 
 let queryEnvs: Array<Record<string, string | undefined>> = []
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     queryEnvs.push(opts.options?.env || {})
@@ -78,7 +80,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 5, output_tokens: 2 },
         },
-        session_id: "sdk-1",
+        session_id: resolveMockSdkSessionId(opts.options, "sdk-1"),
       }
     })()
   },

--- a/src/__tests__/failover-request-id.test.ts
+++ b/src/__tests__/failover-request-id.test.ts
@@ -8,7 +8,7 @@
  * request unfindable by the id the client sent.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let failingDirs = new Set<string>()
 
@@ -19,7 +19,8 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       if ([...failingDirs].some(f => dir.includes(f))) {
         throw new Error("429 rate limit reached for this account")
       }
-      yield assistantMessage([{ type: "text", text: "ok from " + dir }])
+      const message = assistantMessage([{ type: "text", text: "ok from " + dir }])
+      yield withMockSdkSessionId(message, params.options)
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/graceful-shutdown.test.ts
+++ b/src/__tests__/graceful-shutdown.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
 import type { AddressInfo } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { lookupSharedSession, setSessionStoreDir } from "../proxy/sessionStore"
 import {
   assistantMessage,
   messageStart,
@@ -8,6 +12,7 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 interface AttemptControl {
@@ -27,11 +32,11 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
 }
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     queryCalls++
     const control = deferredAttempt()
     controls.push(control)
-    const sessionId = `sdk-drain-${queryCalls}`
+    const sessionId = resolveMockSdkSessionId(params?.options, `sdk-drain-${queryCalls}`)
     const generator = (async function* () {
       control.markStarted()
       yield { ...messageStart(), session_id: sessionId }
@@ -105,10 +110,19 @@ async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptC
 }
 
 describe("graceful shutdown", () => {
+  let isolatedSessionDir = ""
+
   beforeEach(() => {
+    isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-shutdown-test-"))
+    setSessionStoreDir(isolatedSessionDir)
     queryCalls = 0
     controls = []
     clearSessionCache()
+  })
+
+  afterEach(async () => {
+    await Bun.sleep(25)
+    rmSync(isolatedSessionDir, { recursive: true, force: true })
   })
 
   it("exposes beginDrain and getInFlightCount, starting undrained with no in-flight requests", () => {
@@ -183,6 +197,83 @@ describe("graceful shutdown", () => {
     await response.text()
     await Bun.sleep(10)
     expect(server.getInFlightCount!()).toBe(0)
+  })
+
+  it("revokes durable publication when forced shutdown aborts an admitted request", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    const responseP = server.app.fetch(request("forced-shutdown", true))
+    const control = await waitForControl(0)
+
+    server.forceAbortInFlight!()
+    // The mock deliberately ignores AbortSignal and completes normally. This
+    // proves revocation, not cooperative SDK cancellation, fences the late
+    // publication callback after the shutdown deadline.
+    control.release()
+
+    const response = await responseP
+    await response.text()
+    for (let index = 0; index < 100 && server.getInFlightCount!() !== 0; index++) {
+      await Bun.sleep(1)
+    }
+    expect(server.getInFlightCount!()).toBe(0)
+    expect(lookupSharedSession("forced-shutdown")).toBeUndefined()
+  })
+
+  it("evicts an existing mapping when forced shutdown interrupts its next turn", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    const opening = [{ role: "user", content: "hi" }]
+    const firstP = server.app.fetch(request("forced-existing", true, opening))
+    const firstControl = await waitForControl(0)
+    const first = await firstP
+    firstControl.release()
+    await first.text()
+    expect(lookupSharedSession("forced-existing")).toBeDefined()
+
+    const continuation = [
+      ...opening,
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "continue" },
+    ]
+    const interruptedP = server.app.fetch(request("forced-existing", true, continuation))
+    const interruptedControl = await waitForControl(1)
+    const interrupted = await interruptedP
+
+    // The mock ignores AbortSignal and exposes target content after shutdown.
+    // Cleanup must evict the source mapping so that partial fork output cannot
+    // be treated as if it already existed in that immutable source.
+    server.forceAbortInFlight!()
+    interruptedControl.release()
+    await interrupted.text()
+    for (let index = 0; index < 100 && server.getInFlightCount!() !== 0; index++) {
+      await Bun.sleep(1)
+    }
+    expect(server.getInFlightCount!()).toBe(0)
+    expect(lookupSharedSession("forced-existing")).toBeUndefined()
+  })
+
+  it("preserves the source when shutdown cancels a non-stream fork before response", async () => {
+    const server = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+    const opening = [{ role: "user", content: "hi" }]
+    const firstP = server.app.fetch(request("forced-existing-nonstream", false, opening))
+    const firstControl = await waitForControl(0)
+    firstControl.release()
+    const first = await firstP
+    await first.text()
+    const sourceSessionId = lookupSharedSession("forced-existing-nonstream")?.claudeSessionId
+    expect(sourceSessionId).toBeDefined()
+
+    const continuation = [
+      ...opening,
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "continue" },
+    ]
+    const interruptedP = server.app.fetch(request("forced-existing-nonstream", false, continuation))
+    const interruptedControl = await waitForControl(1)
+    server.forceAbortInFlight!()
+    interruptedControl.release()
+    const interrupted = await interruptedP
+    await interrupted.text()
+    expect(lookupSharedSession("forced-existing-nonstream")?.claudeSessionId).toBe(sourceSessionId)
   })
 
   it("counts a same-session request while it waits for the active turn", async () => {

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -4,6 +4,27 @@
 
 import type { SDKMessage, SDKAssistantMessage } from "@anthropic-ai/claude-agent-sdk"
 
+type MockSdkSessionOptions = {
+  sessionId?: string
+  resume?: string
+  forkSession?: boolean
+}
+
+export function resolveMockSdkSessionId(options: unknown): string | undefined
+export function resolveMockSdkSessionId(options: unknown, fallback: string): string
+export function resolveMockSdkSessionId(options: unknown, fallback?: string): string | undefined {
+  const sessionOptions = options as MockSdkSessionOptions | undefined
+  return sessionOptions?.sessionId
+    ?? (sessionOptions?.forkSession ? undefined : sessionOptions?.resume)
+    ?? fallback
+}
+
+export function withMockSdkSessionId<T>(message: T, options: unknown): T {
+  const sessionId = resolveMockSdkSessionId(options)
+  if (!sessionId || message === null || typeof message !== "object") return message
+  return { ...message, session_id: sessionId }
+}
+
 // --- SDK Message Factories ---
 
 /** Create a stream_event message (raw Anthropic SSE event) */

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -20,6 +20,7 @@ import {
   messageStop,
   assistantMessage,
   parseSSE,
+  withMockSdkSessionId,
 } from "./helpers"
 
 // --- Mock SDK ---
@@ -31,7 +32,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedQueryParams = params
     return (async function* () {
       for (const msg of mockMessages) {
-        yield msg
+        yield withMockSdkSessionId(msg, params.options)
       }
     })()
   },

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -15,6 +15,7 @@ import {
   verifyLineage,
   normalizeContextUsage,
   withClientAssistantUuid,
+  reconcileReturnedSessionUuids,
   MIN_SUFFIX_FOR_COMPACTION,
   type SessionState,
 } from "../proxy/session/lineage"
@@ -941,5 +942,67 @@ describe("withClientAssistantUuid", () => {
   it("pads missing client user slots without shifting the assistant UUID", () => {
     expect(withClientAssistantUuid([null, "prior-assistant"], 3, "next-assistant"))
       .toEqual([null, "prior-assistant", null, "next-assistant"])
+  })
+})
+
+describe("reconcileReturnedSessionUuids", () => {
+  it("clears copied UUIDs after an observed session change and keeps the current output", () => {
+    expect(reconcileReturnedSessionUuids(
+      [null, "copied-assistant", null, "current-assistant"],
+      3,
+      "current-assistant",
+      "source-session",
+      "fork-session",
+    )).toEqual([null, null, null, "current-assistant"])
+  })
+
+  it("keeps the UUID map when the SDK returns the resumed session", () => {
+    const map = [null, "existing-assistant", null, "current-assistant"]
+    expect(reconcileReturnedSessionUuids(map, 3, "current-assistant", "same-session", "same-session"))
+      .toBe(map)
+  })
+
+  it("does not discard fresh-request UUIDs", () => {
+    const map = [null, "fresh-assistant"]
+    expect(reconcileReturnedSessionUuids(map, 1, "fresh-assistant", undefined, "fresh-session"))
+      .toBe(map)
+  })
+})
+
+describe("fork-remapped undo boundaries", () => {
+  const stored = [
+    msg("user", "one"),
+    msg("assistant", "reply one"),
+    msg("user", "two"),
+    msg("assistant", "reply two"),
+    msg("user", "three"),
+    msg("assistant", "new fork output"),
+    msg("user", "four"),
+  ]
+  const session = makeSession({
+    messageCount: stored.length,
+    lineageHash: computeLineageHash(stored),
+    messageHashes: computeMessageHashes(stored),
+    sdkMessageUuids: [null, null, null, null, null, "new-fork-output-uuid", null],
+  })
+
+  it("leaves an undo boundary empty when the preserved prefix has only remapped UUIDs", () => {
+    const result = verifyLineage(session, [
+      ...stored.slice(0, 2),
+      msg("user", "branch before the new fork output"),
+    ])
+    expect(result).toMatchObject({ type: "undo", prefixOverlap: 2, rollbackUuid: undefined })
+  })
+
+  it("uses the newly observed fork output UUID when the undo preserves it", () => {
+    const result = verifyLineage(session, [
+      ...stored.slice(0, 6),
+      msg("user", "branch after the new fork output"),
+    ])
+    expect(result).toMatchObject({
+      type: "undo",
+      prefixOverlap: 6,
+      rollbackUuid: "new-fork-output-uuid",
+    })
   })
 })

--- a/src/__tests__/opencode-title-agent-collision.test.ts
+++ b/src/__tests__/opencode-title-agent-collision.test.ts
@@ -25,7 +25,21 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedOptions: any[] = []
@@ -41,14 +55,17 @@ let onTitleEnteredQuery: (() => void) | undefined
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
-    capturedOptions.push(params.options || {})
+    const options = params.options || {}
+    capturedOptions.push(options)
+    const sessionId = resolveMockSdkSessionId(options)
+    if (!sessionId) throw new Error("Expected Meridian to select or resume an SDK session")
     const isTitle = typeof params.prompt === "string" && params.prompt.includes("Generate a title")
     return (async function* () {
       if (isTitle) {
         onTitleEnteredQuery?.()
         if (holdTitleUntil) await holdTitleUntil
       }
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) yield { ...(msg as object), session_id: sessionId }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
@@ -147,12 +164,14 @@ describe("OpenCode title agent vs the user's conversation", () => {
   it("lets the user's conversation resume after a title turn interleaves", async () => {
     const app = createTestApp()
     await post(app, USER_TURN_1, USER_HEADERS)
+    const userSessionId = capturedOptions.at(-1)?.sessionId
+    expect(userSessionId).toMatch(/^[0-9a-f-]{36}$/)
     await post(app, TITLE_BODY, TITLE_HEADERS)
     const turn2 = await post(app, USER_TURN_2, USER_HEADERS)
     expect(turn2.status).toBe(200)
     // The title turn must not have displaced the conversation's stored lineage:
-    // turn 2 still resumes the SDK session rather than replaying cold.
-    expect(capturedOptions.at(-1)?.resume).toBe("test-session")
+    // turn 2 still resumes the exact session Meridian selected for turn 1.
+    expect(capturedOptions.at(-1)?.resume).toBe(userSessionId)
   })
 
   it("keeps the title turn itself working and independent", async () => {
@@ -190,24 +209,17 @@ describe("OpenCode title agent vs the user's conversation", () => {
     for (let i = 0; i < 50 && capturedOptions.length < 2; i++) {
       await new Promise((r) => setTimeout(r, 2))
     }
+    // The title query is still gated. Entering the user's query before release
+    // proves the scoped requests did not contend on the same turn lease. This
+    // is stronger and less clock-sensitive than requiring a 0 ms metric.
+    const userEnteredBeforeRelease = capturedOptions.length === 2
     release()
 
     const [title, user] = await Promise.all([titlePromise, userPromise])
+    expect(userEnteredBeforeRelease).toBe(true)
     expect(title.status).toBe(200)
     expect(user.status).toBe(200)
     const userBody = await user.json() as any
     expect(JSON.stringify(userBody)).not.toContain("session advanced")
-
-    // The title turn held its own lease for the whole duration of the user's
-    // turn, and the user's turn did not wait on it for a millisecond. That
-    // zero IS the fix: live, this wait was 9,836 ms and ended in a 400.
-    //
-    // Asserted as 0 rather than "> 0 to prove the harness raced": the harness
-    // is proven live by running this file against the unscoped key, where the
-    // wait is non-zero and the status is 400. Demanding contention here would
-    // be demanding the bug.
-    const userMetric = telemetryStore.getRecent({ limit: 10 }).find((m) => m.toolCount === 1)
-    expect(userMetric).toBeDefined()
-    expect(userMetric!.sessionQueueWaitMs ?? 0).toBe(0)
   })
 })

--- a/src/__tests__/passthrough-denial.test.ts
+++ b/src/__tests__/passthrough-denial.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { PASSTHROUGH_DENY_REASON, isForwardedDenial } from "../proxy/passthroughDenial"
+
+function denialBlock(id: string) {
+  return { type: "tool_result", tool_use_id: id, is_error: true, content: PASSTHROUGH_DENY_REASON }
+}
+
+describe("isForwardedDenial", () => {
+  test("recognizes only the forwarding hook's synthetic denial", () => {
+    expect(isForwardedDenial(denialBlock("x"))).toBe(true)
+    expect(isForwardedDenial({
+      type: "tool_result",
+      tool_use_id: "x",
+      is_error: true,
+      content: [{ type: "text", text: PASSTHROUGH_DENY_REASON }],
+    })).toBe(true)
+    expect(isForwardedDenial({ type: "tool_result", tool_use_id: "x", is_error: true, content: "ENOENT" })).toBe(false)
+    expect(isForwardedDenial({ type: "tool_result", tool_use_id: "x", content: PASSTHROUGH_DENY_REASON })).toBe(false)
+    expect(isForwardedDenial({ type: "text", content: PASSTHROUGH_DENY_REASON })).toBe(false)
+    expect(isForwardedDenial(undefined)).toBe(false)
+  })
+})

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -307,6 +307,65 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
+  it("stream: keeps the checkpoint when queued user text follows tool results", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "queued-stream-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [
+      messageStart("msg_queued_stream"),
+      toolUseBlockStart(0, "read", "queued-stream-tool"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("queued-stream-tool"),
+    ]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-queued-stream-user")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockMessages = [
+      messageStart("msg_queued_stream_reply"),
+      textBlockStart(0),
+      textDelta(0, "the file says X"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "the file says X" }]),
+    ]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "queued-stream-tool", content: "X" }] },
+        { role: "user", content: "also summarize it" },
+      ],
+    }, "es-queued-stream-user")
+    expect(second.status).toBe(200)
+    await second.text()
+
+    const resumed = capturedQueryParamsAll[1]
+    expect(resumed.options.resume).toBe("test-session")
+    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+    const promptMessages: any[] = []
+    for await (const message of resumed.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "queued-stream-tool", content: "X" },
+      { type: "text", text: "also summarize it" },
+    ])
+  })
+
   it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
     const firstToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },
@@ -399,6 +458,39 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resume).toBeUndefined()
     expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
     expect(typeof capturedQueryParams.prompt).toBe("string")
+  })
+
+  it("non-stream: preserves queued user text when partial results force a fresh replay", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "partial-queued-1", name: "read", input: { file_path: "a" } },
+      { type: "tool_use", id: "partial-queued-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("partial-queued-1"), userDenyMessage("partial-queued-2")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read both" }],
+    }, "es-partial-queued-results")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "safe replay" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read both" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "partial-queued-1", content: "A" }] },
+        { role: "user", content: "keep this queued" },
+      ],
+    }, "es-partial-queued-results")).status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(typeof capturedQueryParams.prompt).toBe("string")
+    expect(capturedQueryParams.prompt).toContain("keep this queued")
   })
 
   it("non-stream: preserves a nested multimodal tool_result wrapper", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -6,8 +6,16 @@
  * the hidden digest through a canonical result; only then is the assistant UUID
  * known durable enough for resumeSessionAt.
  */
-import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
-import { assistantMessage, messageStart, textBlockStart, textDelta, toolUseBlockStart, inputJsonDelta, blockStop, messageDelta, messageStop } from "./helpers"
+import { describe, it, expect, mock, beforeAll, beforeEach, afterEach, afterAll } from "bun:test"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { assistantMessage, messageStart, textBlockStart, textDelta, toolUseBlockStart, inputJsonDelta, blockStop, messageDelta, messageStop, resolveMockSdkSessionId } from "./helpers"
+
+interface LifecycleResourceSnapshot {
+  locator: { sessionId: string }
+  state: string
+}
 
 let mockMessages: any[] = []
 let yieldedCount = 0
@@ -15,6 +23,10 @@ let capturedQueryParams: any = null
 let capturedQueryParamsAll: any[] = []
 let mockTerminalError: Error | undefined
 let forkSessionSequence = 0
+let mockBaseSessionId = "test-session"
+let mockReturnedSessionIdOverride: string | undefined
+let mockOmitReturnedSessionId = false
+const initialManagedSessionId = () => capturedQueryParamsAll[0]?.options?.sessionId ?? mockBaseSessionId
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
@@ -22,9 +34,8 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedQueryParamsAll.push(params)
     const terminalError = mockTerminalError
     const preHook = params?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
-    const returnedSessionId = params?.options?.forkSession
-      ? `test-session-fork-${++forkSessionSequence}`
-      : params?.options?.resume ?? "test-session"
+    const returnedSessionId = mockReturnedSessionIdOverride
+      ?? resolveMockSdkSessionId(params?.options, mockBaseSessionId)
     return (async function* () {
       let sawSyntheticDeny = false
       let sawResult = false
@@ -40,7 +51,11 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           }
           continue
         }
-        const delivered = { ...msg, session_id: returnedSessionId }
+        const { session_id: _ignoredSessionId, ...messageWithoutSessionId } = msg
+        const delivered = {
+          ...messageWithoutSessionId,
+          ...(mockOmitReturnedSessionId ? {} : { session_id: returnedSessionId }),
+        }
         if (delivered?.type === "user" && delivered?.message?.content?.some((b: any) => b?.type === "tool_result")) {
           sawSyntheticDeny = true
         }
@@ -64,7 +79,12 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       // after tool-deny flows unless a fixture provided one explicitly.
       if (sawSyntheticDeny && !sawResult) {
         yieldedCount++
-        yield { type: "result", subtype: "success", is_error: false, session_id: returnedSessionId }
+        yield {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          ...(mockOmitReturnedSessionId ? {} : { session_id: returnedSessionId }),
+        }
       }
     })()
   },
@@ -87,7 +107,7 @@ mock.module("../mcpTools", () => ({
 
 const { createProxyServer } = await import("../proxy/server")
 const { clearSessionCache } = await import("../proxy/session/cache")
-const { evictSharedSession } = await import("../proxy/sessionStore")
+const { evictSharedSession, lookupSharedSession, setSessionStoreDir } = await import("../proxy/sessionStore")
 const { telemetryStore } = await import("../telemetry")
 
 function userDenyMessage(toolUseId: string) {
@@ -104,6 +124,7 @@ function userDenyMessage(toolUseId: string) {
 }
 
 const TEST_RUN_ID = crypto.randomUUID()
+const TEST_SESSION_DIR = mkdtempSync(join(tmpdir(), "meridian-early-stop-"))
 
 const READ_TOOL = {
   name: "read",
@@ -112,6 +133,18 @@ const READ_TOOL = {
 }
 
 const usedSessionKeys = new Set<string>()
+
+async function waitForLifecycleState(sessionId: string, state: string): Promise<void> {
+  const deadline = Date.now() + 1_000
+  while (Date.now() < deadline) {
+    const sidecar = JSON.parse(readFileSync(join(TEST_SESSION_DIR, "session-gc.json"), "utf8"))
+    const resource = Object.values(sidecar.resources as Record<string, LifecycleResourceSnapshot>)
+      .find((candidate) => candidate.locator.sessionId === sessionId)
+    if (resource?.state === state) return
+    await Bun.sleep(10)
+  }
+  throw new Error(`lifecycle resource ${sessionId} did not reach ${state}`)
+}
 
 async function post(app: any, body: any, sessionHeader = "es-session", extraHeaders: Record<string, string> = {}) {
   const sessionKey = `${sessionHeader}-${TEST_RUN_ID}`
@@ -135,8 +168,14 @@ describe("Integration: passthrough early stop", () => {
   let savedEarlyStop: string | undefined
 
   beforeAll(() => {
+    setSessionStoreDir(TEST_SESSION_DIR)
     const { app: a } = createProxyServer({ port: 0, host: "127.0.0.1" })
     app = a
+  })
+
+  afterAll(() => {
+    setSessionStoreDir(null)
+    rmSync(TEST_SESSION_DIR, { recursive: true, force: true })
   })
 
   beforeEach(() => {
@@ -150,6 +189,9 @@ describe("Integration: passthrough early stop", () => {
     capturedQueryParamsAll = []
     mockTerminalError = undefined
     forkSessionSequence = 0
+    mockBaseSessionId = `test-session-${crypto.randomUUID()}`
+    mockReturnedSessionIdOverride = undefined
+    mockOmitReturnedSessionId = false
   })
 
   afterEach(() => {
@@ -160,6 +202,35 @@ describe("Integration: passthrough early stop", () => {
     else delete process.env.MERIDIAN_PASSTHROUGH
     if (savedEarlyStop !== undefined) process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = savedEarlyStop
     else delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+  })
+
+  it("replays and replaces a legacy user-denial boundary without a false conflict", async () => {
+    const sessionHeader = "es-legacy-upgrade"
+    const sessionKey = `${sessionHeader}-${TEST_RUN_ID}`
+    usedSessionKeys.add(sessionKey)
+    const now = Date.now()
+    writeFileSync(join(TEST_SESSION_DIR, "sessions.json"), JSON.stringify({
+      [sessionKey]: {
+        claudeSessionId: "legacy-sdk-session",
+        revision: 1,
+        createdAt: now,
+        lastUsedAt: now,
+        messageCount: 1,
+        lineageHash: "legacy-lineage",
+        passthroughResumeUuid: "legacy-user-denial-uuid",
+      },
+    }))
+    mockMessages = [assistantMessage([{ type: "text", text: "fresh replay" }])]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      messages: [{ role: "user", content: "continue after upgrade" }],
+    }, sessionHeader)
+    expect(response.status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(lookupSharedSession(sessionKey)?.claudeSessionId).toBe(initialManagedSessionId())
   })
 
   it("non-stream: drains the hidden digest to a canonical result without leaking it", async () => {
@@ -223,7 +294,7 @@ describe("Integration: passthrough early stop", () => {
     }, "es-resume")
     expect(second.status).toBe(200)
     // Resume proof: the SDK was invoked with the stored session id.
-    expect(capturedQueryParams.options.resume).toBe("test-session")
+    expect(capturedQueryParams.options.resume).toBe(initialManagedSessionId())
   })
 
   it("non-stream: resumes at the assistant tool-use boundary with structured real results", async () => {
@@ -258,7 +329,7 @@ describe("Integration: passthrough early stop", () => {
 
     // resumeSessionAt only accepts SDKAssistantMessage UUIDs. The synthetic
     // user denial is a discarded side branch, not the canonical checkpoint.
-    expect(capturedQueryParams.options.resume).toBe("test-session")
+    expect(capturedQueryParams.options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParams.options.resumeSessionAt).toBe(assistantForkUuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(syntheticDeny.uuid)
     // The fork makes this rewind durable, replacing the persisted synthetic
@@ -271,6 +342,44 @@ describe("Integration: passthrough early stop", () => {
     expect(promptMessages[0].type).toBe("user")
     expect(promptMessages[0].message.content).toEqual([
       { type: "tool_result", tool_use_id: "tu1", content: "hi" },
+    ])
+  })
+
+  it("non-stream: treats exact pending tool results as causal continuation despite envelope drift", async () => {
+    const assistantToolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-envelope", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [assistantToolTurn, userDenyMessage("tu-envelope")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-envelope-drift")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "done" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: [{ type: "text", text: "inserted volatile prefix" }] },
+        { role: "user", content: [{ type: "text", text: "volatile envelope changed" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-envelope", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-envelope", content: "hi" }] },
+      ],
+    }, "es-envelope-drift")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBe(initialManagedSessionId())
+    expect(capturedQueryParams.options.resumeSessionAt).toBe(assistantToolTurn.uuid)
+    expect(capturedQueryParams.options.forkSession).toBe(true)
+    const promptMessages: any[] = []
+    for await (const message of capturedQueryParams.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tu-envelope", content: "hi" },
     ])
   })
 
@@ -302,7 +411,7 @@ describe("Integration: passthrough early stop", () => {
     }, "es-queued-user")).status).toBe(200)
 
     const resumed = capturedQueryParamsAll[1]
-    expect(resumed.options.resume).toBe("test-session")
+    expect(resumed.options.resume).toBe(initialManagedSessionId())
     expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
     const promptMessages: any[] = []
     for await (const message of resumed.prompt) promptMessages.push(message)
@@ -361,7 +470,7 @@ describe("Integration: passthrough early stop", () => {
     await second.text()
 
     const resumed = capturedQueryParamsAll[1]
-    expect(resumed.options.resume).toBe("test-session")
+    expect(resumed.options.resume).toBe(initialManagedSessionId())
     expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
     const promptMessages: any[] = []
     for await (const message of resumed.prompt) promptMessages.push(message)
@@ -401,7 +510,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-repeated-boundary")).status).toBe(200)
     const secondQuery = capturedQueryParamsAll[1]
-    expect(secondQuery.options.resume).toBe("test-session")
+    expect(secondQuery.options.resume).toBe(initialManagedSessionId())
     expect(secondQuery.options.resumeSessionAt).toBe(firstToolTurn.uuid)
     // resumeSessionAt alone rewinds only for this query. The source transcript
     // still ends in the persisted PreToolUse denial, so a later resume from the
@@ -409,6 +518,16 @@ describe("Integration: passthrough early stop", () => {
     // Forking makes the rewind durable: the new transcript appends result A and
     // subsequent assistant turns descend from the real client result.
     expect(secondQuery.options.forkSession).toBe(true)
+    expect(secondQuery.options.sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    const storedSecond = lookupSharedSession(`es-repeated-boundary-${TEST_RUN_ID}`)
+    expect(storedSecond?.claudeSessionId).toBe(secondQuery.options.sessionId)
+    expect(storedSecond?.previousClaudeSessionId).toBe(initialManagedSessionId())
+    expect(storedSecond?.currentTranscript?.sessionId).toBe(secondQuery.options.sessionId)
+    expect(storedSecond?.previousTranscript?.sessionId).toBe(initialManagedSessionId())
+    const secondSidecar = JSON.parse(readFileSync(join(TEST_SESSION_DIR, "session-gc.json"), "utf8"))
+    const targetResource = Object.values(secondSidecar.resources as Record<string, any>)
+      .find((resource) => resource.locator.sessionId === secondQuery.options.sessionId)
+    expect(targetResource?.state).toBe("live")
     const secondPrompt: any[] = []
     for await (const message of secondQuery.prompt) secondPrompt.push(message)
     expect(secondPrompt[0].message.content).toEqual([
@@ -433,11 +552,12 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-repeated-boundary")).status).toBe(200)
     const thirdQuery = capturedQueryParamsAll[2]
-    expect(thirdQuery.options.resume).toBe("test-session-fork-1")
+    expect(thirdQuery.options.resume).toBe(secondQuery.options.sessionId)
     expect(thirdQuery.options.resumeSessionAt).toBe(secondToolTurn.uuid)
     // Every tool boundary has its own synthetic denial tail. Repeating the fork
     // is what keeps result B durable as the chain grows beyond three resumes.
     expect(thirdQuery.options.forkSession).toBe(true)
+    expect(thirdQuery.options.sessionId).not.toBe(secondQuery.options.sessionId)
     const thirdPrompt: any[] = []
     for await (const message of thirdQuery.prompt) thirdPrompt.push(message)
     expect(thirdPrompt[0].message.content).toEqual([
@@ -461,7 +581,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-repeated-boundary")).status).toBe(200)
     const fourthQuery = capturedQueryParamsAll[3]
-    expect(fourthQuery.options.resume).toBe("test-session-fork-2")
+    expect(fourthQuery.options.resume).toBe(thirdQuery.options.sessionId)
     expect(fourthQuery.options.resumeSessionAt).toBe(thirdToolTurn.uuid)
     expect(fourthQuery.options.forkSession).toBe(true)
     const fourthPrompt: any[] = []
@@ -469,6 +589,159 @@ describe("Integration: passthrough early stop", () => {
     expect(fourthPrompt[0].message.content).toEqual([
       { type: "tool_result", tool_use_id: "tu-round-3", content: "C" },
     ])
+  })
+
+
+  it("non-stream: rejects a fresh SDK session ID contradiction and retires both identities", async () => {
+    const wrongSessionId = `wrong-fresh-${crypto.randomUUID()}`
+    mockReturnedSessionIdOverride = wrongSessionId
+    mockMessages = [assistantMessage([{ type: "text", text: "must not publish" }])]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      messages: [{ role: "user", content: "fresh id mismatch" }],
+    }, "es-fresh-id-mismatch")
+    expect(response.status).toBe(500)
+    expect(await response.text()).toContain("Managed SDK fork returned")
+
+    const targetId = capturedQueryParamsAll[0]?.options?.sessionId
+    expect(targetId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(lookupSharedSession(`es-fresh-id-mismatch-${TEST_RUN_ID}`)).toBeUndefined()
+    const sidecar = JSON.parse(readFileSync(join(TEST_SESSION_DIR, "session-gc.json"), "utf8"))
+    const resources = Object.values(sidecar.resources as Record<string, LifecycleResourceSnapshot>)
+    expect(resources.find((resource) => resource.locator.sessionId === targetId)?.state).toBe("retired")
+    expect(resources.find((resource) => resource.locator.sessionId === wrongSessionId)?.state).toBe("retired")
+  })
+
+  it("stream: rejects a fresh SDK session ID contradiction without publishing it", async () => {
+    const wrongSessionId = `wrong-fresh-stream-${crypto.randomUUID()}`
+    mockReturnedSessionIdOverride = wrongSessionId
+    mockMessages = [assistantMessage([{ type: "text", text: "must not publish" }])]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      messages: [{ role: "user", content: "fresh stream id mismatch" }],
+    }, "es-fresh-stream-id-mismatch")
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    expect(body).toContain("event: error")
+    expect(body).not.toContain("must not publish")
+    expect(lookupSharedSession(`es-fresh-stream-id-mismatch-${TEST_RUN_ID}`)).toBeUndefined()
+
+    const targetId = capturedQueryParamsAll[0]?.options?.sessionId
+    await waitForLifecycleState(targetId, "retired")
+    const sidecar = JSON.parse(readFileSync(join(TEST_SESSION_DIR, "session-gc.json"), "utf8"))
+    const resources = Object.values(sidecar.resources as Record<string, LifecycleResourceSnapshot>)
+    expect(resources.find((resource) => resource.locator.sessionId === targetId)?.state).toBe("retired")
+    expect(resources.find((resource) => resource.locator.sessionId === wrongSessionId)?.state).toBe("retired")
+  })
+
+  it("non-stream: rejects an SDK fork ID mismatch without advancing the shared mapping", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-id-mismatch", name: "read", input: { file_path: "a" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("tu-id-mismatch")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read for mismatch" }],
+    }, "es-managed-id-mismatch")).status).toBe(200)
+
+    const wrongSessionId = `wrong-${crypto.randomUUID()}`
+    mockReturnedSessionIdOverride = wrongSessionId
+    mockMessages = [assistantMessage([{ type: "text", text: "must not publish" }])]
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read for mismatch" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "tu-id-mismatch", content: "A" },
+        ] },
+      ],
+    }, "es-managed-id-mismatch")
+    expect(response.status).toBe(500)
+    expect(await response.text()).toContain("Managed SDK fork returned")
+
+    const managedQuery = capturedQueryParamsAll[1]
+    const targetId = managedQuery.options.sessionId
+    expect(targetId).toMatch(/^[0-9a-f-]{36}$/)
+    const stored = lookupSharedSession(`es-managed-id-mismatch-${TEST_RUN_ID}`)
+    expect(stored?.claudeSessionId).toBe(initialManagedSessionId())
+    expect(stored?.previousClaudeSessionId).toBeUndefined()
+    const sidecar = JSON.parse(readFileSync(join(TEST_SESSION_DIR, "session-gc.json"), "utf8"))
+    const resources = Object.values(sidecar.resources as Record<string, LifecycleResourceSnapshot>)
+    const target = resources.find((resource) => resource.locator.sessionId === targetId)
+    const unexpected = resources.find((resource) => resource.locator.sessionId === wrongSessionId)
+    expect(target?.state).toBe("retired")
+    expect(unexpected?.state).toBe("retired")
+  })
+
+  it("non-stream: rejects a managed fork that completes without a session ID", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-id-missing", name: "read", input: { file_path: "a" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("tu-id-missing")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5", max_tokens: 400, stream: false, tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read without returned id" }],
+    }, "es-managed-id-missing")).status).toBe(200)
+
+    mockOmitReturnedSessionId = true
+    mockMessages = [assistantMessage([{ type: "text", text: "must not publish" }])]
+    const response = await post(app, {
+      model: "claude-sonnet-4-5", max_tokens: 400, stream: false, tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read without returned id" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-id-missing", content: "A" }] },
+      ],
+    }, "es-managed-id-missing")
+    expect(response.status).toBe(500)
+    expect(await response.text()).toContain("no session ID")
+    expect(lookupSharedSession(`es-managed-id-missing-${TEST_RUN_ID}`)?.claudeSessionId).toBe(initialManagedSessionId())
+  })
+
+  it("stream: rejects a managed fork that completes without a session ID", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-stream-id-missing", name: "read", input: { file_path: "a" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("tu-stream-id-missing")]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5", max_tokens: 400, stream: true, tools: [READ_TOOL],
+      messages: [{ role: "user", content: "stream read without returned id" }],
+    }, "es-stream-managed-id-missing")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    mockOmitReturnedSessionId = true
+    mockMessages = [assistantMessage([{ type: "text", text: "must not publish" }])]
+    const response = await post(app, {
+      model: "claude-sonnet-4-5", max_tokens: 400, stream: true, tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "stream read without returned id" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-stream-id-missing", content: "A" }] },
+      ],
+    }, "es-stream-managed-id-missing")
+    expect(response.status).toBe(200)
+    expect(await response.text()).not.toContain("must not publish")
+    expect(lookupSharedSession(`es-stream-managed-id-missing-${TEST_RUN_ID}`)?.claudeSessionId).toBe(initialManagedSessionId())
+    const targetId = capturedQueryParamsAll[1].options.sessionId
+    await waitForLifecycleState(targetId, "retired")
+    const sidecar = JSON.parse(readFileSync(join(TEST_SESSION_DIR, "session-gc.json"), "utf8"))
+    const target = Object.values(sidecar.resources as Record<string, any>)
+      .find((resource) => resource.locator.sessionId === targetId)
+    expect(target == null || target.state === "retired" || target.state === "tombstoned").toBe(true)
   })
 
   it("non-stream: falls back to a fresh replay for partial parallel results", async () => {
@@ -612,6 +885,8 @@ describe("Integration: passthrough early stop", () => {
     }, "es-parallel-undo")).status).toBe(200)
     expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
     expect(capturedQueryParams.options.forkSession).toBe(true)
+    const forkSessionId = capturedQueryParams.options.sessionId
+    expect(forkSessionId).toMatch(/^[0-9a-f-]{36}$/)
 
     mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
     expect((await post(app, {
@@ -630,9 +905,9 @@ describe("Integration: passthrough early stop", () => {
         { role: "user", content: "continue after the fork" },
       ],
     }, "es-parallel-undo")).status).toBe(200)
-    expect(capturedQueryParams.options.resume).toBe("test-session-fork-1")
+    expect(capturedQueryParams.options.resume).toBe(forkSessionId)
     expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBe(true)
 
     const rewrittenBranch = [
       { role: "user", content: "read both for undo" },
@@ -697,7 +972,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-no-boundary")
     expect(second.status).toBe(200)
-    expect(capturedQueryParams.options.resume).toBe("test-session")
+    expect(capturedQueryParams.options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParams.prompt).toBe("and again")
   })
 
@@ -813,7 +1088,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-hidden-hook-race")
     expect(second.status).toBe(200)
-    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(visibleTurn.uuid)
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).not.toBe(hiddenTurn.uuid)
   })
@@ -905,7 +1180,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-late-parallel")
     expect(second.status).toBe(200)
-    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(finalFragment.uuid)
   })
 
@@ -932,10 +1207,14 @@ describe("Integration: passthrough early stop", () => {
       inputJsonDelta(1, '{"file_path":"b"}'),
       blockStop(1),
       messageDelta("tool_use"),
+      { type: "test_pre_tool_hook", tool_name: "read", tool_use_id: "ns-late-1", tool_input: { file_path: "a" } },
+      { type: "test_pre_tool_hook", tool_name: "read", tool_use_id: "ns-late-2", tool_input: { file_path: "b" } },
       firstFragment,
       userDenyMessage("ns-late-1"),
-      finalFragment,
       userDenyMessage("ns-late-2"),
+      // Both results can arrive before the last assistant metadata fragment.
+      // Settlement must recheck after this fragment extends the expected set.
+      finalFragment,
     ]
 
     const res = await post(app, {
@@ -949,6 +1228,25 @@ describe("Integration: passthrough early stop", () => {
     const body = await res.json() as any
     const toolUses = body.content.filter((b: any) => b.type === "tool_use")
     expect(toolUses.map((t: any) => t.id).sort()).toEqual(["ns-late-1", "ns-late-2"])
+
+    mockMessages = [assistantMessage([{ type: "text", text: "both complete" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read a and b" },
+        { role: "assistant", content: toolUses },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "ns-late-1", content: "A" },
+          { type: "tool_result", tool_use_id: "ns-late-2", content: "B" },
+        ] },
+      ],
+    }, "es-ns-late-parallel")
+    expect(second.status).toBe(200)
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(finalFragment.uuid)
+    expect(capturedQueryParamsAll[1].options.forkSession).toBe(true)
   })
 
   // The other half of the same gate. Above, the tracker lags the wire; here it
@@ -1220,7 +1518,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-single-turn-boundary")
     expect(second.status).toBe(200)
-    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
   })
 
@@ -1270,7 +1568,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-capped-stream")
     expect(second.status).toBe(200)
-    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
   })
 
@@ -1315,7 +1613,7 @@ describe("Integration: passthrough early stop", () => {
     }, "es-capped-fork-map", { "x-request-id": forkRequestId })
     expect(forked.status).toBe(200)
     expect(await forked.text()).toContain('"type":"tool_use"')
-    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(parentToolTurn.uuid)
     expect(capturedQueryParamsAll[1].options.forkSession).toBe(true)
     let forkRow: any
@@ -1382,7 +1680,7 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-capped-nonstream")
     expect(second.status).toBe(200)
-    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resume).toBe(initialManagedSessionId())
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
   })
 
@@ -1616,7 +1914,7 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParamsAll[0].options.maxTurns).toBe(1)
   })
 
-  it("stream: closes at turn 1 while digest and canonical result drain invisibly", async () => {
+  it("stream: withholds the terminal tool checkpoint until the canonical drain is published", async () => {
     mockMessages = [
       messageStart("msg_es"),
       toolUseBlockStart(0, "read", "tu1"),
@@ -1625,8 +1923,8 @@ describe("Integration: passthrough early stop", () => {
       messageDelta("tool_use"),
       assistantMessage([{ type: "tool_use", id: "tu1", name: "read", input: { file_path: "x" } }]),
       userDenyMessage("tu1"),
-      // Hidden digest wire events are consumed but never enqueued after the
-      // client controller closes. A closed enqueue must not break the drain.
+      // Hidden digest wire events are consumed but never enqueued. The terminal
+      // pair is withheld until the exact managed target is durable.
       messageStart("msg_turn2"),
       textBlockStart(0),
       textDelta(0, "TURN2_GARBAGE_DIGEST"),
@@ -1650,13 +1948,73 @@ describe("Integration: passthrough early stop", () => {
     expect(text).toContain("message_stop")
     expect(text).not.toContain("TURN2_GARBAGE_DIGEST")
 
-    // The client response completes at turn 1; digest/result draining continues
-    // in the background and must not abort the SDK query.
+    const durable = lookupSharedSession(`es-session-${TEST_RUN_ID}`)
+    expect(durable?.claudeSessionId).toBe(capturedQueryParams.options.sessionId)
+    expect(durable?.passthroughToolCallIds).toEqual(["tu1"])
+
+    // Receiving message_stop proves digest/result draining and target
+    // publication already completed.
     const deadline = Date.now() + 2000
     while (yieldedCount < 15 && Date.now() < deadline) {
       await new Promise(resolve => setTimeout(resolve, 10))
     }
     expect(capturedQueryParams.options.abortController?.signal?.aborted ?? false).toBe(false)
     expect(yieldedCount).toBe(15)
+  })
+
+  it("stream: alternate second-message_start invalidates the source before terminal", async () => {
+    const sessionHeader = "es-alt-boundary"
+    mockMessages = [assistantMessage([{ type: "text", text: "seed" }])]
+    const seed = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "seed" }],
+    }, sessionHeader)
+    await seed.text()
+    const sourceSessionId = lookupSharedSession(`${sessionHeader}-${TEST_RUN_ID}`)?.claudeSessionId
+    expect(sourceSessionId).toBeDefined()
+
+    mockMessages = [
+      messageStart("msg_alt_1"),
+      toolUseBlockStart(0, "read", "tu-alt"),
+      inputJsonDelta(0, '{"file_path":"alt"}'),
+      blockStop(0),
+      // Some SDK versions surface assistant + deny before the first tool-use
+      // message_delta. The second message_start is then the drain boundary.
+      assistantMessage([{ type: "tool_use", id: "tu-alt", name: "read", input: { file_path: "alt" } }]),
+      userDenyMessage("tu-alt"),
+      messageStart("msg_alt_2"),
+      textBlockStart(0),
+      textDelta(0, "HIDDEN_ALT_DIGEST"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "HIDDEN_ALT_DIGEST" }]),
+    ]
+
+    const response = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "seed" },
+        { role: "assistant", content: "seed" },
+        { role: "user", content: "read alt" },
+      ],
+    }, sessionHeader)
+    const text = await response.text()
+    expect(capturedQueryParams.options.resume).toBe(sourceSessionId)
+    expect(text).toContain('"id":"tu-alt"')
+    expect(text).toContain('"stop_reason":"tool_use"')
+    expect(text).toContain("message_stop")
+    expect(text).not.toContain("HIDDEN_ALT_DIGEST")
+
+    // No durable checkpoint UUID was observed in this alternate ordering.
+    // The old source must therefore be absent before message_stop is received,
+    // forcing the client's next tool-result request to replay in full.
+    expect(lookupSharedSession(`${sessionHeader}-${TEST_RUN_ID}`)).toBeUndefined()
   })
 })

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -14,6 +14,7 @@ let yieldedCount = 0
 let capturedQueryParams: any = null
 let capturedQueryParamsAll: any[] = []
 let mockTerminalError: Error | undefined
+let forkSessionSequence = 0
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
@@ -21,6 +22,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedQueryParamsAll.push(params)
     const terminalError = mockTerminalError
     const preHook = params?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+    const returnedSessionId = params?.options?.forkSession
+      ? `test-session-fork-${++forkSessionSequence}`
+      : params?.options?.resume ?? "test-session"
     return (async function* () {
       let sawSyntheticDeny = false
       let sawResult = false
@@ -36,13 +40,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           }
           continue
         }
-        if (msg?.type === "user" && msg?.message?.content?.some((b: any) => b?.type === "tool_result")) {
+        const delivered = { ...msg, session_id: returnedSessionId }
+        if (delivered?.type === "user" && delivered?.message?.content?.some((b: any) => b?.type === "tool_result")) {
           sawSyntheticDeny = true
         }
-        if (msg?.type === "result") sawResult = true
-        yield msg
-        if (preHook && msg?.type === "assistant" && Array.isArray(msg?.message?.content)) {
-          for (const block of msg.message.content) {
+        if (delivered?.type === "result") sawResult = true
+        yield delivered
+        if (preHook && delivered?.type === "assistant" && Array.isArray(delivered?.message?.content)) {
+          for (const block of delivered.message.content) {
             if (block?.type !== "tool_use") continue
             void Promise.resolve(preHook({
               tool_name: block.name,
@@ -59,7 +64,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       // after tool-deny flows unless a fixture provided one explicitly.
       if (sawSyntheticDeny && !sawResult) {
         yieldedCount++
-        yield { type: "result", subtype: "success", is_error: false, session_id: "test-session" }
+        yield { type: "result", subtype: "success", is_error: false, session_id: returnedSessionId }
       }
     })()
   },
@@ -144,6 +149,7 @@ describe("Integration: passthrough early stop", () => {
     capturedQueryParams = null
     capturedQueryParamsAll = []
     mockTerminalError = undefined
+    forkSessionSequence = 0
   })
 
   afterEach(() => {
@@ -255,9 +261,9 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resume).toBe("test-session")
     expect(capturedQueryParams.options.resumeSessionAt).toBe(assistantForkUuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(syntheticDeny.uuid)
-    // Normal passthrough continuation reuses the session ID. Forking is for
-    // semantic branches (undo) or the bounded busy-session fallback only.
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    // The fork makes this rewind durable, replacing the persisted synthetic
+    // denial tail with the client's real result in the new transcript.
+    expect(capturedQueryParams.options.forkSession).toBe(true)
 
     const promptMessages: any[] = []
     for await (const message of capturedQueryParams.prompt) promptMessages.push(message)
@@ -366,7 +372,7 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
-  it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
+  it("non-stream: forks every repeated checkpoint resume so delivered results replace deny tails", async () => {
     const firstToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },
     ])
@@ -397,14 +403,22 @@ describe("Integration: passthrough early stop", () => {
     const secondQuery = capturedQueryParamsAll[1]
     expect(secondQuery.options.resume).toBe("test-session")
     expect(secondQuery.options.resumeSessionAt).toBe(firstToolTurn.uuid)
-    expect(secondQuery.options.forkSession).toBeUndefined()
+    // resumeSessionAt alone rewinds only for this query. The source transcript
+    // still ends in the persisted PreToolUse denial, so a later resume from the
+    // newly produced assistant UUID serializes that marker in place of result A.
+    // Forking makes the rewind durable: the new transcript appends result A and
+    // subsequent assistant turns descend from the real client result.
+    expect(secondQuery.options.forkSession).toBe(true)
     const secondPrompt: any[] = []
     for await (const message of secondQuery.prompt) secondPrompt.push(message)
     expect(secondPrompt[0].message.content).toEqual([
       { type: "tool_result", tool_use_id: "tu-round-1", content: "A" },
     ])
 
-    mockMessages = [assistantMessage([{ type: "text", text: "done" }])]
+    const thirdToolTurn = assistantMessage([
+      { type: "tool_use", id: "tu-round-3", name: "read", input: { file_path: "c" } },
+    ])
+    mockMessages = [thirdToolTurn, userDenyMessage("tu-round-3")]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
@@ -419,13 +433,41 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-repeated-boundary")).status).toBe(200)
     const thirdQuery = capturedQueryParamsAll[2]
-    expect(thirdQuery.options.resume).toBe("test-session")
+    expect(thirdQuery.options.resume).toBe("test-session-fork-1")
     expect(thirdQuery.options.resumeSessionAt).toBe(secondToolTurn.uuid)
-    expect(thirdQuery.options.forkSession).toBeUndefined()
+    // Every tool boundary has its own synthetic denial tail. Repeating the fork
+    // is what keeps result B durable as the chain grows beyond three resumes.
+    expect(thirdQuery.options.forkSession).toBe(true)
     const thirdPrompt: any[] = []
     for await (const message of thirdQuery.prompt) thirdPrompt.push(message)
     expect(thirdPrompt[0].message.content).toEqual([
       { type: "tool_result", tool_use_id: "tu-round-2", content: "B" },
+    ])
+
+    mockMessages = [assistantMessage([{ type: "text", text: "done" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read a" },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-1", content: "A" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-2", name: "read", input: { file_path: "b" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-2", content: "B" }] },
+        { role: "assistant", content: [{ type: "tool_use", id: "tu-round-3", name: "read", input: { file_path: "c" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "tu-round-3", content: "C" }] },
+      ],
+    }, "es-repeated-boundary")).status).toBe(200)
+    const fourthQuery = capturedQueryParamsAll[3]
+    expect(fourthQuery.options.resume).toBe("test-session-fork-2")
+    expect(fourthQuery.options.resumeSessionAt).toBe(thirdToolTurn.uuid)
+    expect(fourthQuery.options.forkSession).toBe(true)
+    const fourthPrompt: any[] = []
+    for await (const message of fourthQuery.prompt) fourthPrompt.push(message)
+    expect(fourthPrompt[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "tu-round-3", content: "C" },
     ])
   })
 
@@ -530,7 +572,7 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
-  it("non-stream: maps parallel SDK fragments to one final undo UUID", async () => {
+  it("non-stream: drops copied rollback UUIDs after a checkpoint fork", async () => {
     const firstFragment = assistantMessage([
       { type: "tool_use", id: "undo-parallel-1", name: "read", input: { file_path: "a" } },
     ])
@@ -552,7 +594,8 @@ describe("Integration: passthrough early stop", () => {
       messages: [{ role: "user", content: "read both for undo" }],
     }, "es-parallel-undo")).status).toBe(200)
 
-    mockMessages = [assistantMessage([{ type: "text", text: "both read" }])]
+    const forkOutput = assistantMessage([{ type: "text", text: "both read" }])
+    mockMessages = [forkOutput]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
@@ -568,9 +611,9 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-parallel-undo")).status).toBe(200)
     expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBe(true)
 
-    mockMessages = [assistantMessage([{ type: "text", text: "changed direction" }])]
+    mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
       max_tokens: 400,
@@ -579,14 +622,39 @@ describe("Integration: passthrough early stop", () => {
       messages: [
         { role: "user", content: "read both for undo" },
         { role: "assistant", content: combinedToolTurn },
-        { role: "user", content: "instead, take a different direction" },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "undo-parallel-1", content: "A" },
+          { type: "tool_result", tool_use_id: "undo-parallel-2", content: "B" },
+        ] },
+        { role: "assistant", content: forkOutput.message.content },
+        { role: "user", content: "continue after the fork" },
       ],
     }, "es-parallel-undo")).status).toBe(200)
-    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
-    expect(capturedQueryParams.options.forkSession).toBe(true)
+    expect(capturedQueryParams.options.resume).toBe("test-session-fork-1")
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
 
-    // The first undo must retain UUIDs for the preserved prefix so another
-    // branch from that prefix still rolls back to the final parallel fragment.
+    const rewrittenBranch = [
+      { role: "user", content: "read both for undo" },
+      { role: "assistant", content: combinedToolTurn },
+      { role: "user", content: "instead, take a different direction" },
+      { role: "assistant", content: [{ type: "text", text: "branch draft" }] },
+      { role: "user", content: "rewrite this branch" },
+    ]
+    mockMessages = [assistantMessage([{ type: "text", text: "changed direction" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: rewrittenBranch,
+    }, "es-parallel-undo")).status).toBe(200)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+
+    // The fresh replay above has the same message count as the cached fork
+    // continuation. It must not inherit forkOutput.uuid from the older slot.
     mockMessages = [assistantMessage([{ type: "text", text: "changed again" }])]
     expect((await post(app, {
       model: "claude-sonnet-4-5",
@@ -594,13 +662,13 @@ describe("Integration: passthrough early stop", () => {
       stream: false,
       tools: [READ_TOOL],
       messages: [
-        { role: "user", content: "read both for undo" },
-        { role: "assistant", content: combinedToolTurn },
-        { role: "user", content: "take yet another direction" },
+        ...rewrittenBranch.slice(0, 4),
+        { role: "user", content: "rewrite this branch again" },
       ],
     }, "es-parallel-undo")).status).toBe(200)
-    expect(capturedQueryParams.options.resumeSessionAt).toBe(finalFragment.uuid)
-    expect(capturedQueryParams.options.forkSession).toBe(true)
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBeUndefined()
   })
 
   it("non-stream: a plain resume with no deny boundary stays bare", async () => {
@@ -781,7 +849,7 @@ describe("Integration: passthrough early stop", () => {
     }, "es-kill-switch-undo")).status).toBe(200)
     expect(capturedQueryParams.options.resumeSessionAt).toBe(visibleToolTurn.uuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(hiddenDigestTurn.uuid)
-    expect(capturedQueryParams.options.forkSession).toBeUndefined()
+    expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
@@ -1125,6 +1193,77 @@ describe("Integration: passthrough early stop", () => {
     expect(second.status).toBe(200)
     expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(toolTurn.uuid)
+  })
+
+  it("stream: a capped checkpoint fork does not store parent rollback UUIDs", async () => {
+    const parentToolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-fork-parent", name: "read", input: { file_path: "parent" } },
+    ])
+    mockMessages = [parentToolTurn, userDenyMessage("capped-fork-parent")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read parent then child" }],
+    }, "es-capped-fork-map")).status).toBe(200)
+
+    const forkToolTurn = assistantMessage([
+      { type: "tool_use", id: "capped-fork-child", name: "read", input: { file_path: "child" } },
+    ])
+    mockMessages = [
+      messageStart("msg_capped_fork_child"),
+      toolUseBlockStart(0, "read", "capped-fork-child"),
+      inputJsonDelta(0, '{"file_path":"child"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      forkToolTurn,
+      userDenyMessage("capped-fork-child"),
+      { type: "result", subtype: "error_max_turns", is_error: true },
+    ]
+    mockTerminalError = new Error("Claude Code returned an error result: Reached maximum number of turns (1)")
+    const forkRequestId = `capped-fork-map-${TEST_RUN_ID}`
+    const forked = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read parent then child" },
+        { role: "assistant", content: parentToolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "capped-fork-parent", content: "P" }] },
+      ],
+    }, "es-capped-fork-map", { "x-request-id": forkRequestId })
+    expect(forked.status).toBe(200)
+    expect(await forked.text()).toContain('"type":"tool_use"')
+    expect(capturedQueryParamsAll[1].options.resume).toBe("test-session")
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(parentToolTurn.uuid)
+    expect(capturedQueryParamsAll[1].options.forkSession).toBe(true)
+    let forkRow: any
+    for (let i = 0; i < 500 && !forkRow; i++) {
+      forkRow = telemetryStore.getRecent({ limit: 200 }).find((row: any) => row.requestId === forkRequestId)
+      if (!forkRow) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(forkRow).toBeDefined()
+
+    mockTerminalError = undefined
+    mockMessages = [assistantMessage([{ type: "text", text: "fresh branch" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read parent then child" },
+        { role: "assistant", content: parentToolTurn.message.content },
+        { role: "user", content: [
+          { type: "tool_result", tool_use_id: "capped-fork-parent", content: "different parent result" },
+        ] },
+      ],
+    }, "es-capped-fork-map")).status).toBe(200)
+    expect(capturedQueryParamsAll[2].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[2].options.resumeSessionAt).toBeUndefined()
+    expect(capturedQueryParamsAll[2].options.forkSession).toBeUndefined()
   })
 
   it("non-stream: stores the checkpoint at the capped stop so the next turn resumes", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -909,6 +909,85 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBe(finalFragment.uuid)
   })
 
+  // The non-stream counterpart of the late-parallel-metadata case above.
+  // Passthrough asks for partial messages on both paths, so non-stream has the
+  // same turn boundary AND the same hazard: after message_delta the tracker
+  // knows only the calls whose assistant fragments it has consumed, and a deny
+  // arriving before the final fragment settles that partial set. Freezing there
+  // hands the client a SUBSET of what the model called — the calls past the
+  // checkpoint are dropped, not replayed, so nothing on the wire looks wrong.
+  it("non-stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
+    const firstFragment = assistantMessage([
+      { type: "tool_use", id: "ns-late-1", name: "read", input: { file_path: "a" } },
+    ])
+    const finalFragment = assistantMessage([
+      { type: "tool_use", id: "ns-late-2", name: "read", input: { file_path: "b" } },
+    ])
+    mockMessages = [
+      messageStart("msg_ns_late_parallel"),
+      toolUseBlockStart(0, "read", "ns-late-1"),
+      inputJsonDelta(0, '{"file_path":"a"}'),
+      blockStop(0),
+      toolUseBlockStart(1, "read", "ns-late-2"),
+      inputJsonDelta(1, '{"file_path":"b"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      firstFragment,
+      userDenyMessage("ns-late-1"),
+      finalFragment,
+      userDenyMessage("ns-late-2"),
+    ]
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a and b" }],
+    }, "es-ns-late-parallel")
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.map((t: any) => t.id).sort()).toEqual(["ns-late-1", "ns-late-2"])
+  })
+
+  // The other half of the same gate. Above, the tracker lags the wire; here it
+  // matches it exactly — but only because the turn has not finished emitting.
+  // Settling on that agreement mid-generation freezes the checkpoint before the
+  // remaining blocks exist, so the completeness oracle alone is not sufficient:
+  // generation must also have ended.
+  it("non-stream: does not freeze when the tracker matches the wire mid-generation", async () => {
+    mockMessages = [
+      messageStart("msg_ns_midgen"),
+      toolUseBlockStart(0, "read", "ns-mid-1"),
+      inputJsonDelta(0, '{"file_path":"a"}'),
+      blockStop(0),
+      // Armed and settled while the turn is still generating: at this point
+      // expected and the streamed set agree on exactly {ns-mid-1}.
+      assistantMessage([{ type: "tool_use", id: "ns-mid-1", name: "read", input: { file_path: "a" } }]),
+      userDenyMessage("ns-mid-1"),
+      // ...and only now does the second call reach the wire.
+      toolUseBlockStart(1, "read", "ns-mid-2"),
+      inputJsonDelta(1, '{"file_path":"b"}'),
+      blockStop(1),
+      messageDelta("tool_use"),
+      assistantMessage([{ type: "tool_use", id: "ns-mid-2", name: "read", input: { file_path: "b" } }]),
+      userDenyMessage("ns-mid-2"),
+    ]
+
+    const res = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read a and b" }],
+    }, "es-ns-midgen")
+    expect(res.status).toBe(200)
+    const body = await res.json() as any
+    const toolUses = body.content.filter((b: any) => b.type === "tool_use")
+    expect(toolUses.map((t: any) => t.id).sort()).toEqual(["ns-mid-1", "ns-mid-2"])
+  })
+
   // #742: a deny can become iterator-visible while a later tool_use block is
   // still mid-input_json_delta. Freezing or closing solely from the tracker's
   // currently-known set can force-emit that block's content_block_stop, so the client

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -268,6 +268,45 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
+  it("non-stream: keeps the checkpoint when queued user text follows tool results", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "queued-tool", name: "read", input: { file_path: "x" } },
+    ])
+    mockMessages = [toolTurn, userDenyMessage("queued-tool")]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read x" }],
+    }, "es-queued-user")).status).toBe(200)
+
+    mockMessages = [assistantMessage([{ type: "text", text: "the file says X" }])]
+    expect((await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "assistant", content: toolTurn.message.content },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "queued-tool", content: "X" }] },
+        { role: "user", content: "also summarize it" },
+      ],
+    }, "es-queued-user")).status).toBe(200)
+
+    const resumed = capturedQueryParamsAll[1]
+    expect(resumed.options.resume).toBe("test-session")
+    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+    const promptMessages: any[] = []
+    for await (const message of resumed.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "queued-tool", content: "X" },
+      { type: "text", text: "also summarize it" },
+    ])
+  })
+
   it("non-stream: advances the assistant checkpoint across repeated tool rounds without forking", async () => {
     const firstToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-round-1", name: "read", input: { file_path: "a" } },

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -259,6 +259,14 @@ describe("coalesceCompleteToolResultContinuation", () => {
     ], ["t1", "t2"])).toEqual([{ role: "user", content: results }])
   })
 
+  it("accepts a parallel result batch in a different order", () => {
+    // Anthropic protocol matches tool_result by tool_use_id, not by position.
+    const results = [result("t2"), result("t1")]
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: results },
+    ], ["t1", "t2"])).toEqual([{ role: "user", content: results }])
+  })
+
   it("rejects a partial batch and an unknown result id", () => {
     expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1")] },
@@ -286,6 +294,28 @@ describe("coalesceCompleteToolResultContinuation", () => {
     expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1"), { type: "text", text: "then continue" }] },
     ], ["t1"])).toBeDefined()
+  })
+
+  it("rejects a text-only assistant message before user results", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "assistant", content: [{ type: "text", text: "intervening turn" }] },
+      { role: "user", content: [result("t1")] },
+    ], ["t1"])).toBeUndefined()
+  })
+
+  it("rejects an extra text-only assistant message after the complete echo", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "read", input: {} }] },
+      { role: "assistant", content: [{ type: "text", text: "intervening turn" }] },
+      { role: "user", content: [result("t1")] },
+    ], ["t1"])).toBeUndefined()
+  })
+
+  it("rejects tool results in a turn after queued user text", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "user", content: [result("t1")] },
+    ], ["t1"])).toBeUndefined()
   })
 
   it("rejects results split across turns, duplicated, or sent after queued content", () => {

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -22,6 +22,7 @@ import {
   noteUserContent,
   settledToolCallAssistantUuid,
   shouldEarlyStop,
+  trackerCoversStreamedCalls,
 } from "../proxy/passthroughEarlyStop"
 
 import { PASSTHROUGH_MCP_PREFIX } from "../proxy/passthroughTools"
@@ -175,6 +176,35 @@ describe("assistant resume checkpoint", () => {
     noteUserContent(tracker, [toolResult("t1"), toolResult("t2")])
     expect(settledToolCallAssistantUuid(tracker)).toBeUndefined()
     expect(shouldEarlyStop(tracker)).toBe(false)
+  })
+})
+
+describe("trackerCoversStreamedCalls", () => {
+  it("is false while an assistant fragment is still in flight", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, sdkAssistant("a1", [toolUse("t1", "read")]))
+    // The wire carried two calls; only one has been armed so far.
+    expect(trackerCoversStreamedCalls(tracker, new Set(["t1", "t2"]))).toBe(false)
+  })
+
+  it("is true once every streamed call is armed", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, sdkAssistant("a1", [toolUse("t1", "read")]))
+    noteAssistantMessage(tracker, sdkAssistant("a2", [toolUse("t2", "read")]))
+    expect(trackerCoversStreamedCalls(tracker, new Set(["t1", "t2"]))).toBe(true)
+  })
+
+  it("is false when nothing was streamed, so an empty turn cannot settle", () => {
+    const tracker = createEarlyStopTracker()
+    expect(trackerCoversStreamedCalls(tracker, new Set())).toBe(false)
+  })
+
+  it("is false when the sets are the same size but disagree", () => {
+    // Equal sizes must not be mistaken for equal sets — a regenerated call
+    // carries a fresh id, so a stale id would otherwise pass the count check.
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, sdkAssistant("a1", [toolUse("t1", "read")]))
+    expect(trackerCoversStreamedCalls(tracker, new Set(["t-other"]))).toBe(false)
   })
 })
 

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -13,10 +13,10 @@
 import { describe, it, expect } from "bun:test"
 import {
   clientAbortDisposition,
+  coalesceCompleteToolResultContinuation,
   createEarlyStopTracker,
   allForwardedCallsResolved,
   isClientForwardedToolUse,
-  isCompleteToolResultContinuation,
   noteAssistantContent,
   noteAssistantMessage,
   noteUserContent,
@@ -249,37 +249,60 @@ describe("early-stop tracking", () => {
 })
 
 
-describe("isCompleteToolResultContinuation", () => {
+describe("coalesceCompleteToolResultContinuation", () => {
   const result = (id: string, content: unknown = "ok") => ({ type: "tool_result", tool_use_id: id, content })
 
   it("accepts one complete parallel result batch", () => {
-    expect(isCompleteToolResultContinuation([
-      { role: "user", content: [result("t1"), result("t2")] },
-    ], ["t1", "t2"])).toBe(true)
+    const results = [result("t1"), result("t2")]
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: results },
+    ], ["t1", "t2"])).toEqual([{ role: "user", content: results }])
   })
 
   it("rejects a partial batch and an unknown result id", () => {
-    expect(isCompleteToolResultContinuation([
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1")] },
-    ], ["t1", "t2"])).toBe(false)
-    expect(isCompleteToolResultContinuation([
+    ], ["t1", "t2"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("unknown")] },
-    ], ["t1"])).toBe(false)
+    ], ["t1"])).toBeUndefined()
   })
 
-  it("rejects multiple user messages so multimodal results stay on the final SDK input", () => {
-    expect(isCompleteToolResultContinuation([
-      { role: "user", content: [result("t1")] },
-      { role: "user", content: [{ type: "text", text: "continue" }] },
-    ], ["t1"])).toBe(false)
+  it("coalesces queued user messages so results stay on the final SDK input", () => {
+    const toolResult = result("t1")
+    const queuedText = { type: "text", text: "continue" }
+    const queuedImage = { type: "image", source: { type: "base64", data: "abc" } }
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [toolResult] },
+      { role: "user", content: "continue" },
+      { role: "user", content: [queuedImage] },
+    ], ["t1"])).toEqual([{ role: "user", content: [toolResult, queuedText, queuedImage] }])
   })
 
   it("requires tool results before ordinary user content", () => {
-    expect(isCompleteToolResultContinuation([
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [{ type: "text", text: "first" }, result("t1")] },
-    ], ["t1"])).toBe(false)
-    expect(isCompleteToolResultContinuation([
+    ], ["t1"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
       { role: "user", content: [result("t1"), { type: "text", text: "then continue" }] },
-    ], ["t1"])).toBe(true)
+    ], ["t1"])).toBeDefined()
+  })
+
+  it("rejects results split across turns, duplicated, or sent after queued content", () => {
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "user", content: [result("t2")] },
+    ], ["t1", "t2"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1"), result("t1")] },
+    ], ["t1"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "user", content: [{ type: "text", text: "continue" }, result("t1")] },
+    ], ["t1"])).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation([
+      { role: "user", content: [result("t1")] },
+      { role: "assistant", content: [{ type: "text", text: "late" }] },
+    ], ["t1"])).toBeUndefined()
   })
 })

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect } from "bun:test"
 import {
   clientAbortDisposition,
   coalesceCompleteToolResultContinuation,
+  findCompleteToolResultCheckpoint,
   createEarlyStopTracker,
   allForwardedCallsResolved,
   isClientForwardedToolUse,
@@ -364,5 +365,25 @@ describe("coalesceCompleteToolResultContinuation", () => {
       { role: "user", content: [result("t1")] },
       { role: "assistant", content: [{ type: "text", text: "late" }] },
     ], ["t1"])).toBeUndefined()
+  })
+})
+
+describe("findCompleteToolResultCheckpoint", () => {
+  const assistant = { role: "assistant", content: [{ type: "tool_use", id: "a" }, { type: "tool_use", id: "b" }] }
+  const result = (id: string) => ({ type: "tool_result", tool_use_id: id, content: id })
+
+  it("accepts only the exact immediate assistant checkpoint batch", () => {
+    expect(findCompleteToolResultCheckpoint([
+      { role: "user", content: "volatile old envelope" },
+      assistant,
+      { role: "user", content: [result("a"), result("b")] },
+    ], ["a", "b"])).toBeDefined()
+  })
+
+  it("rejects duplicate, extra, missing, and wrong-role result tails", () => {
+    expect(findCompleteToolResultCheckpoint([assistant, { role: "user", content: [result("a"), result("a")] }], ["a", "b"])).toBeUndefined()
+    expect(findCompleteToolResultCheckpoint([assistant, { role: "user", content: [result("a"), result("b"), result("extra")] }], ["a", "b"])).toBeUndefined()
+    expect(findCompleteToolResultCheckpoint([assistant, { role: "user", content: [result("a")] }], ["a", "b"])).toBeUndefined()
+    expect(findCompleteToolResultCheckpoint([assistant, { role: "assistant", content: [result("a"), result("b")] }], ["a", "b"])).toBeUndefined()
   })
 })

--- a/src/__tests__/plugin-integration.test.ts
+++ b/src/__tests__/plugin-integration.test.ts
@@ -15,7 +15,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request, ...rest: any[]) => Response | Promise<Response> }
@@ -33,7 +33,10 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedParams = params as CapturedParams
     return (async function* () {
       for (const msg of mockMessages) {
-        yield { ...msg, session_id: "sdk-integ-1" }
+        yield {
+          ...msg,
+          session_id: resolveMockSdkSessionId((params as CapturedParams).options, "sdk-integ-1"),
+        }
       }
     })()
   },

--- a/src/__tests__/pluginless-opencode-warning.test.ts
+++ b/src/__tests__/pluginless-opencode-warning.test.ts
@@ -26,6 +26,7 @@
  * exposed case.
  */
 import { describe, it, expect, beforeEach } from "bun:test"
+import { resolveMockSdkSessionId } from "./helpers"
 import { notePluginlessOpenCodeRequest, clearPluginlessWarnings } from "../proxy/setup"
 
 const OPENCODE_UA = "opencode/1.18.11 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14"
@@ -140,11 +141,11 @@ describe("plugin-less warning through the HTTP path", () => {
   it("records a diagnostic for a plugin-less OpenCode request, and not for a plugin-ful one", async () => {
     const { mock } = await import("bun:test")
     mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-      query: () => (async function* () {
+      query: (params: any) => (async function* () {
         yield {
           type: "assistant",
           uuid: "u1",
-          session_id: "test-session",
+          session_id: resolveMockSdkSessionId(params.options, "test-session"),
           message: { id: "m1", type: "message", role: "assistant", model: "m",
             content: [{ type: "text", text: "ok" }], stop_reason: "end_turn",
             usage: { input_tokens: 1, output_tokens: 1 } },

--- a/src/__tests__/preload.ts
+++ b/src/__tests__/preload.ts
@@ -19,3 +19,13 @@ delete process.env.MERIDIAN_API_KEY
 // Keyed by pid so concurrent runs don't share state.
 process.env.MERIDIAN_CONFIG_DIR = join(tmpdir(), `meridian-test-settings-${process.pid}`)
 mkdirSync(process.env.MERIDIAN_CONFIG_DIR, { recursive: true })
+
+// Isolate durable session mappings and transcript lifecycle metadata too.
+// Fresh SDK sessions are pre-journaled before spawn, so allowing tests to use
+// the developer's real session root would both pollute it and exhaust the
+// bounded ownership budget during the suite.
+process.env.MERIDIAN_SESSION_DIR = join(tmpdir(), `meridian-test-sessions-${process.pid}`)
+mkdirSync(process.env.MERIDIAN_SESSION_DIR, { recursive: true })
+
+// SDK mocks do not spawn an operating-system child. Real proxy/E2E processes do not load this preload.
+process.env.MERIDIAN_TEST_DISABLE_SDK_PROCESS_GATE = "1"

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -9,7 +9,7 @@
  * is byte-identical to today's behavior.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop } from "./helpers"
+import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, resolveMockSdkSessionId } from "./helpers"
 
 let capturedEnvs: string[] = []
 let failingDirs = new Set<string>()
@@ -36,27 +36,31 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
     capturedEnvs.push(dir)
     const streaming = params.options?.includePartialMessages === true
+    const returnedSessionId = resolveMockSdkSessionId(params.options)
+    const withReturnedSessionId = (message: any) => returnedSessionId
+      ? { ...message, session_id: returnedSessionId }
+      : message
     return (async function* () {
       if ([...failingDirs].some((f) => dir.includes(f))) {
         throw new Error(failureMessage)
       }
       if ([...failAfterContentDirs].some((f) => dir.includes(f))) {
         if (streaming) {
-          yield messageStart("msg-1")
-          yield textBlockStart(0)
-          yield textDelta(0, "partial from " + dir)
+          yield withReturnedSessionId(messageStart("msg-1"))
+          yield withReturnedSessionId(textBlockStart(0))
+          yield withReturnedSessionId(textDelta(0, "partial from " + dir))
         }
         throw new Error(failureMessage)
       }
       if (streaming) {
-        yield messageStart("msg-1")
-        yield textBlockStart(0)
-        yield textDelta(0, "ok from " + dir)
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield withReturnedSessionId(messageStart("msg-1"))
+        yield withReturnedSessionId(textBlockStart(0))
+        yield withReturnedSessionId(textDelta(0, "ok from " + dir))
+        yield withReturnedSessionId(blockStop(0))
+        yield withReturnedSessionId(messageDelta("end_turn"))
+        yield withReturnedSessionId(messageStop())
       }
-      yield assistantMessage([{ type: "text", text: "ok from " + dir }])
+      yield withReturnedSessionId(assistantMessage([{ type: "text", text: "ok from " + dir }]))
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/process-incarnation.test.ts
+++ b/src/__tests__/process-incarnation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test"
+import {
+  captureProcessIncarnation,
+  evaluateProcessIncarnation,
+  parseLinuxProcStatStartId,
+  parseProcessIncarnation,
+  parseProcessIncarnationJson,
+  probeProcessIncarnation,
+  type LocalBootIdentity,
+  type ProcessIncarnation,
+} from "../proxy/session/processIncarnation"
+
+const hostId = "a".repeat(64)
+const otherHostId = "b".repeat(64)
+const bootId = "11111111-1111-4111-8111-111111111111"
+const otherBootId = "22222222-2222-4222-8222-222222222222"
+
+const linuxOwner: ProcessIncarnation = {
+  version: 1,
+  pid: 123,
+  hostId,
+  bootId,
+  startId: "987654",
+  startIdKind: "linux-proc-start-ticks",
+}
+
+const localBoot: LocalBootIdentity = { hostId, bootId }
+
+describe("process incarnation protocol", () => {
+  it("strictly parses complete versioned identities", () => {
+    expect(parseProcessIncarnation(linuxOwner)).toEqual(linuxOwner)
+    expect(parseProcessIncarnationJson(JSON.stringify(linuxOwner))).toEqual(linuxOwner)
+    expect(parseProcessIncarnationJson("not json")).toBeUndefined()
+    expect(parseProcessIncarnation({ ...linuxOwner, version: 2 })).toBeUndefined()
+    expect(parseProcessIncarnation({ ...linuxOwner, pid: 0 })).toBeUndefined()
+    expect(parseProcessIncarnation({ ...linuxOwner, hostId: "local" })).toBeUndefined()
+    expect(parseProcessIncarnation({ ...linuxOwner, bootId: "boot" })).toBeUndefined()
+    expect(parseProcessIncarnation({ ...linuxOwner, startId: "0" })).toBeUndefined()
+    expect(parseProcessIncarnation({ ...linuxOwner, startIdKind: "unknown" })).toBeUndefined()
+    expect(parseProcessIncarnation({
+      ...linuxOwner,
+      startId: "638602697690000000",
+      startIdKind: "windows-start-ticks",
+    })).toBeDefined()
+  })
+
+  it("fails closed when host identity or the probe is uncertain", () => {
+    expect(evaluateProcessIncarnation(linuxOwner, undefined, { status: "missing" }))
+      .toBe("indeterminate")
+    expect(evaluateProcessIncarnation(linuxOwner, { hostId: otherHostId, bootId }, { status: "missing" }))
+      .toBe("indeterminate")
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, undefined))
+      .toBe("indeterminate")
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, { status: "indeterminate" }))
+      .toBe("indeterminate")
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, {
+      status: "found",
+      startId: "987654",
+      startIdKind: "darwin-ps-lstart",
+    })).toBe("indeterminate")
+    expect(evaluateProcessIncarnation({ ...linuxOwner, hostId: "bad" }, localBoot, { status: "missing" }))
+      .toBe("indeterminate")
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, {
+      status: "found",
+      startId: "malformed",
+      startIdKind: "linux-proc-start-ticks",
+    })).toBe("indeterminate")
+  })
+
+  it("proves death across a reboot, ESRCH, or exact Linux start mismatch", () => {
+    expect(evaluateProcessIncarnation(
+      linuxOwner,
+      { hostId, bootId: otherBootId },
+      { status: "indeterminate" },
+    )).toBe("dead")
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, { status: "missing" }))
+      .toBe("dead")
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, {
+      status: "found",
+      startId: "987655",
+      startIdKind: "linux-proc-start-ticks",
+    })).toBe("dead")
+  })
+
+  it("recognizes an exact Linux incarnation match", () => {
+    expect(evaluateProcessIncarnation(linuxOwner, localBoot, {
+      status: "found",
+      startId: linuxOwner.startId,
+      startIdKind: linuxOwner.startIdKind,
+    })).toBe("alive")
+  })
+
+  it("keeps a same-second Darwin birth-time collision fail closed", () => {
+    const darwinOwner: ProcessIncarnation = {
+      ...linuxOwner,
+      startId: "Wed Aug 26 11:49:29 2026",
+      startIdKind: "darwin-ps-lstart",
+    }
+    expect(evaluateProcessIncarnation(darwinOwner, localBoot, {
+      status: "found",
+      startId: darwinOwner.startId,
+      startIdKind: darwinOwner.startIdKind,
+    })).toBe("indeterminate")
+    expect(evaluateProcessIncarnation(darwinOwner, localBoot, {
+      status: "found",
+      startId: "Wed Aug 26 11:49:30 2026",
+      startIdKind: darwinOwner.startIdKind,
+    })).toBe("dead")
+  })
+
+  it("parses Linux proc stat field 22 after the final comm parenthesis", () => {
+    const fieldsFromState = ["S", ...Array.from({ length: 18 }, () => "0"), "987654", "0"]
+    const stat = `123 (worker ) with spaces) ${fieldsFromState.join(" ")}
+`
+    expect(parseLinuxProcStatStartId(stat, 123)).toBe("987654")
+    expect(parseLinuxProcStatStartId(stat, 124)).toBeUndefined()
+    expect(parseLinuxProcStatStartId("123 malformed", 123)).toBeUndefined()
+  })
+
+  it("captures and conservatively probes the current process on every supported platform", () => {
+    if (!(["darwin", "linux", "win32"] as string[]).includes(process.platform)) return
+    const current = captureProcessIncarnation()
+    expect(current).toBeDefined()
+    expect(parseProcessIncarnation(current)).toEqual(current)
+    expect(probeProcessIncarnation(current!))
+      .toBe(process.platform === "darwin" ? "indeterminate" : "alive")
+  })
+})

--- a/src/__tests__/profile-switch-integration.test.ts
+++ b/src/__tests__/profile-switch-integration.test.ts
@@ -8,15 +8,17 @@ import { describe, test, expect, beforeEach } from "bun:test"
 import { mock } from "bun:test"
 
 // Mock the SDK before importing server
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (opts: Record<string, unknown>) => {
+  query: (opts: { options?: { sessionId?: string } }) => {
     return (async function* () {
       yield {
         type: "assistant",
         message: { type: "assistant", content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" },
         parent_tool_use_id: null,
         uuid: crypto.randomUUID(),
-        session_id: `session-${Date.now()}`,
+        session_id: resolveMockSdkSessionId(opts.options, `session-${Date.now()}`),
       }
     })()
   },

--- a/src/__tests__/proxy-advisor-support.test.ts
+++ b/src/__tests__/proxy-advisor-support.test.ts
@@ -18,6 +18,7 @@ import {
   messageDelta,
   streamEvent,
   parseSSE,
+  withMockSdkSessionId,
 } from "./helpers"
 
 let capturedOptions: Record<string, unknown> = {}
@@ -27,7 +28,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
     capturedOptions = params.options ?? {}
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-busy-session-retry.test.ts
+++ b/src/__tests__/proxy-busy-session-retry.test.ts
@@ -11,7 +11,22 @@
  * failure the client will blindly re-trigger.
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  // Request completion releases the cross-process lease asynchronously.
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
 import {
   messageStart,
   textBlockStart,
@@ -19,6 +34,7 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 // Shrink retry backoff so tests run fast (read at server.ts import time)
@@ -47,13 +63,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         opts.options?.stderr?.(BUSY_LINE)
         throw new Error("Claude Code process exited with code 1")
       }
+      const returnedSessionId = resolveMockSdkSessionId(opts.options, `sdk-after-${callIndex}`)
       if (isStreaming) {
-        yield messageStart(`msg-${callIndex}`)
-        yield textBlockStart(0)
-        yield textDelta(0, `response-${callIndex}`)
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield { ...messageStart(`msg-${callIndex}`), session_id: returnedSessionId }
+        yield { ...textBlockStart(0), session_id: returnedSessionId }
+        yield { ...textDelta(0, `response-${callIndex}`), session_id: returnedSessionId }
+        yield { ...blockStop(0), session_id: returnedSessionId }
+        yield { ...messageDelta("end_turn"), session_id: returnedSessionId }
+        yield { ...messageStop(), session_id: returnedSessionId }
       }
       yield {
         type: "assistant",
@@ -67,7 +84,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: `sdk-after-${callIndex}`,
+        session_id: returnedSessionId,
       }
     })()
   },
@@ -138,17 +155,19 @@ describe("Busy-session resume retry (#630)", () => {
     const body = await response.json()
     expect(body.content.some((b: any) => b.type === "text")).toBe(true)
 
-    // Attempt 1 and the retry must target the SAME session — not fresh
+    // Attempt 1 and the retry use the same preallocated isolated fork.
     expect(queryCalls.length).toBe(2)
     expect(queryCalls[0]!.resume).toBe("sdk-original")
     expect(queryCalls[1]!.resume).toBe("sdk-original")
-    expect(queryCalls[1]!.forkSession).toBeUndefined()
+    expect(queryCalls[0]!.forkSession).toBe(true)
+    expect(queryCalls[1]!.forkSession).toBe(true)
+    expect(queryCalls[1]!.sessionId).not.toBe(queryCalls[0]!.sessionId)
   })
 
   it("falls back to forkSession when the session stays busy (non-streaming)", async () => {
     const app = createTestApp()
     seed("sess-busy-2")
-    // initial + 3 same-resume retries all busy; the 5th attempt forks
+    // Every resume is already isolated; retries retain one preallocated fork.
     busyFailCount = 4
 
     const response = await post(
@@ -161,8 +180,9 @@ describe("Busy-session resume retry (#630)", () => {
     expect(queryCalls.length).toBe(5)
     for (let i = 0; i < 4; i++) {
       expect(queryCalls[i]!.resume).toBe("sdk-original")
-      expect(queryCalls[i]!.forkSession).toBeUndefined()
+      expect(queryCalls[i]!.forkSession).toBe(true)
     }
+    expect(new Set(queryCalls.map((call) => call.sessionId)).size).toBe(5)
     expect(queryCalls[4]!.resume).toBe("sdk-original")
     expect(queryCalls[4]!.forkSession).toBe(true)
   })
@@ -186,6 +206,9 @@ describe("Busy-session resume retry (#630)", () => {
     expect(queryCalls.length).toBe(2)
     expect(queryCalls[0]!.resume).toBe("sdk-original")
     expect(queryCalls[1]!.resume).toBe("sdk-original")
+    expect(queryCalls[0]!.forkSession).toBe(true)
+    expect(queryCalls[1]!.forkSession).toBe(true)
+    expect(queryCalls[1]!.sessionId).not.toBe(queryCalls[0]!.sessionId)
   })
 
   it("falls back to forkSession when the session stays busy (streaming)", async () => {

--- a/src/__tests__/proxy-cache-eviction.test.ts
+++ b/src/__tests__/proxy-cache-eviction.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 const originalMaxSessions = process.env.CLAUDE_PROXY_MAX_SESSIONS
 process.env.CLAUDE_PROXY_MAX_SESSIONS = "2"
@@ -8,13 +11,14 @@ type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
 
 let mockMessages: MockSdkMessage[] = []
-let capturedQueryParams: { options?: { resume?: string } } | null = null
-let queuedSessionIds: string[] = []
+let capturedQueryParams: { options?: { resume?: string; sessionId?: string } } | null = null
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
-    capturedQueryParams = params as { options?: { resume?: string } }
-    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    const queryParams = params as { options?: { resume?: string; sessionId?: string } }
+    capturedQueryParams = queryParams
+    const sessionId = resolveMockSdkSessionId(queryParams.options)
+    if (typeof sessionId !== "string") throw new Error("Expected Meridian to select or resume an SDK session ID")
     return (async function* () {
       for (const msg of mockMessages) {
         yield { ...msg, session_id: sessionId }
@@ -34,13 +38,10 @@ mock.module("../mcpTools", () => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
-mock.module("../proxy/sessionStore", () => ({
-  lookupSharedSession: () => undefined,
-  storeSharedSession: () => {},
-  clearSharedSessions: () => {},
-}))
-
 const { createProxyServer, clearSessionCache, getMaxSessionsLimit } = await import("../proxy/server")
+const { setSessionStoreDir } = await import("../proxy/sessionStore")
+const testSessionDir = mkdtempSync(join(tmpdir(), "meridian-lru-test-"))
+setSessionStoreDir(testSessionDir)
 
 function createTestApp() {
   const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
@@ -59,8 +60,7 @@ async function post(app: TestApp, body: Record<string, unknown>, headers: Record
   return app.fetch(req)
 }
 
-async function send(app: TestApp, session: string | undefined, firstMessage: string, sessionId: string) {
-  queuedSessionIds.push(sessionId)
+async function send(app: TestApp, session: string | undefined, firstMessage: string): Promise<string> {
   const headers: Record<string, string> = session ? { "x-opencode-session": session } : {}
   const response = await post(app, {
     model: "claude-sonnet-4-5",
@@ -69,10 +69,12 @@ async function send(app: TestApp, session: string | undefined, firstMessage: str
     messages: [{ role: "user", content: firstMessage }],
   }, headers)
   await response.json()
+  const sessionId = capturedQueryParams?.options?.sessionId
+  if (typeof sessionId !== "string") throw new Error("Expected a caller-selected fresh session ID")
+  return sessionId
 }
 
-async function sendContinuation(app: TestApp, session: string, firstMessage: string, followUp: string, sessionId: string) {
-  queuedSessionIds.push(sessionId)
+async function sendContinuation(app: TestApp, session: string, firstMessage: string, followUp: string) {
   const response = await post(app, {
     model: "claude-sonnet-4-5",
     max_tokens: 128,
@@ -89,63 +91,63 @@ async function sendContinuation(app: TestApp, session: string, firstMessage: str
 beforeEach(() => {
   mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
   capturedQueryParams = null
-  queuedSessionIds = []
   clearSessionCache()
 })
 
 afterAll(() => {
   if (originalMaxSessions === undefined) delete process.env.CLAUDE_PROXY_MAX_SESSIONS
   else process.env.CLAUDE_PROXY_MAX_SESSIONS = originalMaxSessions
+  rmSync(testSessionDir, { recursive: true, force: true })
 })
 
 describe("Session cache LRU eviction", () => {
-  it("evicts the least-recently-used session entry", async () => {
+  it("does not resume an exact replay after the least-recently-used entry leaves memory", async () => {
     const app = createTestApp()
 
-    await send(app, "oc-A", "first-A", "sdk-A")
-    await send(app, "oc-B", "first-B", "sdk-B")
-    await send(app, "oc-C", "first-C", "sdk-C")
+    await send(app, "oc-A", "first-A")
+    await send(app, "oc-B", "first-B")
+    await send(app, "oc-C", "first-C")
 
-    await send(app, "oc-A", "first-A", "sdk-A-new")
+    await send(app, "oc-A", "first-A")
     expect(capturedQueryParams?.options?.resume).toBeUndefined()
   })
 
-  it("refreshes recency when a key is accessed", async () => {
+  it("keeps durable resume after a key is accessed", async () => {
     const app = createTestApp()
 
     // Store two sessions (cache limit = 2)
-    await send(app, "oc-A", "first-A", "sdk-A")
-    await send(app, "oc-B", "first-B", "sdk-B")
+    const sdkA = await send(app, "oc-A", "first-A")
+    const sdkB = await send(app, "oc-B", "first-B")
 
     // Access A with a continuation (growing messages) to refresh its recency
-    await sendContinuation(app, "oc-A", "first-A", "follow-up-A", "sdk-A")
-    expect(capturedQueryParams?.options?.resume).toBe("sdk-A")
+    await sendContinuation(app, "oc-A", "first-A", "follow-up-A")
+    expect(capturedQueryParams?.options?.resume).toBe(sdkA)
 
     // Store C — should evict B (not A, since A was accessed more recently)
-    await send(app, "oc-C", "first-C", "sdk-C")
+    await send(app, "oc-C", "first-C")
 
-    // B should be evicted — continuation attempt should not resume
-    await sendContinuation(app, "oc-B", "first-B", "follow-up-B", "sdk-B-new")
-    expect(capturedQueryParams?.options?.resume).toBeUndefined()
+    // B may leave the in-memory LRU, but the durable mapping must rehydrate it.
+    await sendContinuation(app, "oc-B", "first-B", "follow-up-B")
+    expect(capturedQueryParams?.options?.resume).toBe(sdkB)
   })
 
   it("coordinates eviction across session and fingerprint caches", async () => {
     const app = createTestApp()
 
-    await send(app, "oc-A", "alpha", "sdk-A")
-    await send(app, "oc-B", "beta", "sdk-B")
-    await send(app, "oc-C", "gamma", "sdk-C")
+    await send(app, "oc-A", "alpha")
+    await send(app, "oc-B", "beta")
+    await send(app, "oc-C", "gamma")
 
-    await send(app, undefined, "alpha", "sdk-alpha-new")
+    await send(app, undefined, "alpha")
     expect(capturedQueryParams?.options?.resume).toBeUndefined()
 
     clearSessionCache()
 
-    await send(app, "oc-A", "alpha", "sdk-A2")
-    await send(app, undefined, "fp-X", "sdk-X")
-    await send(app, undefined, "fp-Y", "sdk-Y")
+    await send(app, "oc-A", "alpha")
+    await send(app, undefined, "fp-X")
+    await send(app, undefined, "fp-Y")
 
-    await send(app, "oc-A", "alpha", "sdk-A3")
+    await send(app, "oc-A", "alpha")
     expect(capturedQueryParams?.options?.resume).toBeUndefined()
   })
 })

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   assistantMessage,
   messageStart,
@@ -7,6 +10,7 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 interface AttemptControl {
@@ -18,7 +22,8 @@ let activeQueries = 0
 let maxActiveQueries = 0
 let queryCalls = 0
 let controls: AttemptControl[] = []
-let capturedParams: Array<{ options?: { resume?: string } }> = []
+let capturedParams: Array<{ options?: { resume?: string; sessionId?: string; env?: Record<string, string> } }> = []
+let rateLimitWorkQueries = false
 
 function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
   let release = () => {}
@@ -29,17 +34,20 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
 }
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (params: { options?: { resume?: string } }) => {
+  query: (params: { options?: { resume?: string; sessionId?: string; env?: Record<string, string> } }) => {
     capturedParams.push(params)
     queryCalls++
     const control = deferredAttempt()
     controls.push(control)
-    const sessionId = `sdk-concurrency-${queryCalls}`
+    const sessionId = resolveMockSdkSessionId(params.options, `sdk-concurrency-${queryCalls}`)
     const generator = (async function* () {
       activeQueries++
       maxActiveQueries = Math.max(maxActiveQueries, activeQueries)
       control.markStarted()
       try {
+        if (rateLimitWorkQueries && params.options?.env?.CLAUDE_CONFIG_DIR?.includes("hot-work")) {
+          throw new Error("429 rate limit reached for this account")
+        }
         yield { ...messageStart(), session_id: sessionId }
         await control.wait
         yield { ...textBlockStart(0), session_id: sessionId }
@@ -70,12 +78,15 @@ mock.module("../mcpTools", () => ({
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
 const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
 const { telemetryStore } = await import("../telemetry")
+const { setSessionStoreDir, storeSharedSession } = await import("../proxy/sessionStore")
+const { processSessionTurns } = await import("../proxy/session/turnCoordinator")
 
 function request(
   messages: Array<{ role: string; content: unknown }>,
   sessionId: string,
   stream = false,
   extraHeaders: Record<string, string> = {},
+  signal?: AbortSignal,
 ): Request {
   return new Request("http://localhost/v1/messages", {
     method: "POST",
@@ -85,6 +96,7 @@ function request(
       ...extraHeaders,
     },
     body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 128, stream, messages }),
+    signal,
   })
 }
 
@@ -102,16 +114,21 @@ async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptC
 }
 
 describe("SDK and Session concurrency coordination", () => {
+  let testSessionDir: string
   const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
   const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+  const originalRouting = process.env.MERIDIAN_ROUTING
 
   beforeEach(() => {
+    testSessionDir = mkdtempSync(join(tmpdir(), "meridian-concurrency-"))
+    setSessionStoreDir(testSessionDir)
     process.env.MERIDIAN_MAX_CONCURRENT = "1"
     activeQueries = 0
     maxActiveQueries = 0
     queryCalls = 0
     controls = []
     capturedParams = []
+    rateLimitWorkQueries = false
     clearSessionCache()
     resetProcessSdkSemaphoreForTests()
     telemetryStore.clear()
@@ -119,10 +136,14 @@ describe("SDK and Session concurrency coordination", () => {
 
   afterEach(() => {
     resetProcessSdkSemaphoreForTests()
+    setSessionStoreDir(null)
+    rmSync(testSessionDir, { recursive: true, force: true })
     if (originalMax === undefined) delete process.env.MERIDIAN_MAX_CONCURRENT
     else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
     if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
     else process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = originalHold
+    if (originalRouting === undefined) delete process.env.MERIDIAN_ROUTING
+    else process.env.MERIDIAN_ROUTING = originalRouting
   })
 
   it("holds the SDK permit for the complete streaming lifecycle", async () => {
@@ -182,7 +203,8 @@ describe("SDK and Session concurrency coordination", () => {
     expect((await firstP).status).toBe(200)
 
     const secondControl = await waitForControl(1)
-    expect(capturedParams[1]?.options?.resume).toBe("sdk-concurrency-1")
+    expect(capturedParams[0]?.options?.sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(capturedParams[1]?.options?.resume).toBe(capturedParams[0]?.options?.sessionId)
     secondControl.release()
     expect((await secondP).status).toBe(200)
   })
@@ -248,6 +270,40 @@ describe("SDK and Session concurrency coordination", () => {
     expect(queryCalls).toBe(2)
   })
 
+  it("rejects a stale turn when a hot priority profile appears after the arrival snapshot", async () => {
+    process.env.MERIDIAN_ROUTING = "priority"
+    const profiles = [
+      { id: "work", claudeConfigDir: "/tmp/meridian-test-hot-work" },
+    ]
+    const app = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      silent: true,
+      profiles,
+      defaultProfile: "work",
+    }).app
+    const sessionId = `hot-profile-${crypto.randomUUID()}`
+    const lease = await processSessionTurns.acquire(`session:${sessionId}`)
+    const pending = app.fetch(request([{ role: "user", content: "stale body" }], sessionId))
+
+    // Let handleWithQueue take its coherent arrival snapshot, then make a new
+    // profile and its durable mapping visible before the queued turn is granted.
+    await Bun.sleep(20)
+    profiles.push({ id: "hot", claudeConfigDir: "/tmp/meridian-test-hot-new" })
+    storeSharedSession(`hot:${sessionId}`, "hot-existing-sdk", 2, "hot-lineage", ["old-a", "old-b"])
+    rateLimitWorkQueries = true
+    lease.release()
+
+    const response = await pending
+    expect(response.status).toBe(400)
+    expect((await response.json() as { error?: { message?: string } }).error?.message)
+      .toContain("advanced while the request was waiting")
+    expect(capturedParams.length).toBeGreaterThan(0)
+    expect(capturedParams.every((params) =>
+      params.options?.env?.CLAUDE_CONFIG_DIR?.includes("hot-work") === true
+    )).toBe(true)
+  }, 10_000)
+
   it("lets a declared concurrent flow replay instead of refusing it", async () => {
     // fork-/subagent- sources knowingly run parallel turns under one session
     // key; a reclassification is their normal cost. Refusing them would break
@@ -287,26 +343,34 @@ describe("SDK and Session concurrency coordination", () => {
     expect(queryCalls).toBe(2)
   })
 
-  it("force-releases a wedged turn instead of deadlocking the session", async () => {
+  it("aborts a wedged turn without releasing its fencing lease early", async () => {
     process.env.MERIDIAN_MAX_CONCURRENT = "2"
-    process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = "50"
+    process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = "2000"
     resetProcessSdkSemaphoreForTests()
     const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
 
-    // Never released and never read: the response body stays open, so this
-    // request never finishes and would hold its lease for the lifetime of the
-    // process without the watchdog.
+    // This mock intentionally ignores AbortSignal while blocked. The watchdog
+    // may request cancellation, but must retain the lease until the SDK attempt
+    // actually settles or an older request could overwrite its successor.
     const wedged = await app.fetch(request([{ role: "user", content: "one" }], "wedged", true))
     const wedgedControl = await waitForControl(0)
+    const waiterAbort = new AbortController()
+    const secondP = app.fetch(request(
+      [{ role: "user", content: "two" }],
+      "wedged",
+      true,
+      {},
+      waiterAbort.signal,
+    ))
+    await new Promise((resolve) => setTimeout(resolve, 2100))
+    expect(queryCalls).toBe(1)
 
-    const secondP = app.fetch(request([{ role: "user", content: "two" }], "wedged", true))
-    // Only reachable once the wedged turn's lease is force-released.
-    const secondControl = await waitForControl(1)
-    expect(queryCalls).toBe(2)
-
-    secondControl.release()
-    await (await secondP).text()
+    // A waiter can still cancel cleanly; it never enters the SDK while the old
+    // attempt is unfenced. Settle the mock before cancelling the response body
+    // so the test does not intentionally leave background work behind.
+    waiterAbort.abort()
+    expect((await secondP).status).toBe(499)
     wedgedControl.release()
-    await wedged.text()
-  })
+    await wedged.body?.cancel()
+  }, 10_000)
 })

--- a/src/__tests__/proxy-concurrency-limiter.test.ts
+++ b/src/__tests__/proxy-concurrency-limiter.test.ts
@@ -15,7 +15,7 @@
  * subprocesses run at once.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let sdkActive = 0
 let sdkPeak = 0
@@ -28,12 +28,13 @@ function gateClosed() {
 }
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => (async function* () {
+  query: (params: any) => (async function* () {
     sdkActive++
     sdkPeak = Math.max(sdkPeak, sdkActive)
     try {
       await sdkGate
-      yield assistantMessage([{ type: "text", text: "ok" }])
+      const message = assistantMessage([{ type: "text", text: "ok" }])
+      yield withMockSdkSessionId(message, params.options)
     } finally {
       sdkActive--
     }

--- a/src/__tests__/proxy-context-usage-store.test.ts
+++ b/src/__tests__/proxy-context-usage-store.test.ts
@@ -14,10 +14,13 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (_params: unknown) => (async function* () { yield assistantMessage([{ type: "text", text: "ok" }]) })(),
+  query: (params: any) => (async function* () {
+    const message = assistantMessage([{ type: "text", text: "ok" }])
+    yield withMockSdkSessionId(message, params.options)
+  })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
 }))

--- a/src/__tests__/proxy-cross-process-coordination.test.ts
+++ b/src/__tests__/proxy-cross-process-coordination.test.ts
@@ -1,0 +1,426 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const serverModule = pathToFileURL(resolve(testDir, "../proxy/server.ts")).href
+const sessionStoreModule = pathToFileURL(resolve(testDir, "../proxy/sessionStore.ts")).href
+
+// Each worker is a separate Bun OS process with its own module graph and
+// createProxyServer instance. mock.module must run before server.ts is loaded;
+// this is the subprocess seam that keeps the test off the real Agent SDK.
+const workerSource = String.raw`
+import { mock } from "bun:test"
+import { appendFileSync, existsSync } from "node:fs"
+
+const workerId = process.env.WORKER_ID
+const eventFile = process.env.EVENT_FILE
+const releaseFile = process.env.RELEASE_FILE
+let requestActive = false
+let queryCall = 0
+
+function event(name, extra = {}) {
+  appendFileSync(eventFile, JSON.stringify({
+    name,
+    workerId,
+    pid: process.pid,
+    at: Date.now(),
+    ...extra,
+  }) + "\n")
+}
+
+// Import a cache-busted copy as the implementation, then mock the canonical
+// module imported by server.ts. The wrapper exposes the exact moment the route
+// takes its durable arrival snapshot, before it waits on the process lock.
+const realSessionStore = await import(
+  process.env.SESSION_STORE_MODULE + "?cross-process-real=" + encodeURIComponent(workerId)
+)
+const readRealSessionStoreGenerationSnapshot = realSessionStore.readSessionStoreGenerationSnapshot
+mock.module(process.env.SESSION_STORE_MODULE, () => ({
+  ...realSessionStore,
+  readSessionStoreGenerationSnapshot: (...args) => {
+    const snapshot = readRealSessionStoreGenerationSnapshot(...args)
+    if (requestActive) event("arrival-snapshot", { generations: snapshot })
+    return snapshot
+  },
+}))
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params) => {
+    const call = ++queryCall
+    const resume = params?.options?.resume ?? null
+    const sdkSessionId = params?.options?.sessionId
+      ?? (params?.options?.forkSession ? undefined : params?.options?.resume)
+      ?? "sdk-" + workerId
+    const generator = (async function* () {
+      event("sdk-start", { call, resume, sdkSessionId })
+      while (!existsSync(releaseFile)) await Bun.sleep(5)
+
+      const common = {
+        parent_tool_use_id: null,
+        session_id: sdkSessionId,
+        uuid: workerId + "-uuid-" + call,
+      }
+      yield {
+        type: "stream_event",
+        ...common,
+        event: {
+          type: "message_start",
+          message: {
+            id: "msg-" + workerId,
+            type: "message",
+            role: "assistant",
+            content: [],
+            model: "claude-sonnet-4-6",
+            stop_reason: null,
+            usage: { input_tokens: 10, output_tokens: 0 },
+          },
+        },
+      }
+      yield {
+        type: "stream_event",
+        ...common,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+      }
+      yield {
+        type: "stream_event",
+        ...common,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "ok" },
+        },
+      }
+      yield {
+        type: "stream_event",
+        ...common,
+        event: { type: "content_block_stop", index: 0 },
+      }
+      yield {
+        type: "stream_event",
+        ...common,
+        event: {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { output_tokens: 2 },
+        },
+      }
+      yield {
+        type: "stream_event",
+        ...common,
+        event: { type: "message_stop" },
+      }
+      yield {
+        type: "assistant",
+        ...common,
+        message: {
+          id: "msg-" + workerId,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          model: "claude-sonnet-4-6",
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 2 },
+        },
+      }
+      event("sdk-finish", { call, sdkSessionId })
+    })()
+    return Object.assign(generator, { close: () => {} })
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+const { createProxyServer } = await import(process.env.SERVER_MODULE)
+const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+const request = new Request("http://localhost/v1/messages", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "x-opencode-session": process.env.CLIENT_SESSION_ID,
+  },
+  body: process.env.REQUEST_BODY,
+})
+
+requestActive = true
+event("request-start")
+try {
+  const response = await app.fetch(request)
+  const body = await response.text()
+  event("result", { status: response.status, body })
+} catch (error) {
+  event("worker-error", {
+    errorName: error?.name ?? "Error",
+    message: error?.message ?? String(error),
+    stack: error?.stack,
+  })
+  throw error
+} finally {
+  requestActive = false
+}
+`
+
+interface WorkerEvent {
+  name: string
+  workerId: string
+  pid: number
+  at: number
+  status?: number
+  body?: string
+  resume?: string | null
+  sdkSessionId?: string
+  generations?: Record<string, string>
+  errorName?: string
+  message?: string
+}
+
+interface Paths {
+  base: string
+  sessions: string
+  events: string
+}
+
+interface WorkerHandle {
+  id: string
+  releaseFile: string
+  child: ReturnType<typeof Bun.spawn>
+}
+
+const tempRoots: string[] = []
+const children = new Set<ReturnType<typeof Bun.spawn>>()
+
+afterEach(async () => {
+  for (const child of children) child.kill()
+  children.clear()
+  await Promise.all(tempRoots.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+async function makePaths(): Promise<Paths> {
+  const base = await mkdtemp(join(tmpdir(), "meridian-proxy-process-test-"))
+  tempRoots.push(base)
+  return {
+    base,
+    sessions: join(base, "sessions"),
+    events: join(base, "events.jsonl"),
+  }
+}
+
+function spawnProxyWorker(
+  paths: Paths,
+  id: string,
+  clientSessionId: string,
+  messages: Array<{ role: string, content: unknown }>,
+): WorkerHandle {
+  const releaseFile = join(paths.base, `release-${id}`)
+  const requestBody = JSON.stringify({
+    model: "claude-sonnet-4-6",
+    max_tokens: 128,
+    stream: false,
+    messages,
+  })
+  const child = Bun.spawn([process.execPath, "-e", workerSource], {
+    env: {
+      ...process.env,
+      SERVER_MODULE: serverModule,
+      SESSION_STORE_MODULE: sessionStoreModule,
+      MERIDIAN_SESSION_DIR: paths.sessions,
+      MERIDIAN_PASSTHROUGH: "0",
+      CLAUDE_PROXY_PASSTHROUGH: "0",
+      MERIDIAN_MAX_CONCURRENT: "8",
+      MERIDIAN_SESSION_TURN_ACQUIRE_TIMEOUT_MS: "5000",
+      MERIDIAN_SESSION_TURN_MAX_HOLD_MS: "5000",
+      MERIDIAN_SESSION_TURN_RETRY_MS: "5",
+      EVENT_FILE: paths.events,
+      RELEASE_FILE: releaseFile,
+      WORKER_ID: id,
+      CLIENT_SESSION_ID: clientSessionId,
+      REQUEST_BODY: requestBody,
+    },
+    stdout: "ignore",
+    stderr: "pipe",
+  })
+  children.add(child)
+  void child.exited.then(() => children.delete(child))
+  return { id, releaseFile, child }
+}
+
+async function readEvents(path: string): Promise<WorkerEvent[]> {
+  try {
+    const text = await readFile(path, "utf8")
+    return text.trim().split("\n").filter(Boolean).map(line => JSON.parse(line) as WorkerEvent)
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return []
+    throw error
+  }
+}
+
+async function waitForEvent(
+  path: string,
+  workerId: string,
+  name: string,
+  timeoutMs = 5_000,
+): Promise<WorkerEvent> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const all = await readEvents(path)
+    const workerError = all.find(item => item.workerId === workerId && item.name === "worker-error")
+    if (workerError) {
+      throw new Error(`${workerId} failed: ${workerError.errorName}: ${workerError.message}`)
+    }
+    const found = all.find(item => item.workerId === workerId && item.name === name)
+    if (found) return found
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${workerId}:${name}`)
+}
+
+async function release(worker: WorkerHandle): Promise<void> {
+  await writeFile(worker.releaseFile, "release")
+}
+
+async function expectSuccess(worker: WorkerHandle, timeoutMs = 5_000): Promise<void> {
+  const timeout = Symbol("timeout")
+  const outcome = await Promise.race([
+    worker.child.exited,
+    Bun.sleep(timeoutMs).then(() => timeout),
+  ])
+  if (outcome === timeout) {
+    worker.child.kill()
+    throw new Error(`Worker ${worker.id} did not exit within ${timeoutMs}ms`)
+  }
+  if (outcome === 0) return
+  const stderr = worker.child.stderr instanceof ReadableStream
+    ? await new Response(worker.child.stderr).text()
+    : String(worker.child.stderr ?? "")
+  throw new Error(`Worker ${worker.id} exited ${String(outcome)}: ${stderr}`)
+}
+
+async function result(paths: Paths, worker: WorkerHandle): Promise<WorkerEvent> {
+  await expectSuccess(worker)
+  return waitForEvent(paths.events, worker.id, "result", 250)
+}
+
+function conflictBody(event: WorkerEvent): unknown {
+  return JSON.parse(event.body ?? "null")
+}
+
+describe("proxy coordination across OS processes", () => {
+  test("serializes one session and rejects a stale arrival after durable advancement", async () => {
+    const paths = await makePaths()
+    const opening = [{ role: "user", content: "hello" }]
+    const owner = spawnProxyWorker(paths, "stale-owner", "shared-stale", opening)
+    const ownerArrival = await waitForEvent(paths.events, owner.id, "arrival-snapshot")
+    expect(ownerArrival.generations?.["shared-stale"]).toMatch(/^a:/)
+    await waitForEvent(paths.events, owner.id, "sdk-start")
+
+    const stale = spawnProxyWorker(paths, "stale-waiter", "shared-stale", opening)
+    const staleArrival = await waitForEvent(paths.events, stale.id, "arrival-snapshot")
+    expect(staleArrival.generations?.["shared-stale"]).toBe(
+      ownerArrival.generations?.["shared-stale"],
+    )
+
+    // The second proxy has taken its arrival snapshot, but cannot enter the SDK
+    // while the first process owns the same durable turn lock.
+    await Bun.sleep(75)
+    expect((await readEvents(paths.events)).some(
+      item => item.workerId === stale.id && item.name === "sdk-start",
+    )).toBe(false)
+
+    await release(owner)
+    expect((await result(paths, owner)).status).toBe(200)
+    const staleResult = await result(paths, stale)
+    expect(staleResult.status).toBe(400)
+    expect(conflictBody(staleResult)).toEqual({
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message: "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID.",
+      },
+    })
+    expect((await readEvents(paths.events)).some(
+      item => item.workerId === stale.id && item.name === "sdk-start",
+    )).toBe(false)
+  }, 15_000)
+
+  test("refreshes durable lineage and resume state after waiting for another process", async () => {
+    const paths = await makePaths()
+    const opening = [{ role: "user", content: "hello" }]
+    const continuation = [
+      ...opening,
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "continue" },
+    ]
+    const owner = spawnProxyWorker(paths, "refresh-owner", "shared-refresh", opening)
+    const ownerSdk = await waitForEvent(paths.events, owner.id, "sdk-start")
+    expect(ownerSdk.sdkSessionId).toMatch(/^[0-9a-f-]{36}$/)
+
+    const waiter = spawnProxyWorker(paths, "refresh-waiter", "shared-refresh", continuation)
+    const waiterArrival = await waitForEvent(paths.events, waiter.id, "arrival-snapshot")
+    expect(waiterArrival.generations?.["shared-refresh"]).toMatch(/^a:/)
+    await Bun.sleep(75)
+    expect((await readEvents(paths.events)).some(
+      item => item.workerId === waiter.id && item.name === "sdk-start",
+    )).toBe(false)
+
+    await release(owner)
+    expect((await result(paths, owner)).status).toBe(200)
+    const waiterSdk = await waitForEvent(paths.events, waiter.id, "sdk-start")
+    expect(waiterSdk.resume).toBe(ownerSdk.sdkSessionId)
+
+    const allAtResume = await readEvents(paths.events)
+    const ownerFinished = allAtResume.find(
+      item => item.workerId === owner.id && item.name === "sdk-finish",
+    )
+    expect(ownerFinished).toBeDefined()
+    expect(ownerFinished!.at).toBeLessThanOrEqual(waiterSdk.at)
+
+    await release(waiter)
+    expect((await result(paths, waiter)).status).toBe(200)
+    const durable = JSON.parse(await readFile(join(paths.sessions, "sessions.json"), "utf8"))
+    expect(durable["shared-refresh"]).toMatchObject({
+      claudeSessionId: waiterSdk.sdkSessionId,
+      previousClaudeSessionId: ownerSdk.sdkSessionId,
+      revision: 2,
+      messageCount: continuation.length,
+    })
+  }, 15_000)
+
+  test("allows different sessions to run concurrently in different processes", async () => {
+    const paths = await makePaths()
+    const first = spawnProxyWorker(
+      paths,
+      "parallel-first",
+      "parallel-session-a",
+      [{ role: "user", content: "one" }],
+    )
+    await waitForEvent(paths.events, first.id, "sdk-start")
+
+    const second = spawnProxyWorker(
+      paths,
+      "parallel-second",
+      "parallel-session-b",
+      [{ role: "user", content: "two" }],
+    )
+    await waitForEvent(paths.events, second.id, "sdk-start")
+
+    // Both SDK calls started before either release file existed.
+    expect(existsSync(first.releaseFile)).toBe(false)
+    expect(existsSync(second.releaseFile)).toBe(false)
+    expect((await readEvents(paths.events)).filter(item => item.name === "sdk-start")).toHaveLength(2)
+
+    await Promise.all([release(first), release(second)])
+    const [firstResult, secondResult] = await Promise.all([
+      result(paths, first),
+      result(paths, second),
+    ])
+    expect(firstResult.status).toBe(200)
+    expect(secondResult.status).toBe(200)
+  }, 15_000)
+})

--- a/src/__tests__/proxy-crush-integration.test.ts
+++ b/src/__tests__/proxy-crush-integration.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage, toolUseBlockStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, messageStart } from "./helpers"
+import { assistantMessage, toolUseBlockStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, messageStart, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -17,7 +17,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-droid-integration.test.ts
+++ b/src/__tests__/proxy-droid-integration.test.ts
@@ -10,10 +10,21 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { mkdirSync } from "node:fs"
-import { assistantMessage } from "./helpers"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 // Use real, existent directories so server.ts:resolveSdkWorkingDirectory's
 // existsSync check passes — otherwise the SDK cwd silently falls back to
@@ -31,7 +42,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   // Provide tool()/registerTool() on the instance so passthrough-mode setup

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -15,6 +15,8 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 let capturedQueryOptions: any = null
 const savedEnv: Record<string, string | undefined> = {}
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryOptions = params.options
@@ -30,7 +32,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: "sess-env-test",
+        session_id: resolveMockSdkSessionId(params.options, "sess-env-test"),
       }
     })()
   },

--- a/src/__tests__/proxy-error-handling.test.ts
+++ b/src/__tests__/proxy-error-handling.test.ts
@@ -10,8 +10,10 @@ import { describe, it, expect, mock, beforeEach } from "bun:test"
 // Make the SDK throw specific errors
 let mockError: Error | null = null
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     if (mockError) {
       return (async function* () {
         throw mockError
@@ -29,7 +31,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: "sess-1",
+        session_id: resolveMockSdkSessionId(params.options, "sess-1"),
       }
     })()
   },

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { getSessionStoreDir } from "../proxy/sessionStore"
 import {
   messageStart,
   textBlockStart,
@@ -16,13 +19,20 @@ import {
   messageDelta,
   messageStop,
   parseSSE,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 // Track query calls to verify retry behavior
-let queryCalls: Array<{ model: string; callIndex: number; resume?: string }> = []
+interface LifecycleResourceSnapshot {
+  locator?: { sessionId?: string }
+  state?: string
+}
+
+let queryCalls: Array<{ model: string; callIndex: number; resume?: string; sessionId?: string }> = []
 let queryCallCount = 0
 /** Benches recorded when a [1m] model is stripped after a rate limit (#862). */
 let rateLimitBenches: Array<{ profileId: string | undefined; until: number }> = []
+let lifecycleStateAtSpawn: Array<{ sessionId: string; state: string | undefined }> = []
 
 // Control what the mock does
 let mockBehavior: "extra_usage_then_succeed" | "always_extra_usage" | "out_of_extra_usage_then_succeed" | "resume_extra_usage_then_succeed" | "succeed" | "error_assistant_then_ratelimit" = "succeed"
@@ -56,7 +66,15 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     queryCallCount++
       const callIndex = queryCallCount
       const model = opts.options?.model || "sonnet"
-      queryCalls.push({ model, callIndex, resume: opts.options?.resume })
+      const sessionId = opts.options?.sessionId
+      queryCalls.push({ model, callIndex, resume: opts.options?.resume, sessionId })
+      const returnedSessionId = resolveMockSdkSessionId(opts.options, `sdk-session-${callIndex}`)
+      if (sessionId) {
+        const sidecar = JSON.parse(readFileSync(join(getSessionStoreDir(), "session-gc.json"), "utf8"))
+        const resource = Object.values(sidecar.resources as Record<string, LifecycleResourceSnapshot>)
+          .find((candidate) => candidate.locator?.sessionId === sessionId)
+        lifecycleStateAtSpawn.push({ sessionId, state: resource?.state })
+      }
       const isStreaming = opts.options?.includePartialMessages === true
 
     return (async function* () {
@@ -74,7 +92,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
 
       if (
         mockBehavior === "resume_extra_usage_then_succeed" &&
-        opts.options?.resume === "sdk-session-1" &&
+        opts.options?.resume === queryCalls[0]?.sessionId &&
         (model === "sonnet[1m]" || model === "sonnet")
       ) {
         throw new Error(OUT_OF_EXTRA_USAGE_ERROR)
@@ -98,19 +116,19 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
             stop_reason: "stop_sequence",
             usage: { input_tokens: 0, output_tokens: 0 },
           },
-          session_id: `sdk-session-${callIndex}`,
+          session_id: returnedSessionId,
         }
         throw new Error("429 rate limit exceeded for 1m context")
       }
 
       // Success path
       if (isStreaming) {
-        yield messageStart(`msg-${callIndex}`)
-        yield textBlockStart(0)
-        yield textDelta(0, `response-${callIndex}`)
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield { ...messageStart(`msg-${callIndex}`), session_id: returnedSessionId }
+        yield { ...textBlockStart(0), session_id: returnedSessionId }
+        yield { ...textDelta(0, `response-${callIndex}`), session_id: returnedSessionId }
+        yield { ...blockStop(0), session_id: returnedSessionId }
+        yield { ...messageDelta("end_turn"), session_id: returnedSessionId }
+        yield { ...messageStop(), session_id: returnedSessionId }
       }
       yield {
         type: "assistant",
@@ -124,7 +142,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: `sdk-session-${callIndex}`,
+        session_id: returnedSessionId,
       }
     })()
   },
@@ -142,6 +160,7 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { lookupSharedSession } = await import("../proxy/sessionStore")
 
 function createTestApp() {
   const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
@@ -163,6 +182,7 @@ describe("Extra usage required fallback", () => {
     clearSessionCache()
     queryCalls = []
     rateLimitBenches = []
+    lifecycleStateAtSpawn = []
     queryCallCount = 0
     mockBehavior = "succeed"
   })
@@ -182,6 +202,8 @@ describe("Extra usage required fallback", () => {
       expect(response.status).toBe(200)
       const body = await response.json()
       expect(body.content).toBeDefined()
+      expect(lifecycleStateAtSpawn.map((entry) => entry.state)).toEqual(["prepared", "prepared"])
+      expect(new Set(lifecycleStateAtSpawn.map((entry) => entry.sessionId)).size).toBe(2)
     })
 
     it("propagates error when model is already base (no [1m] to strip)", async () => {
@@ -231,6 +253,8 @@ describe("Extra usage required fallback", () => {
       const text = await response.text()
       // Should contain successful stream content after fallback
       expect(text).toContain("event: message_start")
+      expect(lifecycleStateAtSpawn.map((entry) => entry.state)).toEqual(["prepared", "prepared"])
+      expect(new Set(lifecycleStateAtSpawn.map((entry) => entry.sessionId)).size).toBe(2)
     })
 
     it("returns error event when model is already base", async () => {
@@ -276,12 +300,22 @@ describe("Extra usage required fallback", () => {
       }, { "x-opencode-session": "sess-1" })
 
       expect(response.status).toBe(200)
+      expect(response.headers.get("x-claude-session-id")).toBeNull()
       const text = await response.text()
       expect(text).toContain("event: message_start")
+      const initialSessionId = queryCalls[0]?.sessionId
+      const extendedForkSessionId = queryCalls[1]?.sessionId
+      const baseForkSessionId = queryCalls[2]?.sessionId
+      const freshFallbackSessionId = queryCalls[3]?.sessionId
+      for (const sessionId of [initialSessionId, extendedForkSessionId, baseForkSessionId, freshFallbackSessionId]) {
+        expect(sessionId).toMatch(/^[0-9a-f-]{36}$/)
+      }
+      expect(new Set([initialSessionId, extendedForkSessionId, baseForkSessionId, freshFallbackSessionId]).size).toBe(4)
+      expect(lookupSharedSession("sess-1")?.claudeSessionId).toBe(freshFallbackSessionId)
       expect(queryCalls.slice(-3)).toEqual([
-        { model: "sonnet[1m]", callIndex: 2, resume: "sdk-session-1" },
-        { model: "sonnet", callIndex: 3, resume: "sdk-session-1" },
-        { model: "sonnet", callIndex: 4, resume: undefined },
+        { model: "sonnet[1m]", callIndex: 2, resume: initialSessionId, sessionId: extendedForkSessionId },
+        { model: "sonnet", callIndex: 3, resume: initialSessionId, sessionId: baseForkSessionId },
+        { model: "sonnet", callIndex: 4, resume: undefined, sessionId: freshFallbackSessionId },
       ])
     })
   })

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -19,6 +19,7 @@ import {
   messageDelta,
   messageStop,
   parseSSE,
+  withMockSdkSessionId,
 } from "./helpers"
 
 let mockMessages: any[] = []
@@ -33,8 +34,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     return (async function* () {
       const postToolUseHooks = params.options?.hooks?.PostToolUse
       for (const msg of mockMessages) {
-        yield msg
-
+        yield withMockSdkSessionId(msg, params.options)
         // After yielding an assistant message with tool results, fire PostToolUse
         // for any MCP tool blocks (simulating the SDK's internal tool execution)
         if (msg.type === "assistant" && postToolUseHooks) {

--- a/src/__tests__/proxy-forgecode-integration.test.ts
+++ b/src/__tests__/proxy-forgecode-integration.test.ts
@@ -8,10 +8,21 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { mkdirSync } from "node:fs"
-import { assistantMessage, textBlockStart, textDelta, blockStop, messageDelta, messageStop, messageStart } from "./helpers"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
+import { assistantMessage, textBlockStart, textDelta, blockStop, messageDelta, messageStop, messageStart, withMockSdkSessionId } from "./helpers"
 
 // Use a real, existent directory so server.ts:resolveSdkWorkingDirectory's
 // existsSync check passes — otherwise the SDK cwd silently falls back to
@@ -26,7 +37,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-mcp-filtering.test.ts
+++ b/src/__tests__/proxy-mcp-filtering.test.ts
@@ -18,14 +18,17 @@ import {
   messageStop,
   parseSSE,
   streamEvent,
+  withMockSdkSessionId,
 } from "./helpers"
 
 let mockMessages: any[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-mcp-server-per-request.test.ts
+++ b/src/__tests__/proxy-mcp-server-per-request.test.ts
@@ -16,6 +16,8 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 let mcpServerCreateCount = 0
 let capturedMcpServers: any[] = []
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     if (params.options?.mcpServers) {
@@ -33,7 +35,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: `sess-${Date.now()}`,
+        session_id: resolveMockSdkSessionId(params.options, `sess-${Date.now()}`),
       }
     })()
   },

--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 let capturedQueryParams: any = null
 
@@ -25,7 +25,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: "sess-1",
+        session_id: resolveMockSdkSessionId(params.options, "sess-1"),
       }
     })()
   },

--- a/src/__tests__/proxy-nonstream-deny-hold.test.ts
+++ b/src/__tests__/proxy-nonstream-deny-hold.test.ts
@@ -28,14 +28,17 @@ const denyMsg = (ids: string[]) => ({
   },
 })
 
+const boundary = (type: string) => ({
+  type: "stream_event", session_id: "sdk-ns-1", event: { type },
+})
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
-    const isStreaming = opts.options?.includePartialMessages === true
     return (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
       yield { type: "system", subtype: "init", session_id: "sdk-ns-1" }
-      if (isStreaming || !preHook) {
-        // Streaming path not under test here
+      if (!preHook) {
+        // No passthrough hooks — nothing to hold, so answer and stop.
         yield {
           type: "assistant", uuid: "u1",
           message: { id: "m1", type: "message", role: "assistant", content: [{ type: "text", text: "ok" }], model: "claude-sonnet-5", stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 } },
@@ -44,8 +47,13 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         return
       }
 
-      // Turn 1 generation begins. The CLI dispatches block 1's hook while
-      // block 2 is still generating.
+      // Turn 1 generation begins. `message_start`/`message_delta` bracket it on
+      // both paths — passthrough asks for partial messages regardless of whether
+      // the client streams, because they are the only turn-boundary signal and
+      // the deny-hold and the checkpoint both key off it.
+      yield boundary("message_start")
+
+      // The CLI dispatches block 1's hook while block 2 is still generating.
       let settled = false
       const deny1 = preHook({ tool_name: "read", tool_use_id: "tu1", tool_input: { filePath: "/tmp/a.txt" } })
         .then((r: any) => { settled = true; return r })
@@ -56,6 +64,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
 
       if (settled) {
         // Cancel-on-deny: block 2 is beheaded; only block 1 exists.
+        yield boundary("message_delta")
         yield {
           type: "assistant", uuid: "u1",
           message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },
@@ -67,6 +76,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       }
 
       // Deny held → generation completed with BOTH blocks.
+      yield boundary("message_delta")
       yield {
         type: "assistant", uuid: "u1",
         message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt"), tu("tu2", "/tmp/b.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },

--- a/src/__tests__/proxy-nonstream-deny-hold.test.ts
+++ b/src/__tests__/proxy-nonstream-deny-hold.test.ts
@@ -28,21 +28,24 @@ const denyMsg = (ids: string[]) => ({
   },
 })
 
-const boundary = (type: string) => ({
-  type: "stream_event", session_id: "sdk-ns-1", event: { type },
+const boundary = (type: string, sessionId = "sdk-ns-1") => ({
+  type: "stream_event", session_id: sessionId, event: { type },
 })
+
+import { resolveMockSdkSessionId } from "./helpers"
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     return (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
-      yield { type: "system", subtype: "init", session_id: "sdk-ns-1" }
+      const sessionId = resolveMockSdkSessionId(opts.options, "sdk-ns-1")
+      yield { type: "system", subtype: "init", session_id: sessionId }
       if (!preHook) {
         // No passthrough hooks — nothing to hold, so answer and stop.
         yield {
           type: "assistant", uuid: "u1",
           message: { id: "m1", type: "message", role: "assistant", content: [{ type: "text", text: "ok" }], model: "claude-sonnet-5", stop_reason: "end_turn", usage: { input_tokens: 1, output_tokens: 1 } },
-          session_id: "sdk-ns-1",
+          session_id: sessionId,
         }
         return
       }
@@ -51,7 +54,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       // both paths — passthrough asks for partial messages regardless of whether
       // the client streams, because they are the only turn-boundary signal and
       // the deny-hold and the checkpoint both key off it.
-      yield boundary("message_start")
+      yield boundary("message_start", sessionId)
 
       // The CLI dispatches block 1's hook while block 2 is still generating.
       let settled = false
@@ -64,11 +67,11 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
 
       if (settled) {
         // Cancel-on-deny: block 2 is beheaded; only block 1 exists.
-        yield boundary("message_delta")
+        yield boundary("message_delta", sessionId)
         yield {
           type: "assistant", uuid: "u1",
           message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },
-          session_id: "sdk-ns-1",
+          session_id: sessionId,
         }
         await deny1
         yield denyMsg(["tu1"])
@@ -76,11 +79,11 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       }
 
       // Deny held → generation completed with BOTH blocks.
-      yield boundary("message_delta")
+      yield boundary("message_delta", sessionId)
       yield {
         type: "assistant", uuid: "u1",
         message: { id: "m1", type: "message", role: "assistant", content: [tu("tu1", "/tmp/a.txt"), tu("tu2", "/tmp/b.txt")], model: "claude-sonnet-5", stop_reason: "tool_use", usage: { input_tokens: 1, output_tokens: 1 } },
-        session_id: "sdk-ns-1",
+        session_id: sessionId,
       }
       const deny2 = preHook({ tool_name: "read", tool_use_id: "tu2", tool_input: { filePath: "/tmp/b.txt" } })
       await deny1

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -23,10 +23,10 @@ import {
   parseSSE,
   toolUseBlockStart,
   inputJsonDelta,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 let mockMessages: unknown[] = []
-let mockSdkSessionId: string | undefined
 let capturedPromptMessages: unknown[] = []
 let capturedOptions: Record<string, unknown> | null = null
 let capturedOptionHistory: Array<Record<string, unknown>> = []
@@ -35,6 +35,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: ({ prompt, options }: { prompt: string | AsyncIterable<unknown>; options?: Record<string, unknown> }) => {
     capturedOptions = options ?? null
     capturedOptionHistory.push(options ?? {})
+    const sessionId = resolveMockSdkSessionId(options)
     return (async function* () {
       capturedPromptMessages = []
       if (typeof prompt === "string") {
@@ -45,8 +46,8 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         }
       }
       for (const msg of mockMessages) {
-        if (mockSdkSessionId && msg !== null && typeof msg === "object") {
-          yield { ...msg, session_id: mockSdkSessionId }
+        if (typeof sessionId === "string" && msg !== null && typeof msg === "object") {
+          yield { ...msg, session_id: sessionId }
         } else {
           yield msg
         }
@@ -274,7 +275,6 @@ describe("POST /v1/chat/completions — Jcode session continuity", () => {
 
   beforeEach(() => {
     mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
-    mockSdkSessionId = "sdk-1"
     capturedPromptMessages = []
     capturedOptions = null
     capturedOptionHistory = []
@@ -293,7 +293,8 @@ describe("POST /v1/chat/completions — Jcode session continuity", () => {
 
     expect(capturedOptionHistory).toHaveLength(2)
     expect(capturedOptionHistory[0]?.resume).toBeUndefined()
-    expect(capturedOptionHistory[1]?.resume).toBe("sdk-1")
+    expect(capturedOptionHistory[0]?.sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(capturedOptionHistory[1]?.resume).toBe(capturedOptionHistory[0]?.sessionId)
     expect(capturedOptionHistory[1]?.systemPrompt).toBe("stable system")
   })
 

--- a/src/__tests__/proxy-output-tokens-aggregation.test.ts
+++ b/src/__tests__/proxy-output-tokens-aggregation.test.ts
@@ -18,11 +18,13 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (_params: unknown) => (async function* () {
-    for (const m of mockMessages) yield m
+  query: (params: any) => (async function* () {
+    for (const m of mockMessages) {
+      yield withMockSdkSessionId(m, params.options)
+    }
   })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -20,7 +20,22 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { makeRequest, parseSSE } from "./helpers"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  // Request completion releases the cross-process lease asynchronously.
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
+import { makeRequest, parseSSE, resolveMockSdkSessionId } from "./helpers"
 
 const PASSTHROUGH_PREFIX = "mcp__oc__"
 
@@ -101,11 +116,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedResume = opts?.options?.resume
     return (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+      const sessionId = resolveMockSdkSessionId(opts?.options, "test-session")
       for (const turn of mockTurns) {
         if (capturedController?.signal.aborted) {
           throw new Error("Claude Code process aborted by user")
         }
-        yield turn
+        // The real SDK honors Options.sessionId for a fork. Keep this mock
+        // faithful so managed-fork identity validation exercises that contract.
+        yield { ...turn, session_id: sessionId }
         if (preHook && turn.type === "assistant") {
           for (const block of turn.message.content) {
             if (block.type === "tool_use") {
@@ -432,6 +450,9 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
     const first = await post(app, false)
     expect(first.status).toBe(200)
+    const firstSessionId = first.headers.get("x-claude-session-id")
+    expect(firstSessionId).toBeTruthy()
+    if (!firstSessionId) throw new Error("missing caller-selected session ID")
 
     mockTurns = [
       {
@@ -462,7 +483,7 @@ describe("parallel same-tool calls are captured and forwarded (#552 kabo regress
     // '[your read ...]: Tool execution aborted' confusion loop.
     // (?? guard defeats TS narrowing from the `= undefined` reset above —
     // the mock closure reassigns it during the request.)
-    expect(capturedResume ?? "(not resumed)").toBe("test-session")
+    expect(capturedResume ?? "(not resumed)").toBe(firstSessionId)
   })
 
   it("stream: both parallel read blocks reach the client fully terminated, no error", async () => {

--- a/src/__tests__/proxy-passthrough-single-turn.test.ts
+++ b/src/__tests__/proxy-passthrough-single-turn.test.ts
@@ -25,7 +25,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { makeRequest } from "./helpers"
+import { makeRequest, withMockSdkSessionId } from "./helpers"
 
 const PASSTHROUGH_PREFIX = "mcp__oc__"
 
@@ -57,7 +57,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
       for (const turn of mockTurns) {
-        yield turn
+        yield withMockSdkSessionId(turn, opts.options)
         // Simulate the SDK executing this turn's tool call: the passthrough
         // PreToolUse hook fires (captures + blocks) BEFORE the next turn is
         // produced. If the consumer has already broken, this never runs for

--- a/src/__tests__/proxy-passthrough-thinking.test.ts
+++ b/src/__tests__/proxy-passthrough-thinking.test.ts
@@ -34,6 +34,7 @@ import {
   parseSSE,
   assistantMessage,
   makeRequest,
+  withMockSdkSessionId,
 } from "./helpers"
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk"
 
@@ -56,9 +57,11 @@ const EDIT_TOOL = {
 let mockMessages: SDKMessage[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () =>
+  query: (params: any) =>
     (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })(),
   createSdkMcpServer: () => ({
     type: "sdk",

--- a/src/__tests__/proxy-passthrough-tool-use.test.ts
+++ b/src/__tests__/proxy-passthrough-tool-use.test.ts
@@ -28,15 +28,18 @@ import {
   assistantMessage,
   makeRequest,
   READ_TOOL,
+  withMockSdkSessionId,
 } from "./helpers"
 
 // --- Mock the Claude SDK ---
 let mockMessages: any[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () =>
+  query: (params: any) =>
     (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })(),
   createSdkMcpServer: () => ({
     type: "sdk",

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop } from "./helpers"
+import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -22,7 +22,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-rate-limit-retry.test.ts
+++ b/src/__tests__/proxy-rate-limit-retry.test.ts
@@ -17,6 +17,7 @@ import {
   messageDelta,
   messageStop,
   parseSSE,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 // Track query calls to verify retry behavior
@@ -33,6 +34,10 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const model = opts.options?.model || "sonnet"
     queryCalls.push({ model, callIndex })
     const isStreaming = opts.options?.includePartialMessages === true
+    const returnedSessionId = resolveMockSdkSessionId(opts.options)
+    const withReturnedSessionId = (message: any) => returnedSessionId
+      ? { ...message, session_id: returnedSessionId }
+      : message
 
     return (async function* () {
       if (mockBehavior === "always_rate_limit") {
@@ -54,12 +59,12 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
 
       // Success path
       if (isStreaming) {
-        yield messageStart(`msg-${callIndex}`)
-        yield textBlockStart(0)
-        yield textDelta(0, `response-${callIndex}`)
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield withReturnedSessionId(messageStart(`msg-${callIndex}`))
+        yield withReturnedSessionId(textBlockStart(0))
+        yield withReturnedSessionId(textDelta(0, `response-${callIndex}`))
+        yield withReturnedSessionId(blockStop(0))
+        yield withReturnedSessionId(messageDelta("end_turn"))
+        yield withReturnedSessionId(messageStop())
       }
       yield {
         type: "assistant",
@@ -73,7 +78,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: `sdk-session-${callIndex}`,
+        session_id: resolveMockSdkSessionId(opts.options, `sdk-session-${callIndex}`),
       }
     })()
   },

--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -11,6 +11,8 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 
 let capturedPrompts: any[] = []
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedPrompts.push(opts.prompt)
@@ -27,7 +29,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 5, output_tokens: 2 },
         },
-        session_id: "sdk-1",
+        session_id: resolveMockSdkSessionId(opts.options, "sdk-1"),
       }
     })()
   },

--- a/src/__tests__/proxy-request-cancellation.test.ts
+++ b/src/__tests__/proxy-request-cancellation.test.ts
@@ -24,13 +24,16 @@ function assistantMessage() {
   }
 }
 
+import { withMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (params: { options?: { abortController?: AbortController } }) => {
+  query: (params: { options?: { abortController?: AbortController; sessionId?: string } }) => {
     capturedController = params.options?.abortController
     notifyQueryStarted?.()
     return (async function* () {
       if (mode === "complete") {
-        yield assistantMessage()
+        const message = assistantMessage()
+        yield withMockSdkSessionId(message, params.options)
         return
       }
 

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -14,6 +14,7 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 let capturedOptions: any[] = []
@@ -22,16 +23,20 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedOptions.push(opts.options || {})
     const isStreaming = opts.options?.includePartialMessages === true
+    const sessionId = resolveMockSdkSessionId(opts.options)
+    const withReturnedSessionId = (message: any) => sessionId
+      ? { ...message, session_id: sessionId }
+      : message
     return (async function* () {
       // Fire the PreToolUse deny hook if present (passthrough capture path)
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
       if (isStreaming) {
-        yield messageStart("msg-1")
-        yield textBlockStart(0)
-        yield textDelta(0, "Hello from Codex")
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield withReturnedSessionId(messageStart("msg-1"))
+        yield withReturnedSessionId(textBlockStart(0))
+        yield withReturnedSessionId(textDelta(0, "Hello from Codex"))
+        yield withReturnedSessionId(blockStop(0))
+        yield withReturnedSessionId(messageDelta("end_turn"))
+        yield withReturnedSessionId(messageStop())
       }
       void preHook
       yield {
@@ -46,7 +51,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 11, output_tokens: 4 },
         },
-        session_id: "sdk-1",
+        session_id: sessionId,
       }
     })()
   },
@@ -183,7 +188,8 @@ describe("/v1/responses session continuity via prompt_cache_key (#655)", () => {
     expect(r2.status).toBe(200)
     expect(capturedOptions).toHaveLength(2)
     expect(capturedOptions[0].resume).toBeUndefined()
-    expect(capturedOptions[1].resume).toBe("sdk-1")
+    expect(capturedOptions[0].sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
   })
 
   it("does not resume across different prompt_cache_keys", async () => {

--- a/src/__tests__/proxy-responses-image.test.ts
+++ b/src/__tests__/proxy-responses-image.test.ts
@@ -15,6 +15,8 @@ const RED_PNG_B64 =
 // iterable of user messages; a dropped image degrades this to a plain string.
 let capturedPrompt: any = null
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedPrompt = opts.prompt
@@ -31,7 +33,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 20, output_tokens: 5 },
         },
-        session_id: "sdk-1",
+        session_id: resolveMockSdkSessionId(opts.options, "sdk-1"),
       }
     })()
   },

--- a/src/__tests__/proxy-resume-refusal.test.ts
+++ b/src/__tests__/proxy-resume-refusal.test.ts
@@ -13,8 +13,23 @@
  * session is different — an identical attempt fails identically — and stays
  * one-shot.
  */
-import { describe, it, expect, mock, beforeEach } from "bun:test"
-import { messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop } from "./helpers"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  // Request completion releases the cross-process lease asynchronously.
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
+import { messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, resolveMockSdkSessionId } from "./helpers"
 
 // Linear backoff is real time; the retry path is what is under test, not the wait.
 process.env.MERIDIAN_BUSY_RETRY_DELAY_MS = "5"
@@ -34,6 +49,10 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     const callIndex = queryCallCount
     queryCalls.push(opts.options || {})
     const isStreaming = opts.options?.includePartialMessages === true
+    const returnedSessionId = resolveMockSdkSessionId(opts.options)
+    const withReturnedSessionId = (message: any) => returnedSessionId
+      ? { ...message, session_id: returnedSessionId }
+      : message
     return (async function* () {
       // The CLI refuses the resume while the previous subprocess for this
       // session is still exiting. The session itself is intact.
@@ -53,12 +72,12 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         )
       }
       if (isStreaming) {
-        yield messageStart(`msg-${callIndex}`)
-        yield textBlockStart(0)
-        yield textDelta(0, `response-${callIndex}`)
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield withReturnedSessionId(messageStart(`msg-${callIndex}`))
+        yield withReturnedSessionId(textBlockStart(0))
+        yield withReturnedSessionId(textDelta(0, `response-${callIndex}`))
+        yield withReturnedSessionId(blockStop(0))
+        yield withReturnedSessionId(messageDelta("end_turn"))
+        yield withReturnedSessionId(messageStop())
       }
       yield {
         type: "assistant",
@@ -72,7 +91,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: "sdk-original",
+        session_id: resolveMockSdkSessionId(opts.options, "sdk-original"),
       }
     })()
   },

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -18,6 +18,7 @@ import {
   messageDelta,
   messageStop,
   assistantMessage,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 
@@ -28,8 +29,15 @@ let mockMessages: unknown[] = []
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
     capturedOptions = params.options ?? {}
+    const sessionId = resolveMockSdkSessionId(params.options)
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        if (typeof sessionId === "string" && msg !== null && typeof msg === "object") {
+          yield { ...msg, session_id: sessionId }
+        } else {
+          yield msg
+        }
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
@@ -391,7 +399,6 @@ describe("Usage logging", () => {
       },
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
-      session_id: "test-session-fmt",
     }]
     const logSpy = spyOn(console, "error")
     const app = createTestApp()
@@ -437,7 +444,6 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
   })
 
   it("returns usage after a completed request", async () => {
-    const claudeSessionId = "sess_usage_test_001"
     mockMessages = [{
       type: "assistant",
       message: {
@@ -451,7 +457,6 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
       },
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
-      session_id: claudeSessionId,
     }]
 
     const app = createTestApp()
@@ -459,6 +464,7 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
     await post(app, { ...BASE_BODY, "x-opencode-session": "agent-session-abc" }, {
       "x-opencode-session": "agent-session-abc",
     })
+    const claudeSessionId = capturedOptions.sessionId as string
 
     const res = await app.fetch(
       new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
@@ -473,7 +479,6 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
   })
 
   it("returns usage for sessions tracked only by fingerprint fallback", async () => {
-    const claudeSessionId = "sess_usage_fingerprint_only"
     mockMessages = [{
       type: "assistant",
       message: {
@@ -487,11 +492,11 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
       },
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
-      session_id: claudeSessionId,
     }]
 
     const app = createTestApp()
     await post(app, BASE_BODY)
+    const claudeSessionId = capturedOptions.sessionId as string
 
     const res = await app.fetch(
       new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
@@ -505,7 +510,6 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
   })
 
   it("returns the last usage iteration when the SDK reports cumulative top-level usage", async () => {
-    const claudeSessionId = "sess_usage_iterations_001"
     mockMessages = [{
       type: "assistant",
       message: {
@@ -540,13 +544,13 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
       },
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
-      session_id: claudeSessionId,
     }]
 
     const app = createTestApp()
     await post(app, { ...BASE_BODY, "x-opencode-session": "agent-session-iterations" }, {
       "x-opencode-session": "agent-session-iterations",
     })
+    const claudeSessionId = capturedOptions.sessionId as string
 
     const res = await app.fetch(
       new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
@@ -564,7 +568,6 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
   })
 
   it("falls back to top-level usage when iterations is empty", async () => {
-    const claudeSessionId = "sess_usage_empty_iterations_001"
     mockMessages = [{
       type: "assistant",
       message: {
@@ -584,13 +587,13 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
       },
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
-      session_id: claudeSessionId,
     }]
 
     const app = createTestApp()
     await post(app, { ...BASE_BODY, "x-opencode-session": "agent-session-empty-iterations" }, {
       "x-opencode-session": "agent-session-empty-iterations",
     })
+    const claudeSessionId = capturedOptions.sessionId as string
 
     const res = await app.fetch(
       new Request(`http://localhost/v1/sessions/${claudeSessionId}/context-usage`)
@@ -615,8 +618,7 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
     expect(res.status).toBe(404)
   })
 
-  it("uses the Claude session ID from the response, not the agent session ID", async () => {
-    const claudeSessionId = "sess_claude_id_check"
+  it("uses the caller-selected Claude session ID, not the agent session ID", async () => {
     const agentSessionId = "agent-id-xyz-different"
 
     mockMessages = [{
@@ -632,11 +634,11 @@ describe("GET /v1/sessions/:claudeSessionId/context-usage", () => {
       },
       parent_tool_use_id: null,
       uuid: crypto.randomUUID(),
-      session_id: claudeSessionId,
     }]
 
     const app = createTestApp()
     await post(app, BASE_BODY, { "x-opencode-session": agentSessionId })
+    const claudeSessionId = capturedOptions.sessionId as string
 
     // Agent session ID → 404
     const byAgent = await app.fetch(

--- a/src/__tests__/proxy-session-resume.test.ts
+++ b/src/__tests__/proxy-session-resume.test.ts
@@ -19,24 +19,26 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
 } from "./helpers"
 
 // --- Capture SDK calls ---
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 let queryCallCount = 0
-
-// Simulate SDK returning a session_id in messages
-const MOCK_SDK_SESSION = "sdk-session-abc123"
+let firstCallerSelectedSessionId: string | undefined
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     queryCallCount++
+    const sessionId = resolveMockSdkSessionId(params.options)
+    if (typeof sessionId !== "string") throw new Error("Expected Meridian to select or resume an SDK session ID")
+    if (queryCallCount === 1) firstCallerSelectedSessionId = sessionId
     return (async function* () {
       for (const msg of mockMessages) {
-        // Inject session_id into messages (like the real SDK does)
-        yield { ...msg, session_id: MOCK_SDK_SESSION }
+        // The real SDK honors the caller-selected ID for a fresh session.
+        yield { ...msg, session_id: sessionId }
       }
     })()
   },
@@ -125,6 +127,7 @@ describe("Session resume: session ID tracking", () => {
     clearSessionCache()
     capturedQueryParams = null
     queryCallCount = 0
+    firstCallerSelectedSessionId = undefined
   })
 
   it("should return X-Claude-Session-ID header in response", async () => {
@@ -137,10 +140,10 @@ describe("Session resume: session ID tracking", () => {
     })
 
     const sessionHeader = response.headers.get("x-claude-session-id")
-    expect(sessionHeader).toBeTruthy()
+    expect(sessionHeader).toBe(capturedQueryParams.options.sessionId)
   })
 
-  it("should return X-Claude-Session-ID in streaming response", async () => {
+  it("omits a speculative X-Claude-Session-ID from streaming responses", async () => {
     mockMessages = [
       messageStart(),
       textBlockStart(0),
@@ -159,8 +162,9 @@ describe("Session resume: session ID tracking", () => {
     })
 
     const sessionHeader = response.headers.get("x-claude-session-id")
-    expect(sessionHeader).toBeTruthy()
-    await readStreamFull(response) // consume
+    await readStreamFull(response) // consume so the lazy SDK query is captured
+    expect(capturedQueryParams.options.sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(sessionHeader).toBeNull()
   })
 
   it("should use resume option on follow-up requests with same session", async () => {
@@ -175,7 +179,8 @@ describe("Session resume: session ID tracking", () => {
     }, { "x-opencode-session": "oc-session-1" })
     await r1.json()
 
-    const firstCallParams = { ...capturedQueryParams }
+    const firstCallSessionId = capturedQueryParams.options.sessionId
+    expect(firstCallSessionId).toBe(firstCallerSelectedSessionId)
 
     // Second request — same session, should resume
     mockMessages = [
@@ -194,8 +199,8 @@ describe("Session resume: session ID tracking", () => {
     }, { "x-opencode-session": "oc-session-1" })
     await r2.json()
 
-    // Second call should have resume option set
-    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    // Second call should resume the exact ID Meridian selected for the first call.
+    expect(capturedQueryParams.options.resume).toBe(firstCallSessionId)
   })
 
   it("should NOT resume for a different session ID", async () => {
@@ -263,7 +268,7 @@ describe("Session resume: session ID tracking", () => {
       ],
     }, headers)).json()
 
-    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.options.resume).toBe(firstCallerSelectedSessionId)
   })
 })
 
@@ -279,6 +284,7 @@ describe("Session resume: fingerprint fallback", () => {
     clearSessionCache()
     capturedQueryParams = null
     queryCallCount = 0
+    firstCallerSelectedSessionId = undefined
   })
 
   it("should resume via fingerprint when no session header is present", async () => {
@@ -308,7 +314,7 @@ describe("Session resume: fingerprint fallback", () => {
       ],
     })).json()
 
-    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.options.resume).toBe(firstCallerSelectedSessionId)
   })
 
   it("keeps Claude Code fingerprint resume for tool_result without metadata", async () => {
@@ -339,7 +345,7 @@ describe("Session resume: fingerprint fallback", () => {
       ],
     }, headers)).json()
 
-    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.options.resume).toBe(firstCallerSelectedSessionId)
   })
 
   it("should NOT resume when first user message is different", async () => {
@@ -381,6 +387,7 @@ describe("Session resume: only send last user message on resume", () => {
     clearSessionCache()
     capturedQueryParams = null
     queryCallCount = 0
+    firstCallerSelectedSessionId = undefined
   })
 
   it("should send only the last user message when resuming", async () => {
@@ -448,7 +455,7 @@ describe("Session resume: only send last user message on resume", () => {
     }, { "x-opencode-session": "oc-stream-resume" })
 
     await readStreamFull(r2)
-    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.options.resume).toBe(firstCallerSelectedSessionId)
     expect(capturedQueryParams.prompt).toContain("Continue please")
     expect(capturedQueryParams.prompt).not.toContain("Start conversation")
   })
@@ -480,6 +487,7 @@ describe("Session resume: stale cross-node history", () => {
     clearSessionCache()
     capturedQueryParams = null
     queryCallCount = 0
+    firstCallerSelectedSessionId = undefined
   })
 
   it("fresh-replays all 727 messages when only 514/515 cached messages match", async () => {
@@ -516,7 +524,7 @@ describe("Session resume: stale cross-node history", () => {
     }, { "x-opencode-session": "oc-stale-nonstream" })
     await followUp.json()
 
-    expect(capturedQueryParams.options.resume).toBe(MOCK_SDK_SESSION)
+    expect(capturedQueryParams.options.resume).toBe(firstCallerSelectedSessionId)
     expect(capturedQueryParams.prompt).toContain("Continue after recovery")
     expect(capturedQueryParams.prompt).not.toContain("WINDOWS MAXWELL CSV SENTINEL")
   })

--- a/src/__tests__/proxy-session-store-locking.test.ts
+++ b/src/__tests__/proxy-session-store-locking.test.ts
@@ -1,11 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
-import { existsSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs"
+import { hostname, tmpdir } from "node:os"
 import { join } from "node:path"
-import { clearSharedSessions, lookupSharedSession, storeSharedSession, setSessionStoreDir } from "../proxy/sessionStore"
+import {
+  clearSharedSessions,
+  evictSharedSession,
+  lookupSharedSession,
+  readSessionStoreSnapshot,
+  setSessionStoreDir,
+  storeSharedSession,
+} from "../proxy/sessionStore"
+import { captureProcessIncarnation } from "../proxy/session/processIncarnation"
+import {
+  getRecoveryClaimPath,
+  getRecoveryClaimTombstonePath,
+} from "../proxy/session/recoveryClaim"
 
 describe("Shared session store locking", () => {
   let tmpDir: string
+  const originalLockTimeout = process.env.MERIDIAN_SESSION_LOCK_TIMEOUT_MS
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "session-store-locking-test-"))
@@ -16,36 +39,59 @@ describe("Shared session store locking", () => {
   afterEach(() => {
     setSessionStoreDir(null)
     rmSync(tmpDir, { recursive: true, force: true })
+    if (originalLockTimeout === undefined) delete process.env.MERIDIAN_SESSION_LOCK_TIMEOUT_MS
+    else process.env.MERIDIAN_SESSION_LOCK_TIMEOUT_MS = originalLockTimeout
   })
 
-  it("preserves all entries during concurrent writes", async () => {
-    const writes = Array.from({ length: 25 }, (_, i) =>
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          storeSharedSession(`sess-${i}`, `claude-${i}`, i)
-          resolve()
-        }, Math.floor(Math.random() * 6))
-      })
-    )
-
-    await Promise.all(writes)
-
-    for (let i = 0; i < 25; i++) {
-      const stored = lookupSharedSession(`sess-${i}`)
-      expect(stored).toBeDefined()
-      if (!stored) {
-        throw new Error(`expected sess-${i} to be stored`)
+  it("preserves every entry from real concurrent writer processes", async () => {
+    const workerCount = 8
+    const entriesPerWorker = 12
+    const modulePath = join(import.meta.dir, "../proxy/sessionStore.ts")
+    const childCode = `
+      import { storeSharedSession } from ${JSON.stringify(modulePath)}
+      const worker = Number(process.env.WORKER)
+      for (let i = 0; i < ${entriesPerWorker}; i++) {
+        const key = \`worker-\${worker}-session-\${i}\`
+        storeSharedSession(key, \`claude-\${worker}-\${i}\`, i)
       }
-      expect(stored.claudeSessionId).toBe(`claude-${i}`)
-      expect(stored.messageCount).toBe(i)
-    }
-  })
+    `
 
-  it("recovers from stale lock files", () => {
+    const children = Array.from({ length: workerCount }, (_, worker) => Bun.spawn({
+      cmd: [process.execPath, "-e", childCode],
+      env: {
+        ...process.env,
+        MERIDIAN_SESSION_DIR: tmpDir,
+        MERIDIAN_SESSION_LOCK_TIMEOUT_MS: "10000",
+        MERIDIAN_MAX_STORED_SESSIONS: "10000",
+        WORKER: String(worker),
+      },
+      stdout: "ignore",
+      stderr: "pipe",
+    }))
+
+    for (const child of children) {
+      const [exitCode, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+      ])
+      expect(stderr).toBe("")
+      expect(exitCode).toBe(0)
+    }
+
+    const snapshot = readSessionStoreSnapshot()
+    expect(Object.keys(snapshot)).toHaveLength(workerCount * entriesPerWorker)
+    for (let worker = 0; worker < workerCount; worker++) {
+      for (let i = 0; i < entriesPerWorker; i++) {
+        expect(snapshot[`worker-${worker}-session-${i}`]?.claudeSessionId).toBe(`claude-${worker}-${i}`)
+      }
+    }
+  }, 20_000)
+
+  it("atomically takes over a stale lock", () => {
     const sessionsPath = join(tmpDir, "sessions.json")
     const lockPath = `${sessionsPath}.lock`
 
-    writeFileSync(lockPath, "")
+    writeFileSync(lockPath, JSON.stringify({ pid: 999_999_999, hostname: hostname(), token: "stale", incarnation: deadProcessIncarnation(999_999_999) }), { mode: 0o600 })
     const staleTime = (Date.now() - 31_000) / 1000
     utimesSync(lockPath, staleTime, staleTime)
 
@@ -53,39 +99,115 @@ describe("Shared session store locking", () => {
 
     expect(lookupSharedSession("stale-lock-session")?.claudeSessionId).toBe("claude-stale")
     expect(existsSync(lockPath)).toBe(false)
+    expect(readdirSync(tmpDir).some((name) => name.includes(".lock.stale-"))).toBe(false)
   })
 
-  it("logs errors instead of silently swallowing failures", () => {
+  it("repeatedly adopts dead recovery claims and cleans tombstones after resolution", () => {
+    const lockPath = join(tmpDir, "sessions.json.lock")
+    const staleOwner = JSON.stringify({ pid: 999_999_999, hostname: hostname(), token: "stale-generation", incarnation: deadProcessIncarnation(999_999_999) })
+    writeFileSync(lockPath, staleOwner, { mode: 0o600 })
+    const staleTime = (Date.now() - 31_000) / 1000
+    utimesSync(lockPath, staleTime, staleTime)
+
+    const claimPath = getRecoveryClaimPath(lockPath, staleOwner)
+    const firstToken = "first-dead-recoverer"
+    const firstTombstone = getRecoveryClaimTombstonePath(claimPath, firstToken)
+    writeRecoveryClaim(firstTombstone, staleOwner, firstToken, 999_999_998)
+    writeRecoveryClaim(claimPath, staleOwner, "second-dead-recoverer", 999_999_999)
+
+    storeSharedSession("after-orphaned-recovery", "claude-after-orphan")
+
+    expect(lookupSharedSession("after-orphaned-recovery")?.claudeSessionId).toBe("claude-after-orphan")
+    expect(existsSync(lockPath)).toBe(false)
+    expect(readdirSync(tmpDir).some((name) => name.includes(".recover-"))).toBe(false)
+  })
+
+  it("fails closed for live and remote recovery claim owners", () => {
+    const lockPath = join(tmpDir, "sessions.json.lock")
+    const staleOwner = JSON.stringify({ pid: 999_999_999, hostname: hostname(), token: "blocked-generation", incarnation: deadProcessIncarnation(999_999_999) })
+    const staleTime = (Date.now() - 31_000) / 1000
+    process.env.MERIDIAN_SESSION_LOCK_TIMEOUT_MS = "20"
+
+    for (const [claimHostname, claimPid] of [[hostname(), process.pid], ["remote.example", 999_999_999]] as const) {
+      writeFileSync(lockPath, staleOwner, { mode: 0o600 })
+      utimesSync(lockPath, staleTime, staleTime)
+      const claimPath = getRecoveryClaimPath(lockPath, staleOwner)
+      writeRecoveryClaim(claimPath, staleOwner, `blocked-${claimHostname}`, claimPid, claimHostname)
+
+      expect(() => storeSharedSession(`blocked-${claimHostname}`, "claude-never-written"))
+        .toThrow("timed out waiting for lock")
+      expect(existsSync(join(claimPath, "owner.json"))).toBe(true)
+
+      rmSync(claimPath, { recursive: true, force: true })
+      rmSync(lockPath, { force: true })
+    }
+  })
+
+  it("waits for an active owner, then throws without deleting its token", () => {
+    const lockPath = join(tmpDir, "sessions.json.lock")
+    writeFileSync(lockPath, "different-owner-token", { mode: 0o600 })
+    process.env.MERIDIAN_SESSION_LOCK_TIMEOUT_MS = "30"
+
+    expect(() => storeSharedSession("lock-contention", "claude-never-written"))
+      .toThrow("timed out waiting for lock")
+    expect(readFileSync(lockPath, "utf8")).toBe("different-owner-token")
+    expect(lookupSharedSession("lock-contention")).toBeUndefined()
+  })
+
+  it("fails all mutations closed when the store is corrupt", () => {
+    const sessionsPath = join(tmpDir, "sessions.json")
+    const corrupt = "{invalid-json"
     const errorSpy = spyOn(console, "error").mockImplementation(() => {})
+    writeFileSync(sessionsPath, corrupt)
 
-    writeFileSync(join(tmpDir, "sessions.json"), "{invalid-json")
     expect(lookupSharedSession("broken")).toBeUndefined()
-
-    const badDirPath = join(tmpDir, "not-a-dir")
-    writeFileSync(badDirPath, "file")
-    setSessionStoreDir(badDirPath)
-    storeSharedSession("write-failure", "claude-write")
-    clearSharedSessions()
-
-    const messages = errorSpy.mock.calls.map((call) => call[0])
-    expect(messages).toContain("[sessionStore] read failed:")
-    expect(messages).toContain("[sessionStore] write failed:")
-    expect(messages).toContain("[sessionStore] clear failed:")
+    expect(() => storeSharedSession("write", "claude-write")).toThrow()
+    expect(() => evictSharedSession("broken")).toThrow()
+    expect(() => clearSharedSessions()).toThrow()
+    expect(readFileSync(sessionsPath, "utf8")).toBe(corrupt)
+    expect(errorSpy).toHaveBeenCalledWith("[sessionStore] read failed:", expect.any(String))
 
     errorSpy.mockRestore()
   })
 
-  it("warns and degrades gracefully when lock cannot be acquired", () => {
+  it("writes through a unique mode-0600 temporary file and leaves no artifacts", () => {
+    storeSharedSession("secure", "claude-secure")
+
     const sessionsPath = join(tmpDir, "sessions.json")
-    const lockPath = `${sessionsPath}.lock`
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {})
-
-    writeFileSync(lockPath, "")
-    storeSharedSession("lock-contention", "claude-fallback")
-
-    expect(lookupSharedSession("lock-contention")?.claudeSessionId).toBe("claude-fallback")
-    expect(warnSpy).toHaveBeenCalledWith("[sessionStore] could not acquire lock, proceeding without")
-
-    warnSpy.mockRestore()
+    expect(statSync(sessionsPath).mode & 0o777).toBe(0o600)
+    expect(readdirSync(tmpDir).filter((name) => name.includes(".tmp-"))).toEqual([])
+    expect(JSON.parse(readFileSync(sessionsPath, "utf8")).secure.claudeSessionId).toBe("claude-secure")
   })
 })
+
+function deadProcessIncarnation(pid: number) {
+  const current = captureProcessIncarnation()
+  if (!current) throw new Error("test process incarnation unavailable")
+  return { ...current, pid, bootId: "00000000-0000-4000-8000-000000000000" }
+}
+
+function writeRecoveryClaim(
+  path: string,
+  generation: string,
+  token: string,
+  pid: number,
+  ownerHostname = hostname(),
+): void {
+  const current = captureProcessIncarnation()
+  if (!current) throw new Error("test process incarnation unavailable")
+  const incarnation = ownerHostname !== hostname()
+    ? { ...current, pid, hostId: "b".repeat(64) }
+    : pid === process.pid
+      ? current
+      : { ...current, pid, bootId: "00000000-0000-4000-8000-000000000000" }
+  mkdirSync(path, { mode: 0o700 })
+  writeFileSync(join(path, "owner.json"), JSON.stringify({
+    version: 2,
+    generation,
+    token,
+    pid,
+    hostname: ownerHostname,
+    createdAt: 1,
+    incarnation,
+  }), { mode: 0o600 })
+}

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -9,12 +9,17 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import {
   lookupSharedSession,
   lookupSharedSessionByClaudeId,
+  lookupSharedSessionResult,
+  evictSharedSession,
   storeSharedSession,
   clearSharedSessions,
+  getSessionStoreDir,
+  readSessionStoreSnapshot,
+  readSessionStoreGenerationSnapshot,
   setSessionStoreDir,
 } from "../proxy/sessionStore"
 import { join } from "node:path"
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 
 describe("Shared session store", () => {
@@ -186,12 +191,193 @@ describe("Shared session store", () => {
     }
   })
 
-  it("should handle corrupted file gracefully", () => {
-    writeFileSync(join(tmpDir, "sessions.json"), "not json{{{")
-    const result = lookupSharedSession("anything")
-    expect(result).toBeUndefined()
-    // Should still be able to write after corruption
-    storeSharedSession("new-sess", "claude-new")
-    expect(lookupSharedSession("new-sess")!.claudeSessionId).toBe("claude-new")
+  it("keeps tolerant lookups but rejects strict reads and mutations on corruption", () => {
+    const sessionsPath = join(tmpDir, "sessions.json")
+    writeFileSync(sessionsPath, "not json{{{")
+
+    expect(lookupSharedSession("anything")).toBeUndefined()
+    expect(() => readSessionStoreSnapshot()).toThrow()
+    expect(() => storeSharedSession("new-sess", "claude-new")).toThrow()
+    expect(() => clearSharedSessions()).toThrow()
+    expect(readFileSync(sessionsPath, "utf8")).toBe("not json{{{")
   })
+
+  it("reports the overridden session store directory", () => {
+    expect(getSessionStoreDir()).toBe(tmpDir)
+  })
+
+  it("moves the exact transcript locator when the Claude session ID changes", () => {
+    const original = { sessionId: "claude-old", configDir: "/config-a", projectDir: "/project-a" }
+    const replacement = { sessionId: "claude-new", configDir: "/config-b" }
+    storeSharedSession(
+      "located-session", "claude-old", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, original
+    )
+
+    storeSharedSession(
+      "located-session", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, replacement,
+      { sessionId: "claude-old", configDir: "/fallback-must-not-win" }
+    )
+    expect(lookupSharedSession("located-session")).toMatchObject({
+      claudeSessionId: "claude-new",
+      previousClaudeSessionId: "claude-old",
+      currentTranscript: replacement,
+      previousTranscript: original,
+    })
+
+    // Updating the same ID without another locator preserves both locations.
+    storeSharedSession("located-session", "claude-new", 3)
+    expect(lookupSharedSession("located-session")).toMatchObject({
+      currentTranscript: replacement,
+      previousTranscript: original,
+    })
+
+    storeSharedSession("located-session", "claude-third")
+    expect(lookupSharedSession("located-session")?.currentTranscript).toBeUndefined()
+    expect(lookupSharedSession("located-session")?.previousTranscript).toEqual(replacement)
+
+    // Never reuse a locator that belongs to an older, non-immediate ID.
+    storeSharedSession("located-session", "claude-fourth")
+    expect(lookupSharedSession("located-session")?.previousTranscript).toBeUndefined()
+  })
+
+  it("uses a validated legacy source locator for the first managed fork", () => {
+    const source = { sessionId: "claude-legacy", configDir: "/legacy-config", projectDir: "/legacy-project" }
+    const current = { sessionId: "claude-managed", configDir: "/managed-config" }
+    storeSharedSession("legacy-fork", "claude-legacy")
+    storeSharedSession(
+      "legacy-fork", "claude-managed", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, current, source
+    )
+
+    expect(lookupSharedSession("legacy-fork")).toMatchObject({
+      previousClaudeSessionId: "claude-legacy",
+      currentTranscript: current,
+      previousTranscript: source,
+    })
+  })
+
+  it("validates transcript locators before changing the stored mapping", () => {
+    storeSharedSession("validated", "claude-original")
+    const before = readSessionStoreSnapshot()
+
+    expect(() => storeSharedSession(
+      "validated", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined,
+      { sessionId: "wrong-id", configDir: "/config" }
+    )).toThrow("currentTranscript.sessionId")
+    expect(() => storeSharedSession(
+      "validated", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined,
+      { sessionId: "claude-new", configDir: "relative/config" }
+    )).toThrow("currentTranscript.configDir")
+    expect(() => storeSharedSession(
+      "validated", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined,
+      { sessionId: "claude-new", configDir: "/config", projectDir: "relative/project" }
+    )).toThrow("currentTranscript.projectDir")
+    expect(() => storeSharedSession(
+      "validated", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      { sessionId: "not-claude-original", configDir: "/legacy-config" }
+    )).toThrow("sourceTranscript.sessionId")
+    expect(() => storeSharedSession(
+      "validated", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      { sessionId: "claude-original", configDir: "relative/legacy-config" }
+    )).toThrow("sourceTranscript.configDir")
+    expect(() => storeSharedSession(
+      "validated", "claude-new", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      { sessionId: "claude-original", configDir: "/legacy-config", projectDir: "relative/project" }
+    )).toThrow("sourceTranscript.projectDir")
+
+    expect(readSessionStoreSnapshot()).toEqual(before)
+  })
+
+  it("uses a key-bound expected-generation CAS and increments durable revisions", () => {
+    const first = storeSharedSession("cas", "sdk-a")
+    expect(typeof first).toBe("string")
+    expect(String(first)).toStartWith("p:")
+    expect(lookupSharedSession("cas")?.revision).toBe(1)
+
+    expect(storeSharedSession(
+      "cas", "sdk-stale", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, "wrong-source",
+    )).toBe(false)
+    expect(lookupSharedSession("cas")?.claudeSessionId).toBe("sdk-a")
+    expect(lookupSharedSession("cas")?.revision).toBe(1)
+
+    const second = storeSharedSession(
+      "cas", "sdk-b", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, first || undefined,
+    )
+    expect(typeof second).toBe("string")
+    expect(second).not.toBe(first)
+    expect(lookupSharedSession("cas")?.claudeSessionId).toBe("sdk-b")
+    expect(lookupSharedSession("cas")?.revision).toBe(2)
+  })
+
+  it("snapshots key-bound absence for every configured profile scope", () => {
+    const snapshot = readSessionStoreGenerationSnapshot("client-session", ["default", "work", "personal"])
+    expect(snapshot["client-session"]).toMatch(/^a:/)
+    expect(snapshot["work:client-session"]).toMatch(/^a:/)
+    expect(snapshot["personal:client-session"]).toMatch(/^a:/)
+    expect(new Set(Object.values(snapshot))).toHaveLength(3)
+  })
+
+  it("rejects replacement, delete/recreate, and absent-key ABA by exact generation", () => {
+    const first = storeSharedSession("aba", "sdk-a")
+    expect(typeof first).toBe("string")
+    const second = storeSharedSession(
+      "aba", "sdk-b", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, first || undefined,
+    )
+    const third = storeSharedSession(
+      "aba", "sdk-a", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, second || undefined,
+    )
+    expect(typeof third).toBe("string")
+    expect(storeSharedSession(
+      "aba", "sdk-stale", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, first || undefined,
+    )).toBe(false)
+    expect(evictSharedSession("aba", first || undefined)).toBe(false)
+    expect(evictSharedSession("aba", third || undefined)).toBe(true)
+
+    const absentAfterDelete = lookupSharedSessionResult("aba")
+    expect(absentAfterDelete.status).toBe("missing")
+    const recreated = storeSharedSession(
+      "aba", "sdk-recreated", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined,
+      absentAfterDelete.status === "missing" ? absentAfterDelete.generation : undefined,
+    )
+    expect(typeof recreated).toBe("string")
+    expect(storeSharedSession(
+      "aba", "sdk-stale-after-recreate", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, third || undefined,
+    )).toBe(false)
+
+    const neverSeen = lookupSharedSessionResult("never-seen")
+    expect(neverSeen.status).toBe("missing")
+    const initialAbsence = neverSeen.status === "missing" ? neverSeen.generation : undefined
+    const created = storeSharedSession(
+      "never-seen", "sdk-created", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, initialAbsence,
+    )
+    expect(typeof created).toBe("string")
+    expect(evictSharedSession("never-seen", created || undefined)).toBe(true)
+    const alreadyAbsent = lookupSharedSessionResult("never-seen")
+    expect(alreadyAbsent.status).toBe("missing")
+    expect(evictSharedSession(
+      "never-seen",
+      alreadyAbsent.status === "missing" ? alreadyAbsent.generation : undefined,
+    )).toBe(true)
+    expect(storeSharedSession(
+      "never-seen", "sdk-stale-absence", undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, initialAbsence,
+    )).toBe(false)
+  })
+
 })

--- a/src/__tests__/proxy-silent-logging.test.ts
+++ b/src/__tests__/proxy-silent-logging.test.ts
@@ -8,12 +8,16 @@
  * while leaving the structured telemetry (claudeLog) and HTTP responses intact.
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => (async function* () { for (const msg of mockMessages) yield msg })(),
+  query: (params: any) => (async function* () {
+    for (const msg of mockMessages) {
+      yield withMockSdkSessionId(msg, params.options)
+    }
+  })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
 }))

--- a/src/__tests__/proxy-source-header.test.ts
+++ b/src/__tests__/proxy-source-header.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedQueryParams: any = null
@@ -22,7 +22,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-source-keyed-session.test.ts
+++ b/src/__tests__/proxy-source-keyed-session.test.ts
@@ -15,16 +15,18 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedOptions: any[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
-    capturedOptions.push(params.options || {})
+    const options = params.options || {}
+    capturedOptions.push(options)
+    const sessionId = resolveMockSdkSessionId(options, "test-session")
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) yield { ...(msg as object), session_id: sessionId }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
@@ -93,7 +95,7 @@ describe("explicit session keys override the independence guard", () => {
     expect((await post(app, TURN_2, headers)).status).toBe(200)
     expect(capturedOptions).toHaveLength(2)
     expect(capturedOptions[0].resume).toBeUndefined()
-    expect(capturedOptions[1].resume).toBe("test-session")
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
   })
 
   it("keyed OpenCode subagent mode resumes across turns", async () => {
@@ -106,7 +108,7 @@ describe("explicit session keys override the independence guard", () => {
     expect((await post(app, TURN_2, headers)).status).toBe(200)
     expect(capturedOptions).toHaveLength(2)
     expect(capturedOptions[0].resume).toBeUndefined()
-    expect(capturedOptions[1].resume).toBe("test-session")
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
   })
 
   it("pi subagent-worker WITHOUT a session key keeps the independence guard (no resume)", async () => {
@@ -136,7 +138,7 @@ describe("explicit session keys override the independence guard", () => {
     await post(app, TURN_1, headers)
     await post(app, TURN_2, headers)
     expect(capturedOptions).toHaveLength(2)
-    expect(capturedOptions[1].resume).toBe("test-session")
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
   })
 })
 
@@ -188,7 +190,7 @@ describe("OMP body session identity survives the tool-result bypass (#734)", () 
     expect((await post(app, TOOL_TURN_2, headers)).status).toBe(200)
     expect(capturedOptions).toHaveLength(2)
     expect(capturedOptions[0].resume).toBeUndefined()
-    expect(capturedOptions[1].resume).toBe("test-session")
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
   })
 
   it("still refuses to resume a tool-result turn with no identity at all", async () => {
@@ -222,6 +224,6 @@ describe("OMP body session identity survives the tool-result bypass (#734)", () 
     await post(app, { ...TOOL_TURN_2, ...OMP("a-different-body-id") }, headers)
     expect(capturedOptions).toHaveLength(2)
     // Same header across both turns, so it resumes despite the body id changing.
-    expect(capturedOptions[1].resume).toBe("test-session")
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
   })
 })

--- a/src/__tests__/proxy-source-skip-cache.test.ts
+++ b/src/__tests__/proxy-source-skip-cache.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedQueryParams: any = null
@@ -24,7 +24,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-stale-uuid-retry.test.ts
+++ b/src/__tests__/proxy-stale-uuid-retry.test.ts
@@ -6,7 +6,22 @@
  * and retry as a fresh session instead of propagating the error.
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir, storeSharedSession } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  // Request completion releases the cross-process lease asynchronously.
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
 import {
   messageStart,
   textBlockStart,
@@ -14,20 +29,28 @@ import {
   blockStop,
   messageDelta,
   messageStop,
+  resolveMockSdkSessionId,
+  withMockSdkSessionId,
 } from "./helpers"
 
 // Track query calls to verify retry behavior
 let queryCalls: Array<Record<string, any>> = []
+let queryParams: any[] = []
 let queryCallCount = 0
+let queryMutation: ((options: Record<string, any>) => void) | undefined
+let forcedQueryError: Error | undefined
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     queryCallCount++
     const callIndex = queryCallCount
     queryCalls.push(opts.options || {})
+    queryParams.push(opts)
     const isStreaming = opts.options?.includePartialMessages === true
 
     return (async function* () {
+      queryMutation?.(opts.options || {})
+      if (forcedQueryError) throw forcedQueryError
       // First call with resumeSessionAt: simulate stale UUID error
       if (callIndex === 1 && opts.options?.resumeSessionAt) {
         throw new Error(
@@ -36,12 +59,12 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       }
       // Success: yield appropriate message type
       if (isStreaming) {
-        yield messageStart(`msg-${callIndex}`)
-        yield textBlockStart(0)
-        yield textDelta(0, `response-${callIndex}`)
-        yield blockStop(0)
-        yield messageDelta("end_turn")
-        yield messageStop()
+        yield withMockSdkSessionId(messageStart(`msg-${callIndex}`), opts.options)
+        yield withMockSdkSessionId(textBlockStart(0), opts.options)
+        yield withMockSdkSessionId(textDelta(0, `response-${callIndex}`), opts.options)
+        yield withMockSdkSessionId(blockStop(0), opts.options)
+        yield withMockSdkSessionId(messageDelta("end_turn"), opts.options)
+        yield withMockSdkSessionId(messageStop(), opts.options)
       }
       yield {
         type: "assistant",
@@ -55,7 +78,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 10, output_tokens: 5 },
         },
-        session_id: `sdk-fresh-${callIndex}`,
+        session_id: resolveMockSdkSessionId(opts.options, `sdk-fresh-${callIndex}`),
       }
     })()
   },
@@ -94,7 +117,10 @@ describe("Stale UUID retry", () => {
   beforeEach(() => {
     clearSessionCache()
     queryCalls = []
+    queryParams = []
     queryCallCount = 0
+    queryMutation = undefined
+    forcedQueryError = undefined
   })
 
   it("retries as fresh session when undo hits stale UUID (non-streaming)", async () => {
@@ -142,6 +168,54 @@ describe("Stale UUID retry", () => {
     expect(queryCalls[1]!.resume).toBeUndefined()
     expect(queryCalls[1]!.forkSession).toBeUndefined()
     expect(queryCalls[1]!.resumeSessionAt).toBeUndefined()
+    expect(queryCalls[1]!.sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(queryCalls[1]!.sessionId).not.toBe(queryCalls[0]!.sessionId)
+  })
+
+  it("replays the full undo history without rollback options after project drift", async () => {
+    const app = createTestApp()
+    const sessionId = "sess-undo-project-drift"
+    const oldDir = join(isolatedSessionDir, "old-project")
+    const newDir = join(isolatedSessionDir, "new-project")
+    mkdirSync(oldDir)
+    mkdirSync(newDir)
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something" },
+      { role: "assistant", content: "done" },
+    ]
+    storeSession(
+      sessionId,
+      messages,
+      "sdk-old-project",
+      oldDir,
+      [null, "uuid-assistant-1", null, "uuid-assistant-2"],
+      undefined,
+      undefined,
+      undefined,
+      { sessionId: "sdk-old-project", configDir: join(process.env.HOME!, ".claude"), projectDir: oldDir },
+    )
+    const undoMessages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+      { role: "user", content: "do something different" },
+    ]
+    const response = await post(app, {
+      model: "sonnet",
+      stream: false,
+      system: `<env>\nWorking directory: ${newDir}\n</env>`,
+      messages: undoMessages,
+    }, { "x-opencode-session": sessionId })
+
+    expect(response.status).toBe(200)
+    expect(queryCalls).toHaveLength(1)
+    expect(queryCalls[0]!.resume).toBeUndefined()
+    expect(queryCalls[0]!.resumeSessionAt).toBeUndefined()
+    expect(queryCalls[0]!.forkSession).toBeUndefined()
+    expect(String(queryParams[0].prompt)).toContain("hello")
+    expect(String(queryParams[0].prompt)).toContain("hi there")
+    expect(String(queryParams[0].prompt)).toContain("do something different")
   })
 
   it("retries as fresh session when undo hits stale UUID (streaming)", async () => {
@@ -182,6 +256,8 @@ describe("Stale UUID retry", () => {
     // Verify retry happened: first call with resumeSessionAt, second without
     expect(queryCalls[0]!.resumeSessionAt).toBe("uuid-assistant-1")
     expect(queryCalls[1]!.resumeSessionAt).toBeUndefined()
+    expect(queryCalls[1]!.sessionId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(queryCalls[1]!.sessionId).not.toBe(queryCalls[0]!.sessionId)
   })
 
   it("evicts stale session from cache after retry", async () => {
@@ -237,6 +313,45 @@ describe("Stale UUID retry", () => {
     // The second request should NOT have resumeSessionAt
     // (it may have resume if the fresh session was stored, which is fine)
     expect(queryCalls[0]!.resumeSessionAt).toBeUndefined()
+  })
+
+  it("does not quarantine an immutable source when an isolated fork loses publication CAS", async () => {
+    const app = createTestApp()
+    const sessionId = `eviction-cas-${crypto.randomUUID()}`
+    const originalMessages = [{ role: "user", content: "hello" }]
+    storeSession(sessionId, originalMessages, "sdk-source", "/tmp/test", [null])
+
+    queryMutation = () => {
+      queryMutation = undefined
+      // Simulate another proxy advancing this exact durable key after this
+      // process opened the source transcript but before mandatory invalidation.
+      storeSharedSession(sessionId, "sdk-successor", 1, "successor", ["successor"])
+    }
+    forcedQueryError = new Error("terminal resumed query failure")
+    const continuation = [
+      ...originalMessages,
+      { role: "assistant", content: "hi" },
+      { role: "user", content: "continue" },
+    ]
+    const failed = await post(
+      app,
+      { model: "sonnet", stream: false, messages: continuation },
+      { "x-opencode-session": sessionId },
+    )
+    expect(failed.status).toBe(500)
+    expect(queryCallCount).toBe(1)
+
+    const abort = new AbortController()
+    const timer = setTimeout(() => abort.abort(), 50)
+    const blocked = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-opencode-session": sessionId },
+      body: JSON.stringify({ model: "sonnet", stream: false, messages: continuation }),
+      signal: abort.signal,
+    }))
+    clearTimeout(timer)
+    expect(blocked.status).toBe(500)
+    expect(queryCallCount).toBe(2)
   })
 
   it("propagates non-stale errors normally", async () => {

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -267,6 +267,6 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     expect(capturedResume ?? "(fresh)").toBe("test-session")
     expect(capturedResumeSessionAt).toBe(resumeBoundary)
     expect(denyUuids).not.toContain(capturedResumeSessionAt)
-    expect(capturedForkSession).toBeUndefined()
+    expect(capturedForkSession).toBe(true)
   })
 })

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -24,11 +24,27 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { makeRequest, parseSSE } from "./helpers"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  // Request completion releases the cross-process lease asynchronously.
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
+import { makeRequest, parseSSE, resolveMockSdkSessionId } from "./helpers"
 
 const PREFIX = "mcp__oc__"
 
 let capturedController: AbortController | undefined
+let capturedSessionId: string | undefined
 let capturedResume: string | undefined
 let capturedResumeSessionAt: string | undefined
 let capturedForkSession: boolean | undefined
@@ -41,36 +57,36 @@ let denyDelayMs = 0
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
-const streamEvent = (event: any) => ({
+const streamEvent = (event: any, sessionId: string) => ({
   type: "stream_event", event, parent_tool_use_id: null,
-  uuid: crypto.randomUUID(), session_id: "test-session",
+  uuid: crypto.randomUUID(), session_id: sessionId,
 })
-const msgStart = () => streamEvent({
+const msgStart = (sessionId: string) => streamEvent({
   type: "message_start",
   message: { id: "m1", type: "message", role: "assistant", content: [], model: "claude-sonnet-4-5-20250929", stop_reason: null, stop_sequence: null, usage: { input_tokens: 10, output_tokens: 0 } },
-})
-const blockStart = (idx: number, name: string, id: string) =>
-  streamEvent({ type: "content_block_start", index: idx, content_block: { type: "tool_use", id, name: `${PREFIX}${name}`, input: {} } })
-const blockDelta = (idx: number, json: string) =>
-  streamEvent({ type: "content_block_delta", index: idx, delta: { type: "input_json_delta", partial_json: json } })
-const blockStop = (idx: number) => streamEvent({ type: "content_block_stop", index: idx })
-const msgDelta = () => streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } })
-const assistantMsg = (blocks: any[]) => {
+}, sessionId)
+const blockStart = (idx: number, name: string, id: string, sessionId: string) =>
+  streamEvent({ type: "content_block_start", index: idx, content_block: { type: "tool_use", id, name: `${PREFIX}${name}`, input: {} } }, sessionId)
+const blockDelta = (idx: number, json: string, sessionId: string) =>
+  streamEvent({ type: "content_block_delta", index: idx, delta: { type: "input_json_delta", partial_json: json } }, sessionId)
+const blockStop = (idx: number, sessionId: string) => streamEvent({ type: "content_block_stop", index: idx }, sessionId)
+const msgDelta = (sessionId: string) => streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } }, sessionId)
+const assistantMsg = (blocks: any[], sessionId: string) => {
   const uuid = crypto.randomUUID()
   if (blocks.some((block) => block?.type === "tool_use")) assistantToolUuids.push(uuid)
   return {
     type: "assistant",
     message: { id: "m1", type: "message", role: "assistant", content: blocks, model: "claude-sonnet-4-5-20250929", stop_reason: "tool_use", usage: { input_tokens: 10, output_tokens: 30 } },
-    parent_tool_use_id: null, uuid, session_id: "test-session",
+    parent_tool_use_id: null, uuid, session_id: sessionId,
   }
 }
-const denyMsg = (ids: string[]) => {
+const denyMsg = (ids: string[], sessionId: string) => {
   const uuid = crypto.randomUUID()
   denyUuids.push(uuid)
   return {
     type: "user",
     message: { role: "user", content: ids.map((id) => ({ type: "tool_result", tool_use_id: id, is_error: true, content: "denied" })) },
-    parent_tool_use_id: null, uuid, session_id: "test-session",
+    parent_tool_use_id: null, uuid, session_id: sessionId,
   }
 }
 
@@ -79,24 +95,26 @@ const denyMsg = (ids: string[]) => {
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedController = opts?.options?.abortController
+    capturedSessionId = opts?.options?.sessionId
     capturedResume = opts?.options?.resume
     capturedResumeSessionAt = opts?.options?.resumeSessionAt
     capturedForkSession = opts?.options?.forkSession
+    const sessionId = resolveMockSdkSessionId(opts?.options, "test-session")
     const hook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
     return (async function* () {
       if (!hook) {
         // Follow-up turn (no tools emitted): plain final answer.
-        yield assistantMsg([{ type: "text", text: "All done." }])
+        yield assistantMsg([{ type: "text", text: "All done." }], sessionId)
         return
       }
-      yield msgStart()
+      yield msgStart(sessionId)
       timeline.push("message_start")
 
       // bash block streams fully, then its hook dispatches MID-STREAM.
-      yield blockStart(2, "bash", "tb1")
-      yield blockDelta(2, '{"command":"ls /tmp"}')
-      yield assistantMsg([{ type: "tool_use", id: "tb1", name: `${PREFIX}bash`, input: { command: "ls /tmp" } }])
-      yield blockStop(2)
+      yield blockStart(2, "bash", "tb1", sessionId)
+      yield blockDelta(2, '{"command":"ls /tmp"}', sessionId)
+      yield assistantMsg([{ type: "tool_use", id: "tb1", name: `${PREFIX}bash`, input: { command: "ls /tmp" } }], sessionId)
+      yield blockStop(2, sessionId)
       let bashDenied = false
       const bashHook = Promise.resolve(
         hook({ tool_name: `${PREFIX}bash`, tool_use_id: "tb1", tool_input: { command: "ls /tmp" } }, undefined, { signal: new AbortController().signal })
@@ -110,36 +128,36 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         // turn's message_delta never arrives, turn 2 begins. This is the
         // exact field behavior from kabo's v1.49.1 transcript.
         timeline.push("CANCELED")
-        yield blockStart(3, "glob", "tg1")
-        yield blockDelta(3, '{"patt') // cut mid-JSON
-        yield denyMsg(["tb1"])
-        yield msgStart() // turn 2
+        yield blockStart(3, "glob", "tg1", sessionId)
+        yield blockDelta(3, '{"patt', sessionId) // cut mid-JSON
+        yield denyMsg(["tb1"], sessionId)
+        yield msgStart(sessionId) // turn 2
         timeline.push("turn2_message_start")
         return
       }
 
       // Held deny → generation completes normally.
-      yield blockStart(3, "glob", "tg1")
-      yield blockDelta(3, '{"pattern":"*.md"}')
-      yield assistantMsg([{ type: "tool_use", id: "tg1", name: `${PREFIX}glob`, input: { pattern: "*.md" } }])
-      yield blockStop(3)
+      yield blockStart(3, "glob", "tg1", sessionId)
+      yield blockDelta(3, '{"pattern":"*.md"}', sessionId)
+      yield assistantMsg([{ type: "tool_use", id: "tg1", name: `${PREFIX}glob`, input: { pattern: "*.md" } }], sessionId)
+      yield blockStop(3, sessionId)
       timeline.push("glob_streamed")
       const globHook = Promise.resolve(
         hook({ tool_name: `${PREFIX}glob`, tool_use_id: "tg1", tool_input: { pattern: "*.md" } }, undefined, { signal: new AbortController().signal })
       ).then(() => timeline.push("glob_deny_resolved"))
 
-      yield msgDelta()
+      yield msgDelta(sessionId)
       timeline.push("message_delta")
 
       await bashHook
       await globHook
       if (denyDelayMs > 0) await sleep(denyDelayMs)
-      yield denyMsg(["tb1"])
-      yield denyMsg(["tg1"])
+      yield denyMsg(["tb1"], sessionId)
+      yield denyMsg(["tg1"], sessionId)
       timeline.push("post_denies")
-      yield assistantMsg([{ type: "text", text: "turn 2 digest garbage" }])
+      yield assistantMsg([{ type: "text", text: "turn 2 digest garbage" }], sessionId)
       timeline.push("turn2_consumed")
-      yield { type: "result", subtype: "success", is_error: false, session_id: "test-session" }
+      yield { type: "result", subtype: "success", is_error: false, session_id: sessionId }
       timeline.push("canonical_result")
     })()
   },
@@ -198,6 +216,7 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     timeline = []
     denyDelayMs = 0
     capturedController = undefined
+    capturedSessionId = undefined
     capturedResume = undefined
     capturedResumeSessionAt = undefined
     capturedForkSession = undefined
@@ -249,6 +268,9 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     denyDelayMs = 150 // denies (and thus the store) land after the client response
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
     await postStream(app, "hold-3", [{ role: "user", content: "test tools" }])
+    const initialSessionId = capturedSessionId
+    expect(initialSessionId).toMatch(/^[0-9a-f-]{36}$/)
+    if (!initialSessionId) throw new Error("missing caller-selected session ID")
 
     // Immediately send the follow-up — before the drain could have stored.
     capturedResume = undefined
@@ -264,9 +286,9 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
       ]},
     ])
     const resumeBoundary = assistantToolUuids[1]
-    expect(capturedResume ?? "(fresh)").toBe("test-session")
+    expect(capturedResume ?? "(fresh)").toBe(initialSessionId)
     expect(capturedResumeSessionAt).toBe(resumeBoundary)
-    expect(denyUuids).not.toContain(capturedResumeSessionAt)
+    expect(denyUuids).not.toContain(capturedResumeSessionAt!)
     expect(capturedForkSession).toBe(true)
   })
 })

--- a/src/__tests__/proxy-stream-error-recovery.test.ts
+++ b/src/__tests__/proxy-stream-error-recovery.test.ts
@@ -28,17 +28,18 @@ import {
   textDelta,
   blockStop,
   parseSSE,
+  withMockSdkSessionId,
 } from "./helpers"
 
 let mockMessages: any[] = []
 let mockErrorAfter: number | null = null
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     return (async function* () {
       let yielded = 0
       for (const msg of mockMessages) {
-        yield msg
+        yield withMockSdkSessionId(msg, params.options)
         yielded++
         if (mockErrorAfter !== null && yielded >= mockErrorAfter) {
           throw new Error("429 Too Many Requests - rate limit exceeded")

--- a/src/__tests__/proxy-streaming-message.test.ts
+++ b/src/__tests__/proxy-streaming-message.test.ts
@@ -24,14 +24,17 @@ import {
   assistantMessage,
   parseSSE,
   streamEvent,
+  withMockSdkSessionId,
 } from "./helpers"
 
 let mockMessages: any[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-structured-output-hook.test.ts
+++ b/src/__tests__/proxy-structured-output-hook.test.ts
@@ -76,13 +76,15 @@ function resultMessage(withStructuredOutput: boolean) {
   return base
 }
 
+import { withMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: { options?: Record<string, unknown> }) => {
     capturedOptions = opts.options ?? {}
     return (async function* () {
       const preHook = (opts.options as any)?.hooks?.PreToolUse?.[0]?.hooks?.[0]
       const turn = structuredOutputTurn()
-      yield turn
+      yield withMockSdkSessionId(turn, opts.options)
       let denied = false
       if (preHook) {
         const res = await preHook({
@@ -93,7 +95,8 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
         denied = !!res && res.decision === "block"
       }
       hookDeniedStructuredOutput = denied
-      yield resultMessage(!denied)
+      const result = resultMessage(!denied)
+      yield withMockSdkSessionId(result, opts.options)
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),

--- a/src/__tests__/proxy-structured-output.test.ts
+++ b/src/__tests__/proxy-structured-output.test.ts
@@ -3,13 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 let capturedOptions: Record<string, unknown> = {}
 let mockMessages: unknown[] = []
 let queryCalls = 0
+let waitBeforeMessages: Promise<void> | undefined
+
+import { withMockSdkSessionId } from "./helpers"
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: { options?: Record<string, unknown> }) => {
     queryCalls += 1
     capturedOptions = params.options ?? {}
     return (async function* () {
-      for (const message of mockMessages) yield message
+      if (waitBeforeMessages) await waitBeforeMessages
+      for (const message of mockMessages) {
+        yield withMockSdkSessionId(message, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
@@ -26,6 +32,11 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const {
+  clearSharedSessions,
+  evictSharedSession,
+  lookupSharedSessionResult,
+} = await import("../proxy/sessionStore")
 
 const schema = {
   type: "object",
@@ -58,11 +69,15 @@ function resultMessage(structuredOutput: unknown) {
 function request(
   stream: boolean,
   outputConfig: unknown = { format: { type: "json_schema", schema } },
-  extra: Record<string, unknown> = {}
+  extra: Record<string, unknown> = {},
+  sessionId?: string,
 ) {
   return new Request("http://localhost/v1/messages", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...(sessionId ? { "x-opencode-session": sessionId } : {}),
+    },
     body: JSON.stringify({
       model: "claude-sonnet-4-6",
       max_tokens: 512,
@@ -83,7 +98,9 @@ describe("native structured output", () => {
     capturedOptions = {}
     mockMessages = []
     queryCalls = 0
+    waitBeforeMessages = undefined
     clearSessionCache()
+    clearSharedSessions()
   })
 
   afterEach(() => {
@@ -119,6 +136,77 @@ describe("native structured output", () => {
     expect(body).toContain('"text":"{\\"answer\\":\\"streamed\\"}"')
     expect(body).toContain('"stop_reason":"end_turn"')
     expect(body).toContain("event: message_stop")
+  })
+
+  it("withholds resumed structured success when exact publication loses its CAS", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const sessionId = "structured-publication-order"
+    mockMessages = [resultMessage({ answer: "seed" })]
+    const seed = await app.fetch(request(false, undefined, {}, sessionId))
+    expect(seed.status).toBe(200)
+    await seed.text()
+
+    const source = lookupSharedSessionResult(sessionId)
+    expect(source.status).toBe("found")
+    if (source.status !== "found") throw new Error("seed mapping was not stored")
+    expect(source.generation).toBeDefined()
+
+    let releaseResult = () => {}
+    waitBeforeMessages = new Promise<void>((resolve) => { releaseResult = resolve })
+    mockMessages = [resultMessage({ answer: "must-not-finalize" })]
+    const responsePromise = app.fetch(request(true, undefined, {
+      messages: [
+        { role: "user", content: "Return an answer." },
+        { role: "assistant", content: '{"answer":"seed"}' },
+        { role: "user", content: "Return another answer." },
+      ],
+    }, sessionId))
+
+    for (let index = 0; index < 1_000 && queryCalls < 2; index++) await Bun.sleep(1)
+    expect(queryCalls).toBe(2)
+    expect(evictSharedSession(sessionId, source.generation)).toBe(true)
+    releaseResult()
+
+    const response = await responsePromise
+    const body = await response.text()
+    expect(body).toContain("event: error")
+    expect(body).not.toContain('"stop_reason":"end_turn"')
+    expect(body).not.toContain("must-not-finalize")
+  })
+
+  it("never publishes a resumed structured target canceled before its buffered envelope", async () => {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const sessionId = "structured-cancel-order"
+    mockMessages = [resultMessage({ answer: "seed" })]
+    const seed = await app.fetch(request(false, undefined, {}, sessionId))
+    await seed.text()
+    const source = lookupSharedSessionResult(sessionId)
+    if (source.status !== "found") throw new Error("seed mapping was not stored")
+
+    let releaseResult = () => {}
+    waitBeforeMessages = new Promise<void>((resolve) => { releaseResult = resolve })
+    mockMessages = [resultMessage({ answer: "canceled-hidden-turn" })]
+    const response = await app.fetch(request(true, undefined, {
+      messages: [
+        { role: "user", content: "Return an answer." },
+        { role: "assistant", content: '{"answer":"seed"}' },
+        { role: "user", content: "Return another answer." },
+      ],
+    }, sessionId))
+    for (let index = 0; index < 1_000 && queryCalls < 2; index++) await Bun.sleep(1)
+    expect(queryCalls).toBe(2)
+    const canceledTarget = capturedOptions.sessionId
+    expect(canceledTarget).not.toBe(source.session.claudeSessionId)
+
+    await response.body!.cancel("structured test cancellation")
+    releaseResult()
+    await Bun.sleep(100)
+
+    const durable = lookupSharedSessionResult(sessionId)
+    expect(durable.status).toBe("found")
+    if (durable.status !== "found") throw new Error("source mapping was not preserved")
+    expect(durable.session.claudeSessionId).toBe(source.session.claudeSessionId)
+    expect(durable.session.claudeSessionId).not.toBe(canceledTarget)
   })
 
   it("rejects requests that combine tools with output_config.format", async () => {

--- a/src/__tests__/proxy-subagent-model-selection.test.ts
+++ b/src/__tests__/proxy-subagent-model-selection.test.ts
@@ -11,6 +11,8 @@ import { describe, it, expect, mock, beforeEach } from "bun:test"
 let capturedModel: string | null = null
 let capturedOptions: any = null
 
+import { resolveMockSdkSessionId } from "./helpers"
+
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedOptions = opts.options
@@ -28,7 +30,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
           stop_reason: "end_turn",
           usage: { input_tokens: 5, output_tokens: 2 },
         },
-        session_id: "sdk-session-1",
+        session_id: resolveMockSdkSessionId(opts.options, "sdk-session-1"),
       }
     })()
   },

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -22,6 +22,7 @@ import {
   makeRequest,
   makeToolResultRequest,
   parseSSE,
+  withMockSdkSessionId,
 } from "./helpers"
 
 // --- Capture SDK calls ---
@@ -35,7 +36,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     queryCallCount++
     return (async function* () {
       for (const msg of mockMessages) {
-        yield msg
+        yield withMockSdkSessionId(msg, params.options)
       }
     })()
   },

--- a/src/__tests__/proxy-system-reminder-preservation.test.ts
+++ b/src/__tests__/proxy-system-reminder-preservation.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -23,7 +23,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-thinking-setting.test.ts
+++ b/src/__tests__/proxy-thinking-setting.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 // ─── controllable sdk-features state ──────────────────────────────────────────
 // `explicitThinking` = the raw, user-configured value (undefined = unset/default).
@@ -50,7 +50,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
     capturedOptions = params.options ?? {}
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/proxy-tool-blocking.test.ts
+++ b/src/__tests__/proxy-tool-blocking.test.ts
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 let capturedQueryParams: any = null
 let mockMessages: any[] = []
@@ -26,7 +26,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedQueryParams = params
     return (async function* () {
       for (const msg of mockMessages) {
-        yield { ...msg, session_id: "sdk-test" }
+        yield { ...msg, session_id: resolveMockSdkSessionId(params.options, "sdk-test") }
       }
     })()
   },

--- a/src/__tests__/proxy-tool-cache.test.ts
+++ b/src/__tests__/proxy-tool-cache.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
-import { assistantMessage, makeRequest, READ_TOOL } from "./helpers"
+import { assistantMessage, makeRequest, READ_TOOL, withMockSdkSessionId } from "./helpers"
 
 let capturedQueryParams: any = null
 let mockMessages: any[] = []
@@ -14,7 +14,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({

--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -14,7 +14,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
@@ -22,7 +22,7 @@ type TestApp = { fetch: (req: Request) => Promise<Response> }
 let mockMessages: MockSdkMessage[] = []
 interface CapturedParams {
   prompt?: unknown
-  options?: { resume?: string; forkSession?: boolean }
+  options?: { resume?: string; forkSession?: boolean; sessionId?: string }
 }
 let capturedParams: CapturedParams | null = null
 let queuedSessionIds: string[] = []
@@ -30,8 +30,10 @@ function getCaptured(): CapturedParams | null { return capturedParams }
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
-    capturedParams = params as any
-    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    capturedParams = params as CapturedParams
+    const options = (params as CapturedParams).options
+    const queuedSessionId = queuedSessionIds.shift() || "sdk-session-default"
+    const sessionId = resolveMockSdkSessionId(options, queuedSessionId)
     return (async function* () {
       for (const msg of mockMessages) {
         yield { ...msg, session_id: sessionId }
@@ -136,13 +138,15 @@ describe("Issue #386 — tool_use blocks must not leak into SDK prompt as text",
     await postWithSession(app, "sess-continue", [
       { role: "user", content: "write a hello.txt file" },
     ], "sdk-continue")
+    const initialSessionId = getCaptured()?.options?.sessionId
+    expect(initialSessionId).toMatch(/^[0-9a-f-]{36}$/)
 
     // Turn 2 — continuation with full history including tool_use/tool_result blocks
     capturedParams = null
     await postWithSession(app, "sess-continue", history, "sdk-continue")
 
     // Must resume (lineage=continuation) and must not have flattened tool blocks into text
-    expect(getCaptured()?.options?.resume).toBe("sdk-continue")
+    expect(getCaptured()?.options?.resume).toBe(initialSessionId)
     assertNoFlattenedToolBlocks(getCaptured()?.prompt)
   })
 
@@ -320,6 +324,8 @@ describe("transcript-format imitation (#496 self-talk regression)", () => {
     await postWithSession(app, "sess-selftalk", [
       { role: "user", content: "edit the config file" },
     ], "sdk-selftalk")
+    const initialSessionId = getCaptured()?.options?.sessionId
+    expect(initialSessionId).toMatch(/^[0-9a-f-]{36}$/)
 
     // Turn 2 — client returns the executed tool round-trip
     capturedParams = null
@@ -334,7 +340,7 @@ describe("transcript-format imitation (#496 self-talk regression)", () => {
       ]},
     ], "sdk-selftalk")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-selftalk")
+    expect(getCaptured()?.options?.resume).toBe(initialSessionId)
     const prompt = promptToString(getCaptured()?.prompt)
     expect(prompt).not.toMatch(transcriptMarker)
     // The assistant's delta text must NOT be replayed — the resumed SDK

--- a/src/__tests__/proxy-tool-forwarding.test.ts
+++ b/src/__tests__/proxy-tool-forwarding.test.ts
@@ -26,16 +26,17 @@ import {
   parseSSE,
   READ_TOOL,
   makeToolRequest,
+  withMockSdkSessionId,
 } from "./helpers"
 
 // --- Mock the Claude SDK ---
 let mockMessages: any[] = []
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: () => {
+  query: (params: any) => {
     return (async function* () {
       for (const msg of mockMessages) {
-        yield msg
+        yield withMockSdkSessionId(msg, params.options)
       }
     })()
   },

--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -24,6 +24,7 @@ import {
   makeRequest,
   makeToolResultRequest,
   parseSSE,
+  withMockSdkSessionId,
 } from "./helpers"
 
 // --- Capture SDK calls ---
@@ -35,7 +36,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     capturedQueryParams = params
     return (async function* () {
       for (const msg of mockMessages) {
-        yield msg
+        yield withMockSdkSessionId(msg, params.options)
       }
     })()
   },

--- a/src/__tests__/proxy-working-directory.test.ts
+++ b/src/__tests__/proxy-working-directory.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 import { tmpdir } from "node:os"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
@@ -22,7 +22,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -2,7 +2,7 @@
  * Tests for the SDK query options builder.
  */
 import { describe, it, expect } from "bun:test"
-import { buildQueryOptions, GIT_STATUS_PROVENANCE_NOTE, type QueryContext } from "../proxy/query"
+import { buildQueryOptions, GIT_STATUS_PROVENANCE_NOTE, resolveQueryConfigDir, type QueryContext } from "../proxy/query"
 import { BLOCKED_BUILTIN_TOOLS, CLAUDE_CODE_ONLY_TOOLS, MCP_SERVER_NAME, ALLOWED_MCP_TOOLS } from "../proxy/tools"
 import { CHERRY_BLOCKED_BUILTIN_TOOLS, CHERRY_INCOMPATIBLE_TOOLS, CHERRY_WEB_TOOLS } from "../proxy/adapters/cherry"
 
@@ -27,6 +27,39 @@ function makeContext(overrides: Partial<QueryContext> = {}): QueryContext {
     ...overrides,
   }
 }
+
+
+describe("resolveQueryConfigDir", () => {
+  it("uses the exact custom profile root", () => {
+    expect(resolveQueryConfigDir({ CLAUDE_CONFIG_DIR: "/profiles/custom", HOME: "/home/test" }, false))
+      .toBe("/profiles/custom")
+  })
+
+  it("uses the child HOME default when shared memory strips a custom root", () => {
+    expect(resolveQueryConfigDir({ CLAUDE_CONFIG_DIR: "/profiles/custom", HOME: "/home/test" }, true))
+      .toBe("/home/test/.claude")
+  })
+
+  it("resolves a relative custom root from the SDK child working directory", () => {
+    expect(resolveQueryConfigDir(
+      { CLAUDE_CONFIG_DIR: "profiles/custom", HOME: "/home/test" },
+      false,
+      "/srv/project",
+    )).toBe("/srv/project/profiles/custom")
+  })
+
+  it("keeps oauth-token profile isolation with shared memory", () => {
+    expect(resolveQueryConfigDir({
+      CLAUDE_CONFIG_DIR: "/profiles/oauth",
+      CLAUDE_CODE_OAUTH_TOKEN: "secret",
+      HOME: "/home/test",
+    }, true)).toBe("/profiles/oauth")
+  })
+  it("resolves a relative HOME from the SDK child working directory", () => {
+    expect(resolveQueryConfigDir({ HOME: "relative-home" }, false, "/srv/project"))
+      .toBe("/srv/project/relative-home/.claude")
+  })
+})
 
 describe("buildQueryOptions", () => {
   it("forces node as the executable to avoid bun auto-detection on embedded hosts", () => {
@@ -214,15 +247,24 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).resumeSessionAt).toBe("uuid-abc")
   })
 
-  it("forks a passthrough assistant-boundary resume so its replacement tail is durable", () => {
+  it("forks a passthrough assistant-boundary resume with its journaled target ID", () => {
     const result = buildQueryOptions(makeContext({
       passthrough: true,
       resumeSessionId: "sdk-123",
       resumeSessionAtUuid: "assistant-uuid",
+      forkSessionId: "11111111-1111-4111-8111-111111111111",
     }))
     expect((result.options as any).resume).toBe("sdk-123")
     expect((result.options as any).resumeSessionAt).toBe("assistant-uuid")
     expect((result.options as any).forkSession).toBe(true)
+    expect((result.options as { sessionId?: string }).sessionId).toBe("11111111-1111-4111-8111-111111111111")
+  })
+
+  it("applies a preallocated target ID to a fresh session without enabling fork", () => {
+    const sessionId = "11111111-1111-4111-8111-111111111111"
+    const result = buildQueryOptions(makeContext({ forkSessionId: sessionId }))
+    expect((result.options as { forkSession?: boolean }).forkSession).toBeUndefined()
+    expect((result.options as { sessionId?: string }).sessionId).toBe(sessionId)
   })
 
   it("includes agents when provided", () => {

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -214,14 +214,15 @@ describe("buildQueryOptions", () => {
     expect((result.options as any).resumeSessionAt).toBe("uuid-abc")
   })
 
-  it("resumes passthrough at an assistant boundary without creating a new session", () => {
+  it("forks a passthrough assistant-boundary resume so its replacement tail is durable", () => {
     const result = buildQueryOptions(makeContext({
+      passthrough: true,
       resumeSessionId: "sdk-123",
       resumeSessionAtUuid: "assistant-uuid",
     }))
     expect((result.options as any).resume).toBe("sdk-123")
     expect((result.options as any).resumeSessionAt).toBe("assistant-uuid")
-    expect((result.options as any).forkSession).toBeUndefined()
+    expect((result.options as any).forkSession).toBe(true)
   })
 
   it("includes agents when provided", () => {

--- a/src/__tests__/recovery-claim.test.ts
+++ b/src/__tests__/recovery-claim.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test"
+import {
+  getRecoveryClaimPath,
+  getRecoveryClaimTombstonePath,
+  parseRecoveryClaimOwner,
+  recoveryClaimOwnerIsDead,
+  type RecoveryClaimOwner,
+} from "../proxy/session/recoveryClaim"
+
+const owner: RecoveryClaimOwner = {
+  version: 2,
+  generation: "canonical-generation",
+  token: "claim-token",
+  pid: 123,
+  hostname: "local-host",
+  createdAt: 1,
+  incarnation: {
+    version: 1,
+    pid: 123,
+    hostId: "a".repeat(64),
+    bootId: "11111111-1111-4111-8111-111111111111",
+    startId: "12345",
+    startIdKind: "linux-proc-start-ticks",
+  },
+}
+
+describe("recovery claim protocol", () => {
+  it("requires complete versioned owner metadata", () => {
+    expect(parseRecoveryClaimOwner(owner)).toEqual(owner)
+    expect(parseRecoveryClaimOwner({ ...owner, version: 1 })).toBeUndefined()
+    expect(parseRecoveryClaimOwner({ ...owner, generation: "" })).toBeUndefined()
+    expect(parseRecoveryClaimOwner({ ...owner, token: "" })).toBeUndefined()
+    expect(parseRecoveryClaimOwner({ ...owner, pid: 0 })).toBeUndefined()
+    expect(parseRecoveryClaimOwner({ ...owner, hostname: "" })).toBeUndefined()
+  })
+
+  it("takes over only after an authoritative incarnation-death probe", () => {
+    expect(recoveryClaimOwnerIsDead(owner, () => true)).toBe(true)
+    expect(recoveryClaimOwnerIsDead(owner, () => false)).toBe(false)
+    expect(parseRecoveryClaimOwner({ ...owner, incarnation: undefined })).toBeUndefined()
+  })
+
+  it("derives deterministic generation and token-scoped paths", () => {
+    const claim = getRecoveryClaimPath("/locks/session.lock", owner.generation)
+    expect(claim).toBe(getRecoveryClaimPath("/locks/session.lock", owner.generation))
+    expect(claim).not.toBe(getRecoveryClaimPath("/locks/session.lock", "other-generation"))
+    expect(getRecoveryClaimTombstonePath(claim, owner.token))
+      .toBe(getRecoveryClaimTombstonePath(claim, owner.token))
+    expect(getRecoveryClaimTombstonePath(claim, owner.token))
+      .not.toBe(getRecoveryClaimTombstonePath(claim, "other-token"))
+  })
+})

--- a/src/__tests__/sdk-process-gate.test.ts
+++ b/src/__tests__/sdk-process-gate.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createSdkProcessGate } from "../proxy/session/sdkProcessGate"
+import type { ProcessIncarnation } from "../proxy/session/processIncarnation"
+
+describe("SDK process gate", () => {
+  const roots: string[] = []
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+  })
+
+  it("persists the exact wrapper incarnation before opening the child command", async () => {
+    const root = mkdtempSync(join(tmpdir(), "meridian-sdk-gate-"))
+    roots.push(root)
+    let attached: ProcessIncarnation | undefined
+    const gate = await createSdkProcessGate(root, async (executor) => { attached = executor })
+    expect(attached).toEqual(gate.executor)
+
+    const child = gate.spawnClaudeCodeProcess({
+      command: process.execPath,
+      args: ["-e", "process.stdin.pipe(process.stdout)"],
+      env: { ...process.env },
+      signal: new AbortController().signal,
+    })
+    const output = new Promise<string>((resolve) => {
+      child.stdout.once("data", (chunk) => resolve(chunk.toString()))
+    })
+    child.stdin.write("gated-writer\n")
+    expect(await output).toBe("gated-writer\n")
+    child.stdin.end()
+    expect(await gate.closeAndJoin()).toBe(true)
+  })
+  it("drains large stderr output and forwards it without stalling stdout", async () => {
+    const root = mkdtempSync(join(tmpdir(), "meridian-sdk-gate-"))
+    roots.push(root)
+    let stderrBytes = 0
+    const gate = await createSdkProcessGate(root, async () => undefined, (data) => {
+      stderrBytes += Buffer.byteLength(data)
+    })
+    const child = gate.spawnClaudeCodeProcess({
+      command: process.execPath,
+      args: ["-e", 'process.stderr.write("x".repeat(2 * 1024 * 1024)); process.stdout.write("done")'],
+      env: { ...process.env },
+      signal: new AbortController().signal,
+    })
+    let output = ""
+    child.stdout.on("data", (chunk) => { output += chunk.toString() })
+    await Promise.race([
+      new Promise<void>((resolveExit, rejectExit) => {
+        child.once("exit", () => resolveExit())
+        child.once("error", rejectExit)
+      }),
+      Bun.sleep(5_000).then(() => { throw new Error("gated child stdout timed out") }),
+    ])
+    expect(output).toBe("done")
+    expect(stderrBytes).toBe(2 * 1024 * 1024)
+    expect(await gate.closeAndJoin()).toBe(true)
+  })
+
+  it("never opens the command for an already-aborted SpawnOptions signal", async () => {
+    const root = mkdtempSync(join(tmpdir(), "meridian-sdk-gate-"))
+    roots.push(root)
+    const gate = await createSdkProcessGate(root, async () => undefined)
+    const controller = new AbortController()
+    controller.abort()
+    expect(() => gate.spawnClaudeCodeProcess({
+      command: process.execPath,
+      args: ["-e", 'process.stdout.write("must-not-run")'],
+      env: { ...process.env },
+      signal: controller.signal,
+    })).toThrow("aborted")
+    expect(await gate.closeAndJoin()).toBe(true)
+  })
+
+})

--- a/src/__tests__/session-cache-coherence.test.ts
+++ b/src/__tests__/session-cache-coherence.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { clearSessionCache, evictSession, getSessionByClaudeId, lookupSession, storeSession } from "../proxy/session/cache"
+import { getConversationFingerprint } from "../proxy/session/fingerprint"
+import { evictSharedSession, lookupSharedSession, lookupSharedSessionResult, setSessionStoreDir, storeSharedSession } from "../proxy/sessionStore"
+
+describe("cross-process session cache coherence", () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "meridian-cache-coherence-"))
+    setSessionStoreDir(dir, { skipLocking: false })
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    clearSessionCache()
+    setSessionStoreDir(null)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it("refreshes a stale in-memory generation from the shared mapping", () => {
+    const messages = [{ role: "user", content: "hello" }]
+    const continuation = [...messages, { role: "user", content: "next" }]
+    storeSession("client-session", messages, "sdk-generation-a")
+
+    const cached = lookupSession("client-session", continuation)
+    expect(cached.type).toBe("continuation")
+    if (cached.type !== "continuation") throw new Error("expected continuation")
+    expect(cached.session.claudeSessionId).toBe("sdk-generation-a")
+
+    // Simulate a second proxy process advancing this logical session. The
+    // current process must not keep resuming its stale in-memory generation.
+    storeSharedSession("client-session", "sdk-generation-b")
+
+    const refreshed = lookupSession("client-session", continuation)
+    expect(refreshed.type).toBe("continuation")
+    if (refreshed.type !== "continuation") throw new Error("expected continuation")
+    expect(refreshed.session.claudeSessionId).toBe("sdk-generation-b")
+    expect(lookupSharedSession("client-session")?.claudeSessionId).toBe("sdk-generation-b")
+  })
+
+  it("honors an authoritative cross-process eviction over stale local memory", () => {
+    const messages = [{ role: "user", content: "hello" }]
+    storeSession("client-session", messages, "sdk-generation-a")
+    // Leave the process cache populated while another process removes the
+    // authoritative mapping.
+    evictSharedSession("client-session")
+
+    const continuation = lookupSession("client-session", [
+      ...messages,
+      { role: "user", content: "next" },
+    ])
+    expect(continuation).toEqual({ type: "diverged", reason: "not-found" })
+  })
+
+  it("never applies a keyed generation token to an unrelated fingerprint key", () => {
+    const keyedMessages = [{ role: "user", content: "keyed" }]
+    const headerlessMessages = [{ role: "user", content: "headerless" }]
+    const cwd = "/tmp/cache-key-bound"
+    storeSession("keyed-session", keyedMessages, "keyed-sdk", cwd)
+    storeSession(undefined, headerlessMessages, "headerless-sdk", cwd)
+    const keyed = lookupSharedSessionResult("keyed-session")
+    if (keyed.status !== "found" || !keyed.generation) throw new Error("missing keyed generation")
+    const fingerprint = getConversationFingerprint(headerlessMessages, cwd)
+
+    expect(evictSession("keyed-session", cwd, keyedMessages, keyed.generation)).toBe(true)
+    expect(lookupSharedSession("keyed-session")).toBeUndefined()
+    expect(lookupSharedSession(fingerprint)?.claudeSessionId).toBe("headerless-sdk")
+  })
+
+  it("purges every local alias when Claude-ID lookup observes durable absence", () => {
+    const messages = [{ role: "user", content: "hello" }]
+    storeSession("client-session", messages, "sdk-generation-a")
+    expect(getSessionByClaudeId("sdk-generation-a")?.claudeSessionId).toBe("sdk-generation-a")
+    evictSharedSession("client-session")
+    expect(getSessionByClaudeId("sdk-generation-a")).toBeUndefined()
+    expect(lookupSession("client-session", [...messages, { role: "user", content: "next" }]))
+      .toEqual({ type: "diverged", reason: "not-found" })
+  })
+
+})

--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -21,21 +21,37 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
 
 let mockMessages: MockSdkMessage[] = []
-interface CapturedFPQueryParams { prompt?: unknown; options?: { resume?: string; forkSession?: boolean } }
+interface CapturedFPQueryParams {
+  prompt?: unknown
+  options?: { resume?: string; forkSession?: boolean; sessionId?: string }
+}
 let capturedQueryParams: CapturedFPQueryParams | null = null
 function getCaptured(): CapturedFPQueryParams | null { return capturedQueryParams }
-let queuedSessionIds: string[] = []
+let queuedSessionLabels: string[] = []
+let callerSelectedSessionIds = new Map<string, string>()
+
+function getCallerSelectedSessionId(label: string): string {
+  const sessionId = callerSelectedSessionIds.get(label)
+  if (!sessionId) throw new Error(`No caller-selected session ID captured for ${label}`)
+  return sessionId
+}
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
-    capturedQueryParams = params as any
-    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    capturedQueryParams = params as CapturedFPQueryParams
+    const sessionLabel = queuedSessionLabels.shift()
+    const options = (params as CapturedFPQueryParams).options
+    if (sessionLabel && options?.sessionId) {
+      callerSelectedSessionIds.set(sessionLabel, options.sessionId)
+    }
+    const sessionId = resolveMockSdkSessionId(options)
+    if (!sessionId) throw new Error("Expected Meridian to select or resume an SDK session")
     return (async function* () {
       for (const msg of mockMessages) {
         yield { ...msg, session_id: sessionId }
@@ -76,11 +92,11 @@ function createTestApp() {
 async function postNoSession(
   app: TestApp,
   messages: Array<{ role: string; content: string }>,
-  sessionId: string,
+  sessionLabel: string,
   system?: string,
   stream = false
 ) {
-  queuedSessionIds.push(sessionId)
+  queuedSessionLabels.push(sessionLabel)
   const body: Record<string, unknown> = {
     model: "claude-sonnet-4-5",
     max_tokens: 128,
@@ -111,7 +127,8 @@ async function postNoSession(
 beforeEach(() => {
   mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
   capturedQueryParams = null
-  queuedSessionIds = []
+  queuedSessionLabels = []
+  callerSelectedSessionIds = new Map()
   clearSessionCache()
   clearSharedSessions()
 })
@@ -134,7 +151,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
     ], "sdk-1", "System v2: file tree has 15 files, 3 diagnostics")
 
     // MUST resume — fingerprint doesn't include systemContext
-    expect(getCaptured()?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("resumes when systemContext changes between requests (stream)", async () => {
@@ -151,7 +168,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
       { role: "user", content: "what can you do?" },
     ], "sdk-stream-1", "System v2 with more context", true)
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-stream-1")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("resumes when systemContext is added where there was none", async () => {
@@ -169,7 +186,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
     ], "sdk-no-ctx", "You are a helpful assistant.")
 
     // MUST resume — systemContext not in fingerprint
-    expect(getCaptured()?.options?.resume).toBe("sdk-no-ctx")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("resumes when systemContext is removed", async () => {
@@ -186,7 +203,7 @@ describe("Fingerprint resume: stable across dynamic systemContext", () => {
       { role: "user", content: "thanks" },
     ], "sdk-ctx")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-ctx")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 })
 
@@ -251,7 +268,7 @@ describe("Fingerprint resume: cross-project safety via lineage", () => {
       { role: "user", content: "more B work" },
     ], "sdk-project-b")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-project-b")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 })
 
@@ -299,7 +316,7 @@ describe("Fingerprint resume: multi-turn with tool_use blocks", () => {
     ], "sdk-tools", "System prompt v2 with updated file tree")
 
     // MUST resume even though system changed and history has tool blocks
-    expect(getCaptured()?.options?.resume).toBe("sdk-tools")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("does NOT resume after undo even with tool_use in history", async () => {
@@ -334,9 +351,9 @@ describe("Fingerprint isolation: headered sessions must not leak into fingerprin
     app: TestApp,
     sessionHeader: string,
     messages: Array<{ role: string; content: string }>,
-    sdkSessionId: string,
+    sessionLabel: string,
   ) {
-    queuedSessionIds.push(sdkSessionId)
+    queuedSessionLabels.push(sessionLabel)
     const response = await app.fetch(new Request("http://localhost/v1/messages", {
       method: "POST",
       headers: {
@@ -392,6 +409,6 @@ describe("Fingerprint resume: backward compat", () => {
       { role: "user", content: "thanks" },
     ], "sdk-no-ctx")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-no-ctx")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 })

--- a/src/__tests__/session-lifecycle-process.test.ts
+++ b/src/__tests__/session-lifecycle-process.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import {
+  getTranscriptResourceKey,
+  reconcile,
+  runGc,
+  type TranscriptLocator,
+} from "../proxy/sessionLifecycle"
+
+const lifecycleModule = pathToFileURL(
+  resolve(import.meta.dir, "../proxy/sessionLifecycle.ts"),
+).href
+
+const workerSource = String.raw`
+import { appendFile, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
+const lifecycle = await import(process.env.LIFECYCLE_MODULE)
+const locator = JSON.parse(process.env.LOCATOR)
+const options = {
+  storeDir: process.env.STORE_DIR,
+  preparedGraceMs: 0,
+  retiredGraceMs: 0,
+  lockWaitMs: 2_000,
+  lockRetryMs: 5,
+}
+const event = (name, extra = {}) => appendFile(
+  process.env.EVENT_FILE,
+  JSON.stringify({ name, pid: process.pid, ...extra }) + "\n",
+)
+try {
+  await lifecycle.registerLiveTranscript(locator, options)
+  const lease = await lifecycle.acquireActiveTranscriptLease([locator], options)
+  if (process.env.MODE === "gated-crash") {
+    const { createSdkProcessGate } = await import(process.env.SDK_GATE_MODULE)
+    const gate = await createSdkProcessGate(
+      process.env.GATE_ROOT,
+      (executor, recoverableAfterCrash) => lifecycle.attachActiveTranscriptExecutor(
+        lease,
+        executor,
+        options,
+        recoverableAfterCrash,
+      ),
+    )
+    gate.spawnClaudeCodeProcess({
+      command: process.execPath,
+      args: ["-e", "await Bun.sleep(1500)"],
+      env: { ...process.env },
+      signal: new AbortController().signal,
+    })
+    await event("ready", { token: lease.token, executorPid: gate.executor.pid })
+    await Bun.sleep(10_000)
+  } else if (process.env.MODE === "armed") {
+    const { captureProcessIncarnation } = await import(process.env.PROCESS_INCARNATION_MODULE)
+    const executor = captureProcessIncarnation()
+    if (!executor) throw new Error("worker process incarnation unavailable")
+    await lifecycle.attachActiveTranscriptExecutor(lease, executor, options)
+    await event("ready", { token: lease.token })
+    const deadline = Date.now() + 10_000
+    while (!existsSync(process.env.RELEASE_FILE)) {
+      if (Date.now() >= deadline) throw new Error("worker timed out waiting for release")
+      await Bun.sleep(10)
+    }
+    await lifecycle.releaseActiveTranscriptLease(lease, options)
+    await event("released")
+  } else {
+    await event("ready", { token: lease.token })
+    // Exit without arming or releasing. Reconciliation may recover this lease
+    // only after this exact owner process is dead.
+  }
+} catch (error) {
+  await event("worker-error", {
+    errorName: error?.name ?? "Error",
+    message: error?.message ?? String(error),
+  })
+  throw error
+}
+`
+
+interface WorkerEvent {
+  name: string
+  pid: number
+  token?: string
+  executorPid?: number
+  errorName?: string
+  message?: string
+}
+
+interface StoredActiveLease {
+  owner: { pid: number }
+  executor?: { pid: number }
+}
+
+interface StoredResource {
+  state: string
+  activeLeases?: Record<string, StoredActiveLease>
+}
+
+interface StoredSidecar {
+  resources: Record<string, StoredResource>
+}
+
+interface WorkerHandle {
+  name: string
+  child: ReturnType<typeof Bun.spawn>
+  releaseFile: string
+}
+
+const tempRoots: string[] = []
+const children = new Set<ReturnType<typeof Bun.spawn>>()
+
+const processIncarnationModule = pathToFileURL(
+  resolve(import.meta.dir, "../proxy/session/processIncarnation.ts"),
+).href
+
+const sdkGateModule = pathToFileURL(
+  resolve(import.meta.dir, "../proxy/session/sdkProcessGate.ts"),
+).href
+
+afterEach(async () => {
+  for (const child of children) child.kill()
+  await Promise.all([...children].map((child) => Promise.race([
+    child.exited.then(() => undefined),
+    Bun.sleep(1_000),
+  ])))
+  children.clear()
+  await Promise.all(tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+function spawnLeaseWorker(
+  root: string,
+  locator: TranscriptLocator,
+  mode: "armed" | "unarmed" | "gated-crash",
+): WorkerHandle {
+  const releaseFile = join(root, `release-${mode}`)
+  const child = Bun.spawn([process.execPath, "-e", workerSource], {
+    env: {
+      ...process.env,
+      LIFECYCLE_MODULE: lifecycleModule,
+      PROCESS_INCARNATION_MODULE: processIncarnationModule,
+      SDK_GATE_MODULE: sdkGateModule,
+      GATE_ROOT: join(root, "sdk-gates"),
+      STORE_DIR: root,
+      LOCATOR: JSON.stringify(locator),
+      EVENT_FILE: join(root, "events.jsonl"),
+      RELEASE_FILE: releaseFile,
+      MODE: mode,
+    },
+    stdout: "ignore",
+    stderr: "pipe",
+  })
+  children.add(child)
+  return { name: mode, child, releaseFile }
+}
+
+async function readEvents(path: string): Promise<WorkerEvent[]> {
+  try {
+    const contents = await readFile(path, "utf8")
+    return contents.trim().split("\n").filter(Boolean).map(
+      (line) => JSON.parse(line) as WorkerEvent,
+    )
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return []
+    throw error
+  }
+}
+
+async function waitForEvent(
+  path: string,
+  name: string,
+  timeoutMs = 5_000,
+): Promise<WorkerEvent> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const events = await readEvents(path)
+    const failure = events.find((event) => event.name === "worker-error")
+    if (failure) throw new Error(`${failure.errorName}: ${failure.message}`)
+    const found = events.find((event) => event.name === name)
+    if (found) return found
+    await Bun.sleep(10)
+  }
+  throw new Error(`Timed out waiting for worker event ${name}`)
+}
+
+async function expectExit(worker: WorkerHandle, timeoutMs = 5_000): Promise<void> {
+  const timeout = Symbol("timeout")
+  const outcome = await Promise.race([
+    worker.child.exited,
+    Bun.sleep(timeoutMs).then(() => timeout),
+  ])
+  if (outcome === timeout) {
+    worker.child.kill()
+    throw new Error(`Worker ${worker.name} did not exit within ${timeoutMs}ms`)
+  }
+  children.delete(worker.child)
+  if (outcome === 0) return
+  const stderrPromise = worker.child.stderr instanceof ReadableStream
+    ? new Response(worker.child.stderr).text()
+    : Promise.resolve(String(worker.child.stderr ?? ""))
+  const stderr = await Promise.race([
+    stderrPromise,
+    Bun.sleep(1_000).then(() => "<stderr read timed out>"),
+  ])
+  throw new Error(`Worker ${worker.name} exited ${String(outcome)}: ${stderr}`)
+}
+
+function readSidecar(storeDir: string): StoredSidecar {
+  return JSON.parse(readFileSync(join(storeDir, "session-gc.json"), "utf8")) as StoredSidecar
+}
+
+async function makeFixture(sessionId: string): Promise<{
+  root: string
+  events: string
+  locator: TranscriptLocator
+}> {
+  const root = await mkdtemp(join(tmpdir(), "meridian-lifecycle-process-"))
+  tempRoots.push(root)
+  return {
+    root,
+    events: join(root, "events.jsonl"),
+    locator: {
+      sessionId,
+      configDir: join(root, "config"),
+      projectDir: join(root, "project"),
+    },
+  }
+}
+
+function gcOptions(storeDir: string) {
+  return {
+    storeDir,
+    preparedGraceMs: 0,
+    retiredGraceMs: 0,
+    lockWaitMs: 2_000,
+    lockRetryMs: 5,
+  }
+}
+
+describe("session lifecycle leases across OS processes", () => {
+  test("does not retire or delete a transcript leased by a live writer process", async () => {
+    const fixture = await makeFixture("live-cross-process-writer")
+    const worker = spawnLeaseWorker(fixture.root, fixture.locator, "armed")
+    const ready = await waitForEvent(fixture.events, "ready")
+    expect(ready.pid).not.toBe(process.pid)
+
+    const key = getTranscriptResourceKey(fixture.locator)
+    const options = gcOptions(fixture.root)
+    expect((await reconcile([], options)).liveRetired).toBe(0)
+    expect(readSidecar(fixture.root).resources[key]).toMatchObject({
+      state: "live",
+      activeLeases: {
+        [ready.token!]: {
+          owner: { pid: ready.pid },
+          executor: { pid: ready.pid },
+        },
+      },
+    })
+
+    let deletes = 0
+    const blocked = await runGc([], {
+      ...options,
+      deleter: async () => { deletes++ },
+    })
+    expect(blocked.deleted).toBe(0)
+    expect(deletes).toBe(0)
+    expect(readSidecar(fixture.root).resources[key]?.state).toBe("live")
+    expect(existsSync(worker.releaseFile)).toBe(false)
+
+    await writeFile(worker.releaseFile, "release")
+    await waitForEvent(fixture.events, "released")
+    await expectExit(worker)
+
+    const collected = await runGc([], {
+      ...options,
+      deleter: async () => { deletes++ },
+    })
+    expect(collected.deleted).toBe(1)
+    expect(deletes).toBe(1)
+    expect(readSidecar(fixture.root).resources[key]?.state).toBe("deleted")
+  }, 15_000)
+
+  test("keeps an orphaned real SDK gate fenced until its exact executor exits", async () => {
+    if (process.platform === "win32") return
+    const fixture = await makeFixture("crashed-owner-live-gate")
+    const worker = spawnLeaseWorker(fixture.root, fixture.locator, "gated-crash")
+    const ready = await waitForEvent(fixture.events, "ready")
+    expect(ready.pid).not.toBe(process.pid)
+    expect(ready.executorPid).not.toBe(ready.pid)
+
+    worker.child.kill("SIGKILL")
+    const ownerExit = await Promise.race([
+      worker.child.exited,
+      Bun.sleep(3_000).then(() => "timeout" as const),
+    ])
+    expect(ownerExit).not.toBe("timeout")
+    children.delete(worker.child)
+
+    const key = getTranscriptResourceKey(fixture.locator)
+    const options = gcOptions(fixture.root)
+    expect((await reconcile([], options)).liveRetired).toBe(0)
+    expect(readSidecar(fixture.root).resources[key]).toMatchObject({
+      state: "live",
+      activeLeases: {
+        [ready.token!]: {
+          owner: { pid: ready.pid },
+          executor: { pid: ready.executorPid },
+        },
+      },
+    })
+
+    await Bun.sleep(1_700)
+    expect((await reconcile([], options)).liveRetired).toBe(1)
+    expect(readSidecar(fixture.root).resources[key]).toMatchObject({ state: "retired" })
+    expect(readSidecar(fixture.root).resources[key]?.activeLeases).toBeUndefined()
+  }, 15_000)
+
+  test("recovers an unarmed lease after its owner process dies", async () => {
+    const fixture = await makeFixture("dead-unarmed-writer")
+    const worker = spawnLeaseWorker(fixture.root, fixture.locator, "unarmed")
+    const ready = await waitForEvent(fixture.events, "ready")
+    expect(ready.pid).not.toBe(process.pid)
+    await expectExit(worker)
+
+    const key = getTranscriptResourceKey(fixture.locator)
+    expect(Object.keys(readSidecar(fixture.root).resources[key]?.activeLeases ?? {})).toEqual([
+      ready.token!,
+    ])
+
+    const options = gcOptions(fixture.root)
+    expect((await reconcile([], options)).liveRetired).toBe(1)
+    expect(readSidecar(fixture.root).resources[key]).toMatchObject({ state: "retired" })
+    expect(readSidecar(fixture.root).resources[key]?.activeLeases).toBeUndefined()
+
+    let deletes = 0
+    expect((await runGc([], {
+      ...options,
+      deleter: async () => { deletes++ },
+    })).deleted).toBe(1)
+    expect(deletes).toBe(1)
+    expect(readSidecar(fixture.root).resources[key]?.state).toBe("deleted")
+  }, 15_000)
+})

--- a/src/__tests__/session-lifecycle.test.ts
+++ b/src/__tests__/session-lifecycle.test.ts
@@ -1,0 +1,689 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs"
+import { hostname, tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  SessionLifecycleBacklogError,
+  SessionLifecycleCorruptError,
+  SessionLifecycleLockError,
+  abandonFork,
+  acquireActiveTranscriptLease,
+  attachActiveTranscriptExecutor,
+  attachPinnedTranscript,
+  commitFork,
+  getSessionGcNodeExecutable,
+  getTranscriptResourceKey,
+  prepareFork,
+  publishPinnedTranscript,
+  reconcile,
+  registerLiveTranscript,
+  releaseActiveTranscriptLease,
+  runGc,
+  type SessionLifecycleOptions,
+  type TranscriptLocator,
+} from "../proxy/sessionLifecycle"
+import {
+  captureProcessIncarnation,
+  type ProcessIncarnation,
+} from "../proxy/session/processIncarnation"
+import {
+  getRecoveryClaimPath,
+  getRecoveryClaimTombstonePath,
+} from "../proxy/session/recoveryClaim"
+
+interface StoredResource {
+  key: string
+  generation: string
+  locator: TranscriptLocator
+  state: string
+  createdAt: number
+  updatedAt: number
+  attempts: number
+  nextAttemptAt?: number
+  lastError?: string
+  deletionToken?: string
+  deletionOwner?: ProcessIncarnation
+  deletionExecutor?: ProcessIncarnation
+  deletionProcessGroupId?: number
+}
+
+interface StoredSidecar {
+  version: number
+  resources: Record<string, StoredResource>
+}
+
+describe("session transcript lifecycle", () => {
+  let storeDir: string
+  let now: number
+  let options: SessionLifecycleOptions
+
+  beforeEach(() => {
+    storeDir = mkdtempSync(join(tmpdir(), "meridian-session-lifecycle-"))
+    now = 10_000
+    options = {
+      storeDir,
+      now: () => now,
+      preparedGraceMs: 0,
+      retiredGraceMs: 0,
+      lockWaitMs: 20,
+      lockRetryMs: 1,
+      lockStaleMs: 60_000,
+    }
+  })
+
+  afterEach(() => {
+    rmSync(storeDir, { recursive: true, force: true })
+  })
+
+  it("keys ownership by config directory and session id", () => {
+    const first = locator("same-id", "profile-a")
+    const second = locator("same-id", "profile-b")
+
+    expect(getTranscriptResourceKey(first)).toMatch(/^[a-f0-9]{64}$/)
+    expect(getTranscriptResourceKey(first)).not.toBe(getTranscriptResourceKey(second))
+    expect(getTranscriptResourceKey({
+      ...first,
+      configDir: join(first.configDir, "child", ".."),
+    })).toBe(getTranscriptResourceKey(first))
+    expect(() => getTranscriptResourceKey({ sessionId: "id", configDir: "relative" })).toThrow(
+      "configDir must be an absolute path",
+    )
+  })
+
+  it("persists a prepared intent before commit with private atomic storage", async () => {
+    const fork = locator("fork-1")
+    const key = getTranscriptResourceKey(await prepareFork(fork, options))
+
+    let sidecar = readSidecar(storeDir)
+    expect(sidecar.version).toBe(2)
+    expect(sidecar.resources[key]?.state).toBe("prepared")
+    expect(statSync(join(storeDir, "session-gc.json")).mode & 0o777).toBe(0o600)
+    expect(readdirSync(storeDir).filter((name) => name.includes(".tmp-"))).toEqual([])
+
+    await commitFork(fork, options)
+    await commitFork(fork, options)
+    sidecar = readSidecar(storeDir)
+    expect(sidecar.resources[key]?.state).toBe("live")
+  })
+
+  it("registers a legacy live transcript and safely revives only pre-delete states", async () => {
+    const source = locator("legacy-source")
+    const key = getTranscriptResourceKey(await registerLiveTranscript(source, options))
+    expect(readSidecar(storeDir).resources[key]?.state).toBe("live")
+
+    await abandonFork(source, { ...options, retiredGraceMs: 100 })
+    expect(readSidecar(storeDir).resources[key]?.nextAttemptAt).toBe(now + 100)
+    await registerLiveTranscript(source, options)
+    expect(readSidecar(storeDir).resources[key]).toMatchObject({ state: "live" })
+    expect(readSidecar(storeDir).resources[key]?.nextAttemptAt).toBeUndefined()
+
+    await abandonFork(source, options)
+    await runGc([], { ...options, deleter: async () => undefined })
+    await expect(registerLiveTranscript(source, options)).rejects.toThrow("from state deleted")
+
+    const prepared = locator("prepared-registration")
+    const preparedKey = getTranscriptResourceKey(await prepareFork(prepared, options))
+    await registerLiveTranscript(prepared, options)
+    expect(readSidecar(storeDir).resources[preparedKey]?.state).toBe("live")
+
+    const inFlight = locator("in-flight-delete")
+    const inFlightKey = getTranscriptResourceKey(await registerLiveTranscript(inFlight, options))
+    const sidecar = readSidecar(storeDir)
+    sidecar.resources[inFlightKey]!.state = "deleting"
+    writeFileSync(join(storeDir, "session-gc.json"), JSON.stringify(sidecar), { mode: 0o600 })
+    await expect(registerLiveTranscript(inFlight, options)).rejects.toThrow("from state deleting")
+  })
+
+  it("requires preallocation and separately bounds backlog and total ownership", async () => {
+    await expect(commitFork(locator("unknown"), options)).rejects.toThrow("was not prepared")
+
+    const backlogBounded = { ...options, maxPending: 1 }
+    await prepareFork(locator("prepared-backlog"), backlogBounded)
+    await expect(prepareFork(locator("second-prepared"), backlogBounded)).rejects.toBeInstanceOf(
+      SessionLifecycleBacklogError,
+    )
+    // Live mappings do not consume the smaller crash/deletion backlog budget.
+    await registerLiveTranscript(locator("healthy-live"), backlogBounded)
+
+    const ownershipBounded = { ...options, maxPending: 2, maxOwned: 3 }
+    const first = locator("first-owned")
+    await prepareFork(first, ownershipBounded)
+    await commitFork(first, ownershipBounded)
+    await expect(registerLiveTranscript(locator("second-owned"), ownershipBounded)).rejects.toBeInstanceOf(
+      SessionLifecycleBacklogError,
+    )
+  })
+
+  it("reserves live current/predecessor capacity beyond the pending backlog limit", async () => {
+    const saved = process.env.MERIDIAN_MAX_STORED_SESSIONS
+    process.env.MERIDIAN_MAX_STORED_SESSIONS = "2"
+    const derived = { ...options, storeDir: join(storeDir, "derived-capacity"), maxPending: 1 }
+    try {
+      // Two durable mappings can each pin current + predecessor. The smaller
+      // pending budget must not deadlock those four healthy live resources.
+      for (const id of ["live-a", "live-b", "live-c", "live-d"]) {
+        await registerLiveTranscript(locator(id), derived)
+      }
+      await prepareFork(locator("one-transient"), derived)
+      await expect(registerLiveTranscript(locator("over-total"), derived)).rejects.toBeInstanceOf(
+        SessionLifecycleBacklogError,
+      )
+    } finally {
+      if (saved === undefined) delete process.env.MERIDIAN_MAX_STORED_SESSIONS
+      else process.env.MERIDIAN_MAX_STORED_SESSIONS = saved
+    }
+  })
+
+  it("never exceeds the pending bound when many live resources become unpinned", async () => {
+    const bounded = { ...options, storeDir: join(storeDir, "bounded-reconcile"), maxPending: 1 }
+    const first = locator("unpin-first")
+    const second = locator("unpin-second")
+    const third = locator("unpin-third")
+    for (const live of [first, second, third]) await registerLiveTranscript(live, bounded)
+
+    const result = await reconcile([], bounded)
+    expect(result.liveRetired).toBe(1)
+    const resources = Object.values(readSidecar(bounded.storeDir).resources)
+    expect(resources.filter((resource) => resource.state === "retired")).toHaveLength(1)
+    expect(resources.filter((resource) => resource.state === "live")).toHaveLength(2)
+
+    const liveResource = resources.find((resource) => resource.state === "live")!
+    const stillLive = { ...liveResource.locator, lifecycleGeneration: liveResource.generation }
+    await expect(abandonFork(stillLive, bounded)).rejects.toBeInstanceOf(
+      SessionLifecycleBacklogError,
+    )
+    expect(readSidecar(bounded.storeDir).resources[getTranscriptResourceKey(stillLive)]?.state).toBe("live")
+  })
+
+  it("never lets a delayed publisher recreate a deleted locator after tombstone pruning", async () => {
+    const bounded = { ...options, maxTombstones: 1, deleter: async () => undefined }
+    const stale = locator("stale-publisher")
+    await prepareFork(stale, bounded)
+    await commitFork(stale, bounded)
+    await abandonFork(stale, bounded)
+    await runGc([], bounded)
+
+    const replacementTombstone = locator("replacement-tombstone")
+    await prepareFork(replacementTombstone, bounded)
+    await abandonFork(replacementTombstone, bounded)
+    await runGc([], bounded)
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(stale)]).toBeUndefined()
+
+    let published = false
+    await expect(publishPinnedTranscript(stale, () => {
+      published = true
+      return "generation"
+    }, bounded)).rejects.toThrow("unjournaled transcript")
+    expect(published).toBe(false)
+
+    const legacy = locator("legacy-attach")
+    expect(await attachPinnedTranscript(legacy, () => "legacy-generation", bounded))
+      .toBe("legacy-generation")
+  })
+
+  it("rejects delayed exact references after prune and same-locator recreation", async () => {
+    const bounded = { ...options, maxTombstones: 1, deleter: async () => undefined }
+    const oldRef = locator("lifecycle-aba")
+    await prepareFork(oldRef, bounded)
+    const oldGeneration = oldRef.lifecycleGeneration
+    await commitFork(oldRef, bounded)
+    await abandonFork(oldRef, bounded)
+    await runGc([], bounded)
+    const other = locator("lifecycle-aba-pruner")
+    await prepareFork(other, bounded)
+    await abandonFork(other, bounded)
+    await runGc([], bounded)
+
+    const replacement = { ...oldRef, lifecycleGeneration: undefined }
+    await prepareFork(replacement, bounded)
+    expect(replacement.lifecycleGeneration).not.toBe(oldGeneration)
+    let callbackRan = false
+    await expect(publishPinnedTranscript(oldRef, () => {
+      callbackRan = true
+      return "impossible"
+    }, bounded)).rejects.toThrow("lifecycle generation")
+    await expect(commitFork(oldRef, bounded)).rejects.toThrow("lifecycle generation")
+    await expect(abandonFork(oldRef, bounded)).rejects.toThrow("lifecycle generation")
+    expect(callbackRan).toBe(false)
+  })
+
+  it("rolls back legacy lifecycle attachment when its exact store CAS loses or throws", async () => {
+    const lost = locator("legacy-cas-loser")
+    expect(await attachPinnedTranscript(lost, () => false, options)).toBe(false)
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(lost)]).toBeUndefined()
+
+    const failed = locator("legacy-cas-error")
+    await expect(attachPinnedTranscript(failed, () => {
+      throw new Error("store unavailable")
+    }, options)).rejects.toThrow("store unavailable")
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(failed)]).toBeUndefined()
+  })
+
+  it("promotes a pinned prepared intent after crash recovery", async () => {
+    const current = locator("prepared-current")
+    const key = getTranscriptResourceKey(await prepareFork(current, options))
+
+    await reconcile([current], options)
+
+    expect(readSidecar(storeDir).resources[key]?.state).toBe("live")
+  })
+
+  it("blocks cross-process deletion while a durable writer lease is active", async () => {
+    const fork = locator("durably-active-writer")
+    await prepareFork(fork, options)
+    const lease = await acquireActiveTranscriptLease([fork], options)
+    const executor = captureProcessIncarnation()
+    if (!executor) throw new Error("test process incarnation unavailable")
+    await attachActiveTranscriptExecutor(lease, executor, options)
+    await abandonFork(fork, options)
+    let deleted = 0
+
+    const blocked = await runGc([], { ...options, deleter: async () => { deleted++ } })
+    expect(blocked.deleted).toBe(0)
+    expect(blocked.deferred).toBe(1)
+    expect(deleted).toBe(0)
+
+    await releaseActiveTranscriptLease(lease, options)
+    expect((await runGc([], { ...options, deleter: async () => { deleted++ } })).deleted).toBe(1)
+    expect(deleted).toBe(1)
+  })
+
+  it("makes durable SDK writer leases exclusive across requests and proxies", async () => {
+    const fork = locator("exclusive-writer")
+    await prepareFork(fork, options)
+    const first = await acquireActiveTranscriptLease([fork], options)
+    await expect(acquireActiveTranscriptLease([fork], options)).rejects.toThrow("active SDK writer")
+    await releaseActiveTranscriptLease(first, options)
+    const second = await acquireActiveTranscriptLease([fork], options)
+    expect(second.token).not.toBe(first.token)
+    await releaseActiveTranscriptLease(second, options)
+  })
+
+  it("keeps current and previous pins and deletes only retired forks", async () => {
+    const current = locator("current")
+    const previous = locator("previous")
+    const old = locator("old")
+    const abandoned = locator("abandoned")
+    for (const item of [current, previous, old, abandoned]) await prepareFork(item, options)
+    for (const item of [current, previous, old]) await commitFork(item, options)
+    await abandonFork(abandoned, options)
+
+    const reconciled = await reconcile([current, previous], options)
+    expect(reconciled.resourcesPinned).toBe(2)
+    expect(reconciled.liveRetired).toBe(1)
+
+    const deleted: TranscriptLocator[] = []
+    const result = await runGc([current, previous], {
+      ...options,
+      deleter: async (item) => { deleted.push(item) },
+    })
+
+    expect(result).toEqual({ deleted: 2, notFound: 0, failed: 0, deferred: 0 })
+    expect(deleted.map((item) => item.sessionId).sort()).toEqual(["abandoned", "old"])
+    const resources = Object.values(readSidecar(storeDir).resources)
+    expect(resources.filter((resource) => resource.state === "live").map((resource) => resource.locator.sessionId).sort())
+      .toEqual(["current", "previous"])
+    expect(resources.filter((resource) => resource.state === "deleted")).toHaveLength(2)
+  })
+
+  it("treats not-found as idempotent success and tombstones the resource", async () => {
+    const fork = locator("already-gone")
+    await prepareFork(fork, options)
+    await abandonFork(fork, options)
+
+    const result = await runGc([], {
+      ...options,
+      deleter: async () => {
+        throw new Error(`Session ${fork.sessionId} not found in project`)
+      },
+    })
+
+    expect(result.notFound).toBe(1)
+    expect(Object.values(readSidecar(storeDir).resources)[0]?.state).toBe("deleted")
+  })
+
+  it("does not mistake child ENOENT or generic errors for a missing session", async () => {
+    const fork = locator("sdk-load-failure")
+    await prepareFork(fork, options)
+    await abandonFork(fork, options)
+
+    const result = await runGc([], {
+      ...options,
+      deleter: async () => {
+        const error = new Error("SDK module not found") as Error & { code: string }
+        error.code = "ENOENT"
+        throw error
+      },
+    })
+
+    expect(result).toEqual({ deleted: 0, notFound: 0, failed: 1, deferred: 1 })
+    expect(Object.values(readSidecar(storeDir).resources)[0]?.state).toBe("retired")
+  })
+
+  it("uses a real Node executable when tests run under Bun", () => {
+    expect(process.versions.bun).toBeDefined()
+    expect(getSessionGcNodeExecutable()).toBe("node")
+  })
+
+  it("defers retired deletion through the reader-drain grace period", async () => {
+    const fork = locator("reader-grace")
+    const graceOptions = { ...options, retiredGraceMs: 100 }
+    await prepareFork(fork, graceOptions)
+    await abandonFork(fork, graceOptions)
+    let calls = 0
+    const gcOptions = {
+      ...graceOptions,
+      deleter: async () => { calls++ },
+    }
+
+    expect(await runGc([], gcOptions)).toEqual({ deleted: 0, notFound: 0, failed: 0, deferred: 1 })
+    expect(calls).toBe(0)
+    now += 99
+    expect((await runGc([], gcOptions)).deleted).toBe(0)
+    now++
+    expect((await runGc([], gcOptions)).deleted).toBe(1)
+    expect(calls).toBe(1)
+  })
+
+  it("backs off failures and retries deterministically", async () => {
+    const fork = locator("retry")
+    await prepareFork(fork, options)
+    await abandonFork(fork, options)
+    let calls = 0
+    const retryOptions: SessionLifecycleOptions = {
+      ...options,
+      retryBaseMs: 100,
+      retryMaxMs: 1_000,
+      deleter: async () => {
+        calls++
+        if (calls === 1) throw new Error("temporary failure")
+      },
+    }
+
+    expect(await runGc([], retryOptions)).toEqual({ deleted: 0, notFound: 0, failed: 1, deferred: 1 })
+    let resource = Object.values(readSidecar(storeDir).resources)[0]!
+    expect(resource.state).toBe("retired")
+    expect(resource.attempts).toBe(1)
+    expect(resource.nextAttemptAt).toBe(now + 100)
+
+    expect((await runGc([], retryOptions)).deleted).toBe(0)
+    expect(calls).toBe(1)
+    now += 100
+    expect((await runGc([], retryOptions)).deleted).toBe(1)
+    expect(calls).toBe(2)
+    resource = Object.values(readSidecar(storeDir).resources)[0]!
+    expect(resource.state).toBe("deleted")
+  })
+
+  it("keeps an uncertain stale deleting lease fail-closed", async () => {
+    const fork = locator("crash")
+    const key = getTranscriptResourceKey(await prepareFork(fork, options))
+    await abandonFork(fork, options)
+    const sidecar = readSidecar(storeDir)
+    sidecar.resources[key]!.state = "deleting"
+    sidecar.resources[key]!.updatedAt = now - 1_000
+    writeFileSync(join(storeDir, "session-gc.json"), JSON.stringify(sidecar), { mode: 0o600 })
+
+    const result = await reconcile([], { ...options, deletingLeaseMs: 100 })
+    expect(result.deletingRecovered).toBe(0)
+    expect(readSidecar(storeDir).resources[key]?.state).toBe("deleting")
+  })
+
+  it("recovers a deleting orphan only after the exact executor is dead", async () => {
+    const fork = locator("dead-deletion-executor")
+    const key = getTranscriptResourceKey(await prepareFork(fork, options))
+    await abandonFork(fork, options)
+    const sidecar = readSidecar(storeDir)
+    sidecar.resources[key]!.state = "deleting"
+    sidecar.resources[key]!.deletionToken = "old-delete-token"
+    sidecar.resources[key]!.deletionOwner = deadProcessIncarnation(999_999_998)
+    sidecar.resources[key]!.deletionExecutor = deadProcessIncarnation(999_999_999)
+    sidecar.resources[key]!.deletionProcessGroupId = 999_999_999
+    writeFileSync(join(storeDir, "session-gc.json"), JSON.stringify(sidecar), { mode: 0o600 })
+
+    const recovered = await reconcile([], options)
+    expect(recovered.deletingRecovered).toBe(1)
+    expect(readSidecar(storeDir).resources[key]?.state).toBe("retired")
+    expect((await runGc([], { ...options, deleter: async () => undefined })).deleted).toBe(1)
+  })
+
+  it("keeps a deleting orphan fenced while its exact executor may be alive", async () => {
+    const current = captureProcessIncarnation()
+    if (!current) throw new Error("test process incarnation unavailable")
+    const fork = locator("live-deletion-executor")
+    const key = getTranscriptResourceKey(await prepareFork(fork, options))
+    await abandonFork(fork, options)
+    const sidecar = readSidecar(storeDir)
+    sidecar.resources[key]!.state = "deleting"
+    sidecar.resources[key]!.deletionToken = "live-delete-token"
+    sidecar.resources[key]!.deletionOwner = current
+    sidecar.resources[key]!.deletionExecutor = current
+    sidecar.resources[key]!.deletionProcessGroupId = current.pid
+    writeFileSync(join(storeDir, "session-gc.json"), JSON.stringify(sidecar), { mode: 0o600 })
+
+    expect((await reconcile([], options)).deletingRecovered).toBe(0)
+    const gc = await runGc([], { ...options, deleter: async () => undefined })
+    expect(gc.deferred).toBe(1)
+    expect(readSidecar(storeDir).resources[key]?.state).toBe("deleting")
+  })
+
+  it("fails closed on a corrupt sidecar without calling the deleter", async () => {
+    const path = join(storeDir, "session-gc.json")
+    writeFileSync(path, "{broken", { mode: 0o600 })
+    let called = false
+
+    await expect(runGc([], {
+      ...options,
+      deleter: async () => { called = true },
+    })).rejects.toBeInstanceOf(SessionLifecycleCorruptError)
+    expect(called).toBe(false)
+    expect(readFileSync(path, "utf8")).toBe("{broken")
+  })
+
+  it("recovers an abandoned stale lock without unlinking a successor", async () => {
+    const lock = join(storeDir, "session-gc.json.lock")
+    writeFileSync(lock, `${JSON.stringify({ pid: 999_999_999, hostname: hostname(), token: "stale", incarnation: deadProcessIncarnation(999_999_999) })}\n`, { mode: 0o600 })
+    const stale = (Date.now() - 1_000) / 1_000
+    utimesSync(lock, stale, stale)
+
+    await prepareFork(locator("after-crash"), {
+      ...options,
+      lockStaleMs: 10,
+    })
+
+    expect(readdirSync(storeDir)).toEqual(["session-gc.json"])
+  })
+
+  it("repeatedly adopts dead lifecycle recovery claims and cleans resolved tombstones", async () => {
+    const lock = join(storeDir, "session-gc.json.lock")
+    const contents = `${JSON.stringify({ pid: 999_999_999, hostname: hostname(), token: "stale-claim-generation", incarnation: deadProcessIncarnation(999_999_999) })}
+`
+    writeFileSync(lock, contents, { mode: 0o600 })
+    const stale = (Date.now() - 1_000) / 1_000
+    utimesSync(lock, stale, stale)
+
+    const claim = getRecoveryClaimPath(lock, contents)
+    const firstToken = "first-dead-lifecycle-recoverer"
+    writeLifecycleRecoveryClaim(
+      getRecoveryClaimTombstonePath(claim, firstToken),
+      contents,
+      firstToken,
+      999_999_998,
+    )
+    writeLifecycleRecoveryClaim(claim, contents, "second-dead-lifecycle-recoverer", 999_999_999)
+
+    await prepareFork(locator("after-orphaned-lifecycle-recovery"), {
+      ...options,
+      lockStaleMs: 10,
+    })
+
+    expect(readSidecar(storeDir).resources).toBeDefined()
+    expect(readdirSync(storeDir).some((name) => name.includes(".recover-"))).toBe(false)
+  })
+
+  it("fails closed for live and remote lifecycle recovery owners", async () => {
+    const lock = join(storeDir, "session-gc.json.lock")
+    const contents = `${JSON.stringify({ pid: 999_999_999, hostname: hostname(), token: "blocked-claim-generation", incarnation: deadProcessIncarnation(999_999_999) })}
+`
+    const stale = (Date.now() - 1_000) / 1_000
+
+    for (const [claimHostname, claimPid] of [[hostname(), process.pid], ["remote.example", 999_999_999]] as const) {
+      writeFileSync(lock, contents, { mode: 0o600 })
+      utimesSync(lock, stale, stale)
+      const claim = getRecoveryClaimPath(lock, contents)
+      writeLifecycleRecoveryClaim(claim, contents, `blocked-${claimHostname}`, claimPid, claimHostname)
+
+      await expect(prepareFork(locator(`blocked-${claimHostname}`), {
+        ...options,
+        lockWaitMs: 5,
+        lockRetryMs: 1,
+        lockStaleMs: 10,
+      })).rejects.toBeInstanceOf(SessionLifecycleLockError)
+      expect(readFileSync(join(claim, "owner.json"), "utf8")).toContain(`blocked-${claimHostname}`)
+
+      rmSync(claim, { recursive: true, force: true })
+      rmSync(lock, { force: true })
+    }
+  })
+
+  it("times out under lock contention and never proceeds unlocked", async () => {
+    const lock = join(storeDir, "session-gc.json.lock")
+    writeFileSync(lock, "another-owner\n", { mode: 0o600 })
+    chmodSync(lock, 0o600)
+
+    await expect(prepareFork(locator("blocked"), {
+      ...options,
+      lockWaitMs: 3,
+      lockRetryMs: 1,
+    })).rejects.toBeInstanceOf(SessionLifecycleLockError)
+    expect(readdirSync(storeDir)).not.toContain("session-gc.json")
+  })
+  it("never overlaps a second physical deleter with an uncertain first", async () => {
+    const target = locator("lease-token")
+    let now = 1_000
+    await prepareFork(target, { ...options, now: () => now })
+    await commitFork(target, { ...options, now: () => now })
+
+    let releaseFirst!: () => void
+    let markFirstEntered!: () => void
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve })
+    const firstEntered = new Promise<void>((resolve) => { markFirstEntered = resolve })
+    const first = runGc([], {
+      ...options,
+      now: () => now,
+      retiredGraceMs: 0,
+      deletingLeaseMs: 10,
+      deleter: async () => {
+        markFirstEntered()
+        await firstBlocked
+      },
+    })
+    await firstEntered
+
+    now += 11
+    const second = await runGc([], {
+      ...options,
+      now: () => now,
+      retiredGraceMs: 0,
+      deletingLeaseMs: 10,
+      deleter: async () => {},
+    })
+    expect(second.deleted).toBe(0)
+    releaseFirst()
+    expect((await first).deleted).toBe(1)
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(target)]?.state).toBe("deleted")
+  })
+
+  it("leaves a timed-out custom deleter fenced in deleting state", async () => {
+    const target = locator("timed-custom-delete")
+    await prepareFork(target, options)
+    await commitFork(target, options)
+    let calls = 0
+    const result = await runGc([], {
+      ...options,
+      retiredGraceMs: 0,
+      deletionTimeoutMs: 2,
+      runTimeoutMs: 20,
+      deleter: async () => {
+        calls++
+        await new Promise<void>(() => {})
+      },
+    })
+    expect(result.deferred).toBeGreaterThan(0)
+    expect(calls).toBe(1)
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(target)]?.state).toBe("deleting")
+    await runGc([], { ...options, retiredGraceMs: 0, deleter: async () => { calls++ } })
+    expect(calls).toBe(1)
+  })
+
+  it("refreshes durable pins before every destructive claim", async () => {
+    const target = locator("fresh-pin")
+    await prepareFork(target, options)
+    await commitFork(target, options)
+    let deleted = false
+    const result = await runGc([], {
+      ...options,
+      retiredGraceMs: 0,
+      pinProvider: () => [target],
+      deleter: async () => { deleted = true },
+    })
+    expect(deleted).toBe(false)
+    expect(result.deleted).toBe(0)
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(target)]?.state).toBe("live")
+  })
+
+})
+
+function deadProcessIncarnation(pid: number) {
+  const current = captureProcessIncarnation()
+  if (!current) throw new Error("test process incarnation unavailable")
+  return { ...current, pid, bootId: "00000000-0000-4000-8000-000000000000" }
+}
+
+function writeLifecycleRecoveryClaim(
+  path: string,
+  generation: string,
+  token: string,
+  pid: number,
+  ownerHostname = hostname(),
+): void {
+  const current = captureProcessIncarnation()
+  if (!current) throw new Error("test process incarnation unavailable")
+  const incarnation = ownerHostname !== hostname()
+    ? { ...current, pid, hostId: "b".repeat(64) }
+    : pid === process.pid
+      ? current
+      : { ...current, pid, bootId: "00000000-0000-4000-8000-000000000000" }
+  mkdirSync(path, { mode: 0o700 })
+  writeFileSync(join(path, "owner.json"), JSON.stringify({
+    version: 2,
+    generation,
+    token,
+    pid,
+    hostname: ownerHostname,
+    createdAt: 1,
+    incarnation,
+  }), { mode: 0o600 })
+}
+
+function locator(sessionId: string, profile = "profile"): TranscriptLocator {
+  return {
+    sessionId,
+    configDir: join(tmpdir(), profile),
+    projectDir: join(tmpdir(), "project"),
+  }
+}
+
+function readSidecar(storeDir: string): StoredSidecar {
+  return JSON.parse(readFileSync(join(storeDir, "session-gc.json"), "utf8")) as StoredSidecar
+}

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -14,7 +14,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 type MockSdkMessage = Record<string, unknown>
 type TestApp = { fetch: (req: Request) => Promise<Response> }
@@ -22,17 +22,30 @@ type TestApp = { fetch: (req: Request) => Promise<Response> }
 let mockMessages: MockSdkMessage[] = []
 interface CapturedQueryParams {
   prompt?: unknown
-  options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string }
+  options?: { resume?: string; forkSession?: boolean; resumeSessionAt?: string; sessionId?: string }
 }
 let capturedQueryParams: CapturedQueryParams | null = null
 /** Access capturedQueryParams without TS narrowing to `never` after null assignments */
 function getCaptured(): CapturedQueryParams | null { return capturedQueryParams }
-let queuedSessionIds: string[] = []
+let queuedSessionLabels: string[] = []
+let callerSelectedSessionIds = new Map<string, string>()
+
+function getCallerSelectedSessionId(label: string): string {
+  const sessionId = callerSelectedSessionIds.get(label)
+  if (!sessionId) throw new Error(`No caller-selected session ID captured for ${label}`)
+  return sessionId
+}
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: unknown) => {
     capturedQueryParams = params as CapturedQueryParams
-    const sessionId = queuedSessionIds.shift() || "sdk-session-default"
+    const sessionLabel = queuedSessionLabels.shift()
+    const options = (params as CapturedQueryParams).options
+    if (sessionLabel && options?.sessionId && !callerSelectedSessionIds.has(sessionLabel)) {
+      callerSelectedSessionIds.set(sessionLabel, options.sessionId)
+    }
+    const sessionId = resolveMockSdkSessionId(options)
+    if (!sessionId) throw new Error("Expected Meridian to select or resume an SDK session")
     return (async function* () {
       for (const msg of mockMessages) {
         yield { ...msg, session_id: sessionId }
@@ -79,9 +92,9 @@ async function post(
   app: TestApp,
   session: string,
   messages: Array<{ role: string; content: any }>,
-  sessionId: string
+  sessionLabel: string
 ) {
-  queuedSessionIds.push(sessionId)
+  queuedSessionLabels.push(sessionLabel)
   const response = await app.fetch(new Request("http://localhost/v1/messages", {
     method: "POST",
     headers: {
@@ -101,7 +114,8 @@ async function post(
 beforeEach(() => {
   mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
   capturedQueryParams = null
-  queuedSessionIds = []
+  queuedSessionLabels = []
+  callerSelectedSessionIds = new Map()
   clearSessionCache()
   clearSharedSessions()
 })
@@ -223,7 +237,7 @@ describe("Session lineage: normal continuation", () => {
       { role: "user", content: "Remember: Flobulator" },
     ], "sdk-1")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-1")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("resumes with only a late parallel tool result plus later user output", async () => {
@@ -256,7 +270,7 @@ describe("Session lineage: normal continuation", () => {
       { role: "user", content: [toolResult("call-c", "new-c-result")] },
     ], "sdk-parallel")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-parallel")
+    expect(getCaptured()?.options?.resume).toBeDefined()
     const prompt = getCaptured()?.prompt
     expect(typeof prompt).toBe("string")
     expect(prompt as string).toContain("late-b-result")
@@ -290,10 +304,10 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "Do you remember the word?" },
     ], "sdk-new")
 
-    // Should resume the original session with fork
-    expect(getCaptured()?.options?.resume).toBe("sdk-1")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
-    expect(getCaptured()?.options?.resumeSessionAt).toBeDefined()
+    // No durable rollback UUID is available, so replay from fresh state.
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.forkSession).toBeUndefined()
+    expect(getCaptured()?.options?.resumeSessionAt).toBeUndefined()
   })
 
   it("forks session on multi-undo (fewer messages)", async () => {
@@ -324,8 +338,8 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "completely different" },
     ], "sdk-new")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-1")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.forkSession).toBeUndefined()
   })
 
   it("does NOT resume when earlier message is edited", async () => {
@@ -366,18 +380,20 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "remember X" },
     ], "sdk-1")
 
-    // Undo + new message → forks from sdk-1, gets new session sdk-2
+    // Undo + new message → forks from sdk-1 under the preallocated ID.
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
       { role: "assistant", content: "hi" },
       { role: "user", content: "forget about X" },
-    ], "sdk-2")
+    ], "ignored-managed-fork-id")
 
-    // Should fork from original session
-    expect(getCaptured()?.options?.resume).toBe("sdk-1")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    // Should fork from original session using the durable journaled target.
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.forkSession).toBeUndefined()
+    const forkSessionId = getCaptured()?.options?.sessionId
+    expect(forkSessionId).toMatch(/^[0-9a-f-]{36}$/)
 
-    // Continuing from the fork should resume with sdk-2
+    // Continuing from the fork should resume with that exact target.
     capturedQueryParams = null
     await post(app, "sess-1", [
       { role: "user", content: "hello" },
@@ -385,10 +401,10 @@ describe("Session lineage: undo detection", () => {
       { role: "user", content: "forget about X" },
       { role: "assistant", content: "ok" },
       { role: "user", content: "what do you know?" },
-    ], "sdk-2")
+    ], forkSessionId!)
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-2")
-    expect(getCaptured()?.options?.forkSession).toBeUndefined()
+    expect(getCaptured()?.options?.resume).toBe(forkSessionId)
+    expect(getCaptured()?.options?.forkSession).toBe(true)
   })
 })
 
@@ -452,7 +468,7 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "topic E" },
     ], "sdk-c")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-c")
+    expect(getCaptured()?.options?.resume).toBeDefined()
     expect(getCaptured()?.prompt).toContain("INTERMEDIATE COMPACTION SENTINEL")
     expect(getCaptured()?.prompt).toContain("topic E")
   })
@@ -480,7 +496,7 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "step 6" },
     ], "sdk-s")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-s")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("does NOT resume when both prefix AND suffix changed (real branch)", async () => {
@@ -512,10 +528,10 @@ describe("Session lineage: compaction survival", () => {
       { role: "user", content: "continue with C" },
     ], "sdk-new")
 
-    // Prefix overlap (hello, hi) → undo detected → forks from rollback point
-    expect(getCaptured()?.options?.resume).toBe("sdk-b")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
-    expect(getCaptured()?.options?.resumeSessionAt).toBeDefined()
+    // Prefix overlap without a durable rollback UUID fails safely to full replay.
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.forkSession).toBeUndefined()
+    expect(getCaptured()?.options?.resumeSessionAt).toBeUndefined()
   })
 
   it("rejects aggressive compaction where nothing is preserved", async () => {
@@ -583,7 +599,7 @@ describe("Session lineage: pruning survival", () => {
     ], "sdk-p")
 
     // Should resume — suffix (last 2+) of stored messages preserved
-    expect(getCaptured()?.options?.resume).toBe("sdk-p")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 })
 
@@ -651,7 +667,7 @@ describe("Session lineage: post-compaction behavior", () => {
       { role: "user", content: "F" },
     ], "sdk-pc")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-pc")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("second compaction is also detected correctly", async () => {
@@ -703,7 +719,7 @@ describe("Session lineage: post-compaction behavior", () => {
       { role: "user", content: "H" },
     ], "sdk-2c")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-2c")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 
   it("undo after compaction is correctly rejected", async () => {
@@ -764,8 +780,8 @@ describe("Session lineage: post-compaction behavior", () => {
     ], "sdk-new")
 
     // Prefix overlap (Summary, C done, D, D done match) → undo → fork
-    expect(getCaptured()?.options?.resume).toBe("sdk-uc")
-    expect(getCaptured()?.options?.forkSession).toBe(true)
+    expect(getCaptured()?.options?.resume).toBeUndefined()
+    expect(getCaptured()?.options?.forkSession).toBeUndefined()
   })
 })
 
@@ -781,7 +797,7 @@ describe("Session lineage: fingerprint fallback", () => {
       { role: "user", content: "Good evening" },
     ], "sdk-fp1")
 
-    queuedSessionIds.push("sdk-fp1")
+    queuedSessionLabels.push("sdk-fp1")
     const r1 = await app.fetch(new Request("http://localhost/v1/messages", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -797,7 +813,7 @@ describe("Session lineage: fingerprint fallback", () => {
     await r1.json()
 
     // Undo + new message
-    queuedSessionIds.push("sdk-fp-new")
+    queuedSessionLabels.push("sdk-fp-new")
     capturedQueryParams = null
     const r2 = await app.fetch(new Request("http://localhost/v1/messages", {
       method: "POST",
@@ -841,7 +857,7 @@ describe("Session lastAccess refresh on lookup", () => {
       { role: "user", content: "still here?" },
     ], "sdk-A")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-A")
+    expect(getCaptured()?.options?.resume).toBeDefined()
 
     capturedQueryParams = null
     await post(app, "sess-A", [
@@ -852,6 +868,6 @@ describe("Session lastAccess refresh on lookup", () => {
       { role: "user", content: "one more" },
     ], "sdk-A")
 
-    expect(getCaptured()?.options?.resume).toBe("sdk-A")
+    expect(getCaptured()?.options?.resume).toBeDefined()
   })
 })

--- a/src/__tests__/session-store-pruning.test.ts
+++ b/src/__tests__/session-store-pruning.test.ts
@@ -71,6 +71,17 @@ describe("Session store count-based pruning", () => {
     expect(lookupSharedSession("sess-6")).toBeDefined()
   })
 
+  it("never prunes the mapping being published when the wall clock moves backward", () => {
+    for (let i = 0; i < 5; i++) {
+      storeSharedSession(`future-${i}`, `claude-future-${i}`)
+    }
+    dateSpy.mockImplementation(() => 1)
+
+    expect(storeSharedSession("new-after-clock-step", "claude-new")).not.toBe(false)
+    expect(lookupSharedSession("new-after-clock-step")?.claudeSessionId).toBe("claude-new")
+    expect(lookupSharedSession("future-0")).toBeUndefined()
+  })
+
   it("does NOT prune by time — old sessions survive", () => {
     // Store a session, then manually set lastUsedAt to 48 hours ago
     // by writing directly. Under the old TTL system this would be pruned.

--- a/src/__tests__/session-tool-cache-eviction.test.ts
+++ b/src/__tests__/session-tool-cache-eviction.test.ts
@@ -16,7 +16,7 @@
  * into the map — an evicted session simply stops having its tools restored.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage, makeRequest } from "./helpers"
+import { assistantMessage, makeRequest, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = {}
@@ -25,7 +25,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (opts: any) => {
     capturedQueryParams = opts
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, opts.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({

--- a/src/__tests__/silent-turn-recovery.test.ts
+++ b/src/__tests__/silent-turn-recovery.test.ts
@@ -10,16 +10,55 @@
  * recovery turn.
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { lookupSharedSession, setSessionStoreDir, storeSharedSession } from "../proxy/sessionStore"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-http-test-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  // Request completion releases the cross-process lease asynchronously.
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
 
 let queryCalls: any[] = []
 let scripted: any[][] = []
+let mockBaseSessionId = "test-session"
+let queryMutation: ((params: any) => void) | undefined
+const initialManagedSessionId = () => queryCalls[0]?.options?.sessionId ?? mockBaseSessionId
+
+import { resolveMockSdkSessionId } from "./helpers"
 
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     queryCalls.push(params)
+    queryMutation?.(params)
     const messages = scripted.shift() ?? []
     return (async function* () {
-      for (const m of messages) yield m
+      const returnedSessionId = resolveMockSdkSessionId(params.options, mockBaseSessionId)
+      const preHook = params.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
+      const hookPromises: Promise<unknown>[] = []
+      for (const m of messages) {
+        if (m?.__preTool) {
+          if (preHook) hookPromises.push(Promise.resolve(preHook({
+            tool_name: m.name,
+            tool_use_id: m.id,
+            tool_input: m.input,
+          }, undefined, { signal: new AbortController().signal })))
+          continue
+        }
+        if (m?.__throw) {
+          await Promise.allSettled(hookPromises)
+          throw new Error("scripted recovery interruption")
+        }
+        yield { ...m, session_id: returnedSessionId }
+      }
+      await Promise.allSettled(hookPromises)
     })()
   },
   createSdkMcpServer: () => ({
@@ -61,7 +100,29 @@ const forkTextBlock = (index: number, text: string) => [
 const forkMsgEnd = () => [
   forkEv({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 40 } }),
   forkEv({ type: "message_stop" }),
+  { type: "result", subtype: "success", is_error: false },
 ]
+
+const recoveryToolBlock = (index: number, id: string, path: string) => [
+  forkEv({ type: "content_block_start", index, content_block: { type: "tool_use", id, name: "read", input: {} } }),
+  forkEv({ type: "content_block_delta", index, delta: { type: "input_json_delta", partial_json: JSON.stringify({ file_path: path }) } }),
+  forkEv({ type: "content_block_stop", index }),
+]
+const recoveryAssistantTools = (ids: string[], uuid = crypto.randomUUID()) => ({
+  type: "assistant",
+  uuid,
+  message: {
+    role: "assistant",
+    content: ids.map((id, index) => ({ type: "tool_use", id, name: "read", input: { file_path: `${index}.txt` } })),
+  },
+})
+const recoveryDeny = (ids: string[]) => ({
+  type: "user",
+  message: {
+    role: "user",
+    content: ids.map((id) => ({ type: "tool_result", tool_use_id: id, content: "forwarded", is_error: true })),
+  },
+})
 
 const msgStart = () => ev({
   type: "message_start",
@@ -110,6 +171,11 @@ const REQUEST = {
   model: "claude-sonnet-4-5",
   max_tokens: 400,
   stream: true,
+  tools: [{
+    name: "read",
+    description: "Read a file",
+    input_schema: { type: "object", properties: { file_path: { type: "string" } }, required: ["file_path"] },
+  }],
   messages: [{ role: "user", content: "summarise the tool output" }],
 }
 
@@ -127,6 +193,8 @@ describe("silent-turn recovery", () => {
     delete process.env.MERIDIAN_SILENT_TURN_RECOVERY
     queryCalls = []
     scripted = []
+    queryMutation = undefined
+    mockBaseSessionId = `test-session-${crypto.randomUUID()}`
   })
 
   afterEach(() => {
@@ -137,7 +205,7 @@ describe("silent-turn recovery", () => {
   it("turns a thinking-only turn into a real answer the client receives", async () => {
     scripted = [
       [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
-      [msgStart(), ...textBlock(0, "Here is the summary."), ...msgEnd()],
+      [msgStart(), ...forkTextBlock(0, "Here is the summary."), ...forkMsgEnd()],
     ]
 
     const body = await read(await post(app, REQUEST, "silent-recovered"))
@@ -206,6 +274,81 @@ describe("silent-turn recovery", () => {
     expect(body).toContain("message_stop")
   })
 
+  it("does not publish a recovery fork that emitted text before throwing", async () => {
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [forkEv({ type: "message_start", message: { id: "m2", type: "message", role: "assistant", content: [], model: "claude-sonnet-4-5-20250929", stop_reason: null, usage: { input_tokens: 5, output_tokens: 0 } } }),
+       ...forkTextBlock(0, "partial answer"), { __throw: true }],
+    ]
+    const response = await post(app, REQUEST, "silent-partial-throw")
+    const body = await read(response)
+    expect(response.status).toBe(200)
+    expect(body).not.toContain("partial answer")
+    expect(lookupSharedSession("silent-partial-throw")?.claudeSessionId).toBe(initialManagedSessionId())
+  })
+
+  it("publishes and emits only a complete parallel recovery tool checkpoint", async () => {
+    const toolIds = ["recovery-parallel-a", "recovery-parallel-b"]
+    const assistantUuid = crypto.randomUUID()
+    const terminal = forkMsgEnd()
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [forkEv({ type: "message_start", message: { id: "m2", type: "message", role: "assistant", content: [], model: "claude-sonnet-4-5-20250929", stop_reason: null, usage: { input_tokens: 5, output_tokens: 0 } } }),
+       ...recoveryToolBlock(0, toolIds[0]!, "a.txt"),
+       { __preTool: true, id: toolIds[0], name: "read", input: { file_path: "a.txt" } },
+       ...recoveryToolBlock(1, toolIds[1]!, "b.txt"),
+       { __preTool: true, id: toolIds[1], name: "read", input: { file_path: "b.txt" } },
+       terminal[0], terminal[1], recoveryAssistantTools(toolIds, assistantUuid), recoveryDeny(toolIds), terminal[2]],
+    ]
+    const body = await read(await post(app, REQUEST, "silent-recovery-parallel"))
+    expect(body).toContain(toolIds[0]!)
+    expect(body).toContain(toolIds[1]!)
+    const stored = lookupSharedSession("silent-recovery-parallel")
+    expect(stored?.claudeSessionId).toBe(queryCalls[1].options.sessionId)
+    expect(stored?.passthroughToolCallAssistantUuid).toBe(assistantUuid)
+    expect(stored?.passthroughToolCallIds?.sort()).toEqual([...toolIds].sort())
+  })
+
+  it("does not emit or publish recovery tool calls when the recovery throws", async () => {
+    const toolId = "recovery-tool-before-throw"
+    const terminal = forkMsgEnd()
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [forkEv({ type: "message_start", message: { id: "m2", type: "message", role: "assistant", content: [], model: "claude-sonnet-4-5-20250929", stop_reason: null, usage: { input_tokens: 5, output_tokens: 0 } } }),
+       ...recoveryToolBlock(0, toolId, "bad.txt"),
+       { __preTool: true, id: toolId, name: "read", input: { file_path: "bad.txt" } },
+       terminal[0], terminal[1], recoveryAssistantTools([toolId]), recoveryDeny([toolId]),
+       { __throw: true }],
+    ]
+    const body = await read(await post(app, REQUEST, "silent-recovery-tool-throw"))
+    expect(body).not.toContain(toolId)
+    expect(lookupSharedSession("silent-recovery-tool-throw")?.claudeSessionId).toBe(initialManagedSessionId())
+  })
+
+  it("withholds recovery output when its durable publication loses the exact CAS", async () => {
+    const sessionKey = `silent-recovery-cas-${crypto.randomUUID()}`
+    scripted = [
+      [msgStart(), ...thinkingBlock(), ...emptyTextBlock(1), ...msgEnd()],
+      [forkEv({ type: "message_start", message: { id: "m2", type: "message", role: "assistant", content: [], model: "claude-sonnet-4-5-20250929", stop_reason: null, usage: { input_tokens: 5, output_tokens: 0 } } }),
+       ...forkTextBlock(0, "must stay unpublished"), ...forkMsgEnd()],
+    ]
+    queryMutation = () => {
+      if (queryCalls.length !== 2) return
+      queryMutation = undefined
+      const current = lookupSharedSession(sessionKey)
+      if (!current) throw new Error("missing mapping before recovery CAS race")
+      // Another writer advances the exact durable generation after recovery
+      // attached its source, but before the fork can publish.
+      storeSharedSession(sessionKey, current.claudeSessionId)
+    }
+
+    const body = await read(await post(app, REQUEST, sessionKey))
+
+    expect(queryCalls.length).toBe(2)
+    expect(body).not.toContain("must stay unpublished")
+    expect(lookupSharedSession(sessionKey)?.claudeSessionId).toBe(initialManagedSessionId())
+  })
+
   // The recovery forks, so its answer lands in a NEW SDK session. storeSession
   // has already run against the pre-fork id by then, whose tail is the silent
   // turn — leaving the mapping there means the next request resumes the silence
@@ -234,10 +377,10 @@ describe("silent-turn recovery", () => {
 
     expect(queryCalls.length).toBe(3)
     // The recovery itself forks off the silent session...
-    expect(queryCalls[1].options.resume).toBe("test-session")
+    expect(queryCalls[1].options.resume).toBe(initialManagedSessionId())
     expect(queryCalls[1].options.forkSession).toBe(true)
     // ...and the NEXT turn resumes the fork, which is where the answer lives.
-    expect(queryCalls[2].options.resume).toBe("fork-session")
+    expect(queryCalls[2].options.resume).toBe(queryCalls[1].options.sessionId)
   })
 
   it("kill switch keeps detection but skips the extra turn", async () => {

--- a/src/__tests__/sticky-routing-integration.test.ts
+++ b/src/__tests__/sticky-routing-integration.test.ts
@@ -4,7 +4,7 @@
  * SDK subprocess env (CLAUDE_CONFIG_DIR carries the profile's config dir).
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedEnvs: Array<Record<string, string | undefined>> = []
@@ -13,7 +13,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   query: (params: any) => {
     capturedEnvs.push(params.options?.env ?? {})
     return (async function* () {
-      for (const msg of mockMessages) yield msg
+      for (const msg of mockMessages) {
+        yield withMockSdkSessionId(msg, params.options)
+      }
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),

--- a/src/proxy/cwd.ts
+++ b/src/proxy/cwd.ts
@@ -18,6 +18,7 @@
  */
 
 import { existsSync } from "node:fs"
+import { resolve } from "node:path"
 
 export interface CwdResolution {
   /** Path passed to the SDK as `cwd:`. Always exists on the proxy host. */
@@ -45,9 +46,10 @@ export interface ResolveCwdOpts {
 
 export function resolveSdkWorkingDirectory(opts: ResolveCwdOpts): CwdResolution {
   const exists = opts.exists ?? existsSync
-  const claimed = opts.envOverride || opts.adapterCwd || opts.fallback
+  const claimed = resolve(opts.envOverride || opts.adapterCwd || opts.fallback)
+  const fallback = resolve(opts.fallback)
   if (exists(claimed)) {
     return { workingDirectory: claimed, claimedWorkingDirectory: claimed, fellBack: false }
   }
-  return { workingDirectory: opts.fallback, claimedWorkingDirectory: claimed, fellBack: true }
+  return { workingDirectory: fallback, claimedWorkingDirectory: claimed, fellBack: true }
 }

--- a/src/proxy/passthroughDenial.ts
+++ b/src/proxy/passthroughDenial.ts
@@ -1,0 +1,41 @@
+/**
+ * Marker used when Meridian forwards a passthrough tool call to the client.
+ *
+ * Keep this module pure. Runtime hooks, diagnostics, and E2E assertions must
+ * agree on the exact text, but none of them should know the Claude CLI's
+ * private transcript storage format.
+ */
+export const PASSTHROUGH_DENY_REASON =
+  "This tool call has been forwarded to the client for execution. " +
+  "The result will be delivered in a future turn. " +
+  "Do not retry, do not call additional tools, and do not generate further text — end your turn now."
+
+interface ContentTextBlock {
+  text?: unknown
+}
+
+export interface ToolResultLike {
+  type?: unknown
+  tool_use_id?: unknown
+  content?: unknown
+  is_error?: unknown
+}
+
+function blockText(block: ToolResultLike): string {
+  if (typeof block.content === "string") return block.content
+  if (!Array.isArray(block.content)) return ""
+  return block.content
+    .map((item: unknown) => {
+      if (!item || typeof item !== "object") return ""
+      const text = (item as ContentTextBlock).text
+      return typeof text === "string" ? text : ""
+    })
+    .join("")
+}
+
+/** True only for the synthetic error result emitted by the forwarding hook. */
+export function isForwardedDenial(block: ToolResultLike | undefined): boolean {
+  return block?.type === "tool_result" &&
+    block.is_error === true &&
+    blockText(block).includes(PASSTHROUGH_DENY_REASON)
+}

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -143,17 +143,19 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
 
 /**
  * Verify that a resumed tool-result delta settles exactly the tool calls at the
- * stored assistant checkpoint. Tool results must precede any ordinary user
- * content, matching the Anthropic Messages protocol.
+ * stored assistant checkpoint, then coalesce queued user turns into one SDK
+ * input. Tool results must precede any ordinary user content, matching the
+ * Anthropic Messages protocol.
  */
-export function isCompleteToolResultContinuation(
+export function coalesceCompleteToolResultContinuation(
   messages: Array<{ role?: unknown; content?: unknown }>,
   expectedIds: readonly string[]
-): boolean {
-  if (expectedIds.length === 0 || messages.length === 0) return false
+): Array<{ role: "user"; content: unknown[] }> | undefined {
+  if (expectedIds.length === 0 || messages.length === 0) return undefined
   const expected = new Set(expectedIds)
   const actual = new Set<string>()
   const echoedCalls = new Set<string>()
+  const content: unknown[] = []
   let sawUser = false
   let sawNonToolResult = false
 
@@ -166,28 +168,41 @@ export function isCompleteToolResultContinuation(
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; id?: unknown } | null | undefined
           if (block?.type !== "tool_use") continue
-          if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return false
+          if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return undefined
           echoedCalls.add(block.id)
         }
       }
       continue
     }
-    if (message.role !== "user" || !Array.isArray(message.content) || sawUser) return false
+    if (message.role !== "user") return undefined
+    // A queued user turn may follow only after the first turn settled the full
+    // checkpoint batch. Splitting results across turns is not a valid resume.
+    if (sawUser && actual.size !== expected.size) return undefined
+    const userContent = Array.isArray(message.content)
+      ? message.content
+      : typeof message.content === "string"
+        ? [{ type: "text", text: message.content }]
+        : undefined
+    if (!userContent) return undefined
     sawUser = true
-    for (const rawBlock of message.content) {
+    for (const rawBlock of userContent) {
       const block = rawBlock as { type?: unknown; tool_use_id?: unknown } | null | undefined
       if (block?.type === "tool_result") {
-        if (sawNonToolResult || typeof block.tool_use_id !== "string") return false
-        if (!expected.has(block.tool_use_id) || actual.has(block.tool_use_id)) return false
+        if (sawNonToolResult || typeof block.tool_use_id !== "string") return undefined
+        if (!expected.has(block.tool_use_id) || actual.has(block.tool_use_id)) return undefined
         actual.add(block.tool_use_id)
       } else {
         sawNonToolResult = true
       }
+      content.push(rawBlock)
     }
   }
 
-  return actual.size === expected.size &&
-    (echoedCalls.size === 0 || echoedCalls.size === expected.size)
+  if (
+    actual.size !== expected.size ||
+    (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
+  ) return undefined
+  return [{ role: "user", content }]
 }
 
 /** The cache-stable assistant boundary after every forwarded call settled. */

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,14 +164,17 @@ export function coalesceCompleteToolResultContinuation(
     // result. That assistant turn already exists at resumeSessionAt, so the
     // structured SDK delta below intentionally filters it out.
     if (message.role === "assistant" && !sawUser) {
+      let sawToolUse = false
       if (Array.isArray(message.content)) {
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; id?: unknown } | null | undefined
           if (block?.type !== "tool_use") continue
+          sawToolUse = true
           if (typeof block.id !== "string" || !expected.has(block.id) || echoedCalls.has(block.id)) return undefined
           echoedCalls.add(block.id)
         }
       }
+      if (!sawToolUse) return undefined
       continue
     }
     if (message.role !== "user") return undefined

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -12,7 +12,7 @@
  * fires the hidden digest turn. Those messages identify a stable assistant
  * checkpoint, but they are NOT a durability acknowledgement: a live PTY E2E
  * observed the assistant and deny in the iterator while neither existed in the
- * session JSONL after an immediate abort. The proxy therefore freezes the
+ * durable SDK transcript after an immediate abort. The proxy therefore freezes the
  * assistant UUID/tool IDs at deny settlement and stores the checkpoint only
  * after the SDK's canonical terminal result commits the transcript.
  *
@@ -220,6 +220,32 @@ export function coalesceCompleteToolResultContinuation(
   return [{ role: "user", content }]
 }
 
+/** Find and validate the exact echoed assistant checkpoint plus its result tail. */
+export function findCompleteToolResultCheckpoint(
+  messages: Array<{ role?: unknown; content?: unknown }>,
+  expectedIds: readonly string[],
+): Array<{ role: "user"; content: unknown[] }> | undefined {
+  if (expectedIds.length === 0) return undefined
+  const expected = new Set(expectedIds)
+  if (expected.size !== expectedIds.length) return undefined
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index]
+    if (message?.role !== "assistant" || !Array.isArray(message.content)) continue
+    const ids: string[] = []
+    let malformed = false
+    for (const rawBlock of message.content) {
+      const block = rawBlock as { type?: unknown; id?: unknown } | null | undefined
+      if (block?.type !== "tool_use") continue
+      if (typeof block.id !== "string") { malformed = true; break }
+      ids.push(block.id)
+    }
+    if (malformed || ids.length !== expected.size || new Set(ids).size !== ids.length) continue
+    if (!ids.every((id) => expected.has(id))) continue
+    return coalesceCompleteToolResultContinuation(messages.slice(index), expectedIds)
+  }
+  return undefined
+}
+
 /**
  * Has the tracker caught up with every forwarded call the wire actually
  * carried?
@@ -272,7 +298,7 @@ export type ClientAbortDisposition =
  * A client abort leaves the SDK session ending in an interrupted tail. Even an
  * assistant UUID already seen in the iterator is not known durable until the
  * canonical result: the live PTY regression yielded that UUID but never wrote
- * it to JSONL after abort. Therefore every owned mapping is evicted; a replay
+ * it durably after abort. Therefore every owned mapping is evicted; a replay
  * costs one cache miss but cannot wedge on a missing or interrupted boundary.
  */
 export function clientAbortDisposition(input: {

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -26,6 +26,18 @@
  * deferred tools, advisors, structured output, and the kill switch. In those
  * configurations the digest turn does generate and is discarded here.
  *
+ * Settlement is necessary but NOT sufficient to freeze the checkpoint. Two
+ * further conditions belong to the caller, which owns the wire:
+ *
+ *   - the turn has stopped generating, so no further call can appear, and
+ *   - trackerCoversStreamedCalls agrees the tracker has caught up with every
+ *     forwarded call the wire carried.
+ *
+ * Both exist because `expected` is armed from assistant messages, which the SDK
+ * can surface after the deny that settles them — so "everything I know about is
+ * answered" is true long before "everything is answered". Freezing on the
+ * former drops the calls still in flight, silently, from the client's set.
+ *
  * Pure module — no I/O, no imports from server.ts or session/.
  */
 
@@ -206,6 +218,33 @@ export function coalesceCompleteToolResultContinuation(
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
   return [{ role: "user", content }]
+}
+
+/**
+ * Has the tracker caught up with every forwarded call the wire actually
+ * carried?
+ *
+ * `expected` is armed from assistant messages, which the SDK can surface AFTER
+ * the deny that settles them. Settlement alone therefore proves only that the
+ * calls seen SO FAR are answered — freeze on that and any call whose assistant
+ * fragment is still in flight lands past the checkpoint and is dropped from the
+ * client-facing set. Silently: a dropped call is not a malformed envelope, so
+ * nothing downstream looks wrong.
+ *
+ * `streamedToolUseIds` comes from content_block_start, which cannot lag, so it
+ * is the completeness oracle both paths gate on. Callers build it with
+ * isClientForwardedToolUse so the two sets are comparable by construction.
+ */
+export function trackerCoversStreamedCalls(
+  tracker: EarlyStopTracker,
+  streamedToolUseIds: ReadonlySet<string>
+): boolean {
+  if (streamedToolUseIds.size === 0) return false
+  if (tracker.expected.size !== streamedToolUseIds.size) return false
+  for (const id of streamedToolUseIds) {
+    if (!tracker.expected.has(id)) return false
+  }
+  return true
 }
 
 /** The cache-stable assistant boundary after every forwarded call settled. */

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -471,7 +471,11 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       },
       ...(Object.keys(sdkAgents).length > 0 ? { agents: sdkAgents } : {}),
       ...(resumeSessionId ? { resume: resumeSessionId } : {}),
-      ...(isUndo || forkSession ? { forkSession: true } : {}),
+      // A passthrough checkpoint sits immediately before a persisted
+      // PreToolUse denial. resumeSessionAt rewinds that tail for one query but
+      // does not replace it in the source transcript; forking makes the rewind
+      // durable so the client's real tool_result becomes the new ancestry.
+      ...(isUndo || forkSession || (passthrough && resumeSessionAtUuid) ? { forkSession: true } : {}),
       ...(resumeSessionAtUuid ? { resumeSessionAt: resumeSessionAtUuid } : {}),
       ...(sdkHooks ? { hooks: sdkHooks } : {}),
       ...(effort ? { effort } : {}),

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -366,7 +366,13 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       model,
       pathToClaudeCodeExecutable: claudeExecutable,
       ...(abortController ? { abortController } : {}),
-      ...(stream ? { includePartialMessages: true } : {}),
+      // Passthrough needs them on BOTH paths, not just streaming: the deny-hold
+      // and the early-stop checkpoint both key off the turn-generation boundary,
+      // and `message_start`/`message_delta` are the only place it is observable.
+      // Without them non-stream releases its holds on the first assistant
+      // message and freezes the checkpoint there, so a parallel turn hands the
+      // client the first call and silently drops the rest (measured 1 of 3).
+      ...(stream || passthrough ? { includePartialMessages: true } : {}),
       permissionMode: "bypassPermissions" as const,
       allowDangerouslySkipPermissions: true,
       ...resolveSystemPrompt(systemContext, passthrough, settingSources, codeSystemPrompt, clientSystemPrompt, cwdNote),

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -5,7 +5,8 @@
  * between the streaming and non-streaming paths in server.ts.
  */
 
-import { join } from "node:path"
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve } from "node:path"
 import type { Options, OutputFormat, SdkBeta, SettingSource } from "@anthropic-ai/claude-agent-sdk"
 import { createOpencodeMcpServer } from "../mcpTools"
 import { createPassthroughMcpServer, PASSTHROUGH_MCP_NAME } from "./passthroughTools"
@@ -53,6 +54,26 @@ function stripConfigDir(env: Record<string, string | undefined>): Record<string,
   const out = { ...env }
   delete out.CLAUDE_CONFIG_DIR
   return out
+}
+
+/** Resolve the exact config root the child SDK process will use. Lifecycle GC
+ * stores this absolute locator at creation time so later profile changes cannot
+ * redirect deletion at a different root. */
+export function resolveQueryConfigDir(
+  cleanEnv: Record<string, string | undefined>,
+  sharedMemory: boolean | undefined,
+  workingDirectory: string = process.cwd(),
+): string {
+  const effectiveEnv = sharedMemory ? stripConfigDir(cleanEnv) : cleanEnv
+  const absoluteWorkingDirectory = resolve(workingDirectory)
+  const configured = effectiveEnv.CLAUDE_CONFIG_DIR
+  if (configured) return isAbsolute(configured)
+    ? resolve(configured)
+    : resolve(absoluteWorkingDirectory, configured)
+  const home = effectiveEnv.HOME || homedir()
+  return isAbsolute(home)
+    ? resolve(home, ".claude")
+    : resolve(absoluteWorkingDirectory, home, ".claude")
 }
 
 export interface QueryContext {
@@ -107,6 +128,10 @@ export interface QueryContext {
    *  fallback — the original stays registered as a bg agent; the fork gets a
    *  fresh id with the full history). */
   forkSession?: boolean
+  /** Preallocated SDK session ID for any Meridian-created transcript. Persisting
+   *  this ID before spawn lets lifecycle recovery identify a fresh session or
+   *  fork even if the proxy crashes before the SDK emits its first event. */
+  forkSessionId?: string
   /** SDK hooks (PreToolUse etc.) */
   sdkHooks?: any
   /** Blocked SDK built-in tools (from pipeline) */
@@ -336,7 +361,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
   const {
     prompt, model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
     passthrough, stream, sdkAgents, passthroughMcp, cleanEnv, hasDeferredTools,
-    resumeSessionId, isUndo, resumeSessionAtUuid, forkSession, sdkHooks, blockedTools, incompatibleTools,
+    resumeSessionId, isUndo, resumeSessionAtUuid, forkSession, forkSessionId, sdkHooks, blockedTools, incompatibleTools,
     mcpServerName, allowedMcpTools, onStderr,
     effort, thinking, taskBudget, outputFormat, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
     memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
@@ -481,7 +506,13 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
       // PreToolUse denial. resumeSessionAt rewinds that tail for one query but
       // does not replace it in the source transcript; forking makes the rewind
       // durable so the client's real tool_result becomes the new ancestry.
-      ...(isUndo || forkSession || (passthrough && resumeSessionAtUuid) ? { forkSession: true } : {}),
+      ...(isUndo || forkSession || (resumeSessionId && forkSessionId) || (passthrough && resumeSessionAtUuid)
+        ? { forkSession: true }
+        : {}),
+      // Every Meridian-created transcript is preallocated and journaled before
+      // spawn. For resumes this identifies the fork; for fresh turns it closes
+      // the same crash-created-orphan window without enabling forkSession.
+      ...(forkSessionId ? { sessionId: forkSessionId } : {}),
       ...(resumeSessionAtUuid ? { resumeSessionAt: resumeSessionAtUuid } : {}),
       ...(sdkHooks ? { hooks: sdkHooks } : {}),
       ...(effort ? { effort } : {}),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -45,7 +45,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
+import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, findCompleteToolResultCheckpoint, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -76,7 +76,7 @@ import { translateResponsesToAnthropic, translateAnthropicToResponses, createRes
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, consolidateMultimodalOntoLastUser, MULTIMODAL_TYPES, buildToolUseIndex, describeToolCall, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
 import { detectAdapter } from "./adapters/detect"
-import { buildQueryOptions, type QueryContext } from "./query"
+import { buildQueryOptions, resolveQueryConfigDir, type QueryContext } from "./query"
 import { normalizeEffort } from "./effort"
 import { parseOutputFormat, structuredOutputText } from "./structuredOutput"
 import { runTransformHook, buildPipeline, createRequestContext } from "./transform"
@@ -102,12 +102,46 @@ import {
   type TokenUsageIteration,
   type TokenUsage,
 } from "./session/lineage"
-import { getPriorityAssignmentKey } from "./session/fingerprint"
+import { getConversationFingerprint, getPriorityAssignmentKey } from "./session/fingerprint"
 // Re-export for backwards compatibility (existing tests import from here)
 
-import { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession, getSessionByClaudeId } from "./session/cache"
+import { lookupSession, storeSession, clearSessionCache, getMaxSessionsLimit, evictSession as evictCachedSession, getSessionByClaudeId } from "./session/cache"
 import { processSessionTurns, type SessionTurnLease } from "./session/turnCoordinator"
-import { lookupSessionRecovery, listStoredSessions } from "./sessionStore"
+import {
+  CrossProcessTurnAcquireTimeoutError,
+  CrossProcessTurnCoordinator,
+  type CrossProcessTurnLease,
+} from "./session/crossProcessTurnCoordinator"
+import {
+  attachSharedTranscriptLocator,
+  getSessionStoreDir,
+  lookupSessionRecovery,
+  lookupSharedSession,
+  lookupSharedSessionResult,
+  listStoredSessions,
+  readSessionStoreSnapshot,
+  readSessionStoreGenerationSnapshot,
+  type StoredSessionGeneration,
+} from "./sessionStore"
+import {
+  abandonFork,
+  acquireActiveTranscriptLease,
+  attachActiveTranscriptExecutor,
+  attachPinnedTranscript,
+  commitFork,
+  canonicalizeTranscriptLocator,
+  ensureTranscriptJournaled,
+  prepareFork,
+  publishPinnedTranscript,
+  registerLiveTranscript,
+  releaseActiveTranscriptLease,
+  runGc as runSessionGc,
+  getTranscriptResourceKey,
+  SessionLifecycleError,
+  type SessionLifecycleOptions,
+  type TranscriptLocator,
+} from "./sessionLifecycle"
+import { createSdkProcessGate } from "./session/sdkProcessGate"
 // Re-export for backwards compatibility (existing tests import from here)
 export { computeLineageHash, hashMessage, computeMessageHashes }
 export { clearSessionCache, getMaxSessionsLimit }
@@ -183,11 +217,16 @@ interface RequestMeta {
    */
   ttfbMs?: number
   sessionTurnLease?: SessionTurnLease
+  /** Durable revisions observed before cross-process turn acquisition. */
+  sharedSessionRevisionsAtArrival?: Record<string, string | null>
+  /** Permanently retain the session lease when mandatory durable cleanup fails. */
+  retainSessionTurnFence?: () => void
 }
 
 interface HandleMessagesOptions {
   body: any
   forcedProfileId?: string
+  turnWatchdogSignal?: AbortSignal
 }
 
 function totalQueueWaitMs(meta: RequestMeta): number {
@@ -540,6 +579,102 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // recoverable; a permanent deadlock is not. Read per instance (like the busy
   // retry delay above) so tests don't have to wait out the real ceiling.
   const SESSION_TURN_MAX_HOLD_MS = envInt("SESSION_TURN_MAX_HOLD_MS", 600_000)
+  // The in-memory coordinator prevents overlap only inside this process. Most
+  // Meridian deployments run one proxy per terminal, so the same OpenCode
+  // session must also be serialized through the shared session directory.
+  const crossProcessTurnStaleMs = Math.max(1_000, envInt("SESSION_TURN_STALE_MS", 30_000))
+  const crossProcessSessionTurns = new CrossProcessTurnCoordinator(
+    join(getSessionStoreDir(), "turn-locks"),
+    {
+      acquireTimeoutMs: Math.max(
+        1_000,
+        envInt("SESSION_TURN_ACQUIRE_TIMEOUT_MS", SESSION_TURN_MAX_HOLD_MS + 30_000),
+      ),
+      staleAfterMs: crossProcessTurnStaleMs,
+      heartbeatIntervalMs: Math.max(1, Math.floor(crossProcessTurnStaleMs / 3)),
+      retryDelayMs: Math.max(1, envInt("SESSION_TURN_RETRY_MS", 25)),
+    },
+  )
+  const sessionGcOptions: SessionLifecycleOptions = {
+    maxPending: Math.max(1, envInt("SESSION_GC_MAX_PENDING", 256)),
+    maxDeletesPerRun: Math.max(1, envInt("SESSION_GC_MAX_DELETES", 16)),
+    // A prepared fork is an active write lease. Never age it out before the
+    // request watchdog plus a drain margin, even if an unsafe lower value is configured.
+    preparedGraceMs: Math.max(
+      SESSION_TURN_MAX_HOLD_MS + 60_000,
+      envInt("SESSION_GC_PREPARED_GRACE_MS", SESSION_TURN_MAX_HOLD_MS + 60_000),
+    ),
+    retiredGraceMs: Math.max(
+      0,
+      envInt("SESSION_GC_GRACE_MS", SESSION_TURN_MAX_HOLD_MS + 60_000),
+    ),
+    deletionTimeoutMs: Math.max(1_000, envInt("SESSION_GC_DELETE_TIMEOUT_MS", 30_000)),
+    runTimeoutMs: Math.max(1_000, envInt("SESSION_GC_RUN_TIMEOUT_MS", 30_000)),
+  }
+  let sessionGcRunning: Promise<void> | undefined
+
+  const activeSessionGcPins = new Map<string, { locator: TranscriptLocator; refs: number }>()
+  const pinActiveSessionGcLocators = (...locators: TranscriptLocator[]): (() => void) => {
+    const keys: string[] = []
+    for (const locator of locators) {
+      const key = getTranscriptResourceKey(locator)
+      const existing = activeSessionGcPins.get(key)
+      if (existing) existing.refs++
+      else activeSessionGcPins.set(key, { locator, refs: 1 })
+      keys.push(key)
+    }
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      for (const key of keys) {
+        const existing = activeSessionGcPins.get(key)
+        if (!existing) continue
+        if (existing.refs <= 1) activeSessionGcPins.delete(key)
+        else existing.refs--
+      }
+    }
+  }
+
+  const collectSessionGcPins = (): TranscriptLocator[] => {
+    const pins: TranscriptLocator[] = [...activeSessionGcPins.values()].map((entry) => entry.locator)
+    for (const session of Object.values(readSessionStoreSnapshot())) {
+      if (session.currentTranscript?.sessionId === session.claudeSessionId) {
+        pins.push(session.currentTranscript)
+      }
+      if (
+        session.previousTranscript
+        && session.previousTranscript.sessionId === session.previousClaudeSessionId
+      ) {
+        pins.push(session.previousTranscript)
+      }
+    }
+    return pins
+  }
+  sessionGcOptions.pinProvider = collectSessionGcPins
+
+  const sweepSessionGc = (): Promise<void> => {
+    if (sessionGcRunning) return sessionGcRunning
+    sessionGcRunning = (async () => {
+      const result = await runSessionGc(collectSessionGcPins(), sessionGcOptions)
+      if (result.deleted || result.notFound || result.failed) {
+        claudeLog("session.gc", { ...result })
+        if (result.failed) {
+          plog(`[PROXY] session GC deferred ${result.failed} failed deletion(s); retry is scheduled`)
+        }
+      }
+    })().catch((error) => {
+      // Corrupt or contended metadata is fail-closed: keep transcripts and try
+      // later instead of guessing at ownership.
+      const message = error instanceof Error ? error.message : String(error)
+      claudeLog("session.gc_failed_closed", { error: message })
+      plog(`[PROXY] session GC postponed: ${message}`)
+    }).finally(() => {
+      sessionGcRunning = undefined
+    })
+    return sessionGcRunning
+  }
+
   // Default: share the process-wide budget, because the failure this guards
   // against (many SDK subprocesses spawned at once) is a property of the host
   // process, not of any one instance. `maxConcurrent` is the opt-out for
@@ -556,7 +691,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // that were admitted past that gate, so it drains to 0 on its own — no
   // separate bookkeeping of queued vs. active is needed.
   let draining = false
+  let durableWritesRevoked = false
   let inFlightRequests = 0
+  const activeRequestAborts = new Set<AbortController>()
 
   // Admission belongs at the PUBLIC entrypoint. /v1/chat/completions and
   // /v1/responses translate their body before re-entering /v1/messages, so
@@ -617,6 +754,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     signal: AbortSignal,
     requestMeta: RequestMeta,
     mode: string,
+    activeLocators: readonly TranscriptLocator[],
   ) {
     // Measured around the wait itself, not read from the granted lease: an
     // aborted wait never produces a lease, and crediting queue time only on
@@ -635,7 +773,30 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const startedAt = Date.now()
     requestMeta.currentSdkStartedAt = startedAt
     let sdkQuery: ReturnType<typeof query> | undefined
+    let activeTranscriptLease: Awaited<ReturnType<typeof acquireActiveTranscriptLease>> | undefined
+    let processGate: Awaited<ReturnType<typeof createSdkProcessGate>> | undefined
+    let writerJoined = true
     try {
+      for (const locator of activeLocators) {
+        await ensureTranscriptJournaled(locator, sessionGcOptions)
+      }
+      activeTranscriptLease = await acquireActiveTranscriptLease(activeLocators, sessionGcOptions)
+      // Unit SDK doubles never create an OS child. Production and real E2E runs
+      // always use the gated exact-incarnation writer path.
+      if (process.env.MERIDIAN_TEST_DISABLE_SDK_PROCESS_GATE !== "1") {
+        processGate = await createSdkProcessGate(
+          join(getSessionStoreDir(), "sdk-process-gates"),
+          (executor, recoverableAfterCrash) => attachActiveTranscriptExecutor(
+            activeTranscriptLease!,
+            executor,
+            sessionGcOptions,
+            recoverableAfterCrash,
+          ),
+          params.options?.stderr,
+        )
+        params.options ??= {}
+        params.options.spawnClaudeCodeProcess = processGate.spawnClaudeCodeProcess
+      }
       sdkQuery = query(params)
       yield* guardUpstreamIdle(sdkQuery, UPSTREAM_IDLE_MS, (sinceLastMs) =>
         claudeLog("upstream.stalled", { mode, sinceLastMs }))
@@ -645,6 +806,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // shims may be plain async generators whose iterator return() is
         // already invoked by guardUpstreamIdle.
         if (typeof sdkQuery?.close === "function") sdkQuery.close()
+        if (processGate) writerJoined = await processGate.closeAndJoin()
+        if (!writerJoined) {
+          throw new SessionLifecycleError("SDK writer could not be joined; transcript remains fenced")
+        }
+        if (activeTranscriptLease) {
+          await releaseActiveTranscriptLease(activeTranscriptLease, sessionGcOptions)
+        }
       } finally {
         requestMeta.sdkActiveDurationMs += Date.now() - startedAt
         lease.release()
@@ -872,13 +1040,25 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return { failed: false, errorPayload: null, errorType: null, response }
   }
 
-  async function dispatchPriority(c: Context, body: any, requestMeta: RequestMeta, orderedCandidateIds: string[], sessionKey: string | null, wantsStream: boolean): Promise<Response> {
+  async function dispatchPriority(
+    c: Context,
+    body: any,
+    requestMeta: RequestMeta,
+    orderedCandidateIds: string[],
+    sessionKey: string | null,
+    wantsStream: boolean,
+    turnWatchdogSignal?: AbortSignal,
+  ): Promise<Response> {
     let lastError: unknown = null
     let lastStatus = 429
     let previous: string | null = null
     let previousReason = "rate_limit_error"
     for (const [attempt, candidate] of orderedCandidateIds.entries()) {
-      const inner = await handleMessages(c, forkAttemptMeta(requestMeta, attempt), { body, forcedProfileId: candidate })
+      const inner = await handleMessages(c, forkAttemptMeta(requestMeta, attempt), {
+        body,
+        forcedProfileId: candidate,
+        turnWatchdogSignal,
+      })
       const sniffed = await sniffAccountFailure(inner)
       if (!sniffed.failed) {
         if (sessionKey) priorityAssignments.set(sessionKey, candidate)
@@ -944,12 +1124,100 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     options: HandleMessagesOptions,
   ) => {
     const requestStartAt = requestMeta.queueEnteredAt
-    const requestAbort = linkRequestAbort(c.req.raw.signal)
+    const requestSignal = options.turnWatchdogSignal
+      ? AbortSignal.any([c.req.raw.signal, options.turnWatchdogSignal])
+      : c.req.raw.signal
+    const requestAbort = linkRequestAbort(requestSignal)
     let streamOwnsAbortLink = false
 
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
       // Hoist adapter detection before try so it's available in the catch block for telemetry
       const adapter = detectAdapter(c)
+      const assertDurableWritesAllowed = (): void => {
+        if (durableWritesRevoked) throw new Error("Proxy shutdown revoked this request's durable writes")
+        if (requestAbort.controller.signal.aborted) {
+          throw new Error("Request cancellation revoked this request's durable writes")
+        }
+      }
+      // Becomes true immediately before an SDK resume can mutate its source
+      // transcript. A failed durable invalidation after that point must retain
+      // the logical-turn fence; failures before any resume are safe to release.
+      let resumedMappingMayBeAdvanced = false
+      const evictSession = (...args: Parameters<typeof evictCachedSession>): boolean => {
+        try {
+          const evicted = evictCachedSession(...args)
+          if (!evicted && resumedMappingMayBeAdvanced) {
+            // A failed generation-fenced invalidation of a mapping this turn
+            // actually resumed is just as uncertain as an exception. Keep both
+            // turn fences held so no peer can resume a transcript this request
+            // may already have advanced physically. Fresh turns have no source
+            // generation to quarantine, so an absent mapping is harmless.
+            requestMeta.retainSessionTurnFence?.()
+          }
+          if (evicted) resumedMappingMayBeAdvanced = false
+          return evicted
+        } catch (error) {
+          // If durable cleanup is uncertain, keep both process-local and
+          // cross-process turn fences held. Releasing would let another proxy
+          // resume the mapping we failed to invalidate.
+          if (resumedMappingMayBeAdvanced) requestMeta.retainSessionTurnFence?.()
+          throw error
+        }
+      }
+      let managedForkTarget: TranscriptLocator | undefined
+      let managedForkSource: TranscriptLocator | undefined
+      let managedForkCommitted = false
+      let managedForkPublished = false
+      let managedForkAbandoned = false
+      let managedForkSuperseded = false
+      // A fresh transcript uses the caller-selected SDK sessionId as its
+      // identity. Returned event IDs are advisory for this supported SDK path;
+      // resumed forks remain strict because they must prove fork identity.
+      let managedFreshTarget = false
+      let unexpectedManagedForkTarget: TranscriptLocator | undefined
+      let releaseManagedForkPins: (() => void) | undefined
+
+      const releaseManagedPins = (): void => {
+        releaseManagedForkPins?.()
+        releaseManagedForkPins = undefined
+      }
+
+      const abandonManagedFork = async (reason: string): Promise<void> => {
+        if (unexpectedManagedForkTarget) {
+          const unexpected = unexpectedManagedForkTarget
+          unexpectedManagedForkTarget = undefined
+          await registerLiveTranscript(unexpected, sessionGcOptions)
+            .then((exact) => abandonFork(exact, sessionGcOptions))
+            .catch((error) => {
+              claudeLog("session.unexpected_fork_track_failed", {
+                reason,
+                sessionId: unexpected.sessionId,
+                error: error instanceof Error ? error.message : String(error),
+              })
+            })
+        }
+        if (!managedForkTarget || managedForkPublished || managedForkAbandoned) {
+          if (managedForkPublished || !managedForkTarget) releaseManagedPins()
+          return
+        }
+        managedForkAbandoned = true
+        await abandonFork(managedForkTarget, sessionGcOptions).catch((error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          claudeLog("session.fork_abandon_failed", { reason, error: message })
+        })
+        releaseManagedPins()
+        void sweepSessionGc()
+      }
+
+      const commitManagedFork = async (): Promise<void> => {
+        if (!managedForkTarget || managedForkSuperseded || managedForkCommitted) return
+        // Promote under the lifecycle lock before publishing the mapping. A
+        // crash here leaves an unpinned live resource that reconciliation can
+        // retire; the reverse order could expose a mapping to a deleted target.
+        await commitFork(managedForkTarget, sessionGcOptions)
+        managedForkCommitted = true
+      }
+
       try {
         const body = options.body
 
@@ -1037,7 +1305,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               first = pick?.id ?? order[0]!
             }
             const candidates = [first, ...order.filter(id => id !== first && !priorityExhaustion.isExhausted(id))]
-            return dispatchPriority(c, body, requestMeta, candidates, sessionKey, body.stream === true)
+            return dispatchPriority(
+              c,
+              body,
+              requestMeta,
+              candidates,
+              sessionKey,
+              body.stream === true,
+              options.turnWatchdogSignal,
+            )
           }
         }
         const profile = resolveProfile(
@@ -1226,6 +1502,62 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // Instances (#476): base-resolved features with the instance's own
         // overrides layered on top.
         const sdkFeatures = { ...getFeaturesForAdapter(adapterBase), ...(adapter.instanceFeatures ?? {}) }
+        const transcriptConfigDir = resolveQueryConfigDir(
+          profileEnv,
+          sdkFeatures.sharedMemory,
+          workingDirectory,
+        )
+        const transcriptLocator = (sessionId: string): TranscriptLocator => ({
+          sessionId,
+          configDir: transcriptConfigDir,
+          projectDir: workingDirectory,
+        })
+        const managedSdkAttemptLocators = (): TranscriptLocator[] => {
+          const locators = [
+            managedForkSource,
+            managedForkTarget,
+          ].filter((locator): locator is TranscriptLocator => locator !== undefined)
+          return [...new Map(
+            locators.map((locator) => [getTranscriptResourceKey(locator), locator]),
+          ).values()]
+        }
+
+        const publicationTranscriptLocator = (sessionId: string): TranscriptLocator => {
+          if (managedForkTarget?.sessionId === sessionId) return managedForkTarget
+          if (managedForkSource?.sessionId === sessionId) return managedForkSource
+          return transcriptLocator(sessionId)
+        }
+
+      const validateManagedForkResult = (returnedSessionId: string | undefined): void => {
+        if ((!managedForkTarget || managedForkSuperseded) && resumeSessionId) {
+          if (returnedSessionId === resumeSessionId) return
+          if (returnedSessionId) {
+            unexpectedManagedForkTarget = transcriptLocator(returnedSessionId)
+          }
+          throw new Error(
+            `Resumed SDK session returned ${returnedSessionId || "no session ID"}; expected ${resumeSessionId}`,
+          )
+        }
+        if (!managedForkTarget || managedForkSuperseded) return
+        // The supported fresh-session path does not require the SDK to echo an
+        // ID on every event, but any ID it does echo must agree with the
+        // caller-selected target. Contradiction means the physical transcript
+        // may exist under another identity and must fail closed.
+        if (managedFreshTarget && returnedSessionId === undefined) return
+        if (returnedSessionId !== managedForkTarget.sessionId) {
+          if (returnedSessionId && returnedSessionId !== managedForkSource?.sessionId) {
+            unexpectedManagedForkTarget = {
+              sessionId: returnedSessionId,
+              configDir: managedForkTarget.configDir,
+              ...(managedForkTarget.projectDir ? { projectDir: managedForkTarget.projectDir } : {}),
+            }
+          }
+          throw new Error(
+            `Managed SDK fork returned ${returnedSessionId || "no session ID"}; expected ${managedForkTarget.sessionId}`,
+          )
+        }
+      }
+
 
         // Resolve thinking against the per-adapter setting.
         //
@@ -1346,9 +1678,45 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // fork/subagent source. Without this, pylon's long-lived subagent
         // workers fresh-replayed every turn: prompt-cache hits decayed to the
         // static-prefix floor and turn latency grew with conversation length.
-        const isIndependentSession =
+        let isIndependentSession =
           (!agentSessionId && (requestSource?.startsWith("fork-") || isSubagentRequest)) ||
           isClientDrivenLoop || false
+        const durableMappingKey = profileSessionId
+          || getConversationFingerprint(body.messages || [], profileScopedCwd)
+        // Image-only and otherwise text-free headerless requests have no stable
+        // cache identity. Run them fresh instead of manufacturing a generation
+        // for an empty key or failing before the SDK is called.
+        if (!durableMappingKey) isIndependentSession = true
+        const durableMappingAtTurn = durableMappingKey
+          ? lookupSharedSessionResult(durableMappingKey)
+          : { status: "missing" as const }
+        if (durableMappingAtTurn.status === "error") {
+          throw new Error(`Shared session store is unavailable: ${durableMappingAtTurn.error.message}`)
+        }
+        const mappingGenerationAtTurn = durableMappingAtTurn.generation
+        if (durableMappingKey && !mappingGenerationAtTurn) {
+          throw new Error("Shared session store did not return a durable key generation")
+        }
+        let mappingExpectedGeneration = mappingGenerationAtTurn
+        const refreshGenerationAfterEviction = (): StoredSessionGeneration => {
+          if (!durableMappingKey) throw new Error("Cannot refresh an empty durable mapping key")
+          const refreshed = lookupSharedSessionResult(durableMappingKey)
+          if (refreshed.status === "error") throw refreshed.error
+          if (refreshed.status === "found" || !refreshed.generation) {
+            throw new Error("Session mapping changed while it was being evicted")
+          }
+          return refreshed.generation
+        }
+        // Legacy passthrough boundaries are intentionally treated as a missing
+        // resumable session, but their real durable generation still fences the
+        // replay that replaces them.
+        const currentDurableRevision = mappingGenerationAtTurn
+        const arrivalRevision = profileSessionId && requestMeta.sharedSessionRevisionsAtArrival
+          ? requestMeta.sharedSessionRevisionsAtArrival[profileSessionId]
+          : undefined
+        const advancedAcrossProcesses = arrivalRevision !== undefined
+          ? arrivalRevision !== currentDurableRevision
+          : durableMappingAtTurn.status === "found"
         let lineageResult: LineageResult = isIndependentSession
           ? { type: "diverged", reason: "independent-request" }
           : lookupSession(profileSessionId, body.messages || [], profileScopedCwd)
@@ -1368,10 +1736,40 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // would break flows that worked before turn coordination existed.
         const declaresConcurrentFlow =
           requestSource?.startsWith("fork-") === true || isSubagentRequest
+        // NOTE: agent-specific (opencode) — OpenCode begins the tool-result
+        // request as soon as the visible checkpoint closes, while Meridian is
+        // still draining and committing that checkpoint. Its prompt envelope
+        // may change enough that hash lineage is "unrelated-history". Echoing
+        // every exact pending tool ID is nevertheless a causal continuation,
+        // not a stale competing branch.
+        const durableCheckpointIds = durableMappingAtTurn.status === "found"
+          ? durableMappingAtTurn.session.passthroughToolCallIds
+          : undefined
+        const durableCheckpointContinuation = durableCheckpointIds?.length
+          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds)
+          : undefined
+        const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
         if (
+          advancesDurableCheckpoint &&
+          lineageResult.type !== "continuation" &&
+          lineageResult.type !== "compaction" &&
+          durableMappingAtTurn.status === "found"
+        ) {
+          const checkpointSession = getSessionByClaudeId(durableMappingAtTurn.session.claudeSessionId)
+          if (checkpointSession) {
+            lineageResult = {
+              type: "continuation",
+              session: checkpointSession,
+              resumeFrom: checkpointSession.messageCount,
+            }
+          }
+        }
+        if (
+          agentSessionId &&
           profileSessionId &&
           !declaresConcurrentFlow &&
-          requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
+          !advancesDurableCheckpoint &&
+          (requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) || advancedAcrossProcesses) &&
           lineageResult.type !== "continuation" &&
           lineageResult.type !== "compaction"
         ) {
@@ -1461,7 +1859,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         }
 
         let isResume = lineageResult.type === "continuation" || lineageResult.type === "compaction"
-        const isUndo = lineageResult.type === "undo"
+        let isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         let resumeSessionId = cachedSession?.claudeSessionId
         // --- Passthrough mode ---
@@ -1484,12 +1882,40 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? lineageResult.resumeContentFrom
           : undefined
         // For undo: fork the session at the rollback point
-        const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
-        const sdkUndo = isUndo && Boolean(undoRollbackUuid)
+        let undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
+        let sdkUndo = isUndo && Boolean(undoRollbackUuid)
         if (isUndo && !undoRollbackUuid) {
           // Forks remap copied-history UUIDs. Without a valid boundary in the
           // preserved prefix, replay fresh rather than first attempting a
           // deterministic missing-message resume against the returned session.
+          resumeSessionId = undefined
+        }
+        const expectedResumeTranscript = resumeSessionId
+          ? canonicalizeTranscriptLocator(transcriptLocator(resumeSessionId))
+          : undefined
+        if (
+          resumeSessionId
+          && cachedSession?.currentTranscript
+          && expectedResumeTranscript
+          && (
+            cachedSession.currentTranscript.configDir !== expectedResumeTranscript.configDir
+            || cachedSession.currentTranscript.projectDir !== expectedResumeTranscript.projectDir
+          )
+        ) {
+          // A session ID is scoped to the config root that created it. Never
+          // relabel an old transcript with a newly selected profile: replay the
+          // structured history under the new root and leave the old locator for
+          // recovery/GC in its original namespace.
+          claudeLog("session.transcript_locator_changed", {
+            fromConfigDir: cachedSession.currentTranscript.configDir,
+            toConfigDir: transcriptConfigDir,
+            fromProjectDir: cachedSession.currentTranscript.projectDir,
+            toProjectDir: workingDirectory,
+          })
+          isResume = false
+          isUndo = false
+          sdkUndo = false
+          undoRollbackUuid = undefined
           resumeSessionId = undefined
         }
         // Early-stopped sessions resume at the assistant tool-use turn, before synthetic denials.
@@ -1558,7 +1984,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const allMessages = body.messages || []
       let messagesToConvert: typeof allMessages
 
-      if ((isResume || isUndo) && cachedSession) {
+      if (passthroughToolCallAssistantUuid && durableCheckpointContinuation) {
+        // Envelope drift can move the exact echoed checkpoint relative to the
+        // stored message count. Use the validated tail itself, never re-slice
+        // it through a stale lineage index.
+        messagesToConvert = durableCheckpointContinuation
+      } else if ((isResume || isUndo) && cachedSession) {
         if (isUndo && undoRollbackUuid) {
           // Undo with SDK rollback: the SDK will fork to the correct point,
           // so we only need to send the new user message.
@@ -1623,6 +2054,96 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         messagesToConvert?.some((m: any) =>
           m.role === "user" && Array.isArray(m.content) &&
           m.content.some((block: any) => block?.type === "tool_result"))
+
+      const lifecycleMappingKey = durableMappingKey
+      const prepareManagedFork = async (sourceSessionId: string): Promise<void> => {
+        if (managedForkTarget) return
+        managedFreshTarget = false
+        managedForkSource = cachedSession?.currentTranscript?.sessionId === sourceSessionId
+          ? cachedSession.currentTranscript
+          : transcriptLocator(sourceSessionId)
+        managedForkTarget = transcriptLocator(randomUUID())
+        releaseManagedForkPins = pinActiveSessionGcLocators(managedForkSource, managedForkTarget)
+        // A legacy mapping may predate transcript locators. Attach the source
+        // with the exact durable generation and ID before registering it for GC; otherwise a
+        // crash before target publication could leave the still-current source
+        // unpinned and eligible for deletion.
+        const attachedGeneration = lifecycleMappingKey
+          ? await attachPinnedTranscript(
+            managedForkSource,
+            () => {
+              assertDurableWritesAllowed()
+              return attachSharedTranscriptLocator(
+                lifecycleMappingKey,
+                sourceSessionId,
+                managedForkSource!,
+                mappingExpectedGeneration ?? undefined,
+              )
+            },
+            sessionGcOptions,
+          )
+          : false
+        if (!attachedGeneration) {
+          throw new Error("Session mapping changed before managed fork preparation; retry the turn")
+        }
+        mappingExpectedGeneration = attachedGeneration
+        // Journal both ownership and the chosen target before query() can create
+        // a fork file. This closes the crash window where the SDK file exists
+        // but no emitted event or shared mapping names it yet.
+        managedForkSource = await registerLiveTranscript(managedForkSource, sessionGcOptions)
+        managedForkTarget = await prepareFork(managedForkTarget, sessionGcOptions)
+        claudeLog("session.fork_prepared", {
+          sourceSessionId: managedForkSource.sessionId,
+          targetSessionId: managedForkTarget.sessionId,
+        })
+      }
+
+      const resetManagedCreationState = (): void => {
+        managedForkTarget = undefined
+        managedForkSource = undefined
+        managedForkCommitted = false
+        managedForkPublished = false
+        managedForkAbandoned = false
+        managedForkSuperseded = false
+        managedFreshTarget = false
+        unexpectedManagedForkTarget = undefined
+        releaseManagedForkPins = undefined
+      }
+
+      const prepareFreshTarget = async (): Promise<void> => {
+        if (managedForkTarget) return
+        // Preallocate every Meridian-created transcript, not only resumed
+        // forks. Otherwise a crash after SDK creation but before the first event
+        // leaves an ownerless transcript that reconcile/GC cannot discover.
+        managedForkTarget = transcriptLocator(randomUUID())
+        managedFreshTarget = true
+        releaseManagedForkPins = pinActiveSessionGcLocators(managedForkTarget)
+        managedForkTarget = await prepareFork(managedForkTarget, sessionGcOptions)
+        claudeLog("session.fresh_prepared", { targetSessionId: managedForkTarget.sessionId })
+      }
+
+      const rotateManagedCreationTarget = async (reason: string): Promise<void> => {
+        const sourceSessionId = managedFreshTarget ? undefined : managedForkSource?.sessionId
+        await abandonManagedFork(reason)
+        resetManagedCreationState()
+        if (sourceSessionId) await prepareManagedFork(sourceSessionId)
+        else await prepareFreshTarget()
+      }
+
+      const replaceWithFreshTarget = async (reason: string): Promise<void> => {
+        await abandonManagedFork(reason)
+        resetManagedCreationState()
+        await prepareFreshTarget()
+      }
+
+      if (resumeSessionId) {
+        // Every resume writes a preallocated supported SDK fork. The mapped
+        // source stays immutable until the exact target wins publication, so a
+        // proxy crash can never leave an uncommitted in-place tail resumable.
+        await prepareManagedFork(resumeSessionId)
+      } else {
+        await prepareFreshTarget()
+      }
 
       // Build the prompt — either structured or text.
       // Structured prompts are stored as arrays so they can be replayed on retry.
@@ -1756,7 +2277,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       let sawDuplicateToolUse = false
       // Stable checkpoint tracking: observe the forwarded assistant tool turn
       // and every synthetic denial, but do NOT abort at that point. A live PTY
-      // E2E proved those iterator messages can precede the CLI's durable JSONL
+      // E2E proved those iterator messages can precede the CLI's durable transcript
       // write; aborting there left only the initial user message on disk, so
       // resumeSessionAt failed with `missing-message`. We therefore drain the
       // hidden digest to a canonical SDK terminal result, suppress its content,
@@ -2077,7 +2598,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           let structuredOutput: unknown
           const upstreamStartAt = Date.now()
           let firstChunkAt: number | undefined
-          let currentSessionId: string | undefined
+          let currentSessionId: string | undefined = managedFreshTarget
+            ? managedForkTarget?.sessionId
+            : undefined
 
           // Build SDK UUID map: start with previously stored UUIDs (if resuming),
           // then capture new ones from the response. Declared outside try so
@@ -2108,6 +2631,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           let nextPassthroughToolCallAssistantUuid: string | undefined
           let nextPassthroughToolCallIds: string[] | undefined
           let sawCanonicalResult = false
+          let mappingInvalidated = false
+          const invalidateNonStreamMapping = (): boolean => {
+            if (isIndependentSession || mappingInvalidated) return true
+            const evicted = evictSession(
+              profileSessionId,
+              profileScopedCwd,
+              body.messages || [],
+              mappingExpectedGeneration,
+            )
+            if (evicted) mappingInvalidated = true
+            return evicted
+          }
 
           try {
             // Lazy-resolve executable if not already set (e.g. when using createProxyServer directly)
@@ -2141,7 +2676,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               let resumeRefusalRetries = 0
               let busySessionFork = false
               let sawUnresumableRefusal = false
+              let managedCreationAttemptStarted = false
               while (true) {
+                if (managedForkTarget) {
+                  if (managedCreationAttemptStarted) {
+                    await rotateManagedCreationTarget("non_stream_retry")
+                    if (managedFreshTarget) currentSessionId = managedForkTarget?.sessionId
+                  }
+                  managedCreationAttemptStarted = true
+                }
                 // Track whether response content was yielded.
                 // The SDK emits metadata (session_id etc.) before the API call;
                 // only "assistant" messages represent actual response content.
@@ -2155,10 +2698,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // consumer loop, attempt error, loop exit).
                 turnGenerating = true
                 try {
+                  if (resumeSessionId) resumedMappingMayBeAdvanced = true
                   for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                    resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, forkSessionId: managedForkTarget?.sessionId, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2170,7 +2714,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
-                  }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream")) {
+                  }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream", managedSdkAttemptLocators())) {
                     // Capture Claude Max subscription quota updates emitted by
                     // the SDK as rate_limit_event. We snapshot them in this
                     // profile's slot of the (per-profile-scoped) rate limit
@@ -2221,6 +2765,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       continue
                     }
                     if (refusal === "busy" && !busySessionFork) {
+                      await prepareManagedFork(resumeSessionId)
                       busySessionFork = true
                       claudeLog("session.busy_fork", { mode: "non_stream", resumeSessionId })
                       plog(`[PROXY] ${requestMeta.requestId} session still busy after ${RESUME_REFUSAL_MAX_RETRIES} retries — forking session`)
@@ -2242,14 +2787,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       resumeSessionId,
                     })
                     plog(`[PROXY] ${requestMeta.requestId} session unusable (${refusal}), evicting and replaying as fresh session`)
-                    evictSession(profileSessionId, profileScopedCwd, allMessages)
+                    managedForkSuperseded = true
+                    await abandonManagedFork("resume_replay")
+                    if (!evictSession(
+                      profileSessionId,
+                      profileScopedCwd,
+                      allMessages,
+                      mappingExpectedGeneration,
+                    )) throw new Error("Session mapping changed before resume fallback eviction")
+                    mappingExpectedGeneration = refreshGenerationAfterEviction()
+                    await replaceWithFreshTarget("non_stream_resume_replay")
+                    currentSessionId = managedForkTarget?.sessionId
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                     yield* runSdkQueryAttempt(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                      resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, forkSessionId: managedForkTarget?.sessionId, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2261,7 +2816,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh")
+                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh", managedSdkAttemptLocators())
                     return
                   }
 
@@ -2292,14 +2847,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       reason: "extra_usage_required_resume",
                     })
                     plog(`[PROXY] ${requestMeta.requestId} extra usage persisted on resumed ${model}, retrying as fresh session`)
-                    evictSession(profileSessionId, profileScopedCwd, allMessages)
+                    managedForkSuperseded = true
+                    await abandonManagedFork("fresh_model_fallback")
+                    if (!evictSession(
+                      profileSessionId,
+                      profileScopedCwd,
+                      allMessages,
+                      mappingExpectedGeneration,
+                    )) throw new Error("Session mapping changed before model fallback eviction")
+                    mappingExpectedGeneration = refreshGenerationAfterEviction()
+                    await replaceWithFreshTarget("non_stream_model_fallback")
+                    currentSessionId = managedForkTarget?.sessionId
                     sdkUuidMap.length = 0
                     for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                     yield* runSdkQueryAttempt(buildQueryOptions({
                       prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                       model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                      resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, forkSessionId: managedForkTarget?.sessionId, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2311,7 +2876,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh")
+                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "non_stream_fresh", managedSdkAttemptLocators())
                     return
                   }
 
@@ -2371,8 +2936,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
             for await (const message of response) {
               // Capture session ID from SDK messages
-              if ((message as any).session_id) {
-                currentSessionId = (message as any).session_id
+              const observedSessionId = (message as { session_id?: unknown }).session_id
+              if (typeof observedSessionId === "string" && observedSessionId) {
+                const returnedSessionId = observedSessionId
+                currentSessionId = managedFreshTarget && managedForkTarget && !managedForkSuperseded
+                  ? managedForkTarget.sessionId
+                  : returnedSessionId
+                validateManagedForkResult(returnedSessionId)
               }
               // Passthrough single-turn guard: once the model re-emits a call it
               // already made (detected in the PreToolUse hook between turns), it
@@ -2392,26 +2962,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               if (
                 passthrough &&
                 message.type === "assistant" &&
-                !earlyStopFired &&
-                earlyStop.resolved.size === 0
+                !earlyStopFired
               ) {
                 // Non-stream can expose a parallel tool turn as several
-                // assistant fragments. They all precede the first synthetic deny;
-                // later assistants are the hidden digest. Stop extending the
-                // checkpoint once any deny is consumed, and do not use the hook
-                // set as an oracle because a producer-side digest hook can race
-                // ahead of iterator consumption.
+                // assistant fragments, and a deny for call N can precede the
+                // assistant metadata for call N+1. Keep extending the candidate
+                // until the full client-visible ID set is covered; internal and
+                // duplicate calls are filtered by noteAssistantMessage.
                 const expectedBefore = earlyStop.expected.size
                 noteAssistantMessage(earlyStop, message)
                 assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
               } else if (passthrough && message.type === "user" && !earlyStopFired) {
                 noteUserContent(earlyStop, (message as any).message?.content)
+              }
+              if (
+                passthrough &&
+                !earlyStopFired &&
+                (message.type === "assistant" || message.type === "user")
+              ) {
                 // The completeness gate the streaming path already applies:
                 // generation has ended AND the tracker has caught up with every
-                // tool_use the wire actually carried. Either half alone is not
-                // enough — a deny can settle the calls known so far while a
-                // later assistant fragment is still to come, and freezing there
-                // drops it.
+                // tool_use the wire actually carried. Recheck after both sides:
+                // all denies can arrive before the last assistant fragment.
                 const turnComplete = sawTurnBoundarySignal
                   ? !turnGenerating && trackerCoversStreamedCalls(earlyStop, streamedToolUseIds)
                   : true // nothing to gate on — settle on the tracker alone
@@ -2590,12 +3162,33 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               plog(`[PROXY] ${requestMeta.requestId} discovered=${discoveredTools.size} (${newNames}) session_total=${allNames.length}`)
             }
           } catch (error) {
+            // Revocation blocks publication, not mandatory cleanup. A resumed
+            // non-stream turn interrupted by shutdown must not leave its source
+            // mapping available for another process to resume.
+            const failedResumedTurn = isResume && !managedForkTarget && !sawCanonicalResult
+            if (
+              (requestAbort.controller.signal.aborted || durableWritesRevoked || failedResumedTurn)
+              && !isIndependentSession
+            ) {
+              if (!invalidateNonStreamMapping()) {
+                throw new Error("Shared session mapping changed before interrupted non-stream invalidation")
+              }
+              claudeLog("session.interrupted_mapping_evicted", {
+                mode: "non_stream",
+                reason: failedResumedTurn ? "noncanonical_resume" : "request_abort",
+              })
+            }
             // #592: mirror the loop-exit release on the failure path.
             releaseHeldDenies("non_stream_error")
-            if (passthrough && capturedToolUses.length > 0 && !sawCanonicalResult) {
+            if (
+              !isIndependentSession &&
+              passthrough && capturedToolUses.length > 0 && !sawCanonicalResult
+            ) {
               // A failed durability drain must not leave either a newly cached
               // checkpoint or an older mapping behind for the advanced client.
-              evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+              if (!invalidateNonStreamMapping()) {
+                throw new Error("Shared session mapping changed before non-stream recovery invalidation")
+              }
               claudeLog("passthrough.noncanonical_session_evicted", { mode: "non_stream", reason: "drain_error" })
             }
             const stderrOutput = stderrLines.join("\n").trim()
@@ -2831,6 +3424,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             ])
           }
 
+          // A managed fork must identify its preallocated target even when the
+          // SDK yielded no session-bearing event. Missing IDs fail closed.
+          validateManagedForkResult(currentSessionId)
+
           // Store session for future resume.
           // Fork/subagent requests don't write to the cache — see lookupSession
           // block above for rationale (avoids polluting the parent's key).
@@ -2846,13 +3443,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // Iterator visibility is not durability. Never publish a
                   // resumeSessionAt UUID unless the CLI reached its terminal
                   // result and had a chance to commit the transcript.
-                  evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                  if (!invalidateNonStreamMapping()) {
+                    throw new Error("Shared session mapping changed before non-stream terminal invalidation")
+                  }
                   claudeLog("passthrough.noncanonical_session_evicted", { mode: "non_stream" })
                 } else {
-                  storeSession(
+                  validateManagedForkResult(currentSessionId)
+                  await commitManagedFork()
+                  let mappingStored: false | StoredSessionGeneration
+                  try {
+                    mappingStored = await publishPinnedTranscript(
+                      publicationTranscriptLocator(currentSessionId!),
+                      () => {
+                        assertDurableWritesAllowed()
+                        const stored = storeSession(
                     profileSessionId,
                     body.messages || [],
-                    currentSessionId,
+                    currentSessionId!,
                     profileScopedCwd,
                     reconcileReturnedSessionUuids(
                       sdkUuidMap,
@@ -2863,9 +3470,53 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     ),
                     lastUsage,
                     earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
-                    earlyStopFired ? nextPassthroughToolCallIds : null
-                  )
-                  commitSessionTurn()
+                    earlyStopFired ? nextPassthroughToolCallIds : null,
+                    publicationTranscriptLocator(currentSessionId!),
+                    managedForkTarget?.sessionId === currentSessionId ? managedForkSource : undefined,
+                    mappingExpectedGeneration,
+                      )
+                        if (stored) {
+                          mappingExpectedGeneration = stored
+                          if (managedForkTarget?.sessionId === currentSessionId) managedForkPublished = true
+                        }
+                        return stored
+                      },
+                      sessionGcOptions,
+                    )
+                  } catch (error) {
+                    if (
+                      (requestAbort.controller.signal.aborted || durableWritesRevoked) &&
+                      managedForkPublished &&
+                      !invalidateNonStreamMapping()
+                    ) {
+                      throw new Error("Shared session mapping changed before canceled non-stream publication cleanup")
+                    }
+                    throw error
+                  }
+                  if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                    if (mappingStored && !invalidateNonStreamMapping()) {
+                      throw new Error("Shared session mapping changed after canceled non-stream publication")
+                    }
+                    throw new Error("Request canceled after non-stream publication")
+                  }
+                  if (!mappingStored) {
+                    if (profileSessionId) {
+                      throw new Error("Shared session mapping changed before publication")
+                    }
+                    // A fingerprint is a weak hint, not a client session identity.
+                    // Concurrent headerless chats may share it; let the CAS winner
+                    // own resume state without failing the other successful response.
+                    claudeLog("session.fingerprint_publication_lost", {})
+                    void sweepSessionGc()
+                  } else {
+                    mappingExpectedGeneration = mappingStored
+                    if (managedForkTarget?.sessionId === currentSessionId) {
+                      managedForkPublished = true
+                      releaseManagedPins()
+                      void sweepSessionGc()
+                    }
+                    commitSessionTurn()
+                  }
                 }
               }
 
@@ -2899,6 +3550,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const streamCompletion = new Promise<void>((resolve) => {
           resolveStreamCompletion = resolve
         })
+        let clientAssistantContentExposed = false
         const readable = new ReadableStream({
           start(controller) {
             return (async () => {
@@ -2928,6 +3580,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               if (streamClosed) return false
               try {
                 controller.enqueue(payload)
+                if (source.includes("content_block") || source.includes("tool_block") || source.includes("tool_input")) {
+                  clientAssistantContentExposed = true
+                }
                 bytesSent += payload.byteLength
                 return true
               } catch (error) {
@@ -2985,6 +3640,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // terminal delta leaves the proxy, and it leaves last, once the
             // turn's real stop_reason is known.
             let pendingTerminalDelta: Uint8Array | null = null
+            let pendingStructuredFrames: Array<{ payload: Uint8Array; source: string }> = []
+            let pendingStructuredTextLength = 0
             let terminalDeltaSent = false
             const sendTerminalDelta = (stopReasonOverride?: string): void => {
               if (terminalDeltaSent) return
@@ -3037,7 +3694,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
 
             // Hoisted out of the try so the client-abort branch of the catch
             // below can settle this session (see clientAbortDisposition).
-            let currentSessionId: string | undefined
+            let currentSessionId: string | undefined = managedFreshTarget
+              ? managedForkTarget?.sessionId
+              : undefined
+            let nextClientBlockIndex = 0
             try {
               // Same transparent retry wrapper as the non-streaming path.
               // Rate-limit retry strategy:
@@ -3059,8 +3719,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 let resumeRefusalRetries = 0
                 let busySessionFork = false
                 let sawUnresumableRefusal = false
+                let managedCreationAttemptStarted = false
 
                 while (true) {
+                  if (managedForkTarget) {
+                    if (managedCreationAttemptStarted) {
+                      await rotateManagedCreationTarget("stream_retry")
+                      if (managedFreshTarget) currentSessionId = managedForkTarget?.sessionId
+                    }
+                    managedCreationAttemptStarted = true
+                  }
                   // Track whether client-visible SSE events were yielded.
                   // The SDK emits metadata events (session_id, internal routing)
                   // before the API call — those are NOT client-visible and must
@@ -3070,10 +3738,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // must not re-match a previous attempt's refusal text.
                   const attemptStderrStart = stderrLines.length
                   try {
+                    if (resumeSessionId) resumedMappingMayBeAdvanced = true
                     for await (const event of runSdkQueryAttempt(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                      resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, forkSessionId: managedForkTarget?.sessionId, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -3085,7 +3754,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                         : undefined,
                       advisorModel,
-                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream")) {
+                    }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream", managedSdkAttemptLocators())) {
                       // Same SDK rate-limit capture as the non-stream path.
                       if ((event as any).type === "rate_limit_event") {
                         rateLimitStore.record(profile.id, (event as any).rate_limit_info)
@@ -3118,6 +3787,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         continue
                       }
                       if (refusal === "busy" && !busySessionFork) {
+                        await prepareManagedFork(resumeSessionId)
                         busySessionFork = true
                         claudeLog("session.busy_fork", { mode: "stream", resumeSessionId })
                         plog(`[PROXY] ${requestMeta.requestId} session still busy after ${RESUME_REFUSAL_MAX_RETRIES} retries — forking session`)
@@ -3136,14 +3806,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         resumeSessionId,
                       })
                       plog(`[PROXY] ${requestMeta.requestId} session unusable (${refusal}), evicting and replaying as fresh session`)
-                      evictSession(profileSessionId, profileScopedCwd, allMessages)
+                      managedForkSuperseded = true
+                      await abandonManagedFork("resume_replay")
+                      if (!evictSession(
+                        profileSessionId,
+                        profileScopedCwd,
+                        allMessages,
+                        mappingExpectedGeneration,
+                      )) throw new Error("Session mapping changed before resume fallback eviction")
+                      mappingExpectedGeneration = refreshGenerationAfterEviction()
+                      await replaceWithFreshTarget("stream_resume_replay")
+                      currentSessionId = managedForkTarget?.sessionId
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                       yield* runSdkQueryAttempt(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                        resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                        resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, forkSessionId: managedForkTarget?.sessionId, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -3155,7 +3835,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
-                      }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh")
+                      }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh", managedSdkAttemptLocators())
                       return
                     }
 
@@ -3182,14 +3862,24 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         reason: "extra_usage_required_resume",
                       })
                       plog(`[PROXY] ${requestMeta.requestId} extra usage persisted on resumed ${model}, retrying as fresh session`)
-                      evictSession(profileSessionId, profileScopedCwd, allMessages)
+                      managedForkSuperseded = true
+                      await abandonManagedFork("fresh_model_fallback")
+                      if (!evictSession(
+                        profileSessionId,
+                        profileScopedCwd,
+                        allMessages,
+                        mappingExpectedGeneration,
+                      )) throw new Error("Session mapping changed before model fallback eviction")
+                      mappingExpectedGeneration = refreshGenerationAfterEviction()
+                      await replaceWithFreshTarget("stream_model_fallback")
+                      currentSessionId = managedForkTarget?.sessionId
                       sdkUuidMap.length = 0
                       for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
                       yield* runSdkQueryAttempt(buildQueryOptions({
                         prompt: buildFreshPrompt(allMessages, sanitizeOpts),
                         model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                         passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                        resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                        resumeSessionId: undefined, isUndo: false, resumeSessionAtUuid: undefined, forkSessionId: managedForkTarget?.sessionId, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                         effort, thinking, taskBudget, outputFormat, betas, settingSources,
                         codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -3201,7 +3891,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                           : undefined,
                         advisorModel,
-                      }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh")
+                      }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "stream_fresh", managedSdkAttemptLocators())
                       return
                     }
 
@@ -3290,7 +3980,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // Block index remapping: the SDK resets indices on each turn, but
               // we skip intermediate message_start/stop so the client sees one
               // message. Without remapping, turn 2's index=0 collides with turn 1's.
-              let nextClientBlockIndex = 0
+              nextClientBlockIndex = 0
               const sdkToClientIndex = new Map<number, number>()
 
               const guardedResponse = guardUpstreamIdle(response, UPSTREAM_IDLE_MS, (sinceLastMs) =>
@@ -3312,8 +4002,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // Capture session ID and only client-visible assistant
                   // UUIDs. Hidden digest assistants share the same client slot
                   // and must not replace its stable tool checkpoint.
-                  if ((message as any).session_id) {
-                    currentSessionId = (message as any).session_id
+                  const observedSessionId = (message as { session_id?: unknown }).session_id
+                  if (typeof observedSessionId === "string" && observedSessionId) {
+                    const returnedSessionId = observedSessionId
+                    currentSessionId = managedFreshTarget && managedForkTarget && !managedForkSuperseded
+                      ? managedForkTarget.sessionId
+                      : returnedSessionId
+                    validateManagedForkResult(returnedSessionId)
                   }
                   let assistantAddedForwardedCall = false
                   if (earlyStopEnabled && message.type === "assistant" && !earlyStopFired) {
@@ -3374,7 +4069,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // belong to the hidden digest. Ignore them wholesale so a
                     // closed-controller enqueue cannot break the durability
                     // drain before the canonical result arrives.
-                    if (streamClosed && awaitingEarlyStopDrain) continue
+                    if (awaitingEarlyStopDrain) continue
                     streamEventsSeen += 1
                     if (!firstChunkAt) {
                       firstChunkAt = Date.now()
@@ -3438,17 +4133,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         if (passthrough && streamedToolUseIds.size > 0) {
                           if (!streamClosed) {
                             flushOpenClientBlocks("turn2_suppression")
-                            sendTerminalDelta("tool_use")
-                            safeEnqueue(encoder.encode(
-                              `event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`
-                            ), "passthrough_turn2_stop")
-                            streamClosed = true
-                            controller.close()
+                            if (earlyStopEnabled) {
+                              // Alternate SDK ordering: turn 2 can start before
+                              // the tool-use message_delta arms the ordinary
+                              // drain path. Suppress it, but do not grant the
+                              // client a terminal checkpoint until publication.
+                              awaitingEarlyStopDrain = true
+                              claudeLog("passthrough.turn2_suppressed", { mode: "stream", toolUses: streamedToolUseIds.size })
+                              continue
+                            }
+                            // Kill-switch compatibility interrupts the SDK
+                            // tail, but still withholds the terminal wire pair
+                            // until the old mapping is durably evicted below.
+                            exitedBeforeCanonicalTerminal = true
+                            break
                           }
-                          // Suppress the entire hidden digest turn, but drain it
-                          // through the canonical result so the transcript is durable.
-                          awaitingEarlyStopDrain = true
-                          claudeLog("passthrough.turn2_suppressed", { mode: "stream", toolUses: streamedToolUseIds.size })
                           continue
                         }
                         continue
@@ -3658,19 +4357,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       streamedToolUseIds.size > 0
                     ) {
                       flushOpenClientBlocks("drain_close")
-                      // This path used to rely on the delta having gone out
-                      // inline above; it is now withheld, so send it here.
-                      sendTerminalDelta()
-                      safeEnqueue(
-                        encoder.encode(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`),
-                        "passthrough_tool_stream_stop"
-                      )
-                      streamClosed = true
-                      controller.close()
                       if (earlyStopEnabled) {
+                        // The tool blocks may be visible, but the terminal pair
+                        // is the client's permission to act on them. Withhold it
+                        // until the fork target wins durable publication below.
+                        // A crash before then leaves an incomplete SSE message,
+                        // so retry starts from the still-immutable source.
                         awaitingEarlyStopDrain = true
                         continue
                       }
+                      // Kill-switch compatibility interrupts the SDK tail,
+                      // but does not emit a successful terminal checkpoint
+                      // until the old mapping is durably evicted below.
                       exitedBeforeCanonicalTerminal = true
                       break
                     }
@@ -3697,49 +4395,60 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
                 const text = structuredOutputText(structuredOutput)
                 const messageId = `msg_${Date.now()}`
-                safeEnqueue(encoder.encode(
-                  `event: message_start\ndata: ${JSON.stringify({
-                    type: "message_start",
-                    message: {
-                      id: messageId,
-                      type: "message",
-                      role: "assistant",
-                      content: [],
-                      model: body.model,
-                      stop_reason: null,
-                      stop_sequence: null,
-                      usage: { input_tokens: lastUsage?.input_tokens ?? 0, output_tokens: 0 },
-                    },
-                  })}\n\n`
-                ), "structured_message_start")
-                safeEnqueue(encoder.encode(
-                  `event: content_block_start\ndata: ${JSON.stringify({
-                    type: "content_block_start",
-                    index: 0,
-                    content_block: { type: "text", text: "" },
-                  })}\n\n`
-                ), "structured_block_start")
-                safeEnqueue(encoder.encode(
-                  `event: content_block_delta\ndata: ${JSON.stringify({
-                    type: "content_block_delta",
-                    index: 0,
-                    delta: { type: "text_delta", text },
-                  })}\n\n`
-                ), "structured_text_delta")
-                safeEnqueue(encoder.encode(
-                  `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`
-                ), "structured_block_stop")
-                safeEnqueue(encoder.encode(
+                pendingStructuredFrames = [
+                  {
+                    payload: encoder.encode(
+                      `event: message_start\ndata: ${JSON.stringify({
+                        type: "message_start",
+                        message: {
+                          id: messageId,
+                          type: "message",
+                          role: "assistant",
+                          content: [],
+                          model: body.model,
+                          stop_reason: null,
+                          stop_sequence: null,
+                          usage: { input_tokens: lastUsage?.input_tokens ?? 0, output_tokens: 0 },
+                        },
+                      })}\n\n`,
+                    ),
+                    source: "structured_message_start",
+                  },
+                  {
+                    payload: encoder.encode(
+                      `event: content_block_start\ndata: ${JSON.stringify({
+                        type: "content_block_start",
+                        index: 0,
+                        content_block: { type: "text", text: "" },
+                      })}\n\n`,
+                    ),
+                    source: "structured_block_start",
+                  },
+                  {
+                    payload: encoder.encode(
+                      `event: content_block_delta\ndata: ${JSON.stringify({
+                        type: "content_block_delta",
+                        index: 0,
+                        delta: { type: "text_delta", text },
+                      })}\n\n`,
+                    ),
+                    source: "structured_text_delta",
+                  },
+                  {
+                    payload: encoder.encode(
+                      `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: 0 })}\n\n`,
+                    ),
+                    source: "structured_block_stop",
+                  },
+                ]
+                pendingTerminalDelta = encoder.encode(
                   `event: message_delta\ndata: ${JSON.stringify({
                     type: "message_delta",
                     delta: { stop_reason: "end_turn", stop_sequence: null },
                     usage: { output_tokens: lastUsage?.output_tokens ?? 0 },
-                  })}\n\n`
-                ), "structured_message_delta")
-                messageStartEmitted = true
-                eventsForwarded += 5
-                textEventsForwarded += 1
-                textCharsForwarded += text.length
+                  })}\n\n`,
+                )
+                pendingStructuredTextLength = text.length
               }
 
               if (passthrough) {
@@ -3764,10 +4473,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 plog(`[PROXY] ${requestMeta.requestId} discovered=${discoveredTools.size} (${newNames}) session_total=${allNames.length}`)
               }
 
+              // A managed fork must identify its preallocated target even when
+              // the SDK yielded no session-bearing event. Missing IDs fail closed.
+              validateManagedForkResult(currentSessionId)
+
               // Store only canonical, durable checkpoint turns. Fork/subagent
               // requests and duplicate-aborted sessions never write the cache.
               // A live PTY E2E proved assistant/deny iterator messages may be
-              // yielded before their JSONL records are committed, so a tool turn
+              // yielded before their durable transcript records are committed, so a tool turn
               // also requires both a valid assistant checkpoint and SDK result.
               if (currentSessionId && !isIndependentSession && !sawDuplicateToolUse) {
                 const checkpointTurn = passthrough && streamedToolUseIds.size > 0
@@ -3775,13 +4488,27 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   exitedBeforeCanonicalTerminal ||
                   (checkpointTurn && (!earlyStopFired || !sawCanonicalResult))
                 ) {
-                  evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                  const evicted = evictSession(
+                    profileSessionId,
+                    profileScopedCwd,
+                    body.messages || [],
+                    mappingExpectedGeneration,
+                  )
+                  if (!evicted) {
+                    throw new Error("Shared session mapping changed before terminal invalidation")
+                  }
                   claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream" })
                 } else {
-                  storeSession(
+                  validateManagedForkResult(currentSessionId)
+                  await commitManagedFork()
+                  const mappingStored = await publishPinnedTranscript(
+                    publicationTranscriptLocator(currentSessionId!),
+                    () => {
+                      assertDurableWritesAllowed()
+                      const stored = storeSession(
                     profileSessionId,
                     body.messages || [],
-                    currentSessionId,
+                    currentSessionId!,
                     profileScopedCwd,
                     reconcileReturnedSessionUuids(
                       sdkUuidMap,
@@ -3792,10 +4519,63 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     ),
                     lastUsage,
                     earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
-                    earlyStopFired ? nextPassthroughToolCallIds : null
+                    earlyStopFired ? nextPassthroughToolCallIds : null,
+                    publicationTranscriptLocator(currentSessionId!),
+                    managedForkTarget?.sessionId === currentSessionId ? managedForkSource : undefined,
+                    mappingExpectedGeneration,
+                      )
+                      if (stored) {
+                        mappingExpectedGeneration = stored
+                        if (managedForkTarget?.sessionId === currentSessionId) managedForkPublished = true
+                      }
+                      return stored
+                    },
+                    sessionGcOptions,
                   )
-                  commitSessionTurn()
+                  if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                    if (
+                      mappingStored && !isIndependentSession &&
+                      !evictSession(profileSessionId, profileScopedCwd, body.messages || [], mappingExpectedGeneration)
+                    ) {
+                      throw new Error("Shared session mapping changed after canceled stream publication")
+                    }
+                    throw new Error("Request canceled after stream publication")
+                  }
+                  if (!mappingStored) {
+                    if (profileSessionId) {
+                      throw new Error("Shared session mapping changed before publication")
+                    }
+                    // A fingerprint is a weak hint, not a client session identity.
+                    // Concurrent headerless chats may share it; let the CAS winner
+                    // own resume state without failing the other successful response.
+                    claudeLog("session.fingerprint_publication_lost", {})
+                    void sweepSessionGc()
+                  } else {
+                    mappingExpectedGeneration = mappingStored
+                    if (managedForkTarget?.sessionId === currentSessionId) {
+                      managedForkPublished = true
+                      releaseManagedPins()
+                      void sweepSessionGc()
+                    }
+                    commitSessionTurn()
+                  }
                 }
+              }
+
+              // Structured output is synthetic, so buffer its complete envelope
+              // until the same durable publication barrier as ordinary output.
+              // In particular, message_delta is client permission to finalize.
+              if (pendingStructuredFrames.length > 0) {
+                clientAssistantContentExposed = true
+                for (const frame of pendingStructuredFrames) {
+                  safeEnqueue(frame.payload, frame.source)
+                }
+                eventsForwarded += pendingStructuredFrames.length
+                pendingStructuredFrames = []
+                messageStartEmitted = true
+                textEventsForwarded += 1
+                textCharsForwarded += pendingStructuredTextLength
+                pendingStructuredTextLength = 0
               }
 
               // Last chance to save a silent turn. The three known causes are
@@ -3844,6 +4624,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   sdkSessionId: currentSessionId || resumeSessionId,
                 })
                 const recoveryLifter = createRecoveryLifter(() => nextClientBlockIndex++)
+                // Recovery output is provisional until its exact fork wins the
+                // durable mapping CAS. Buffer it so a losing or failed
+                // publication cannot expose an answer that no later turn can
+                // resume.
+                const recoveryLiftedFrames: Array<NonNullable<ReturnType<typeof recoveryLifter.lift>>> = []
                 // The fork's identity. Without capturing it the recovered answer
                 // lives only in a session nothing points at: storeSession has
                 // already run against the pre-fork id, whose tail is the silent
@@ -3852,8 +4637,52 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // resumable session never saw.
                 let recoverySessionId: string | undefined
                 let recoveryToolCallAssistantUuid: string | undefined
+                let recoveryTextObserved = false
+                let recoverySawCanonicalResult = false
                 const recoveryEarlyStop = createEarlyStopTracker()
+                const recoveryStreamedToolUseIds = new Set<string>()
+                const recoverySourceId = currentSessionId || resumeSessionId
+                let recoveryForkSource: TranscriptLocator | undefined
+                let recoveryForkTarget: TranscriptLocator | undefined
+                let recoveryForkPublished = false
+                let recoveryCompleted = false
+                let releaseRecoveryForkPins: (() => void) | undefined
+                let unexpectedRecoveryFork: TranscriptLocator | undefined
                 try {
+                  if (!recoverySourceId || !lifecycleMappingKey) {
+                    throw new Error("Silent recovery has no durable source mapping")
+                  }
+                  recoveryForkSource = lookupSharedSession(lifecycleMappingKey)?.currentTranscript
+                    ?? transcriptLocator(recoverySourceId)
+                  const recoveryAttachedGeneration = recoveryForkSource.sessionId === recoverySourceId
+                    ? await attachPinnedTranscript(
+                      recoveryForkSource,
+                      () => {
+                        assertDurableWritesAllowed()
+                        return attachSharedTranscriptLocator(
+                          lifecycleMappingKey,
+                          recoverySourceId,
+                          recoveryForkSource!,
+                          mappingExpectedGeneration ?? undefined,
+                        )
+                      },
+                      sessionGcOptions,
+                    )
+                    : false
+                  if (!recoveryAttachedGeneration) {
+                    throw new Error("Session mapping changed before silent recovery fork preparation")
+                  }
+                  mappingExpectedGeneration = recoveryAttachedGeneration
+                  recoveryForkTarget = transcriptLocator(randomUUID())
+                  releaseRecoveryForkPins = pinActiveSessionGcLocators(recoveryForkSource, recoveryForkTarget)
+                  recoveryForkSource = await registerLiveTranscript(recoveryForkSource, sessionGcOptions)
+                  recoveryForkTarget = await prepareFork(recoveryForkTarget, sessionGcOptions)
+                  try {
+                  // Protect recovery parallel calls with the same deny hold as
+                  // the main stream. Producer hooks can run before the first
+                  // stream event reaches this consumer.
+                  turnGenerating = true
+                  resumedMappingMayBeAdvanced = true
                   // Bounded by the same idle limit as the main stream. Iterating
                   // the recovery query directly left a stalled recovery holding
                   // an open SSE response and its concurrency slot with nothing
@@ -3873,6 +4702,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // empty turn into an empty session (#768 client-abort).
                     resumeSessionAtUuid: nextPassthroughToolCallAssistantUuid,
                     forkSession: true,
+                    forkSessionId: recoveryForkTarget.sessionId,
                     sdkHooks, blockedTools: pipelineCtx.blockedTools,
                     incompatibleTools: pipelineCtx.incompatibleTools,
                     mcpServerName: adapter.getMcpServerName(),
@@ -3891,34 +4721,59 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
                       : undefined,
                     advisorModel,
-                  }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "silent_recovery")) {
+                  }, requestAbort.controller), requestAbort.controller.signal, requestMeta, "silent_recovery", [
+                    recoveryForkSource,
+                    recoveryForkTarget,
+                  ])) {
                     const recoveryMessage = event as any
-                    if (recoveryMessage.session_id) recoverySessionId = recoveryMessage.session_id
+                    if (recoveryMessage.session_id) {
+                      if (recoveryMessage.session_id !== recoveryForkTarget.sessionId) {
+                        if (recoveryMessage.session_id !== recoveryForkSource?.sessionId) {
+                          unexpectedRecoveryFork = transcriptLocator(recoveryMessage.session_id)
+                        }
+                        throw new Error(
+                          `Managed silent recovery fork returned ${recoveryMessage.session_id}; expected ${recoveryForkTarget.sessionId}`,
+                        )
+                      }
+                      recoverySessionId = recoveryMessage.session_id
+                    }
                     if (recoveryMessage.type === "assistant") {
                       noteAssistantMessage(recoveryEarlyStop, recoveryMessage)
                     } else if (recoveryMessage.type === "user") {
                       noteUserContent(recoveryEarlyStop, recoveryMessage.message?.content)
-                      recoveryToolCallAssistantUuid = settledToolCallAssistantUuid(recoveryEarlyStop)
                     }
+                    if (recoveryMessage.type === "result") recoverySawCanonicalResult = true
                     if (recoveryMessage.type !== "stream_event") continue
+                    const recoveryEvent = recoveryMessage.event as {
+                      type?: string
+                      content_block?: unknown
+                    }
+                    if (
+                      recoveryEvent.type === "message_delta"
+                      || recoveryEvent.type === "message_stop"
+                    ) releaseHeldDenies(`silent_recovery_${recoveryEvent.type}`)
+                    if (recoveryEvent.type === "message_start") turnGenerating = true
+                    if (
+                      recoveryEvent.type === "content_block_start"
+                      && isClientForwardedToolUse(recoveryEvent.content_block)
+                    ) {
+                      recoveryStreamedToolUseIds.add(
+                        (recoveryEvent.content_block as { id: string }).id,
+                      )
+                    }
                     // Only text is lifted into the already-open message; the
                     // re-indexing handshake lives in createRecoveryLifter. A
                     // tool call arriving here still counts as a productive
                     // recovery, through the shared PreToolUse capture below.
                     const lifted = recoveryLifter.lift((event as any).event)
                     if (!lifted) continue
-                    safeEnqueue(encoder.encode(
-                      `event: ${lifted.frame.type}\ndata: ${JSON.stringify(lifted.frame)}\n\n`
-                    ), `silent_recovery_${lifted.kind}`)
-                    if (lifted.kind === "block_start") {
-                      eventsForwarded += 1
-                    } else if (lifted.kind === "text_delta") {
-                      textEventsForwarded += 1
-                      textCharsForwarded += lifted.textChars
-                      silentTurnRecovered = true
-                    }
+                    recoveryLiftedFrames.push(lifted)
+                    if (lifted.kind === "text_delta") recoveryTextObserved = true
                   }
+                  recoveryCompleted = true
+                  releaseHeldDenies("silent_recovery_complete")
                 } catch (recoveryError) {
+                  releaseHeldDenies("silent_recovery_failed")
                   // A failed recovery must never turn a delivered turn into a
                   // failed request: the client still gets the original envelope,
                   // and the attempt is recorded for the operator.
@@ -3926,13 +4781,37 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     mode: "stream",
                     error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
                   })
+                  if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                    throw recoveryError
+                  }
                 }
-                // Tool calls made in the recovery turn are captured by the
-                // shared PreToolUse hook and delivered through the unseen-
-                // capture emission below — an equally valid recovery, and for
-                // an announce stall the expected one.
-                if (capturedToolUses.length > capturedBeforeRecovery) {
-                  silentTurnRecovered = true
+                // A recovery tool batch is deliverable only after natural
+                // iterator exhaustion, an exact settled assistant checkpoint,
+                // and a verified managed target. Otherwise remove every recovery
+                // capture so the client cannot receive calls from an abandoned
+                // or non-durable fork.
+                const recoveryCapturedToolUses = capturedToolUses.slice(capturedBeforeRecovery)
+                const recoveryCompletenessIds = recoveryStreamedToolUseIds.size > 0
+                  ? recoveryStreamedToolUseIds
+                  : new Set(recoveryCapturedToolUses.map((tool) => tool.id))
+                const recoveryToolBatchComplete = recoveryCapturedToolUses.length === 0 || (
+                  recoveryCompleted
+                  && trackerCoversStreamedCalls(recoveryEarlyStop, recoveryCompletenessIds)
+                  && shouldEarlyStop(recoveryEarlyStop)
+                  && Boolean(settledToolCallAssistantUuid(recoveryEarlyStop))
+                )
+                const recoveryDurable = recoveryCompleted
+                  && recoverySawCanonicalResult
+                  && recoverySessionId === recoveryForkTarget?.sessionId
+                  && recoveryToolBatchComplete
+                if (recoveryDurable && recoveryCapturedToolUses.length > 0) {
+                  recoveryToolCallAssistantUuid = settledToolCallAssistantUuid(recoveryEarlyStop)
+                }
+                silentTurnRecovered = recoveryDurable && (
+                  recoveryTextObserved || recoveryCapturedToolUses.length > 0
+                )
+                if (!silentTurnRecovered && recoveryCapturedToolUses.length > 0) {
+                  capturedToolUses.splice(capturedBeforeRecovery)
                 }
                 // Point the client's session at the fork, so the turn that
                 // actually answered is the one the next request resumes. The
@@ -3941,27 +4820,87 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // so undo falls back to a full replay — correct, just less
                 // efficient, where keeping them would be neither.
                 if (
-                  silentTurnRecovered && recoverySessionId &&
+                  recoveryCompleted && silentTurnRecovered && recoverySessionId &&
                   !isIndependentSession && !sawDuplicateToolUse
                 ) {
-                  currentSessionId = recoverySessionId
-                  nextPassthroughToolCallAssistantUuid = recoveryToolCallAssistantUuid
-                  nextPassthroughToolCallIds = recoveryToolCallAssistantUuid
-                    ? [...recoveryEarlyStop.expected]
-                    : undefined
-                  sdkUuidMap.length = 0
-                  for (let i = 0; i < allMessages.length; i++) sdkUuidMap.push(null)
-                  storeSession(
+                  const recoverySdkUuidMap = allMessages.map(() => null)
+                  await commitFork(recoveryForkTarget, sessionGcOptions)
+                  const recoveryMappingStored = await publishPinnedTranscript(
+                    recoveryForkTarget,
+                    () => {
+                      assertDurableWritesAllowed()
+                      const stored = storeSession(
                     profileSessionId,
                     body.messages || [],
-                    recoverySessionId,
+                    recoverySessionId!,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    recoverySdkUuidMap,
                     lastUsage,
                     recoveryToolCallAssistantUuid ?? null,
-                    recoveryToolCallAssistantUuid ? [...recoveryEarlyStop.expected] : null
+                    recoveryToolCallAssistantUuid ? [...recoveryEarlyStop.expected] : null,
+                    recoveryForkTarget,
+                    recoveryForkSource,
+                    mappingExpectedGeneration,
+                      )
+                      if (stored) {
+                        mappingExpectedGeneration = stored
+                        recoveryForkPublished = true
+                      }
+                      return stored
+                    },
+                    sessionGcOptions,
                   )
-                  commitSessionTurn()
+                  if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                    if (
+                      recoveryMappingStored && !isIndependentSession &&
+                      !evictSession(profileSessionId, profileScopedCwd, body.messages || [], mappingExpectedGeneration)
+                    ) {
+                      throw new Error("Shared session mapping changed after canceled silent-recovery publication")
+                    }
+                    throw new Error("Request canceled after silent-recovery publication")
+                  }
+                  if (!recoveryMappingStored) {
+                    // Recovery tool calls are withheld until their exact fork is
+                    // durably addressable. A fingerprint CAS loser must not emit
+                    // calls from the fork that cleanup is about to retire.
+                    silentTurnRecovered = false
+                    recoveryToolCallAssistantUuid = undefined
+                    capturedToolUses.splice(capturedBeforeRecovery)
+                    if (profileSessionId) {
+                      throw new Error("Shared session mapping changed before silent recovery publication")
+                    }
+                    claudeLog("session.fingerprint_publication_lost", { mode: "silent_recovery" })
+                    void sweepSessionGc()
+                  } else {
+                    currentSessionId = recoverySessionId
+                    nextPassthroughToolCallAssistantUuid = recoveryToolCallAssistantUuid
+                    nextPassthroughToolCallIds = recoveryToolCallAssistantUuid
+                      ? [...recoveryEarlyStop.expected]
+                      : undefined
+                    sdkUuidMap.length = 0
+                    sdkUuidMap.push(...recoverySdkUuidMap)
+                    mappingExpectedGeneration = recoveryMappingStored
+                    recoveryForkPublished = true
+                    void sweepSessionGc()
+                    commitSessionTurn()
+                  }
+                }
+                if (!recoveryForkPublished) {
+                  silentTurnRecovered = false
+                  recoveryToolCallAssistantUuid = undefined
+                  capturedToolUses.splice(capturedBeforeRecovery)
+                } else if (silentTurnRecovered) {
+                  for (const lifted of recoveryLiftedFrames) {
+                    safeEnqueue(encoder.encode(
+                      `event: ${lifted.frame.type}\ndata: ${JSON.stringify(lifted.frame)}\n\n`,
+                    ), `silent_recovery_${lifted.kind}`)
+                    if (lifted.kind === "block_start") {
+                      eventsForwarded += 1
+                    } else if (lifted.kind === "text_delta") {
+                      textEventsForwarded += 1
+                      textCharsForwarded += lifted.textChars
+                    }
+                  }
                 }
                 claudeLog("response.silent_turn_recovery_result", {
                   mode: "stream",
@@ -3982,6 +4921,41 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     requestMeta.requestId,
                   )
                 }
+                } catch (recoveryError) {
+                  claudeLog("response.silent_turn_recovery_failed", {
+                    mode: "stream_lifecycle",
+                    error: recoveryError instanceof Error ? recoveryError.message : String(recoveryError),
+                  })
+                  if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                    throw recoveryError
+                  }
+                } finally {
+                  if (unexpectedRecoveryFork) {
+                    await registerLiveTranscript(unexpectedRecoveryFork, sessionGcOptions)
+                      .then((exact) => abandonFork(exact, sessionGcOptions))
+                      .catch((error) => {
+                        claudeLog("session.unexpected_fork_track_failed", {
+                          mode: "silent_recovery",
+                          sessionId: unexpectedRecoveryFork?.sessionId,
+                          error: error instanceof Error ? error.message : String(error),
+                        })
+                      })
+                  }
+                  if (recoveryForkTarget && !recoveryForkPublished) {
+                    await abandonFork(recoveryForkTarget, sessionGcOptions).catch((error) => {
+                      claudeLog("session.fork_abandon_failed", {
+                        mode: "silent_recovery",
+                        error: error instanceof Error ? error.message : String(error),
+                      })
+                    })
+                    void sweepSessionGc()
+                  }
+                  releaseRecoveryForkPins?.()
+                }
+              }
+
+              if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                throw new Error("Request canceled before final stream envelope")
               }
 
               if (!streamClosed) {
@@ -3991,7 +4965,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 if (passthrough && unseenToolUses.length > 0 && messageStartEmitted) {
                   for (let i = 0; i < unseenToolUses.length; i++) {
                     const tu = unseenToolUses[i]!
-                    const blockIndex = eventsForwarded + i
+                    const blockIndex = nextClientBlockIndex++
                     streamedToolUseIds.add(tu.id)
 
                     // content_block_start
@@ -4070,7 +5044,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // so recovered content lands ahead of them, where clients can
                 // still see it).
                 if (messageStartEmitted) {
-                  sendTerminalDelta()
+                  sendTerminalDelta(streamedToolUseIds.size > 0 ? "tool_use" : undefined)
                   safeEnqueue(encoder.encode(`event: message_stop\ndata: {"type":"message_stop"}\n\n`), "final_message_stop")
                 }
 
@@ -4178,6 +5152,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
               }
             } catch (error) {
+              // Forced shutdown revokes publication, but cleanup must remain
+              // destructive: a client-visible interrupted turn cannot leave its
+              // previously published source mapping resumable.
+              const failedResumedTurn = isResume && !managedForkTarget && !sawCanonicalResult
+              const interruptedMappingMayBeAdvanced =
+                !managedForkTarget || managedForkPublished || clientAssistantContentExposed
+              if (
+                (requestAbort.controller.signal.aborted || durableWritesRevoked || failedResumedTurn)
+                && interruptedMappingMayBeAdvanced
+                && !isIndependentSession
+              ) {
+                evictSession(
+                  profileSessionId,
+                  profileScopedCwd,
+                  body.messages || [],
+                  mappingExpectedGeneration,
+                )
+                claudeLog("session.interrupted_mapping_evicted", {
+                  mode: "stream",
+                  reason: failedResumedTurn ? "noncanonical_resume" : "request_abort",
+                })
+              }
               if (isClosedControllerError(error)) {
                 streamClosed = true
                 claudeLog("stream.client_closed", {
@@ -4200,10 +5196,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   toolCallAssistantUuid: nextPassthroughToolCallAssistantUuid,
                   passthrough,
                 })
-                if (disposition.action === "evict") {
-                  evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                const mayEvictInterruptedMapping =
+                  !managedForkTarget || managedForkPublished || clientAssistantContentExposed
+                if (disposition.action === "evict" && mayEvictInterruptedMapping) {
+                  evictSession(
+                    profileSessionId,
+                    profileScopedCwd,
+                    body.messages || [],
+                    mappingExpectedGeneration,
+                  )
                 }
-                claudeLog("passthrough.client_abort_settled", { action: disposition.action })
+                claudeLog("passthrough.client_abort_settled", {
+                  action: disposition.action === "evict" && !mayEvictInterruptedMapping
+                    ? "preserve_managed_source"
+                    : disposition.action,
+                })
                 return
               }
 
@@ -4290,15 +5297,29 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 !isIndependentSession &&
                 !sawDuplicateToolUse
 
+              const mustEvictBeforeRecoveredTerminal =
+                !isIndependentSession && canRecoverAsToolUse && !recoverableCheckpoint
               if (
-                passthrough &&
-                streamedToolUseIds.size > 0 &&
-                !sawCanonicalResult &&
-                !recoverableCheckpoint
+                mustEvictBeforeRecoveredTerminal ||
+                (
+                  !isIndependentSession &&
+                  passthrough &&
+                  streamedToolUseIds.size > 0 &&
+                  !sawCanonicalResult &&
+                  !recoverableCheckpoint
+                )
               ) {
-                // The client may already have advanced past this tool turn, so
-                // a failed hidden drain invalidates even an older cached mapping.
-                evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+                // Do not grant a terminal tool checkpoint while the durable
+                // mapping still names an ancestry that lacks those calls.
+                const evicted = evictSession(
+                  profileSessionId,
+                  profileScopedCwd,
+                  body.messages || [],
+                  mappingExpectedGeneration,
+                )
+                if (mustEvictBeforeRecoveredTerminal && !evicted) {
+                  throw new Error("Shared session mapping changed before recovery invalidation")
+                }
                 claudeLog("passthrough.noncanonical_session_evicted", { mode: "stream", reason: "drain_error" })
               }
 
@@ -4329,7 +5350,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 const unseenToolUses = capturedToolUses.filter(tu => !streamedToolUseIds.has(tu.id))
                 for (let i = 0; i < unseenToolUses.length; i++) {
                   const tu = unseenToolUses[i]!
-                  const blockIndex = eventsForwarded + i
+                  const blockIndex = nextClientBlockIndex++
                   streamedToolUseIds.add(tu.id)
                   safeEnqueue(encoder.encode(
                     `event: content_block_start\ndata: ${JSON.stringify({
@@ -4352,21 +5373,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     })}\n\n`
                   ), "recover_tool_block_stop")
                 }
-                safeEnqueue(encoder.encode(
-                  `event: message_delta\ndata: ${JSON.stringify({
-                    type: "message_delta",
-                    delta: { stop_reason: "tool_use", stop_sequence: null },
-                    usage: { output_tokens: 0 }
-                  })}\n\n`
-                ), "recover_message_delta")
-                safeEnqueue(encoder.encode(
-                  `event: message_stop\ndata: {"type":"message_stop"}\n\n`
-                ), "recover_message_stop")
-
-                recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
-
                 if (recoverableCheckpoint) {
-                  storeSession(
+                  validateManagedForkResult(currentSessionId)
+                  await commitManagedFork()
+                  const mappingStored = await publishPinnedTranscript(
+                    publicationTranscriptLocator(currentSessionId!),
+                    () => {
+                      assertDurableWritesAllowed()
+                      const stored = storeSession(
                     profileSessionId,
                     body.messages || [],
                     currentSessionId!,
@@ -4381,14 +5395,64 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     lastUsage,
                     nextPassthroughToolCallAssistantUuid!,
                     nextPassthroughToolCallIds!,
+                    publicationTranscriptLocator(currentSessionId!),
+                    managedForkTarget?.sessionId === currentSessionId ? managedForkSource : undefined,
+                    mappingExpectedGeneration,
+                      )
+                      if (stored) {
+                        mappingExpectedGeneration = stored
+                        if (managedForkTarget?.sessionId === currentSessionId) managedForkPublished = true
+                      }
+                      return stored
+                    },
+                    sessionGcOptions,
                   )
-                  commitSessionTurn()
-                  claudeLog("passthrough.checkpoint_persisted", {
-                    mode: "stream",
-                    reason: "single_turn_boundary",
-                    toolCalls: nextPassthroughToolCallIds!.length,
-                  })
+                  if (requestAbort.controller.signal.aborted || durableWritesRevoked) {
+                    if (
+                      mappingStored && !isIndependentSession &&
+                      !evictSession(profileSessionId, profileScopedCwd, body.messages || [], mappingExpectedGeneration)
+                    ) {
+                      throw new Error("Shared session mapping changed after canceled recovery publication")
+                    }
+                    throw new Error("Request canceled after recovery publication")
+                  }
+                  if (!mappingStored) {
+                    // Recovered tool calls remain incomplete on the wire unless
+                    // their exact fork wins publication. A fingerprint CAS loss
+                    // is not authority to expose a terminal checkpoint either.
+                    throw new Error("Shared session mapping changed before recovery publication")
+                  } else {
+                    mappingExpectedGeneration = mappingStored
+                    if (managedForkTarget?.sessionId === currentSessionId) {
+                      managedForkPublished = true
+                      releaseManagedPins()
+                      void sweepSessionGc()
+                    }
+                    commitSessionTurn()
+                  }
+                  if (mappingStored) {
+                    claudeLog("passthrough.checkpoint_persisted", {
+                      mode: "stream",
+                      reason: "single_turn_boundary",
+                      toolCalls: nextPassthroughToolCallIds!.length,
+                    })
+                  }
                 }
+
+                // Publication or exact source invalidation is now durable. Only
+                // now may the terminal pair authorize the client to submit the
+                // recovered tool results.
+                safeEnqueue(encoder.encode(
+                  `event: message_delta\ndata: ${JSON.stringify({
+                    type: "message_delta",
+                    delta: { stop_reason: "tool_use", stop_sequence: null },
+                    usage: { output_tokens: 0 }
+                  })}\n\n`
+                ), "recover_message_delta")
+                safeEnqueue(encoder.encode(
+                  `event: message_stop\ndata: {"type":"message_stop"}\n\n`
+                ), "recover_message_stop")
+                recordEnvelopeViolations(checkUndeliveredToolUses(capturedToolUses, streamedToolUseIds))
 
                 // Record as success — the client got a usable response.
                 if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
@@ -4559,6 +5623,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 streamClosed = true
               }
             } finally {
+              await abandonManagedFork("stream_complete_without_commit")
               requestAbort.detach()
             }
             })().finally(() => {
@@ -4568,24 +5633,34 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           cancel(reason) {
             requestAbort.abort(reason)
             requestAbort.detach()
-            if (!isIndependentSession) {
-              // Cancellation can terminate the iterator without producing the
-              // closed-controller error handled above. Evict synchronously so
-              // no interrupted tail remains resumable even if the SDK never yields.
-              evictSession(profileSessionId, profileScopedCwd, body.messages || [])
+            if (!isIndependentSession && (
+              !managedForkTarget || managedForkPublished || clientAssistantContentExposed
+            )) {
+              // A direct resume or already-published target may have advanced.
+              // An unpublished managed fork writes only its isolated target, so
+              // preserve the still-authoritative source mapping and abandon it.
+              evictSession(
+                    profileSessionId,
+                    profileScopedCwd,
+                    body.messages || [],
+                    mappingExpectedGeneration,
+                  )
               claudeLog("passthrough.client_abort_settled", { action: "evict", source: "stream_cancel" })
             }
           },
         })
 
-        const streamSessionId = resumeSessionId || `session_${Date.now()}`
+        // Streaming retries and silent recovery can replace the physical SDK
+        // transcript after the HTTP headers have already been sent. Advertising
+        // a speculative ID here would let clients persist an abandoned target.
+        // The canonical session ID remains available in non-stream responses
+        // and in the durable session mapping used for every continuation.
         streamOwnsAbortLink = true
         const streamResponse = new Response(readable, {
           headers: {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
             Connection: "keep-alive",
-            "X-Claude-Session-ID": streamSessionId
           }
         })
         responseCompletions.set(streamResponse, streamCompletion)
@@ -4650,7 +5725,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           { status: classified.status, headers: { "Content-Type": "application/json" } }
         )
       } finally {
-        if (!streamOwnsAbortLink) requestAbort.detach()
+        if (!streamOwnsAbortLink) {
+          await abandonManagedFork("request_complete_without_commit")
+          requestAbort.detach()
+        }
       }
     })
   }
@@ -4666,31 +5744,51 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const queueEnteredAt = Date.now()
     claudeLog("request.enter", { requestId, endpoint })
     let sessionTurnLease: SessionTurnLease | undefined
+    let crossProcessTurnLease: CrossProcessTurnLease | undefined
+    const turnWatchdogAbort = new AbortController()
+    activeRequestAborts.add(turnWatchdogAbort)
     let finished = false
     let leaseReleased = false
+    let retainSessionTurnFence = false
     let leaseWatchdog: ReturnType<typeof setTimeout> | undefined
     inFlightRequests++
     // Releasing the lease is deliberately separate from finishing the request:
     // the watchdog must be able to unblock the session without also corrupting
     // the in-flight count that the shutdown drain reads.
     const releaseSessionTurn = (forced: boolean) => {
-      if (leaseReleased || !sessionTurnLease) return
+      if (leaseReleased || (!sessionTurnLease && !crossProcessTurnLease)) return
       leaseReleased = true
       if (leaseWatchdog) clearTimeout(leaseWatchdog)
       if (forced) {
         claudeLog("session.turn_lease_forced", { requestId, heldMs: SESSION_TURN_MAX_HOLD_MS })
         plog(`[PROXY] ${requestId} session turn lease force-released after ${SESSION_TURN_MAX_HOLD_MS}ms`)
       }
-      sessionTurnLease.release()
+      sessionTurnLease?.release()
+      if (crossProcessTurnLease) {
+        void crossProcessTurnLease.release().catch((error) => {
+          const message = error instanceof Error ? error.message : String(error)
+          claudeLog("session.cross_process_release_failed", { requestId, error: message })
+          plog(`[PROXY] ${requestId} cross-process session lease release failed: ${message}`)
+        })
+      }
     }
     const finishRequest = () => {
       if (finished) return
       finished = true
-      releaseSessionTurn(false)
+      if (retainSessionTurnFence && (sessionTurnLease || crossProcessTurnLease)) {
+        leaseReleased = true
+        if (leaseWatchdog) clearTimeout(leaseWatchdog)
+        claudeLog("session.turn_fenced_after_cleanup_failure", { requestId })
+        plog(`[PROXY] ${requestId} retaining session turn fence after mandatory durable cleanup failed`)
+      } else {
+        releaseSessionTurn(false)
+      }
+      activeRequestAborts.delete(turnWatchdogAbort)
       inFlightRequests--
     }
 
     let body: any
+    let sharedSessionRevisionsAtArrival: Record<string, string | null> | undefined
     try {
       try {
         body = await c.req.json()
@@ -4717,15 +5815,35 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const adapter = detectAdapter(c)
         const agentSessionId = adapter.getSessionId(c, body)
         if (agentSessionId) {
+          const arrivalProfileIds = new Set(
+            getEffectiveProfiles(finalConfig.profiles).map((profile) => profile.id),
+          )
+          const explicitlyRequestedProfile = c.req.header("x-meridian-profile")?.trim()
+          if (explicitlyRequestedProfile) arrivalProfileIds.add(explicitlyRequestedProfile)
+          sharedSessionRevisionsAtArrival = readSessionStoreGenerationSnapshot(
+            agentSessionId,
+            [...arrivalProfileIds],
+          )
           try {
-            sessionTurnLease = await processSessionTurns.acquire(
-              `session:${agentSessionId}`,
-              c.req.raw.signal,
-            )
-            leaseWatchdog = setTimeout(() => releaseSessionTurn(true), SESSION_TURN_MAX_HOLD_MS)
+            const turnKey = `session:${agentSessionId}`
+            // Bound both lock acquisition and SDK ownership with the same
+            // shutdown/hold signal. Starting this only after acquisition leaves
+            // local waiters impossible to drain.
+            leaseWatchdog = setTimeout(() => {
+              claudeLog("session.turn_watchdog_abort", { requestId, heldMs: SESSION_TURN_MAX_HOLD_MS })
+              plog(`[PROXY] ${requestId} session turn exceeded ${SESSION_TURN_MAX_HOLD_MS}ms — aborting without releasing its fencing lease`)
+              turnWatchdogAbort.abort(new Error("Session turn exceeded its maximum hold time"))
+            }, SESSION_TURN_MAX_HOLD_MS)
             leaseWatchdog.unref?.()
+            const acquireSignal = AbortSignal.any([c.req.raw.signal, turnWatchdogAbort.signal])
+            sessionTurnLease = await processSessionTurns.acquire(turnKey, acquireSignal)
+            crossProcessTurnLease = await crossProcessSessionTurns.acquire(turnKey, acquireSignal)
           } catch (error) {
-            if (c.req.raw.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+            if (
+              c.req.raw.signal.aborted
+              || turnWatchdogAbort.signal.aborted
+              || (error instanceof Error && error.name === "AbortError")
+            ) {
               // This return happens before RequestMeta exists, so no other
               // telemetry path can see it — without a row here, every request
               // cancelled while queued behind another turn is invisible, and
@@ -4765,6 +5883,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 error: { type: "request_cancelled", message: "The request was cancelled" },
               }), { status: 499, headers: { "Content-Type": "application/json" } })
             }
+            // The local lease may already be held when the cross-process
+            // acquisition fails. Never leave it wedged until the watchdog.
+            releaseSessionTurn(false)
+            if (error instanceof CrossProcessTurnAcquireTimeoutError) {
+              finishRequest()
+              return new Response(JSON.stringify({
+                type: "error",
+                error: {
+                  type: "overloaded_error",
+                  message: "Timed out waiting for another process to finish this session turn",
+                },
+              }), { status: 529, headers: { "Content-Type": "application/json" } })
+            }
             throw error
           }
         }
@@ -4774,12 +5905,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         requestId,
         endpoint,
         queueEnteredAt,
-        sessionQueueWaitMs: sessionTurnLease?.waitedMs ?? 0,
+        sessionQueueWaitMs: (sessionTurnLease?.waitedMs ?? 0) + (crossProcessTurnLease?.waitedMs ?? 0),
         sdkQueueWaitMs: 0,
         sdkActiveDurationMs: 0,
         sessionTurnLease,
+        sharedSessionRevisionsAtArrival,
+        retainSessionTurnFence: () => { retainSessionTurnFence = true },
       }
-      const response = await handleMessages(c, requestMeta, { body })
+      const response = await handleMessages(c, requestMeta, {
+        body,
+        turnWatchdogSignal: turnWatchdogAbort.signal,
+      })
       const completion = responseCompletions.get(response)
       if (completion) {
         // .finally() re-throws whatever it settled with, so the catch is what
@@ -5783,7 +6919,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     config: finalConfig,
     initPlugins: initPluginsAsync,
     beginDrain: () => { draining = true },
+    forceAbortInFlight: () => {
+      durableWritesRevoked = true
+      for (const controller of activeRequestAborts) {
+        controller.abort(new Error("Proxy shutdown grace period elapsed"))
+      }
+    },
     getInFlightCount: () => inFlightRequests,
+    sweepSessionGc,
   }
 }
 
@@ -5813,8 +6956,26 @@ export function installProxyProcessErrorHandlers(): void {
 
 export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promise<ProxyInstance> {
   claudeExecutable = await resolveClaudeExecutableAsync()
-  const { app, config: finalConfig, initPlugins, beginDrain, getInFlightCount } = createProxyServer(config)
+  const {
+    app,
+    config: finalConfig,
+    initPlugins,
+    beginDrain,
+    forceAbortInFlight,
+    getInFlightCount,
+    sweepSessionGc,
+  } = createProxyServer(config)
   if (initPlugins) await initPlugins()
+
+  // Only the owned HTTP-server lifecycle starts a periodic sweep. Embedders
+  // using createProxyServer().app still sweep opportunistically after managed
+  // commits without accumulating hidden timers they cannot close.
+  const sessionGcIntervalMs = Math.max(0, envInt("SESSION_GC_INTERVAL_MS", 60_000))
+  const sessionGcInterval = sweepSessionGc && sessionGcIntervalMs > 0
+    ? setInterval(() => { void sweepSessionGc() }, sessionGcIntervalMs)
+    : undefined
+  sessionGcInterval?.unref?.()
+  if (sweepSessionGc) void sweepSessionGc()
 
   // Cached, once a day, never on the request path. Opt out with
   // MERIDIAN_NO_UPDATE_CHECK=1. The banner below reports build-source drift
@@ -5933,6 +7094,9 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
       closePromise ??= (async () => {
         clearInterval(profileTokenRefreshInterval)
         if (authKeepaliveInterval) clearInterval(authKeepaliveInterval)
+        if (sessionGcInterval) clearInterval(sessionGcInterval)
+        // Refuse new work before potentially waiting for a deletion child.
+        beginDrain?.()
         stopBackgroundRefresh()
         stopUpdateCheck()
 
@@ -5940,16 +7104,34 @@ export async function startProxyServer(config: Partial<ProxyConfig> = {}): Promi
         // up to SHUTDOWN_GRACE_MS to finish naturally before pulling the plug.
         // This makes existing "call close() on SIGTERM" plugin code (see the
         // Stable API Contract) graceful for free, with no signature change.
-        beginDrain?.()
         try {
           await closeServerWithGracePeriod(server, {
             graceMs: SHUTDOWN_GRACE_MS,
             getInFlightCount: () => getInFlightCount?.() ?? 0,
             warn: finalConfig.silent ? undefined : (message) => console.warn(message),
-            forceCloseConnections: () => connectionTracker.forceCloseAll(),
+            forceCloseConnections: () => {
+              forceAbortInFlight?.()
+              connectionTracker.forceCloseAll()
+            },
           })
         } finally {
           connectionTracker.dispose()
+        }
+        // Give aborted SDK iterators one short bounded window to observe the
+        // revocation and release their fencing leases. Durable callbacks also
+        // check the revocation synchronously, so a late task cannot republish.
+        const settleDeadline = Date.now() + 2_000
+        while ((getInFlightCount?.() ?? 0) > 0 && Date.now() < settleDeadline) {
+          await new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, 25)
+            timer.unref?.()
+          })
+        }
+        // Never delete while an unjoined request may still own an SDK child.
+        if ((getInFlightCount?.() ?? 0) === 0) {
+          if (sweepSessionGc) await sweepSessionGc()
+        } else if (!finalConfig.silent) {
+          console.warn("[PROXY] Skipping final session GC because revoked requests have not settled.")
         }
       })()
       return closePromise

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -96,6 +96,7 @@ import {
   computeMessageHashes,
   normalizeContextUsage,
   withClientAssistantUuid,
+  reconcileReturnedSessionUuids,
   type LineageResult,
   type TokenUsageIteration,
   type TokenUsage,
@@ -1465,6 +1466,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           : undefined
         // For undo: fork the session at the rollback point
         const undoRollbackUuid = isUndo && lineageResult.type === "undo" ? lineageResult.rollbackUuid : undefined
+        const sdkUndo = isUndo && Boolean(undoRollbackUuid)
+        if (isUndo && !undoRollbackUuid) {
+          // Forks remap copied-history UUIDs. Without a valid boundary in the
+          // preserved prefix, replay fresh rather than first attempting a
+          // deterministic missing-message resume against the returned session.
+          resumeSessionId = undefined
+        }
         // Early-stopped sessions resume at the assistant tool-use turn, before synthetic denials.
         let passthroughToolCallAssistantUuid = passthrough && isResume ? cachedSession?.passthroughToolCallAssistantUuid : undefined
         const passthroughToolCallIds = passthrough && isResume ? cachedSession?.passthroughToolCallIds : undefined
@@ -1557,9 +1565,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             messagesToConvert = getLastUserMessage(allMessages)
           }
         } else {
-          // Undo without UUID (legacy session) — fall back to last user message
-          // to avoid the catastrophic flat text replay.
-          messagesToConvert = getLastUserMessage(allMessages)
+          // Undo without a valid SDK boundary is a fresh structured replay.
+          messagesToConvert = allMessages
         }
       } else {
         messagesToConvert = allMessages
@@ -2055,11 +2062,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // RangeError when allMessages.length was 0. Cold-start requests
           // are now also rejected at the entrypoint (#450) but the defensive
           // initializer keeps any future reentry safe.
-          let sdkUuidMap: Array<string | null> = (isResume || isUndo) && cachedSession?.sdkMessageUuids
+          let sdkUuidMap: Array<string | null> = (isResume || sdkUndo) && cachedSession?.sdkMessageUuids
             ? [...cachedSession.sdkMessageUuids]
             : []
           // Pad to current message count (the last user message has no UUID yet)
           while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
+          let currentClientAssistantUuid: string | null = null
 
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
@@ -2117,7 +2125,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   for await (const event of runSdkQueryAttempt(buildQueryOptions({
                     prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                     passthrough, stream: false, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                    resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                    resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                     effort, thinking, taskBudget, outputFormat, betas, settingSources,
                     codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -2398,6 +2406,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     allMessages.length,
                     (message as any).uuid
                   )
+                  currentClientAssistantUuid = sdkUuidMap[allMessages.length] ?? null
                 }
                 if (!firstChunkAt) {
                   firstChunkAt = Date.now()
@@ -2782,7 +2791,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     body.messages || [],
                     currentSessionId,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    reconcileReturnedSessionUuids(
+                      sdkUuidMap,
+                      allMessages.length,
+                      currentClientAssistantUuid,
+                      resumeSessionId,
+                      currentSessionId,
+                    ),
                     lastUsage,
                     earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
                     earlyStopFired ? nextPassthroughToolCallIds : null
@@ -2871,10 +2886,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // Defensive: start empty so allMessages.length === 0 doesn't crash the
             // ReadableStream's start() with `RangeError: Invalid array length`.
             // Cold-start requests with no messages are also rejected upstream now (#450).
-            let sdkUuidMap: Array<string | null> = (isResume || isUndo) && cachedSession?.sdkMessageUuids
+            let sdkUuidMap: Array<string | null> = (isResume || sdkUndo) && cachedSession?.sdkMessageUuids
               ? [...cachedSession.sdkMessageUuids]
               : []
             while (sdkUuidMap.length < allMessages.length) sdkUuidMap.push(null)
+            let currentClientAssistantUuid: string | null = null
 
             let messageStartEmitted = false
             let lastUsage: TokenUsage | undefined
@@ -2994,7 +3010,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     for await (const event of runSdkQueryAttempt(buildQueryOptions({
                       prompt: makePrompt(), model, workingDirectory, clientWorkingDirectory, systemContext, claudeExecutable,
                       passthrough, stream: true, sdkAgents, passthroughMcp, cleanEnv: profileEnv, envOverrides, hasDeferredTools, earlyStop: earlyStopEnabled,
-                      resumeSessionId, isUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
+                      resumeSessionId, isUndo: sdkUndo, resumeSessionAtUuid: undoRollbackUuid ?? passthroughToolCallAssistantUuid, forkSession: busySessionFork || undefined, sdkHooks, blockedTools: pipelineCtx.blockedTools, incompatibleTools: pipelineCtx.incompatibleTools, mcpServerName: adapter.getMcpServerName(), allowedMcpTools: pipelineCtx.allowedMcpTools, onStderr,
                       effort, thinking, taskBudget, outputFormat, betas, settingSources,
                       codeSystemPrompt: sdkFeatures.codeSystemPrompt, clientSystemPrompt: sdkFeatures.clientSystemPrompt === false ? false : undefined,
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
@@ -3282,6 +3298,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       allMessages.length,
                       (message as any).uuid
                     )
+                    currentClientAssistantUuid = sdkUuidMap[allMessages.length] ?? null
                   }
                   if (message.type === "result") {
                     sawCanonicalResult = true
@@ -3707,7 +3724,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     body.messages || [],
                     currentSessionId,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    reconcileReturnedSessionUuids(
+                      sdkUuidMap,
+                      allMessages.length,
+                      currentClientAssistantUuid,
+                      resumeSessionId,
+                      currentSessionId,
+                    ),
                     lastUsage,
                     earlyStopFired ? nextPassthroughToolCallAssistantUuid : null,
                     earlyStopFired ? nextPassthroughToolCallIds : null
@@ -4289,7 +4312,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     body.messages || [],
                     currentSessionId!,
                     profileScopedCwd,
-                    sdkUuidMap,
+                    reconcileReturnedSessionUuids(
+                      sdkUuidMap,
+                      allMessages.length,
+                      currentClientAssistantUuid,
+                      resumeSessionId,
+                      currentSessionId,
+                    ),
                     lastUsage,
                     nextPassthroughToolCallAssistantUuid!,
                     nextPassthroughToolCallIds!,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -38,13 +38,14 @@ export type {
 // transforms through the same runner meridian uses internally.
 export { runTransformHook, runObserveHook, buildPipeline, createRequestContext } from "./transform"
 import { claudeLog } from "../logger"
+import { PASSTHROUGH_DENY_REASON } from "./passthroughDenial"
 import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -141,6 +142,24 @@ let claudeExecutable = ""
 // to abort the same hung model — see the coordination contract in
 // streamIdleGuard.ts.
 const UPSTREAM_IDLE_MS = envInt("UPSTREAM_IDLE_MS", 90_000)
+
+// How long a passthrough deny may be held waiting for the turn-generation
+// boundary. Derived from UPSTREAM_IDLE_MS, never a standalone number, because
+// this is the same coordination contract: guardUpstreamIdle owns model-stream
+// liveness, so every other timer must sit ABOVE it and let it decide.
+//
+// The hazard this guards is a CLI version that serialises hook-then-stream, in
+// which case a held deny blocks generation forever. That case is already
+// covered by the layer that owns it: no upstream messages flow, so
+// guardUpstreamIdle throws UpstreamIdleError and the turn fails loudly. A
+// shorter timer here would only pre-empt that with a WORSE outcome — releasing
+// mid-generation lets the CLI cancel the in-flight request, which beheads every
+// parallel call still generating and hands the client a truncated tool set
+// under a 200 (measured: 1 of 3 calls delivered).
+//
+// An override BELOW UPSTREAM_IDLE_MS deliberately re-enables that race; that is
+// how scripts/probe-passthrough-proxy.mjs reproduces the leak on demand.
+const DENY_HOLD_TIMEOUT_MS = envInt("DENY_HOLD_TIMEOUT_MS", UPSTREAM_IDLE_MS + 30_000)
 
 // Bounds how long ProxyInstance.close() waits for in-flight /v1/messages
 // requests to finish (after beginDrain() stops admitting new ones) before it
@@ -1754,8 +1773,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // beheads trailing parallel calls (#552 red reads: `glob {}` aborted)
       // and re-loops the model. Fix: hold every deny response until turn-1
       // generation completes (message_delta observed), so the cancel can
-      // never land mid-generation. Timeout is a deadlock backstop in case a
-      // CLI version serializes hook-then-stream.
+      // never land mid-generation. The hold defers to guardUpstreamIdle for
+      // liveness — see DENY_HOLD_TIMEOUT_MS — so its own timer sits above that
+      // limit and is a last-ditch backstop, not the thing that decides.
       // Envelope integrity: violations of the proxy's own output contract
       // (dangling blocks, undelivered captured calls, empty required tool
       // inputs). Logged loudly + counted on /telemetry so #552-family
@@ -1768,7 +1788,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           diagnosticLog.error(`${requestMeta.requestId} ENVELOPE VIOLATION [${v.type}] ${v.detail}`, requestMeta.requestId)
         }
       }
-      const DENY_HOLD_TIMEOUT_MS = 8000
       const pendingDenyReleases: Array<() => void> = []
       // True while a model turn is actively generating (message_start seen,
       // no message_delta/message_stop yet). Hooks dispatched AFTER generation
@@ -1776,6 +1795,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // hooks can fire post-turn) must NOT hold — there is no in-flight
       // request left to protect, and holding would only add dead time.
       let turnGenerating = false
+      // Whether this request ever saw a raw turn-boundary event. Partial
+      // messages are requested for passthrough on both paths, but if they are
+      // ever absent (an older CLI, a mocked SDK) the gates below must fall back
+      // to releasing on the assistant message rather than wedge waiting for a
+      // boundary that never arrives.
+      let sawTurnBoundarySignal = false
       const releaseHeldDenies = (reason: string): void => {
         turnGenerating = false
         if (pendingDenyReleases.length === 0) return
@@ -1786,6 +1811,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         new Promise<void>((resolve) => {
           const timer = setTimeout(() => {
             claudeLog("passthrough.deny_hold_timeout", { afterMs: DENY_HOLD_TIMEOUT_MS })
+            // This is only a last-ditch deadlock backstop. The checkpoint
+            // completeness gates below must still observe the full streamed tool
+            // set and the turn boundary; otherwise the session is evicted rather
+            // than publishing a truncated resume point.
             resolve()
           }, DENY_HOLD_TIMEOUT_MS)
           pendingDenyReleases.push(() => {
@@ -2023,10 +2052,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
                 return {
                   decision: "block" as const,
-                  reason:
-                    "This tool call has been forwarded to the client for execution. " +
-                    "The result will be delivered in a future turn. " +
-                    "Do not retry, do not call additional tools, and do not generate further text — end your turn now.",
+                  reason: PASSTHROUGH_DENY_REASON,
                 }
               }],
             }],
@@ -2072,6 +2098,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           claudeLog("upstream.start", { mode: "non_stream", model })
           let lastUsage: TokenUsage | undefined
           let lastStopReason: string | undefined
+          // Completeness oracle, the non-stream twin of the streaming path's
+          // `streamedToolUseIds`. Built from content_block_start, so it names
+          // every tool_use the turn actually produced — including calls whose
+          // assistant fragment the iterator has not surfaced yet. Without it the
+          // checkpoint can freeze on the fragments consumed so far and silently
+          // drop the rest from the client-facing set.
+          const streamedToolUseIds = new Set<string>()
           let nextPassthroughToolCallAssistantUuid: string | undefined
           let nextPassthroughToolCallIds: string[] | undefined
           let sawCanonicalResult = false
@@ -2373,7 +2406,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
               } else if (passthrough && message.type === "user" && !earlyStopFired) {
                 noteUserContent(earlyStop, (message as any).message?.content)
-                if (earlyStopEnabled && shouldEarlyStop(earlyStop)) {
+                // The completeness gate the streaming path already applies:
+                // generation has ended AND the tracker has caught up with every
+                // tool_use the wire actually carried. Either half alone is not
+                // enough — a deny can settle the calls known so far while a
+                // later assistant fragment is still to come, and freezing there
+                // drops it.
+                const turnComplete = sawTurnBoundarySignal
+                  ? !turnGenerating && trackerCoversStreamedCalls(earlyStop, streamedToolUseIds)
+                  : true // nothing to gate on — settle on the tracker alone
+                if (earlyStopEnabled && turnComplete && shouldEarlyStop(earlyStop)) {
                   nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
                   nextPassthroughToolCallIds = [...earlyStop.expected]
                   earlyStopFired = true
@@ -2393,10 +2435,31 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   })
                 }
               }
+              // #592/#625: the turn-generation boundary, observable here because
+              // passthrough requests partial messages on both paths. An assistant
+              // message is NOT this boundary: the CLI emits one per tool-use
+              // block, so releasing there frees the denies while later parallel
+              // blocks are still generating, and those denies cancel the
+              // in-flight request — beheading calls 2..N and freezing the
+              // checkpoint on call 1.
+              if (message.type === "stream_event") {
+                const event = (message as any).event as any
+                const eventType = event?.type
+                if (eventType === "message_delta" || eventType === "message_stop") {
+                  sawTurnBoundarySignal = true
+                  releaseHeldDenies(eventType)
+                } else if (eventType === "message_start") {
+                  sawTurnBoundarySignal = true
+                  turnGenerating = true
+                } else if (passthrough && eventType === "content_block_start") {
+                  // The predicate the tracker arms `expected` with, so the two
+                  // sets are comparable by construction.
+                  const block = event.content_block
+                  if (isClientForwardedToolUse(block)) streamedToolUseIds.add(block.id)
+                }
+              }
               if (message.type === "assistant") {
-                // #592: the turn's generation is complete — held denies can
-                // return without the CLI cancelling anything in flight.
-                releaseHeldDenies("assistant_message")
+                if (!sawTurnBoundarySignal) releaseHeldDenies("assistant_message")
                 assistantMessages += 1
                 // One Anthropic assistant response may combine several SDK
                 // assistant fragments (for example parallel tool calls).
@@ -3266,14 +3329,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     // until generation ended, every block closed, and metadata
                     // names exactly the full forwarded ID set. Recheck on both
                     // assistant and user messages so either ordering can settle.
-                    const hasCompleteStreamedSet =
-                      streamedToolUseIds.size > 0 &&
-                      earlyStop.expected.size === streamedToolUseIds.size &&
-                      [...streamedToolUseIds].every((id) => earlyStop.expected.has(id))
                     if (
                       !turnGenerating &&
                       openClientBlocks.size === 0 &&
-                      hasCompleteStreamedSet &&
+                      trackerCoversStreamedCalls(earlyStop, streamedToolUseIds) &&
                       shouldEarlyStop(earlyStop)
                     ) {
                       nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, createEarlyStopTracker, isCompleteToolResultContinuation, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
+import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -1565,21 +1565,28 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         messagesToConvert = allMessages
       }
 
-      // Rewinding to a tool-use checkpoint is valid only when the immediate
-      // delta settles that exact batch. Partial, late, duplicate, or unknown
-      // results get one safe fresh replay rather than an invalid SDK resume.
-      if (
-        passthroughToolCallAssistantUuid &&
-        !isCompleteToolResultContinuation(messagesToConvert, passthroughToolCallIds ?? [])
-      ) {
-        claudeLog("passthrough.checkpoint_replay", {
-          expectedToolIds: passthroughToolCallIds?.length ?? 0,
-          reason: "incomplete_or_mismatched_results",
-        })
-        isResume = false
-        resumeSessionId = undefined
-        passthroughToolCallAssistantUuid = undefined
-        messagesToConvert = allMessages
+      if (passthroughToolCallAssistantUuid) {
+        // Rewinding to a tool-use checkpoint is valid only when the immediate
+        // delta settles that exact batch. Coalesce any subsequent queued user
+        // turns so multimodal tool results remain on the final SDK input.
+        const checkpointContinuation = coalesceCompleteToolResultContinuation(
+          messagesToConvert,
+          passthroughToolCallIds ?? []
+        )
+        if (checkpointContinuation) {
+          messagesToConvert = checkpointContinuation
+        } else {
+          // Partial, late, duplicate, or unknown results get one safe fresh
+          // replay rather than an invalid SDK resume.
+          claudeLog("passthrough.checkpoint_replay", {
+            expectedToolIds: passthroughToolCallIds?.length ?? 0,
+            reason: "incomplete_or_mismatched_results",
+          })
+          isResume = false
+          resumeSessionId = undefined
+          passthroughToolCallAssistantUuid = undefined
+          messagesToConvert = allMessages
+        }
       }
 
       // Multimodal blocks and passthrough tool results must remain structured.

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -9,10 +9,12 @@ import { LRUMap } from "../../utils/lruMap"
 import { diagnosticLog } from "../../telemetry"
 import {
   lookupSharedSession,
-  lookupSharedSessionByClaudeId,
+  lookupSharedSessionResult,
+  lookupSharedSessionByClaudeIdResult,
   storeSharedSession,
   clearSharedSessions,
   evictSharedSession,
+  type StoredSessionGeneration,
 } from "../sessionStore"
 import { getConversationFingerprint } from "./fingerprint"
 import {
@@ -99,15 +101,21 @@ export function clearSessionCache() {
 export function evictSession(
   sessionId: string | undefined,
   workingDirectory?: string,
-  messages?: Array<{ role: string; content: any }>
-): void {
+  messages?: Array<{ role: string; content: any }>,
+  expectedGeneration?: StoredSessionGeneration,
+): boolean {
   if (sessionId) {
     const cached = sessionCache.get(sessionId)
     if (cached) {
       removeFingerprintEntriesByClaudeSessionId(cached.claudeSessionId)
       sessionCache.delete(sessionId)
     }
-    try { evictSharedSession(sessionId) } catch {}
+    // Store failures are safety-significant: callers must not release a turn
+    // after claiming cleanup succeeded while the durable mapping remains.
+    const evicted = evictSharedSession(sessionId, expectedGeneration)
+    // Header-keyed and fingerprint-keyed conversations are independent durable
+    // keys. Never apply one key's generation token to the other key.
+    return evicted
   }
   if (messages) {
     const fp = getConversationFingerprint(messages, workingDirectory)
@@ -117,9 +125,10 @@ export function evictSession(
         removeSessionEntriesByClaudeSessionId(cached.claudeSessionId)
         fingerprintCache.delete(fp)
       }
-      try { evictSharedSession(fp) } catch {}
+      return evictSharedSession(fp, expectedGeneration)
     }
   }
+  return false
 }
 
 // --- Session operations ---
@@ -128,6 +137,25 @@ export function evictSession(
 function touchSession(state: SessionState): SessionState {
   state.lastAccess = Date.now()
   return state
+}
+
+function stateFromSharedSession(
+  shared: NonNullable<ReturnType<typeof lookupSharedSession>>,
+): SessionState {
+  return {
+    claudeSessionId: shared.claudeSessionId,
+    lastAccess: Date.now(),
+    messageCount: shared.messageCount || 0,
+    lineageHash: shared.lineageHash || "",
+    messageHashes: shared.messageHashes,
+    messageBlockHashes: shared.messageBlockHashes,
+    sdkMessageUuids: shared.sdkMessageUuids,
+    passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
+    passthroughToolCallIds: shared.passthroughToolCallIds,
+    contextUsage: shared.contextUsage,
+    currentTranscript: shared.currentTranscript,
+    previousTranscript: shared.previousTranscript,
+  }
 }
 
 function classifyLineage(
@@ -171,63 +199,49 @@ export function lookupSession(
   workingDirectory?: string
 ): LineageResult {
   if (sessionId) {
+    // A durable absence is an authoritative eviction. Only an actual store
+    // read error may use the local fallback; otherwise another proxy's abort
+    // could be resurrected from stale memory.
+    const shared = lookupSharedSessionResult(sessionId)
     const cached = sessionCache.get(sessionId)
-    if (cached) {
-      const result = classifyLineage(cached, messages, sessionId)
-      if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
-      return result
-    }
-    const shared = lookupSharedSession(sessionId)
-    if (shared) {
-      const state: SessionState = {
-        claudeSessionId: shared.claudeSessionId,
-        lastAccess: Date.now(),
-        messageCount: shared.messageCount || 0,
-        lineageHash: shared.lineageHash || "",
-        messageHashes: shared.messageHashes,
-        messageBlockHashes: shared.messageBlockHashes,
-        sdkMessageUuids: shared.sdkMessageUuids,
-        passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
-        passthroughToolCallIds: shared.passthroughToolCallIds,
-        contextUsage: shared.contextUsage,
+    const state = shared.status === "found"
+      ? stateFromSharedSession(shared.session)
+      : shared.status === "error" ? cached : undefined
+    if (shared.status === "missing") {
+      sessionCache.delete(sessionId)
+      if (cached) {
+        removeSessionEntriesByClaudeSessionId(cached.claudeSessionId)
+        removeFingerprintEntriesByClaudeSessionId(cached.claudeSessionId)
       }
-      const result = classifyLineage(state, messages, sessionId)
-      if (result.type === "continuation" || result.type === "compaction") {
-        sessionCache.set(sessionId, state)
-      }
-      return result
     }
-    return { type: "diverged", reason: "not-found" }
+    if (!state) return { type: "diverged", reason: "not-found" }
+    const result = classifyLineage(state, messages, sessionId)
+    if (result.type === "continuation" || result.type === "compaction") {
+      sessionCache.set(sessionId, touchSession(state))
+    }
+    return result
   }
 
   const fp = getConversationFingerprint(messages, workingDirectory)
   if (fp) {
+    const shared = lookupSharedSessionResult(fp)
     const cached = fingerprintCache.get(fp)
-    if (cached) {
-      const result = classifyLineage(cached, messages, fp)
-      if (result.type === "continuation" || result.type === "compaction") touchSession(result.session)
-      return result
-    }
-    const shared = lookupSharedSession(fp)
-    if (shared) {
-      const state: SessionState = {
-        claudeSessionId: shared.claudeSessionId,
-        lastAccess: Date.now(),
-        messageCount: shared.messageCount || 0,
-        lineageHash: shared.lineageHash || "",
-        messageHashes: shared.messageHashes,
-        messageBlockHashes: shared.messageBlockHashes,
-        sdkMessageUuids: shared.sdkMessageUuids,
-        passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
-        passthroughToolCallIds: shared.passthroughToolCallIds,
-        contextUsage: shared.contextUsage,
+    const state = shared.status === "found"
+      ? stateFromSharedSession(shared.session)
+      : shared.status === "error" ? cached : undefined
+    if (shared.status === "missing") {
+      fingerprintCache.delete(fp)
+      if (cached) {
+        removeSessionEntriesByClaudeSessionId(cached.claudeSessionId)
+        removeFingerprintEntriesByClaudeSessionId(cached.claudeSessionId)
       }
-      const result = classifyLineage(state, messages, fp)
-      if (result.type === "continuation" || result.type === "compaction") {
-        fingerprintCache.set(fp, state)
-      }
-      return result
     }
+    if (!state) return { type: "diverged", reason: "not-found" }
+    const result = classifyLineage(state, messages, fp)
+    if (result.type === "continuation" || result.type === "compaction") {
+      fingerprintCache.set(fp, touchSession(state))
+    }
+    return result
   }
   return { type: "diverged", reason: "not-found" }
 }
@@ -236,35 +250,16 @@ export function lookupSession(
  *  Searches both in-memory caches and the shared file store, returning the
  *  freshest matching state if multiple cache keys point to the same Claude session. */
 export function getSessionByClaudeId(claudeSessionId: string): SessionState | undefined {
-  let newest: SessionState | undefined
-
-  const consider = (state: SessionState | undefined) => {
-    if (!state || state.claudeSessionId !== claudeSessionId) return
-    if (!newest || state.lastAccess > newest.lastAccess) {
-      newest = state
-    }
+  const shared = lookupSharedSessionByClaudeIdResult(claudeSessionId)
+  if (shared.status === "error") {
+    throw new Error(`Shared session store is unavailable: ${shared.error.message}`)
   }
-
-  for (const state of sessionCache.values()) consider(state)
-  for (const state of fingerprintCache.values()) consider(state)
-
-  const shared = lookupSharedSessionByClaudeId(claudeSessionId)
-  if (shared) {
-    consider({
-      claudeSessionId: shared.claudeSessionId,
-      lastAccess: shared.lastUsedAt,
-      messageCount: shared.messageCount || 0,
-      lineageHash: shared.lineageHash || "",
-      messageHashes: shared.messageHashes,
-      messageBlockHashes: shared.messageBlockHashes,
-      sdkMessageUuids: shared.sdkMessageUuids,
-      passthroughToolCallAssistantUuid: shared.passthroughToolCallAssistantUuid,
-      passthroughToolCallIds: shared.passthroughToolCallIds,
-      contextUsage: shared.contextUsage,
-    })
+  if (shared.status === "missing") {
+    removeSessionEntriesByClaudeSessionId(claudeSessionId)
+    removeFingerprintEntriesByClaudeSessionId(claudeSessionId)
+    return undefined
   }
-
-  return newest
+  return stateFromSharedSession(shared.session)
 }
 
 /** Store a session mapping with lineage hash and SDK UUIDs for divergence detection.
@@ -279,9 +274,12 @@ export function storeSession(
   sdkMessageUuids?: Array<string | null>,
   contextUsage?: TokenUsage,
   passthroughToolCallAssistantUuid?: string | null,
-  passthroughToolCallIds?: string[] | null
-) {
-  if (!claudeSessionId) return
+  passthroughToolCallIds?: string[] | null,
+  currentTranscript?: { sessionId: string; configDir: string; projectDir?: string },
+  sourceTranscript?: { sessionId: string; configDir: string; projectDir?: string },
+  expectedGeneration?: StoredSessionGeneration | null,
+): StoredSessionGeneration | false {
+  if (!claudeSessionId) return false
   const lineageHash = computeLineageHash(messages)
   const messageHashes = computeMessageHashes(messages)
   const messageBlockHashes = computeMessageBlockHashes(messages)
@@ -296,31 +294,32 @@ export function storeSession(
     ...(passthroughToolCallAssistantUuid ? { passthroughToolCallAssistantUuid } : {}),
     ...(passthroughToolCallIds ? { passthroughToolCallIds } : {}),
     ...(contextUsage ? { contextUsage } : {}),
+    ...(currentTranscript ? { currentTranscript } : {}),
+    ...(sourceTranscript ? { previousTranscript: sourceTranscript } : {}),
   }
-  // In-memory cache
-  if (sessionId) sessionCache.set(sessionId, state)
   const fp = getConversationFingerprint(messages, workingDirectory)
-  // Only populate the fingerprint cache for headerless requests. When a
-  // session header is present the session is already tracked by ID; writing
-  // to the fingerprint cache too causes cross-session collisions when a
-  // later headerless request (e.g. OpenCode category-dispatched or title
-  // generation) happens to share the same first-message fingerprint.
-  if (fp && !sessionId) fingerprintCache.set(fp, state)
-  // Shared file store (cross-proxy resume)
   const key = sessionId || fp
-  if (key) {
-    storeSharedSession(
-      key,
-      claudeSessionId,
-      state.messageCount,
-      lineageHash,
-      messageHashes,
-      sdkMessageUuids,
-      contextUsage,
-      messageBlockHashes,
-      // undefined would preserve the stored checkpoint; a full store must rewrite it.
-      passthroughToolCallAssistantUuid ?? null,
-      passthroughToolCallIds ?? null
-    )
-  }
+  if (!key) return false
+  const storedGeneration = storeSharedSession(
+    key,
+    claudeSessionId,
+    state.messageCount,
+    lineageHash,
+    messageHashes,
+    sdkMessageUuids,
+    contextUsage,
+    messageBlockHashes,
+    // undefined would preserve the stored checkpoint; a full store must rewrite it.
+    passthroughToolCallAssistantUuid ?? null,
+    passthroughToolCallIds ?? null,
+    currentTranscript,
+    sourceTranscript,
+    expectedGeneration,
+  )
+  if (!storedGeneration) return false
+
+  // Publish to memory only after the durable CAS succeeds.
+  if (sessionId) sessionCache.set(sessionId, state)
+  if (fp && !sessionId) fingerprintCache.set(fp, state)
+  return storedGeneration
 }

--- a/src/proxy/session/crossProcessTurnCoordinator.ts
+++ b/src/proxy/session/crossProcessTurnCoordinator.ts
@@ -1,0 +1,631 @@
+import { createHash, randomUUID } from "node:crypto"
+import { hostname } from "node:os"
+import { basename, dirname, join } from "node:path"
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises"
+import {
+  createRecoveryClaimOwner,
+  getRecoveryClaimPath,
+  getRecoveryClaimTombstonePath,
+  parseRecoveryClaimOwnerJson,
+  recoveryClaimOwnerIsDead,
+  type RecoveryClaimOwner,
+} from "./recoveryClaim"
+import {
+  captureProcessIncarnation,
+  parseProcessIncarnation,
+  processIncarnationIsDead,
+  type ProcessIncarnation,
+} from "./processIncarnation"
+
+const OWNER_FILE = "owner.json"
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 30_000
+const DEFAULT_STALE_AFTER_MS = 30_000
+const DEFAULT_RETRY_DELAY_MS = 25
+
+export interface CrossProcessTurnCoordinatorOptions {
+  /** Maximum time an acquire may wait. Acquires always have a finite bound. */
+  acquireTimeoutMs?: number
+  /** A lock with no fresh heartbeat for this long may be recovered. */
+  staleAfterMs?: number
+  /** Defaults to one third of `staleAfterMs`. Must be shorter than it. */
+  heartbeatIntervalMs?: number
+  /** Delay between attempts while another process owns the turn. */
+  retryDelayMs?: number
+}
+
+export interface CrossProcessTurnLease {
+  readonly waitedMs: number
+  /** Stop the heartbeat and release the lock if this lease still owns it. */
+  release(): Promise<void>
+}
+
+interface OwnerRecord {
+  token: string
+  pid: number
+  hostname: string
+  createdAt: number
+  incarnation: ProcessIncarnation
+}
+
+interface LockSnapshot {
+  dev: bigint
+  ino: bigint
+  mtimeMs: number
+  owner?: OwnerRecord
+  heartbeatMtimeMs?: number
+}
+
+export class CrossProcessTurnAcquireTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Timed out acquiring cross-process turn lock after ${timeoutMs}ms`)
+    this.name = "CrossProcessTurnAcquireTimeoutError"
+  }
+}
+
+export class CrossProcessTurnOwnershipError extends Error {
+  constructor(message = "Cross-process turn lease no longer owns its lock") {
+    super(message)
+    this.name = "CrossProcessTurnOwnershipError"
+  }
+}
+
+function abortError(reason?: unknown): Error {
+  if (reason instanceof Error) return reason
+  return new DOMException(
+    typeof reason === "string" && reason ? reason : "The request was cancelled",
+    "AbortError",
+  )
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code
+}
+
+function positiveFinite(value: number, name: string): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError(`${name} must be a positive finite number`)
+  }
+  return value
+}
+
+function heartbeatName(token: string): string {
+  return `heartbeat-${token}`
+}
+
+function lockName(key: string): string {
+  return `${createHash("sha256").update(key).digest("hex")}.lock`
+}
+
+async function readOwner(lockPath: string): Promise<OwnerRecord | undefined> {
+  let raw: string
+  try {
+    raw = await readFile(join(lockPath, OWNER_FILE), "utf8")
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return undefined
+    throw error
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) throw error
+    // A process may die during its owner write. Keep the incomplete directory
+    // busy until its mtime becomes stale.
+    return undefined
+  }
+  if (
+    typeof value === "object"
+    && value !== null
+    && "token" in value
+    && typeof value.token === "string"
+    && value.token.length > 0
+    && "pid" in value
+    && typeof value.pid === "number"
+    && Number.isInteger(value.pid)
+    && value.pid > 0
+    && "hostname" in value
+    && typeof value.hostname === "string"
+    && "createdAt" in value
+    && typeof value.createdAt === "number"
+    && Number.isFinite(value.createdAt)
+    && "incarnation" in value
+    && parseProcessIncarnation(value.incarnation) !== undefined
+  ) {
+    return value as OwnerRecord
+  }
+  return undefined
+}
+
+async function snapshotLock(lockPath: string): Promise<LockSnapshot | undefined> {
+  let lockStat
+  try {
+    lockStat = await lstat(lockPath, { bigint: true })
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return undefined
+    throw error
+  }
+  if (!lockStat.isDirectory()) {
+    throw new Error(`Cross-process turn lock is not a directory: ${lockPath}`)
+  }
+
+  const owner = await readOwner(lockPath)
+  let heartbeatMtimeMs: number | undefined
+  if (owner) {
+    try {
+      heartbeatMtimeMs = (await stat(join(lockPath, heartbeatName(owner.token)))).mtimeMs
+    } catch (error) {
+      if (!isErrno(error, "ENOENT")) throw error
+    }
+  }
+
+  return {
+    dev: lockStat.dev,
+    ino: lockStat.ino,
+    mtimeMs: Number(lockStat.mtimeMs),
+    owner,
+    heartbeatMtimeMs,
+  }
+}
+
+function sameIdentity(left: LockSnapshot, right: LockSnapshot): boolean {
+  return left.dev === right.dev && left.ino === right.ino
+}
+
+function ownerIsDead(owner: OwnerRecord | undefined): boolean {
+  return owner ? processIncarnationIsDead(owner.incarnation) : false
+}
+
+function canRecover(snapshot: LockSnapshot, staleAfterMs: number, now = Date.now()): boolean {
+  // Never steal from a process that may still be executing: without a fencing
+  // token in sessions.json, a stale-but-live owner could later overwrite its
+  // successor. Same-host PID death is authoritative. Ownerless half-created
+  // directories are recoverable only after their quarantine age. Cross-host
+  // locks fail closed and require operator cleanup after the host is confirmed
+  // dead.
+  const lastHeartbeat = snapshot.heartbeatMtimeMs ?? snapshot.mtimeMs
+  if (now - lastHeartbeat <= staleAfterMs) return false
+  if (snapshot.owner) return ownerIsDead(snapshot.owner)
+  // A canonical directory without owner.json may be an initializer suspended
+  // after mkdir. Its ownership is uncertain, so recovery must fail closed.
+  return false
+}
+
+interface RecoveryClaimSnapshot {
+  dev: bigint
+  ino: bigint
+  owner?: RecoveryClaimOwner
+}
+
+async function snapshotRecoveryClaim(claimPath: string): Promise<RecoveryClaimSnapshot | undefined> {
+  let info
+  try {
+    info = await lstat(claimPath, { bigint: true })
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return undefined
+    throw error
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) return { dev: info.dev, ino: info.ino }
+
+  let owner: RecoveryClaimOwner | undefined
+  try {
+    owner = parseRecoveryClaimOwnerJson(await readFile(join(claimPath, OWNER_FILE), "utf8"))
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) throw error
+  }
+  return { dev: info.dev, ino: info.ino, owner }
+}
+
+/** Atomically publish a fully initialized, non-empty recovery owner directory. */
+async function tryPublishRecoveryClaim(
+  claimPath: string,
+  generation: string,
+): Promise<RecoveryClaimOwner | undefined> {
+  const owner = createRecoveryClaimOwner(generation)
+  const candidate = `${claimPath}.candidate-${process.pid}-${owner.token}`
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  let published = false
+  try {
+    await mkdir(candidate, { mode: 0o700 })
+    handle = await open(join(candidate, OWNER_FILE), "wx", 0o600)
+    await handle.writeFile(JSON.stringify(owner), "utf8")
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+    const candidateDirectoryHandle = await open(candidate, "r")
+    try {
+      await candidateDirectoryHandle.sync()
+    } finally {
+      await candidateDirectoryHandle.close()
+    }
+
+    // Every protocol-created destination is non-empty, which makes directory
+    // rename an atomic no-replace publication. Malformed existing paths block.
+    try {
+      await lstat(claimPath)
+      return undefined
+    } catch (error) {
+      if (!isErrno(error, "ENOENT")) throw error
+    }
+    try {
+      await rename(candidate, claimPath)
+      published = true
+      const parentDirectoryHandle = await open(dirname(claimPath), "r")
+      try {
+        await parentDirectoryHandle.sync()
+      } finally {
+        await parentDirectoryHandle.close()
+      }
+      return owner
+    } catch (error) {
+      if (["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].some((code) => isErrno(error, code))) {
+        return undefined
+      }
+      throw error
+    }
+  } finally {
+    await handle?.close().catch(() => undefined)
+    if (!published) await rm(candidate, { recursive: true, force: true }).catch(() => undefined)
+  }
+}
+
+/** Retire only the observed dead claim generation. Its tombstone fences ABA. */
+async function retireDeadRecoveryClaim(claimPath: string, generation: string): Promise<boolean> {
+  const observed = await snapshotRecoveryClaim(claimPath)
+  if (!observed) return true
+  if (
+    !observed.owner
+    || observed.owner.generation !== generation
+    || !recoveryClaimOwnerIsDead(observed.owner)
+  ) return false
+
+  const tombstone = getRecoveryClaimTombstonePath(claimPath, observed.owner.token)
+  try {
+    await lstat(tombstone)
+    return false
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) throw error
+  }
+
+  const current = await snapshotRecoveryClaim(claimPath)
+  if (!current) return true
+  const currentOwner = current.owner
+  if (
+    current.dev !== observed.dev
+    || current.ino !== observed.ino
+    || !currentOwner
+    || currentOwner.token !== observed.owner.token
+    || currentOwner.generation !== generation
+    || !recoveryClaimOwnerIsDead(currentOwner)
+  ) return false
+
+  try {
+    await rename(claimPath, tombstone)
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return true
+    if (["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].some((code) => isErrno(error, code))) {
+      return false
+    }
+    throw error
+  }
+
+  const moved = await snapshotRecoveryClaim(tombstone)
+  if (
+    !moved
+    || moved.dev !== observed.dev
+    || moved.ino !== observed.ino
+    || moved.owner?.token !== observed.owner.token
+    || moved.owner?.generation !== generation
+  ) throw new CrossProcessTurnOwnershipError("Recovery claim changed during retirement")
+  return true
+}
+
+async function releaseRecoveryClaim(
+  claimPath: string,
+  owner: RecoveryClaimOwner,
+): Promise<void> {
+  const current = await snapshotRecoveryClaim(claimPath).catch(() => undefined)
+  if (current?.owner?.token === owner.token && current.owner.generation === owner.generation) {
+    await rm(claimPath, { recursive: true }).catch(() => undefined)
+  }
+}
+
+async function cleanupRecoveryTombstones(claimPath: string): Promise<void> {
+  const prefix = `${basename(claimPath)}.orphan-`
+  try {
+    for (const name of await readdir(dirname(claimPath))) {
+      if (!name.startsWith(prefix)) continue
+      const path = join(dirname(claimPath), name)
+      const info = await lstat(path)
+      if (info.isDirectory() && !info.isSymbolicLink()) {
+        await rm(path, { recursive: true })
+      }
+    }
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) throw error
+  }
+}
+
+async function restoreMovedLock(movedPath: string, lockPath: string): Promise<void> {
+  try {
+    await rename(movedPath, lockPath)
+  } catch (error) {
+    throw new CrossProcessTurnOwnershipError(
+      `Lock changed during atomic recovery and could not be restored: ${(error as Error).message}`,
+    )
+  }
+}
+
+/**
+ * Serializes one logical turn key across processes using atomic filesystem
+ * directory operations. Lock errors never cause an unlocked turn to proceed.
+ */
+export class CrossProcessTurnCoordinator {
+  private readonly root: string
+  private readonly acquireTimeoutMs: number
+  private readonly staleAfterMs: number
+  private readonly heartbeatIntervalMs: number
+  private readonly retryDelayMs: number
+
+  constructor(root: string, options: CrossProcessTurnCoordinatorOptions = {}) {
+    if (!root) throw new TypeError("root must not be empty")
+    this.root = root
+    this.acquireTimeoutMs = positiveFinite(
+      options.acquireTimeoutMs ?? DEFAULT_ACQUIRE_TIMEOUT_MS,
+      "acquireTimeoutMs",
+    )
+    this.staleAfterMs = positiveFinite(
+      options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS,
+      "staleAfterMs",
+    )
+    this.heartbeatIntervalMs = positiveFinite(
+      options.heartbeatIntervalMs ?? Math.max(1, Math.floor(this.staleAfterMs / 3)),
+      "heartbeatIntervalMs",
+    )
+    this.retryDelayMs = positiveFinite(
+      options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+      "retryDelayMs",
+    )
+    if (this.heartbeatIntervalMs >= this.staleAfterMs) {
+      throw new TypeError("heartbeatIntervalMs must be shorter than staleAfterMs")
+    }
+  }
+
+  async acquire(key: string, signal?: AbortSignal): Promise<CrossProcessTurnLease> {
+    if (signal?.aborted) throw abortError(signal.reason)
+
+    const arrivedAt = Date.now()
+    const deadline = arrivedAt + this.acquireTimeoutMs
+    const lockPath = join(this.root, lockName(key))
+    await mkdir(this.root, { recursive: true, mode: 0o700 })
+    const rootInfo = await lstat(this.root)
+    if (!rootInfo.isDirectory() || rootInfo.isSymbolicLink()) {
+      throw new Error(`Cross-process turn root is not a private directory: ${this.root}`)
+    }
+    await chmod(this.root, 0o700)
+
+    while (true) {
+      if (signal?.aborted) throw abortError(signal.reason)
+      const remainingMs = deadline - Date.now()
+      if (remainingMs <= 0) {
+        throw new CrossProcessTurnAcquireTimeoutError(this.acquireTimeoutMs)
+      }
+
+      const lease = await this.tryAcquire(lockPath, arrivedAt)
+      if (lease) {
+        if (signal?.aborted) {
+          await lease.release()
+          throw abortError(signal.reason)
+        }
+        if (Date.now() > deadline) {
+          await lease.release()
+          throw new CrossProcessTurnAcquireTimeoutError(this.acquireTimeoutMs)
+        }
+        return lease
+      }
+
+      const snapshot = await snapshotLock(lockPath)
+      if (snapshot && canRecover(snapshot, this.staleAfterMs)) {
+        await this.recover(lockPath, snapshot)
+        continue
+      }
+
+      await this.wait(Math.min(this.retryDelayMs, remainingMs), signal)
+    }
+  }
+
+  private async tryAcquire(
+    lockPath: string,
+    arrivedAt: number,
+  ): Promise<CrossProcessTurnLease | undefined> {
+    const incarnation = captureProcessIncarnation()
+    if (!incarnation) throw new Error("cannot capture turn-lock owner process incarnation")
+    const owner: OwnerRecord = {
+      token: randomUUID(),
+      pid: process.pid,
+      hostname: hostname(),
+      createdAt: Date.now(),
+      incarnation,
+    }
+    const candidate = `${lockPath}.candidate-${process.pid}-${owner.token}`
+    let published = false
+    try {
+      await mkdir(candidate, { mode: 0o700 })
+      await writeFile(join(candidate, OWNER_FILE), JSON.stringify(owner), {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      })
+      await writeFile(join(candidate, heartbeatName(owner.token)), "", {
+        flag: "wx",
+        mode: 0o600,
+      })
+      // Renaming a fully initialized, non-empty directory publishes one lock
+      // generation atomically. A competing initialized directory cannot be
+      // replaced by rename on supported filesystems (EEXIST/ENOTEMPTY).
+      try {
+        await rename(candidate, lockPath)
+        published = true
+      } catch (error) {
+        if (isErrno(error, "EEXIST") || isErrno(error, "ENOTEMPTY")) return undefined
+        throw error
+      }
+
+      return this.createLease(lockPath, owner, Date.now() - arrivedAt)
+    } finally {
+      if (!published) await rm(candidate, { recursive: true, force: true }).catch(() => undefined)
+    }
+  }
+
+  private createLease(
+    lockPath: string,
+    owner: OwnerRecord,
+    waitedMs: number,
+  ): CrossProcessTurnLease {
+    const heartbeatPath = join(lockPath, heartbeatName(owner.token))
+    let heartbeatError: Error | undefined
+    let refreshing = false
+    let released = false
+    let releasePromise: Promise<void> | undefined
+
+    const timer = setInterval(() => {
+      if (refreshing || released) return
+      refreshing = true
+      const now = new Date()
+      void utimes(heartbeatPath, now, now)
+        .then(() => {
+          heartbeatError = undefined
+        })
+        .catch((error: unknown) => {
+          // Keep retrying. A transient filesystem error must not silently stop
+          // all future heartbeats; a persistent one is reported on release.
+          heartbeatError = error instanceof Error ? error : new Error(String(error))
+        })
+        .finally(() => {
+          refreshing = false
+        })
+    }, this.heartbeatIntervalMs)
+    timer.unref()
+
+    return {
+      waitedMs,
+      release: () => {
+        if (releasePromise) return releasePromise
+        released = true
+        clearInterval(timer)
+        releasePromise = this.releaseOwned(lockPath, owner.token, heartbeatError)
+        return releasePromise
+      },
+    }
+  }
+
+  private async recover(lockPath: string, snapshot: LockSnapshot): Promise<void> {
+    const generation = snapshot.owner?.token
+    if (!generation) return
+    const claimPath = getRecoveryClaimPath(lockPath, generation)
+    let claimOwner = await tryPublishRecoveryClaim(claimPath, generation)
+    if (!claimOwner) {
+      if (!await retireDeadRecoveryClaim(claimPath, generation)) return
+      claimOwner = await tryPublishRecoveryClaim(claimPath, generation)
+      if (!claimOwner) return
+    }
+
+    let generationResolved = false
+    try {
+      // Only one recoverer may act on this exact generation. Dead claim owners
+      // are moved to token-scoped tombstones before a successor claim appears.
+      const current = await snapshotLock(lockPath)
+      if (!current || !sameIdentity(snapshot, current)) {
+        generationResolved = true
+        return
+      }
+      if (!canRecover(current, this.staleAfterMs)) return
+
+      const movedPath = `${lockPath}.stale-${randomUUID()}`
+      await rename(lockPath, movedPath)
+      generationResolved = true
+      const moved = await snapshotLock(movedPath)
+      if (!moved || !sameIdentity(current, moved)) {
+        throw new CrossProcessTurnOwnershipError("Lock changed during claimed stale recovery")
+      }
+      await rm(movedPath, { recursive: true })
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) generationResolved = true
+      else throw error
+    } finally {
+      await releaseRecoveryClaim(claimPath, claimOwner)
+      if (generationResolved) {
+        await cleanupRecoveryTombstones(claimPath).catch((error) => {
+          console.error("[crossProcessTurnCoordinator] recovery tombstone cleanup failed:", (error as Error).message)
+        })
+      }
+    }
+  }
+
+  private async releaseOwned(
+    lockPath: string,
+    token: string,
+    heartbeatError?: Error,
+  ): Promise<void> {
+    const before = await snapshotLock(lockPath)
+    if (!before || before.owner?.token !== token) {
+      throw new CrossProcessTurnOwnershipError()
+    }
+
+    const movedPath = `${lockPath}.released-${token}`
+    try {
+      await rename(lockPath, movedPath)
+    } catch (error) {
+      if (isErrno(error, "ENOENT")) throw new CrossProcessTurnOwnershipError()
+      throw error
+    }
+
+    const moved = await snapshotLock(movedPath)
+    if (!moved || !sameIdentity(before, moved) || moved.owner?.token !== token) {
+      await restoreMovedLock(movedPath, lockPath)
+      throw new CrossProcessTurnOwnershipError("Refused to release a lock owned by another token")
+    }
+
+    await rm(movedPath, { recursive: true })
+    if (heartbeatError) {
+      throw new Error(`Cross-process turn heartbeat failed: ${heartbeatError.message}`, {
+        cause: heartbeatError,
+      })
+    }
+  }
+
+  private wait(delayMs: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false
+      const finish = (error?: Error) => {
+        if (settled) return
+        settled = true
+        if (signal) signal.removeEventListener("abort", onAbort)
+        if (error) reject(error)
+        else resolve()
+      }
+      const timer = setTimeout(() => finish(), delayMs)
+      timer.unref()
+      const onAbort = () => {
+        clearTimeout(timer)
+        finish(abortError(signal?.reason))
+      }
+      if (signal) {
+        signal.addEventListener("abort", onAbort, { once: true })
+        if (signal.aborted) onAbort()
+      }
+    })
+  }
+}

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -85,6 +85,27 @@ export function withClientAssistantUuid(
 }
 
 /**
+ * Reconcile rollback UUIDs with the session the SDK actually returned.
+ *
+ * A fork remaps every copied transcript UUID, so UUIDs inherited from the
+ * resumed session are invalid in the returned session. The one UUID observed
+ * for this request's new client-visible assistant remains valid and occupies
+ * its future client message slot.
+ */
+export function reconcileReturnedSessionUuids(
+  existing: Array<string | null>,
+  clientMessageCount: number,
+  currentAssistantUuid: string | null,
+  resumeSessionId: string | undefined,
+  returnedSessionId: string | undefined,
+): Array<string | null> {
+  if (!resumeSessionId || !returnedSessionId || returnedSessionId === resumeSessionId) return existing
+  const next = new Array<string | null>(clientMessageCount + 1).fill(null)
+  next[clientMessageCount] = currentAssistantUuid
+  return next
+}
+
+/**
  * Result of lineage verification — classifies the mutation and provides
  * the information needed to take the correct SDK action.
  */

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -63,6 +63,9 @@ export interface SessionState {
   passthroughToolCallIds?: string[]
   /** Last observed token usage for this session (from SDK message_start / message_delta events) */
   contextUsage?: TokenUsage
+  /** Exact SDK transcript roots for cross-process lifecycle retention. */
+  currentTranscript?: { sessionId: string; configDir: string; projectDir?: string }
+  previousTranscript?: { sessionId: string; configDir: string; projectDir?: string }
 }
 
 /**

--- a/src/proxy/session/processIncarnation.ts
+++ b/src/proxy/session/processIncarnation.ts
@@ -1,0 +1,344 @@
+import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { readFileSync, readlinkSync } from "node:fs"
+
+export const PROCESS_INCARNATION_VERSION = 1
+
+export type ProcessStartIdKind =
+  | "linux-proc-start-ticks"
+  | "darwin-ps-lstart"
+  | "windows-start-ticks"
+
+/**
+ * OS-backed identity for one process incarnation.
+ *
+ * `hostId` identifies the machine (and Linux PID namespace), `bootId`
+ * identifies one boot of that machine, and `startId` distinguishes PID reuse
+ * within the boot. Raw machine IDs are hashed before they are persisted.
+ */
+export interface ProcessIncarnation {
+  version: typeof PROCESS_INCARNATION_VERSION
+  pid: number
+  hostId: string
+  bootId: string
+  startId: string
+  startIdKind: ProcessStartIdKind
+}
+
+export type ProcessIncarnationProbe = "alive" | "dead" | "indeterminate"
+
+export interface LocalBootIdentity {
+  hostId: string
+  bootId: string
+}
+
+export type ProcessStartObservation =
+  | { status: "found"; startId: string; startIdKind: ProcessStartIdKind }
+  | { status: "missing" }
+  | { status: "indeterminate" }
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+const LINUX_START_PATTERN = /^[1-9][0-9]{0,31}$/
+const WINDOWS_START_PATTERN = /^[1-9][0-9]{0,31}$/
+const DARWIN_START_PATTERN = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ 0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-6][0-9] [0-9]{4}$/
+const PROBE_TIMEOUT_MS = 2_000
+
+let cachedLocalBootIdentity: LocalBootIdentity | undefined
+let cachedCurrentProcessIncarnation: ProcessIncarnation | undefined
+
+function hashIdentity(value: string): string {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+function isPositivePid(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isSafeInteger(value)
+    && value > 0
+}
+
+function validStartId(kind: unknown, value: unknown): kind is ProcessStartIdKind {
+  if (typeof value !== "string") return false
+  if (kind === "linux-proc-start-ticks") return LINUX_START_PATTERN.test(value)
+  if (kind === "darwin-ps-lstart") return DARWIN_START_PATTERN.test(value)
+  if (kind === "windows-start-ticks") return WINDOWS_START_PATTERN.test(value)
+  return false
+}
+
+export function parseProcessIncarnation(value: unknown): ProcessIncarnation | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const identity = value as Record<string, unknown>
+  if (
+    identity.version !== PROCESS_INCARNATION_VERSION
+    || !isPositivePid(identity.pid)
+    || typeof identity.hostId !== "string"
+    || !SHA256_PATTERN.test(identity.hostId)
+    || typeof identity.bootId !== "string"
+    || !UUID_PATTERN.test(identity.bootId)
+    || !validStartId(identity.startIdKind, identity.startId)
+  ) return undefined
+  return identity as unknown as ProcessIncarnation
+}
+
+export function parseProcessIncarnationJson(raw: string): ProcessIncarnation | undefined {
+  try {
+    return parseProcessIncarnation(JSON.parse(raw) as unknown)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Pure recovery decision. Only `dead` is permission to retire an owner's lock.
+ * Unknown hosts and every unavailable or malformed observation fail closed.
+ */
+export function evaluateProcessIncarnation(
+  owner: ProcessIncarnation,
+  localBoot: LocalBootIdentity | undefined,
+  observedStart: ProcessStartObservation | undefined,
+): ProcessIncarnationProbe {
+  const parsedOwner = parseProcessIncarnation(owner)
+  if (
+    !parsedOwner
+    || !localBoot
+    || !SHA256_PATTERN.test(localBoot.hostId)
+    || !UUID_PATTERN.test(localBoot.bootId)
+    || parsedOwner.hostId !== localBoot.hostId
+  ) return "indeterminate"
+  if (parsedOwner.bootId !== localBoot.bootId) return "dead"
+  if (!observedStart || observedStart.status === "indeterminate") return "indeterminate"
+  if (observedStart.status === "missing") return "dead"
+  if (
+    !validStartId(observedStart.startIdKind, observedStart.startId)
+    || observedStart.startIdKind !== parsedOwner.startIdKind
+  ) return "indeterminate"
+  if (observedStart.startId !== parsedOwner.startId) return "dead"
+
+  // Linux start ticks are an exact kernel process-birth marker. Darwin's stock
+  // ps only exposes birth time to one second, so equality cannot exclude an
+  // extremely fast same-second PID reuse. Treat that collision as unknown.
+  return parsedOwner.startIdKind === "linux-proc-start-ticks" ? "alive" : "indeterminate"
+}
+
+function normalizeUuid(raw: string): string | undefined {
+  const value = raw.trim().toLowerCase()
+  return UUID_PATTERN.test(value) ? value : undefined
+}
+
+function readFirst(paths: readonly string[]): string | undefined {
+  for (const path of paths) {
+    try {
+      const value = readFileSync(path, "utf8").trim()
+      if (value) return value
+    } catch {
+      // Try the next canonical OS location. Failure remains fail-closed.
+    }
+  }
+  return undefined
+}
+
+function linuxLocalBootIdentity(): LocalBootIdentity | undefined {
+  const machineId = readFirst(["/etc/machine-id", "/var/lib/dbus/machine-id"])
+  const bootId = normalizeUuid(readFileSync("/proc/sys/kernel/random/boot_id", "utf8"))
+  const pidNamespace = readlinkSync("/proc/self/ns/pid")
+  if (!machineId || !/^[0-9a-fA-F]{32}$/.test(machineId) || !bootId || !/^pid:\[[0-9]+\]$/.test(pidNamespace)) {
+    return undefined
+  }
+  return {
+    hostId: hashIdentity(`linux:${machineId.toLowerCase()}:${pidNamespace}`),
+    bootId,
+  }
+}
+
+function runDarwin(command: string, args: readonly string[]): string | undefined {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C", LANG: "C", TZ: "UTC0" },
+    timeout: PROBE_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+  })
+  if (result.error || result.status !== 0 || typeof result.stdout !== "string") return undefined
+  return result.stdout
+}
+
+function darwinLocalBootIdentity(): LocalBootIdentity | undefined {
+  const ioreg = runDarwin("/usr/sbin/ioreg", ["-rd1", "-c", "IOPlatformExpertDevice"])
+  const boot = runDarwin("/usr/sbin/sysctl", ["-n", "kern.bootsessionuuid"])
+  const machineMatch = ioreg?.match(/"IOPlatformUUID"\s*=\s*"([0-9A-Fa-f-]+)"/)
+  const machineId = machineMatch?.[1] ? normalizeUuid(machineMatch[1]) : undefined
+  const bootId = boot ? normalizeUuid(boot) : undefined
+  if (!machineId || !bootId) return undefined
+  return {
+    hostId: hashIdentity(`darwin:${machineId}`),
+    bootId,
+  }
+}
+
+function uuidFromIdentity(value: string): string {
+  const hex = createHash("sha256").update(value).digest("hex").slice(0, 32)
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+function runWindowsPowerShell(script: string): { status: number | null; stdout?: string } {
+  const result = spawnSync("powershell.exe", [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy", "Bypass",
+    "-Command", script,
+  ], {
+    encoding: "utf8",
+    windowsHide: true,
+    timeout: PROBE_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024,
+  })
+  return {
+    status: result.error ? null : result.status,
+    ...(typeof result.stdout === "string" ? { stdout: result.stdout } : {}),
+  }
+}
+
+function windowsLocalBootIdentity(): LocalBootIdentity | undefined {
+  const result = runWindowsPowerShell(String.raw`
+$ErrorActionPreference = 'Stop'
+$machine = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Cryptography' -Name MachineGuid).MachineGuid
+try { $boot = (Get-CimInstance Win32_OperatingSystem).LastBootUpTime }
+catch { $boot = (Get-WmiObject Win32_OperatingSystem).ConvertToDateTime((Get-WmiObject Win32_OperatingSystem).LastBootUpTime) }
+Write-Output $machine
+Write-Output $boot.ToUniversalTime().Ticks
+`)
+  if (result.status !== 0 || !result.stdout) return undefined
+  const [machine, bootTicks] = result.stdout.trim().split(/\r?\n/).map((part) => part.trim())
+  if (!machine || !bootTicks || !WINDOWS_START_PATTERN.test(bootTicks)) return undefined
+  return {
+    hostId: hashIdentity(`windows:${machine.toLowerCase()}`),
+    bootId: uuidFromIdentity(`windows-boot:${machine.toLowerCase()}:${bootTicks}`),
+  }
+}
+
+function getLocalBootIdentity(): LocalBootIdentity | undefined {
+  if (cachedLocalBootIdentity) return cachedLocalBootIdentity
+  try {
+    const identity = process.platform === "linux"
+      ? linuxLocalBootIdentity()
+      : process.platform === "darwin"
+        ? darwinLocalBootIdentity()
+        : process.platform === "win32"
+          ? windowsLocalBootIdentity()
+          : undefined
+    if (identity) cachedLocalBootIdentity = identity
+    return identity
+  } catch {
+    return undefined
+  }
+}
+
+function pidPresence(pid: number): "present" | "missing" | "indeterminate" {
+  try {
+    process.kill(pid, 0)
+    return "present"
+  } catch (error) {
+    const code = error instanceof Error && "code" in error ? error.code : undefined
+    return code === "ESRCH" ? "missing" : "indeterminate"
+  }
+}
+
+/** Parse field 22 (`starttime`) without assuming that comm contains no `)`. */
+export function parseLinuxProcStatStartId(raw: string, expectedPid: number): string | undefined {
+  const prefix = `${expectedPid} (`
+  if (!raw.startsWith(prefix)) return undefined
+  const commEnd = raw.lastIndexOf(")")
+  if (commEnd < prefix.length || raw[commEnd + 1] !== " ") return undefined
+  const fieldsFromState = raw.slice(commEnd + 2).trim().split(/\s+/)
+  const startId = fieldsFromState[19]
+  return startId && LINUX_START_PATTERN.test(startId) ? startId : undefined
+}
+
+function linuxProcessStart(pid: number): ProcessStartObservation {
+  let raw: string
+  try {
+    raw = readFileSync(`/proc/${pid}/stat`, "utf8")
+  } catch (error) {
+    const code = error instanceof Error && "code" in error ? error.code : undefined
+    if (code === "ENOENT" || code === "ESRCH") return { status: "missing" }
+    return { status: "indeterminate" }
+  }
+  const startId = parseLinuxProcStatStartId(raw, pid)
+  if (startId) return { status: "found", startId, startIdKind: "linux-proc-start-ticks" }
+  return pidPresence(pid) === "missing" ? { status: "missing" } : { status: "indeterminate" }
+}
+
+function darwinProcessStart(pid: number): ProcessStartObservation {
+  const output = runDarwin("/bin/ps", ["-p", String(pid), "-o", "lstart="])
+  if (output !== undefined) {
+    const startId = output.trimEnd().trimStart()
+    if (DARWIN_START_PATTERN.test(startId)) {
+      return { status: "found", startId, startIdKind: "darwin-ps-lstart" }
+    }
+  }
+  return pidPresence(pid) === "missing" ? { status: "missing" } : { status: "indeterminate" }
+}
+
+function windowsProcessStart(pid: number): ProcessStartObservation {
+  const result = runWindowsPowerShell(String.raw`
+$ErrorActionPreference = 'Stop'
+try {
+  $process = Get-Process -Id ${pid} -ErrorAction Stop
+  Write-Output $process.StartTime.ToUniversalTime().Ticks
+} catch [Microsoft.PowerShell.Commands.ProcessCommandException] {
+  exit 3
+} catch {
+  exit 4
+}
+`)
+  const startId = result.stdout?.trim()
+  if (result.status === 0 && startId && WINDOWS_START_PATTERN.test(startId)) {
+    return { status: "found", startId, startIdKind: "windows-start-ticks" }
+  }
+  if (result.status === 3) return { status: "missing" }
+  return pidPresence(pid) === "missing" ? { status: "missing" } : { status: "indeterminate" }
+}
+
+function observeProcessStart(pid: number): ProcessStartObservation {
+  if (process.platform === "linux") return linuxProcessStart(pid)
+  if (process.platform === "darwin") return darwinProcessStart(pid)
+  if (process.platform === "win32") return windowsProcessStart(pid)
+  return { status: "indeterminate" }
+}
+
+/** Capture metadata for a lock created by `pid` (normally the current process). */
+export function captureProcessIncarnation(pid = process.pid): ProcessIncarnation | undefined {
+  if (!isPositivePid(pid)) return undefined
+  if (pid === process.pid && cachedCurrentProcessIncarnation) {
+    return { ...cachedCurrentProcessIncarnation }
+  }
+  const localBoot = getLocalBootIdentity()
+  if (!localBoot) return undefined
+  const start = observeProcessStart(pid)
+  if (start.status !== "found") return undefined
+  const identity: ProcessIncarnation = {
+    version: PROCESS_INCARNATION_VERSION,
+    pid,
+    ...localBoot,
+    startId: start.startId,
+    startIdKind: start.startIdKind,
+  }
+  if (pid === process.pid) cachedCurrentProcessIncarnation = identity
+  return { ...identity }
+}
+
+/** Probe one stored owner. Recovery callers must act only on `dead`. */
+export function probeProcessIncarnation(owner: ProcessIncarnation): ProcessIncarnationProbe {
+  const parsed = parseProcessIncarnation(owner)
+  if (!parsed) return "indeterminate"
+  const localBoot = getLocalBootIdentity()
+  if (!localBoot || parsed.hostId !== localBoot.hostId) return "indeterminate"
+  if (parsed.bootId !== localBoot.bootId) {
+    return evaluateProcessIncarnation(parsed, localBoot, undefined)
+  }
+  return evaluateProcessIncarnation(parsed, localBoot, observeProcessStart(parsed.pid))
+}
+
+export function processIncarnationIsDead(owner: ProcessIncarnation): boolean {
+  return probeProcessIncarnation(owner) === "dead"
+}

--- a/src/proxy/session/recoveryClaim.ts
+++ b/src/proxy/session/recoveryClaim.ts
@@ -1,0 +1,82 @@
+import { createHash, randomUUID } from "node:crypto"
+import { hostname } from "node:os"
+import {
+  captureProcessIncarnation,
+  parseProcessIncarnation,
+  processIncarnationIsDead,
+  type ProcessIncarnation,
+} from "./processIncarnation"
+
+export const RECOVERY_CLAIM_VERSION = 2
+
+export interface RecoveryClaimOwner {
+  version: typeof RECOVERY_CLAIM_VERSION
+  generation: string
+  token: string
+  pid: number
+  hostname: string
+  createdAt: number
+  incarnation: ProcessIncarnation
+}
+
+export function createRecoveryClaimOwner(generation: string): RecoveryClaimOwner {
+  if (!generation) throw new TypeError("recovery generation must not be empty")
+  const incarnation = captureProcessIncarnation()
+  if (!incarnation) throw new Error("cannot capture recovery owner process incarnation")
+  return {
+    version: RECOVERY_CLAIM_VERSION,
+    generation,
+    token: randomUUID(),
+    pid: process.pid,
+    hostname: hostname(),
+    createdAt: Date.now(),
+    incarnation,
+  }
+}
+
+export function parseRecoveryClaimOwner(value: unknown): RecoveryClaimOwner | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const owner = value as Record<string, unknown>
+  if (
+    owner.version !== RECOVERY_CLAIM_VERSION
+    || typeof owner.generation !== "string"
+    || owner.generation.length === 0
+    || typeof owner.token !== "string"
+    || owner.token.length === 0
+    || typeof owner.pid !== "number"
+    || !Number.isInteger(owner.pid)
+    || owner.pid <= 0
+    || typeof owner.hostname !== "string"
+    || owner.hostname.length === 0
+    || typeof owner.createdAt !== "number"
+    || !Number.isFinite(owner.createdAt)
+    || !parseProcessIncarnation(owner.incarnation)
+  ) return undefined
+  return owner as unknown as RecoveryClaimOwner
+}
+
+export function parseRecoveryClaimOwnerJson(raw: string): RecoveryClaimOwner | undefined {
+  try {
+    return parseRecoveryClaimOwner(JSON.parse(raw) as unknown)
+  } catch {
+    return undefined
+  }
+}
+
+/** Only an authoritative OS incarnation mismatch proves that an owner is dead. */
+export function recoveryClaimOwnerIsDead(
+  owner: RecoveryClaimOwner,
+  probe: (incarnation: ProcessIncarnation) => boolean = processIncarnationIsDead,
+): boolean {
+  return probe(owner.incarnation)
+}
+
+export function getRecoveryClaimPath(lockPath: string, generation: string): string {
+  const digest = createHash("sha256").update(generation).digest("hex")
+  return `${lockPath}.recover-${digest}`
+}
+
+export function getRecoveryClaimTombstonePath(claimPath: string, claimToken: string): string {
+  const digest = createHash("sha256").update(claimToken).digest("hex")
+  return `${claimPath}.orphan-${digest}`
+}

--- a/src/proxy/session/sdkProcessGate.ts
+++ b/src/proxy/session/sdkProcessGate.ts
@@ -1,0 +1,290 @@
+import { spawn, type ChildProcess } from "node:child_process"
+import { randomUUID } from "node:crypto"
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { dirname, join } from "node:path"
+import type {
+  SpawnedProcess,
+  SpawnOptions,
+} from "@anthropic-ai/claude-agent-sdk"
+import {
+  captureProcessIncarnation,
+  type ProcessIncarnation,
+} from "./processIncarnation"
+
+export interface SdkProcessGate {
+  readonly executor: ProcessIncarnation
+  /** False means a crashed proxy's lease must remain fail-closed forever. */
+  readonly recoverableAfterCrash: boolean
+  readonly spawnClaudeCodeProcess: (options: SpawnOptions) => SpawnedProcess
+  /** True only after the exact wrapper/CLI process has exited safely. */
+  closeAndJoin(timeoutMs?: number): Promise<boolean>
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+function posixGateScript(options: SpawnOptions): string {
+  const environment = Object.entries(options.env)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([key, value]) => shellQuote(`${key}=${value}`))
+  const command = [options.command, ...options.args].map(shellQuote)
+  return [
+    options.cwd ? `cd -- ${shellQuote(options.cwd)} || exit 72` : undefined,
+    `exec /usr/bin/env -i ${environment.join(" ")} ${command.join(" ")}`,
+    "",
+  ].filter((line): line is string => line !== undefined).join("\n")
+}
+
+function gateContents(options: SpawnOptions): string {
+  if (process.platform !== "win32") return posixGateScript(options)
+  return JSON.stringify({
+    command: options.command,
+    args: options.args,
+    cwd: options.cwd,
+    env: Object.fromEntries(Object.entries(options.env)
+      .filter((entry): entry is [string, string] => entry[1] !== undefined)),
+  })
+}
+
+function publishGate(path: string, contents: string): void {
+  const temporary = `${path}.tmp-${process.pid}-${randomUUID()}`
+  let fd: number | undefined
+  try {
+    fd = openSync(temporary, "wx", 0o600)
+    writeFileSync(fd, contents, "utf8")
+    fsyncSync(fd)
+    closeSync(fd)
+    fd = undefined
+    renameSync(temporary, path)
+    if (process.platform !== "win32") {
+      const parent = openSync(dirname(path), "r")
+      try {
+        fsyncSync(parent)
+      } finally {
+        closeSync(parent)
+      }
+    }
+  } finally {
+    if (fd !== undefined) closeSync(fd)
+    rmSync(temporary, { force: true })
+  }
+}
+
+function asSpawnedProcess(child: ChildProcess, killOwned: (signal: NodeJS.Signals) => void): SpawnedProcess {
+  if (!child.stdin || !child.stdout) throw new Error("SDK gate process is missing stdio")
+  if (process.platform !== "win32") return child as ChildProcess & SpawnedProcess
+  return {
+    stdin: child.stdin,
+    stdout: child.stdout,
+    get killed() { return child.killed },
+    get exitCode() { return child.exitCode },
+    kill(signal) {
+      killOwned(signal)
+      return true
+    },
+    on: child.on.bind(child),
+    once: child.once.bind(child),
+    off: child.off.bind(child),
+  } as SpawnedProcess
+}
+
+function spawnGateWrapper(gatePath: string, cancelPath: string): ChildProcess {
+  if (process.platform !== "win32") {
+    const wrapper = String.raw`
+gate=$1
+remaining=6000
+while [ ! -r "$gate" ]; do
+  [ "$remaining" -le 0 ] && exit 75
+  remaining=$((remaining - 1))
+  sleep 0.01
+done
+. "$gate"
+exit $?
+`
+    return spawn("/bin/sh", ["-c", wrapper, "meridian-sdk-gate", gatePath], {
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    })
+  }
+  // Windows cannot exec in-place. This exact wrapper owns the native CLI
+  // handle, forwards all three standard streams, and exits only after that
+  // exact child settles. A cancel request terminates the child handle rather
+  // than killing the wrapper first.
+  const wrapper = String.raw`
+import { existsSync, readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { setTimeout as wait } from "node:timers/promises";
+const gate = process.env.MERIDIAN_SDK_GATE_PATH;
+const cancel = process.env.MERIDIAN_SDK_CANCEL_PATH;
+const gateDeadline = Date.now() + 60_000;
+while (!existsSync(gate)) {
+  if (existsSync(cancel)) process.exit(0);
+  if (Date.now() >= gateDeadline) process.exit(75);
+  await wait(10);
+}
+if (existsSync(cancel)) process.exit(0);
+const job = JSON.parse(readFileSync(gate, "utf8"));
+const child = spawn(job.command, job.args, {
+  cwd: job.cwd || undefined,
+  env: job.env,
+  stdio: "inherit",
+  windowsHide: true,
+});
+let escalated = false;
+const cancellation = setInterval(() => {
+  if (!existsSync(cancel)) return;
+  child.kill(escalated ? "SIGKILL" : "SIGTERM");
+  escalated = true;
+}, 50);
+cancellation.unref?.();
+const status = await new Promise((resolve) => {
+  child.once("close", (code, signal) => resolve({ code, signal }));
+  child.once("error", (error) => resolve({ code: 70, signal: String(error) }));
+});
+clearInterval(cancellation);
+process.exit(status.code ?? (status.signal ? 1 : 0));
+`
+  return spawn(process.execPath, ["--input-type=module", "--eval", wrapper], {
+    env: {
+      ...process.env,
+      MERIDIAN_SDK_GATE_PATH: gatePath,
+      MERIDIAN_SDK_CANCEL_PATH: cancelPath,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  })
+}
+
+async function waitForExit(exited: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<false>((resolveTimeout) => {
+    timer = setTimeout(() => resolveTimeout(false), timeoutMs)
+    timer.unref?.()
+  })
+  try {
+    return await Promise.race([exited.then(() => true), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+/**
+ * Start a harmless gated wrapper and capture its exact incarnation before the
+ * SDK can execute Claude Code. POSIX wrappers `exec` the CLI in the same PID.
+ * Windows keeps a PowerShell parent for the complete CLI lifetime; crash
+ * recovery of that lease is deliberately disabled because Windows has no
+ * built-in, authoritative descendant-group incarnation.
+ */
+export async function createSdkProcessGate(
+  root: string,
+  attachExecutor: (executor: ProcessIncarnation, recoverableAfterCrash: boolean) => Promise<void>,
+  onStderr?: (data: string) => void,
+): Promise<SdkProcessGate> {
+  mkdirSync(root, { recursive: true, mode: 0o700 })
+  const token = `${process.pid}-${randomUUID()}`
+  const gatePath = join(root, `${token}.gate`)
+  const cancelPath = join(root, `${token}.cancel`)
+  const child = spawnGateWrapper(gatePath, cancelPath)
+  const recoverableAfterCrash = process.platform !== "win32"
+  const killOwned = (signal: NodeJS.Signals): void => {
+    if (process.platform === "win32") {
+      try {
+        const fd = openSync(cancelPath, "wx", 0o600)
+        closeSync(fd)
+      } catch (error) {
+        if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error
+      }
+      return
+    }
+    if (child.exitCode === null) child.kill(signal)
+  }
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    const data = chunk.toString()
+    if (!onStderr) return
+    try {
+      onStderr(data)
+    } catch (error) {
+      console.error("[sdkProcessGate] stderr callback failed:", error)
+    }
+  })
+  // `error` does not prove process exit. Node emits `close` only after the
+  // process has ended (or spawn failed) and all owned stdio handles close.
+  const exited = new Promise<void>((resolveExit) => {
+    child.once("close", () => resolveExit())
+  })
+  let attached = false
+  let spawned = false
+  try {
+    if (!child.pid) throw new Error("SDK gate process has no PID")
+    const executor = captureProcessIncarnation(child.pid)
+    if (!executor) throw new Error("cannot capture SDK writer process incarnation")
+    await attachExecutor(executor, recoverableAfterCrash)
+    attached = true
+
+    const spawnClaudeCodeProcess = (options: SpawnOptions): SpawnedProcess => {
+      if (spawned) throw new Error("SDK process gate may be opened only once")
+      spawned = true
+      const abortError = (): Error => Object.assign(new Error("SDK process spawn was aborted"), {
+        name: "AbortError",
+      })
+      if (options.signal.aborted) {
+        killOwned("SIGTERM")
+        throw abortError()
+      }
+      const onAbort = (): void => { killOwned("SIGTERM") }
+      options.signal.addEventListener("abort", onAbort, { once: true })
+      void exited.then(() => options.signal.removeEventListener("abort", onAbort))
+      if (options.signal.aborted) {
+        onAbort()
+        throw abortError()
+      }
+      publishGate(gatePath, gateContents(options))
+      return asSpawnedProcess(child, killOwned)
+    }
+
+    return {
+      executor,
+      recoverableAfterCrash,
+      spawnClaudeCodeProcess,
+      async closeAndJoin(timeoutMs = 7_000): Promise<boolean> {
+        let joined = child.exitCode !== null
+        // Give a terminal SDK process a short chance to report its natural exit
+        // before cancellation turns Windows recovery into a permanent fence.
+        if (!joined) joined = await waitForExit(exited, Math.min(250, timeoutMs))
+        if (!joined) {
+          killOwned("SIGTERM")
+          joined = await waitForExit(exited, timeoutMs)
+        }
+        if (!joined && process.platform !== "win32") {
+          killOwned("SIGKILL")
+          joined = await waitForExit(exited, Math.min(2_000, timeoutMs))
+        }
+        if (joined) {
+          rmSync(gatePath, { force: true })
+          rmSync(cancelPath, { force: true })
+        } else {
+          void exited.then(() => {
+            rmSync(gatePath, { force: true })
+            rmSync(cancelPath, { force: true })
+          })
+        }
+        return joined
+      },
+    }
+  } catch (error) {
+    if (!attached || child.exitCode === null) killOwned("SIGKILL")
+    await waitForExit(exited, 2_000)
+    rmSync(gatePath, { force: true })
+    rmSync(cancelPath, { force: true })
+    throw error
+  }
+}

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -1,0 +1,1683 @@
+import { createHash, randomUUID } from "node:crypto"
+import { spawn } from "node:child_process"
+import { realpathSync } from "node:fs"
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  unlink,
+} from "node:fs/promises"
+import { hostname } from "node:os"
+import { basename, dirname, isAbsolute, join, resolve } from "node:path"
+import { getMaxStoredSessionsLimit, getSessionStoreDir } from "./sessionStore"
+import {
+  createRecoveryClaimOwner,
+  getRecoveryClaimPath,
+  getRecoveryClaimTombstonePath,
+  parseRecoveryClaimOwnerJson,
+  recoveryClaimOwnerIsDead,
+  type RecoveryClaimOwner,
+} from "./session/recoveryClaim"
+import {
+  captureProcessIncarnation,
+  parseProcessIncarnation,
+  processIncarnationIsDead,
+  type ProcessIncarnation,
+} from "./session/processIncarnation"
+
+const SIDECAR_VERSION = 2
+const SIDECAR_NAME = "session-gc.json"
+const DEFAULT_MAX_PENDING = 256
+const DEFAULT_MAX_TOMBSTONES = 256
+const DEFAULT_MAX_DELETES = 16
+const DEFAULT_LOCK_WAIT_MS = 2_000
+const DEFAULT_LOCK_RETRY_MS = 25
+const DEFAULT_LOCK_STALE_MS = 60_000
+const DEFAULT_PREPARED_GRACE_MS = 5 * 60_000
+const DEFAULT_DELETING_LEASE_MS = 60_000
+const DEFAULT_RETIRED_GRACE_MS = 11 * 60_000
+const DEFAULT_RETRY_BASE_MS = 5_000
+const DEFAULT_RETRY_MAX_MS = 60 * 60_000
+const DEFAULT_DELETE_TIMEOUT_MS = 30_000
+
+export interface TranscriptLocator {
+  sessionId: string
+  /** The absolute CLAUDE_CONFIG_DIR which owns this transcript. */
+  configDir: string
+  /** SDK project directory, passed as deleteSession(..., { dir }). */
+  projectDir?: string
+  /** Opaque physical-ownership fence. Omitted only on legacy store locators. */
+  lifecycleGeneration?: string
+}
+
+export type TranscriptResourceState = "prepared" | "live" | "retired" | "deleting" | "deleted"
+
+interface ActiveTranscriptLeaseRecord {
+  token: string
+  owner: ProcessIncarnation
+  executor?: ProcessIncarnation
+  executorRecoverable?: boolean
+  createdAt: number
+}
+
+interface TranscriptResource {
+  key: string
+  generation: string
+  locator: TranscriptLocator
+  state: TranscriptResourceState
+  createdAt: number
+  updatedAt: number
+  attempts: number
+  nextAttemptAt?: number
+  lastError?: string
+  deletionToken?: string
+  deletionOwner?: ProcessIncarnation
+  deletionExecutor?: ProcessIncarnation
+  deletionProcessGroupId?: number
+  activeLeases?: Record<string, ActiveTranscriptLeaseRecord>
+}
+
+interface SessionGcSidecar {
+  version: typeof SIDECAR_VERSION
+  meta: { fenceSlots: Record<string, number> }
+  resources: Record<string, TranscriptResource>
+}
+
+export type SessionDeleter = (locator: TranscriptLocator) => Promise<void>
+
+export interface SessionLifecycleOptions {
+  /** Test seam. Production callers should use getSessionStoreDir(). */
+  storeDir?: string
+  deleter?: SessionDeleter
+  now?: () => number
+  /** Maximum non-live ownership backlog (prepared/retired/deleting). */
+  maxPending?: number
+  /** Hard ceiling across every non-deleted owned transcript. */
+  maxOwned?: number
+  maxTombstones?: number
+  maxDeletesPerRun?: number
+  lockWaitMs?: number
+  lockRetryMs?: number
+  lockStaleMs?: number
+  preparedGraceMs?: number
+  deletingLeaseMs?: number
+  /** Quarantine after retirement so old readers and rolling upgrades can drain. */
+  retiredGraceMs?: number
+  retryBaseMs?: number
+  retryMaxMs?: number
+  deletionTimeoutMs?: number
+  /** Refresh durable mapping pins before each destructive claim. */
+  pinProvider?: () => readonly TranscriptLocator[]
+  /** Bound one complete sweep, including all child deletions. */
+  runTimeoutMs?: number
+}
+
+export interface ActiveTranscriptLease {
+  token: string
+  resourceKeys: string[]
+}
+
+export interface ReconcileResult {
+  preparedRetired: number
+  liveRetired: number
+  resourcesPinned: number
+  deletingRecovered: number
+}
+
+export interface GcResult {
+  deleted: number
+  notFound: number
+  failed: number
+  deferred: number
+}
+
+export class SessionLifecycleError extends Error {}
+export class SessionLifecycleLockError extends SessionLifecycleError {}
+export class SessionLifecycleCorruptError extends SessionLifecycleError {}
+export class SessionLifecycleBacklogError extends SessionLifecycleError {}
+
+/** Stable ownership key. The separator prevents ambiguous concatenation. */
+export function getTranscriptResourceKey(locator: TranscriptLocator): string {
+  validateLocator(locator)
+  return createHash("sha256")
+    .update(locator.configDir)
+    .update("\0")
+    .update(locator.sessionId)
+    .digest("hex")
+}
+
+function physicalLocator(locator: TranscriptLocator): TranscriptLocator {
+  const { lifecycleGeneration: _generation, ...physical } = locator
+  return physical
+}
+
+function exactLocator(resource: TranscriptResource): TranscriptLocator {
+  return { ...resource.locator, lifecycleGeneration: resource.generation }
+}
+
+function assertExactLifecycleGeneration(resource: TranscriptResource, locator: TranscriptLocator): void {
+  if (locator.lifecycleGeneration !== resource.generation) {
+    throw new SessionLifecycleError(`stale or missing lifecycle generation for transcript ${resource.key}`)
+  }
+}
+
+/** Persist a cross-process writer lease before an SDK child can touch transcripts. */
+export async function acquireActiveTranscriptLease(
+  locators: readonly TranscriptLocator[],
+  options: SessionLifecycleOptions = {},
+): Promise<ActiveTranscriptLease> {
+  const normalized = [...new Map(
+    locators.map(canonicalizeTranscriptLocator).map((locator) => [getTranscriptResourceKey(locator), locator]),
+  ).entries()]
+  if (normalized.length === 0) throw new TypeError("active transcript lease requires at least one locator")
+  const owner = captureProcessIncarnation()
+  if (!owner) throw new SessionLifecycleError("cannot capture active transcript owner incarnation")
+  const token = randomUUID()
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    for (const [key, locator] of normalized) {
+      const resource = sidecar.resources[key]
+      if (!resource) throw new SessionLifecycleError(`cannot lease unjournaled transcript ${key}`)
+      assertSameLocator(resource.locator, locator)
+      assertExactLifecycleGeneration(resource, locator)
+      pruneDeadActiveLeases(resource)
+      if (hasActiveTranscriptLease(resource)) {
+        throw new SessionLifecycleError(`transcript ${key} already has an active SDK writer`)
+      }
+      if (resource.state === "deleting" || resource.state === "deleted") {
+        throw new SessionLifecycleError(`cannot lease transcript ${key} from state ${resource.state}`)
+      }
+      resource.activeLeases ??= {}
+      resource.activeLeases[token] = { token, owner, createdAt: nowMs(options) }
+    }
+    await writeSidecar(paths.sidecar, sidecar)
+  })
+  return { token, resourceKeys: normalized.map(([key]) => key) }
+}
+
+/** Arm a writer lease with the exact gated shell/CLI process incarnation. */
+export async function attachActiveTranscriptExecutor(
+  lease: ActiveTranscriptLease,
+  executor: ProcessIncarnation,
+  options: SessionLifecycleOptions = {},
+  executorRecoverable = true,
+): Promise<void> {
+  const parsedExecutor = parseProcessIncarnation(executor)
+  if (!parsedExecutor) throw new TypeError("invalid active transcript executor incarnation")
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    for (const key of lease.resourceKeys) {
+      const record = sidecar.resources[key]?.activeLeases?.[lease.token]
+      if (!record) throw new SessionLifecycleError(`active transcript lease ${lease.token} was lost`)
+      record.executor = parsedExecutor
+      record.executorRecoverable = executorRecoverable
+    }
+    await writeSidecar(paths.sidecar, sidecar)
+  })
+}
+
+/** Release only this exact writer lease after its child has been joined. */
+export async function releaseActiveTranscriptLease(
+  lease: ActiveTranscriptLease,
+  options: SessionLifecycleOptions = {},
+): Promise<void> {
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    let changed = false
+    for (const key of lease.resourceKeys) {
+      const resource = sidecar.resources[key]
+      if (!resource?.activeLeases?.[lease.token]) continue
+      delete resource.activeLeases[lease.token]
+      if (Object.keys(resource.activeLeases).length === 0) delete resource.activeLeases
+      changed = true
+    }
+    if (changed) await writeSidecar(paths.sidecar, sidecar)
+  })
+}
+
+/** Persist ownership before the SDK process which can create the transcript starts. */
+export async function prepareFork(
+  locator: TranscriptLocator,
+  options: SessionLifecycleOptions = {},
+): Promise<TranscriptLocator> {
+  const normalized = canonicalizeTranscriptLocator(locator)
+  const key = getTranscriptResourceKey(normalized)
+  return withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const existing = sidecar.resources[key]
+    if (existing) {
+      assertSameLocator(existing.locator, normalized)
+      assertExactLifecycleGeneration(existing, normalized)
+      if (existing.state === "deleted") {
+        throw new SessionLifecycleError(`transcript resource ${key} is already deleted`)
+      }
+      Object.assign(locator, exactLocator(existing))
+      return exactLocator(existing)
+    }
+    assertResourceCapacity(sidecar, options, "prepared")
+    const now = nowMs(options)
+    const resource: TranscriptResource = {
+      key,
+      generation: allocateLifecycleGeneration(sidecar, key),
+      locator: physicalLocator(normalized),
+      state: "prepared",
+      createdAt: now,
+      updatedAt: now,
+      attempts: 0,
+    }
+    sidecar.resources[key] = resource
+    pruneTombstones(sidecar, options)
+    await writeSidecar(paths.sidecar, sidecar)
+    Object.assign(locator, exactLocator(resource))
+    return exactLocator(resource)
+  })
+}
+
+/** Ensure a legacy/direct-resume locator is journaled without promoting a prepared target. */
+export async function ensureTranscriptJournaled(
+  locator: TranscriptLocator,
+  options: SessionLifecycleOptions = {},
+): Promise<TranscriptLocator> {
+  const normalized = canonicalizeTranscriptLocator(locator)
+  const key = getTranscriptResourceKey(normalized)
+  return withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const existing = sidecar.resources[key]
+    if (existing) {
+      assertSameLocator(existing.locator, normalized)
+      if (normalized.lifecycleGeneration !== undefined) assertExactLifecycleGeneration(existing, normalized)
+      if (existing.state === "deleting" || existing.state === "deleted") {
+        throw new SessionLifecycleError(`cannot journal transcript ${key} from state ${existing.state}`)
+      }
+      Object.assign(locator, exactLocator(existing))
+      return exactLocator(existing)
+    }
+    if (normalized.lifecycleGeneration !== undefined) {
+      throw new SessionLifecycleError(`stale lifecycle generation for missing transcript ${key}`)
+    }
+    assertResourceCapacity(sidecar, options, "live")
+    const now = nowMs(options)
+    const resource: TranscriptResource = {
+      key,
+      generation: allocateLifecycleGeneration(sidecar, key),
+      locator: physicalLocator(normalized),
+      state: "live",
+      createdAt: now,
+      updatedAt: now,
+      attempts: 0,
+    }
+    sidecar.resources[key] = resource
+    pruneTombstones(sidecar, options)
+    await writeSidecar(paths.sidecar, sidecar)
+    Object.assign(locator, exactLocator(resource))
+    return exactLocator(resource)
+  })
+}
+
+/** Register an existing SDK transcript as Meridian-owned without a fork intent. */
+export async function registerLiveTranscript(
+  locator: TranscriptLocator,
+  options: SessionLifecycleOptions = {},
+): Promise<TranscriptLocator> {
+  const normalized = canonicalizeTranscriptLocator(locator)
+  const key = getTranscriptResourceKey(normalized)
+  return withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    let resource = sidecar.resources[key]
+    if (!resource) {
+      if (normalized.lifecycleGeneration !== undefined) {
+        throw new SessionLifecycleError(`stale lifecycle generation for missing transcript ${key}`)
+      }
+      assertResourceCapacity(sidecar, options, "live")
+      const now = nowMs(options)
+      resource = {
+        key,
+        generation: allocateLifecycleGeneration(sidecar, key),
+        locator: physicalLocator(normalized),
+        state: "live",
+        createdAt: now,
+        updatedAt: now,
+        attempts: 0,
+      }
+      sidecar.resources[key] = resource
+      pruneTombstones(sidecar, options)
+      await writeSidecar(paths.sidecar, sidecar)
+      Object.assign(locator, exactLocator(resource))
+      return exactLocator(resource)
+    }
+    assertSameLocator(resource.locator, normalized)
+    if (normalized.lifecycleGeneration !== undefined) assertExactLifecycleGeneration(resource, normalized)
+    if (resource.state === "live") {
+      Object.assign(locator, exactLocator(resource))
+      return exactLocator(resource)
+    }
+    if (resource.state === "deleting" || resource.state === "deleted") {
+      throw new SessionLifecycleError(`cannot register transcript ${key} from state ${resource.state}`)
+    }
+    resource.state = "live"
+    resource.updatedAt = nowMs(options)
+    delete resource.nextAttemptAt
+    delete resource.lastError
+    await writeSidecar(paths.sidecar, sidecar)
+    Object.assign(locator, exactLocator(resource))
+    return exactLocator(resource)
+  })
+}
+
+/** Mark a successfully spawned, Meridian-owned fork as live. */
+export async function commitFork(
+  locator: TranscriptLocator,
+  options: SessionLifecycleOptions = {},
+): Promise<void> {
+  const normalized = canonicalizeTranscriptLocator(locator)
+  const key = getTranscriptResourceKey(normalized)
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const resource = sidecar.resources[key]
+    if (!resource) {
+      throw new SessionLifecycleError(`fork ${key} was not prepared`)
+    }
+    assertSameLocator(resource.locator, normalized)
+    assertExactLifecycleGeneration(resource, normalized)
+    if (resource.state === "live") return
+    if (resource.state !== "prepared") {
+      throw new SessionLifecycleError(`cannot commit fork ${key} from state ${resource.state}`)
+    }
+    resource.state = "live"
+    resource.updatedAt = nowMs(options)
+    delete resource.nextAttemptAt
+    delete resource.lastError
+    await writeSidecar(paths.sidecar, sidecar)
+  })
+}
+
+/**
+ * Fence durable mapping publication against GC's final claim transaction.
+ * The callback must be synchronous and must perform the session-store CAS.
+ * A normal publisher must refer to an already journaled resource. This makes
+ * tombstone pruning safe: a delayed old publisher cannot recreate a locator
+ * that GC already deleted.
+ */
+export async function publishPinnedTranscript<T extends boolean | string>(
+  locator: TranscriptLocator,
+  publish: () => T,
+  options: SessionLifecycleOptions = {},
+): Promise<T> {
+  return updatePinnedTranscript(locator, publish, options, false)
+}
+
+/**
+ * Atomically attach a legacy mapping whose source predates lifecycle metadata.
+ * Missing-resource creation is allowed only inside the same lifecycle critical
+ * section as the exact session-store CAS, so there is no stale publish gap.
+ */
+export async function attachPinnedTranscript<T extends boolean | string>(
+  locator: TranscriptLocator,
+  publish: () => T,
+  options: SessionLifecycleOptions = {},
+): Promise<T> {
+  return updatePinnedTranscript(locator, publish, options, true)
+}
+
+async function updatePinnedTranscript<T extends boolean | string>(
+  locator: TranscriptLocator,
+  publish: () => T,
+  options: SessionLifecycleOptions,
+  allowMissing: boolean,
+): Promise<T> {
+  const normalized = canonicalizeTranscriptLocator(locator)
+  const key = getTranscriptResourceKey(normalized)
+  const originalGeneration = locator.lifecycleGeneration
+  return withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const beforeMutation = structuredClone(sidecar)
+    let resource = sidecar.resources[key]
+    let changed = false
+    const now = nowMs(options)
+    if (!resource) {
+      if (!allowMissing) {
+        throw new SessionLifecycleError(`cannot publish unjournaled transcript ${key}`)
+      }
+      assertResourceCapacity(sidecar, options, "live")
+      resource = sidecar.resources[key] = {
+        key,
+        generation: allocateLifecycleGeneration(sidecar, key),
+        locator: physicalLocator(normalized),
+        state: "live",
+        createdAt: now,
+        updatedAt: now,
+        attempts: 0,
+      }
+      changed = true
+    } else {
+      assertSameLocator(resource.locator, normalized)
+      if (!allowMissing || normalized.lifecycleGeneration !== undefined) {
+        assertExactLifecycleGeneration(resource, normalized)
+      }
+      if (resource.state === "deleting" || resource.state === "deleted") {
+        throw new SessionLifecycleError(`cannot publish transcript ${key} from state ${resource.state}`)
+      }
+      if (resource.state !== "live") {
+        resource.state = "live"
+        resource.updatedAt = now
+        delete resource.nextAttemptAt
+        delete resource.lastError
+        changed = true
+      }
+    }
+    if (changed) {
+      pruneTombstones(sidecar, options)
+      await writeSidecar(paths.sidecar, sidecar)
+    }
+    // Keep the lifecycle lock held across the synchronous session-store CAS.
+    locator.lifecycleGeneration = resource.generation
+    try {
+      const result = publish()
+      if (result === false) {
+        if (changed) await writeSidecar(paths.sidecar, beforeMutation)
+        if (originalGeneration === undefined) delete locator.lifecycleGeneration
+        else locator.lifecycleGeneration = originalGeneration
+      }
+      return result
+    } catch (error) {
+      if (changed) await writeSidecar(paths.sidecar, beforeMutation)
+      if (originalGeneration === undefined) delete locator.lifecycleGeneration
+      else locator.lifecycleGeneration = originalGeneration
+      throw error
+    }
+  })
+}
+
+/** Retire an intent when spawn fails. It remains tracked until SDK deletion succeeds. */
+export async function abandonFork(
+  locator: TranscriptLocator,
+  options: SessionLifecycleOptions = {},
+): Promise<void> {
+  const normalized = canonicalizeTranscriptLocator(locator)
+  const key = getTranscriptResourceKey(normalized)
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const resource = sidecar.resources[key]
+    if (!resource) {
+      throw new SessionLifecycleError(`fork ${key} was not prepared`)
+    }
+    assertSameLocator(resource.locator, normalized)
+    assertExactLifecycleGeneration(resource, normalized)
+    if (resource.state === "prepared" || resource.state === "live") {
+      if (resource.state === "live") assertPendingCapacity(sidecar, options)
+      resource.state = "retired"
+      resource.updatedAt = nowMs(options)
+      resource.nextAttemptAt = resource.updatedAt + retiredGraceMs(options)
+      await writeSidecar(paths.sidecar, sidecar)
+    }
+  })
+}
+
+/**
+ * Reconcile durable ownership with caller-provided current and previous pins.
+ * Pins are the retention authority. Callers should pass both generations.
+ */
+export async function reconcile(
+  pins: readonly TranscriptLocator[],
+  options: SessionLifecycleOptions = {},
+): Promise<ReconcileResult> {
+  // Validate caller pins before waiting for the lock. The authoritative pin
+  // provider is refreshed again while the lifecycle lock is held.
+  pins.map(canonicalizeTranscriptLocator)
+  return withSidecarLock(options, async (paths) => {
+    const effectivePins = (options.pinProvider?.() ?? pins).map(canonicalizeTranscriptLocator)
+    const sidecar = await readSidecar(paths.sidecar)
+    const pinKeys = new Set(Object.values(sidecar.resources)
+      .filter((resource) => resourceIsPinned(resource, effectivePins))
+      .map((resource) => resource.key))
+    const result: ReconcileResult = {
+      preparedRetired: 0,
+      liveRetired: 0,
+      resourcesPinned: 0,
+      deletingRecovered: 0,
+    }
+    const now = nowMs(options)
+    const preparedCutoff = now - nonNegativeOption(options.preparedGraceMs, DEFAULT_PREPARED_GRACE_MS, "preparedGraceMs")
+    let changed = false
+    for (const resource of Object.values(sidecar.resources)) {
+      if (pruneDeadActiveLeases(resource)) changed = true
+    }
+    let pending = pendingResourceCount(sidecar)
+    const maxPending = option(options.maxPending, DEFAULT_MAX_PENDING, "maxPending")
+
+    // A deletion claim is recoverable only after the exact persisted executor
+    // is provably dead. Before the executor handshake, authoritative death of
+    // the claiming proxy is enough because the gated child cannot start the
+    // physical SDK deletion without that handshake.
+    for (const resource of Object.values(sidecar.resources)) {
+      if (resource.state !== "deleting") continue
+      const executorDead = resource.deletionExecutor
+        && resource.deletionProcessGroupId !== undefined
+        ? processIncarnationIsDead(resource.deletionExecutor)
+          && processGroupIsEmpty(resource.deletionProcessGroupId)
+        : false
+      const ownerDiedBeforeHandshake = !resource.deletionExecutor
+        && resource.deletionOwner !== undefined
+        && processIncarnationIsDead(resource.deletionOwner)
+      if (!executorDead && !ownerDiedBeforeHandshake) continue
+      resource.state = "retired"
+      resource.updatedAt = now
+      resource.nextAttemptAt = now
+      delete resource.deletionToken
+      delete resource.deletionOwner
+      delete resource.deletionExecutor
+      delete resource.deletionProcessGroupId
+      result.deletingRecovered++
+      changed = true
+    }
+
+    // Rescue durable pins first. This releases pending capacity before any
+    // unpinned live resource tries to enter the bounded retirement backlog.
+    for (const resource of Object.values(sidecar.resources)) {
+      if (!pinKeys.has(resource.key)) continue
+      result.resourcesPinned++
+      if (resource.state === "deleted") {
+        throw new SessionLifecycleError(`pinned transcript ${resource.key} was already deleted`)
+      }
+      if (resource.state === "prepared" || resource.state === "retired") {
+        resource.state = "live"
+        resource.updatedAt = now
+        delete resource.nextAttemptAt
+        delete resource.lastError
+        pending--
+        changed = true
+      }
+      // A deleting resource may have an in-flight child. It cannot be rescued safely.
+    }
+
+    for (const resource of Object.values(sidecar.resources)) {
+      if (pinKeys.has(resource.key) || hasActiveTranscriptLease(resource)) continue
+      if (resource.state === "prepared" && resource.updatedAt <= preparedCutoff) {
+        // prepared and retired both consume one pending slot.
+        resource.state = "retired"
+        resource.updatedAt = now
+        resource.nextAttemptAt = now + retiredGraceMs(options)
+        result.preparedRetired++
+        changed = true
+      } else if (resource.state === "live" && pending < maxPending) {
+        resource.state = "retired"
+        resource.updatedAt = now
+        resource.nextAttemptAt = now + retiredGraceMs(options)
+        result.liveRetired++
+        pending++
+        changed = true
+      }
+    }
+
+    if (changed) await writeSidecar(paths.sidecar, sidecar)
+    return result
+  })
+}
+
+/** Delete a bounded batch of unpinned retired transcripts through the supported SDK API. */
+export async function runGc(
+  pins: readonly TranscriptLocator[],
+  options: SessionLifecycleOptions = {},
+): Promise<GcResult> {
+  await reconcile(pins, options)
+  let currentPins = pins.map(canonicalizeTranscriptLocator)
+  if (!options.deleter && process.platform === "win32") {
+    return {
+      deleted: 0,
+      notFound: 0,
+      failed: 0,
+      deferred: await countDeferred(currentPins, options),
+    }
+  }
+  const limit = option(options.maxDeletesPerRun, DEFAULT_MAX_DELETES, "maxDeletesPerRun")
+  const result: GcResult = { deleted: 0, notFound: 0, failed: 0, deferred: 0 }
+  const runTimeoutMs = option(options.runTimeoutMs, DEFAULT_DELETE_TIMEOUT_MS, "runTimeoutMs")
+  const deadline = Date.now() + runTimeoutMs
+
+  for (let index = 0; index < limit; index++) {
+    if (Date.now() >= deadline) break
+    const refreshedPins = options.pinProvider?.()
+    if (refreshedPins) {
+      currentPins = refreshedPins.map(canonicalizeTranscriptLocator)
+    }
+    const candidate = await claimDeletion(currentPins, options)
+    if (!candidate) break
+
+    let failure: unknown
+    let notFound = false
+    let deletionStillRunning = false
+    try {
+      const remainingMs = Math.max(1, deadline - Date.now())
+      const deletionTimeout = Math.min(
+        option(options.deletionTimeoutMs, DEFAULT_DELETE_TIMEOUT_MS, "deletionTimeoutMs"),
+        remainingMs,
+      )
+      if (options.deleter) {
+        await awaitCustomDeleter(options.deleter(candidate.locator), deletionTimeout)
+      } else {
+        await deleteWithSdkChild(
+          candidate.locator,
+          candidate.deletionToken!,
+          deletionTimeout,
+          (executor, processGroupId) => attachDeletionExecutor(
+            candidate.key,
+            candidate.deletionToken!,
+            executor,
+            processGroupId,
+            options,
+          ),
+          options,
+        )
+      }
+    } catch (error) {
+      if (error instanceof DeletionStillRunningError) deletionStillRunning = true
+      else if (isNotFoundError(error, candidate.locator.sessionId)) notFound = true
+      else failure = error
+    }
+
+    if (deletionStillRunning) {
+      // The SDK has no deletion fencing token. Keep the resource permanently
+      // deleting until an operator proves the old deleter is gone; retrying
+      // could let an old physical delete race a newly pinned generation.
+      result.deferred++
+      break
+    }
+    await finishDeletion(candidate.key, candidate.deletionToken!, failure, options)
+    if (failure) result.failed++
+    else if (notFound) result.notFound++
+    else result.deleted++
+  }
+
+  result.deferred += await countDeferred(currentPins, options)
+  return result
+}
+
+async function claimDeletion(
+  pins: readonly TranscriptLocator[],
+  options: SessionLifecycleOptions,
+): Promise<TranscriptResource | undefined> {
+  return withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const finalPins = (options.pinProvider?.() ?? pins).map(canonicalizeTranscriptLocator)
+    const now = nowMs(options)
+    let leasesChanged = false
+    for (const resource of Object.values(sidecar.resources)) {
+      if (pruneDeadActiveLeases(resource)) leasesChanged = true
+    }
+    const candidate = Object.values(sidecar.resources)
+      .filter((resource) =>
+        resource.state === "retired"
+        && !resourceIsPinned(resource, finalPins)
+        && !hasActiveTranscriptLease(resource)
+        && (resource.nextAttemptAt ?? 0) <= now)
+      .sort((left, right) => left.updatedAt - right.updatedAt || left.key.localeCompare(right.key))[0]
+    if (!candidate) {
+      if (leasesChanged) await writeSidecar(paths.sidecar, sidecar)
+      return undefined
+    }
+    const deletionOwner = captureProcessIncarnation()
+    if (!deletionOwner) throw new SessionLifecycleError("cannot capture deletion owner process incarnation")
+    candidate.state = "deleting"
+    candidate.updatedAt = now
+    candidate.deletionToken = randomUUID()
+    candidate.deletionOwner = deletionOwner
+    delete candidate.deletionExecutor
+    delete candidate.deletionProcessGroupId
+    await writeSidecar(paths.sidecar, sidecar)
+    return structuredClone(candidate)
+  })
+}
+
+async function attachDeletionExecutor(
+  key: string,
+  deletionToken: string,
+  executor: ProcessIncarnation,
+  processGroupId: number,
+  options: SessionLifecycleOptions,
+): Promise<void> {
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const resource = sidecar.resources[key]
+    if (!resource || resource.state !== "deleting" || resource.deletionToken !== deletionToken) {
+      throw new SessionLifecycleError(`deletion lease for ${key} was lost before executor handshake`)
+    }
+    resource.deletionExecutor = executor
+    resource.deletionProcessGroupId = processGroupId
+    resource.updatedAt = nowMs(options)
+    await writeSidecar(paths.sidecar, sidecar)
+  })
+}
+
+async function finishDeletion(
+  key: string,
+  deletionToken: string,
+  failure: unknown,
+  options: SessionLifecycleOptions,
+): Promise<void> {
+  await withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    const resource = sidecar.resources[key]
+    if (!resource || resource.state !== "deleting" || resource.deletionToken !== deletionToken) {
+      throw new SessionLifecycleError(`deletion lease for ${key} was lost`)
+    }
+    const now = nowMs(options)
+    resource.updatedAt = now
+    delete resource.deletionToken
+    delete resource.deletionOwner
+    delete resource.deletionExecutor
+    delete resource.deletionProcessGroupId
+    if (!failure) {
+      resource.state = "deleted"
+      delete resource.nextAttemptAt
+      delete resource.lastError
+    } else {
+      resource.state = "retired"
+      resource.attempts++
+      resource.lastError = errorMessage(failure).slice(0, 1_000)
+      const base = option(options.retryBaseMs, DEFAULT_RETRY_BASE_MS, "retryBaseMs")
+      const maximum = option(options.retryMaxMs, DEFAULT_RETRY_MAX_MS, "retryMaxMs")
+      const delay = Math.min(maximum, base * (2 ** Math.min(resource.attempts - 1, 20)))
+      resource.nextAttemptAt = now + delay
+    }
+    pruneTombstones(sidecar, options)
+    await writeSidecar(paths.sidecar, sidecar)
+  })
+}
+
+async function countDeferred(
+  pins: readonly TranscriptLocator[],
+  options: SessionLifecycleOptions,
+): Promise<number> {
+  return withSidecarLock(options, async (paths) => {
+    const sidecar = await readSidecar(paths.sidecar)
+    return Object.values(sidecar.resources).filter((resource) =>
+      (resource.state === "retired" || resource.state === "deleting")
+      && !resourceIsPinned(resource, pins)).length
+  })
+}
+
+class DeletionStillRunningError extends Error {}
+
+async function awaitCustomDeleter(deletion: Promise<void>, timeoutMs: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new DeletionStillRunningError("custom deleter did not settle before timeout")), timeoutMs)
+    timer.unref?.()
+  })
+  try {
+    await Promise.race([deletion, timeout])
+  } catch (error) {
+    if (error instanceof DeletionStillRunningError) {
+      void deletion.catch(() => undefined)
+    }
+    throw error
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+function processGroupIsEmpty(processGroupId: number): boolean {
+  if (process.platform === "win32") return false
+  try {
+    process.kill(-processGroupId, 0)
+    return false
+  } catch (error) {
+    return hasCode(error, "ESRCH")
+  }
+}
+
+function signalProcessGroup(processGroupId: number, signal: NodeJS.Signals): void {
+  if (process.platform === "win32") return
+  try {
+    process.kill(-processGroupId, signal)
+  } catch (error) {
+    if (!hasCode(error, "ESRCH")) throw error
+  }
+}
+
+async function waitForProcessGroupEmpty(
+  processGroupId: number,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (processGroupIsEmpty(processGroupId)) return true
+    await new Promise<void>((resolveWait) => {
+      const timer = setTimeout(resolveWait, Math.min(25, Math.max(1, deadline - Date.now())))
+      timer.unref?.()
+    })
+  }
+  return processGroupIsEmpty(processGroupId)
+}
+
+async function waitForDeletionExit(
+  exited: Promise<unknown>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<false>((resolveTimeout) => {
+    timer = setTimeout(() => resolveTimeout(false), timeoutMs)
+    timer.unref?.()
+  })
+  try {
+    return await Promise.race([exited.then(() => true, () => true), timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+async function deleteWithSdkChild(
+  locator: TranscriptLocator,
+  deletionToken: string,
+  timeoutMs: number,
+  attachExecutor: (executor: ProcessIncarnation, processGroupId: number) => Promise<void>,
+  options: SessionLifecycleOptions,
+): Promise<void> {
+  const sdkUrl = import.meta.resolve("@anthropic-ai/claude-agent-sdk")
+  const gateDirectory = join(getStoreDir(options), "deletion-gates")
+  await mkdir(gateDirectory, { recursive: true, mode: 0o700 })
+  const gatePath = join(gateDirectory, `${deletionToken}.go`)
+  await unlink(gatePath).catch((error) => {
+    if (!hasCode(error, "ENOENT")) throw error
+  })
+  const script = `
+const { existsSync } = await import("node:fs");
+const { setTimeout: wait } = await import("node:timers/promises");
+const gateDeadline = Date.now() + Number(process.env.MERIDIAN_GC_GATE_TIMEOUT_MS);
+while (!existsSync(process.env.MERIDIAN_GC_GATE_PATH)) {
+  if (Date.now() >= gateDeadline) process.exit(75);
+  await wait(10);
+}
+const sdk = await import(process.env.MERIDIAN_GC_SDK_URL);
+const options = process.env.MERIDIAN_GC_PROJECT_DIR
+  ? { dir: process.env.MERIDIAN_GC_PROJECT_DIR }
+  : undefined;
+try {
+  await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID, options);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (!options || !message.includes("not found")) throw error;
+  await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID);
+}
+`
+  const child = spawn(getSessionGcNodeExecutable(), ["--input-type=module", "--eval", script], {
+    env: {
+      ...process.env,
+      CLAUDE_CONFIG_DIR: locator.configDir,
+      MERIDIAN_GC_SDK_URL: sdkUrl,
+      MERIDIAN_GC_SESSION_ID: locator.sessionId,
+      MERIDIAN_GC_PROJECT_DIR: locator.projectDir ?? "",
+      MERIDIAN_GC_GATE_PATH: gatePath,
+      MERIDIAN_GC_GATE_TIMEOUT_MS: String(timeoutMs),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+    detached: process.platform !== "win32",
+  })
+  let output = ""
+  const collect = (chunk: Buffer | string): void => {
+    if (output.length < 64 * 1024) output += chunk.toString()
+  }
+  child.stdout?.on("data", collect)
+  child.stderr?.on("data", collect)
+  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit, rejectExit) => {
+    child.once("error", rejectExit)
+    child.once("exit", (code, signal) => resolveExit({ code, signal }))
+  })
+  let joined = false
+  let unjoined = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const joinTimeoutMs = Math.max(100, Math.min(2_000, timeoutMs))
+  const processGroupId = child.pid
+  try {
+    if (!processGroupId) throw new Error("session deletion child has no PID")
+    const executor = captureProcessIncarnation(processGroupId)
+    if (!executor) throw new Error("cannot capture session deletion executor incarnation")
+    if (process.platform === "win32") {
+      throw new SessionLifecycleError("fenced session deletion is unavailable on win32")
+    }
+    await attachExecutor(executor, processGroupId)
+    const gateHandle = await open(gatePath, "wx", 0o600)
+    try {
+      await gateHandle.writeFile("go\n", "utf8")
+      await gateHandle.sync()
+    } finally {
+      await gateHandle.close()
+    }
+
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        signalProcessGroup(processGroupId, "SIGKILL")
+        reject(new Error("session deletion process group timed out and was killed"))
+      }, timeoutMs)
+      timer.unref?.()
+    })
+    const status = await Promise.race([exited, timeout])
+    joined = await waitForProcessGroupEmpty(processGroupId, joinTimeoutMs)
+    if (!joined) {
+      throw new DeletionStillRunningError("session deletion process group remains active")
+    }
+    if (status.code !== 0) {
+      throw new Error(`session deletion child exited ${status.code ?? status.signal}: ${output.slice(-4_000)}`)
+    }
+  } finally {
+    if (timer) clearTimeout(timer)
+    if (!joined && processGroupId) {
+      signalProcessGroup(processGroupId, "SIGKILL")
+      const [leaderExited, groupEmpty] = await Promise.all([
+        waitForDeletionExit(exited, joinTimeoutMs),
+        waitForProcessGroupEmpty(processGroupId, joinTimeoutMs),
+      ])
+      joined = leaderExited && groupEmpty
+      unjoined = !joined
+    }
+    await unlink(gatePath).catch((error) => {
+      if (!hasCode(error, "ENOENT")) {
+        console.error("[sessionLifecycle] deletion gate cleanup failed:", errorMessage(error))
+      }
+    })
+    if (unjoined) {
+      throw new DeletionStillRunningError("session deletion process group remains unjoined")
+    }
+  }
+}
+
+function getStoreDir(options: SessionLifecycleOptions): string {
+  if (options.storeDir) return options.storeDir
+  return getSessionStoreDir()
+}
+
+interface SidecarPaths {
+  sidecar: string
+  lock: string
+}
+
+async function publishInitializedSidecarLock(path: string, contents: string): Promise<boolean> {
+  const staging = `${path}.candidate-${process.pid}-${randomUUID()}`
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  try {
+    handle = await open(staging, "wx", 0o600)
+    await handle.writeFile(contents, "utf8")
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+    try {
+      await link(staging, path)
+      return true
+    } catch (error) {
+      if (hasCode(error, "EEXIST")) return false
+      throw error
+    }
+  } finally {
+    await handle?.close().catch(() => undefined)
+    await unlink(staging).catch((error) => {
+      if (!hasCode(error, "ENOENT")) {
+        console.error("[sessionLifecycle] lock staging cleanup failed:", errorMessage(error))
+      }
+    })
+  }
+}
+
+async function withSidecarLock<T>(
+  options: SessionLifecycleOptions,
+  operation: (paths: SidecarPaths) => Promise<T>,
+): Promise<T> {
+  const dir = getStoreDir(options)
+  await mkdir(dir, { recursive: true, mode: 0o700 })
+  await chmod(dir, 0o700)
+  const paths = { sidecar: join(dir, SIDECAR_NAME), lock: join(dir, `${SIDECAR_NAME}.lock`) }
+  const incarnation = captureProcessIncarnation()
+  if (!incarnation) throw new SessionLifecycleLockError("cannot capture lock owner process incarnation")
+  const token = JSON.stringify({ pid: process.pid, hostname: hostname(), token: randomUUID(), incarnation })
+  const deadline = Date.now() + nonNegativeOption(options.lockWaitMs, DEFAULT_LOCK_WAIT_MS, "lockWaitMs")
+  const retryMs = option(options.lockRetryMs, DEFAULT_LOCK_RETRY_MS, "lockRetryMs")
+  const staleMs = option(options.lockStaleMs, DEFAULT_LOCK_STALE_MS, "lockStaleMs")
+  let acquired = false
+
+  while (!acquired) {
+    acquired = await publishInitializedSidecarLock(paths.lock, `${token}
+${Date.now()}
+`)
+    if (acquired) break
+    await recoverStaleLock(paths.lock, staleMs)
+    if (Date.now() >= deadline) {
+      throw new SessionLifecycleLockError(`timed out waiting for ${paths.lock}`)
+    }
+    await delay(Math.min(retryMs, Math.max(1, deadline - Date.now())))
+  }
+
+  try {
+    return await operation(paths)
+  } finally {
+    // Only the owner may release. A stale-lock recovery must not unlink a successor.
+    try {
+      const contents = await readFile(paths.lock, "utf8")
+      if (contents.startsWith(`${token}\n`)) await unlink(paths.lock)
+    } catch (error) {
+      if (!hasCode(error, "ENOENT")) {
+        console.error("[sessionLifecycle] lock release failed:", errorMessage(error))
+      }
+    }
+  }
+}
+
+interface CanonicalLifecycleLockOwner {
+  pid: number
+  hostname: string
+  token: string
+  incarnation: ProcessIncarnation
+}
+
+function parseCanonicalLifecycleLockOwner(contents: string): CanonicalLifecycleLockOwner | undefined {
+  const token = contents.split("\n", 1)[0] ?? ""
+  try {
+    const owner = JSON.parse(token) as Record<string, unknown>
+    if (
+      typeof owner.pid !== "number"
+      || !Number.isInteger(owner.pid)
+      || owner.pid <= 0
+      || typeof owner.hostname !== "string"
+      || owner.hostname.length === 0
+      || typeof owner.token !== "string"
+      || owner.token.length === 0
+      || !parseProcessIncarnation(owner.incarnation)
+    ) return undefined
+    return owner as unknown as CanonicalLifecycleLockOwner
+  } catch {
+    return undefined
+  }
+}
+
+function canonicalLifecycleLockOwnerIsDead(contents: string): boolean {
+  const owner = parseCanonicalLifecycleLockOwner(contents)
+  return owner ? processIncarnationIsDead(owner.incarnation) : false
+}
+
+interface LifecycleRecoveryClaimSnapshot {
+  dev: number
+  ino: number
+  owner?: RecoveryClaimOwner
+}
+
+async function snapshotLifecycleRecoveryClaim(
+  claimPath: string,
+): Promise<LifecycleRecoveryClaimSnapshot | undefined> {
+  let info: Awaited<ReturnType<typeof lstat>>
+  try {
+    info = await lstat(claimPath)
+  } catch (error) {
+    if (hasCode(error, "ENOENT")) return undefined
+    throw error
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) return { dev: info.dev, ino: info.ino }
+
+  let owner: RecoveryClaimOwner | undefined
+  try {
+    owner = parseRecoveryClaimOwnerJson(await readFile(join(claimPath, "owner.json"), "utf8"))
+  } catch (error) {
+    if (!hasCode(error, "ENOENT")) throw error
+  }
+  return { dev: info.dev, ino: info.ino, owner }
+}
+
+/** Atomically publish a fully initialized, non-empty recovery owner directory. */
+async function publishLifecycleRecoveryClaim(
+  claimPath: string,
+  owner: RecoveryClaimOwner,
+): Promise<boolean> {
+  const candidate = `${claimPath}.candidate-${process.pid}-${owner.token}`
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  let published = false
+  try {
+    await mkdir(candidate, { mode: 0o700 })
+    handle = await open(join(candidate, "owner.json"), "wx", 0o600)
+    await handle.writeFile(JSON.stringify(owner), "utf8")
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+    const candidateDirectoryHandle = await open(candidate, "r")
+    try {
+      await candidateDirectoryHandle.sync()
+    } finally {
+      await candidateDirectoryHandle.close()
+    }
+
+    try {
+      await lstat(claimPath)
+      return false
+    } catch (error) {
+      if (!hasCode(error, "ENOENT")) throw error
+    }
+    try {
+      await rename(candidate, claimPath)
+      published = true
+      const parentDirectoryHandle = await open(dirname(claimPath), "r")
+      try {
+        await parentDirectoryHandle.sync()
+      } finally {
+        await parentDirectoryHandle.close()
+      }
+      return true
+    } catch (error) {
+      if (["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].some((code) => hasCode(error, code))) {
+        return false
+      }
+      throw error
+    }
+  } finally {
+    await handle?.close().catch(() => undefined)
+    if (!published) await rm(candidate, { recursive: true, force: true }).catch(() => undefined)
+  }
+}
+
+/** Retire only the observed dead claim generation. Its tombstone fences ABA. */
+async function retireDeadLifecycleRecoveryClaim(
+  claimPath: string,
+  generation: string,
+): Promise<boolean> {
+  const observed = await snapshotLifecycleRecoveryClaim(claimPath)
+  if (!observed) return true
+  if (
+    !observed.owner
+    || observed.owner.generation !== generation
+    || !recoveryClaimOwnerIsDead(observed.owner)
+  ) return false
+
+  const tombstone = getRecoveryClaimTombstonePath(claimPath, observed.owner.token)
+  try {
+    await lstat(tombstone)
+    return false
+  } catch (error) {
+    if (!hasCode(error, "ENOENT")) throw error
+  }
+
+  const current = await snapshotLifecycleRecoveryClaim(claimPath)
+  if (!current) return true
+  const currentOwner = current.owner
+  if (
+    current.dev !== observed.dev
+    || current.ino !== observed.ino
+    || !currentOwner
+    || currentOwner.token !== observed.owner.token
+    || currentOwner.generation !== generation
+    || !recoveryClaimOwnerIsDead(currentOwner)
+  ) return false
+
+  try {
+    await rename(claimPath, tombstone)
+  } catch (error) {
+    if (hasCode(error, "ENOENT")) return true
+    if (["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].some((code) => hasCode(error, code))) {
+      return false
+    }
+    throw error
+  }
+
+  const moved = await snapshotLifecycleRecoveryClaim(tombstone)
+  if (
+    !moved
+    || moved.dev !== observed.dev
+    || moved.ino !== observed.ino
+    || moved.owner?.token !== observed.owner.token
+    || moved.owner?.generation !== generation
+  ) throw new SessionLifecycleLockError("recovery claim identity changed during retirement")
+  return true
+}
+
+async function releaseLifecycleRecoveryClaim(
+  claimPath: string,
+  owner: RecoveryClaimOwner,
+): Promise<void> {
+  try {
+    const current = await snapshotLifecycleRecoveryClaim(claimPath)
+    if (current?.owner?.token === owner.token && current.owner.generation === owner.generation) {
+      await rm(claimPath, { recursive: true })
+    }
+  } catch (error) {
+    console.error("[sessionLifecycle] stale recovery claim cleanup failed:", errorMessage(error))
+  }
+}
+
+async function cleanupLifecycleRecoveryTombstones(claimPath: string): Promise<void> {
+  const prefix = `${basename(claimPath)}.orphan-`
+  try {
+    for (const name of await readdir(dirname(claimPath))) {
+      if (!name.startsWith(prefix)) continue
+      const path = join(dirname(claimPath), name)
+      const info = await lstat(path)
+      if (info.isDirectory() && !info.isSymbolicLink()) {
+        await rm(path, { recursive: true })
+      }
+    }
+  } catch (error) {
+    if (!hasCode(error, "ENOENT")) {
+      console.error("[sessionLifecycle] stale recovery tombstone cleanup failed:", errorMessage(error))
+    }
+  }
+}
+
+async function recoverStaleLock(lockPath: string, staleMs: number): Promise<void> {
+  let contents: string
+  let info: Awaited<ReturnType<typeof stat>>
+  try {
+    contents = await readFile(lockPath, "utf8")
+    info = await stat(lockPath)
+  } catch (error) {
+    if (hasCode(error, "ENOENT")) return
+    throw error
+  }
+  if (
+    Date.now() - info.mtimeMs <= staleMs
+    || !canonicalLifecycleLockOwnerIsDead(contents)
+  ) return
+
+  const generation = contents
+  const claimPath = getRecoveryClaimPath(lockPath, generation)
+  const claimOwner = createRecoveryClaimOwner(generation)
+  if (!await publishLifecycleRecoveryClaim(claimPath, claimOwner)) {
+    if (!await retireDeadLifecycleRecoveryClaim(claimPath, generation)) return
+    if (!await publishLifecycleRecoveryClaim(claimPath, claimOwner)) return
+  }
+
+  let generationResolved = false
+  try {
+    let currentContents: string
+    let currentInfo: Awaited<ReturnType<typeof stat>>
+    try {
+      currentContents = await readFile(lockPath, "utf8")
+      currentInfo = await stat(lockPath)
+    } catch (error) {
+      if (hasCode(error, "ENOENT")) {
+        generationResolved = true
+        return
+      }
+      throw error
+    }
+    if (
+      currentContents !== contents
+      || currentInfo.dev !== info.dev
+      || currentInfo.ino !== info.ino
+    ) {
+      generationResolved = true
+      return
+    }
+    if (
+      Date.now() - currentInfo.mtimeMs <= staleMs
+      || !canonicalLifecycleLockOwnerIsDead(currentContents)
+    ) return
+
+    const quarantine = `${lockPath}.stale-${process.pid}-${randomUUID()}`
+    await rename(lockPath, quarantine)
+    generationResolved = true
+    const movedContents = await readFile(quarantine, "utf8")
+    if (movedContents !== currentContents) {
+      throw new SessionLifecycleLockError("claimed lock identity changed during stale recovery")
+    }
+    await unlink(quarantine)
+  } catch (error) {
+    if (hasCode(error, "ENOENT")) generationResolved = true
+    else throw error
+  } finally {
+    await releaseLifecycleRecoveryClaim(claimPath, claimOwner)
+    if (generationResolved) await cleanupLifecycleRecoveryTombstones(claimPath)
+  }
+}
+
+async function readSidecar(path: string): Promise<SessionGcSidecar> {
+  let raw: string
+  try {
+    raw = await readFile(path, "utf8")
+  } catch (error) {
+    if (hasCode(error, "ENOENT")) return {
+      version: SIDECAR_VERSION,
+      meta: { fenceSlots: {} },
+      resources: {},
+    }
+    throw error
+  }
+
+  let value: unknown
+  try {
+    value = JSON.parse(raw)
+  } catch (error) {
+    throw new SessionLifecycleCorruptError(`cannot parse ${path}: ${errorMessage(error)}`)
+  }
+  const upgraded = upgradeLegacySidecar(value)
+  if (!isValidSidecar(upgraded)) {
+    throw new SessionLifecycleCorruptError(`invalid or unsupported ${path}`)
+  }
+  return upgraded
+}
+
+async function writeSidecar(path: string, sidecar: SessionGcSidecar): Promise<void> {
+  const temp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  let handle: Awaited<ReturnType<typeof open>> | undefined
+  try {
+    handle = await open(temp, "wx", 0o600)
+    await handle.writeFile(`${JSON.stringify(sidecar, null, 2)}\n`, "utf8")
+    await handle.sync()
+    await handle.close()
+    handle = undefined
+    await rename(temp, path)
+    await chmod(path, 0o600)
+    // Persist the rename itself, not only the temporary file contents. This is
+    // the durability boundary before the SDK may create a managed fork.
+    const directoryHandle = await open(dirname(path), "r")
+    try {
+      await directoryHandle.sync()
+    } finally {
+      await directoryHandle.close()
+    }
+  } catch (error) {
+    await handle?.close().catch(() => undefined)
+    await unlink(temp).catch(() => undefined)
+    throw error
+  }
+}
+
+function isValidActiveLeases(value: unknown): value is Record<string, ActiveTranscriptLeaseRecord> {
+  if (!isRecord(value)) return false
+  return Object.entries(value).every(([token, lease]) =>
+    token.length > 0
+    && isRecord(lease)
+    && lease.token === token
+    && parseProcessIncarnation(lease.owner) !== undefined
+    && (lease.executor === undefined || parseProcessIncarnation(lease.executor) !== undefined)
+    && (lease.executorRecoverable === undefined || typeof lease.executorRecoverable === "boolean")
+    && (lease.executorRecoverable === undefined || lease.executor !== undefined)
+    && isFiniteNumber(lease.createdAt)
+  )
+}
+
+function fenceSlotForKey(key: string): string {
+  return key.slice(0, 4)
+}
+
+function allocateLifecycleGeneration(sidecar: SessionGcSidecar, key: string): string {
+  const slot = fenceSlotForKey(key)
+  const current = sidecar.meta.fenceSlots[slot] ?? 0
+  if (!Number.isSafeInteger(current) || current < 0 || current === Number.MAX_SAFE_INTEGER) {
+    throw new SessionLifecycleCorruptError(`lifecycle fence slot ${slot} is exhausted or corrupt`)
+  }
+  const next = current + 1
+  sidecar.meta.fenceSlots[slot] = next
+  return `r:${key}:${next}`
+}
+
+function lifecycleGenerationIsValid(value: unknown, key: string): value is string {
+  if (typeof value !== "string") return false
+  const prefix = `r:${key}:`
+  if (!value.startsWith(prefix)) return false
+  const counter = Number(value.slice(prefix.length))
+  return Number.isSafeInteger(counter) && counter > 0
+}
+
+function upgradeLegacySidecar(value: unknown): unknown {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.resources)) return value
+  const upgraded: SessionGcSidecar = {
+    version: SIDECAR_VERSION,
+    meta: { fenceSlots: {} },
+    resources: {},
+  }
+  for (const [key, raw] of Object.entries(value.resources)) {
+    if (!isRecord(raw)) return value
+    const generation = allocateLifecycleGeneration(upgraded, key)
+    upgraded.resources[key] = {
+      ...(raw as unknown as TranscriptResource),
+      key,
+      generation,
+    }
+  }
+  return upgraded
+}
+
+function isValidSidecar(value: unknown): value is SessionGcSidecar {
+  if (!isRecord(value) || value.version !== SIDECAR_VERSION
+    || !isRecord(value.meta) || !isRecord(value.meta.fenceSlots)
+    || !isRecord(value.resources)) return false
+  const meta = value.meta as { fenceSlots: Record<string, unknown> }
+  if (!Object.entries(meta.fenceSlots).every(([slot, counter]) =>
+    /^[a-f0-9]{4}$/.test(slot)
+    && typeof counter === "number"
+    && Number.isSafeInteger(counter)
+    && counter > 0)) return false
+  return Object.entries(value.resources).every(([key, resource]) => {
+    if (!/^[a-f0-9]{64}$/.test(key) || !isRecord(resource)) return false
+    if (resource.key !== key || !isValidLocator(resource.locator)) return false
+    if (!lifecycleGenerationIsValid(resource.generation, key)) return false
+    if (Number(meta.fenceSlots[fenceSlotForKey(key)] ?? 0)
+      < Number(resource.generation.slice(`r:${key}:`.length))) return false
+    if (getTranscriptResourceKey(resource.locator) !== key) return false
+    if (!isState(resource.state)) return false
+    if (!isFiniteNumber(resource.createdAt) || !isFiniteNumber(resource.updatedAt)) return false
+    if (typeof resource.attempts !== "number"
+      || !Number.isSafeInteger(resource.attempts)
+      || resource.attempts < 0) return false
+    if (resource.nextAttemptAt !== undefined && !isFiniteNumber(resource.nextAttemptAt)) return false
+    if (resource.lastError !== undefined && typeof resource.lastError !== "string") return false
+    if (resource.deletionToken !== undefined && typeof resource.deletionToken !== "string") return false
+    if (resource.deletionOwner !== undefined && !parseProcessIncarnation(resource.deletionOwner)) return false
+    if (resource.deletionExecutor !== undefined && !parseProcessIncarnation(resource.deletionExecutor)) return false
+    if (resource.deletionProcessGroupId !== undefined && (
+      typeof resource.deletionProcessGroupId !== "number"
+      || !Number.isSafeInteger(resource.deletionProcessGroupId)
+      || resource.deletionProcessGroupId <= 0
+    )) return false
+    // Legacy deleting entries without exact owners/group identity remain permanently fenced.
+    if (resource.state !== "deleting" && (
+      resource.deletionToken !== undefined
+      || resource.deletionOwner !== undefined
+      || resource.deletionExecutor !== undefined
+      || resource.deletionProcessGroupId !== undefined
+    )) return false
+    if (resource.deletionExecutor !== undefined && resource.deletionOwner === undefined) return false
+    if (resource.deletionProcessGroupId !== undefined && resource.deletionExecutor === undefined) return false
+    if (resource.activeLeases !== undefined && !isValidActiveLeases(resource.activeLeases)) return false
+    return true
+  })
+}
+
+function assertResourceCapacity(
+  sidecar: SessionGcSidecar,
+  options: SessionLifecycleOptions,
+  nextState: "prepared" | "live",
+): void {
+  const resources = Object.values(sidecar.resources)
+  const owned = resources.filter((resource) => resource.state !== "deleted").length
+  const maxPending = option(options.maxPending, DEFAULT_MAX_PENDING, "maxPending")
+  // One durable mapping can pin its current transcript and direct predecessor.
+  // Keep a separate hard ownership ceiling so normal live mappings cannot
+  // consume the crash/deletion backlog allowance or deadlock fresh allocation
+  // at the much smaller pending limit.
+  const defaultMaxOwned = Math.min(
+    Number.MAX_SAFE_INTEGER,
+    getMaxStoredSessionsLimit() * 2 + maxPending,
+  )
+  const maxOwned = option(options.maxOwned, defaultMaxOwned, "maxOwned")
+  if (owned >= maxOwned) {
+    throw new SessionLifecycleBacklogError("session transcript ownership capacity is full")
+  }
+  if (nextState === "prepared" && pendingResourceCount(sidecar) >= maxPending) {
+    throw new SessionLifecycleBacklogError("session transcript ownership backlog is full")
+  }
+}
+
+function resourceIsPinned(
+  resource: TranscriptResource,
+  pins: readonly TranscriptLocator[],
+): boolean {
+  return pins.some((pin) =>
+    getTranscriptResourceKey(pin) === resource.key
+    // Legacy mappings conservatively pin the physical locator until their
+    // first exact-CAS lifecycle attachment stores a generation.
+    && (pin.lifecycleGeneration === undefined || pin.lifecycleGeneration === resource.generation))
+}
+
+function hasActiveTranscriptLease(resource: TranscriptResource): boolean {
+  return resource.activeLeases !== undefined && Object.keys(resource.activeLeases).length > 0
+}
+
+function pruneDeadActiveLeases(resource: TranscriptResource): boolean {
+  if (!resource.activeLeases) return false
+  let changed = false
+  for (const [token, lease] of Object.entries(resource.activeLeases)) {
+    const executorDead = lease.executor && lease.executorRecoverable !== false
+      ? processIncarnationIsDead(lease.executor)
+      : false
+    // An unarmed lease cannot have started a physical writer: production opens
+    // the SDK gate only after attachActiveTranscriptExecutor commits.
+    const unarmedOwnerDead = !lease.executor && processIncarnationIsDead(lease.owner)
+    if (!executorDead && !unarmedOwnerDead) continue
+    delete resource.activeLeases[token]
+    changed = true
+  }
+  if (Object.keys(resource.activeLeases).length === 0) delete resource.activeLeases
+  return changed
+}
+
+function pendingResourceCount(sidecar: SessionGcSidecar): number {
+  return Object.values(sidecar.resources).filter((resource) =>
+    resource.state === "prepared"
+    || resource.state === "retired"
+    || resource.state === "deleting"
+  ).length
+}
+
+function assertPendingCapacity(
+  sidecar: SessionGcSidecar,
+  options: SessionLifecycleOptions,
+): void {
+  const maximum = option(options.maxPending, DEFAULT_MAX_PENDING, "maxPending")
+  if (pendingResourceCount(sidecar) >= maximum) {
+    throw new SessionLifecycleBacklogError("session transcript ownership backlog is full")
+  }
+}
+
+function pruneTombstones(sidecar: SessionGcSidecar, options: SessionLifecycleOptions): void {
+  const maximum = option(options.maxTombstones, DEFAULT_MAX_TOMBSTONES, "maxTombstones")
+  const tombstones = Object.values(sidecar.resources)
+    .filter((resource) => resource.state === "deleted")
+    .sort((left, right) => right.updatedAt - left.updatedAt || left.key.localeCompare(right.key))
+  for (const resource of tombstones.slice(maximum)) delete sidecar.resources[resource.key]
+}
+
+function canonicalLocatorPath(path: string): string {
+  const lexical = resolve(path)
+  try {
+    return realpathSync.native(lexical)
+  } catch (error) {
+    if (hasCode(error, "ENOENT")) return lexical
+    throw error
+  }
+}
+
+export function canonicalizeTranscriptLocator(locator: TranscriptLocator): TranscriptLocator {
+  validateLocator(locator)
+  return {
+    sessionId: locator.sessionId,
+    configDir: canonicalLocatorPath(locator.configDir),
+    ...(locator.projectDir ? { projectDir: canonicalLocatorPath(locator.projectDir) } : {}),
+    ...(locator.lifecycleGeneration ? { lifecycleGeneration: locator.lifecycleGeneration } : {}),
+  }
+}
+
+function validateLocator(locator: TranscriptLocator): void {
+  if (!locator || typeof locator.sessionId !== "string" || locator.sessionId.length === 0) {
+    throw new TypeError("sessionId must be a non-empty string")
+  }
+  if (typeof locator.configDir !== "string" || !isAbsolute(locator.configDir)) {
+    throw new TypeError("configDir must be an absolute path")
+  }
+  if (locator.projectDir !== undefined
+    && (typeof locator.projectDir !== "string" || !isAbsolute(locator.projectDir))) {
+    throw new TypeError("projectDir must be an absolute path when provided")
+  }
+  if (locator.lifecycleGeneration !== undefined
+    && (typeof locator.lifecycleGeneration !== "string" || locator.lifecycleGeneration.length === 0)) {
+    throw new TypeError("lifecycleGeneration must be a non-empty string when provided")
+  }
+}
+
+function isValidLocator(value: unknown): value is TranscriptLocator {
+  if (!isRecord(value)) return false
+  try {
+    validateLocator(value as unknown as TranscriptLocator)
+    return Object.keys(value).every((key) =>
+      key === "sessionId" || key === "configDir" || key === "projectDir" || key === "lifecycleGeneration")
+  } catch {
+    return false
+  }
+}
+
+function assertSameLocator(left: TranscriptLocator, right: TranscriptLocator): void {
+  if (left.sessionId !== right.sessionId
+    || left.configDir !== right.configDir
+    || left.projectDir !== right.projectDir) {
+    throw new SessionLifecycleCorruptError("resource key collision or locator mismatch")
+  }
+}
+
+function isState(value: unknown): value is TranscriptResourceState {
+  return value === "prepared" || value === "live" || value === "retired"
+    || value === "deleting" || value === "deleted"
+}
+
+function isNotFoundError(error: unknown, sessionId: string): boolean {
+  // Match the SDK's UUID-specific response only. ENOENT and generic "not found"
+  // errors can mean the child or SDK failed to load and must be retried.
+  return errorMessage(error).includes(`Session ${sessionId} not found`)
+}
+
+/** Resolve a real Node runtime even when Meridian itself is bundled under Bun. */
+export function getSessionGcNodeExecutable(): string {
+  return typeof process.versions.bun === "string" ? "node" : process.execPath
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function hasCode(error: unknown, code: string): boolean {
+  return isRecord(error) && error.code === code
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+function nowMs(options: SessionLifecycleOptions): number {
+  const value = (options.now ?? Date.now)()
+  if (!Number.isFinite(value)) throw new TypeError("now() must return a finite number")
+  return value
+}
+
+function option(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) throw new TypeError(`${name} must be a positive integer`)
+  return resolved
+}
+
+function nonNegativeOption(value: number | undefined, fallback: number, name: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isSafeInteger(resolved) || resolved < 0) throw new TypeError(`${name} must be a non-negative integer`)
+  return resolved
+}
+
+function retiredGraceMs(options: SessionLifecycleOptions): number {
+  return nonNegativeOption(options.retiredGraceMs, DEFAULT_RETIRED_GRACE_MS, "retiredGraceMs")
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -11,22 +11,56 @@
  */
 
 import {
+  chmodSync,
   closeSync,
   existsSync,
+  fchmodSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
   mkdirSync,
   openSync,
   readFileSync,
+  readdirSync,
   renameSync,
+  rmSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs"
-import { homedir } from "node:os"
-import { join } from "node:path"
+import { createHash, randomUUID } from "node:crypto"
+import { homedir, hostname } from "node:os"
+import { basename, dirname, isAbsolute, join } from "node:path"
 import type { TokenUsage } from "./session/lineage"
+import {
+  createRecoveryClaimOwner,
+  getRecoveryClaimPath,
+  getRecoveryClaimTombstonePath,
+  parseRecoveryClaimOwnerJson,
+  recoveryClaimOwnerIsDead,
+  type RecoveryClaimOwner,
+} from "./session/recoveryClaim"
+import {
+  captureProcessIncarnation,
+  parseProcessIncarnation,
+  processIncarnationIsDead,
+  type ProcessIncarnation,
+} from "./session/processIncarnation"
+
+export interface TranscriptLocator {
+  sessionId: string
+  configDir: string
+  projectDir?: string
+  /** Opaque lifecycle ownership fence; absent only on legacy mappings. */
+  lifecycleGeneration?: string
+}
 
 export interface StoredSession {
   claudeSessionId: string
+  /** Monotonic per-entry revision retained for diagnostics and upgrades. */
+  revision?: number
+  /** Unique publication token. Replaced on every durable mapping mutation. */
+  generationId?: string
   createdAt: number
   lastUsedAt: number
   messageCount: number
@@ -49,6 +83,67 @@ export interface StoredSession {
    *  Enables recovery when a lineage bug (e.g. false compaction) causes the
    *  original session to be abandoned and a new one started. */
   previousClaudeSessionId?: string
+  /** Exact transcript location for the current Claude session. */
+  currentTranscript?: TranscriptLocator
+  /** Transcript location retained when the session mapping is replaced. */
+  previousTranscript?: TranscriptLocator
+}
+
+export type StoredSessionGeneration = string
+
+const STORE_META_KEY = "\u0000meridian-session-store"
+const STORE_META_VERSION = 1
+
+interface SessionStoreMeta {
+  version: 1
+  /** Fixed hash slots fence absent-key create/delete ABA without unbounded tombstones. */
+  slots: Record<string, number>
+}
+
+interface SessionStoreDocument {
+  sessions: Record<string, StoredSession>
+  meta: SessionStoreMeta
+}
+
+function keyDigest(key: string): string {
+  return createHash("sha256").update(key).digest("hex")
+}
+
+function keySlot(key: string): string {
+  // At most 65,536 counters are persisted. A collision can reject safe work,
+  // but can never admit stale work because the full key digest is in the token.
+  return keyDigest(key).slice(0, 4)
+}
+
+function absenceGeneration(key: string, meta: SessionStoreMeta): StoredSessionGeneration {
+  return `a:${keyDigest(key)}:${meta.slots[keySlot(key)] ?? 0}`
+}
+
+/** Exact, key-bound durable generation used for compare-and-swap fencing. */
+export function getStoredSessionGeneration(
+  session: StoredSession,
+  key: string,
+): StoredSessionGeneration {
+  const generationId = session.generationId
+    ?? `legacy-${createHash("sha256").update(JSON.stringify(session)).digest("hex")}`
+  return `p:${keyDigest(key)}:${generationId}`
+}
+
+function keyGeneration(
+  key: string,
+  session: StoredSession | undefined,
+  meta: SessionStoreMeta,
+): StoredSessionGeneration {
+  return session ? getStoredSessionGeneration(session, key) : absenceGeneration(key, meta)
+}
+
+function advanceKeySlot(key: string, meta: SessionStoreMeta): void {
+  const slot = keySlot(key)
+  const current = meta.slots[slot] ?? 0
+  if (!Number.isSafeInteger(current) || current < 0 || current >= Number.MAX_SAFE_INTEGER) {
+    throw new Error(`session store generation slot ${slot} is exhausted`)
+  }
+  meta.slots[slot] = current + 1
 }
 
 // No time-based session expiry. SDK sessions persist on Anthropic's side
@@ -56,8 +151,11 @@ export interface StoredSession {
 // replay on the next request. Storage is bounded by MAX_STORED_SESSIONS.
 const DEFAULT_MAX_STORED_SESSIONS = 10_000
 const STALE_LOCK_THRESHOLD_MS = 30_000
+const DEFAULT_LOCK_WAIT_MS = 10_000
+const LOCK_RETRY_MS = 10
+const lockWaitBuffer = new Int32Array(new SharedArrayBuffer(4))
 
-function getMaxStoredSessions(): number {
+export function getMaxStoredSessionsLimit(): number {
   const raw = process.env.MERIDIAN_MAX_STORED_SESSIONS ?? process.env.CLAUDE_PROXY_MAX_STORED_SESSIONS
   if (!raw) return DEFAULT_MAX_STORED_SESSIONS
   const parsed = Number.parseInt(raw, 10)
@@ -65,64 +163,394 @@ function getMaxStoredSessions(): number {
   return parsed
 }
 
-function acquireLock(lockPath: string): boolean {
+function getLockWaitMs(): number {
+  const raw = process.env.MERIDIAN_SESSION_LOCK_TIMEOUT_MS
+    ?? process.env.CLAUDE_PROXY_SESSION_LOCK_TIMEOUT_MS
+  if (!raw) return DEFAULT_LOCK_WAIT_MS
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_LOCK_WAIT_MS
+  return parsed
+}
+
+interface StoreLock {
+  path: string
+  token: string
+}
+
+function sleepSync(milliseconds: number): void {
+  Atomics.wait(lockWaitBuffer, 0, 0, milliseconds)
+}
+
+/** Publish fully initialized lock metadata with an atomic no-replace hard link. */
+function publishInitializedLockFile(path: string, contents: string): boolean {
+  const staging = `${path}.candidate-${process.pid}-${randomUUID()}`
+  let fd: number | undefined
   try {
-    const fd = openSync(lockPath, "wx")
+    fd = openSync(staging, "wx", 0o600)
+    fchmodSync(fd, 0o600)
+    writeFileSync(fd, contents, "utf8")
+    fsyncSync(fd)
     closeSync(fd)
-    return true
-  } catch (e) {
-    const err = e as NodeJS.ErrnoException
-    if (err.code !== "EEXIST") {
-      console.error("[sessionStore] lock acquire failed:", err.message)
-      return false
-    }
+    fd = undefined
     try {
-      const stat = statSync(lockPath)
-      if (Date.now() - stat.mtimeMs > STALE_LOCK_THRESHOLD_MS) {
-        // TOCTOU: another process could grab the lock between unlink and open.
-        // The second openSync("wx") will throw EEXIST in that case, caught below.
-        // This is acceptable — one process wins, the other proceeds without lock.
-        unlinkSync(lockPath)
-        const fd = openSync(lockPath, "wx")
-        closeSync(fd)
-        return true
-      }
-    } catch (staleError) {
-      console.error("[sessionStore] stale lock recovery failed:", (staleError as Error).message)
+      linkSync(staging, path)
+      return true
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return false
+      throw error
     }
-    return false
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd) } catch (error) {
+        console.error("[sessionStore] lock staging close failed:", (error as Error).message)
+      }
+    }
+    try { unlinkSync(staging) } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error("[sessionStore] lock staging cleanup failed:", (error as Error).message)
+      }
+    }
   }
 }
 
-function releaseLock(lockPath: string): void {
+interface CanonicalStoreLockOwner {
+  pid: number
+  hostname: string
+  token: string
+  incarnation: ProcessIncarnation
+}
+
+function parseCanonicalStoreLockOwner(contents: string): CanonicalStoreLockOwner | undefined {
   try {
-    unlinkSync(lockPath)
-  } catch (e) {
-    console.error("[sessionStore] lock release failed:", (e as Error).message)
+    const owner = JSON.parse(contents) as Record<string, unknown>
+    if (
+      typeof owner.pid !== "number"
+      || !Number.isInteger(owner.pid)
+      || owner.pid <= 0
+      || typeof owner.hostname !== "string"
+      || owner.hostname.length === 0
+      || typeof owner.token !== "string"
+      || owner.token.length === 0
+      || !parseProcessIncarnation(owner.incarnation)
+    ) return undefined
+    return owner as unknown as CanonicalStoreLockOwner
+  } catch {
+    return undefined
+  }
+}
+
+function canonicalStoreLockOwnerIsDead(contents: string): boolean {
+  const owner = parseCanonicalStoreLockOwner(contents)
+  return owner ? processIncarnationIsDead(owner.incarnation) : false
+}
+
+interface StoreRecoveryClaimSnapshot {
+  dev: number
+  ino: number
+  owner?: RecoveryClaimOwner
+}
+
+function snapshotStoreRecoveryClaim(claimPath: string): StoreRecoveryClaimSnapshot | undefined {
+  let info: ReturnType<typeof lstatSync>
+  try {
+    info = lstatSync(claimPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined
+    throw error
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) return { dev: info.dev, ino: info.ino }
+
+  let owner: RecoveryClaimOwner | undefined
+  try {
+    owner = parseRecoveryClaimOwnerJson(readFileSync(join(claimPath, "owner.json"), "utf8"))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  return { dev: info.dev, ino: info.ino, owner }
+}
+
+/** Atomically publish a fully initialized, non-empty recovery owner directory. */
+function publishStoreRecoveryClaim(claimPath: string, owner: RecoveryClaimOwner): boolean {
+  const candidate = `${claimPath}.candidate-${process.pid}-${owner.token}`
+  let fd: number | undefined
+  let published = false
+  try {
+    mkdirSync(candidate, { mode: 0o700 })
+    fd = openSync(join(candidate, "owner.json"), "wx", 0o600)
+    writeFileSync(fd, JSON.stringify(owner), "utf8")
+    fsyncSync(fd)
+    closeSync(fd)
+    fd = undefined
+    const candidateDirectoryFd = openSync(candidate, "r")
+    try {
+      fsyncSync(candidateDirectoryFd)
+    } finally {
+      closeSync(candidateDirectoryFd)
+    }
+
+    // Protocol-created destinations are non-empty directories, so rename is
+    // atomic and no-replace. Refuse malformed pre-existing paths as well.
+    try {
+      lstatSync(claimPath)
+      return false
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+    try {
+      renameSync(candidate, claimPath)
+      published = true
+      const parentDirectoryFd = openSync(dirname(claimPath), "r")
+      try {
+        fsyncSync(parentDirectoryFd)
+      } finally {
+        closeSync(parentDirectoryFd)
+      }
+      return true
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].includes(code ?? "")) return false
+      throw error
+    }
+  } finally {
+    if (fd !== undefined) {
+      try { closeSync(fd) } catch (error) {
+        console.error("[sessionStore] recovery claim owner close failed:", (error as Error).message)
+      }
+    }
+    if (!published) {
+      try { rmSync(candidate, { recursive: true, force: true }) } catch (error) {
+        console.error("[sessionStore] recovery claim candidate cleanup failed:", (error as Error).message)
+      }
+    }
+  }
+}
+
+/** Retire only the observed dead claim generation. Its tombstone fences ABA. */
+function retireDeadStoreRecoveryClaim(claimPath: string, generation: string): boolean {
+  const observed = snapshotStoreRecoveryClaim(claimPath)
+  if (!observed) return true
+  if (
+    !observed.owner
+    || observed.owner.generation !== generation
+    || !recoveryClaimOwnerIsDead(observed.owner)
+  ) return false
+
+  const tombstone = getRecoveryClaimTombstonePath(claimPath, observed.owner.token)
+  try {
+    lstatSync(tombstone)
+    return false
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+
+  const current = snapshotStoreRecoveryClaim(claimPath)
+  if (
+    !current
+    || current.dev !== observed.dev
+    || current.ino !== observed.ino
+    || current.owner?.token !== observed.owner.token
+    || current.owner.generation !== generation
+    || !recoveryClaimOwnerIsDead(current.owner)
+  ) return !current
+
+  try {
+    renameSync(claimPath, tombstone)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT") return true
+    if (["EEXIST", "ENOTEMPTY", "ENOTDIR", "EISDIR"].includes(code ?? "")) return false
+    throw error
+  }
+
+  const moved = snapshotStoreRecoveryClaim(tombstone)
+  if (
+    !moved
+    || moved.dev !== observed.dev
+    || moved.ino !== observed.ino
+    || moved.owner?.token !== observed.owner.token
+    || moved.owner.generation !== generation
+  ) throw new Error("recovery claim identity changed during retirement")
+  return true
+}
+
+function releaseStoreRecoveryClaim(claimPath: string, owner: RecoveryClaimOwner): void {
+  try {
+    const current = snapshotStoreRecoveryClaim(claimPath)
+    if (current?.owner?.token === owner.token && current.owner.generation === owner.generation) {
+      rmSync(claimPath, { recursive: true })
+    }
+  } catch (error) {
+    console.error("[sessionStore] stale recovery claim cleanup failed:", (error as Error).message)
+  }
+}
+
+function cleanupStoreRecoveryTombstones(claimPath: string): void {
+  const prefix = `${basename(claimPath)}.orphan-`
+  try {
+    for (const name of readdirSync(dirname(claimPath))) {
+      if (!name.startsWith(prefix)) continue
+      const path = join(dirname(claimPath), name)
+      const info = lstatSync(path)
+      if (info.isDirectory() && !info.isSymbolicLink()) {
+        rmSync(path, { recursive: true })
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.error("[sessionStore] stale recovery tombstone cleanup failed:", (error as Error).message)
+    }
+  }
+}
+
+function retireStaleLock(lockPath: string): boolean {
+  let token: string
+  let info: ReturnType<typeof statSync>
+  try {
+    token = readFileSync(lockPath, "utf8")
+    info = statSync(lockPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true
+    throw new Error(`[sessionStore] stale lock inspection failed: ${(error as Error).message}`, { cause: error })
+  }
+  if (
+    Date.now() - info.mtimeMs <= STALE_LOCK_THRESHOLD_MS
+    || !canonicalStoreLockOwnerIsDead(token)
+  ) return false
+
+  const generation = token
+  const claimPath = getRecoveryClaimPath(lockPath, generation)
+  const claimOwner = createRecoveryClaimOwner(generation)
+  try {
+    if (!publishStoreRecoveryClaim(claimPath, claimOwner)) {
+      if (!retireDeadStoreRecoveryClaim(claimPath, generation)) return false
+      if (!publishStoreRecoveryClaim(claimPath, claimOwner)) return false
+    }
+  } catch (error) {
+    throw new Error(`[sessionStore] stale recovery claim failed: ${(error as Error).message}`, { cause: error })
+  }
+
+  let generationResolved = false
+  try {
+    let currentToken: string
+    let currentInfo: ReturnType<typeof statSync>
+    try {
+      currentToken = readFileSync(lockPath, "utf8")
+      currentInfo = statSync(lockPath)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        generationResolved = true
+        return true
+      }
+      throw error
+    }
+    if (
+      currentToken !== token
+      || currentInfo.dev !== info.dev
+      || currentInfo.ino !== info.ino
+    ) {
+      generationResolved = true
+      return true
+    }
+    if (
+      Date.now() - currentInfo.mtimeMs <= STALE_LOCK_THRESHOLD_MS
+      || !canonicalStoreLockOwnerIsDead(currentToken)
+    ) return false
+
+    const retiredPath = `${lockPath}.stale-${process.pid}-${randomUUID()}`
+    renameSync(lockPath, retiredPath)
+    generationResolved = true
+    try {
+      const movedToken = readFileSync(retiredPath, "utf8")
+      if (movedToken !== currentToken) {
+        throw new Error("claimed lock identity changed during stale recovery")
+      }
+      unlinkSync(retiredPath)
+    } catch (error) {
+      console.error("[sessionStore] stale lock cleanup failed:", (error as Error).message)
+    }
+    return true
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code === "ENOENT") {
+      generationResolved = true
+      return true
+    }
+    throw new Error(`[sessionStore] stale lock recovery failed: ${err.message}`, { cause: err })
+  } finally {
+    releaseStoreRecoveryClaim(claimPath, claimOwner)
+    if (generationResolved) cleanupStoreRecoveryTombstones(claimPath)
+  }
+}
+
+function acquireLock(lockPath: string): StoreLock {
+  const incarnation = captureProcessIncarnation()
+  if (!incarnation) throw new Error("[sessionStore] cannot capture lock owner process incarnation")
+  const token = JSON.stringify({
+    pid: process.pid,
+    hostname: hostname(),
+    token: randomUUID(),
+    incarnation,
+  })
+  const deadline = performance.now() + getLockWaitMs()
+
+  while (true) {
+    try {
+      if (publishInitializedLockFile(lockPath, token)) return { path: lockPath, token }
+    } catch (error) {
+      throw new Error(`[sessionStore] lock acquire failed: ${(error as Error).message}`, { cause: error })
+    }
+
+    if (deadline - performance.now() <= 0) {
+      throw new Error(`[sessionStore] timed out waiting for lock ${lockPath}`)
+    }
+    if (retireStaleLock(lockPath)) continue
+    const remaining = deadline - performance.now()
+    if (remaining <= 0) {
+      throw new Error(`[sessionStore] timed out waiting for lock ${lockPath}`)
+    }
+    sleepSync(Math.min(LOCK_RETRY_MS, remaining))
+  }
+}
+
+function releaseLock(lock: StoreLock): void {
+  try {
+    if (readFileSync(lock.path, "utf8") !== lock.token) {
+      console.error("[sessionStore] lock ownership changed before release")
+      return
+    }
+    unlinkSync(lock.path)
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code !== "ENOENT") {
+      console.error("[sessionStore] lock release failed:", err.message)
+    }
   }
 }
 
 /** Override for testing — avoids env var race when test files run in parallel */
 let sessionDirOverride: string | null = null
-/** When true, skip file locking entirely (for testing) */
-let skipLocking = false
 
 /** Set an explicit session store directory. Takes priority over env var.
- *  Pass null to clear. For testing only.
- *  @param opts.skipLocking — skip file locking (default true for test isolation) */
-export function setSessionStoreDir(dir: string | null, opts?: { skipLocking?: boolean }): void {
+ *  Pass null to clear. For testing only. The legacy options parameter remains
+ *  accepted for compatibility, but transactions are always locked. */
+export function setSessionStoreDir(dir: string | null, _opts?: { skipLocking?: boolean }): void {
   sessionDirOverride = dir
-  skipLocking = dir !== null && (opts?.skipLocking ?? true)
 }
 
-function getStorePath(): string {
-  const dir = sessionDirOverride
+/** Return the directory containing the cross-process session store. */
+export function getSessionStoreDir(): string {
+  return sessionDirOverride
     || process.env.MERIDIAN_SESSION_DIR
     || process.env.CLAUDE_PROXY_SESSION_DIR
     || getDefaultCacheDir()
+}
+
+function getStorePath(): string {
+  const dir = getSessionStoreDir()
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true })
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
   }
+  chmodSync(dir, 0o700)
   return join(dir, "sessions.json")
 }
 
@@ -154,32 +582,216 @@ function getDefaultCacheDir(): string {
   return newDir
 }
 
-function readStore(): Record<string, StoredSession> {
-  const path = getStorePath()
-  if (!existsSync(path)) return {}
+function isTranscriptLocator(value: unknown, expectedSessionId: string): value is TranscriptLocator {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const locator = value as Record<string, unknown>
+  return locator.sessionId === expectedSessionId
+    && typeof locator.configDir === "string"
+    && isAbsolute(locator.configDir)
+    && (locator.projectDir === undefined
+      || (typeof locator.projectDir === "string" && isAbsolute(locator.projectDir)))
+    && (locator.lifecycleGeneration === undefined
+      || (typeof locator.lifecycleGeneration === "string" && locator.lifecycleGeneration.length > 0))
+}
+
+function validateStoredSession(key: string, value: unknown): asserts value is StoredSession {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`session store entry ${JSON.stringify(key)} must be an object`)
+  }
+  const entry = value as Record<string, unknown>
+  if (typeof entry.claudeSessionId !== "string" || entry.claudeSessionId.length === 0) {
+    throw new Error(`session store entry ${JSON.stringify(key)} has an invalid Claude session ID`)
+  }
+  if (entry.revision !== undefined && (
+    typeof entry.revision !== "number" || !Number.isInteger(entry.revision) || entry.revision < 1
+  )) throw new Error(`session store entry ${JSON.stringify(key)} has invalid revision`)
+  if (entry.generationId !== undefined && (
+    typeof entry.generationId !== "string" || entry.generationId.length === 0
+  )) throw new Error(`session store entry ${JSON.stringify(key)} has invalid generationId`)
+  for (const field of ["createdAt", "lastUsedAt", "messageCount"] as const) {
+    if (typeof entry[field] !== "number" || !Number.isFinite(entry[field]) || entry[field] < 0) {
+      throw new Error(`session store entry ${JSON.stringify(key)} has invalid ${field}`)
+    }
+  }
+  if (entry.lineageHash !== undefined && typeof entry.lineageHash !== "string") {
+    throw new Error(`session store entry ${JSON.stringify(key)} has invalid lineageHash`)
+  }
+  const stringArrays = ["messageHashes", "passthroughToolCallIds"] as const
+  for (const field of stringArrays) {
+    const item = entry[field]
+    if (item !== undefined && (!Array.isArray(item) || item.some((part) => typeof part !== "string"))) {
+      throw new Error(`session store entry ${JSON.stringify(key)} has invalid ${field}`)
+    }
+  }
+  if (entry.sdkMessageUuids !== undefined && (
+    !Array.isArray(entry.sdkMessageUuids)
+    || entry.sdkMessageUuids.some((part) => part !== null && typeof part !== "string")
+  )) throw new Error(`session store entry ${JSON.stringify(key)} has invalid sdkMessageUuids`)
+  if (entry.passthroughToolCallAssistantUuid !== undefined
+    && typeof entry.passthroughToolCallAssistantUuid !== "string") {
+    throw new Error(`session store entry ${JSON.stringify(key)} has invalid passthrough UUID`)
+  }
+  if (entry.previousClaudeSessionId !== undefined && typeof entry.previousClaudeSessionId !== "string") {
+    throw new Error(`session store entry ${JSON.stringify(key)} has invalid previous Claude session ID`)
+  }
+  if (entry.currentTranscript !== undefined
+    && !isTranscriptLocator(entry.currentTranscript, entry.claudeSessionId)) {
+    throw new Error(`session store entry ${JSON.stringify(key)} has invalid current transcript locator`)
+  }
+  if (entry.previousTranscript !== undefined) {
+    if (typeof entry.previousClaudeSessionId !== "string"
+      || !isTranscriptLocator(entry.previousTranscript, entry.previousClaudeSessionId)) {
+      throw new Error(`session store entry ${JSON.stringify(key)} has invalid previous transcript locator`)
+    }
+  }
+}
+
+function emptyStoreDocument(): SessionStoreDocument {
+  return { sessions: {}, meta: { version: STORE_META_VERSION, slots: {} } }
+}
+
+function validateStoreMeta(value: unknown): SessionStoreMeta {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("session store metadata must be an object")
+  }
+  const meta = value as { version?: unknown; slots?: unknown }
+  if (meta.version !== STORE_META_VERSION || typeof meta.slots !== "object" || meta.slots === null || Array.isArray(meta.slots)) {
+    throw new Error("session store metadata has an unsupported format")
+  }
+  for (const [slot, counter] of Object.entries(meta.slots)) {
+    if (!/^[0-9a-f]{4}$/.test(slot) || typeof counter !== "number" || !Number.isSafeInteger(counter) || counter < 0) {
+      throw new Error(`session store metadata has invalid generation slot ${JSON.stringify(slot)}`)
+    }
+  }
+  return { version: STORE_META_VERSION, slots: { ...(meta.slots as Record<string, number>) } }
+}
+
+function readStoreDocumentStrict(path: string): SessionStoreDocument {
+  let data: string
   try {
-    const data = readFileSync(path, "utf-8")
-    return JSON.parse(data) as Record<string, StoredSession>
-  } catch (e) {
-    console.error("[sessionStore] read failed:", (e as Error).message)
+    data = readFileSync(path, "utf8")
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyStoreDocument()
+    throw error
+  }
+
+  const parsed: unknown = JSON.parse(data)
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("session store must contain a JSON object")
+  }
+  const sessions: Record<string, StoredSession> = {}
+  let meta: SessionStoreMeta = { version: STORE_META_VERSION, slots: {} }
+  for (const [key, value] of Object.entries(parsed)) {
+    if (key === STORE_META_KEY) {
+      meta = validateStoreMeta(value)
+      continue
+    }
+    validateStoredSession(key, value)
+    sessions[key] = value as StoredSession
+  }
+  return { sessions, meta }
+}
+
+function readStoreStrict(path: string): Record<string, StoredSession> {
+  return readStoreDocumentStrict(path).sessions
+}
+
+/** Read a strict, coherent snapshot for maintenance tasks such as session GC.
+ *  Unlike lookup helpers, malformed JSON and I/O errors are propagated. */
+export function readSessionStoreSnapshot(): Record<string, StoredSession> {
+  return readStoreStrict(getStorePath())
+}
+
+/** Capture exact durable generations for one adapter session across profile keys. */
+export function readSessionStoreGenerationSnapshot(
+  adapterSessionId: string,
+  profileIds: readonly string[] = [],
+): Record<string, StoredSessionGeneration> {
+  const document = readStoreDocumentStrict(getStorePath())
+  const keys = new Set(Object.keys(document.sessions).filter((key) =>
+    key === adapterSessionId || key.endsWith(`:${adapterSessionId}`)))
+  keys.add(adapterSessionId)
+  // Profile selection happens after the cross-process turn lease is acquired.
+  // Snapshot every configured profile's absent generation now so a mapping
+  // created while this request waits can be distinguished from durable absence.
+  for (const profileId of profileIds) {
+    if (profileId && profileId !== "default") keys.add(`${profileId}:${adapterSessionId}`)
+  }
+  return Object.fromEntries([...keys].map((key) => [
+    key,
+    keyGeneration(key, document.sessions[key], document.meta),
+  ]))
+}
+
+
+function readStore(): Record<string, StoredSession> {
+  try {
+    return readSessionStoreSnapshot()
+  } catch (error) {
+    console.error("[sessionStore] read failed:", (error as Error).message)
     return {}
   }
 }
 
-function writeStore(store: Record<string, StoredSession>): void {
-  const path = getStorePath()
-  const tmp = `${path}.tmp`
+function fsyncParentDirectory(path: string): void {
+  let fd: number | undefined
   try {
-    writeFileSync(tmp, JSON.stringify(store, null, 2))
-    renameSync(tmp, path) // atomic write
-  } catch (e) {
-    console.error("[sessionStore] write failed:", (e as Error).message)
-    // If rename fails, try direct write
-    try {
-      writeFileSync(path, JSON.stringify(store, null, 2))
-    } catch (directWriteError) {
-      console.error("[sessionStore] write failed:", (directWriteError as Error).message)
+    fd = openSync(dirname(path), "r")
+    fsyncSync(fd)
+  } catch (error) {
+    // Some platforms do not support opening or syncing directories.
+    void error
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch (error) {
+        console.error("[sessionStore] parent directory close failed:", (error as Error).message)
+      }
     }
+  }
+}
+
+function writeStore(path: string, document: SessionStoreDocument): void {
+  const tmp = `${path}.tmp-${process.pid}-${randomUUID()}`
+  let fd: number | undefined
+  try {
+    fd = openSync(tmp, "wx", 0o600)
+    fchmodSync(fd, 0o600)
+    const serialized = { [STORE_META_KEY]: document.meta, ...document.sessions }
+    writeFileSync(fd, JSON.stringify(serialized, null, 2), "utf8")
+    fsyncSync(fd)
+    closeSync(fd)
+    fd = undefined
+    renameSync(tmp, path)
+    fsyncParentDirectory(path)
+  } catch (error) {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch (closeError) {
+        console.error("[sessionStore] temp close failed:", (closeError as Error).message)
+      }
+    }
+    try {
+      unlinkSync(tmp)
+    } catch (cleanupError) {
+      if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error("[sessionStore] temp cleanup failed:", (cleanupError as Error).message)
+      }
+    }
+    throw new Error(`[sessionStore] write failed: ${(error as Error).message}`, { cause: error })
+  }
+}
+
+function mutateStore(mutator: (document: SessionStoreDocument) => boolean): void {
+  const path = getStorePath()
+  const lock = acquireLock(`${path}.lock`)
+  try {
+    const document = readStoreDocumentStrict(path)
+    if (mutator(document)) writeStore(path, document)
+  } finally {
+    releaseLock(lock)
   }
 }
 
@@ -188,27 +800,76 @@ function hasLegacyUserDenialBoundary(session: StoredSession): boolean {
   return typeof legacy === "string" && legacy.length > 0 && !session.passthroughToolCallAssistantUuid
 }
 
+export type SharedSessionLookupResult =
+  | { status: "found"; session: StoredSession; generation?: StoredSessionGeneration }
+  | { status: "missing"; existing?: StoredSession; generation?: StoredSessionGeneration }
+  | { status: "error"; error: Error }
+
+/** Distinguish an authoritative absence from a transient/corrupt read. */
+export function lookupSharedSessionResult(key: string): SharedSessionLookupResult {
+  try {
+    const document = readStoreDocumentStrict(getStorePath())
+    const session = document.sessions[key]
+    const generation = keyGeneration(key, session, document.meta)
+    if (!session) return { status: "missing", generation }
+    // Versions 1.61.0–1.62.3 stored a user/tool_result UUID even though the SDK's
+    // resumeSessionAt accepts assistant UUIDs only. Replaying once is safer than
+    // resuming that invalid tail and re-triggering full-history cache churn.
+    if (hasLegacyUserDenialBoundary(session)) return { status: "missing", existing: session, generation }
+    return { status: "found", session, generation }
+  } catch (error) {
+    const normalized = error instanceof Error ? error : new Error(String(error))
+    console.error("[sessionStore] read failed:", normalized.message)
+    return { status: "error", error: normalized }
+  }
+}
+
 export function lookupSharedSession(key: string): StoredSession | undefined {
-  const store = readStore()
-  const session = store[key]
-  // Versions 1.61.0–1.62.3 stored a user/tool_result UUID even though the SDK's
-  // resumeSessionAt accepts assistant UUIDs only. Replaying once is safer than
-  // resuming that invalid tail and re-triggering full-history cache churn.
-  return session && !hasLegacyUserDenialBoundary(session) ? session : undefined
+  const result = lookupSharedSessionResult(key)
+  return result.status === "found" ? result.session : undefined
+}
+
+export function lookupSharedSessionByClaudeIdResult(claudeSessionId: string): SharedSessionLookupResult {
+  try {
+    const document = readStoreDocumentStrict(getStorePath())
+    let newest: StoredSession | undefined
+    let newestKey: string | undefined
+    for (const [key, session] of Object.entries(document.sessions)) {
+      if (session.claudeSessionId !== claudeSessionId || hasLegacyUserDenialBoundary(session)) continue
+      if (!newest || session.lastUsedAt > newest.lastUsedAt) {
+        newest = session
+        newestKey = key
+      }
+    }
+    return newest && newestKey
+      ? { status: "found", session: newest, generation: getStoredSessionGeneration(newest, newestKey) }
+      : { status: "missing" }
+  } catch (error) {
+    const normalized = error instanceof Error ? error : new Error(String(error))
+    console.error("[sessionStore] read failed:", normalized.message)
+    return { status: "error", error: normalized }
+  }
 }
 
 export function lookupSharedSessionByClaudeId(claudeSessionId: string): StoredSession | undefined {
-  const sessions = Object.values(readStore())
-  let newest: StoredSession | undefined
+  const result = lookupSharedSessionByClaudeIdResult(claudeSessionId)
+  return result.status === "found" ? result.session : undefined
+}
 
-  for (const session of sessions) {
-    if (session.claudeSessionId !== claudeSessionId || hasLegacyUserDenialBoundary(session)) continue
-    if (!newest || session.lastUsedAt > newest.lastUsedAt) {
-      newest = session
-    }
+function validateTranscriptLocator(locator: TranscriptLocator, claudeSessionId: string): void {
+  if (locator.sessionId !== claudeSessionId) {
+    throw new Error("currentTranscript.sessionId must match claudeSessionId")
   }
-
-  return newest
+  if (!isAbsolute(locator.configDir)) {
+    throw new Error("currentTranscript.configDir must be an absolute path")
+  }
+  if (locator.projectDir !== undefined && !isAbsolute(locator.projectDir)) {
+    throw new Error("currentTranscript.projectDir must be an absolute path")
+  }
+  if (locator.lifecycleGeneration !== undefined
+    && (typeof locator.lifecycleGeneration !== "string" || locator.lifecycleGeneration.length === 0)) {
+    throw new Error("currentTranscript.lifecycleGeneration must be non-empty")
+  }
 }
 
 export function storeSharedSession(
@@ -221,26 +882,56 @@ export function storeSharedSession(
   contextUsage?: TokenUsage,
   messageBlockHashes?: string[][],
   passthroughToolCallAssistantUuid?: string | null,
-  passthroughToolCallIds?: string[] | null
-): void {
-  const path = getStorePath()
-  const lockPath = `${path}.lock`
-  const hasLock = skipLocking ? false : acquireLock(lockPath)
-  if (!hasLock && !skipLocking) {
-    console.warn("[sessionStore] could not acquire lock, proceeding without")
+  passthroughToolCallIds?: string[] | null,
+  currentTranscript?: TranscriptLocator,
+  sourceTranscript?: TranscriptLocator,
+  expectedGeneration?: StoredSessionGeneration | null,
+): StoredSessionGeneration | false {
+  if (currentTranscript !== undefined) {
+    validateTranscriptLocator(currentTranscript, claudeSessionId)
   }
-  try {
-    const store = readStore()
+  if (sourceTranscript !== undefined) {
+    if (!isAbsolute(sourceTranscript.configDir)) {
+      throw new Error("sourceTranscript.configDir must be an absolute path")
+    }
+    if (sourceTranscript.projectDir !== undefined && !isAbsolute(sourceTranscript.projectDir)) {
+      throw new Error("sourceTranscript.projectDir must be an absolute path")
+    }
+  }
+
+  let storedGeneration: StoredSessionGeneration | false = false
+  mutateStore(({ sessions: store, meta }) => {
     const existing = store[key]
+    if (expectedGeneration !== undefined) {
+      const actual = keyGeneration(key, existing, meta)
+      const expected = expectedGeneration === null
+        ? `a:${keyDigest(key)}:0`
+        : expectedGeneration
+      if (actual !== expected) return false
+    }
     // Preserve the previous Claude session ID when the mapping changes.
     // This enables recovery when a lineage bug causes the original session
     // to be abandoned — the old ID still points to the full conversation
     // in ~/.claude/projects/.
-    const previousClaudeSessionId = existing && existing.claudeSessionId !== claudeSessionId
+    const sessionIdChanged = existing !== undefined && existing.claudeSessionId !== claudeSessionId
+    if (sourceTranscript !== undefined) {
+      if (!sessionIdChanged || sourceTranscript.sessionId !== existing?.claudeSessionId) {
+        throw new Error("sourceTranscript.sessionId must match the replaced claudeSessionId")
+      }
+    }
+    const previousClaudeSessionId = sessionIdChanged
       ? existing.claudeSessionId
       : existing?.previousClaudeSessionId
+    const resolvedCurrentTranscript = sessionIdChanged
+      ? currentTranscript
+      : existing?.currentTranscript ?? currentTranscript
+    const previousTranscript = sessionIdChanged
+      ? existing?.currentTranscript ?? sourceTranscript
+      : existing?.previousTranscript
     store[key] = {
       claudeSessionId,
+      revision: (existing?.revision ?? 0) + 1,
+      generationId: randomUUID(),
       createdAt: existing?.createdAt || Date.now(),
       lastUsedAt: Date.now(),
       messageCount: messageCount ?? existing?.messageCount ?? 0,
@@ -255,48 +946,84 @@ export function storeSharedSession(
         ? existing?.passthroughToolCallIds
         : passthroughToolCallIds ?? undefined,
       contextUsage: contextUsage ?? existing?.contextUsage,
+      ...(resolvedCurrentTranscript ? { currentTranscript: resolvedCurrentTranscript } : {}),
+      ...(previousTranscript ? { previousTranscript } : {}),
       ...(previousClaudeSessionId ? { previousClaudeSessionId } : {}),
     }
 
-    // Prune oldest entries if over capacity (count-based, not time-based)
-    const maxEntries = getMaxStoredSessions()
+    // Prune oldest entries if over capacity (count-based, not time-based).
+    // This runs inside the same transaction as the insertion.
+    const maxEntries = getMaxStoredSessionsLimit()
     const keys = Object.keys(store)
     if (keys.length > maxEntries) {
-      const sorted = keys.sort((a, b) => (store[a]!.lastUsedAt || 0) - (store[b]!.lastUsedAt || 0))
+      const sorted = keys
+        .filter((candidate) => candidate !== key)
+        .sort((a, b) => (store[a]!.lastUsedAt || 0) - (store[b]!.lastUsedAt || 0))
       const toRemove = sorted.slice(0, keys.length - maxEntries)
-      for (const k of toRemove) {
-        delete store[k]
-      }
+      for (const candidate of toRemove) delete store[candidate]
     }
-
-    writeStore(store)
-  } finally {
-    if (hasLock) {
-      releaseLock(lockPath)
-    }
-  }
+    advanceKeySlot(key, meta)
+    storedGeneration = getStoredSessionGeneration(store[key]!, key)
+    return true
+  })
+  return storedGeneration
 }
 
-/** Remove a single session from the shared file store.
- *  Used when a session is detected as stale (e.g. expired upstream). */
-export function evictSharedSession(key: string): void {
-  const path = getStorePath()
-  const lockPath = `${path}.lock`
-  const hasLock = skipLocking ? false : acquireLock(lockPath)
-  if (!hasLock && !skipLocking) {
-    console.warn("[sessionStore] could not acquire lock for eviction, proceeding without")
-  }
-  try {
-    const store = readStore()
-    if (store[key]) {
-      delete store[key]
-      writeStore(store)
+function sameTranscriptLocator(left: TranscriptLocator | undefined, right: TranscriptLocator): boolean {
+  return left?.sessionId === right.sessionId
+    && left.configDir === right.configDir
+    && left.projectDir === right.projectDir
+    && left.lifecycleGeneration === right.lifecycleGeneration
+}
+
+/** Attach an exact transcript locator without changing lineage or SDK identity.
+ * The durable revision advances so concurrent readers cannot miss the mutation. */
+export function attachSharedTranscriptLocator(
+  key: string,
+  expectedClaudeSessionId: string,
+  locator: TranscriptLocator,
+  expectedGeneration?: StoredSessionGeneration,
+): StoredSessionGeneration | false {
+  validateTranscriptLocator(locator, expectedClaudeSessionId)
+  let attachedGeneration: StoredSessionGeneration | false = false
+  mutateStore(({ sessions: store, meta }) => {
+    const existing = store[key]
+    if (!existing || existing.claudeSessionId !== expectedClaudeSessionId) return false
+    if (expectedGeneration !== undefined && getStoredSessionGeneration(existing, key) !== expectedGeneration) return false
+    if (!sameTranscriptLocator(existing.currentTranscript, locator)) {
+      existing.currentTranscript = locator
+      existing.revision = (existing.revision ?? 0) + 1
+      existing.generationId = randomUUID()
+      advanceKeySlot(key, meta)
     }
-  } finally {
-    if (hasLock) {
-      releaseLock(lockPath)
+    attachedGeneration = getStoredSessionGeneration(existing, key)
+    return true
+  })
+  return attachedGeneration
+}
+
+/** Ensure a single session is absent from the shared file store.
+ *  Used when a session is detected as stale (e.g. expired upstream).
+ *  Absence is an idempotent success; false is reserved for a present mapping
+ *  whose exact expected generation no longer matches. */
+export function evictSharedSession(
+  key: string,
+  expectedGeneration?: StoredSessionGeneration,
+): boolean {
+  let evicted = false
+  mutateStore(({ sessions: store, meta }) => {
+    const existing = store[key]
+    if (!existing) {
+      evicted = true
+      return false
     }
-  }
+    if (expectedGeneration !== undefined && getStoredSessionGeneration(existing, key) !== expectedGeneration) return false
+    delete store[key]
+    advanceKeySlot(key, meta)
+    evicted = true
+    return true
+  })
+  return evicted
 }
 
 /** Look up recovery information for a session key.
@@ -343,10 +1070,11 @@ export function listStoredSessions(): Array<{
 }
 
 export function clearSharedSessions(): void {
-  const path = getStorePath()
-  try {
-    writeFileSync(path, "{}")
-  } catch (e) {
-    console.error("[sessionStore] clear failed:", (e as Error).message)
-  }
+  mutateStore(({ sessions: store, meta }) => {
+    for (const key of Object.keys(store)) {
+      delete store[key]
+      advanceKeySlot(key, meta)
+    }
+    return true
+  })
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -58,8 +58,12 @@ export interface ProxyServer {
    * to drain in-flight requests before the HTTP server actually shuts down.
    */
   beginDrain?(): void
+  /** Revoke durable writes and abort work that outlived the shutdown grace. */
+  forceAbortInFlight?(): void
   /** Count of requests admitted past the draining gate that haven't finished yet. */
   getInFlightCount?(): number
+  /** Run one fail-closed transcript maintenance sweep. */
+  sweepSessionGc?(): Promise<void>
 }
 
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {


### PR DESCRIPTION
## Summary
- preserve the passthrough fixes and contributor-authored commits from #871 and #875
- replace private transcript mutation with supported preallocated Agent SDK sessions and isolated forks
- add durable generation fencing, cross-process turn coordination, exclusive writer leases, crash recovery, and supported bounded deletion
- complete stream/non-stream checkpoint handling, undo/full-replay safety, cancellation/shutdown fencing, and cross-proxy resume

## Safety invariants
- never read or rewrite Claude private JSONL transcripts
- every Meridian-created transcript is journaled before SDK spawn
- every resume writes only to a fresh supported fork and publishes it by exact CAS
- terminal tool/structured responses follow durable publication or exact source eviction
- active/unjoined SDK writers and uncertain deleters remain durably fenced

## Validation
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- real Agent SDK + headless OpenCode 1.18.11: tool, 99%-cached continuation, three parallel tools, revert/undo, cross-proxy resume, and supported GC verification via `getSessionMessages()`
- real owner-SIGKILL process-gate regression
- Windows CI now runs the process-incarnation and SDK gate tests on `windows-latest`

## Attribution
The original contributor commits remain in history with their original authors:
- Aleksey Proshutinskiy: `b35362a7`, `f82b2606`, `f798f362`
- Serge Baranov: `8a095e8b`
