### PR TITLE
chore(ci): allow manual dependency checks

### DIFF
--- a/.github/workflows/bun-nix-sync.yml
+++ b/.github/workflows/bun-nix-sync.yml
@@ -1,6 +1,7 @@
 name: Sync bun.nix
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - bun.lock
@@ -14,7 +15,7 @@ on:
 
 jobs:
   verify:
-    if: github.event_name == 'pull_request'
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/check-claude-code.yml
+++ b/.github/workflows/check-claude-code.yml
@@ -1,6 +1,7 @@
 name: Check claude-code availability
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - package.json


### PR DESCRIPTION
## Summary

- allow maintainers to run the Bun/Nix lock consistency gate manually on an exact branch head
- allow maintainers to run the Claude Code package-floor gate manually on an exact branch head
- keep automatic PR path filters and main-branch synchronization unchanged
- keep manual Bun/Nix runs read-only by routing them through the existing verify job, never the write-capable sync job

## Why

Source-only security and routing changes do not touch dependency files, so these hosted gates are intentionally skipped by path filters. Manual dispatch makes exact-head release and contributor validation possible without adding unrelated dependency changes to a PR.

## Validation

- `git diff --check`
- manual Bun/Nix dispatch is gated by `github.event_name != 'push'`
- write-capable Bun/Nix sync remains gated by `github.event_name == 'push'`
