### PR TITLE
fix(errors): classify exhausted usage credits

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -620,6 +620,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's 'You're out of usage credits' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You're out of usage credits. /model to switch models.")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -626,6 +626,25 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it.each([
+    ["bare banner", "You're out of usage credits"],
+    ["nested SDK wrappers", "Error: API Error: You’re out of usage credits! /model to switch models."],
+  ])("maps the canonical usage-credit %s to rate_limit_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  it.each([
+    ["incidental prose", "The MCP docs say users may be out of usage credits"],
+    ["quoted banner", "Claude Code returned an error result: The docs say ‘You're out of usage credits.’"],
+    ["negated banner", "Claude Code returned an error result: You're not out of usage credits."],
+    ["filename prefix", "Claude Code returned an error result: usage-credits.ts says You're out of usage credits."],
+    ["unfinished quotation", "Claude Code returned an error result: You're out of usage credits is a test string"],
+  ])("does not classify usage-credit %s as a rate limit", (_label, msg) => {
+    expect(classifyError(msg).type).not.toBe("rate_limit_error")
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for classifyError — pure function, no mocks needed.
  */
 import { describe, it, expect } from "bun:test"
-import { canRecoverCapturedToolUses, classifyError, extendedContextHint, classifyResumeRefusal, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
+import { canRecoverCapturedToolUses, classifyError, extendedContextHint, classifyResumeRefusal, isBusySessionError, isExtraUsageRequiredError, extractSdkTermination, formatSdkTermination, isAccountFailoverError, isQuotaRefusal, isRateLimitError } from "../proxy/errors"
 
 describe("classifyError", () => {
   describe("authentication errors", () => {
@@ -620,10 +620,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
-  it("maps the CLI's 'You're out of usage credits' to rate_limit_error", () => {
-    const r = classifyError("Claude Code returned an error result: You're out of usage credits. /model to switch models.")
+  it("maps the CLI's 'You're out of usage credits' to rate_limit_error without a same-profile retry", () => {
+    const msg = "Claude Code returned an error result: You're out of usage credits. /model to switch models."
+    const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
     expect(r.status).toBe(429)
+    expect(isRateLimitError(msg)).toBe(false)
   })
 
   it.each([
@@ -641,6 +643,8 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["negated banner", "Claude Code returned an error result: You're not out of usage credits."],
     ["filename prefix", "Claude Code returned an error result: usage-credits.ts says You're out of usage credits."],
     ["unfinished quotation", "Claude Code returned an error result: You're out of usage credits is a test string"],
+    ["punctuated documentation suffix", "Error: You're out of usage credits. This is only a documentation example, account healthy."],
+    ["punctuated MCP suffix", "Claude Code returned an error result: You're out of usage credits. (quoted by an MCP error, not account state)"],
   ])("does not classify usage-credit %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).not.toBe("rate_limit_error")
   })

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -234,7 +234,7 @@ describe("priority routing", () => {
   }, 20_000)
 
   it("does not spend or exhaust the pool for incidental usage-credit prose", async () => {
-    failureMessage = "Claude Code returned an error result: The MCP docs say users may be out of usage credits"
+    failureMessage = "Claude Code returned an error result: You're out of usage credits. This is only a documentation example, account healthy."
     failingDirs.add("prof-work")
     const app = createTestApp()
 

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -233,6 +233,23 @@ describe("priority routing", () => {
     expect(body.content[0]?.text).toContain("prof-personal")
   }, 20_000)
 
+  it("does not spend or exhaust the pool for incidental usage-credit prose", async () => {
+    failureMessage = "Claude Code returned an error result: The MCP docs say users may be out of usage credits"
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+
+    const refused = await post(app, { "x-opencode-session": "incidental-usage-credit" })
+    expect(refused.status).toBe(500)
+    expect(capturedEnvs.length).toBeGreaterThan(0)
+    expect(capturedEnvs.every(env => env.includes("prof-work"))).toBe(true)
+
+    failingDirs.clear()
+    capturedEnvs = []
+    const recovered = await post(app, { "x-opencode-session": "incidental-usage-credit" }, "try again")
+    expect(recovered.status).toBe(200)
+    expect(capturedEnvs[0]).toContain("prof-work")
+  })
+
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {
     failingDirs.add("prof-work")
     failingDirs.add("prof-personal")

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -223,6 +223,16 @@ describe("priority routing", () => {
     expect(body.content[0]?.text).toContain("prof-personal")
   }, 20_000)
 
+  it("fails over on the CLI's 'You're out of usage credits' wording", async () => {
+    failureMessage = "Claude Code returned an error result: You're out of usage credits. /model to switch models."
+    failingDirs.add("prof-work")
+    const app = createTestApp()
+    const res = await post(app)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { content: Array<{ text: string }> }
+    expect(body.content[0]?.text).toContain("prof-personal")
+  }, 20_000)
+
   it("surfaces the LAST tried profile's error when every profile is exhausted", async () => {
     failingDirs.add("prof-work")
     failingDirs.add("prof-personal")

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -114,7 +114,8 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // variants seen so far and the daily/monthly/5-hour ones that would
   // otherwise be the next report.
   if (HTTP_429.test(lower) || lower.includes("rate limit") || lower.includes("too many requests")
-    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")) {
+    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")
+    || lower.includes("out of usage credits")) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -65,7 +65,7 @@ const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
  * cannot exhaust every profile in a priority pool. */
-const OUT_OF_USAGE_CREDITS = /^(?:(?:error|api error|claude code returned an error result):\s*)*you(?:'|’)re out of usage credits(?:[.!](?:\s|$)|\s*$)/
+const OUT_OF_USAGE_CREDITS = /^\s*(?:(?:error|api error|claude code returned an error result):\s*)*you(?:'|’)re out of usage credits(?:[.!]\s*)?(?:\/model to switch models\.?)?\s*$/
 
 /** Bare HTTP codes are useful SDK signals only when they are not embedded in
  * an opaque hexadecimal identity. Managed transcript errors include random

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -62,6 +62,11 @@ const BILLING_SIGNALS: readonly RegExp[] = [
  *  can't drift into unrelated text that happens to contain "limit". */
 const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
 
+/** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
+ * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
+ * cannot exhaust every profile in a priority pool. */
+const OUT_OF_USAGE_CREDITS = /^(?:(?:error|api error|claude code returned an error result):\s*)*you(?:'|’)re out of usage credits(?:[.!](?:\s|$)|\s*$)/
+
 /** Bare HTTP codes are useful SDK signals only when they are not embedded in
  * an opaque hexadecimal identity. Managed transcript errors include random
  * UUIDs, so substring matching (for example `includes("503")`) made their HTTP
@@ -115,7 +120,7 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // otherwise be the next report.
   if (HTTP_429.test(lower) || lower.includes("rate limit") || lower.includes("too many requests")
     || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")
-    || lower.includes("out of usage credits")) {
+    || OUT_OF_USAGE_CREDITS.test(lower)) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)
       : ""


### PR DESCRIPTION
## Summary

- classify Claude Code's exact `You're out of usage credits` banner as `rate_limit_error`
- allow priority routing to fail over to the next configured profile without a same-profile retry or `[1m]` downgrade
- require the complete banner or its canonical `/model to switch models` suffix so quoted docs, MCP errors, negated text, filenames, and arbitrary trailing prose cannot exhaust the pool
- preserve WarGloom's original implementation and test commits with Nikita Bige as their Git author

## Provenance

This is the current-main, signed replacement for #835.

Cherry-picked with original authorship preserved:

- `d63ff1d8` -> `d5030d8b` — `Nikita Bige <wargloom@gmail.com>`
- `af7a728c` -> `3e1cc133` — `Nikita Bige <wargloom@gmail.com>`

The follow-up commits retain current main's hardened HTTP-code matching and add the adversarial false-positive boundary required before failover can safely use this classifier.

If this replacement merges, #835 can be closed as superseded with attribution preserved.

## Adversarial proof

- exact banner: classifier 429 and priority work -> personal failover
- same banner in pre-content streaming: failover succeeds
- punctuated documentation/MCP suffix: remains 500, tries only the current profile, and does not mark it exhausted
- incidental, quoted, negated, filename-prefixed, unfinished, suffix-injected, and newline-forged variants: not rate limits
- `isRateLimitError(exactBanner) === false`: no same-profile backoff or model downgrade
- independent final review: no blockers

## Validation

- `npm test`: **3,064 passed, 0 failed** (1 existing skip)
- changed focused tests: **157 passed, 0 failed**
- rate-limit retry suite: **7 passed, 0 failed**
- cancellation timing race: **30/30** on this head and **30/30** on the unmodified release control
- isolated prior mock-contamination cases: **40 passed, 0 failed**
- `npm run typecheck`: passed
- `npm run build`: passed
- PR-range `git diff --check`: passed
- banned-cast/directive/private-transcript audit: passed

Co-authored-by: Nikita Bige <wargloom@gmail.com>
