### PR TITLE
fix: forward SSE keepalive comments in OpenAI-compat streams

### DIFF
--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -501,6 +501,50 @@ describe("POST /v1/chat/completions — streaming", () => {
     expect([...uniqueIds][0]).toMatch(/^chatcmpl-/)
   })
 
+  it("forwards internal SSE keepalive comments to the client", async () => {
+    const app = createTestApp()
+    const originalFetch = app.fetch.bind(app)
+    const internalFrames = [
+      `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "claude-sonnet-5", stop_reason: null, usage: { input_tokens: 10, output_tokens: 0 } } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+      `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}`,
+      `data: ${JSON.stringify({ type: "message_stop" })}`,
+    ]
+    app.fetch = (req, env, executionCtx) => {
+      if (req.url === "http://internal/v1/messages") {
+        return Promise.resolve(new Response(`${internalFrames.join("\n\n")}\n\n`, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }))
+      }
+      return originalFetch(req, env, executionCtx)
+    }
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    const pingLines = text.split("\n").filter(l => l === ": ping")
+    expect(pingLines).toHaveLength(2)
+
+    const contentChunks = text.split("\n")
+      .filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+      .map(l => JSON.parse(l.slice(6)) as Record<string, unknown>)
+      .map(c => {
+        const choices = c.choices as Array<Record<string, unknown>>
+        return (choices[0]!.delta as Record<string, unknown>).content
+      })
+      .filter((content): content is string => typeof content === "string" && content.length > 0)
+    expect(contentChunks.join("")).toBe("Hello")
+    expect(text).toContain("data: [DONE]")
+  })
+
   // --- tool_call_counter increment behavior ---
 
   type DeltaToolCall = {

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -151,6 +151,40 @@ describe("/v1/responses (#475)", () => {
     expect(lastCompleted).toContain("Hello from Codex")
   })
 
+  it("stream: forwards internal SSE keepalive comments to the client", async () => {
+    const app = createTestApp()
+    const originalFetch = app.fetch.bind(app)
+    const internalFrames = [
+      `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "claude-sonnet-5", stop_reason: null, usage: { input_tokens: 11, output_tokens: 0 } } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello from Codex" } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+      `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 4 } })}`,
+      `data: ${JSON.stringify({ type: "message_stop" })}`,
+    ]
+    app.fetch = (req: Request, env?: any, executionCtx?: any) => {
+      if (req.url === "http://internal/v1/messages") {
+        return Promise.resolve(new Response(`${internalFrames.join("\n\n")}\n\n`, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }))
+      }
+      return originalFetch(req, env, executionCtx)
+    }
+
+    const res = await postResponses(app, { model: "claude-sonnet-5", input: "hi", stream: true })
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    const pingLines = text.split("\n").filter((l: string) => l === ": ping")
+    expect(pingLines).toHaveLength(2)
+    expect(text).toContain("event: response.output_text.delta")
+    expect(text).toContain("event: response.completed")
+    const lastCompleted = text.split("event: response.completed")[1] || ""
+    expect(lastCompleted).toContain("Hello from Codex")
+  })
+
   it("is advertised in the root endpoint list", async () => {
     const app = createTestApp()
     const res = await app.fetch(new Request("http://localhost/", { headers: { accept: "application/json" } }))

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -6384,6 +6384,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             buffer = lines.pop() ?? ""
 
             for (const line of lines) {
+              if (line.startsWith(":")) {
+                controller.enqueue(encoder.encode(`${line}\n\n`))
+                continue
+              }
               if (!line.startsWith("data: ")) continue
               const dataStr = line.slice(6).trim()
               if (!dataStr) continue
@@ -6512,6 +6516,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const lines = buffer.split("\n")
             buffer = lines.pop() ?? ""
             for (const line of lines) {
+              if (line.startsWith(":")) {
+                controller.enqueue(encoder.encode(`${line}\n\n`))
+                continue
+              }
               if (!line.startsWith("data: ")) continue
               const dataStr = line.slice(6).trim()
               if (!dataStr) continue


### PR DESCRIPTION
## Summary

- forward SSE comment lines from the internal `/v1/messages` stream through `/v1/chat/completions`
- forward the same comments through `/v1/responses`
- cover both adapters while preserving their translated data frames and completion events

## Why

The internal messages stream emits `: ping` every 15 seconds, but both translating adapters filtered every line that did not start with `data: `. During a long thinking phase this could leave a downstream client without any bytes until content appeared, allowing a normal idle timeout to sever a live stream.

SSE comments are valid keepalive frames and are ignored by event consumers, so relaying them preserves the existing response semantics while keeping the connection active.

## Validation

- `bun run typecheck`
- `bun test src/__tests__/proxy-openai-compat.test.ts src/__tests__/proxy-responses-endpoint.test.ts` (42 passed)
- `git diff --check`
