### PR TITLE
fix: run session garbage collection on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,13 @@ jobs:
       - run: bun test src/__tests__/durable-file-system.test.ts src/__tests__/windows-durable-storage.test.ts
         shell: bash
 
+      # Session GC's fenced deletion path was a silent no-op on win32 until it
+      # was ported. The ubuntu job runs this file too, but the win32-only
+      # branches (handle-based join, taskkill tree kill, pid-reuse-proof
+      # deleting-claim recovery) only execute on a real Windows runtime.
+      - run: bun test src/__tests__/session-lifecycle-windows-gc.test.ts
+        shell: bash
+
       # Plugin loader exercises `await import(absolutePath)` which on Windows
       # rejects raw backslash paths with `Received protocol c:`. The test
       # writes a real plugin file to a tempdir and loads it, so it actually

--- a/src/__tests__/session-lifecycle-windows-gc.test.ts
+++ b/src/__tests__/session-lifecycle-windows-gc.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, readFileSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import {
+  abandonFork,
+  getTranscriptResourceKey,
+  prepareFork,
+  runGc,
+  type TranscriptLocator,
+} from "../proxy/sessionLifecycle"
+
+// Regression coverage for the Windows session-GC stall: runGc used to no-op on
+// win32 whenever no custom deleter was injected (the production configuration),
+// so retired transcripts were never deleted, the prepared/retired/deleting
+// backlog grew unbounded, and prepareFork eventually threw "session transcript
+// ownership backlog is full". These tests drive the *default* (fenced SDK
+// child) deletion path against a stub SDK and assert it drains on every
+// platform, Windows included. Do NOT add a `process.platform === "win32"` skip:
+// running here on Windows is the whole point.
+
+interface StoredResource {
+  state: string
+}
+
+interface StoredSidecar {
+  resources: Record<string, StoredResource>
+}
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+// A stand-in for @anthropic-ai/claude-agent-sdk. deleteSession records the
+// session id it was asked to delete (keyed off CLAUDE_CONFIG_DIR, which the
+// fenced child sets per locator) so the test can prove the child actually ran.
+const STUB_SDK_SOURCE = String.raw`
+import { appendFileSync, mkdirSync } from "node:fs"
+import { dirname } from "node:path"
+export async function deleteSession(sessionId, options) {
+  const log = process.env.CLAUDE_CONFIG_DIR + ".deleted.log"
+  mkdirSync(dirname(log), { recursive: true })
+  appendFileSync(log, JSON.stringify({ sessionId, dir: options?.dir ?? null }) + "\n")
+}
+`
+
+async function makeFixture(sessionId: string): Promise<{
+  root: string
+  storeDir: string
+  locator: TranscriptLocator
+  deletionLog: string
+  sdkModuleUrl: string
+}> {
+  const root = await mkdtemp(join(tmpdir(), "meridian-win-gc-"))
+  tempRoots.push(root)
+  const storeDir = join(root, "store")
+  const configDir = join(root, "config")
+  const projectDir = join(root, "project")
+  await mkdir(storeDir, { recursive: true })
+  const sdkPath = join(root, "stub-sdk.mjs")
+  await writeFile(sdkPath, STUB_SDK_SOURCE, "utf8")
+  return {
+    root,
+    storeDir,
+    locator: { sessionId, configDir, projectDir },
+    deletionLog: `${configDir}.deleted.log`,
+    sdkModuleUrl: pathToFileURL(sdkPath).href,
+  }
+}
+
+function gcOptions(fixture: Awaited<ReturnType<typeof makeFixture>>) {
+  return {
+    storeDir: fixture.storeDir,
+    preparedGraceMs: 0,
+    retiredGraceMs: 0,
+    lockWaitMs: 2_000,
+    lockRetryMs: 5,
+    sdkModuleUrl: fixture.sdkModuleUrl,
+  }
+}
+
+function readSidecar(storeDir: string): StoredSidecar {
+  return JSON.parse(readFileSync(join(storeDir, "session-gc.json"), "utf8")) as StoredSidecar
+}
+
+describe("session GC deletes retired transcripts on every platform", () => {
+  test("runGc drives a retired transcript to deleted through the default fenced child", async () => {
+    const fixture = await makeFixture("windows-gc-retired")
+    const options = gcOptions(fixture)
+    const key = getTranscriptResourceKey(fixture.locator)
+
+    const exact = await prepareFork(fixture.locator, options)
+    await abandonFork(exact, options)
+    expect(readSidecar(fixture.storeDir).resources[key]?.state).toBe("retired")
+
+    const result = await runGc([], options)
+
+    expect(result.deleted).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(readSidecar(fixture.storeDir).resources[key]?.state).toBe("deleted")
+
+    // The fenced child really imported the (stub) SDK and asked it to delete the
+    // exact session id. On the buggy win32 path this file never appeared.
+    expect(existsSync(fixture.deletionLog)).toBe(true)
+    const logged = (await readFile(fixture.deletionLog, "utf8")).trim().split("\n").map(
+      (line) => JSON.parse(line) as { sessionId: string },
+    )
+    expect(logged.map((entry) => entry.sessionId)).toContain("windows-gc-retired")
+  }, 20_000)
+
+  test("the pending backlog drains instead of filling up", async () => {
+    const fixture = await makeFixture("windows-gc-backlog")
+    const options = { ...gcOptions(fixture), maxPending: 4 }
+
+    // Fill, retire, and collect more resources than maxPending across sweeps.
+    // Before the fix this loop threw "session transcript ownership backlog is
+    // full" on win32 because runGc never reclaimed a single slot.
+    for (let index = 0; index < 10; index++) {
+      const locator: TranscriptLocator = {
+        sessionId: `backlog-${index}`,
+        configDir: join(fixture.root, `config-${index}`),
+        projectDir: join(fixture.root, `project-${index}`),
+      }
+      const exact = await prepareFork(locator, options)
+      await abandonFork(exact, options)
+      const swept = await runGc([], options)
+      expect(swept.failed).toBe(0)
+    }
+
+    const states = Object.values(readSidecar(fixture.storeDir).resources).map((r) => r.state)
+    expect(states.filter((state) => state === "retired" || state === "deleting")).toHaveLength(0)
+  }, 30_000)
+})

--- a/src/__tests__/session-lifecycle-windows-gc.test.ts
+++ b/src/__tests__/session-lifecycle-windows-gc.test.ts
@@ -8,9 +8,11 @@ import {
   abandonFork,
   getTranscriptResourceKey,
   prepareFork,
+  reconcile,
   runGc,
   type TranscriptLocator,
 } from "../proxy/sessionLifecycle"
+import { captureProcessIncarnation } from "../proxy/session/processIncarnation"
 
 // Regression coverage for the Windows session-GC stall: runGc used to no-op on
 // win32 whenever no custom deleter was injected (the production configuration),
@@ -19,10 +21,17 @@ import {
 // ownership backlog is full". These tests drive the *default* (fenced SDK
 // child) deletion path against a stub SDK and assert it drains on every
 // platform, Windows included. Do NOT add a `process.platform === "win32"` skip:
-// running here on Windows is the whole point.
+// running here on Windows is the whole point. Timeouts are generous because
+// capturing each spawned child's incarnation shells out to PowerShell/CIM on
+// Windows, which is budgeted up to 10s per probe on a cold host.
 
 interface StoredResource {
   state: string
+  deletionToken?: string
+  deletionOwner?: unknown
+  deletionExecutor?: unknown
+  deletionProcessGroupId?: number
+  lastError?: string
 }
 
 interface StoredSidecar {
@@ -40,11 +49,17 @@ afterEach(async () => {
 // fenced child sets per locator) so the test can prove the child actually ran.
 const STUB_SDK_SOURCE = String.raw`
 import { appendFileSync, mkdirSync } from "node:fs"
+import { createServer } from "node:net"
 import { dirname } from "node:path"
 export async function deleteSession(sessionId, options) {
   const log = process.env.CLAUDE_CONFIG_DIR + ".deleted.log"
   mkdirSync(dirname(log), { recursive: true })
   appendFileSync(log, JSON.stringify({ sessionId, dir: options?.dir ?? null }) + "\n")
+  if (sessionId === "windows-gc-timeout") {
+    createServer().listen(0)
+    const { promise } = Promise.withResolvers()
+    await promise
+  }
 }
 `
 
@@ -110,7 +125,25 @@ describe("session GC deletes retired transcripts on every platform", () => {
       (line) => JSON.parse(line) as { sessionId: string },
     )
     expect(logged.map((entry) => entry.sessionId)).toContain("windows-gc-retired")
-  }, 20_000)
+  }, 60_000)
+
+  test("runGc tree-kills and joins a timed-out deletion child", async () => {
+    const fixture = await makeFixture("windows-gc-timeout")
+    const options = { ...gcOptions(fixture), deletionTimeoutMs: 2_000 }
+    const key = getTranscriptResourceKey(fixture.locator)
+
+    const exact = await prepareFork(fixture.locator, options)
+    await abandonFork(exact, options)
+
+    const result = await runGc([], options)
+
+    expect(result.failed).toBe(1)
+    expect(result.deferred).toBe(1)
+    const resource = readSidecar(fixture.storeDir).resources[key]
+    expect(resource?.state).toBe("retired")
+    expect(resource?.lastError).toContain("timed out and was killed")
+    expect(existsSync(fixture.deletionLog)).toBe(true)
+  }, 60_000)
 
   test("the pending backlog drains instead of filling up", async () => {
     const fixture = await makeFixture("windows-gc-backlog")
@@ -119,7 +152,7 @@ describe("session GC deletes retired transcripts on every platform", () => {
     // Fill, retire, and collect more resources than maxPending across sweeps.
     // Before the fix this loop threw "session transcript ownership backlog is
     // full" on win32 because runGc never reclaimed a single slot.
-    for (let index = 0; index < 10; index++) {
+    for (let index = 0; index < 6; index++) {
       const locator: TranscriptLocator = {
         sessionId: `backlog-${index}`,
         configDir: join(fixture.root, `config-${index}`),
@@ -133,5 +166,46 @@ describe("session GC deletes retired transcripts on every platform", () => {
 
     const states = Object.values(readSidecar(fixture.storeDir).resources).map((r) => r.state)
     expect(states.filter((state) => state === "retired" || state === "deleting")).toHaveLength(0)
-  }, 30_000)
+  }, 120_000)
+
+  // win32 recycles pids aggressively: by the next reconcile, a crashed
+  // deletion child's pid routinely belongs to an unrelated live process
+  // (here: this very test process). Recovery must key off the reuse-proof
+  // executor incarnation (pid + OS start id) alone — probing the raw pid
+  // would misread the reused pid as a live deleter and block recovery of the
+  // claim forever. POSIX genuinely differs (the group probe waits out
+  // surviving group members), so this test is win32-only rather than a win32
+  // skip.
+  test.if(process.platform === "win32")(
+    "reconcile recovers a deleting claim whose executor pid was reused by a live process",
+    async () => {
+      const fixture = await makeFixture("windows-gc-reused-pid")
+      const options = gcOptions(fixture)
+      const key = getTranscriptResourceKey(fixture.locator)
+
+      const exact = await prepareFork(fixture.locator, options)
+      await abandonFork(exact, options)
+
+      const current = captureProcessIncarnation()
+      if (!current) throw new Error("test process incarnation unavailable")
+      // Same live pid as this process, but a boot id that can never match the
+      // local host: a provably dead incarnation on a provably live pid.
+      const reusedPidExecutor = { ...current, bootId: "00000000-0000-4000-8000-000000000000" }
+      const sidecarPath = join(fixture.storeDir, "session-gc.json")
+      const sidecar = JSON.parse(await readFile(sidecarPath, "utf8")) as StoredSidecar
+      const resource = sidecar.resources[key]
+      if (!resource) throw new Error("expected sidecar resource for fixture locator")
+      resource.state = "deleting"
+      resource.deletionToken = "reused-pid-token"
+      resource.deletionOwner = reusedPidExecutor
+      resource.deletionExecutor = reusedPidExecutor
+      resource.deletionProcessGroupId = current.pid
+      await writeFile(sidecarPath, JSON.stringify(sidecar), "utf8")
+
+      const recovered = await reconcile([], options)
+      expect(recovered.deletingRecovered).toBe(1)
+      expect(readSidecar(fixture.storeDir).resources[key]?.state).toBe("retired")
+    },
+    60_000,
+  )
 })

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -567,10 +567,19 @@ export async function reconcile(
     // physical SDK deletion without that handshake.
     for (const resource of Object.values(sidecar.resources)) {
       if (resource.state !== "deleting") continue
+      // The incarnation probe (pid + OS start id) is immune to pid reuse. On
+      // POSIX the group probe additionally waits out surviving descendants.
+      // win32 has no process groups and recycles pids aggressively: probing
+      // the stored pid there could misread an unrelated process as a live
+      // deleter forever, permanently blocking recovery of this claim, and a
+      // single-pid probe observes no descendants anyway — executor death is
+      // the entire win32 signal (the un-detached deletion child spawns none;
+      // see deleteWithSdkChild).
       const executorDead = resource.deletionExecutor
         && resource.deletionProcessGroupId !== undefined
         ? processIncarnationIsDead(resource.deletionExecutor)
-          && processGroupIsEmpty(resource.deletionProcessGroupId)
+          && (process.platform === "win32"
+            || processGroupIsEmpty(resource.deletionProcessGroupId))
         : false
       const ownerDiedBeforeHandshake = !resource.deletionExecutor
         && resource.deletionOwner !== undefined
@@ -825,12 +834,17 @@ async function awaitCustomDeleter(deletion: Promise<void>, timeoutMs: number): P
 }
 
 function processGroupIsEmpty(processGroupId: number): boolean {
+  // POSIX only: a negative pid probes the whole process group, and a stale
+  // pgid cannot be recycled until the pid space wraps. On win32 a pid is
+  // reusable the moment its last handle closes, so a pid probe can pin
+  // "still running" on an unrelated process indefinitely while observing no
+  // descendants; win32 callers must join the leader through its ChildProcess
+  // handle or the persisted executor incarnation instead.
+  if (process.platform === "win32") {
+    throw new SessionLifecycleError("process-group probes are POSIX-only")
+  }
   try {
-    // Windows has no process groups. The deletion child is spawned un-detached
-    // (see deleteWithSdkChild), so its leader pid stands in for the "group": a
-    // reaped child no longer exists, and process.kill(pid, 0) then throws ESRCH.
-    // On POSIX a negative pid probes the whole group instead.
-    process.kill(process.platform === "win32" ? processGroupId : -processGroupId, 0)
+    process.kill(-processGroupId, 0)
     return false
   } catch (error) {
     return hasCode(error, "ESRCH")
@@ -842,7 +856,10 @@ function signalProcessGroup(processGroupId: number, signal: NodeJS.Signals): voi
     // No POSIX process groups on Windows. taskkill /T force-terminates the
     // deletion child together with any descendants it may have spawned; the
     // requested POSIX signal collapses to a forced kill (both call sites pass
-    // SIGKILL). Best effort: losing a race to an already-exited child is fine.
+    // SIGKILL). Call sites only reach this while the un-reaped ChildProcess
+    // handle still pins the pid, so the kill cannot land on a reused pid.
+    // Best effort beyond that: losing a race to an already-exiting tree is
+    // fine.
     spawnSync("taskkill", ["/PID", String(processGroupId), "/T", "/F"], {
       stdio: "ignore",
       windowsHide: true,
@@ -950,6 +967,14 @@ try {
   let timer: ReturnType<typeof setTimeout> | undefined
   const joinTimeoutMs = Math.max(100, Math.min(2_000, timeoutMs))
   const processGroupId = child.pid
+  // win32 recycles a pid the instant the child is reaped, so pid-level kills
+  // are only safe while our un-reaped handle still pins it. If the leader is
+  // already gone there, so is its taskkill-visible tree.
+  const killDeletionTree = (): void => {
+    if (!processGroupId) return
+    if (process.platform === "win32" && (child.exitCode !== null || child.signalCode !== null)) return
+    signalProcessGroup(processGroupId, "SIGKILL")
+  }
   try {
     if (!processGroupId) throw new Error("session deletion child has no PID")
     const executor = captureProcessIncarnation(processGroupId)
@@ -965,13 +990,22 @@ try {
 
     const timeout = new Promise<never>((_resolve, reject) => {
       timer = setTimeout(() => {
-        signalProcessGroup(processGroupId, "SIGKILL")
+        killDeletionTree()
         reject(new Error("session deletion process group timed out and was killed"))
       }, timeoutMs)
       timer.unref?.()
     })
     const status = await Promise.race([exited, timeout])
-    joined = await waitForProcessGroupEmpty(processGroupId, joinTimeoutMs)
+    // The leader was just joined through its own ChildProcess handle, which
+    // is immune to pid reuse. On win32 the un-detached leader is the entire
+    // observable "group" (the SDK's deleteSession spawns no descendants) and
+    // its pid is already reusable, so probing it could only misread a reused
+    // pid as a still-running deleter and wedge this resource in permanent
+    // deferral; the handle join is the fence. POSIX still waits out group
+    // survivors.
+    joined = process.platform === "win32"
+      ? true
+      : await waitForProcessGroupEmpty(processGroupId, joinTimeoutMs)
     if (!joined) {
       throw new DeletionStillRunningError("session deletion process group remains active")
     }
@@ -981,10 +1015,14 @@ try {
   } finally {
     if (timer) clearTimeout(timer)
     if (!joined && processGroupId) {
-      signalProcessGroup(processGroupId, "SIGKILL")
+      killDeletionTree()
       const [leaderExited, groupEmpty] = await Promise.all([
         waitForDeletionExit(exited, joinTimeoutMs),
-        waitForProcessGroupEmpty(processGroupId, joinTimeoutMs),
+        // win32: the leader's ChildProcess handle is the only reuse-proof
+        // join signal; see the comment on the un-timed-out path above.
+        process.platform === "win32"
+          ? Promise.resolve(true)
+          : waitForProcessGroupEmpty(processGroupId, joinTimeoutMs),
       ])
       joined = leaderExited && groupEmpty
       unjoined = !joined

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto"
-import { spawn } from "node:child_process"
+import { spawn, spawnSync } from "node:child_process"
 import { realpathSync } from "node:fs"
 import {
   chmod,
@@ -123,6 +123,9 @@ export interface SessionLifecycleOptions {
   pinProvider?: () => readonly TranscriptLocator[]
   /** Bound one complete sweep, including all child deletions. */
   runTimeoutMs?: number
+  /** Test seam. Overrides the resolved @anthropic-ai/claude-agent-sdk module the
+   * deletion child imports, so the fenced-delete path can run against a stub. */
+  sdkModuleUrl?: string
 }
 
 export interface ActiveTranscriptLease {
@@ -634,14 +637,6 @@ export async function runGc(
 ): Promise<GcResult> {
   await reconcile(pins, options)
   let currentPins = pins.map(canonicalizeTranscriptLocator)
-  if (!options.deleter && process.platform === "win32") {
-    return {
-      deleted: 0,
-      notFound: 0,
-      failed: 0,
-      deferred: await countDeferred(currentPins, options),
-    }
-  }
   const limit = option(options.maxDeletesPerRun, DEFAULT_MAX_DELETES, "maxDeletesPerRun")
   const result: GcResult = { deleted: 0, notFound: 0, failed: 0, deferred: 0 }
   const runTimeoutMs = option(options.runTimeoutMs, DEFAULT_DELETE_TIMEOUT_MS, "runTimeoutMs")
@@ -830,9 +825,12 @@ async function awaitCustomDeleter(deletion: Promise<void>, timeoutMs: number): P
 }
 
 function processGroupIsEmpty(processGroupId: number): boolean {
-  if (process.platform === "win32") return false
   try {
-    process.kill(-processGroupId, 0)
+    // Windows has no process groups. The deletion child is spawned un-detached
+    // (see deleteWithSdkChild), so its leader pid stands in for the "group": a
+    // reaped child no longer exists, and process.kill(pid, 0) then throws ESRCH.
+    // On POSIX a negative pid probes the whole group instead.
+    process.kill(process.platform === "win32" ? processGroupId : -processGroupId, 0)
     return false
   } catch (error) {
     return hasCode(error, "ESRCH")
@@ -840,7 +838,17 @@ function processGroupIsEmpty(processGroupId: number): boolean {
 }
 
 function signalProcessGroup(processGroupId: number, signal: NodeJS.Signals): void {
-  if (process.platform === "win32") return
+  if (process.platform === "win32") {
+    // No POSIX process groups on Windows. taskkill /T force-terminates the
+    // deletion child together with any descendants it may have spawned; the
+    // requested POSIX signal collapses to a forced kill (both call sites pass
+    // SIGKILL). Best effort: losing a race to an already-exited child is fine.
+    spawnSync("taskkill", ["/PID", String(processGroupId), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    })
+    return
+  }
   try {
     process.kill(-processGroupId, signal)
   } catch (error) {
@@ -886,7 +894,7 @@ async function deleteWithSdkChild(
   attachExecutor: (executor: ProcessIncarnation, processGroupId: number) => Promise<void>,
   options: SessionLifecycleOptions,
 ): Promise<void> {
-  const sdkUrl = import.meta.resolve("@anthropic-ai/claude-agent-sdk")
+  const sdkUrl = options.sdkModuleUrl ?? import.meta.resolve("@anthropic-ai/claude-agent-sdk")
   const gateDirectory = join(getStoreDir(options), "deletion-gates")
   await mkdir(gateDirectory, { recursive: true, mode: 0o700 })
   const gatePath = join(gateDirectory, `${deletionToken}.go`)
@@ -946,9 +954,6 @@ try {
     if (!processGroupId) throw new Error("session deletion child has no PID")
     const executor = captureProcessIncarnation(processGroupId)
     if (!executor) throw new Error("cannot capture session deletion executor incarnation")
-    if (process.platform === "win32") {
-      throw new SessionLifecycleError("fenced session deletion is unavailable on win32")
-    }
     await attachExecutor(executor, processGroupId)
     const gateHandle = await open(gatePath, "wx", 0o600)
     try {


### PR DESCRIPTION
Fixes #895

## Problem

Session GC is a no-op on Windows because fenced deletion assumes POSIX process groups. Retired transcripts accumulate until the pending backlog fills.

## Fix

- Run fenced SDK deletion on Windows.
- Use `taskkill /PID <pid> /T /F` for timed-out deletion trees.
- Fence PID reuse during join and crash recovery.
- Add Windows regression coverage and run it in CI.

## Testing

- Session lifecycle tests pass.
- Typecheck passes.
- Build passes.

I also tested it locally on my Windows machine and it worked.