### PR TITLE
fix(errors): classify org spend-limit refusals as rate limits

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -620,6 +620,18 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's 'You've hit your org's monthly spend limit' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  it("maps the CLI's 'You've hit your monthly spend limit' to rate_limit_error", () => {
+    const r = classifyError("You've hit your monthly spend limit · raise it at claude.ai/settings/usage · your session limit resets 5pm (Europe/Warsaw)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps the CLI's 'You're out of usage credits' to rate_limit_error without a same-profile retry", () => {
     const msg = "Claude Code returned an error result: You're out of usage credits. /model to switch models."
     const r = classifyError(msg)

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -62,6 +62,19 @@ const BILLING_SIGNALS: readonly RegExp[] = [
  *  can't drift into unrelated text that happens to contain "limit". */
 const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
 
+/** The multi-word spend/usage variants: "You've hit your org's monthly spend
+ *  limit · ask your admin to raise it at claude.ai/settings/usage" was observed
+ *  live and matched none of the single-word shapes above, so the profile was
+ *  never marked exhausted and priority routing never failed over — the pool
+ *  sat on a dead account while a healthy one waited behind it.
+ *
+ *  Widening HIT_YOUR_LIMIT to a multi-word wildcard is not safe: it would also
+ *  swallow "you have hit your configured tool call depth limit", which is not a
+ *  quota refusal. Anchor on the limit's *kind* instead — "spend" or "usage" —
+ *  so any number of qualifier words is allowed without matching unrelated
+ *  limits. Apostrophes are included for the possessive ("org's"). */
+const HIT_YOUR_SPEND_LIMIT = /hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/
+
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
  * cannot exhaust every profile in a priority pool. */
@@ -119,7 +132,8 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // variants seen so far and the daily/monthly/5-hour ones that would
   // otherwise be the next report.
   if (HTTP_429.test(lower) || lower.includes("rate limit") || lower.includes("too many requests")
-    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")
+    || HIT_YOUR_LIMIT.test(lower) || HIT_YOUR_SPEND_LIMIT.test(lower)
+    || lower.includes("usage limit reached")
     || OUT_OF_USAGE_CREDITS.test(lower)) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)


### PR DESCRIPTION
## Problem

When an organization caps Extra Usage, Claude Code refuses with:

```
Claude Code returned an error result: You've hit your org's monthly spend limit ·
ask your admin to raise it at claude.ai/settings/usage
```

`HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/` allows exactly one qualifier word, and `[\w-]` excludes the apostrophe — so `hit your org's monthly spend limit` matches nothing.

Consequences, in order:

1. `classifyError()` falls through to a generic `api_error`
2. `isAccountFailoverError()` returns false
3. the profile is never marked exhausted

With `MERIDIAN_ROUTING=priority` this is the bad case: `/profiles/list` reports `exhausted: []` while every request fails, and the pool keeps serving the dead account with a healthy one waiting behind it. Same class as #764 and #787 — one qualifier shape further out than the current pattern reaches.

## Why not just widen `HIT_YOUR_LIMIT`

Because `/hit your (?:[\w'-]+ ){0,4}limit/` also matches:

```
you have hit your configured tool call depth limit
```

which `errors.test.ts` already pins as a non-quota error ("does not treat unrelated 'limit' prose as a rate limit"). A wildcard qualifier can't distinguish a quota refusal from any other limit.

## Fix

Anchor on the *kind* of limit instead. `HIT_YOUR_SPEND_LIMIT` requires the word `spend` or `usage` immediately before `limit`, so an arbitrary number of qualifier words is fine without swallowing unrelated limits. Apostrophes (straight and typographic) are allowed for the possessive.

Two tests added for the live wordings: the `org's monthly spend limit` form and the shorter `monthly spend limit` one that the CLI emits when talking straight to the API.

`bun test src/__tests__/errors.test.ts` — 118 pass, 0 fail.

## Verification

Against a live refusal on a Claude Max org that had hit its cap:

before
```
exhausted: []                      # both accounts failing, pool sees nothing wrong
```

after
```
exhausted: [{ id: "max", until: <reset>, reason: "rate_limit_error" }]
profile=max(priority) → 429 → profile=pro(priority) → 200
```
