### PR TITLE
feat: add OpenCode V2 beta compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ RUN --mount=type=cache,target=/root/.bun \
 
 COPY tsconfig.json* ./
 COPY bin/ ./bin/
+COPY plugin/ ./plugin/
 COPY src/ ./src/
 # Run bun build directly (not "bun run build") to skip postbuild hook,
 # which calls "node --check" — unavailable in oven/bun image
-RUN rm -rf dist && bun build bin/cli.ts src/proxy/server.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --external libsql --external jsonc-parser --entry-naming '[name].js'
+RUN rm -rf dist && bun build bin/cli.ts src/proxy/server.ts plugin/meridian-v2.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --external libsql --external jsonc-parser --entry-naming '[name].js'
 
 # ---- Runtime stage ----
 FROM node:22-alpine
@@ -33,6 +34,7 @@ WORKDIR /app
 
 COPY --from=build --chown=claude:claude /app/node_modules ./node_modules
 COPY --from=build --chown=claude:claude /app/dist ./dist
+COPY --from=build --chown=claude:claude /app/plugin ./plugin
 COPY --from=build --chown=claude:claude /app/package.json ./
 
 # Run claude-code's install.cjs in the runtime stage so the native binary

--- a/E2E.md
+++ b/E2E.md
@@ -94,6 +94,7 @@ kill $(lsof -ti :3456)
 | E39 | [OpenCode internal-agent session key (#845)](#e39-opencode-internal-agent-session-key-845) | **Manual**, real OpenCode: its `title` agent runs under the USER'S session id, so the user's first turn used to queue behind it and then get HTTP 400 `session_turn_conflict`. Asserts the first turn succeeds, waits ~0ms on the session lease, and every later request is `lineage=continuation`. **Run after any OpenCode upgrade and before releases touching session keys or the turn coordinator** | 2026-08-19 |
 | E40 | [Passthrough digest-turn cap](#e40-passthrough-digest-turn-cap) | **Automated**: `bun scripts/e2e-digest-turn-cap.mjs` — real SDK. Asserts the capped tool turn generates no digest text, costs materially less than uncapped on an identical prompt, still RESUMES at its captured checkpoint, leaves text-only turns returning `success`, and does not truncate parallel tool calls. **Run before any release touching the passthrough tool loop, `maxTurns`, or the early-stop checkpoint** | 2026-08-20 |
 | E41 | [Passthrough multi-turn: one call, one answer](#e41-passthrough-multi-turn-one-call-one-answer) | **Automated**: `bun scripts/e2e-passthrough-turns.mjs [--stream]` — real proxy + SDK + Claude Max. Chain and `PROBE_PARALLEL=1` modes assert exact tool-call batching, a distinct durable fork per result round, one real answer per delivered call in the active transcript, and full prompt-cache continuity. **Run all four chain/parallel × stream/non-stream combinations before releases touching passthrough resume or the deny hook** | 2026-08-26 |
+| E42 | [OpenCode V2 beta compatibility](#e42-opencode-v2-beta-compatibility) | **Manual**, pinned `@opencode-ai/cli@0.0.0-beta-18314`: hidden title/summary isolation, durable continuation and restart, passthrough tools, supported undo/fork/compaction, and concurrent general subagents. **Run after any V2 plugin/API change; another beta version is not a pass** | 2026-08-27 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3573,3 +3574,69 @@ fresh prepared transcript with 98% cache reuse. With
 current and direct-predecessor transcripts. Supported SDK GC then deleted ten
 retired transcripts, retained both pinned transcripts, and verified every
 history only through `getSessionMessages()`.
+
+## E42: OpenCode V2 beta compatibility
+
+**What it proves:** the V2-native plugin separates OpenCode's primary session,
+hidden title/summary work, attached compaction, and child sessions without
+changing request bodies. It also proves that durable primary lineage survives
+real V2 tools, a Meridian restart, undo, fork, and parallel subagents.
+
+Use only the pinned beta. The beta CLI can update itself, so verify the version
+before and after the run and disable automatic updates:
+
+```bash
+npm install -g --prefix ~/.local @opencode-ai/cli@0.0.0-beta-18314
+export OPENCODE_DISABLE_AUTOUPDATE=1
+BIN=$HOME/.local/bin/opencode2
+$BIN --version                 # → opencode2 v0.0.0-beta-18314
+npm run build
+meridian setup --v2 --opencode-bin "$BIN"
+```
+
+Use an isolated `XDG_CONFIG_HOME`, `XDG_DATA_HOME`, `XDG_CACHE_HOME`,
+`XDG_STATE_HOME`, project directory, and `MERIDIAN_SESSION_STORE_DIR`. The
+OpenCode config must load only `dist/meridian-v2.js` plus the Anthropic provider
+pointed at the test Meridian port. Do not use third-party plugins, MCP servers,
+custom agents, or unrelated credentials for this gate.
+
+Run this real-client sequence:
+
+1. Start a fresh primary session while the hidden title request runs. The
+   primary must answer and the proxy log must show `source=subagent-title`
+   separately from `agent=primary`.
+2. Continue the same OpenCode session, drive a write/read tool loop, restart
+   Meridian while preserving the isolated durable store, and continue again.
+3. Run `--agent summary` and require `source=subagent-summary` with no primary
+   mapping write.
+4. Use V2's supported `/api/session/:id/revert/stage` and `revert/commit`
+   endpoints, then continue. Meridian must log `lineage=undo` and the removed
+   tool turn must not be visible.
+5. Run with `--fork --session <id>`. The fork must get a different OpenCode
+   session id, and a later turn on the original must not contain the fork reply.
+6. Ask the primary to launch two `general` subagents in parallel. Both child
+   requests must show `agent=subagent`, overlap in the proxy, and return to the
+   primary without a session conflict.
+7. On a persistent V2 API server, call `/api/session/:id/compact`, wait with
+   `/api/session/:id/wait`, inspect the supported message API for the compaction
+   summary, and continue the primary successfully.
+
+**Pass criteria:**
+
+- The exact V2 version is unchanged at the end of the gate.
+- No `session_turn_conflict`, "session advanced while the request was waiting",
+  dangling tool envelope, or plugin schema error appears.
+- Title and summary are detached with their exact source names. Compaction stays
+  attached but is classified as a subagent. Primary and visible child requests
+  carry their trusted V2 session identities.
+- Ordinary continuation reads the cached prefix; restart continuation uses the
+  same durable mapping; undo logs `lineage=undo`; fork and original histories
+  remain isolated.
+- The packaged `dist/meridian-v2.js` is the plugin under test, not the TypeScript
+  source or a diagnostic plugin.
+
+**Verified:** 2026-08-27 on `0.0.0-beta-18314`. The exact pinned binary returned
+`EXACTFIRST`, `EXACTCONT`, `EXACTTOOL`, `EXACTRESTART`, `EXACTSUMMARY`,
+`EXACTUNDO`, `EXACTFORK`, `EXACTORIGINAL`,
+`EXACTPARALLEL[ALPHA,BRAVO]`, and `EXACTAFTERCOMPACT`. The binary SHA-256 stayed
+unchanged through the matrix.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ npm install -g @rynfar/meridian
 claude login
 
 # 3. Configure OpenCode plugin (one time — OpenCode users only)
-meridian setup
+meridian setup                # OpenCode V1
+# meridian setup --v2 --opencode-bin ~/.local/bin/opencode2  # pinned V2 beta
 
 # 4. Start
 meridian
@@ -96,7 +97,7 @@ The Claude Agent SDK provides programmatic access to Claude. But your favorite c
 
 | Agent | Status | Notes |
 |-------|--------|-------|
-| [OpenCode](https://github.com/anomalyco/opencode) | ✅ Verified | Requires `meridian setup` ([setup](docs/agents.md#opencode)) — full tool support, session resume, streaming, subagents |
+| [OpenCode](https://github.com/anomalyco/opencode) | ✅ Verified | V1 and pinned V2 beta support; requires the matching `meridian setup` mode ([setup](docs/agents.md#opencode)) — tools, durable resume, restart, undo, compaction, parallel subagents |
 | [ForgeCode](https://forgecode.dev) | ✅ Verified | Provider config (see [Agent Setup](docs/agents.md)) — passthrough tool execution, session resume, streaming |
 | [Droid (Factory AI)](https://factory.ai/product/ide) | ✅ Verified | BYOK config (see [Agent Setup](docs/agents.md)) — full tool support, session resume, streaming |
 | [Crush](https://github.com/charmbracelet/crush) | ✅ Verified | Provider config (see [Agent Setup](docs/agents.md)) — full tool support, session resume, headless `crush run` |

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -29,6 +29,11 @@ Commands:
   profile          Manage Claude account profiles (add, list, switch, remove)
   refresh-token    Refresh the Claude Code OAuth token
 
+Setup options:
+  --v1                         Install the OpenCode V1 plugin
+  --v2                         Install the pinned OpenCode V2 beta plugin
+  --opencode-bin <executable>  Probe this OpenCode executable
+
 Options:
   -v, --version   Show version
   -h, --help      Show this help
@@ -69,11 +74,68 @@ if (args[0] === "profile") {
 }
 
 if (args[0] === "setup") {
-  const { findPluginPath, runSetup, UnparseableConfigError } = await import("../src/proxy/setup")
-  const pluginPath = findPluginPath(import.meta.url)
+  const {
+    detectOpenCodeGeneration,
+    DuplicateMeridianConfigError,
+    MissingV2PluginError,
+    pluginPathForGeneration,
+    runSetup,
+    SUPPORTED_OPENCODE_V2_VERSION,
+    UnparseableConfigError,
+  } = await import("../src/proxy/setup")
+
+  const forceV1 = args.includes("--v1")
+  const forceV2 = args.includes("--v2")
+  if (forceV1 && forceV2) {
+    console.error("Choose only one OpenCode generation: --v1 or --v2")
+    process.exit(1)
+  }
+
+  const binaryIndex = args.indexOf("--opencode-bin")
+  const binary = binaryIndex >= 0 ? args[binaryIndex + 1] : undefined
+  if (binaryIndex >= 0 && (!binary || binary.startsWith("--"))) {
+    console.error("--opencode-bin requires an executable path")
+    process.exit(1)
+  }
+
+  const environmentBinary = process.env.OPENCODE_BIN
+  const commands = binary
+    ? [binary]
+    : environmentBinary ? [environmentBinary]
+    : forceV2 ? ["opencode2", "opencode"] : undefined
+  const detected = forceV1
+    ? { generation: "v1" as const }
+    : detectOpenCodeGeneration(commands)
+
+  if (!forceV1 && (binary || environmentBinary) && !detected.version) {
+    console.error(`Could not read a supported OpenCode version from ${binary ?? environmentBinary}.`)
+    process.exit(1)
+  }
+  if (forceV2 && detected.generation !== "v2") {
+    console.error("Could not find an OpenCode V2 beta. Install the pinned beta or pass --opencode-bin <path>.")
+    process.exit(1)
+  }
+  if (detected.generation === "v2" && detected.version !== SUPPORTED_OPENCODE_V2_VERSION) {
+    console.error(`OpenCode V2 ${detected.version ?? "unknown"} is not supported by this Meridian build.`)
+    console.error(`Install @opencode-ai/cli@${SUPPORTED_OPENCODE_V2_VERSION}, then re-run meridian setup --v2.`)
+    process.exit(1)
+  }
+
+  let pluginPath: string
+  try {
+    pluginPath = pluginPathForGeneration(import.meta.url, detected.generation)
+  } catch (err) {
+    if (err instanceof MissingV2PluginError) {
+      console.error(`OpenCode V2 plugin bundle is missing: ${err.expectedPath}`)
+      console.error("Reinstall Meridian, then re-run meridian setup --v2.")
+      process.exit(1)
+    }
+    throw err
+  }
+
   let result
   try {
-    result = runSetup(pluginPath)
+    result = runSetup(pluginPath, undefined, detected.generation)
   } catch (err) {
     if (err instanceof UnparseableConfigError) {
       console.error(`\x1b[31m✗ Could not parse ${err.configPath}\x1b[0m`)
@@ -82,17 +144,25 @@ if (args[0] === "setup") {
       console.error(`    "plugin": ["${pluginPath}"]`)
       process.exit(1)
     }
+    if (err instanceof DuplicateMeridianConfigError) {
+      console.error("\x1b[31m✗ Meridian is already present in the other OpenCode config file\x1b[0m")
+      console.error(`  OpenCode loads both ${err.configPath} and ${err.siblingPath}.`)
+      console.error(`  Remove the Meridian entry from ${err.siblingPath}, then re-run 'meridian setup'.`)
+      console.error("  Both files were left untouched.")
+      process.exit(1)
+    }
     throw err
   }
 
+  const generationLabel = detected.generation === "v2" ? "OpenCode V2" : "OpenCode V1"
   if (result.alreadyConfigured) {
-    console.log(`\x1b[32m✓ Meridian plugin already configured\x1b[0m`)
+    console.log(`\x1b[32m✓ Meridian plugin already configured for ${generationLabel}\x1b[0m`)
     console.log(`  ${result.configPath}`)
   } else {
     if (result.removedStale.length > 0) {
       console.log(`  Removed ${result.removedStale.length} stale plugin entr${result.removedStale.length === 1 ? "y" : "ies"}`)
     }
-    console.log(`\x1b[32m✓ Meridian plugin configured\x1b[0m`)
+    console.log(`\x1b[32m✓ Meridian plugin configured for ${generationLabel}\x1b[0m`)
     console.log(`  Config: ${result.configPath}`)
     console.log(`  Plugin: ${result.pluginPath}`)
     if (!result.created) {

--- a/bun.lock
+++ b/bun.lock
@@ -7,12 +7,16 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.117",
         "@anthropic-ai/claude-code": "^2.1.198",
+        "cross-spawn": "7.0.6",
         "jsonc-parser": "^3.3.1",
         "libsql": "^0.5.29",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@hono/node-server": "^1.19.11",
+        "@opencode-ai/plugin": "0.0.0-beta-18314",
         "@types/bun": "^1.3.11",
+        "@types/cross-spawn": "6.0.6",
         "@types/node": "^22.0.0",
         "bun2nix": "^2.0.8",
         "glob": "^13.0.0",
@@ -22,6 +26,8 @@
     },
   },
   "packages": {
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.119", "", { "dependencies": { "@anthropic-ai/sdk": "^0.81.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA=="],
 
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw=="],
@@ -60,6 +66,12 @@
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.5", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
@@ -67,6 +79,8 @@
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@libsql/darwin-arm64": ["@libsql/darwin-arm64@0.5.29", "", { "os": "darwin", "cpu": "arm64" }, "sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A=="],
 
@@ -88,19 +102,79 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
+    "@opencode-ai/ai": ["@opencode-ai/ai@0.0.0-beta-18314", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-beta-18314", "@smithy/eventstream-codec": "4.2.14", "@smithy/util-utf8": "4.2.2", "aws4fetch": "1.0.20", "effect": "4.0.0-rc.111", "google-auth-library": "10.5.0" } }, "sha512-0dcd86JMVv3ADsy9XdTJIgN5Bx6kSKYkS80lcxeBUEcWGUi3UAub0dokZVmsqg8TN11sYLRLiEFjHlqPNQnhHw=="],
+
+    "@opencode-ai/client": ["@opencode-ai/client@0.0.0-beta-18314", "", { "dependencies": { "@opencode-ai/protocol": "0.0.0-beta-18314", "@opencode-ai/schema": "0.0.0-beta-18314" }, "peerDependencies": { "effect": "4.0.0-rc.111", "solid-js": ">=1.9.0" }, "optionalPeers": ["effect", "solid-js"] }, "sha512-LpzH20P0BTsoes7ewylQV2cdBg8WlmJMCeBIsYm789mDN0hXXXmCS8WFA7RWbnvoN7yE5l3I/KSMQuBrKx9puw=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@0.0.0-beta-18314", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/ai": "0.0.0-beta-18314", "@opencode-ai/client": "0.0.0-beta-18314", "@opencode-ai/protocol": "0.0.0-beta-18314", "@opencode-ai/schema": "0.0.0-beta-18314", "@standard-schema/spec": "1.1.0", "effect": "4.0.0-rc.111", "zod": "4.1.8" }, "peerDependencies": { "@opencode-ai/theme": "0.0.0-beta-18314", "@opentui/core": ">=0.5.8", "@opentui/solid": ">=0.5.8", "solid-js": ">=1.9.0" }, "optionalPeers": ["@opencode-ai/theme", "@opentui/core", "@opentui/solid", "solid-js"] }, "sha512-CB6fWjiUf69woHn3QRgwH4YimjrpawMEhgh9b8tBfjnRWrc+qP+vgKztkdTGcNqUjrBcJ1BqOYuUFAYlTZdTcA=="],
+
+    "@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-beta-18314", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-beta-18314", "effect": "4.0.0-rc.111" } }, "sha512-/85qh6QvznNvl8X/Jd8fFoD9Rr3N+fDgbtDS0sdcegwAEwP8KfmcQ+JSpOB2JHdmr6GiM5N6Qguz3ptfgyqjHA=="],
+
+    "@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-beta-18314", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-rc.111" } }, "sha512-nPXQdQQBLPXOYGYz8n/vYSq1eVHqAZLcWFIvaNHn04WCnW8NwBXjpH0zww2CmaJfcOd9pNChpoiK8MbjnrMU0A=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@smithy/core": ["@smithy/core@3.33.3", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "tslib": "^2.6.2" } }, "sha512-nxu3SgmAw9JXT2CtkU0m/XNLWpP9MsaBx1zAGAypCbYj15tIFlmcYwpF+Oh18le83d+IM9PT7ENdXnE4C+d5mA=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "tslib": "^2.6.2" } }, "sha512-iq+cW3mAb7vfcxEEpYi3zXKpDtbrIFyanWjQl4zBq4seWD4OSxXDWSfespZxenX6aEaighn+NR3u1nU1DSvs3w=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.2", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/cross-spawn": ["@types/cross-spawn@6.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA=="],
 
     "@types/node": ["@types/node@22.19.7", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "ansi-regex": ["ansi-regex@6.3.0", "", {}, "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
@@ -111,6 +185,10 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -124,6 +202,8 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
@@ -132,7 +212,15 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -154,11 +242,21 @@
 
     "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
@@ -166,13 +264,23 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "gaxios": ["gaxios@7.3.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.4", "", { "dependencies": { "gaxios": "7.1.3", "google-logging-utils": "1.1.3", "json-bigint": "^1.0.0" } }, "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
 
+    "google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
+
+    "google-logging-utils": ["google-logging-utils@1.2.0", "", {}, "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A=="],
+
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -182,6 +290,8 @@
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -190,11 +300,19 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
@@ -203,6 +321,10 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
@@ -226,7 +348,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@2.0.6", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -235,6 +367,8 @@
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -248,6 +382,8 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
@@ -256,9 +392,13 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -280,11 +420,23 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
@@ -296,12 +448,56 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
+
+    "gcp-metadata/gaxios": ["gaxios@7.1.3", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2", "rimraf": "^5.0.1" } }, "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ=="],
+
+    "gcp-metadata/google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "rimraf/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
   }
 }

--- a/bun.nix
+++ b/bun.nix
@@ -13,6 +13,10 @@
   ...
 }:
 {
+  "@ai-sdk/provider@3.0.8" = fetchurl {
+    url = "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz";
+    hash = "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==";
+  };
   "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119" = fetchurl {
     url = "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz";
     hash = "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==";
@@ -89,6 +93,18 @@
     url = "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz";
     hash = "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==";
   };
+  "@aws-crypto/crc32@5.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz";
+    hash = "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==";
+  };
+  "@aws-crypto/util@5.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz";
+    hash = "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==";
+  };
+  "@aws-sdk/types@3.974.5" = fetchurl {
+    url = "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz";
+    hash = "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==";
+  };
   "@babel/runtime@7.29.2" = fetchurl {
     url = "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz";
     hash = "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==";
@@ -104,6 +120,10 @@
   "@isaacs/brace-expansion@5.0.0" = fetchurl {
     url = "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz";
     hash = "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==";
+  };
+  "@isaacs/cliui@8.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz";
+    hash = "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==";
   };
   "@libsql/darwin-arm64@0.5.29" = fetchurl {
     url = "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.29.tgz";
@@ -145,13 +165,105 @@
     url = "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz";
     hash = "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==";
   };
+  "@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz";
+    hash = "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==";
+  };
+  "@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz";
+    hash = "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==";
+  };
+  "@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz";
+    hash = "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==";
+  };
+  "@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz";
+    hash = "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==";
+  };
+  "@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz";
+    hash = "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==";
+  };
+  "@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz";
+    hash = "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==";
+  };
   "@neon-rs/load@0.0.4" = fetchurl {
     url = "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz";
     hash = "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==";
   };
+  "@opencode-ai/ai@0.0.0-beta-18314" = fetchurl {
+    url = "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-beta-18314.tgz";
+    hash = "sha512-0dcd86JMVv3ADsy9XdTJIgN5Bx6kSKYkS80lcxeBUEcWGUi3UAub0dokZVmsqg8TN11sYLRLiEFjHlqPNQnhHw==";
+  };
+  "@opencode-ai/client@0.0.0-beta-18314" = fetchurl {
+    url = "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-beta-18314.tgz";
+    hash = "sha512-LpzH20P0BTsoes7ewylQV2cdBg8WlmJMCeBIsYm789mDN0hXXXmCS8WFA7RWbnvoN7yE5l3I/KSMQuBrKx9puw==";
+  };
+  "@opencode-ai/plugin@0.0.0-beta-18314" = fetchurl {
+    url = "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-beta-18314.tgz";
+    hash = "sha512-CB6fWjiUf69woHn3QRgwH4YimjrpawMEhgh9b8tBfjnRWrc+qP+vgKztkdTGcNqUjrBcJ1BqOYuUFAYlTZdTcA==";
+  };
+  "@opencode-ai/protocol@0.0.0-beta-18314" = fetchurl {
+    url = "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-beta-18314.tgz";
+    hash = "sha512-/85qh6QvznNvl8X/Jd8fFoD9Rr3N+fDgbtDS0sdcegwAEwP8KfmcQ+JSpOB2JHdmr6GiM5N6Qguz3ptfgyqjHA==";
+  };
+  "@opencode-ai/schema@0.0.0-beta-18314" = fetchurl {
+    url = "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-beta-18314.tgz";
+    hash = "sha512-nPXQdQQBLPXOYGYz8n/vYSq1eVHqAZLcWFIvaNHn04WCnW8NwBXjpH0zww2CmaJfcOd9pNChpoiK8MbjnrMU0A==";
+  };
+  "@pkgjs/parseargs@0.11.0" = fetchurl {
+    url = "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz";
+    hash = "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==";
+  };
+  "@smithy/core@3.33.3" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz";
+    hash = "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==";
+  };
+  "@smithy/eventstream-codec@4.2.14" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz";
+    hash = "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==";
+  };
+  "@smithy/is-array-buffer@2.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz";
+    hash = "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==";
+  };
+  "@smithy/types@4.17.2" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz";
+    hash = "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==";
+  };
+  "@smithy/util-buffer-from@2.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz";
+    hash = "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==";
+  };
+  "@smithy/util-buffer-from@4.5.2" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.5.2.tgz";
+    hash = "sha512-nxu3SgmAw9JXT2CtkU0m/XNLWpP9MsaBx1zAGAypCbYj15tIFlmcYwpF+Oh18le83d+IM9PT7ENdXnE4C+d5mA==";
+  };
+  "@smithy/util-hex-encoding@4.5.2" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.5.2.tgz";
+    hash = "sha512-iq+cW3mAb7vfcxEEpYi3zXKpDtbrIFyanWjQl4zBq4seWD4OSxXDWSfespZxenX6aEaighn+NR3u1nU1DSvs3w==";
+  };
+  "@smithy/util-utf8@2.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz";
+    hash = "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==";
+  };
+  "@smithy/util-utf8@4.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz";
+    hash = "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==";
+  };
+  "@standard-schema/spec@1.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz";
+    hash = "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==";
+  };
   "@types/bun@1.3.11" = fetchurl {
     url = "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz";
     hash = "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==";
+  };
+  "@types/cross-spawn@6.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz";
+    hash = "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==";
   };
   "@types/node@22.19.7" = fetchurl {
     url = "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz";
@@ -161,6 +273,10 @@
     url = "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz";
     hash = "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==";
   };
+  "agent-base@7.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz";
+    hash = "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==";
+  };
   "ajv-formats@3.0.1" = fetchurl {
     url = "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz";
     hash = "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==";
@@ -169,9 +285,49 @@
     url = "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz";
     hash = "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==";
   };
+  "ansi-regex@5.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz";
+    hash = "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==";
+  };
+  "ansi-regex@6.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz";
+    hash = "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==";
+  };
+  "ansi-styles@4.3.0" = fetchurl {
+    url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz";
+    hash = "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==";
+  };
+  "ansi-styles@6.2.3" = fetchurl {
+    url = "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz";
+    hash = "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==";
+  };
+  "aws4fetch@1.0.20" = fetchurl {
+    url = "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz";
+    hash = "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==";
+  };
+  "balanced-match@1.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz";
+    hash = "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==";
+  };
+  "base64-js@1.5.1" = fetchurl {
+    url = "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz";
+    hash = "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==";
+  };
+  "bignumber.js@9.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz";
+    hash = "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==";
+  };
   "body-parser@2.2.2" = fetchurl {
     url = "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz";
     hash = "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==";
+  };
+  "brace-expansion@2.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz";
+    hash = "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==";
+  };
+  "buffer-equal-constant-time@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz";
+    hash = "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==";
   };
   "bun-types@1.3.11" = fetchurl {
     url = "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz";
@@ -192,6 +348,14 @@
   "call-bound@1.0.4" = fetchurl {
     url = "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz";
     hash = "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==";
+  };
+  "color-convert@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz";
+    hash = "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==";
+  };
+  "color-name@1.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz";
+    hash = "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==";
   };
   "content-disposition@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz";
@@ -217,6 +381,10 @@
     url = "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz";
     hash = "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==";
   };
+  "data-uri-to-buffer@4.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz";
+    hash = "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==";
+  };
   "debug@4.4.3" = fetchurl {
     url = "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz";
     hash = "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==";
@@ -233,9 +401,29 @@
     url = "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz";
     hash = "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==";
   };
+  "eastasianwidth@0.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz";
+    hash = "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==";
+  };
+  "ecdsa-sig-formatter@1.0.11" = fetchurl {
+    url = "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz";
+    hash = "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==";
+  };
   "ee-first@1.1.1" = fetchurl {
     url = "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz";
     hash = "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==";
+  };
+  "effect@4.0.0-rc.111" = fetchurl {
+    url = "https://registry.npmjs.org/effect/-/effect-4.0.0-rc.111.tgz";
+    hash = "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA==";
+  };
+  "emoji-regex@8.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz";
+    hash = "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==";
+  };
+  "emoji-regex@9.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz";
+    hash = "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==";
   };
   "encodeurl@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz";
@@ -277,6 +465,14 @@
     url = "https://registry.npmjs.org/express/-/express-5.2.1.tgz";
     hash = "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==";
   };
+  "extend@3.0.2" = fetchurl {
+    url = "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz";
+    hash = "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==";
+  };
+  "fast-check@4.9.0" = fetchurl {
+    url = "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz";
+    hash = "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==";
+  };
   "fast-deep-equal@3.1.3" = fetchurl {
     url = "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz";
     hash = "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==";
@@ -285,9 +481,21 @@
     url = "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz";
     hash = "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==";
   };
+  "fetch-blob@3.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz";
+    hash = "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==";
+  };
   "finalhandler@2.1.1" = fetchurl {
     url = "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz";
     hash = "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==";
+  };
+  "foreground-child@3.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz";
+    hash = "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==";
+  };
+  "formdata-polyfill@4.0.10" = fetchurl {
+    url = "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz";
+    hash = "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==";
   };
   "forwarded@0.2.0" = fetchurl {
     url = "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz";
@@ -301,6 +509,18 @@
     url = "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz";
     hash = "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==";
   };
+  "gaxios@7.1.3" = fetchurl {
+    url = "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz";
+    hash = "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==";
+  };
+  "gaxios@7.3.1" = fetchurl {
+    url = "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz";
+    hash = "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==";
+  };
+  "gcp-metadata@8.1.4" = fetchurl {
+    url = "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz";
+    hash = "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==";
+  };
   "get-intrinsic@1.3.0" = fetchurl {
     url = "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz";
     hash = "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==";
@@ -309,13 +529,33 @@
     url = "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz";
     hash = "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==";
   };
+  "glob@10.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz";
+    hash = "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==";
+  };
   "glob@13.0.0" = fetchurl {
     url = "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz";
     hash = "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==";
   };
+  "google-auth-library@10.5.0" = fetchurl {
+    url = "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz";
+    hash = "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==";
+  };
+  "google-logging-utils@1.1.3" = fetchurl {
+    url = "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz";
+    hash = "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==";
+  };
+  "google-logging-utils@1.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.2.0.tgz";
+    hash = "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A==";
+  };
   "gopd@1.2.0" = fetchurl {
     url = "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz";
     hash = "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==";
+  };
+  "gtoken@8.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz";
+    hash = "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==";
   };
   "has-symbols@1.1.0" = fetchurl {
     url = "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz";
@@ -333,6 +573,10 @@
     url = "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz";
     hash = "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==";
   };
+  "https-proxy-agent@7.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz";
+    hash = "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==";
+  };
   "iconv-lite@0.7.2" = fetchurl {
     url = "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz";
     hash = "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==";
@@ -349,6 +593,10 @@
     url = "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz";
     hash = "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==";
   };
+  "is-fullwidth-code-point@3.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz";
+    hash = "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==";
+  };
   "is-promise@4.0.0" = fetchurl {
     url = "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz";
     hash = "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==";
@@ -357,9 +605,17 @@
     url = "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz";
     hash = "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==";
   };
+  "jackspeak@3.4.3" = fetchurl {
+    url = "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz";
+    hash = "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==";
+  };
   "jose@6.2.2" = fetchurl {
     url = "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz";
     hash = "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==";
+  };
+  "json-bigint@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz";
+    hash = "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==";
   };
   "json-schema-to-ts@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz";
@@ -373,13 +629,29 @@
     url = "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz";
     hash = "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==";
   };
+  "json-schema@0.4.0" = fetchurl {
+    url = "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz";
+    hash = "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==";
+  };
   "jsonc-parser@3.3.1" = fetchurl {
     url = "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz";
     hash = "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==";
   };
+  "jwa@2.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz";
+    hash = "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==";
+  };
+  "jws@4.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz";
+    hash = "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==";
+  };
   "libsql@0.5.29" = fetchurl {
     url = "https://registry.npmjs.org/libsql/-/libsql-0.5.29.tgz";
     hash = "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==";
+  };
+  "lru-cache@10.4.3" = fetchurl {
+    url = "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz";
+    hash = "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==";
   };
   "lru-cache@11.2.5" = fetchurl {
     url = "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz";
@@ -409,6 +681,10 @@
     url = "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz";
     hash = "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==";
   };
+  "minimatch@9.0.9" = fetchurl {
+    url = "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz";
+    hash = "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==";
+  };
   "minipass@7.1.2" = fetchurl {
     url = "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz";
     hash = "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==";
@@ -421,9 +697,29 @@
     url = "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz";
     hash = "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==";
   };
+  "msgpackr-extract@3.0.4" = fetchurl {
+    url = "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz";
+    hash = "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==";
+  };
+  "msgpackr@2.0.6" = fetchurl {
+    url = "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz";
+    hash = "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==";
+  };
   "negotiator@1.0.0" = fetchurl {
     url = "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz";
     hash = "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==";
+  };
+  "node-domexception@1.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz";
+    hash = "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==";
+  };
+  "node-fetch@3.3.2" = fetchurl {
+    url = "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz";
+    hash = "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==";
+  };
+  "node-gyp-build-optional-packages@5.2.2" = fetchurl {
+    url = "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz";
+    hash = "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==";
   };
   "object-assign@4.1.1" = fetchurl {
     url = "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz";
@@ -441,6 +737,10 @@
     url = "https://registry.npmjs.org/once/-/once-1.4.0.tgz";
     hash = "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==";
   };
+  "package-json-from-dist@1.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz";
+    hash = "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==";
+  };
   "parseurl@1.3.3" = fetchurl {
     url = "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz";
     hash = "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==";
@@ -448,6 +748,10 @@
   "path-key@3.1.1" = fetchurl {
     url = "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz";
     hash = "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==";
+  };
+  "path-scurry@1.11.1" = fetchurl {
+    url = "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz";
+    hash = "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==";
   };
   "path-scurry@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz";
@@ -465,6 +769,10 @@
     url = "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz";
     hash = "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==";
   };
+  "pure-rand@8.4.2" = fetchurl {
+    url = "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz";
+    hash = "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==";
+  };
   "qs@6.15.0" = fetchurl {
     url = "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz";
     hash = "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==";
@@ -481,6 +789,10 @@
     url = "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz";
     hash = "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==";
   };
+  "rimraf@5.0.10" = fetchurl {
+    url = "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz";
+    hash = "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==";
+  };
   "router@2.2.0" = fetchurl {
     url = "https://registry.npmjs.org/router/-/router-2.2.0.tgz";
     hash = "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==";
@@ -488,6 +800,10 @@
   "sade@1.8.1" = fetchurl {
     url = "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz";
     hash = "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==";
+  };
+  "safe-buffer@5.2.1" = fetchurl {
+    url = "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz";
+    hash = "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==";
   };
   "safer-buffer@2.1.2" = fetchurl {
     url = "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz";
@@ -529,9 +845,29 @@
     url = "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz";
     hash = "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==";
   };
+  "signal-exit@4.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz";
+    hash = "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==";
+  };
   "statuses@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz";
     hash = "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==";
+  };
+  "string-width@4.2.3" = fetchurl {
+    url = "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz";
+    hash = "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==";
+  };
+  "string-width@5.1.2" = fetchurl {
+    url = "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz";
+    hash = "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==";
+  };
+  "strip-ansi@6.0.1" = fetchurl {
+    url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz";
+    hash = "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==";
+  };
+  "strip-ansi@7.2.0" = fetchurl {
+    url = "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz";
+    hash = "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==";
   };
   "toidentifier@1.0.1" = fetchurl {
     url = "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz";
@@ -540,6 +876,10 @@
   "ts-algebra@2.0.0" = fetchurl {
     url = "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz";
     hash = "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==";
+  };
+  "tslib@2.8.1" = fetchurl {
+    url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
+    hash = "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
   };
   "type-is@2.0.1" = fetchurl {
     url = "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz";
@@ -561,9 +901,21 @@
     url = "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz";
     hash = "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==";
   };
+  "web-streams-polyfill@3.3.3" = fetchurl {
+    url = "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz";
+    hash = "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==";
+  };
   "which@2.0.2" = fetchurl {
     url = "https://registry.npmjs.org/which/-/which-2.0.2.tgz";
     hash = "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==";
+  };
+  "wrap-ansi@7.0.0" = fetchurl {
+    url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz";
+    hash = "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==";
+  };
+  "wrap-ansi@8.1.0" = fetchurl {
+    url = "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz";
+    hash = "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==";
   };
   "wrappy@1.0.2" = fetchurl {
     url = "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz";
@@ -576,5 +928,13 @@
   "zod@3.25.76" = fetchurl {
     url = "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz";
     hash = "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==";
+  };
+  "zod@4.1.8" = fetchurl {
+    url = "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz";
+    hash = "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==";
+  };
+  "zod@4.4.3" = fetchurl {
+    url = "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz";
+    hash = "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==";
   };
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,19 +6,24 @@ Per-agent configuration for every tested client. All agents share the same basic
 
 ### OpenCode
 
+### OpenCode V1
+
 **Step 1: Run `meridian setup` (required, one time)**
 
 ```bash
 meridian setup
 ```
 
-This adds the Meridian plugin to your OpenCode global config (`~/.config/opencode/opencode.json`). The plugin enables:
+When V1 and V2 are both installed, the default command keeps V1 selected. You can
+also select it explicitly:
 
-- **Session tracking** — reliable conversation continuity across requests
-- **Safe model defaults** — Opus uses 1M context (included with Max subscription); Sonnet uses 200k to avoid Extra Usage charges ([details](configuration.md#configuration))
-- **Subagent model selection** — subagents automatically use `sonnet`/`opus` (200k), preserving rate-limit budget
+```bash
+meridian setup --v1
+```
 
-If the plugin is missing, Meridian warns at startup and reports `"plugin": "not-configured"` in the health endpoint.
+Setup adds the V1 Meridian plugin to the OpenCode global config
+(`~/.config/opencode/opencode.json`). It preserves unrelated plugin entries and
+all other settings.
 
 **Step 2: Start**
 
@@ -26,14 +31,82 @@ If the plugin is missing, Meridian warns at startup and reports `"plugin": "not-
 ANTHROPIC_API_KEY=x ANTHROPIC_BASE_URL=http://127.0.0.1:3456 opencode
 ```
 
-Or set these in your shell profile so they're always active:
+Or set these in your shell profile so they are always active:
 
 ```bash
 export ANTHROPIC_API_KEY=x
 export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 ```
 
+### OpenCode V2 beta
+
+Meridian currently supports the exact public beta used by its V2 plugin:
+`@opencode-ai/cli@0.0.0-beta-18314`. V2 plugin APIs are still changing, so setup
+fails closed for another V2 version instead of installing a plugin with an
+unknown contract.
+
+Install the pinned beta and select its executable:
+
+```bash
+npm install -g --prefix ~/.local @opencode-ai/cli@0.0.0-beta-18314
+meridian setup --v2 --opencode-bin ~/.local/bin/opencode2
+```
+
+If your binary is elsewhere, pass that path to `--opencode-bin`. V2 can
+self-update to a newer beta, so keep it pinned and launch it with automatic
+updates disabled while this compatibility target is current:
+
+```bash
+export OPENCODE_DISABLE_AUTOUPDATE=1
+```
+
+Configure V2's Anthropic provider to use Meridian. Keep the existing settings in
+`~/.config/opencode/opencode.json`; the important provider fields are:
+
+```json
+{
+  "model": "anthropic/claude-opus-4-6",
+  "small_model": "anthropic/claude-haiku-4-5",
+  "provider": {
+    "anthropic": {
+      "options": {
+        "apiKey": "x",
+        "baseURL": "http://127.0.0.1:3456"
+      },
+      "models": {
+        "claude-opus-4-6": { "name": "Claude Opus 4.6" },
+        "claude-haiku-4-5": { "name": "Claude Haiku 4.5" }
+      }
+    }
+  }
+}
+```
+
+Then start the pinned client:
+
+```bash
+OPENCODE_DISABLE_AUTOUPDATE=1 ~/.local/bin/opencode2
+```
+
+The V2 plugin uses the native `model.request` and `http.request` hooks. It keeps
+primary and compaction requests attached to the correct OpenCode session,
+detaches concurrent hidden title/summary requests, and gives each visible
+subagent its own trusted identity. Request bodies and model input are unchanged.
+
+For either generation, the plugin enables:
+
+- **Session tracking** — reliable conversation continuity across requests
+- **Safe hidden-agent concurrency** — title and summary work cannot advance the primary lineage
+- **Safe model defaults** — Opus uses 1M context; Sonnet uses 200k to avoid Extra Usage charges ([details](configuration.md#configuration))
+- **Subagent model selection** — subagents use the 200k tier, preserving rate-limit budget
+
+If the plugin is missing, Meridian warns at request time. Restart OpenCode after
+running setup so it loads the selected plugin.
+
 #### oh-my-opencagent (OMO)
+
+> **OpenCode V1:** The integration below is validated on V1. Do not assume that
+> its plugin schema is compatible with the pinned V2 beta.
 
 [oh-my-opencagent](https://github.com/nicobailey/oh-my-opencagent) adds multi-agent orchestration on top of OpenCode. It works transparently through Meridian with no extra configuration — OMO uses the same OpenCode headers and tool format, so Meridian detects it automatically.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-        "@anthropic-ai/claude-code": "^2.1.117",
+        "@anthropic-ai/claude-code": "^2.1.198",
+        "cross-spawn": "7.0.6",
         "jsonc-parser": "^3.3.1",
-        "libsql": "^0.5.29"
+        "libsql": "^0.5.29",
+        "zod": "4.4.3"
       },
       "bin": {
         "claude-max-proxy": "dist/cli.js",
@@ -21,7 +23,9 @@
       },
       "devDependencies": {
         "@hono/node-server": "^1.19.11",
+        "@opencode-ai/plugin": "0.0.0-beta-18314",
         "@types/bun": "^1.3.11",
+        "@types/cross-spawn": "6.0.6",
         "@types/node": "^22.0.0",
         "bun2nix": "^2.0.8",
         "glob": "^13.0.0",
@@ -30,6 +34,19 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -163,32 +180,32 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.178.tgz",
-      "integrity": "sha512-XhNQu2QkthrwznlzQA1ZrnRmApA2fgjQ2jxlcPP5B581Tg/E5+hUcbWTkW4OkPDgXg9KljtK7XZ20KszNxt8xg==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.247.tgz",
+      "integrity": "sha512-2Z2UQKom3x6GBQDYlFFi00KbRciqsuGL9CpK+IN3fXmmJb7IXVitrRZ6HZyUw0ixnckr814GIp0FUaXwDEbBrw==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "bin/claude.exe"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.178",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.178",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.178",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.178",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.178",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.178",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.178",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.178"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.247",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.247",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.247",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.247",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.247",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.247",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.247",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.247"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.178.tgz",
-      "integrity": "sha512-y2oFhS2EPfUBl7RMaM1fcVZ9ZMCsSfKxst5j+kmy0WUtS0FE0538KN/ECLDlZkpslAg2WdBNz01M0woMLk6uqw==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.247.tgz",
+      "integrity": "sha512-PgInuhsq1LONloSE6puAPzQUakRDDkX8fYPz+k7CCJK8uvfsxtSwA19T1l3ebVuZauPcss+E4abk+WFwGlY3Cg==",
       "cpu": [
         "arm64"
       ],
@@ -199,9 +216,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.178.tgz",
-      "integrity": "sha512-QjVYEoyEgBU4xRvMHKKSlafl1rG/4dENlpZEDG/9sinGftFdzgm0kuzmq7l/heOM0+ZXJ1LQJdI6xIRaa1lGag==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.247.tgz",
+      "integrity": "sha512-CAMN8THavM7V0qhX6JwvfXIAMuQHxQf8XYP2ztMR2MsIT1Vrac1bmXav/tmlVFmA2UaRBHImGIHO+4oiyaziTA==",
       "cpu": [
         "x64"
       ],
@@ -212,9 +229,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.178.tgz",
-      "integrity": "sha512-tDdcLyUNahnj71lj5c/BEsAHt6Ad1KjRznfzE2IuHflUrHgQtCpObjV8QK2YtoDVgDaPT7frGekse/SK6eKweQ==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.247.tgz",
+      "integrity": "sha512-oz5zSpSHY3WBaajo70L61YVM0efGxhoguOhz2DjbVy/Q6EvXoDaAj6813IzIHHsRugLYQ36D1B32GDSL63mz6Q==",
       "cpu": [
         "arm64"
       ],
@@ -225,9 +242,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.178.tgz",
-      "integrity": "sha512-ICUv3w1tYPU5KZOmdwn1vihMyqmkITbu3VFUZInYU7LlBpOFq8WwzO/G61mRQih2iKciN6WE2tJ06WeJhGXJFA==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.247.tgz",
+      "integrity": "sha512-894hf5lB/+nBIHkzWwo4iDFzTCaJxKqLMfZRmiEj4FMoToepNXRr+jROwuXTAdWE7wKqZjUGi7SDbykfLR40Jw==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +255,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.178.tgz",
-      "integrity": "sha512-W3XUZDHi3XtsftWK+phsnPyKWx5y7ULfyCiNQFLH5LNih73v0/wRg5t/Kqtj8+rl4pI0LCgcJW2USeK/7CCmvQ==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.247.tgz",
+      "integrity": "sha512-ZHjg+YRpBDKmTzIWtVF7ofABjwz387bCjDCUyO89ttuOwlUvh1zmCVwTlL6BdJO/v9uCTbQOrM7GUIDqzmPAoA==",
       "cpu": [
         "x64"
       ],
@@ -251,9 +268,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.178.tgz",
-      "integrity": "sha512-qkNHcT9XVM5NegMMm5gbJ3SFb4uvwVHPUU3RAVWXFGaGIN74n1G/Pvfoo9Qn+wp9owzlh3NAGnav3Css9AUtFQ==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.247.tgz",
+      "integrity": "sha512-/2ZS9KFUxvXlO4z1byS4BJExUfh51IbtrUVuF4QbdkAMBirnNF16ACJyorzcKfvQR8+aLoPuznMuIZd2yltRXQ==",
       "cpu": [
         "x64"
       ],
@@ -264,9 +281,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.178.tgz",
-      "integrity": "sha512-oEOSzGhzbPEHK863q+87ojdLmvo6jKVJAcCM5/CX4Bdcf/qtZqY7EuZW2fJ5RQTqy6GRUUbFjGuf5No8GVJdOQ==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.247.tgz",
+      "integrity": "sha512-vN73B/ofkhj939CN5aEW84wuJKWJ7t7Ecn0u1tu59zcUfuIjIllliTjnuVmmYolaR8mncLjK81d1dXMqHhbb7w==",
       "cpu": [
         "arm64"
       ],
@@ -277,9 +294,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.178",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.178.tgz",
-      "integrity": "sha512-WXOoz69alLEaXS4uqeipjT1sArOhuhCbDy08+gTAjPCohGBoyisxEbDxpGUM0jnr2IGg6du0tvd2AM0ZBMqqAg==",
+      "version": "2.1.247",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.247.tgz",
+      "integrity": "sha512-nCg+StYkQjcZh4cWUwwD4ECTj/9jfWlNMxpsFvg2BgWkEtoA/q6bX+1NyYw9FRibbdD6MUfi7dtvK36koWqL2w==",
       "cpu": [
         "x64"
       ],
@@ -307,6 +324,75 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -345,6 +431,24 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@libsql/darwin-arm64": {
@@ -504,10 +608,317 @@
         }
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@neon-rs/load": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
       "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
+    },
+    "node_modules/@opencode-ai/ai": {
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/ai/-/ai-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-0dcd86JMVv3ADsy9XdTJIgN5Bx6kSKYkS80lcxeBUEcWGUi3UAub0dokZVmsqg8TN11sYLRLiEFjHlqPNQnhHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/schema": "0.0.0-beta-18314",
+        "@smithy/eventstream-codec": "4.2.14",
+        "@smithy/util-utf8": "4.2.2",
+        "aws4fetch": "1.0.20",
+        "effect": "4.0.0-rc.111",
+        "google-auth-library": "10.5.0"
+      }
+    },
+    "node_modules/@opencode-ai/client": {
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/client/-/client-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-LpzH20P0BTsoes7ewylQV2cdBg8WlmJMCeBIsYm789mDN0hXXXmCS8WFA7RWbnvoN7yE5l3I/KSMQuBrKx9puw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/protocol": "0.0.0-beta-18314",
+        "@opencode-ai/schema": "0.0.0-beta-18314"
+      },
+      "peerDependencies": {
+        "effect": "4.0.0-rc.111",
+        "solid-js": ">=1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "effect": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-CB6fWjiUf69woHn3QRgwH4YimjrpawMEhgh9b8tBfjnRWrc+qP+vgKztkdTGcNqUjrBcJ1BqOYuUFAYlTZdTcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/ai": "0.0.0-beta-18314",
+        "@opencode-ai/client": "0.0.0-beta-18314",
+        "@opencode-ai/protocol": "0.0.0-beta-18314",
+        "@opencode-ai/schema": "0.0.0-beta-18314",
+        "@standard-schema/spec": "1.1.0",
+        "effect": "4.0.0-rc.111",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opencode-ai/theme": "0.0.0-beta-18314",
+        "@opentui/core": ">=0.5.8",
+        "@opentui/solid": ">=0.5.8",
+        "solid-js": ">=1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opencode-ai/theme": {
+          "optional": true
+        },
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/plugin/node_modules/zod": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.8.tgz",
+      "integrity": "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@opencode-ai/protocol": {
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/protocol/-/protocol-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-/85qh6QvznNvl8X/Jd8fFoD9Rr3N+fDgbtDS0sdcegwAEwP8KfmcQ+JSpOB2JHdmr6GiM5N6Qguz3ptfgyqjHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/schema": "0.0.0-beta-18314",
+        "effect": "4.0.0-rc.111"
+      }
+    },
+    "node_modules/@opencode-ai/schema": {
+      "version": "0.0.0-beta-18314",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/schema/-/schema-0.0.0-beta-18314.tgz",
+      "integrity": "sha512-nPXQdQQBLPXOYGYz8n/vYSq1eVHqAZLcWFIvaNHn04WCnW8NwBXjpH0zww2CmaJfcOd9pNChpoiK8MbjnrMU0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "1.1.0",
+        "effect": "4.0.0-rc.111"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.5.2.tgz",
+      "integrity": "sha512-nxu3SgmAw9JXT2CtkU0m/XNLWpP9MsaBx1zAGAypCbYj15tIFlmcYwpF+Oh18le83d+IM9PT7ENdXnE4C+d5mA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.5.2.tgz",
+      "integrity": "sha512-iq+cW3mAb7vfcxEEpYi3zXKpDtbrIFyanWjQl4zBq4seWD4OSxXDWSfespZxenX6aEaighn+NR3u1nU1DSvs3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/bun": {
@@ -516,6 +927,16 @@
       "license": "MIT",
       "dependencies": {
         "bun-types": "1.3.11"
+      }
+    },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -537,6 +958,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -570,6 +1001,77 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -608,6 +1110,23 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/bun-types": {
       "version": "1.3.11",
@@ -667,6 +1186,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -739,6 +1278,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -788,10 +1337,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-rc.111",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-rc.111.tgz",
+      "integrity": "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.9.0",
+        "msgpackr": "^2.0.5"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -930,6 +1515,36 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -952,6 +1567,30 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -971,6 +1610,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -998,6 +1667,62 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.4.tgz",
+      "integrity": "sha512-iJ9KMsiu+xKtNRX0PmGLSaIU3bUBAyzWTyqKemKPzNPsmmsBCQYmlNg+brEbES7IHSXtdVwzBPzx1vz3FAaipw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "7.1.3",
+        "google-logging-utils": "1.1.3",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
+      "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "rimraf": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1053,6 +1778,35 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^8.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.2.0.tgz",
+      "integrity": "sha512-WE9av4wKDZgRjBwgVUabocx8T6/7o3Ca1Fat46FXDhXVAFibzNadedcOXrdgd1Kzmk8tsk/9ZH89Wyf/SqeZ3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1063,6 +1817,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/has-symbols": {
@@ -1116,6 +1884,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1156,6 +1938,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -1168,6 +1960,22 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jose": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
@@ -1176,6 +1984,23 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -1207,6 +2032,29 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/libsql": {
       "version": "0.5.29",
@@ -1341,6 +2189,39 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.6.tgz",
+      "integrity": "sha512-plGul/tqjt9vqWFR9zyqyLZls6gb5KTLvnsRO2B9+TZ8tNiXiVI/CR8LiDWlAX4IUeVkQ9gsmzKA6voC2QOciw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1348,6 +2229,62 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/object-assign": {
@@ -1391,6 +2328,13 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -1457,6 +2401,23 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -1505,6 +2466,84 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -1533,6 +2572,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1684,6 +2744,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1691,6 +2764,110 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/toidentifier": {
@@ -1707,6 +2884,13 @@
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "2.1.0",
@@ -1774,6 +2958,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1787,6 +2981,104 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "scripts": {
     "start": "./bin/claude-proxy-supervisor.sh",
     "proxy": "./bin/claude-proxy-supervisor.sh",
-    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && bun build bin/cli.ts src/proxy/server.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --external jsonc-parser --entry-naming \"[name].js\" && tsc -p tsconfig.build.json",
-    "postbuild": "node scripts/fix-bun-exports.mjs && node --check dist/cli.js && node --check dist/server.js && node -e \"if(!require('fs').existsSync('dist/proxy/server.d.ts'))process.exit(1)\"",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && bun build bin/cli.ts src/proxy/server.ts plugin/meridian-v2.ts --outdir dist --target node --splitting --external @anthropic-ai/claude-agent-sdk --external jsonc-parser --entry-naming \"[name].js\" && tsc -p tsconfig.build.json",
+    "postbuild": "node scripts/fix-bun-exports.mjs && node --check dist/cli.js && node --check dist/server.js && node --check dist/meridian-v2.js && node -e \"if(!require('fs').existsSync('dist/proxy/server.d.ts'))process.exit(1)\"",
     "postinstall": "node -e \"try{require('child_process').spawnSync(process.execPath,[require.resolve('@anthropic-ai/claude-code/install.cjs')],{stdio:'inherit'})}catch(e){console.error('[meridian] claude-code postinstall skipped:',e.message)}\"",
     "prepublishOnly": "bun run build",
     "test": "bun test --path-ignore-patterns '**/*session-store*' --path-ignore-patterns '**/*proxy-async-ops*' --path-ignore-patterns '**/*models-auth-status*' --path-ignore-patterns '**/*proxy-context-usage-store*' --path-ignore-patterns '**/*proxy-passthrough-thinking*' --path-ignore-patterns '**/*proxy-thinking-setting*' --path-ignore-patterns '**/*session-recovery*' --path-ignore-patterns '**/*models.test*' --path-ignore-patterns '**/*proxy-health-build*' && bun test src/__tests__/proxy-async-ops.test.ts && bun test src/__tests__/proxy-session-store.test.ts && bun test src/__tests__/session-store-pruning.test.ts && bun test src/__tests__/proxy-session-store-locking.test.ts && bun test src/__tests__/proxy-context-usage-store.test.ts && bun test src/__tests__/models-auth-status.test.ts && bun test src/__tests__/proxy-passthrough-thinking.test.ts && bun test src/__tests__/proxy-session-recovery.test.ts && bun test src/__tests__/proxy-thinking-setting.test.ts && bun test src/__tests__/models.test.ts && bun test src/__tests__/proxy-health-build.test.ts",
@@ -33,12 +33,16 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.117",
     "@anthropic-ai/claude-code": "^2.1.198",
+    "cross-spawn": "7.0.6",
     "jsonc-parser": "^3.3.1",
-    "libsql": "^0.5.29"
+    "libsql": "^0.5.29",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.11",
+    "@opencode-ai/plugin": "0.0.0-beta-18314",
     "@types/bun": "^1.3.11",
+    "@types/cross-spawn": "6.0.6",
     "@types/node": "^22.0.0",
     "bun2nix": "^2.0.8",
     "glob": "^13.0.0",

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -1,0 +1,112 @@
+/**
+ * Meridian OpenCode plugin — **v2 line** (`@opencode-ai/cli@beta`, `opencode2`).
+ *
+ * The v1 plugin next to this file hooks `chat.headers`. That hook does not
+ * exist in opencode v2 at all, so on a v2 client the v1 plugin is inert: no
+ * agent tier, and — worse — no chance to fix what v2's core does on its own.
+ *
+ * What v2's core does: `SessionModelHeaders.make` stamps `x-opencode-session`
+ * (plus `x-session-affinity` / `X-Session-Id`) on **every** model request,
+ * including the `title` and `summary` one-shots that run inside the parent
+ * session and fire in parallel with the user's real turn. Both requests then
+ * carry the same session id, both contend for the proxy's per-session turn
+ * lease, and the loser — in practice the user's first turn — dies with
+ * `400 session_turn_conflict` ("This session advanced while the request was
+ * waiting"). Same failure the v1 fix addressed; v2 needs its own hook.
+ *
+ * This plugin uses v2's `session.model.request` hook, which fires for the
+ * one-shots too and may rewrite headers before the request goes out:
+ *   1. title/summary → session affinity stripped, `x-meridian-source:
+ *      subagent-<name>` added, so the proxy sees an explicitly parallel
+ *      stream instead of a contender for the session's turn (and its lineage
+ *      fingerprint fallback cannot glue them back onto the session — the
+ *      title prompt embeds the conversation's own first message).
+ *   2. every request → `x-opencode-agent-name` / `x-opencode-agent-mode`, so
+ *      the proxy picks the model tier per agent: primary gets the 1M
+ *      variants, subagents the 200k ones.
+ *
+ * compaction deliberately keeps its session id: the proxy needs it to attach
+ * the compaction to the lineage and already exempts it from the conflict
+ * check.
+ *
+ * Install (opencode v2) — add to ~/.config/opencode/opencode.json:
+ *   { "plugin": ["/absolute/path/to/plugin/meridian-v2.ts"] }
+ */
+
+/** Providers that point at a Meridian endpoint in practice. */
+const MERIDIAN_PROVIDERS = new Set(["anthropic", "meridian"])
+
+/**
+ * Modes of v2's built-in agents. Used when the agent lookup can't answer — a
+ * miss must not silently promote a subagent to the 1M tier.
+ */
+const BUILTIN_AGENT_MODES: Record<string, string> = {
+  build: "primary",
+  plan: "primary",
+  general: "subagent",
+  explore: "subagent",
+  title: "subagent",
+  summary: "subagent",
+  compaction: "subagent",
+}
+
+/** Utilities v2 runs inside the PARENT session, concurrently with its turn. */
+const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
+
+/**
+ * Header names that bind a request to a session. Spelled here exactly as
+ * `SessionModelHeaders.make` writes them — the hook hands over a plain
+ * record, so a case that does not match is a header left behind.
+ */
+const SESSION_AFFINITY_HEADERS = [
+  "x-opencode-session",
+  "x-session-affinity",
+  "X-Session-Id",
+  "x-parent-session-id",
+]
+
+interface ModelRequest {
+  sessionID: string
+  agent: string
+  model: { providerID?: string }
+  headers: Record<string, string>
+}
+
+export default {
+  id: "meridian",
+  setup(context: any) {
+    const resolveMode = async (agent: string): Promise<string> => {
+      try {
+        // v2 takes an object and answers { location, data: Agent.Info }.
+        const info = await context.agent?.get?.({ agentID: agent })
+        const mode = info?.data?.mode ?? info?.mode
+        if (typeof mode === "string") return mode
+      } catch {
+        // An agent the runtime cannot describe falls back to the table below.
+      }
+      return BUILTIN_AGENT_MODES[agent] ?? "primary"
+    }
+
+    return context.session.hook("model.request", async (input: ModelRequest) => {
+      if (!MERIDIAN_PROVIDERS.has(String(input.model?.providerID ?? ""))) return
+
+      // Strip non-ASCII characters (zero-width spaces and the like) that make
+      // undici reject the whole request with "Header has invalid value".
+      const name = String(input.agent ?? "unknown").replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
+      const mode = (await resolveMode(name)) === "subagent" ? "subagent" : "primary"
+
+      if (PARENT_SESSION_ONE_SHOTS.has(name)) {
+        for (const header of SESSION_AFFINITY_HEADERS) delete input.headers[header]
+        input.headers["x-meridian-source"] = `subagent-${name}`
+      } else {
+        // Core already sets this; restated so the header is present even if a
+        // future core stops stamping it, and so the value is the one this
+        // hook was handed rather than whatever survived another plugin.
+        input.headers["x-opencode-session"] = String(input.sessionID)
+      }
+
+      input.headers["x-opencode-agent-name"] = name
+      input.headers["x-opencode-agent-mode"] = mode
+    })
+  },
+}

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -90,12 +90,17 @@ export default {
     return context.session.hook("model.request", async (input: ModelRequest) => {
       if (!MERIDIAN_PROVIDERS.has(String(input.model?.providerID ?? ""))) return
 
-      // Strip non-ASCII characters (zero-width spaces and the like) that make
-      // undici reject the whole request with "Header has invalid value".
-      const name = String(input.agent ?? "unknown").replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
-      const mode = (await resolveMode(name)) === "subagent" ? "subagent" : "primary"
+      const raw = String(input.agent ?? "")
+      // The built-ins arrive under exactly these names. A user-defined agent
+      // that merely sanitizes to the same name is distinct and keeps affinity.
+      const isOneShot = PARENT_SESSION_ONE_SHOTS.has(raw)
+      const mode = (await resolveMode(raw)) === "subagent" ? "subagent" : "primary"
 
-      if (PARENT_SESSION_ONE_SHOTS.has(name)) {
+      // Strip non-ASCII characters (zero-width spaces and the like) only at
+      // the header boundary, where undici otherwise rejects the request.
+      const name = raw.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
+
+      if (isOneShot) {
         for (const header of SESSION_AFFINITY_HEADERS) delete input.headers[header]
         input.headers["x-meridian-source"] = `subagent-${name}`
       } else {

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -1,117 +1,190 @@
 /**
- * Meridian OpenCode plugin — **v2 line** (`@opencode-ai/cli@beta`, `opencode2`).
+ * Meridian OpenCode plugin for the V2 beta line.
  *
- * The v1 plugin next to this file hooks `chat.headers`. That hook does not
- * exist in opencode v2 at all, so on a v2 client the v1 plugin is inert: no
- * agent tier, and — worse — no chance to fix what v2's core does on its own.
+ * OpenCode V2 runs hidden title and summary requests in the parent session,
+ * often in parallel with the visible first turn. V2's core gives all of those
+ * requests the same session-affinity headers. Meridian must detach the hidden
+ * one-shots before they reach the proxy or they can advance the visible
+ * conversation's durable lineage.
  *
- * What v2's core does: `SessionModelHeaders.make` stamps `x-opencode-session`
- * (plus `x-session-affinity` / `X-Session-Id`) on **every** model request,
- * including the `title` and `summary` one-shots that run inside the parent
- * session and fire in parallel with the user's real turn. Both requests then
- * carry the same session id, both contend for the proxy's per-session turn
- * lease, and the loser — in practice the user's first turn — dies with
- * `400 session_turn_conflict` ("This session advanced while the request was
- * waiting"). Same failure the v1 fix addressed; v2 needs its own hook.
+ * The model hook applies the identity as early as V2 permits. The HTTP hook
+ * enforces it again at the final request boundary. This removes stale or
+ * spoofed control headers regardless of header casing.
  *
- * This plugin uses v2's `session.model.request` hook, which fires for the
- * one-shots too and may rewrite headers before the request goes out:
- *   1. title/summary → session affinity stripped, `x-meridian-source:
- *      subagent-<name>` added, so the proxy sees an explicitly parallel
- *      stream instead of a contender for the session's turn (and its lineage
- *      fingerprint fallback cannot glue them back onto the session — the
- *      title prompt embeds the conversation's own first message).
- *   2. every request → `x-opencode-agent-name` / `x-opencode-agent-mode`, so
- *      the proxy picks the model tier per agent: primary gets the 1M
- *      variants, subagents the 200k ones.
- *
- * compaction deliberately keeps its session id: the proxy needs it to attach
- * the compaction to the lineage and already exempts it from the conflict
- * check.
- *
- * Install (opencode v2) — add to ~/.config/opencode/opencode.json:
- *   { "plugin": ["/absolute/path/to/plugin/meridian-v2.ts"] }
+ * NOTE: OpenCode-specific. Keep this separate from plugin/meridian.ts: V1
+ * expects a default plugin function and V2 expects a Plugin.define() object.
  */
 
-/** Providers that point at a Meridian endpoint in practice. */
+import * as Plugin from "@opencode-ai/plugin/promise/plugin"
+
+/** Exact V2 host used to compile and validate this beta-only integration. */
+export const SUPPORTED_OPENCODE_V2_VERSION = "0.0.0-beta-18314"
+
 const MERIDIAN_PROVIDERS = new Set(["anthropic", "meridian"])
-
-/**
- * Modes of v2's built-in agents. Used when the agent lookup can't answer — a
- * miss must not silently promote a subagent to the 1M tier.
- */
-const BUILTIN_AGENT_MODES: Record<string, string> = {
-  build: "primary",
-  plan: "primary",
-  general: "subagent",
-  explore: "subagent",
-  title: "subagent",
-  summary: "subagent",
-  compaction: "subagent",
-}
-
-/** Utilities v2 runs inside the PARENT session, concurrently with its turn. */
 const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
+const ATTACHED_COMPACTION_AGENT = "compaction"
 
-/**
- * Header names that bind a request to a session. Spelled here exactly as
- * `SessionModelHeaders.make` writes them — the hook hands over a plain
- * record, so a case that does not match is a header left behind.
- */
 const SESSION_AFFINITY_HEADERS = [
   "x-opencode-session",
   "x-session-affinity",
-  "X-Session-Id",
+  "x-session-id",
   "x-parent-session-id",
-]
+] as const
 
-interface ModelRequest {
-  sessionID: string
-  agent: string
-  model: { providerID?: string }
-  headers: Record<string, string>
+const MERIDIAN_CONTROL_HEADERS = [
+  "x-meridian-source",
+  "x-opencode-agent-name",
+  "x-opencode-agent-mode",
+] as const
+
+export interface AgentTraits {
+  mode: "primary" | "subagent"
+  hidden: boolean
 }
 
-export default {
+const BUILTIN_AGENT_TRAITS: Record<string, AgentTraits> = {
+  build: { mode: "primary", hidden: false },
+  plan: { mode: "primary", hidden: false },
+  general: { mode: "subagent", hidden: false },
+  explore: { mode: "subagent", hidden: false },
+  // Exact beta-18314 defines all three hidden internal agents as primary.
+  title: { mode: "primary", hidden: true },
+  summary: { mode: "primary", hidden: true },
+  compaction: { mode: "primary", hidden: true },
+}
+
+export function fallbackAgentTraits(agent: string): AgentTraits {
+  return BUILTIN_AGENT_TRAITS[agent] ?? { mode: "primary", hidden: false }
+}
+
+type MutableHeaders = Record<string, string> | Headers
+
+function deleteHeader(headers: MutableHeaders, name: string): void {
+  if (headers instanceof Headers) {
+    headers.delete(name)
+    return
+  }
+  const lower = name.toLowerCase()
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) delete headers[key]
+  }
+}
+
+function setHeader(headers: MutableHeaders, name: string, value: string): void {
+  deleteHeader(headers, name)
+  if (headers instanceof Headers) headers.set(name, value)
+  else headers[name] = value
+}
+
+function safeAgentName(agent: string): string {
+  return agent.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
+}
+
+export function shouldDetachFromParentSession(agent: string, _traits: AgentTraits): boolean {
+  // The exact built-in ID is authoritative. `hidden` is presentation config:
+  // making the built-in visible does not stop V2 from running its parent-
+  // session title/summary job concurrently with the primary turn.
+  return PARENT_SESSION_ONE_SHOTS.has(agent)
+}
+
+/**
+ * Rewrite one V2 request's identity without changing its body or model input.
+ * This pure helper is shared by model.request and http.request.
+ */
+export function applyMeridianV2Headers(
+  headers: MutableHeaders,
+  input: { sessionID: string; agent: string; traits: AgentTraits },
+): void {
+  for (const name of SESSION_AFFINITY_HEADERS) deleteHeader(headers, name)
+  for (const name of MERIDIAN_CONTROL_HEADERS) deleteHeader(headers, name)
+
+  const name = safeAgentName(input.agent)
+  const detached = shouldDetachFromParentSession(input.agent, input.traits)
+
+  if (detached) {
+    setHeader(headers, "x-meridian-source", `subagent-${name}`)
+  } else {
+    // Set every V2 affinity spelling from the trusted hook input. Do not retain
+    // provider-config values that can bind this request to another session.
+    setHeader(headers, "x-opencode-session", input.sessionID)
+    setHeader(headers, "x-session-affinity", input.sessionID)
+    setHeader(headers, "x-session-id", input.sessionID)
+    if (input.agent === ATTACHED_COMPACTION_AGENT) {
+      // Source selects the base model tier without making the adapter append
+      // `#compaction` to the primary session key.
+      setHeader(headers, "x-meridian-source", "subagent-compaction")
+    }
+  }
+
+  const internalMode = PARENT_SESSION_ONE_SHOTS.has(input.agent)
+    ? "subagent"
+    : input.agent === ATTACHED_COMPACTION_AGENT ? "primary" : input.traits.mode
+  setHeader(headers, "x-opencode-agent-name", name)
+  setHeader(headers, "x-opencode-agent-mode", internalMode)
+}
+
+const MeridianV2Plugin = Plugin.define({
   id: "meridian",
-  setup(context: any) {
-    const resolveMode = async (agent: string): Promise<string> => {
-      try {
-        // v2 takes an object and answers { location, data: Agent.Info }.
-        const info = await context.agent?.get?.({ agentID: agent })
-        const mode = info?.data?.mode ?? info?.mode
-        if (typeof mode === "string") return mode
-      } catch {
-        // An agent the runtime cannot describe falls back to the table below.
-      }
-      return BUILTIN_AGENT_MODES[agent] ?? "primary"
+  setup: async (context) => {
+    const traitsByAgent = new Map<string, {
+      expiresAt: number
+      pending: Promise<AgentTraits>
+    }>()
+    const registered: Array<{ dispose: () => Promise<void> }> = []
+
+    const resolveAgentTraits = (agent: string): Promise<AgentTraits> => {
+      const cached = traitsByAgent.get(agent)
+      if (cached && cached.expiresAt > Date.now()) return cached.pending
+
+      const pending = Promise.resolve()
+        .then(() => context.agent.get({ agentID: agent }))
+        .then(({ data }) => ({
+          mode: data.mode === "subagent" ? "subagent" as const : "primary" as const,
+          hidden: data.hidden,
+        }))
+        .catch(() => {
+          // A transient lookup failure must not permanently promote a custom
+          // child to primary. Retry at the final HTTP boundary or next turn.
+          if (traitsByAgent.get(agent)?.pending === pending) traitsByAgent.delete(agent)
+          return fallbackAgentTraits(agent)
+        })
+      traitsByAgent.set(agent, { expiresAt: Date.now() + 5_000, pending })
+      return pending
     }
 
-    return context.session.hook("model.request", async (input: ModelRequest) => {
-      if (!MERIDIAN_PROVIDERS.has(String(input.model?.providerID ?? ""))) return
+    const apply = async (
+      input: { sessionID: string; agent: string; model: { providerID: string } },
+      headers: MutableHeaders,
+    ): Promise<void> => {
+      if (!MERIDIAN_PROVIDERS.has(String(input.model.providerID))) return
+      const agent = String(input.agent)
+      applyMeridianV2Headers(headers, {
+        sessionID: String(input.sessionID),
+        agent,
+        traits: await resolveAgentTraits(agent),
+      })
+    }
 
-      const raw = String(input.agent ?? "")
-      // The built-ins arrive under exactly these names. A user-defined agent
-      // that merely sanitizes to the same name is distinct and keeps affinity.
-      const isOneShot = PARENT_SESSION_ONE_SHOTS.has(raw)
-      const mode = (await resolveMode(raw)) === "subagent" ? "subagent" : "primary"
-
-      // Strip non-ASCII characters (zero-width spaces and the like) only at
-      // the header boundary, where undici otherwise rejects the request.
-      const name = raw.replace(/[^\x20-\x7E]/g, "").trim() || "unknown"
-
-      if (isOneShot) {
-        for (const header of SESSION_AFFINITY_HEADERS) delete input.headers[header]
-        input.headers["x-meridian-source"] = `subagent-${name}`
-      } else {
-        // Core already sets this; restated so the header is present even if a
-        // future core stops stamping it, and so the value is the one this
-        // hook was handed rather than whatever survived another plugin.
-        input.headers["x-opencode-session"] = String(input.sessionID)
+    try {
+      for (const providerID of MERIDIAN_PROVIDERS) {
+        registered.push(await context.session.hook("model.request", async (input) => {
+          await apply(input, input.headers)
+        }, { providerID }))
+        registered.push(await context.session.hook("http.request", async (input) => {
+          await apply(input, input.request.headers)
+        }, { providerID }))
       }
+    } catch (error) {
+      await Promise.allSettled(registered.map(({ dispose }) => dispose()))
+      throw error
+    }
 
-      input.headers["x-opencode-agent-name"] = name
-      input.headers["x-opencode-agent-mode"] = mode
-    })
+    return async () => {
+      const results = await Promise.allSettled(registered.map(({ dispose }) => dispose()))
+      const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : [])
+      if (failures.length > 0) throw new AggregateError(failures, "Failed to dispose Meridian V2 hooks")
+    }
   },
-}
+})
+
+export default MeridianV2Plugin

--- a/src/__tests__/passthrough-tool-sort.test.ts
+++ b/src/__tests__/passthrough-tool-sort.test.ts
@@ -5,17 +5,30 @@ import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test"
 // been mocked differently by a sibling test file).
 let registeredTools: Array<{ name: string; config: any }> = []
 mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  createSdkMcpServer: () => ({
-    type: "sdk",
-    name: "test",
-    instance: {
-      tool: () => {},
-      registerTool: (name: string, config: any, _handler: any) => {
-        registeredTools.push({ name, config })
-        return {}
-      },
-    },
-  }),
+  createSdkMcpServer: (options: {
+    tools?: Array<{
+      name: string
+      description: string
+      inputSchema: unknown
+      _meta?: Record<string, unknown>
+    }>
+  }) => {
+    for (const definition of options.tools ?? []) {
+      registeredTools.push({
+        name: definition.name,
+        config: {
+          description: definition.description,
+          inputSchema: definition.inputSchema,
+          _meta: definition._meta,
+        },
+      })
+    }
+    return {
+      type: "sdk",
+      name: "test",
+      instance: { tool: () => {}, registerTool: () => ({}) },
+    }
+  },
 }))
 
 import { createPassthroughMcpServer, getAutoDeferThreshold } from "../proxy/passthroughTools"

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -84,13 +84,28 @@ describe("plugin/meridian-v2.ts parent-session one-shots", () => {
 
   for (const agent of ["build", "compaction", "general", "explore"]) {
     test(`${agent} keeps the session header`, async () => {
-      const headers = await run(agent)
+      const headers = await run(agent, { parentID: "ses_parent" })
 
       expect(headers["x-opencode-session"]).toBe("ses_abc")
       expect(headers["x-session-affinity"]).toBe("ses_abc")
+      expect(headers["X-Session-Id"]).toBe("ses_abc")
+      expect(headers["x-parent-session-id"]).toBe("ses_parent")
       expect(headers["x-meridian-source"]).toBeUndefined()
     })
   }
+
+  test("an agent padded like a one-shot keeps the session header", async () => {
+    const headers = await run(" title ")
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBeUndefined()
+  })
+
+  test("an agent containing a zero-width character keeps the session header", async () => {
+    const headers = await run("ti\u200btle")
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+  })
 })
 
 describe("plugin/meridian-v2.ts agent mode", () => {
@@ -102,9 +117,15 @@ describe("plugin/meridian-v2.ts agent mode", () => {
   })
 
   test("a configured agent takes its mode from the runtime, not the table", async () => {
-    const headers = await run("reviewer", { modes: { reviewer: "subagent" } })
+    const headers = await run("réviewer", { modes: { "réviewer": "subagent" } })
 
     expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("a non-ASCII agent name is sanitized only for the header", async () => {
+    const headers = await run("réviewer")
+
+    expect(headers["x-opencode-agent-name"]).toBe("rviewer")
   })
 
   test("an unknown agent falls back to primary", async () => {

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -1,22 +1,21 @@
 /**
- * Tests for the opencode **v2** plugin (plugin/meridian-v2.ts).
- *
- * The property under test is the one a v2 client gets wrong on its own: the
- * core stamps session affinity on every model request, including the
- * title/summary one-shots that run in parallel with the user's turn. The
- * plugin must take that affinity off those two and declare them as parallel
- * streams instead, while leaving every other agent's session intact.
+ * Unit tests for the OpenCode V2 plugin's request identity boundary.
  */
 
 import { describe, expect, test } from "bun:test"
-import MeridianV2Plugin from "../../plugin/meridian-v2"
+import MeridianV2Plugin, {
+  applyMeridianV2Headers,
+  fallbackAgentTraits,
+  shouldDetachFromParentSession,
+  type AgentTraits,
+} from "../../plugin/meridian-v2"
+import { openCodeAdapter } from "../proxy/adapters/opencode"
 
-/** Headers as v2's SessionModelHeaders.make writes them, verbatim. */
-function coreHeaders(sessionID: string, parentID?: string): Record<string, string> {
+function coreHeaders(sessionID: string, parentID = "ses_parent"): Record<string, string> {
   return {
     "x-session-affinity": sessionID,
     "X-Session-Id": sessionID,
-    ...(parentID ? { "x-parent-session-id": parentID } : {}),
+    "x-parent-session-id": parentID,
     "User-Agent": "opencode/2",
     "x-opencode-project": "prj_1",
     "x-opencode-session": sessionID,
@@ -24,129 +23,352 @@ function coreHeaders(sessionID: string, parentID?: string): Record<string, strin
   }
 }
 
-type Hook = (input: {
-  sessionID: string
-  agent: string
-  model: { providerID?: string }
-  headers: Record<string, string>
-}) => Promise<void> | void
-
-/** Runs the plugin's setup and returns the registered model.request hook. */
-function install(agentModes: Record<string, string> = {}): Hook {
-  let registered: Hook | undefined
-  const context = {
-    agent: {
-      get: async ({ agentID }: { agentID: string }) => {
-        const mode = agentModes[agentID]
-        return mode ? { data: { mode } } : undefined
-      },
-    },
-    session: {
-      hook: (name: string, callback: Hook) => {
-        if (name === "model.request") registered = callback
-        return Promise.resolve({ dispose: async () => {} })
-      },
-    },
-  }
-  MeridianV2Plugin.setup(context)
-  if (!registered) throw new Error("the plugin did not register a model.request hook")
-  return registered
-}
-
-async function run(
+function rewrite(
   agent: string,
-  options: { providerID?: string; parentID?: string; modes?: Record<string, string> } = {},
-) {
-  const headers = coreHeaders("ses_abc", options.parentID)
-  await install(options.modes)({
-    sessionID: "ses_abc",
-    agent,
-    model: { providerID: options.providerID ?? "anthropic" },
-    headers,
-  })
+  traits: AgentTraits = fallbackAgentTraits(agent),
+  headers: Record<string, string> = coreHeaders("ses_abc"),
+): Record<string, string> {
+  applyMeridianV2Headers(headers, { sessionID: "ses_abc", agent, traits })
   return headers
 }
 
-describe("plugin/meridian-v2.ts parent-session one-shots", () => {
+describe("plugin/meridian-v2.ts export", () => {
+  test("uses the V2 object contract", () => {
+    expect(MeridianV2Plugin.id).toBe("meridian")
+    expect(typeof MeridianV2Plugin.setup).toBe("function")
+  })
+})
+
+describe("plugin/meridian-v2.ts hidden parent-session one-shots", () => {
   for (const agent of ["title", "summary"]) {
-    test(`${agent} goes out detached from the session`, async () => {
-      const headers = await run(agent, { parentID: "ses_parent" })
+    test(`${agent} is detached from the parent session`, () => {
+      const headers = rewrite(agent)
 
       expect(headers["x-opencode-session"]).toBeUndefined()
       expect(headers["x-session-affinity"]).toBeUndefined()
       expect(headers["X-Session-Id"]).toBeUndefined()
       expect(headers["x-parent-session-id"]).toBeUndefined()
       expect(headers["x-meridian-source"]).toBe(`subagent-${agent}`)
-      // Everything the request needs that is not session affinity survives.
+      expect(headers["x-opencode-agent-mode"]).toBe("subagent")
       expect(headers["x-opencode-project"]).toBe("prj_1")
     })
   }
 
-  for (const agent of ["build", "compaction", "general", "explore"]) {
-    test(`${agent} keeps the session header`, async () => {
-      const headers = await run(agent, { parentID: "ses_parent" })
+  test("the hidden title agent detaches even when V2 reports mode primary", () => {
+    const headers = rewrite("title", { mode: "primary", hidden: true })
 
+    expect(headers["x-opencode-session"]).toBeUndefined()
+    expect(headers["x-meridian-source"]).toBe("subagent-title")
+    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("the built-in title job still detaches when configured visible", () => {
+    const headers = rewrite("title", { mode: "primary", hidden: false })
+
+    expect(headers["x-opencode-session"]).toBeUndefined()
+    expect(headers["x-meridian-source"]).toBe("subagent-title")
+  })
+
+  test("a padded one-shot lookalike remains attached", () => {
+    const headers = rewrite(" title ", { mode: "subagent", hidden: true })
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBeUndefined()
+  })
+
+  test("a zero-width one-shot lookalike remains attached", () => {
+    const headers = rewrite("ti​tle", { mode: "subagent", hidden: true })
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBeUndefined()
+  })
+
+  test("compaction remains on the primary key but gets the subagent tier", () => {
+    const headers = rewrite("compaction", { mode: "primary", hidden: false })
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBe("subagent-compaction")
+    expect(headers["x-opencode-agent-mode"]).toBe("primary")
+
+    const sessionKey = Reflect.apply(openCodeAdapter.getSessionId, openCodeAdapter, [{
+      req: { header: (name: string) => headers[name.toLowerCase()] },
+    }])
+    expect(sessionKey).toBe("ses_abc")
+  })
+
+  test("exact beta built-ins fall back to their native primary traits", () => {
+    for (const agent of ["title", "summary", "compaction"]) {
+      expect(fallbackAgentTraits(agent)).toEqual({ mode: "primary", hidden: true })
+    }
+  })
+})
+
+describe("plugin/meridian-v2.ts primary and subagent identity", () => {
+  for (const agent of ["build", "plan"]) {
+    test(`${agent} keeps the primary session`, () => {
+      const headers = rewrite(agent)
       expect(headers["x-opencode-session"]).toBe("ses_abc")
       expect(headers["x-session-affinity"]).toBe("ses_abc")
-      expect(headers["X-Session-Id"]).toBe("ses_abc")
-      expect(headers["x-parent-session-id"]).toBe("ses_parent")
+      expect(headers["x-session-id"]).toBe("ses_abc")
+      expect(headers["x-opencode-agent-mode"]).toBe("primary")
+    })
+  }
+
+  for (const agent of ["general", "explore", "code-reviewer"]) {
+    test(`${agent} keeps its own session as a subagent`, () => {
+      const traits = agent === "code-reviewer"
+        ? { mode: "subagent" as const, hidden: false }
+        : fallbackAgentTraits(agent)
+      const headers = rewrite(agent, traits)
+
+      expect(headers["x-opencode-session"]).toBe("ses_abc")
+      expect(headers["x-opencode-agent-name"]).toBe(agent)
+      expect(headers["x-opencode-agent-mode"]).toBe("subagent")
       expect(headers["x-meridian-source"]).toBeUndefined()
     })
   }
 
-  test("an agent padded like a one-shot keeps the session header", async () => {
-    const headers = await run(" title ")
-
-    expect(headers["x-opencode-session"]).toBe("ses_abc")
-    expect(headers["x-meridian-source"]).toBeUndefined()
-  })
-
-  test("an agent containing a zero-width character keeps the session header", async () => {
-    const headers = await run("ti\u200btle")
-
-    expect(headers["x-opencode-session"]).toBe("ses_abc")
-  })
-})
-
-describe("plugin/meridian-v2.ts agent mode", () => {
-  test("a built-in subagent is not promoted to the primary tier", async () => {
-    const headers = await run("explore")
-
-    expect(headers["x-opencode-agent-name"]).toBe("explore")
-    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
-  })
-
-  test("a configured agent takes its mode from the runtime, not the table", async () => {
-    const headers = await run("réviewer", { modes: { "réviewer": "subagent" } })
-
-    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
-  })
-
-  test("a non-ASCII agent name is sanitized only for the header", async () => {
-    const headers = await run("réviewer")
-
+  test("a non-ASCII agent name is sanitized only at the header boundary", () => {
+    const headers = rewrite("réviewer", { mode: "subagent", hidden: false })
     expect(headers["x-opencode-agent-name"]).toBe("rviewer")
+    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
   })
 
-  test("an unknown agent falls back to primary", async () => {
-    const headers = await run("something-custom")
-
-    expect(headers["x-opencode-agent-mode"]).toBe("primary")
-  })
-
-  test('"all" agents are treated as primary, as the proxy-side plugin does', async () => {
-    const headers = await run("switcher", { modes: { switcher: "all" } })
-
-    expect(headers["x-opencode-agent-mode"]).toBe("primary")
+  test("unknown agents preserve V1's primary fallback", () => {
+    expect(fallbackAgentTraits("something-custom")).toEqual({ mode: "primary", hidden: false })
   })
 })
 
-describe("plugin/meridian-v2.ts scope", () => {
-  test("a request to another provider is left untouched", async () => {
-    const headers = await run("title", { providerID: "openai" })
+describe("plugin/meridian-v2.ts spoof resistance", () => {
+  test("removes control headers case-insensitively before writing trusted values", () => {
+    const headers = rewrite("build", fallbackAgentTraits("build"), {
+      "X-OpenCode-Session": "spoofed",
+      "X-SESSION-AFFINITY": "spoofed",
+      "x-SESSION-id": "spoofed",
+      "X-Parent-Session-ID": "spoofed-parent",
+      "X-Meridian-Source": "subagent-spoofed",
+      "X-OpenCode-Agent-Name": "spoofed",
+      "X-OpenCode-Agent-Mode": "subagent",
+    })
 
-    expect(headers["x-opencode-session"]).toBe("ses_abc")
-    expect(headers["x-meridian-source"]).toBeUndefined()
-    expect(headers["x-opencode-agent-mode"]).toBeUndefined()
+    expect(headers).toEqual({
+      "x-opencode-session": "ses_abc",
+      "x-session-affinity": "ses_abc",
+      "x-session-id": "ses_abc",
+      "x-opencode-agent-name": "build",
+      "x-opencode-agent-mode": "primary",
+    })
+  })
+
+  test("the final HTTP Headers boundary enforces the same identity", () => {
+    const headers = new Headers({
+      "X-OpenCode-Session": "spoofed",
+      "X-Meridian-Source": "fork-spoofed",
+      "X-OpenCode-Agent-Mode": "subagent",
+    })
+
+    applyMeridianV2Headers(headers, {
+      sessionID: "ses_final",
+      agent: "build",
+      traits: fallbackAgentTraits("build"),
+    })
+
+    expect(headers.get("x-opencode-session")).toBe("ses_final")
+    expect(headers.get("x-session-affinity")).toBe("ses_final")
+    expect(headers.get("x-session-id")).toBe("ses_final")
+    expect(headers.get("x-meridian-source")).toBeNull()
+    expect(headers.get("x-opencode-agent-mode")).toBe("primary")
+  })
+})
+
+describe("plugin/meridian-v2.ts classification", () => {
+  test("only hidden subagent title and summary requests detach", () => {
+    expect(shouldDetachFromParentSession("title", { mode: "subagent", hidden: true })).toBe(true)
+    expect(shouldDetachFromParentSession("summary", { mode: "subagent", hidden: true })).toBe(true)
+    expect(shouldDetachFromParentSession("title", { mode: "primary", hidden: true })).toBe(true)
+    expect(shouldDetachFromParentSession("title", { mode: "subagent", hidden: false })).toBe(true)
+    expect(shouldDetachFromParentSession("compaction", { mode: "subagent", hidden: true })).toBe(false)
+  })
+})
+
+
+type ModelHookInput = {
+  sessionID: string
+  agent: string
+  model: { providerID: string }
+  headers: Record<string, string>
+}
+
+type HttpHookInput = {
+  sessionID: string
+  agent: string
+  model: { providerID: string }
+  request: Request
+}
+
+type HookInput = ModelHookInput | HttpHookInput
+type HookCallback = (input: HookInput) => Promise<void>
+type HookOptions = { providerID?: string }
+
+async function installHooks(options: {
+  traits?: Record<string, AgentTraits>
+  lookup?: (agentID: string, call: number) => AgentTraits | Promise<AgentTraits>
+  failHttpRegistration?: boolean
+  disposed?: string[]
+} = {}) {
+  let modelHook: HookCallback | undefined
+  let httpHook: HookCallback | undefined
+  const disposed = options.disposed ?? []
+  const lookups: string[] = []
+  const registrations: Array<{ name: string; providerID: string | undefined }> = []
+
+  const context = {
+    agent: {
+      get: async ({ agentID }: { agentID: string }) => {
+        lookups.push(agentID)
+        const traits = options.lookup
+          ? await options.lookup(agentID, lookups.length)
+          : options.traits?.[agentID] ?? fallbackAgentTraits(agentID)
+        return { data: traits }
+      },
+    },
+    session: {
+      hook: async (name: string, callback: HookCallback, hookOptions?: HookOptions) => {
+        registrations.push({ name, providerID: hookOptions?.providerID })
+        if (hookOptions?.providerID === "anthropic" && name === "model.request") modelHook = callback
+        if (hookOptions?.providerID === "anthropic" && name === "http.request") {
+          if (options.failHttpRegistration) throw new Error("http hook unavailable")
+          httpHook = callback
+        }
+        const registration = `${hookOptions?.providerID ?? "unscoped"}:${name}`
+        return { dispose: async () => { disposed.push(registration) } }
+      },
+    },
+  }
+
+  const cleanup = await Reflect.apply(MeridianV2Plugin.setup, MeridianV2Plugin, [context])
+  return {
+    model: () => {
+      if (!modelHook) throw new Error("model.request hook was not registered")
+      return modelHook
+    },
+    http: () => {
+      if (!httpHook) throw new Error("http.request hook was not registered")
+      return httpHook
+    },
+    cleanup: () => {
+      if (typeof cleanup !== "function") throw new Error("plugin setup did not return cleanup")
+      return cleanup()
+    },
+    disposed,
+    lookups,
+    registrations,
+  }
+}
+
+describe("plugin/meridian-v2.ts V2 hook registration", () => {
+  test("enforces trusted identity in both model and final HTTP hooks", async () => {
+    const hooks = await installHooks({
+      traits: { title: { mode: "primary", hidden: true } },
+    })
+    const modelInput: ModelHookInput = {
+      sessionID: "ses_real",
+      agent: "title",
+      model: { providerID: "anthropic" },
+      headers: coreHeaders("ses_spoofed"),
+    }
+
+    await hooks.model()(modelInput)
+    expect(modelInput.headers["x-opencode-session"]).toBeUndefined()
+    expect(modelInput.headers["x-meridian-source"]).toBe("subagent-title")
+
+    const request = new Request("http://127.0.0.1/v1/messages", {
+      headers: {
+        "X-OpenCode-Session": "spoofed-after-model-hook",
+        "X-Meridian-Source": "spoofed-source",
+      },
+    })
+    await hooks.http()({
+      sessionID: "ses_real",
+      agent: "title",
+      model: { providerID: "anthropic" },
+      request,
+    })
+
+    expect(request.headers.get("x-opencode-session")).toBeNull()
+    expect(request.headers.get("x-meridian-source")).toBe("subagent-title")
+    expect(hooks.lookups).toEqual(["title"])
+
+    await hooks.cleanup()
+    expect(hooks.disposed.sort()).toEqual([
+      "anthropic:http.request",
+      "anthropic:model.request",
+      "meridian:http.request",
+      "meridian:model.request",
+    ])
+  })
+
+  test("scopes every hook registration to a Meridian provider", async () => {
+    const hooks = await installHooks()
+    expect(hooks.registrations).toEqual([
+      { name: "model.request", providerID: "anthropic" },
+      { name: "http.request", providerID: "anthropic" },
+      { name: "model.request", providerID: "meridian" },
+      { name: "http.request", providerID: "meridian" },
+    ])
+    expect(hooks.registrations.every(registration => registration.providerID !== undefined)).toBe(true)
+    await hooks.cleanup()
+  })
+
+  test("retries a transient trait lookup at the final request boundary", async () => {
+    const hooks = await installHooks({
+      lookup: (_agentID, call) => {
+        if (call === 1) throw new Error("transient lookup failure")
+        return { mode: "subagent", hidden: false }
+      },
+    })
+    const modelInput: ModelHookInput = {
+      sessionID: "ses_child",
+      agent: "custom-reviewer",
+      model: { providerID: "anthropic" },
+      headers: {},
+    }
+
+    await hooks.model()(modelInput)
+    expect(modelInput.headers["x-opencode-agent-mode"]).toBe("primary")
+
+    const request = new Request("http://127.0.0.1/v1/messages")
+    await hooks.http()({
+      sessionID: "ses_child",
+      agent: "custom-reviewer",
+      model: { providerID: "anthropic" },
+      request,
+    })
+    expect(request.headers.get("x-opencode-agent-mode")).toBe("subagent")
+    expect(hooks.lookups).toEqual(["custom-reviewer", "custom-reviewer"])
+    await hooks.cleanup()
+  })
+
+  test("does not rewrite requests for unrelated providers", async () => {
+    const hooks = await installHooks()
+    const input: ModelHookInput = {
+      sessionID: "ses_real",
+      agent: "title",
+      model: { providerID: "openai" },
+      headers: coreHeaders("ses_original"),
+    }
+
+    await hooks.model()(input)
+    expect(input.headers["x-opencode-session"]).toBe("ses_original")
+    expect(input.headers["x-meridian-source"]).toBeUndefined()
+    expect(hooks.lookups).toEqual([])
+    await hooks.cleanup()
+  })
+
+  test("disposes an earlier hook if later registration fails", async () => {
+    const disposed: string[] = []
+    const installed = installHooks({ failHttpRegistration: true, disposed })
+    await expect(installed).rejects.toThrow("http hook unavailable")
+    expect(disposed).toEqual(["anthropic:model.request"])
   })
 })

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the opencode **v2** plugin (plugin/meridian-v2.ts).
+ *
+ * The property under test is the one a v2 client gets wrong on its own: the
+ * core stamps session affinity on every model request, including the
+ * title/summary one-shots that run in parallel with the user's turn. The
+ * plugin must take that affinity off those two and declare them as parallel
+ * streams instead, while leaving every other agent's session intact.
+ */
+
+import { describe, expect, test } from "bun:test"
+import MeridianV2Plugin from "../../plugin/meridian-v2"
+
+/** Headers as v2's SessionModelHeaders.make writes them, verbatim. */
+function coreHeaders(sessionID: string, parentID?: string): Record<string, string> {
+  return {
+    "x-session-affinity": sessionID,
+    "X-Session-Id": sessionID,
+    ...(parentID ? { "x-parent-session-id": parentID } : {}),
+    "User-Agent": "opencode/2",
+    "x-opencode-project": "prj_1",
+    "x-opencode-session": sessionID,
+    "x-opencode-client": "opencode",
+  }
+}
+
+type Hook = (input: {
+  sessionID: string
+  agent: string
+  model: { providerID?: string }
+  headers: Record<string, string>
+}) => Promise<void> | void
+
+/** Runs the plugin's setup and returns the registered model.request hook. */
+function install(agentModes: Record<string, string> = {}): Hook {
+  let registered: Hook | undefined
+  const context = {
+    agent: {
+      get: async ({ agentID }: { agentID: string }) => {
+        const mode = agentModes[agentID]
+        return mode ? { data: { mode } } : undefined
+      },
+    },
+    session: {
+      hook: (name: string, callback: Hook) => {
+        if (name === "model.request") registered = callback
+        return Promise.resolve({ dispose: async () => {} })
+      },
+    },
+  }
+  MeridianV2Plugin.setup(context)
+  if (!registered) throw new Error("the plugin did not register a model.request hook")
+  return registered
+}
+
+async function run(
+  agent: string,
+  options: { providerID?: string; parentID?: string; modes?: Record<string, string> } = {},
+) {
+  const headers = coreHeaders("ses_abc", options.parentID)
+  await install(options.modes)({
+    sessionID: "ses_abc",
+    agent,
+    model: { providerID: options.providerID ?? "anthropic" },
+    headers,
+  })
+  return headers
+}
+
+describe("plugin/meridian-v2.ts parent-session one-shots", () => {
+  for (const agent of ["title", "summary"]) {
+    test(`${agent} goes out detached from the session`, async () => {
+      const headers = await run(agent, { parentID: "ses_parent" })
+
+      expect(headers["x-opencode-session"]).toBeUndefined()
+      expect(headers["x-session-affinity"]).toBeUndefined()
+      expect(headers["X-Session-Id"]).toBeUndefined()
+      expect(headers["x-parent-session-id"]).toBeUndefined()
+      expect(headers["x-meridian-source"]).toBe(`subagent-${agent}`)
+      // Everything the request needs that is not session affinity survives.
+      expect(headers["x-opencode-project"]).toBe("prj_1")
+    })
+  }
+
+  for (const agent of ["build", "compaction", "general", "explore"]) {
+    test(`${agent} keeps the session header`, async () => {
+      const headers = await run(agent)
+
+      expect(headers["x-opencode-session"]).toBe("ses_abc")
+      expect(headers["x-session-affinity"]).toBe("ses_abc")
+      expect(headers["x-meridian-source"]).toBeUndefined()
+    })
+  }
+})
+
+describe("plugin/meridian-v2.ts agent mode", () => {
+  test("a built-in subagent is not promoted to the primary tier", async () => {
+    const headers = await run("explore")
+
+    expect(headers["x-opencode-agent-name"]).toBe("explore")
+    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("a configured agent takes its mode from the runtime, not the table", async () => {
+    const headers = await run("reviewer", { modes: { reviewer: "subagent" } })
+
+    expect(headers["x-opencode-agent-mode"]).toBe("subagent")
+  })
+
+  test("an unknown agent falls back to primary", async () => {
+    const headers = await run("something-custom")
+
+    expect(headers["x-opencode-agent-mode"]).toBe("primary")
+  })
+
+  test('"all" agents are treated as primary, as the proxy-side plugin does', async () => {
+    const headers = await run("switcher", { modes: { switcher: "all" } })
+
+    expect(headers["x-opencode-agent-mode"]).toBe("primary")
+  })
+})
+
+describe("plugin/meridian-v2.ts scope", () => {
+  test("a request to another provider is left untouched", async () => {
+    const headers = await run("title", { providerID: "openai" })
+
+    expect(headers["x-opencode-session"]).toBe("ses_abc")
+    expect(headers["x-meridian-source"]).toBeUndefined()
+    expect(headers["x-opencode-agent-mode"]).toBeUndefined()
+  })
+})

--- a/src/__tests__/setup-cli.test.ts
+++ b/src/__tests__/setup-cli.test.ts
@@ -1,0 +1,126 @@
+/**
+ * CLI boundary tests for OpenCode generation selection and fail-closed setup.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { tmpdir, platform } from "os"
+import { join } from "path"
+import { spawnSync } from "child_process"
+
+const repoRoot = join(import.meta.dir, "../..")
+const cliPath = join(repoRoot, "bin", "cli.ts")
+
+function writeVersionCommand(dir: string, output: string): string {
+  const windows = platform() === "win32"
+  const path = join(dir, windows ? "fake-opencode.cmd" : "fake-opencode")
+  const script = windows
+    ? `@echo off
+echo ${output}
+`
+    : `#!/bin/sh
+printf '%s\n' '${output}'
+`
+  writeFileSync(path, script)
+  if (!windows) chmodSync(path, 0o755)
+  return path
+}
+
+describe("meridian setup CLI", () => {
+  let root: string
+  let configDir: string
+  let configPath: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "meridian-setup-cli-test-"))
+    configDir = join(root, "config")
+    mkdirSync(configDir)
+    configPath = join(configDir, "opencode.json")
+  })
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+  function runSetup(args: string[]) {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      FORCE_COLOR: "0",
+      OPENCODE_CONFIG_DIR: configDir,
+    }
+    delete env.OPENCODE_BIN
+    return spawnSync(process.execPath, [cliPath, "setup", ...args], {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+      timeout: 30_000,
+      windowsHide: true,
+    })
+  }
+
+  test("installs the V2 source plugin for the exact beta through an npm-style shim", () => {
+    const binary = writeVersionCommand(root, "opencode2 v0.0.0-beta-18314")
+    const result = runSetup(["--v2", "--opencode-bin", binary])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("configured for OpenCode V2")
+    const config = JSON.parse(readFileSync(configPath, "utf8"))
+    expect(config.plugins).toHaveLength(1)
+    expect(config.plugins[0]).toEndWith(join("plugin", "meridian-v2.ts"))
+  })
+
+  test("preserves the V1 setup path when explicitly selected", () => {
+    const binary = writeVersionCommand(root, "1.18.11")
+    const result = runSetup(["--opencode-bin", binary])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("configured for OpenCode V1")
+    const config = JSON.parse(readFileSync(configPath, "utf8"))
+    expect(config.plugin[0]).toEndWith(join("plugin", "meridian.ts"))
+  })
+
+  test("rejects an invalid explicit version probe without touching config", () => {
+    const binary = writeVersionCommand(root, "OpenCode 2 beta unknown")
+    const original = '{"plugin":["keep-me"]}\n'
+    writeFileSync(configPath, original, { flag: "wx" })
+    const result = runSetup(["--opencode-bin", binary])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("Could not read a supported OpenCode version")
+    expect(readFileSync(configPath, "utf8")).toBe(original)
+  })
+
+  test("rejects beta API churn without touching config", () => {
+    const binary = writeVersionCommand(root, "opencode2 v0.0.0-beta-18371")
+    const original = '{"plugin":["keep-me"]}\n'
+    writeFileSync(configPath, original, { flag: "wx" })
+    const result = runSetup(["--v2", "--opencode-bin", binary])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("0.0.0-beta-18371 is not supported")
+    expect(readFileSync(configPath, "utf8")).toBe(original)
+  })
+
+  test("rejects a Meridian entry in the sibling JSONC document without touching either file", () => {
+    const binary = writeVersionCommand(root, "opencode2 v0.0.0-beta-18314")
+    const original = '{"plugins":["keep-me"]}\n'
+    const siblingPath = join(configDir, "opencode.jsonc")
+    const sibling = '{\n  "plugins": ["/old/meridian-v2.js"]\n}\n'
+    writeFileSync(configPath, original)
+    writeFileSync(siblingPath, sibling)
+
+    const result = runSetup(["--v2", "--opencode-bin", binary])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("other OpenCode config file")
+    expect(result.stderr).toContain("Both files were left untouched")
+    expect(readFileSync(configPath, "utf8")).toBe(original)
+    expect(readFileSync(siblingPath, "utf8")).toBe(sibling)
+  })
+
+  test("rejects conflicting generation flags before writing config", () => {
+    const result = runSetup(["--v1", "--v2"])
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("Choose only one OpenCode generation")
+    expect(() => readFileSync(configPath, "utf8")).toThrow()
+  })
+})

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -8,10 +8,24 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
+import { pathToFileURL } from "url"
 import { parse as parseJsonc } from "jsonc-parser"
-import { checkPluginConfigured, findOpencodeConfigPath, runSetup, UnparseableConfigError } from "../proxy/setup"
+import {
+  checkPluginConfigured,
+  classifyOpenCodeVersion,
+  detectOpenCodeGeneration,
+  DuplicateMeridianConfigError,
+  findOpencodeConfigPath,
+  findV2PluginPath,
+  MissingV2PluginError,
+  runSetup,
+  SUPPORTED_OPENCODE_V2_VERSION,
+  UnparseableConfigError,
+} from "../proxy/setup"
+import { SUPPORTED_OPENCODE_V2_VERSION as PLUGIN_V2_VERSION } from "../../plugin/meridian-v2"
 
 const PLUGIN_PATH = "/usr/local/lib/node_modules/@rynfar/meridian/plugin/meridian.ts"
+const V2_PLUGIN_PATH = "/usr/local/lib/node_modules/@rynfar/meridian/dist/meridian-v2.js"
 
 function makeTmpDir() {
   return mkdtempSync(join(tmpdir(), "meridian-setup-test-"))
@@ -32,6 +46,16 @@ describe("findOpencodeConfigPath", () => {
     expect(findOpencodeConfigPath()).toBe("/custom/opencode/opencode.json")
   })
 
+  it("prefers an existing opencode.jsonc when opencode.json is absent", () => {
+    const dir = makeTmpDir()
+    process.env.OPENCODE_CONFIG_DIR = dir
+    const jsoncPath = join(dir, "opencode.jsonc")
+    writeFileSync(jsoncPath, "{}\n")
+
+    expect(findOpencodeConfigPath()).toBe(jsoncPath)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
   it("respects XDG_CONFIG_HOME", () => {
     delete process.env.OPENCODE_CONFIG_DIR
     process.env.XDG_CONFIG_HOME = "/xdg/config"
@@ -45,6 +69,91 @@ describe("findOpencodeConfigPath", () => {
     const path = findOpencodeConfigPath()
     expect(path).toContain("opencode")
     expect(path).toEndWith("opencode.json")
+  })
+})
+
+describe("OpenCode generation detection", () => {
+  it("keeps setup and the bundled plugin pinned to the same V2 host", () => {
+    expect(SUPPORTED_OPENCODE_V2_VERSION).toBe(PLUGIN_V2_VERSION)
+  })
+
+  it("classifies the stable V1 version format", () => {
+    expect(classifyOpenCodeVersion("1.18.11\n")).toEqual({ generation: "v1", version: "1.18.11" })
+  })
+
+  it("classifies the pinned V2 beta format", () => {
+    expect(classifyOpenCodeVersion("opencode2 v0.0.0-beta-18314\n")).toEqual({
+      generation: "v2",
+      version: "0.0.0-beta-18314",
+    })
+  })
+
+  it("routes future stable major versions through the fail-closed V2 gate", () => {
+    expect(classifyOpenCodeVersion("opencode v2.0.0\n")).toEqual({
+      generation: "v2",
+      version: "2.0.0",
+    })
+  })
+
+  it("rejects output that is not only a version", () => {
+    expect(classifyOpenCodeVersion("OpenCode 2 beta")).toBeUndefined()
+  })
+
+  it("uses the first executable that returns a valid version", () => {
+    const detected = detectOpenCodeGeneration(["missing", "opencode2"], command =>
+      command === "opencode2" ? "v0.0.0-beta-18314" : undefined)
+    expect(detected).toEqual({
+      generation: "v2",
+      version: "0.0.0-beta-18314",
+      command: "opencode2",
+    })
+  })
+
+  it("falls back to V1 when no OpenCode executable is available", () => {
+    expect(detectOpenCodeGeneration(["missing"], () => undefined)).toEqual({ generation: "v1" })
+  })
+})
+
+describe("findV2PluginPath", () => {
+  let tmp: string
+
+  beforeEach(() => { tmp = makeTmpDir() })
+  afterEach(() => rmSync(tmp, { recursive: true }))
+
+  it("selects the bundle beside an installed CLI", () => {
+    const dist = join(tmp, "dist")
+    mkdirSync(dist)
+    const cli = join(dist, "cli.js")
+    const plugin = join(dist, "meridian-v2.js")
+    writeFileSync(cli, "")
+    writeFileSync(plugin, "")
+
+    expect(findV2PluginPath(pathToFileURL(cli).href)).toBe(plugin)
+  })
+
+  it("selects TypeScript source in a development tree even when dist is stale", () => {
+    const bin = join(tmp, "bin")
+    const pluginDir = join(tmp, "plugin")
+    const dist = join(tmp, "dist")
+    mkdirSync(bin)
+    mkdirSync(pluginDir)
+    mkdirSync(dist)
+    const cli = join(bin, "cli.ts")
+    const sourcePlugin = join(pluginDir, "meridian-v2.ts")
+    writeFileSync(cli, "")
+    writeFileSync(sourcePlugin, "current source")
+    writeFileSync(join(dist, "meridian-v2.js"), "stale build")
+
+    expect(findV2PluginPath(pathToFileURL(cli).href)).toBe(sourcePlugin)
+  })
+
+  it("fails closed when an installed CLI is missing its V2 bundle", () => {
+    const dist = join(tmp, "dist")
+    mkdirSync(dist)
+    const cli = join(dist, "cli.js")
+    writeFileSync(cli, "")
+
+    expect(() => findV2PluginPath(pathToFileURL(cli).href)).toThrow(MissingV2PluginError)
   })
 })
 
@@ -74,6 +183,30 @@ describe("checkPluginConfigured", () => {
     const path = join(tmp, "opencode.json")
     writeFileSync(path, JSON.stringify({ plugin: [PLUGIN_PATH] }))
     expect(checkPluginConfigured(path)).toBe(true)
+  })
+
+  it("can require the plugin for the selected OpenCode generation", () => {
+    const path = join(tmp, "opencode.json")
+    writeFileSync(path, JSON.stringify({ plugin: [PLUGIN_PATH] }))
+
+    expect(checkPluginConfigured(path, PLUGIN_PATH)).toBe(true)
+    expect(checkPluginConfigured(path, V2_PLUGIN_PATH)).toBe(false)
+  })
+
+  it("recognizes the bundled V2 plugin in the canonical plural field", () => {
+    const path = join(tmp, "opencode.json")
+    writeFileSync(path, JSON.stringify({ plugins: [V2_PLUGIN_PATH] }))
+    expect(checkPluginConfigured(path)).toBe(true)
+    expect(checkPluginConfigured(path, V2_PLUGIN_PATH)).toBe(true)
+  })
+
+  it("recognizes object-form V2 plugin entries", () => {
+    const path = join(tmp, "opencode.json")
+    writeFileSync(path, JSON.stringify({
+      plugins: [{ package: V2_PLUGIN_PATH, options: { enabled: true } }],
+    }))
+    expect(checkPluginConfigured(path)).toBe(true)
+    expect(checkPluginConfigured(path, V2_PLUGIN_PATH)).toBe(true)
   })
 
   it("returns true when stale claude-max-headers path is present", () => {
@@ -150,6 +283,102 @@ describe("runSetup", () => {
     expect(written.plugin).toContain("opencode-antigravity-auth")
     expect(written.plugin).not.toContain(stalePath)
     expect(written.plugin).toContain(PLUGIN_PATH)
+  })
+
+  it("replaces the V1 plugin with the V2 bundle and keeps unrelated plugins", () => {
+    const configPath = join(tmp, "opencode.json")
+    writeFileSync(configPath, JSON.stringify({ plugin: ["keep-me", PLUGIN_PATH] }))
+
+    const result = runSetup(V2_PLUGIN_PATH, configPath, "v2")
+    const written = JSON.parse(readFileSync(configPath, "utf-8"))
+
+    expect(result.removedStale).toContain(PLUGIN_PATH)
+    expect(written.plugin).toEqual(["keep-me"])
+    expect(written.plugins).toEqual([V2_PLUGIN_PATH])
+  })
+
+  it("configures canonical V2 plugins in an existing JSONC document", () => {
+    const configPath = join(tmp, "opencode.jsonc")
+    writeFileSync(configPath, '{\n  // keep this comment\n  "theme": "dark",\n}\n')
+
+    const result = runSetup(V2_PLUGIN_PATH, configPath, "v2")
+    const text = readFileSync(configPath, "utf-8")
+    const written = parseJsonc(text, [], { allowTrailingComma: true }) as Record<string, unknown>
+
+    expect(result.configPath).toBe(configPath)
+    expect(written.plugins).toEqual([V2_PLUGIN_PATH])
+    expect(text).toContain("// keep this comment")
+  })
+
+  it("fails closed when the sibling OpenCode document already defines Meridian", () => {
+    const configPath = join(tmp, "opencode.json")
+    const siblingPath = join(tmp, "opencode.jsonc")
+    const original = '{"plugins":["keep-me"]}\n'
+    const sibling = `{\n  // OpenCode loads this too\n  "plugins": ["${V2_PLUGIN_PATH}"]\n}\n`
+    writeFileSync(configPath, original)
+    writeFileSync(siblingPath, sibling)
+
+    expect(() => runSetup(V2_PLUGIN_PATH, configPath, "v2")).toThrow(DuplicateMeridianConfigError)
+    expect(readFileSync(configPath, "utf-8")).toBe(original)
+    expect(readFileSync(siblingPath, "utf-8")).toBe(sibling)
+  })
+
+  it("deduplicates Meridian across singular and plural fields", () => {
+    const configPath = join(tmp, "opencode.json")
+    writeFileSync(configPath, JSON.stringify({
+      plugin: [PLUGIN_PATH, "keep-singular"],
+      plugins: [V2_PLUGIN_PATH, "keep-plural"],
+    }))
+
+    const result = runSetup(V2_PLUGIN_PATH, configPath, "v2")
+    const written = JSON.parse(readFileSync(configPath, "utf-8"))
+
+    expect(result.alreadyConfigured).toBe(false)
+    expect(written.plugin).toEqual(["keep-singular"])
+    expect(written.plugins).toEqual(["keep-plural", V2_PLUGIN_PATH])
+  })
+
+  it("removes object-form stale Meridian entries and preserves unrelated objects", () => {
+    const configPath = join(tmp, "opencode.json")
+    const unrelated = { package: "keep-object", options: { setting: true } }
+    writeFileSync(configPath, JSON.stringify({
+      plugins: [
+        { package: PLUGIN_PATH, options: { stale: true } },
+        unrelated,
+      ],
+    }))
+
+    const result = runSetup(V2_PLUGIN_PATH, configPath, "v2")
+    const written = JSON.parse(readFileSync(configPath, "utf-8"))
+
+    expect(result.removedStale).toEqual([PLUGIN_PATH])
+    expect(written.plugins).toEqual([unrelated, V2_PLUGIN_PATH])
+  })
+
+  it("preserves options on one exact canonical object entry", () => {
+    const configPath = join(tmp, "opencode.json")
+    const configured = { package: V2_PLUGIN_PATH, options: { future: "value" } }
+    writeFileSync(configPath, JSON.stringify({ plugins: [configured] }))
+
+    const result = runSetup(V2_PLUGIN_PATH, configPath, "v2")
+    const written = JSON.parse(readFileSync(configPath, "utf-8"))
+
+    expect(result.alreadyConfigured).toBe(true)
+    expect(written.plugins).toEqual([configured])
+  })
+
+  it("switches back to V1 without leaving a duplicate V2 definition", () => {
+    const configPath = join(tmp, "opencode.json")
+    writeFileSync(configPath, JSON.stringify({
+      plugin: ["keep-singular"],
+      plugins: [V2_PLUGIN_PATH, "keep-plural"],
+    }))
+
+    runSetup(PLUGIN_PATH, configPath, "v1")
+    const written = JSON.parse(readFileSync(configPath, "utf-8"))
+
+    expect(written.plugin).toEqual(["keep-singular", PLUGIN_PATH])
+    expect(written.plugins).toEqual(["keep-plural"])
   })
 
   it("reports alreadyConfigured when same path already present", () => {

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -10,7 +10,7 @@
  * We just need the definitions so Claude can call them.
  */
 
-import { createSdkMcpServer } from "@anthropic-ai/claude-agent-sdk"
+import { createSdkMcpServer, type SdkMcpToolDefinition } from "@anthropic-ai/claude-agent-sdk"
 import { z } from "zod"
 
 export const PASSTHROUGH_MCP_NAME = "oc"
@@ -76,9 +76,6 @@ export function createPassthroughMcpServer(
   tools: Array<{ name: string; description?: string; input_schema?: any; defer_loading?: boolean }>,
   coreToolNames?: readonly string[]
 ) {
-  const server = createSdkMcpServer({ name: PASSTHROUGH_MCP_NAME })
-  const toolNames: string[] = []
-
   // Auto-defer: if tool count exceeds threshold and adapter provides core tools
   const threshold = getAutoDeferThreshold()
   const autoDefer = !!(threshold > 0 && coreToolNames && coreToolNames.length > 0 && tools.length > threshold)
@@ -91,49 +88,38 @@ export function createPassthroughMcpServer(
   // order. Non-deterministic ordering changes the SDK system prompt between
   // requests, invalidating prompt cache and causing full context re-reads.
   const sortedTools = [...tools].sort((a, b) => a.name.localeCompare(b.name))
-
-  for (const tool of sortedTools) {
+  const definitions = sortedTools.map((passthroughTool) => {
+    const alwaysLoad = hasDeferredTools && shouldAlwaysLoad(passthroughTool, coreSet)
+    const defineTool = (shape: Record<string, z.ZodType>): SdkMcpToolDefinition<Record<string, z.ZodType>> => ({
+      name: passthroughTool.name,
+      description: passthroughTool.description || passthroughTool.name,
+      inputSchema: shape,
+      handler: async () => ({ content: [{ type: "text" as const, text: "passthrough" }] }),
+      ...(alwaysLoad ? { _meta: { "anthropic/alwaysLoad": true } } : {}),
+    })
     try {
-      // Convert OpenCode's JSON Schema to Zod for MCP registration
-      const zodSchema = tool.input_schema?.properties
-        ? jsonSchemaToZod(tool.input_schema)
+      // Register through the Agent SDK helper so its Zod 4 peer owns the MCP
+      // compatibility boundary. Registering through the nested MCP instance
+      // instead couples this module to that package's separate Zod version.
+      const zodSchema = passthroughTool.input_schema?.properties
+        ? jsonSchemaToZod(passthroughTool.input_schema)
         : z.object({})
-
-      // The raw shape for the tool() call needs to be a record of Zod types
-      const shape: Record<string, z.ZodTypeAny> =
-        zodSchema instanceof z.ZodObject
-          ? (zodSchema as any).shape
-          : { input: z.any() }
-
-      server.instance.registerTool(
-        tool.name,
-        {
-          description: tool.description || tool.name,
-          inputSchema: shape,
-          // Mark tool as alwaysLoad when it should stay in the prompt:
-          // - Client explicitly did NOT set defer_loading on this tool, OR
-          // - Auto-defer is active and this tool is in the core set
-          ...(hasDeferredTools ? (shouldAlwaysLoad(tool, coreSet) ? { _meta: { "anthropic/alwaysLoad": true } } : {}) : {}),
-        },
-        async () => ({ content: [{ type: "text" as const, text: "passthrough" }] })
-      )
-      toolNames.push(`${PASSTHROUGH_MCP_PREFIX}${tool.name}`)
+      const shape: Record<string, z.ZodType> = zodSchema instanceof z.ZodObject
+        ? zodSchema.shape
+        : { input: z.any() }
+      return defineTool(shape)
     } catch {
-      // If schema conversion fails, register with permissive schema
-      server.instance.registerTool(
-        tool.name,
-        {
-          description: tool.description || tool.name,
-          inputSchema: { input: z.string().optional() },
-          ...(hasDeferredTools ? (shouldAlwaysLoad(tool, coreSet) ? { _meta: { "anthropic/alwaysLoad": true } } : {}) : {}),
-        },
-        async () => ({ content: [{ type: "text" as const, text: "passthrough" }] })
-      )
-      toolNames.push(`${PASSTHROUGH_MCP_PREFIX}${tool.name}`)
+      const fallbackShape: Record<string, z.ZodType> = { input: z.string().optional() }
+      return defineTool(fallbackShape)
     }
-  }
+  })
 
-  return { server, toolNames, hasDeferredTools }
+  const server = createSdkMcpServer({ name: PASSTHROUGH_MCP_NAME, tools: definitions })
+  return {
+    server,
+    toolNames: sortedTools.map(tool => `${PASSTHROUGH_MCP_PREFIX}${tool.name}`),
+    hasDeferredTools,
+  }
 }
 
 /**

--- a/src/proxy/setup.ts
+++ b/src/proxy/setup.ts
@@ -10,9 +10,10 @@
  *                          headers (see notePluginlessOpenCodeRequest)
  */
 
+import spawn from "cross-spawn"
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
 import { homedir, platform } from "os"
-import { dirname, join } from "path"
+import { basename, dirname, join } from "path"
 import { fileURLToPath } from "url"
 import { applyEdits, modify, parse as parseJsonc, type ParseError } from "jsonc-parser"
 import { LRUMap } from "../utils/lruMap"
@@ -26,6 +27,23 @@ export class UnparseableConfigError extends Error {
   constructor(public readonly configPath: string) {
     super(`Could not parse ${configPath} — it may contain a syntax error.`)
     this.name = "UnparseableConfigError"
+  }
+}
+
+export class MissingV2PluginError extends Error {
+  constructor(public readonly expectedPath: string) {
+    super(`OpenCode V2 plugin bundle not found at ${expectedPath}`)
+    this.name = "MissingV2PluginError"
+  }
+}
+
+export class DuplicateMeridianConfigError extends Error {
+  constructor(
+    public readonly configPath: string,
+    public readonly siblingPath: string,
+  ) {
+    super(`A Meridian entry in ${siblingPath} conflicts with setup target ${configPath}`)
+    this.name = "DuplicateMeridianConfigError"
   }
 }
 
@@ -51,17 +69,25 @@ function parseOpencodeConfig(text: string): Record<string, unknown> | null {
  * Resolve the OpenCode global config file path.
  * Respects OPENCODE_CONFIG_DIR and XDG_CONFIG_HOME env vars.
  */
+function opencodeConfigDirectory(): string {
+  if (process.env.OPENCODE_CONFIG_DIR) return process.env.OPENCODE_CONFIG_DIR
+  if (process.env.XDG_CONFIG_HOME) return join(process.env.XDG_CONFIG_HOME, "opencode")
+  if (platform() === "win32" && process.env.APPDATA) return join(process.env.APPDATA, "opencode")
+  return join(homedir(), ".config", "opencode")
+}
+
 export function findOpencodeConfigPath(): string {
-  if (process.env.OPENCODE_CONFIG_DIR) {
-    return join(process.env.OPENCODE_CONFIG_DIR, "opencode.json")
-  }
-  if (process.env.XDG_CONFIG_HOME) {
-    return join(process.env.XDG_CONFIG_HOME, "opencode", "opencode.json")
-  }
-  if (platform() === "win32" && process.env.APPDATA) {
-    return join(process.env.APPDATA, "opencode", "opencode.json")
-  }
-  return join(homedir(), ".config", "opencode", "opencode.json")
+  const dir = opencodeConfigDirectory()
+  const jsonPath = join(dir, "opencode.json")
+  const jsoncPath = join(dir, "opencode.jsonc")
+  return !existsSync(jsonPath) && existsSync(jsoncPath) ? jsoncPath : jsonPath
+}
+
+function siblingOpencodeConfigPath(configPath: string): string | undefined {
+  const name = basename(configPath)
+  if (name === "opencode.json") return join(dirname(configPath), "opencode.jsonc")
+  if (name === "opencode.jsonc") return join(dirname(configPath), "opencode.json")
+  return undefined
 }
 
 /**
@@ -71,6 +97,85 @@ export function findOpencodeConfigPath(): string {
 export function findPluginPath(fromUrl: string): string {
   const dir = dirname(fileURLToPath(fromUrl))
   return join(dir, "..", "plugin", "meridian.ts")
+}
+
+export type OpenCodeGeneration = "v1" | "v2"
+
+export interface OpenCodeDetection {
+  generation: OpenCodeGeneration
+  version?: string
+  command?: string
+}
+
+export const SUPPORTED_OPENCODE_V2_VERSION = "0.0.0-beta-18314"
+
+/** Resolve the V2 plugin without selecting stale or incomplete artifacts. */
+export function findV2PluginPath(fromUrl: string): string {
+  const entryPath = fileURLToPath(fromUrl)
+  const dir = dirname(entryPath)
+
+  // A source CLI must use the source plugin even when an old dist/ exists.
+  if (entryPath.endsWith(".ts")) {
+    const sourcePlugin = join(dir, "..", "plugin", "meridian-v2.ts")
+    if (existsSync(sourcePlugin)) return sourcePlugin
+    throw new MissingV2PluginError(sourcePlugin)
+  }
+
+  // Published and Docker CLIs use the bundle beside dist/cli.js. Do not fall
+  // back to TypeScript: production installs omit the V2 SDK dev dependency.
+  const bundledPlugin = join(dir, "meridian-v2.js")
+  if (existsSync(bundledPlugin)) return bundledPlugin
+  throw new MissingV2PluginError(bundledPlugin)
+}
+
+/** Parse the public V1 and beta V2 version formats without guessing. */
+export function classifyOpenCodeVersion(output: string): OpenCodeDetection | undefined {
+  const match = output.trim().match(/^(?:opencode2?\s+)?v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/i)
+  const version = match?.[1]
+  if (!version) return undefined
+  const major = Number(version.split(".", 1)[0])
+  return {
+    // The supported V1 line is 1.x. Treat every other well-formed version as
+    // V2 so the CLI's exact-version gate rejects unknown beta/stable hosts
+    // instead of installing the incompatible V1 plugin.
+    generation: major === 1 ? "v1" : "v2",
+    version,
+  }
+}
+
+type VersionProbe = (command: string) => string | undefined
+
+/**
+ * Detect the installed OpenCode generation with bounded probes. `opencode`
+ * remains first so an existing V1 installation keeps its current behavior;
+ * side-by-side beta users can select `opencode2` explicitly.
+ */
+export function detectOpenCodeGeneration(
+  commands: readonly string[] = process.env.OPENCODE_BIN
+    ? [process.env.OPENCODE_BIN]
+    : ["opencode", "opencode2"],
+  probe: VersionProbe = (command) => {
+    // cross-spawn resolves and safely executes npm's .cmd shims on Windows.
+    const result = spawn.sync(command, ["--version"], {
+      encoding: "utf8",
+      timeout: 3_000,
+      windowsHide: true,
+    })
+    if (result.error || result.status !== 0) return undefined
+    return String(result.stdout ?? "")
+  },
+): OpenCodeDetection {
+  for (const command of commands) {
+    const output = probe(command)
+    if (!output) continue
+    const detected = classifyOpenCodeVersion(output)
+    if (detected) return { ...detected, command }
+  }
+  return { generation: "v1" }
+}
+
+export function pluginPathForGeneration(fromUrl: string, generation: OpenCodeGeneration): string {
+  return generation === "v2" ? findV2PluginPath(fromUrl) : findPluginPath(fromUrl)
 }
 
 // ---------------------------------------------------------------------------
@@ -83,10 +188,20 @@ const STALE_PATTERNS = [
   "meridian-agent-mode",
 ]
 
-function isMeridianEntry(entry: string): boolean {
-  return STALE_PATTERNS.some(p => entry.includes(p)) ||
-    entry.includes("meridian.ts") ||
-    entry.includes("@rynfar/meridian")
+function pluginEntryPackage(entry: unknown): string | undefined {
+  if (typeof entry === "string") return entry
+  if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return undefined
+  const packageName = Reflect.get(entry, "package")
+  return typeof packageName === "string" ? packageName : undefined
+}
+
+function isMeridianEntry(entry: unknown): boolean {
+  const packageName = pluginEntryPackage(entry)
+  if (!packageName) return false
+  return STALE_PATTERNS.some(pattern => packageName.includes(pattern)) ||
+    packageName.includes("meridian.ts") ||
+    packageName.includes("meridian-v2.") ||
+    packageName.includes("@rynfar/meridian")
 }
 
 /**
@@ -94,13 +209,22 @@ function isMeridianEntry(entry: string): boolean {
  * OpenCode global config. Returns false if config doesn't exist or
  * plugin is missing.
  */
-export function checkPluginConfigured(configPath?: string): boolean {
-  const path = configPath ?? findOpencodeConfigPath()
-  if (!existsSync(path)) return false
-  const config = parseOpencodeConfig(readFileSync(path, "utf-8"))
-  if (config === null) return false
-  const plugins: unknown[] = Array.isArray(config.plugin) ? config.plugin : []
-  return plugins.some(p => typeof p === "string" && isMeridianEntry(p))
+export function checkPluginConfigured(configPath?: string, expectedPluginPath?: string): boolean {
+  const selectedPath = configPath ?? findOpencodeConfigPath()
+  const siblingPath = configPath ? undefined : siblingOpencodeConfigPath(selectedPath)
+  const paths = siblingPath ? [selectedPath, siblingPath] : [selectedPath]
+
+  return paths.some((path) => {
+    if (!existsSync(path)) return false
+    const config = parseOpencodeConfig(readFileSync(path, "utf-8"))
+    if (config === null) return false
+    const plugins: unknown[] = [
+      ...(Array.isArray(config.plugin) ? config.plugin : []),
+      ...(Array.isArray(config.plugins) ? config.plugins : []),
+    ]
+    if (expectedPluginPath) return plugins.some(entry => pluginEntryPackage(entry) === expectedPluginPath)
+    return plugins.some(isMeridianEntry)
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -190,21 +314,43 @@ export interface SetupResult {
 }
 
 /**
- * Configure the meridian plugin in ~/.config/opencode/opencode.json.
+ * Configure the Meridian plugin in ~/.config/opencode/opencode.json.
  *
- * - Creates the config file if it doesn't exist
- * - Removes stale meridian plugin entries from previous installs
+ * - Uses `plugin` for V1 and canonical `plugins` for V2
+ * - Removes Meridian entries from both fields to prevent duplicate plugin IDs
  * - Adds the current plugin path
- * - Leaves all other plugins untouched
+ * - Leaves all unrelated plugins and settings untouched
  */
-export function runSetup(pluginPath: string, configPath?: string): SetupResult {
+export function runSetup(
+  pluginPath: string,
+  configPath?: string,
+  generation: OpenCodeGeneration = "v1",
+): SetupResult {
   const path = configPath ?? findOpencodeConfigPath()
   const dir = dirname(path)
+  const targetField = generation === "v2" ? "plugins" : "plugin"
+  const otherField = generation === "v2" ? "plugin" : "plugins"
 
-  // New file — write a minimal config.
+  // Exact beta-18314 loads opencode.json and opencode.jsonc together. Refuse
+  // to create a second Meridian definition in the sibling document: updating
+  // two user-owned files cannot be made atomic, so ambiguity fails closed.
+  const siblingPath = siblingOpencodeConfigPath(path)
+  if (siblingPath && existsSync(siblingPath)) {
+    const siblingConfig = parseOpencodeConfig(readFileSync(siblingPath, "utf-8"))
+    if (siblingConfig === null) throw new UnparseableConfigError(siblingPath)
+    const siblingPlugins = [
+      ...(Array.isArray(siblingConfig.plugin) ? siblingConfig.plugin : []),
+      ...(Array.isArray(siblingConfig.plugins) ? siblingConfig.plugins : []),
+    ]
+    if (siblingPlugins.some(isMeridianEntry)) {
+      throw new DuplicateMeridianConfigError(path, siblingPath)
+    }
+  }
+
+  // New file — write a minimal config using the generation's canonical field.
   if (!existsSync(path)) {
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
-    writeFileSync(path, `${JSON.stringify({ plugin: [pluginPath] }, null, 2)}\n`, "utf-8")
+    writeFileSync(path, `${JSON.stringify({ [targetField]: [pluginPath] }, null, 2)}\n`, "utf-8")
     return { configPath: path, pluginPath, alreadyConfigured: false, removedStale: [], created: true }
   }
 
@@ -217,22 +363,41 @@ export function runSetup(pluginPath: string, configPath?: string): SetupResult {
     throw new UnparseableConfigError(path)
   }
 
-  const existing: string[] = Array.isArray(config.plugin)
-    ? (config.plugin as unknown[]).filter((p): p is string => typeof p === "string")
-    : []
+  const entries = (field: "plugin" | "plugins"): unknown[] =>
+    Array.isArray(config[field]) ? config[field] : []
+  const targetEntries = entries(targetField)
+  const otherEntries = entries(otherField)
+  const targetMeridian = targetEntries.filter(isMeridianEntry)
+  const otherMeridian = otherEntries.filter(isMeridianEntry)
+  const targetExact = targetMeridian.filter(entry => pluginEntryPackage(entry) === pluginPath)
+  const removedStale = [...targetMeridian, ...otherMeridian]
+    .flatMap(entry => {
+      const packageName = pluginEntryPackage(entry)
+      return packageName ? [packageName] : []
+    })
+  const alreadyConfigured = targetMeridian.length === 1 &&
+    targetExact.length === 1 &&
+    otherMeridian.length === 0
 
-  // Split into stale meridian entries and everything else
-  const removedStale = existing.filter(isMeridianEntry)
-  const others = existing.filter(p => !isMeridianEntry(p))
-  const alreadyConfigured = removedStale.some(p => p === pluginPath)
-  const newPlugins = [...others, pluginPath]
+  const targetPlugin = targetExact.length === 1 && targetMeridian.length === 1
+    ? targetExact[0]
+    : pluginPath
+  const targetPlugins = [
+    ...targetEntries.filter(entry => !isMeridianEntry(entry)),
+    targetPlugin,
+  ]
+  const otherPlugins = otherEntries.filter(entry => !isMeridianEntry(entry))
 
-  // Surgically rewrite ONLY the `plugin` key, preserving the rest of the file —
-  // comments, formatting, key order, and every other setting stay intact.
-  const edits = modify(text, ["plugin"], newPlugins, {
-    formattingOptions: { insertSpaces: true, tabSize: 2 },
-  })
-  writeFileSync(path, applyEdits(text, edits), "utf-8")
+  // V2 normalizes both `plugin` and canonical `plugins`. Remove Meridian from
+  // the non-target field as well so switching generations cannot load two
+  // definitions with the same plugin ID. Preserve unrelated entries in place.
+  let updated = text
+  const formattingOptions = { insertSpaces: true, tabSize: 2 }
+  updated = applyEdits(updated, modify(updated, [targetField], targetPlugins, { formattingOptions }))
+  if (Array.isArray(config[otherField]) && otherMeridian.length > 0) {
+    updated = applyEdits(updated, modify(updated, [otherField], otherPlugins, { formattingOptions }))
+  }
+  writeFileSync(path, updated, "utf-8")
 
   return { configPath: path, pluginPath, alreadyConfigured, removedStale, created: false }
 }


### PR DESCRIPTION
## Summary

- add a separate V2-native Meridian plugin for exactly `@opencode-ai/cli@0.0.0-beta-18314`
- isolate hidden title/summary work, keep compaction on the primary session key, and preserve visible/custom subagent isolation
- scope V2 model and HTTP hooks to Meridian providers and enforce trusted headers at the final request boundary
- add fail-closed V1/V2 setup detection, canonical `plugins` handling, JSONC collision protection, Windows `.cmd` probing, and complete npm/Docker/Bun-Nix packaging
- preserve OpenCode V1 behavior and move passthrough MCP definitions onto the Agent SDK Zod boundary

This incorporates and hardens #846. Aleksey Proshutinskiy remains the author of the two original commits and is explicitly credited on the hardening commit for squash-merge preservation.

## Validation

- `bun run typecheck`
- `npm test` — 3,052 passed, 0 failed
- `npm run build`
- `npm pack` install + installed `meridian setup --v2`
- Docker build + in-container V2 setup
- `bun run nix:lock`
- exact immutable `opencode2 v0.0.0-beta-18314` real-client matrix:
  - first turn and continuation
  - write/read tools
  - durable Meridian restart
  - hidden summary
  - supported undo
  - fork/original isolation
  - concurrent `general` subagents
  - supported compaction and post-compaction continuation
- OpenCode V1 `1.18.11` first turn + cached continuation regression
- `git diff --check "$(git merge-base HEAD origin/main)"..HEAD`
- read-only final production review: no blockers

The exact beta binary SHA-256 remained `a7107521efd1ee8b9d27f727efc5d8f5cfc4a8768f053cb828414b77cc2bc8be` before and after validation.
