### PR TITLE
fix: preserve cached input usage in OpenAI responses

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -284,7 +284,32 @@ describe("translateAnthropicToResponses (non-stream)", () => {
     const msg = out.output.find((o: any) => o.type === "message")
     expect(msg.role).toBe("assistant")
     expect(msg.content).toEqual([{ type: "output_text", text: "Hello!", annotations: [] }])
-    expect(out.usage).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 })
+    expect(out.usage).toEqual({
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })
+  })
+
+  it("includes cache reads and writes in input usage", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "text", text: "Cached answer" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 23,
+        output_tokens: 41,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 77,
+      },
+    }, ctx)
+
+    expect(out.usage).toEqual({
+      input_tokens: 1000,
+      output_tokens: 41,
+      total_tokens: 1041,
+      input_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
   })
 
   it("maps tool_use blocks to function_call items", () => {
@@ -368,9 +393,48 @@ describe("createResponsesSseTranslator (stream)", () => {
     const completed = out.find((e) => e.event === "response.completed")!
     const resp = (completed.data as any).response
     expect(resp.status).toBe("completed")
-    expect(resp.usage).toEqual({ input_tokens: 12, output_tokens: 7, total_tokens: 19 })
+    expect(resp.usage).toEqual({
+      input_tokens: 12,
+      output_tokens: 7,
+      total_tokens: 19,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })
     const msg = resp.output.find((o: any) => o.type === "message")
     expect(msg.content[0].text).toBe("Hello")
+  })
+
+  it("preserves start usage and applies only cumulative delta fields", () => {
+    const out = run([
+      {
+        type: "message_start",
+        message: {
+          id: "m1",
+          usage: {
+            input_tokens: 23,
+            output_tokens: 0,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 77,
+          },
+        },
+      },
+      { type: "message_delta", usage: { output_tokens: 17 } },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { input_tokens: 25, output_tokens: 41, cache_read_input_tokens: 910 },
+      },
+      { type: "message_stop" },
+    ])
+    const completed = out.find((event) => event.event === "response.completed")!
+
+    expect(completed.data.response).toEqual(expect.objectContaining({
+      usage: {
+        input_tokens: 1012,
+        output_tokens: 41,
+        total_tokens: 1053,
+        input_tokens_details: { cached_tokens: 910, cache_write_tokens: 77 },
+      },
+    }))
   })
 
   it("emits function_call items with argument deltas for tool_use blocks", () => {

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -758,6 +758,30 @@ describe("translateAnthropicToOpenAi", () => {
     expect(result.usage.prompt_tokens).toBe(10)
     expect(result.usage.completion_tokens).toBe(5)
     expect(result.usage.total_tokens).toBe(15)
+    expect(result.usage.prompt_tokens_details).toEqual({ cached_tokens: 0, cache_write_tokens: 0 })
+  })
+
+  it("includes cache reads and writes in prompt usage", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [{ type: "text", text: "Cached answer" }],
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 23,
+          output_tokens: 41,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 77,
+        },
+      },
+      ID, MODEL, CREATED,
+    )
+
+    expect(result.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 41,
+      total_tokens: 1041,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
   })
 
   it("maps max_tokens stop_reason to length finish_reason", () => {
@@ -1224,14 +1248,70 @@ describe("createSseTranslator", () => {
     const chunk = translate.buildUsageChunk()
     expect(chunk).not.toBeNull()
     expect(chunk!.choices).toEqual([])
-    expect(chunk!.usage).toEqual({ prompt_tokens: 132, completion_tokens: 37, total_tokens: 169 })
+    expect(chunk!.usage).toEqual({
+      prompt_tokens: 132,
+      completion_tokens: 37,
+      total_tokens: 169,
+      prompt_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })
   })
 
-  it("buildUsageChunk uses the latest message_delta.usage if multiple arrive", () => {
+  it("buildUsageChunk uses message_start usage when message_delta omits usage", () => {
     const translate = createSseTranslator({ ...CTX, includeUsage: true })
-    translate({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { input_tokens: 100, output_tokens: 10 } })
-    translate({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 100, output_tokens: 42 } })
-    expect(translate.buildUsageChunk()!.usage).toEqual({ prompt_tokens: 100, completion_tokens: 42, total_tokens: 142 })
+    translate({
+      type: "message_start",
+      message: {
+        id: "msg_1",
+        usage: {
+          input_tokens: 23,
+          output_tokens: 3,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 77,
+        },
+      },
+    })
+    translate({ type: "message_delta", delta: { stop_reason: "end_turn" } })
+
+    expect(translate.buildUsageChunk()!.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 3,
+      total_tokens: 1003,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
+  })
+
+  it("buildUsageChunk preserves start fields and applies cumulative delta overrides", () => {
+    const translate = createSseTranslator({ ...CTX, includeUsage: true })
+    translate({
+      type: "message_start",
+      message: {
+        id: "msg_1",
+        usage: {
+          input_tokens: 23,
+          output_tokens: 0,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 77,
+        },
+      },
+    })
+    translate({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 17 } })
+    expect(translate.buildUsageChunk()!.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 17,
+      total_tokens: 1017,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
+    translate({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { input_tokens: 25, output_tokens: 41, cache_read_input_tokens: 910 },
+    })
+    expect(translate.buildUsageChunk()!.usage).toEqual({
+      prompt_tokens: 1012,
+      completion_tokens: 41,
+      total_tokens: 1053,
+      prompt_tokens_details: { cached_tokens: 910, cache_write_tokens: 77 },
+    })
   })
 })
 

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -24,6 +24,7 @@ import {
   toolUseBlockStart,
   inputJsonDelta,
   resolveMockSdkSessionId,
+  streamEvent,
 } from "./helpers"
 
 let mockMessages: unknown[] = []
@@ -476,6 +477,55 @@ describe("POST /v1/chat/completions — streaming", () => {
 
     const text = await readStream(res)
     expect(text).toContain("data: [DONE]")
+  })
+
+  it("emits complete cached usage immediately before [DONE] when requested", async () => {
+    mockMessages = [
+      streamEvent({
+        type: "message_start",
+        message: {
+          id: "msg_usage",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-5-20250929",
+          stop_reason: null,
+          usage: {
+            input_tokens: 23,
+            output_tokens: 0,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 77,
+          },
+        },
+      }),
+      textBlockStart(0),
+      textDelta(0, "cached"),
+      blockStop(0),
+      streamEvent({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 41 },
+      }),
+      messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: [{ role: "user", content: "Use the cached prompt" }],
+    })
+
+    const frames = (await readStream(res)).split("\n").filter(line => line.startsWith("data: "))
+    expect(frames.at(-1)).toBe("data: [DONE]")
+    const usageChunk = JSON.parse(frames.at(-2)!.slice(6)) as Record<string, unknown>
+    expect(usageChunk.choices).toEqual([])
+    expect(usageChunk.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 41,
+      total_tokens: 1041,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
   })
 
   it("all chunks share the same completion id", async () => {

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -134,6 +134,34 @@ export interface AnthropicRequestBody {
 export interface AnthropicUsage {
   input_tokens?: number
   output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+const ANTHROPIC_USAGE_FIELDS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+] as const
+
+/** Merge cumulative usage snapshots without erasing fields omitted by a delta. */
+export function mergeAnthropicUsage(
+  current: AnthropicUsage | undefined,
+  update: AnthropicUsage,
+): AnthropicUsage {
+  const merged = { ...current }
+  for (const field of ANTHROPIC_USAGE_FIELDS) {
+    if (typeof update[field] === "number") merged[field] = update[field]
+  }
+  return merged
+}
+
+/** Anthropic reports fresh, cache-read, and cache-written input separately. */
+export function totalAnthropicInputTokens(usage: AnthropicUsage | undefined): number {
+  return (usage?.input_tokens ?? 0)
+    + (usage?.cache_read_input_tokens ?? 0)
+    + (usage?.cache_creation_input_tokens ?? 0)
 }
 
 export interface AnthropicContentBlockText {
@@ -207,7 +235,15 @@ export interface OpenAiStreamChunk {
     }
     finish_reason: "stop" | "length" | "tool_calls" | null
   }>
-  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+  usage?: {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+    prompt_tokens_details: {
+      cached_tokens: number
+      cache_write_tokens: number
+    }
+  }
 }
 
 export interface OpenAiCompletionFunctionToolCall {
@@ -247,6 +283,10 @@ export interface OpenAiCompletion {
     prompt_tokens: number
     completion_tokens: number
     total_tokens: number
+    prompt_tokens_details: {
+      cached_tokens: number
+      cache_write_tokens: number
+    }
   }
 }
 
@@ -630,7 +670,7 @@ export function translateAnthropicToOpenAi(
         .join("")
     : ""
 
-  const promptTokens = response.usage?.input_tokens ?? 0
+  const promptTokens = totalAnthropicInputTokens(response.usage)
   const completionTokens = response.usage?.output_tokens ?? 0
 
   return {
@@ -652,6 +692,10 @@ export function translateAnthropicToOpenAi(
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
       total_tokens: promptTokens + completionTokens,
+      prompt_tokens_details: {
+        cached_tokens: response.usage?.cache_read_input_tokens ?? 0,
+        cache_write_tokens: response.usage?.cache_creation_input_tokens ?? 0,
+      },
     },
   }
 }
@@ -680,7 +724,7 @@ export interface AnthropicSseEvent {
     | { type: "text"; text?: string }
     | { type: "thinking"; thinking?: string }
     | AnthropicToolUseBlock
-  message?: { id?: string }
+  message?: { id?: string; usage?: AnthropicUsage }
   usage?: AnthropicUsage
 }
 
@@ -726,8 +770,12 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
       toolCallIndex++
     }
 
+    if (event.type === "message_start" && event.message?.usage) {
+      lastUsage = mergeAnthropicUsage(lastUsage, event.message.usage)
+    }
+
     if (event.type === "message_delta" && event.usage) {
-      lastUsage = event.usage
+      lastUsage = mergeAnthropicUsage(lastUsage, event.usage)
     }
 
     return translateAnthropicSseEvent(
@@ -742,7 +790,7 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
 
   translate.buildUsageChunk = () => {
     if (!ctx.includeUsage || !lastUsage) return null
-    const promptTokens = lastUsage.input_tokens ?? 0
+    const promptTokens = totalAnthropicInputTokens(lastUsage)
     const completionTokens = lastUsage.output_tokens ?? 0
     return {
       id: ctx.completionId,
@@ -754,6 +802,10 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
         prompt_tokens: promptTokens,
         completion_tokens: completionTokens,
         total_tokens: promptTokens + completionTokens,
+        prompt_tokens_details: {
+          cached_tokens: lastUsage.cache_read_input_tokens ?? 0,
+          cache_write_tokens: lastUsage.cache_creation_input_tokens ?? 0,
+        },
       },
     }
   }

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -23,8 +23,9 @@ import type {
   AnthropicMessage,
   AnthropicContentBlock,
   AnthropicTool,
+  AnthropicUsage,
 } from "./openai"
-import { parseDataUrlImage } from "./openai"
+import { mergeAnthropicUsage, parseDataUrlImage, totalAnthropicInputTokens } from "./openai"
 
 // ---------------------------------------------------------------------------
 // Responses request types (subset Codex actually sends)
@@ -288,13 +289,21 @@ export function reasoningRequested(body: ResponsesRequest): boolean {
 interface AnthropicResponseLike {
   content?: Array<Record<string, unknown>>
   stop_reason?: string
-  usage?: { input_tokens?: number; output_tokens?: number }
+  usage?: AnthropicUsage
 }
 
-function mapUsage(usage: { input_tokens?: number; output_tokens?: number } | undefined) {
-  const input = usage?.input_tokens ?? 0
+function mapUsage(usage: AnthropicUsage | undefined) {
+  const input = totalAnthropicInputTokens(usage)
   const output = usage?.output_tokens ?? 0
-  return { input_tokens: input, output_tokens: output, total_tokens: input + output }
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    total_tokens: input + output,
+    input_tokens_details: {
+      cached_tokens: usage?.cache_read_input_tokens ?? 0,
+      cache_write_tokens: usage?.cache_creation_input_tokens ?? 0,
+    },
+  }
 }
 
 /**
@@ -377,10 +386,10 @@ export function translateAnthropicToResponses(res: AnthropicResponseLike, ctx: R
 export interface AnthropicSseEvent {
   type: string
   index?: number
-  message?: { id?: string; usage?: { input_tokens?: number } }
+  message?: { id?: string; usage?: AnthropicUsage }
   content_block?: { type?: string; id?: string; name?: string; input?: unknown }
   delta?: { type?: string; text?: string; partial_json?: string; thinking?: string; stop_reason?: string }
-  usage?: { output_tokens?: number }
+  usage?: AnthropicUsage
 }
 
 export interface ResponsesSseEmission {
@@ -395,8 +404,7 @@ export interface ResponsesSseEmission {
 export function createResponsesSseTranslator(ctx: ResponsesCtx) {
   let seq = 0
   let outputIndex = 0
-  let inputTokens = 0
-  let outputTokens = 0
+  let usage: AnthropicUsage | undefined
   let createdEmitted = false
   let stopReason: string | undefined
 
@@ -439,7 +447,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
 
     switch (event.type) {
       case "message_start": {
-        inputTokens = event.message?.usage?.input_tokens ?? 0
+        if (event.message?.usage) usage = mergeAnthropicUsage(usage, event.message.usage)
         if (!createdEmitted) {
           createdEmitted = true
           out.push(emit("response.created", { response: responseEnvelope("in_progress", { output: [] }) }))
@@ -542,7 +550,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
       }
 
       case "message_delta": {
-        if (typeof event.usage?.output_tokens === "number") outputTokens = event.usage.output_tokens
+        if (event.usage) usage = mergeAnthropicUsage(usage, event.usage)
         if (typeof event.delta?.stop_reason === "string") stopReason = event.delta.stop_reason
         break
       }
@@ -552,7 +560,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
         out.push(emit(status === "incomplete" ? "response.incomplete" : "response.completed", {
           response: responseEnvelope(status, {
             output: finalOutput,
-            usage: { input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: inputTokens + outputTokens },
+            usage: mapUsage(usage),
             parallel_tool_calls: true,
             tool_choice: "auto",
             tools: [],


### PR DESCRIPTION
## Summary
- preserve Anthropic input and cache usage across streaming message_start/message_delta events
- report full OpenAI prompt/input totals with cached and cache-write details
- apply the same accounting to Chat Completions and Responses, streaming and non-streaming

## Tests
- npm test
- npm run typecheck
- npm run build
- git diff --check