### PR TITLE
feat(openai): support structured output via response_format

### DIFF
--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -732,6 +732,68 @@ describe("translateOpenAiToAnthropic", () => {
     expect(result!.tools).toHaveLength(1)
     expect(result!.tools![0]!.description).toBe("")
   })
+
+  // --- structured output ---
+
+  const personSchema = {
+    type: "object",
+    properties: { name: { type: "string" } },
+    required: ["name"],
+  }
+
+  it("maps response_format json_schema to output_config.format", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "hi" }],
+      response_format: {
+        type: "json_schema",
+        json_schema: { name: "person", schema: personSchema, strict: true },
+      },
+    })
+    // `name` and `strict` have no Anthropic equivalent and are dropped: the
+    // SDK always validates, which is never weaker than strict asked for.
+    expect(result!.output_config).toEqual({
+      format: { type: "json_schema", schema: personSchema },
+    })
+  })
+
+  it("keeps response_format alongside output_config.effort", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "hi" }],
+      output_config: { effort: "high" },
+      response_format: { type: "json_schema", json_schema: { schema: personSchema } },
+    })
+    expect(result!.output_config).toEqual({
+      effort: "high",
+      format: { type: "json_schema", schema: personSchema },
+    })
+  })
+
+  it("passes through an Anthropic-shaped output_config.format unchanged", () => {
+    const format = { type: "json_schema", schema: personSchema }
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "hi" }],
+      output_config: { format },
+    })
+    expect(result!.output_config).toEqual({ format })
+  })
+
+  it("forwards json_object intact so the boundary can reject it", () => {
+    // Not widened into a permissive schema: Anthropic has no schema-less JSON
+    // mode, and accepting it here would promise an enforcement never applied.
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "hi" }],
+      response_format: { type: "json_object" },
+    })
+    expect(result!.output_config).toEqual({ format: { type: "json_object" } })
+  })
+
+  it("treats response_format text as no constraint", () => {
+    const result = translateOpenAiToAnthropic({
+      messages: [{ role: "user", content: "hi" }],
+      response_format: { type: "text" },
+    })
+    expect(result!.output_config).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -194,6 +194,62 @@ describe("POST /v1/chat/completions — non-streaming", () => {
     expect(capturedOptions?.effort).toBe("high")
   })
 
+  it("carries response_format json_schema through to the SDK outputFormat", async () => {
+    // Structured output is enforced by the SDK on the internal /v1/messages
+    // hop. Without this the field is dropped at the endpoint boundary and the
+    // client silently gets prose back instead of schema-valid JSON.
+    const schema = {
+      type: "object",
+      properties: { answer: { type: "string" } },
+      required: ["answer"],
+      additionalProperties: false,
+    }
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    await postChatCompletion(app, {
+      stream: false,
+      response_format: { type: "json_schema", json_schema: { name: "answer", schema } },
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(capturedOptions?.outputFormat).toEqual({ type: "json_schema", schema })
+  })
+
+  it("rejects response_format json_object instead of silently ignoring it", async () => {
+    // Anthropic has no schema-less JSON mode, so the request cannot be honored.
+    // Failing loudly beats returning prose to a client expecting JSON.
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: false,
+      response_format: { type: "json_object" },
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects response_format combined with tools", async () => {
+    // Structured-output mode replaces the response content, which would swallow
+    // a tool_use turn and strand the client's tool loop.
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: false,
+      response_format: {
+        type: "json_schema",
+        json_schema: { schema: { type: "object", properties: {} } },
+      },
+      tools: [{ type: "function", function: { name: "fn", parameters: {} } }],
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    expect(res.status).toBe(400)
+  })
+
   it("sends the client system prompt verbatim, without the claude_code preset", async () => {
     // The OpenAI endpoint serves generic chat clients (Open WebUI, curl).
     // Their system prompt must reach the SDK as a plain string — NOT wrapped

--- a/src/__tests__/structured-output-parse.test.ts
+++ b/src/__tests__/structured-output-parse.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for src/proxy/structuredOutput.ts - pure parsing/normalization.
+ * No I/O, no mocks required.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { parseOutputFormat } from "../proxy/structuredOutput"
+
+const schema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["a"],
+  properties: { a: { type: "integer" } },
+}
+
+function parseSchema(input: Record<string, unknown>) {
+  const result = parseOutputFormat({ format: { type: "json_schema", schema: input } })
+  if (!result.ok) throw new Error(`expected ok, got: ${result.message}`)
+  return result.value as { type: "json_schema"; schema: Record<string, unknown> }
+}
+
+describe("parseOutputFormat - $schema handling", () => {
+  it("strips a root-level $schema before reaching the SDK", () => {
+    // Any dialect but draft-07 makes the model fail to submit its structured
+    // result, which surfaces as a 500. The keyword constrains nothing, so it
+    // is dropped rather than passed through.
+    const value = parseSchema({
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      ...schema,
+    })
+    expect(value.schema).toEqual(schema)
+    expect("$schema" in value.schema).toBe(false)
+  })
+
+  it("strips the draft-07 $schema too, for one consistent shape", () => {
+    const value = parseSchema({ $schema: "http://json-schema.org/draft-07/schema#", ...schema })
+    expect(value.schema).toEqual(schema)
+  })
+
+  it("leaves a schema without $schema untouched", () => {
+    const value = parseSchema({ ...schema })
+    expect(value.schema).toEqual(schema)
+  })
+
+  it("does not mutate the caller's schema object", () => {
+    const input = { $schema: "https://json-schema.org/draft/2020-12/schema", ...schema }
+    parseSchema(input)
+    expect(input.$schema).toBe("https://json-schema.org/draft/2020-12/schema")
+  })
+
+  it("keeps a nested $schema, which the SDK already tolerates", () => {
+    // Only the root keyword breaks submission. Rewriting deeper would risk
+    // clobbering a property legitimately named `$schema`.
+    const nested = {
+      type: "object",
+      properties: {
+        p: { $schema: "https://json-schema.org/draft/2020-12/schema", type: "object" },
+      },
+    }
+    expect(parseSchema(nested).schema).toEqual(nested)
+  })
+})

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -67,6 +67,15 @@ export interface OpenAiChatToolCustom {
 
 export type OpenAiChatTool = OpenAiChatToolFunction | OpenAiChatToolCustom
 
+export interface OpenAiResponseFormat {
+  type: "text" | "json_object" | "json_schema"
+  json_schema?: {
+    name?: string
+    schema?: unknown
+    strict?: boolean
+  }
+}
+
 export interface OpenAiChatRequest {
   model?: string
   messages?: OpenAiMessage[]
@@ -79,7 +88,9 @@ export interface OpenAiChatRequest {
   /** Standard OpenAI reasoning level (low/medium/high/…). */
   reasoning_effort?: string
   /** Anthropic-style nesting some clients use. */
-  output_config?: { effort?: string }
+  output_config?: { effort?: string; format?: unknown }
+  /** Standard OpenAI structured output (json_schema / json_object / text). */
+  response_format?: OpenAiResponseFormat
   stream_options?: { include_usage?: boolean }
 }
 
@@ -128,7 +139,7 @@ export interface AnthropicRequestBody {
   /** Reasoning effort carried from the OpenAI request so the internal
    *  /v1/messages hop forwards it to the SDK (value gated by normalizeEffort). */
   reasoning_effort?: string
-  output_config?: { effort?: string }
+  output_config?: { effort?: string; format?: unknown }
 }
 
 export interface AnthropicUsage {
@@ -423,6 +434,24 @@ function summarizeAnthropicContent(content: string | AnthropicContentBlock[]): s
  *
  * Returns null if the request has no messages (caller should return 400).
  */
+/**
+ * Map OpenAI's `response_format` onto Anthropic's `output_config.format`.
+ *
+ * `json_object` is forwarded intact rather than widened into a permissive
+ * `{"type":"object"}` schema: Anthropic has no schema-less JSON mode, and
+ * accepting it silently would promise an enforcement the request never gets.
+ * parseOutputFormat rejects it with an actionable message.
+ */
+function translateResponseFormat(format: OpenAiResponseFormat | undefined): unknown {
+  if (format === undefined || format.type === "text") return undefined
+  // `name` is a client-side label; `strict` has no equivalent - the SDK always
+  // validates, which is never weaker than strict asked for.
+  if (format.type === "json_schema") {
+    return { type: "json_schema", schema: format.json_schema?.schema }
+  }
+  return { type: format.type }
+}
+
 export function translateOpenAiToAnthropic(
   body: OpenAiChatRequest,
   options: OpenAiTranslationOptions = {},
@@ -572,7 +601,19 @@ export function translateOpenAiToAnthropic(
   // and OpenAI clients always run at the model default. Validation happens
   // downstream via normalizeEffort.
   if (body.reasoning_effort !== undefined) result.reasoning_effort = body.reasoning_effort
-  if (body.output_config?.effort !== undefined) result.output_config = { effort: body.output_config.effort }
+
+  // Structured output. `response_format` is the standard OpenAI spelling;
+  // `output_config.format` is accepted too because some clients send the
+  // Anthropic shape at this endpoint. Both are forwarded unvalidated so the
+  // single check in parseOutputFormat rejects them at the HTTP boundary.
+  const outputFormat = translateResponseFormat(body.response_format) ?? body.output_config?.format
+  const effort = body.output_config?.effort
+  if (effort !== undefined || outputFormat !== undefined) {
+    const outputConfig: NonNullable<AnthropicRequestBody["output_config"]> = {}
+    if (effort !== undefined) outputConfig.effort = effort
+    if (outputFormat !== undefined) outputConfig.format = outputFormat
+    result.output_config = outputConfig
+  }
 
   return result
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -6312,6 +6312,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       )
     }
 
+    // Validate structured output here, while the client's own spelling is still
+    // known. The inner hop only sees the translated `output_config`, so letting
+    // it reject would name a field the OpenAI caller never sent.
+    if (rawBody.response_format !== undefined) {
+      const parsed = parseOutputFormat(anthropicBody.output_config, anthropicBody.tools, "openai")
+      if (!parsed.ok) {
+        return c.json(
+          { type: "error", error: { type: "invalid_request_error", message: parsed.message } },
+          400
+        )
+      }
+    }
+
     // Route internally via app.fetch() — no network roundtrip.
     // Hono resolves the path in-process; the URL scheme/host are ignored.
     // Forward the caller's auth headers so requireAuth on /v1/messages accepts

--- a/src/proxy/structuredOutput.ts
+++ b/src/proxy/structuredOutput.ts
@@ -17,8 +17,32 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * mode buffers the SDK's wire events and replaces the response content with the
  * validated result, so a tool_use turn would be swallowed and the client-driven
  * tool loop would never see it.
+ *
+ * `dialect` selects which spelling errors name. The OpenAI endpoint translates
+ * `response_format` into this shape before validating, so it asks for its own
+ * field paths and errors point at what the client actually sent.
  */
-export function parseOutputFormat(outputConfig: unknown, tools?: unknown): OutputFormatParseResult {
+export type OutputFormatDialect = "anthropic" | "openai"
+
+const ERROR_PATHS = {
+  anthropic: {
+    format: "output_config.format",
+    type: "output_config.format.type",
+    schema: "output_config.format.schema",
+  },
+  openai: {
+    format: "response_format",
+    type: "response_format.type",
+    schema: "response_format.json_schema.schema",
+  },
+} as const
+
+export function parseOutputFormat(
+  outputConfig: unknown,
+  tools?: unknown,
+  dialect: OutputFormatDialect = "anthropic",
+): OutputFormatParseResult {
+  const paths = ERROR_PATHS[dialect]
   if (outputConfig === undefined) return { ok: true, value: undefined }
   if (!isRecord(outputConfig)) {
     return { ok: false, message: "output_config: Expected an object" }
@@ -27,22 +51,43 @@ export function parseOutputFormat(outputConfig: unknown, tools?: unknown): Outpu
   const format = outputConfig.format
   if (format === undefined) return { ok: true, value: undefined }
   if (!isRecord(format)) {
-    return { ok: false, message: "output_config.format: Expected an object" }
+    return { ok: false, message: `${paths.format}: Expected an object` }
   }
   if (format.type !== "json_schema") {
-    return { ok: false, message: "output_config.format.type: Only 'json_schema' is supported" }
+    return { ok: false, message: `${paths.type}: Only 'json_schema' is supported` }
   }
   if (!isRecord(format.schema)) {
-    return { ok: false, message: "output_config.format.schema: Expected a JSON Schema object" }
+    return { ok: false, message: `${paths.schema}: Expected a JSON Schema object` }
   }
   if (Array.isArray(tools) && tools.length > 0) {
-    return { ok: false, message: "output_config.format: Cannot be combined with tools" }
+    return { ok: false, message: `${paths.format}: Cannot be combined with tools` }
   }
 
   return {
     ok: true,
-    value: { type: "json_schema", schema: format.schema },
+    value: { type: "json_schema", schema: stripRootSchemaKeyword(format.schema) },
   }
+}
+
+/**
+ * Drop a root-level `$schema` before handing the schema to the SDK.
+ *
+ * Anything but the draft-07 URI makes the model fail to submit its structured
+ * result: the request burns its turn budget and ends with no structured_output,
+ * surfacing as a 500. That includes the 2020-12 URI, which zod v4's
+ * `z.toJSONSchema()` emits by default - so every schema from the zod/Vercel AI
+ * SDK toolchain hits it.
+ *
+ * The keyword only declares which dialect the schema is written in and
+ * constrains nothing, so dropping it changes no validation semantics. Nested
+ * occurrences are left alone: they are already tolerated, and rewriting a
+ * caller's schema deeper than necessary risks touching a `properties` key
+ * legitimately named `$schema`.
+ */
+function stripRootSchemaKeyword(schema: Record<string, unknown>): Record<string, unknown> {
+  if (!("$schema" in schema)) return schema
+  const { $schema: _dialect, ...rest } = schema
+  return rest
 }
 
 export function structuredOutputText(value: unknown): string {


### PR DESCRIPTION
## Problem

`/v1/chat/completions` dropped `response_format` entirely. A request asking for schema-valid JSON got prose back. It did not support [structured output](https://developers.openai.com/api/docs/guides/structured-outputs?example=structured-data) well.

```bash
$ curl -s localhost:3456/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -d '{"model":"claude-sonnet-5","max_tokens":200,
         "messages":[{"role":"user","content":"Give me a person with name and age."}],
         "response_format":{"type":"json_schema","json_schema":{"name":"person","schema":{...}}}}'

{"choices":[{"message":{"content":"Here's a person for you:\n\n**Name:** Sarah Johnson\n**Age:** 32"}}]}
```

The Anthropic spelling `output_config.format` was ignored at this endpoint too. Structured output already worked correctly on native `/v1/messages`. Only the OpenAI-compatible route was missing the wiring.

## Fix

Translate `response_format` into the `output_config.format` that the internal `/v1/messages` hop already understands. Enforcement is the SDK's native structured output - schema validation and retry included, so this is plumbing into a working path rather than a second implementation. Streaming works the same way: the SDK buffers until the result validates, then emits it as one delta.

| Request | Before | After |
|---|---|---|
| `response_format: json_schema` | prose, 200 | schema-valid JSON, 200 |
| same, `stream: true` | prose | valid SSE, JSON delta |
| `response_format: json_object` | silently ignored | 400 |
| `response_format` + `tools` | silently ignored | 400 |
| `response_format: text` | 200 | 200 (unchanged) |
| native `/v1/messages` | 200 | 200 (unchanged) |

### Design decisions

**`json_object` is rejected, not approximated.** Anthropic has no schema-less JSON mode. Widening it into a permissive `{"type":"object"}` schema would promise an enforcement the request never gets, so it fails with an actionable
message instead.

**`strict` and `name` are dropped.** The SDK always validates, which is never weaker than `strict` asked for; `name` is a client-side label.

**Errors name the field the caller actually sent.** `parseOutputFormat` takes a dialect, and the OpenAI route validates before the hop - otherwise a client sending `response_format` is told about `output_config.format`, a field it never wrote. Clients using the Anthropic spelling at this endpoint still get `output_config.*` errors.

```console
$ ... "response_format":{"type":"json_object"}
{"error":{"message":"response_format.type: Only 'json_schema' is supported"}}

$ ... "output_config":{"format":{"type":"json_object"}}
{"error":{"message":"output_config.format.type: Only 'json_schema' is supported"}}
```

## Also fixed: `$schema` caused HTTP 500

A schema carrying a root-level `"$schema"` set to anything but the draft-07 URI returned:

```json
{"error":{"message":"Structured output was requested but the SDK returned no structured_output result"}}
```

The model never submitted its result.

**zod v4's `z.toJSONSchema()` emits the 2020-12 URI by default**, so every schema from the zod / Vercel AI SDK toolchain hit this. It is not a draft-version issue: 2020-12 (both spellings), 2019-09, and an arbitrary string all failed; only draft-07 or an absent key worked. **Both endpoints were affected**, since `/v1/chat/completions` forwards the schema to the same handler.

| `$schema` | Before | After |
|---|---|---|
| *(absent)* | 200 | 200 |
| `http://json-schema.org/draft-07/schema#` | 200 | 200 |
| `https://json-schema.org/draft/2020-12/schema` | **500** | 200 |
| `http://json-schema.org/draft/2020-12/schema` | **500** | 200 |
| `https://json-schema.org/draft/2019-09/schema` | **500** | 200 |
| arbitrary string | **500** | 200 |

The keyword only declares which dialect a schema is written in and constrains nothing, so it is dropped rather than translated. Only the root is touched: nested occurrences already round-trip fine. The strip lives in `parseOutputFormat`, the single funnel both endpoints pass through, so no path reaches the SDK unnormalized.

## Testing

`bun run test` - 160 tests pass across the affected files, typecheck clean.
Adds 9 tests: translation mapping, both error vocabularies, tools rejection, and `$schema` handling (root stripped, nested preserved, caller's object not mutated).

Verified end-to-end against a live proxy: nested schemas with `enum` and `integer` constraints are still fully enforced, tool-calling without `response_format` is unaffected, and native `/v1/messages` is unchanged.

## Not addressed

- **`/v1/responses`** has the same gap - it silently drops `text.format`. That is a different request shape and warrants its own change; happy to follow up.
- **Numeric bounds** (`minimum`/`maximum`) are not enforced - upstream moves them into the property description. This matches direct Anthropic behavior and is not a Meridian issue.
