### PR TITLE
fix(models): use configured profile auth for context window

### DIFF
--- a/src/__tests__/proxy-health-build.test.ts
+++ b/src/__tests__/proxy-health-build.test.ts
@@ -109,6 +109,10 @@ describe("/v1/models profile auth context", () => {
     const body = await response.json() as { data: Array<{ id: string; context_window: number }> }
 
     expect(response.status).toBe(200)
+    expect(authCalls).toEqual([{
+      profileId: "pro",
+      envOverrides: { CLAUDE_CONFIG_DIR: "/profiles/pro" },
+    }])
     expect(body.data.every((model) => model.context_window === 200_000)).toBe(true)
   })
 })

--- a/src/__tests__/proxy-health-build.test.ts
+++ b/src/__tests__/proxy-health-build.test.ts
@@ -19,13 +19,18 @@ import { describe, expect, it, mock, afterEach } from "bun:test"
 // crash somewhere unrelated.
 import * as realModels from "../proxy/models"
 
+const authCalls: Array<{ profileId?: string; envOverrides?: Record<string, string> }> = []
+
 mock.module("../proxy/models", () => ({
   ...realModels,
-  getClaudeAuthStatusAsync: async () => ({
-    loggedIn: true,
-    email: "test@example.com",
-    subscriptionType: "max",
-  }),
+  getClaudeAuthStatusAsync: async (profileId?: string, envOverrides?: Record<string, string>) => {
+    authCalls.push({ profileId, envOverrides })
+    return {
+      loggedIn: true,
+      email: "test@example.com",
+      subscriptionType: profileId === "pro" ? "pro" : "max",
+    }
+  },
   resolveClaudeExecutableAsync: async () => "claude",
 }))
 
@@ -57,7 +62,55 @@ const STAMPS = [
 
 afterEach(() => {
   for (const key of STAMPS) delete process.env[key]
+  authCalls.length = 0
   stopUpdateCheck()
+})
+
+describe("/v1/models profile auth context", () => {
+  it("uses the legacy auth context when no profiles are configured", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+
+    const response = await app.fetch(new Request("http://localhost/v1/models"))
+
+    expect(response.status).toBe(200)
+    expect(authCalls).toEqual([{ profileId: undefined, envOverrides: undefined }])
+  })
+
+  it("advertises 1M Opus and Fable context from the configured Max profile", async () => {
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [{ id: "work", type: "claude-max", claudeConfigDir: "/profiles/work" }],
+      defaultProfile: "work",
+    })
+
+    const response = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await response.json() as { data: Array<{ id: string; context_window: number }> }
+    const models = new Map(body.data.map((model) => [model.id, model]))
+
+    expect(response.status).toBe(200)
+    expect(authCalls).toEqual([{
+      profileId: "work",
+      envOverrides: { CLAUDE_CONFIG_DIR: "/profiles/work" },
+    }])
+    expect(models.get("claude-opus-4-6")?.context_window).toBe(1_000_000)
+    expect(models.get("claude-fable-5")?.context_window).toBe(1_000_000)
+  })
+
+  it("keeps the 200k catalog for a non-Max profile", async () => {
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [{ id: "pro", type: "claude-max", claudeConfigDir: "/profiles/pro" }],
+      defaultProfile: "pro",
+    })
+
+    const response = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await response.json() as { data: Array<{ id: string; context_window: number }> }
+
+    expect(response.status).toBe(200)
+    expect(body.data.every((model) => model.context_window === 200_000)).toBe(true)
+  })
 })
 
 describe("/health build provenance", () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -6556,7 +6556,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // comparison here used to advertise 200k to Team accounts that Meridian was
   // already routing to opus[1m] (#826).
   app.get("/v1/models", async (c) => {
-    const authStatus = await getClaudeAuthStatusAsync()
+    const profile = resolveProfile(finalConfig.profiles, finalConfig.defaultProfile)
+    const profileEnvOverrides = Object.keys(profile.env).length > 0 ? profile.env : undefined
+    const authStatus = await getClaudeAuthStatusAsync(
+      profile.id !== "default" ? profile.id : undefined,
+      profileEnvOverrides,
+    )
     const extendedContext = subscriptionIncludesExtendedContext(authStatus?.subscriptionType)
     return c.json({ object: "list", data: buildModelList(extendedContext) })
   })


### PR DESCRIPTION
## Summary

- resolve the active/configured profile before building `/v1/models`
- pass that profile's id and environment to the Claude auth probe
- preserve the legacy auth context when no profiles are configured

## Why

The model catalog derives its advertised context window from the authenticated subscription. With profiles configured, the endpoint still probed the process-global auth context, so it could advertise 200k for a routed Max profile or 1M for a profile that does not include extended context.

Using the same profile auth context as routing makes discovery reflect the account that will serve requests.

## Validation

- `bun run typecheck`
- `bun test src/__tests__/proxy-health-build.test.ts` (8 passed)
- coverage for legacy, Max 1M, and non-Max 200k contexts
- `git diff --check`
