### PR TITLE
fix(docker): initialize machine identity in runtime image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,3 +55,56 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # The build-push job proves the image builds, which is exactly the gap that
+  # let #884 ship: a runtime image with no /etc/machine-id builds perfectly and
+  # then fails EVERY /v1/messages request with a 500. /health still reports
+  # healthy, so nothing downstream notices. Actually serve a request.
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: meridian:smoke
+          cache-from: type=gha
+
+      - name: Serve a request
+        run: |
+          set -euo pipefail
+          docker run -d --name smoke \
+            -e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-smoke-not-a-real-token \
+            -p 3456:3456 meridian:smoke
+
+          for _ in $(seq 1 60); do
+            curl -sf localhost:3456/health >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -sf localhost:3456/health >/dev/null
+
+          # A dummy token cannot authenticate, so 401 is the pass condition: it
+          # proves the request reached the auth layer. Any 5xx means the proxy
+          # broke before it got there — which is the failure being guarded.
+          status=$(curl -s -o /tmp/body.json -w '%{http_code}' -X POST localhost:3456/v1/messages \
+            -H 'content-type: application/json' \
+            -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}')
+
+          echo "status=$status"
+          cat /tmp/body.json
+
+          if [ "$status" -ge 500 ]; then
+            echo "::error::/v1/messages returned $status — the runtime image cannot serve requests"
+            docker logs smoke
+            exit 1
+          fi
+
+      - name: Container logs
+        if: failure()
+        run: docker logs smoke || true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,84 @@ permissions:
   packages: write
 
 jobs:
+  # Runs BEFORE build-push, which gates on it. The gap that let #884 ship was
+  # not just "CI never started the container" — it was that publication did not
+  # depend on the container working. A runtime image with no /etc/machine-id
+  # builds perfectly, fails EVERY /v1/messages with a 500, and still reports
+  # /health healthy, so nothing downstream notices.
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: meridian:smoke
+          cache-from: type=gha
+          # Publishes the amd64 layers that build-push then reuses, so gating on
+          # this job costs far less than a second full build.
+          cache-to: type=gha,mode=max
+
+      - name: Machine identity is well formed
+        run: |
+          set -euo pipefail
+          # Assert what the runtime actually asserts. linuxLocalBootIdentity()
+          # reads the WHOLE file, trim()s it, and tests /^[0-9a-fA-F]{32}$/ — so
+          # a stray banner line would pass a line-scoped `grep -q` in the build
+          # and still 500 at runtime.
+          docker run --rm meridian:smoke sh -c '
+            id=$(cat /etc/machine-id)
+            case "$id" in
+              *[!0-9a-f]* | "") echo "machine-id is not 32 lowercase hex: [$id]" >&2; exit 1 ;;
+            esac
+            [ "${#id}" -eq 32 ] || { echo "machine-id length ${#id} != 32: [$id]" >&2; exit 1; }
+          '
+
+      - name: Serve a request
+        run: |
+          set -euo pipefail
+          docker run -d --name smoke \
+            -e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-smoke-not-a-real-token \
+            -p 3456:3456 meridian:smoke
+
+          for _ in $(seq 1 60); do
+            curl -sf localhost:3456/health >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -sf localhost:3456/health >/dev/null
+
+          status=$(curl -s -o /tmp/body.json -w '%{http_code}' -X POST localhost:3456/v1/messages \
+            -H 'content-type: application/json' \
+            -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}')
+
+          echo "status=$status"
+          cat /tmp/body.json
+
+          # Pin to exactly 401. The dummy token cannot authenticate, so 401 is
+          # proof the request reached the auth layer with the image intact.
+          # Asserting merely "< 500" would let a 404 from a renamed route pass,
+          # and would also turn an upstream Anthropic incident (which
+          # classifyError maps to 502/503/504) into a red build on every PR.
+          if [ "$status" != "401" ]; then
+            echo "::error::/v1/messages returned $status, expected 401 — the runtime image cannot serve requests"
+            exit 1
+          fi
+
+      - name: Container logs
+        if: failure()
+        run: docker logs smoke || true
+
   build-push:
+    needs: smoke
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,55 +133,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # The build-push job proves the image builds, which is exactly the gap that
-  # let #884 ship: a runtime image with no /etc/machine-id builds perfectly and
-  # then fails EVERY /v1/messages request with a 500. /health still reports
-  # healthy, so nothing downstream notices. Actually serve a request.
-  smoke:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build runtime image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: meridian:smoke
-          cache-from: type=gha
-
-      - name: Serve a request
-        run: |
-          set -euo pipefail
-          docker run -d --name smoke \
-            -e CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-smoke-not-a-real-token \
-            -p 3456:3456 meridian:smoke
-
-          for _ in $(seq 1 60); do
-            curl -sf localhost:3456/health >/dev/null 2>&1 && break
-            sleep 1
-          done
-          curl -sf localhost:3456/health >/dev/null
-
-          # A dummy token cannot authenticate, so 401 is the pass condition: it
-          # proves the request reached the auth layer. Any 5xx means the proxy
-          # broke before it got there — which is the failure being guarded.
-          status=$(curl -s -o /tmp/body.json -w '%{http_code}' -X POST localhost:3456/v1/messages \
-            -H 'content-type: application/json' \
-            -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}')
-
-          echo "status=$status"
-          cat /tmp/body.json
-
-          if [ "$status" -ge 500 ]; then
-            echo "::error::/v1/messages returned $status — the runtime image cannot serve requests"
-            docker logs smoke
-            exit 1
-          fi
-
-      - name: Container logs
-        if: failure()
-        run: docker logs smoke || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN deluser --remove-home node 2>/dev/null; \
     && mkdir -p /home/claude/.claude \
     && chown -R claude:claude /home/claude
 
+# Alpine does not provide /etc/machine-id. Durable process-owner fencing needs
+# one to distinguish lock owners safely, so create it once in the image layer.
+RUN node -e "process.stdout.write(require('node:crypto').randomBytes(16).toString('hex') + '\n')" > /etc/machine-id \
+    && grep -Eq '^[0-9a-f]{32}$' /etc/machine-id \
+    && chmod 0444 /etc/machine-id
+
 USER claude
 WORKDIR /app
 


### PR DESCRIPTION
Cherry-picks @CrazyCoder's fix from #884, plus a CI commit so this class of failure cannot ship green again.

## The bug

`linuxLocalBootIdentity()` (`src/proxy/session/processIncarnation.ts:153`) requires `/etc/machine-id` or `/var/lib/dbus/machine-id` matching `^[0-9a-fA-F]{32}$`. `node:22-alpine` ships neither, so `captureProcessIncarnation()` returns `undefined` and the eight call sites that require it throw — including `sessionStore.ts:580`, which is on the `/v1/messages` path.

Every request to a container built from this Dockerfile returns:

```
500 {"type":"api_error","message":"cannot capture lock owner process incarnation"}
```

Introduced by #879 (merged 2026-08-27). `/health` still reports `healthy`, which is why it reads as an auth or upstream problem rather than a build one.

## Verified locally

Built `origin/main` and this branch, ran both:

| image | `POST /v1/messages` |
|---|---|
| `main` | `500 cannot capture lock owner process incarnation` |
| this branch | `401 authentication_error` (dummy token — the request reached the auth layer) |

`/etc/machine-id` in the fixed image: `283fb629f331ada67a1c8141f31271af`, mode `0444`.

## Why CI missed it

`docker.yml` built the image and pushed it. It never started a container. A runtime image that cannot serve a single request passed every check and shipped to `ghcr.io`.

`build-push` now **needs** `smoke`, so publication cannot happen unless the container actually served a request. Ordering matters here: an earlier revision of this PR ran the two jobs concurrently, which meant a tag push would publish `:latest` while smoke was still starting — the same outcome as no smoke test at all. `smoke` also writes the amd64 layer cache that `build-push` reuses, so gating is close to free.

The assertion is exactly `401`, not `< 500`: a renamed route returning 404 would otherwise pass, and an upstream Anthropic incident (`classifyError` maps overload/timeout to 502/503/504) would otherwise fail every PR in the repo with a message blaming the image.

Verified the gate discriminates: it fails on `main`'s image and passes on this one.

## Follow-up, not fixed here

`hostId` is `sha256("linux:" + machineId + ":" + pidNamespace)`, and the pid-namespace inode changes on every `docker restart` (measured: `pid:[4026533322]` → `pid:[4026533323]`). A lock left behind by a killed process therefore probes `indeterminate`, never `dead`, so `retireStaleLock` refuses to retire it and `acquireLock` times out. Narrow — it needs a SIGKILL mid-write — but it means the durable fencing from #879 cannot self-heal inside a container.

**A constant machine-id per image weakens the cross-host guarantee.** Every container from a given tag has a byte-identical `/etc/machine-id`, so `hostId` reduces to the pid-namespace inode. Two freshly-booted hosts can land on the same inode; if they share a session directory (`MERIDIAN_SESSION_DIR`, or a mounted `/home/claude/.cache` on NFS/RWX), host B reads host A's live lock, sees a matching `hostId` with a different `bootId`, and `evaluateProcessIncarnation` returns `dead` — permission to retire a lock whose owner is alive. With a real per-host machine-id that probe returns `indeterminate` and fails closed.

Both stem from `hostId` being neither stable nor unique inside a container, and both want the same remedy — a `MERIDIAN_HOST_ID` override in `processIncarnation.ts` that a container can pin to something stable and unique. That is a source change with its own tests, so it is not in this PR. Filing separately.

Neither is a reason to hold this: without it every containerized request fails, unconditionally, today.

## On the alternative implementation

@diwakar-s-maurya suggested `cat /proc/sys/kernel/random/uuid | tr -d '-'` on #884. That is equally correct — it is what systemd itself does, and both draw from a CSPRNG. I kept @CrazyCoder's version, but review caught that its build-time `grep -Eq '^[0-9a-f]{32}$'` is line-scoped while the runtime reads the whole file, `trim()`s it, and tests `^[0-9a-fA-F]{32}$`. A file containing a banner line plus a valid id passes the build and still 500s. The smoke job now asserts the id the way the runtime does; verified the two agree on banner / short / empty / valid inputs.

Credit to @CrazyCoder (#884) and @StanChmielewski, who independently reported and fixed the same bug in #899.

Closes #884
Closes #899
