### PR TITLE
fix(docker): initialize machine identity in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN deluser --remove-home node 2>/dev/null; \
     && mkdir -p /home/claude/.claude \
     && chown -R claude:claude /home/claude
 
+# Alpine does not provide /etc/machine-id. Durable process-owner fencing needs
+# one to distinguish lock owners safely, so create it once in the image layer.
+RUN node -e "process.stdout.write(require('node:crypto').randomBytes(16).toString('hex') + '\n')" > /etc/machine-id \
+    && grep -Eq '^[0-9a-f]{32}$' /etc/machine-id \
+    && chmod 0444 /etc/machine-id
+
 USER claude
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- initialize `/etc/machine-id` in the Alpine runtime image
- validate its 32-character hexadecimal format during the image build
- make the identifier read-only for the runtime user

## Problem

The durable process-incarnation fencing added in #879 requires a Linux
machine ID. `node:22-alpine` provides neither `/etc/machine-id` nor
`/var/lib/dbus/machine-id`, so `captureProcessIncarnation()` returns
undefined. Every `/v1/messages` request then fails with HTTP 500:

```
cannot capture lock owner process incarnation
```

The existing Docker workflow only builds the image, so it does not
exercise this request path.

## Verification

Tests were not run locally. The production failure was reproduced with
a direct request and the OPNsense real-request liveness probe. Adding a
valid machine ID to the running container restored both to HTTP 200.