### PR TITLE
fix(docker): generate /etc/machine-id so every request does not 500

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,13 @@ RUN deluser --remove-home node 2>/dev/null; \
     && mkdir -p /home/claude/.claude \
     && chown -R claude:claude /home/claude
 
+# alpine ships no /etc/machine-id. Without it linuxLocalBootIdentity() returns
+# undefined, captureProcessIncarnation() throws, and EVERY request fails with
+# 500 "cannot capture lock owner process incarnation". Generate a stable id at
+# build time so each image has its own.
+RUN head -c 16 /dev/urandom | od -An -tx1 | tr -d ' \n' > /etc/machine-id \
+    && chmod 444 /etc/machine-id
+
 USER claude
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

`node:22-alpine` ships no `/etc/machine-id`. `linuxLocalBootIdentity()` returns `undefined`, `captureProcessIncarnation()` throws, and **every** request to a container built from this Dockerfile fails:

```
500 {"type":"api_error","message":"cannot capture lock owner process incarnation"}
```

This is not intermittent — the boot identity is read per request, so nothing works. `/health` still reports `healthy`, which makes it look like an auth or upstream problem rather than a build one.

## Reproduction

On v1.65.0 (`a53e83e`):

```
docker build -t meridian-test .
docker run -d --name meridian-test -e CLAUDE_CODE_OAUTH_TOKEN=... -p 3456:3456 meridian-test
curl -s localhost:3456/health          # healthy
curl -s -X POST localhost:3456/v1/messages -H 'content-type: application/json' \
  -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
# 500 cannot capture lock owner process incarnation
```

```
docker exec meridian-test cat /etc/machine-id   # No such file or directory
```

## Fix

Generate a random machine-id at build time, in a layer before `USER claude` so the write to `/etc` succeeds. Each image gets its own stable id, which is what the boot-identity check wants.

Verified: with this layer the same image serves `/v1/messages` normally (8/8 on our stack's smoke suite). Running in production since this morning.
