### PR TITLE
feat: emit Retry-After and scope [1m] rate-limit benching per session

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,6 +45,7 @@ src/
 │   │   └── forgecode.ts       ← ForgeCode adapter (fingerprint sessions, XML CWD, passthrough)
 │   ├── query.ts               ← SDK query options builder (shared between stream/non-stream paths)
 │   ├── errors.ts              ← Error classification (SDK errors → HTTP responses)
+│   ├── retryAfter.ts          ← Retry-After computation for 429/503/529 (PURE)
 │   ├── models.ts              ← Model mapping, Claude executable resolution
 │   ├── buildInfo.ts           ← Build provenance: source detection, semver compare (PURE)
 │   ├── updateCheck.ts         ← Cached npm registry lookup for the newest published version
@@ -95,6 +96,7 @@ server.ts (HTTP layer)
     ├── adapters/opencode.ts ──► messages.ts, session/fingerprint.ts, tools.ts
     ├── query.ts ──► adapter.ts, mcpTools.ts, passthroughTools.ts
     ├── errors.ts
+    ├── retryAfter.ts
     ├── models.ts
     ├── tools.ts
     ├── messages.ts
@@ -117,7 +119,7 @@ server.ts (HTTP layer)
 
 2. **`session/cache.ts` owns all mutable session state.** No other module should create or manage LRU caches for sessions.
 
-3. **`errors.ts`, `models.ts`, `tools.ts`, `messages.ts`, `profiles.ts`, `profileCli.ts`, `buildInfo.ts`, `updateCheck.ts` are leaf modules.** They must not import from `server.ts`, `session/`, or `adapter.ts`. `buildInfo.ts` is additionally pure — every export is a function of its arguments plus `process.env`, so the registry I/O lives in `updateCheck.ts` instead.
+3. **`errors.ts`, `retryAfter.ts`, `models.ts`, `tools.ts`, `messages.ts`, `profiles.ts`, `profileCli.ts`, `buildInfo.ts`, `updateCheck.ts` are leaf modules.** They must not import from `server.ts`, `session/`, or `adapter.ts`. `buildInfo.ts` and `retryAfter.ts` are additionally pure — every export is a function of its arguments (plus `process.env` for `buildInfo.ts`), so the registry I/O lives in `updateCheck.ts` instead.
 
 4. **`server.ts` is the only module that imports from Hono** or touches HTTP concerns.
 
@@ -198,6 +200,30 @@ session and a replay boundary, but updated message counts and hashes are only
 stored after the upstream request succeeds. When Meridian cannot prove that an
 SDK session contains a section of client history, it starts fresh rather than
 silently skipping that section.
+
+## Throttling Contract
+
+Meridian's clients are increasingly harnesses that run many concurrent sessions
+through one account, so a refusal has to say enough for them to coordinate.
+
+**Every 429, 503, and 529 carries a wait.** `retryAfter.ts` computes the number:
+upstream's own `Retry-After` if it survived into the error, then a hint embedded
+in the upstream error text, then the account's observed window reset from
+`rateLimitStore`, then a per-status constant (60s for a rate limit, 5s for
+overload). It is clamped to at least 1 second and at most 24 hours, so no source
+can produce "retry immediately" or "retry never". Non-streaming responses carry
+it as a real `Retry-After` header; SSE turns carry it as `error.retry_after` in
+the error frame, because a stream's headers went out with `message_start` long
+before the failure existed. Under priority routing the wait names the *pool's*
+earliest opening, not the last account tried.
+
+**A `[1m]` bench is scoped to whatever actually failed.** Extra Usage exhaustion
+is an entitlement fact about the account, so it benches the whole profile. A
+plain rate limit benches only the session that hit it (`models.ts`,
+`recordExtendedContextRateLimited`). Benching the profile on a rate limit
+downgraded every concurrent sibling at once, and the model switch cold-caches
+each of them — their cached prefixes were built on the 1M model. Clients with no
+session identity still bench profile-wide; there is nothing narrower to use.
 
 ## Testing Strategy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ before investigating anything else.
 
 - **Do not add code to `server.ts` that belongs in a leaf module.** If it's pure logic (no HTTP, no Hono), extract it.
 - **`session/lineage.ts` must stay pure.** No side effects, no I/O, no imports from cache or server.
-- **Leaf modules (`errors.ts`, `models.ts`, `tools.ts`, `messages.ts`) must not import from `server.ts` or `session/`.** Dependencies flow downward only.
+- **Leaf modules (`errors.ts`, `retryAfter.ts`, `models.ts`, `tools.ts`, `messages.ts`) must not import from `server.ts` or `session/`.** Dependencies flow downward only.
 - **No circular dependencies.**
 
 ### Agent-Specific Logic
@@ -76,6 +76,7 @@ adapters/
   forgecode.ts     → ForgeCode-specific: XML CWD, patch/shell tools, passthrough
 query.ts           → buildQueryOptions (shared stream/non-stream SDK call builder)
 errors.ts          → classifyError (pure)
+retryAfter.ts      → Retry-After seconds for 429/503/529 (PURE)
 models.ts          → mapModelToClaudeModel, resolveClaudeExecutableAsync
 buildInfo.ts       → build provenance + semver compare (PURE)
 updateCheck.ts     → cached npm registry check for the newest release

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -608,3 +608,79 @@ describe("extended-context bench is per profile (#862)", () => {
     expect(isExtendedContextKnownUnavailable("personal")).toBe(false)
   })
 })
+
+describe("rate-limit bench is scoped to the session that earned it (#901)", () => {
+  afterEach(() => {
+    resetExtendedContextUnavailable()
+  })
+
+  it("leaves a concurrent sibling on [1m] when one session is rate-limited", () => {
+    // The RLM case: N children of one harness share an account. Benching the
+    // profile downgrades every sibling at once, and the model switch cold-caches
+    // each of them, because their cached prefixes were built on the 1M model.
+    recordExtendedContextRateLimited("work", Date.now() + 60_000, "child-1")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-1")).toBe("opus")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-2")).toBe("opus[1m]")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-3")).toBe("opus[1m]")
+  })
+
+  it("does not leak a session bench to the same session id on another profile", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000, "child-1")
+    expect(isExtendedContextKnownUnavailable("personal", "child-1")).toBe(false)
+  })
+
+  it("keeps a session bench invisible to the profile-wide check", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000, "child-1")
+    expect(isExtendedContextKnownUnavailable("work")).toBe(false)
+    expect(isExtendedContextKnownUnavailable("work", "child-1")).toBe(true)
+  })
+
+  it("stays profile-wide for a client with no session identity", () => {
+    // Nothing narrower exists to scope to, so the pre-#901 behavior stands.
+    recordExtendedContextRateLimited("work", Date.now() + 60_000)
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work")).toBe("opus")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-1")).toBe("opus")
+  })
+
+  it("keeps Extra Usage exhaustion profile-wide — that one really is account-scoped", () => {
+    // Entitlement is a property of the subscription. Every session on the
+    // account would fail identically, so making each prove it buys nothing.
+    recordExtendedContextUnavailable("work")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-1")).toBe("opus")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-2")).toBe("opus")
+    expect(isExtendedContextKnownUnavailable("work")).toBe(true)
+  })
+
+  it("does not bench a session when the supplied reset has already passed", () => {
+    recordExtendedContextRateLimited("work", Date.now() - 1_000, "child-1")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-1")).toBe("opus[1m]")
+  })
+
+  it("lets a later session bench extend an earlier one, never shorten it", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000, "child-1")
+    recordExtendedContextRateLimited("work", Date.now() + 1, "child-1")
+    expect(mapModelToClaudeModel("opus", "max", undefined, "work", "child-1")).toBe("opus")
+  })
+
+  it("clears session benches along with their profile on reset", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000, "child-1")
+    resetExtendedContextUnavailable("work")
+    expect(isExtendedContextKnownUnavailable("work", "child-1")).toBe(false)
+  })
+
+  it("applies the same scoping to the fable and sonnet[1m] tiers", () => {
+    recordExtendedContextRateLimited("work", Date.now() + 60_000, "child-1")
+    expect(mapModelToClaudeModel("fable", "max", undefined, "work", "child-1")).toBe("fable")
+    expect(mapModelToClaudeModel("fable", "max", undefined, "work", "child-2")).toBe("fable[1m]")
+
+    const previous = process.env.MERIDIAN_SONNET_MODEL
+    process.env.MERIDIAN_SONNET_MODEL = "sonnet[1m]"
+    try {
+      expect(mapModelToClaudeModel("sonnet", "max", undefined, "work", "child-1")).toBe("sonnet")
+      expect(mapModelToClaudeModel("sonnet", "max", undefined, "work", "child-2")).toBe("sonnet[1m]")
+    } finally {
+      if (previous === undefined) delete process.env.MERIDIAN_SONNET_MODEL
+      else process.env.MERIDIAN_SONNET_MODEL = previous
+    }
+  })
+})

--- a/src/__tests__/proxy-error-handling.test.ts
+++ b/src/__tests__/proxy-error-handling.test.ts
@@ -157,6 +157,73 @@ describe("Error classification", () => {
     expect(res.status).toBe(200)
   })
 
+  describe("Retry-After (#901)", () => {
+    it("puts a conservative hint on a 429 with no known reset", async () => {
+      // A bare 429 gives a concurrent harness nothing to coordinate against:
+      // every child backs off on its own schedule and they all wake together.
+      mockError = new Error("429 Too Many Requests - rate limit exceeded")
+      const app = createTestApp()
+      const res = await post(app, BASIC_REQUEST)
+
+      expect(res.status).toBe(429)
+      expect(res.headers.get("Retry-After")).toBe("60")
+      const body = await res.json()
+      expect(body.error.retry_after).toBe(60)
+    })
+
+    it("propagates the wait upstream named instead of guessing", async () => {
+      mockError = new Error('API Error: 429 {"type":"rate_limit_error","retry-after":17}')
+      const app = createTestApp()
+      const res = await post(app, BASIC_REQUEST)
+
+      expect(res.status).toBe(429)
+      expect(res.headers.get("Retry-After")).toBe("17")
+    })
+
+    it("puts a short hint on a 503 — overload is transient, not a spent window", async () => {
+      mockError = new Error("503 overloaded")
+      const app = createTestApp()
+      const res = await post(app, BASIC_REQUEST)
+
+      expect(res.status).toBe(503)
+      expect(res.headers.get("Retry-After")).toBe("5")
+    })
+
+    it("stays silent on failures that waiting cannot fix", async () => {
+      for (const [message, status] of [
+        ["402 billing_error - subscription expired", 402],
+        ["Request timed out after 120s", 504],
+        ["Something weird happened", 500],
+      ] as const) {
+        mockError = new Error(message)
+        const app = createTestApp()
+        const res = await post(app, BASIC_REQUEST)
+        expect(res.status).toBe(status)
+        expect(res.headers.get("Retry-After")).toBeNull()
+        const body = await res.json()
+        expect(body.error.retry_after).toBeUndefined()
+      }
+    })
+
+    it("carries the hint in the SSE error frame, where headers cannot reach", async () => {
+      // A streaming turn's response headers went out with message_start, long
+      // before the rate limit that killed it existed.
+      mockError = new Error("429 Too Many Requests - rate limit exceeded")
+      const app = createTestApp()
+      const res = await post(app, { ...BASIC_REQUEST, stream: true })
+
+      expect(res.status).toBe(200)
+      const text: string = await res.text()
+      const frame = text
+        .split("\n")
+        .find((line) => line.startsWith("data:") && line.includes("rate_limit_error"))
+      expect(frame).toBeDefined()
+      const payload = JSON.parse(frame!.slice("data:".length))
+      expect(payload.error.type).toBe("rate_limit_error")
+      expect(payload.error.retry_after).toBe(60)
+    })
+  })
+
   it("should return 400 for missing messages field", async () => {
     const app = createTestApp()
     const res = await post(app, {

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -30,8 +30,9 @@ interface LifecycleResourceSnapshot {
 
 let queryCalls: Array<{ model: string; callIndex: number; resume?: string; sessionId?: string }> = []
 let queryCallCount = 0
-/** Benches recorded when a [1m] model is stripped after a rate limit (#862). */
-let rateLimitBenches: Array<{ profileId: string | undefined; until: number }> = []
+/** Benches recorded when a [1m] model is stripped after a rate limit (#862),
+ *  with the session scope they were recorded against (#901). */
+let rateLimitBenches: Array<{ profileId: string | undefined; until: number; sessionKey?: string }> = []
 let lifecycleStateAtSpawn: Array<{ sessionId: string; state: string | undefined }> = []
 
 // Control what the mock does
@@ -54,8 +55,8 @@ mock.module("../proxy/models", () => ({
   stripExtendedContext: (model: string) => model.replace("[1m]", ""),
   isClosedControllerError: () => false,
   recordExtendedContextUnavailable: () => {},
-  recordExtendedContextRateLimited: (profileId: string | undefined, until: number) => {
-    rateLimitBenches.push({ profileId, until })
+  recordExtendedContextRateLimited: (profileId: string | undefined, until: number, sessionKey?: string) => {
+    rateLimitBenches.push({ profileId, until, sessionKey })
   },
   isExtendedContextKnownUnavailable: () => false,
   getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
@@ -380,6 +381,39 @@ describe("Extra usage required fallback", () => {
 
       expect(rateLimitBenches.length).toBe(1)
       expect(rateLimitBenches[0]!.until).toBeGreaterThan(Date.now())
+    })
+
+    it("scopes the rate-limit bench to the requesting session (#901)", async () => {
+      // A profile-wide bench downgrades every concurrent sibling of an RLM
+      // harness the instant one child is limited, and the model switch cold-
+      // caches all of them. The bench has to name the session that earned it.
+      mockBehavior = "error_assistant_then_ratelimit"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      }, { "x-opencode-session": "rlm-child-7" })
+      expect(response.status).toBe(200)
+
+      expect(rateLimitBenches.length).toBe(1)
+      expect(rateLimitBenches[0]!.sessionKey).toBe("rlm-child-7")
+    })
+
+    it("falls back to a profile-wide bench when the client has no session id (#901)", async () => {
+      mockBehavior = "error_assistant_then_ratelimit"
+      const app = createTestApp()
+
+      const response = await post(app, {
+        model: "sonnet",
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      })
+      expect(response.status).toBe(200)
+
+      expect(rateLimitBenches.length).toBe(1)
+      expect(rateLimitBenches[0]!.sessionKey).toBeUndefined()
     })
   })
 })

--- a/src/__tests__/retry-after-unit.test.ts
+++ b/src/__tests__/retry-after-unit.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for the Retry-After computation (#901) — pure functions, no mocks.
+ */
+import { describe, it, expect } from "bun:test"
+import {
+  parseRetryAfterMs,
+  extractRetryAfterSeconds,
+  retryAfterSeconds,
+  retryAfterHeaders,
+  retryAfterBodyFields,
+  OVERLOADED_RETRY_AFTER_SECONDS,
+  RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS,
+  RETRY_AFTER_MIN_SECONDS,
+  RETRY_AFTER_MAX_SECONDS,
+} from "../proxy/retryAfter"
+
+const NOW = 1_800_000_000_000
+
+describe("parseRetryAfterMs", () => {
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfterMs("120", NOW)).toBe(120_000)
+  })
+
+  it("parses an HTTP-date relative to now", () => {
+    const at = new Date(NOW + 90_000).toUTCString()
+    // toUTCString truncates to whole seconds, so allow the sub-second slack.
+    expect(parseRetryAfterMs(at, NOW)).toBeLessThanOrEqual(90_000)
+    expect(parseRetryAfterMs(at, NOW)).toBeGreaterThan(89_000)
+  })
+
+  it("never returns a negative wait for a date already past", () => {
+    const at = new Date(NOW - 60_000).toUTCString()
+    expect(parseRetryAfterMs(at, NOW)).toBe(0)
+  })
+
+  it("returns null for absent or unparseable values", () => {
+    expect(parseRetryAfterMs(null, NOW)).toBeNull()
+    expect(parseRetryAfterMs(undefined, NOW)).toBeNull()
+    expect(parseRetryAfterMs("", NOW)).toBeNull()
+    expect(parseRetryAfterMs("soon", NOW)).toBeNull()
+  })
+})
+
+describe("extractRetryAfterSeconds", () => {
+  it("reads the JSON spelling the CLI echoes", () => {
+    expect(extractRetryAfterSeconds('API Error: 429 {"error":{"type":"rate_limit_error"},"retry-after":30}')).toBe(30)
+  })
+
+  it("reads the header spelling", () => {
+    expect(extractRetryAfterSeconds("429 Too Many Requests (Retry-After: 45)")).toBe(45)
+  })
+
+  it("reads the snake_case spelling", () => {
+    expect(extractRetryAfterSeconds("rate limited, retry_after=15")).toBe(15)
+  })
+
+  it("does not invent a hint from unrelated digits", () => {
+    expect(extractRetryAfterSeconds("Claude Max rate limit reached at handler.js:402:15")).toBeNull()
+    expect(extractRetryAfterSeconds("429 rate limit exceeded")).toBeNull()
+    expect(extractRetryAfterSeconds(undefined)).toBeNull()
+  })
+})
+
+describe("retryAfterSeconds", () => {
+  it("returns null for statuses that do not take a Retry-After", () => {
+    for (const status of [200, 400, 401, 402, 404, 500, 502, 504]) {
+      expect(retryAfterSeconds({ status, now: NOW })).toBeNull()
+    }
+  })
+
+  it("covers every throttle-shaped status Meridian returns", () => {
+    for (const status of [429, 503, 529]) {
+      expect(retryAfterSeconds({ status, now: NOW })).not.toBeNull()
+    }
+  })
+
+  it("prefers the upstream header over everything else", () => {
+    expect(retryAfterSeconds({
+      status: 429,
+      upstreamRetryAfter: "42",
+      errorMessage: "retry-after: 999",
+      resetAtMs: NOW + 600_000,
+      now: NOW,
+    })).toBe(42)
+  })
+
+  it("falls back to a hint embedded in the upstream error text", () => {
+    expect(retryAfterSeconds({
+      status: 429,
+      errorMessage: 'API Error: 429 {"retry-after":30}',
+      resetAtMs: NOW + 600_000,
+      now: NOW,
+    })).toBe(30)
+  })
+
+  it("derives from a known window reset when upstream said nothing", () => {
+    expect(retryAfterSeconds({
+      status: 429,
+      errorMessage: "Claude Max rate limit reached",
+      resetAtMs: NOW + 300_000,
+      now: NOW,
+    })).toBe(300)
+  })
+
+  it("ignores a reset that has already passed", () => {
+    expect(retryAfterSeconds({ status: 429, resetAtMs: NOW - 1, now: NOW }))
+      .toBe(RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS)
+  })
+
+  it("uses the conservative default for a rate limit with no known reset", () => {
+    expect(retryAfterSeconds({ status: 429, now: NOW })).toBe(RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS)
+  })
+
+  it("uses the short constant for overload, which is transient", () => {
+    expect(retryAfterSeconds({ status: 503, now: NOW })).toBe(OVERLOADED_RETRY_AFTER_SECONDS)
+    expect(retryAfterSeconds({ status: 529, now: NOW })).toBe(OVERLOADED_RETRY_AFTER_SECONDS)
+  })
+
+  it("never emits 0 — that is the bare-429 hammering this replaces", () => {
+    expect(retryAfterSeconds({ status: 429, upstreamRetryAfter: "0", now: NOW }))
+      .toBe(RETRY_AFTER_MIN_SECONDS)
+    expect(retryAfterSeconds({ status: 429, resetAtMs: NOW + 1, now: NOW }))
+      .toBe(RETRY_AFTER_MIN_SECONDS)
+  })
+
+  it("caps a week-long reset so clients do not read it as 'never'", () => {
+    expect(retryAfterSeconds({ status: 429, resetAtMs: NOW + 7 * 24 * 3600_000, now: NOW }))
+      .toBe(RETRY_AFTER_MAX_SECONDS)
+    expect(retryAfterSeconds({ status: 429, upstreamRetryAfter: "999999", now: NOW }))
+      .toBe(RETRY_AFTER_MAX_SECONDS)
+  })
+})
+
+describe("header and body helpers", () => {
+  it("emit nothing when there is nothing to say", () => {
+    expect(retryAfterHeaders(null)).toEqual({})
+    expect(retryAfterBodyFields(null)).toEqual({})
+  })
+
+  it("emit the same number on both channels", () => {
+    expect(retryAfterHeaders(30)).toEqual({ "Retry-After": "30" })
+    expect(retryAfterBodyFields(30)).toEqual({ retry_after: 30 })
+  })
+})

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -150,7 +150,14 @@ function supports1mContext(model: string): boolean {
   return true
 }
 
-export function mapModelToClaudeModel(model: string, subscriptionType?: string | null, agentMode?: string | null, profileId?: string): ClaudeModel {
+/**
+ * `sessionKey` scopes the extended-context bench to one conversation. See
+ * `recordExtendedContextRateLimited` — a rate limit on one session must not
+ * downgrade its concurrent siblings, while an Extra Usage refusal still does
+ * (#901). Optional: clients without a session identity fall back to the
+ * profile-wide bench.
+ */
+export function mapModelToClaudeModel(model: string, subscriptionType?: string | null, agentMode?: string | null, profileId?: string, sessionKey?: string): ClaudeModel {
   if (model.includes("haiku")) return "haiku"
 
   const use1m = supports1mContext(model)
@@ -186,7 +193,7 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
     if (fableOverrideRaw && fableOverride !== "fable[1m]") {
       warnUnrecognizedTierOverride("FABLE_MODEL", fableOverrideRaw, "fable")
     }
-    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable(profileId)) return "fable[1m]"
+    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable(profileId, sessionKey)) return "fable[1m]"
     return "fable"
   }
 
@@ -209,7 +216,7 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
     if (opusOverrideRaw && opusOverride !== "opus[1m]") {
       warnUnrecognizedTierOverride("OPUS_MODEL", opusOverrideRaw, "opus")
     }
-    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable(profileId)) return "opus[1m]"
+    if (use1m && !isSubagent && !isExtendedContextKnownUnavailable(profileId, sessionKey)) return "opus[1m]"
     return "opus"
   }
 
@@ -219,7 +226,7 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
   // avoid unexpected charges. Users opt in via MERIDIAN_SONNET_MODEL=sonnet[1m].
   const sonnetOverride = process.env.MERIDIAN_SONNET_MODEL ?? process.env.CLAUDE_PROXY_SONNET_MODEL
   if (sonnetOverride === "sonnet[1m]") {
-    if (!use1m || isSubagent || isExtendedContextKnownUnavailable(profileId)) return "sonnet"
+    if (!use1m || isSubagent || isExtendedContextKnownUnavailable(profileId, sessionKey)) return "sonnet"
     return "sonnet[1m]"
   }
 
@@ -234,34 +241,94 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
 const EXTRA_USAGE_RETRY_MS = 60 * 60 * 1000 // 1 hour
 
 /**
- * Per-profile "[1m] is benched until" timestamps.
+ * "[1m] is benched until" timestamps, keyed by scope.
  *
- * Keyed by profile because both reasons to bench are account-scoped: Extra
- * Usage is a subscription setting, and a rate limit is charged against one
- * account's window. This was a single process-global timestamp, which benched
- * [1m] for EVERY profile the moment any one of them failed — so an account
- * whose plan includes the 1M window lost it for an hour because an unrelated
- * account ran out of Extra Usage (#862).
+ * Two scopes share this map, because the two reasons to bench have genuinely
+ * different blast radii:
  *
- * Requests carrying no profile share one default bucket, which leaves the
- * single-profile case behaving exactly as it did.
+ *  - **Profile scope** (`recordExtendedContextUnavailable`) — Extra Usage is a
+ *    subscription setting. When an account does not have it, no session on that
+ *    account can use [1m], so the whole profile is benched. This was once a
+ *    single process-global timestamp, which benched [1m] for EVERY profile the
+ *    moment any one of them failed — an account whose plan includes the 1M
+ *    window lost it for an hour because an unrelated account ran out of Extra
+ *    Usage (#862).
+ *
+ *  - **Session scope** (`recordExtendedContextRateLimited`) — a plain rate
+ *    limit. Benching the whole profile here is what let one child of a
+ *    concurrent harness downgrade every sibling to the 200k model at the same
+ *    instant, and the model switch cold-caches each of them: their cached
+ *    prefixes were built on the 1M model, so the "cheap" fallback costs a full
+ *    re-read of every sibling's context (#901). Each session now learns from
+ *    its own refusal. If the account's window really is spent, every session
+ *    still discovers that — one extra refused attempt each, once, instead of N
+ *    simultaneous cache misses.
+ *
+ * Requests carrying no profile share one default bucket, and requests carrying
+ * no session key fall back to profile scope, which leaves the single-session
+ * case behaving exactly as it did.
  */
 const DEFAULT_BENCH_KEY = "__default__"
+/** Bound on session-scoped entries so a long-lived proxy cannot accumulate one
+ *  per conversation forever. Entries are all self-expiring, so the sweep below
+ *  reclaims normally and the eviction is a backstop. */
+const BENCH_MAX_ENTRIES = 5000
 const extendedContextBenchedUntil = new Map<string, number>()
 
+function profileBenchKey(profileId: string | undefined): string {
+  return profileId || DEFAULT_BENCH_KEY
+}
+
+/** Session keys are namespaced under their profile so the same client session
+ *  id on two accounts cannot share a bench. The separator is NUL because a
+ *  profile id and a client session id are both arbitrary strings: any printable
+ *  delimiter is a value one of them could legitimately contain, and a collision
+ *  here would silently bench the wrong conversation. */
+function sessionBenchKey(profileId: string | undefined, sessionKey: string): string {
+  return `${profileBenchKey(profileId)}\u0000session:${sessionKey}`
+}
+
+function pruneBenchEntries(now: number): void {
+  if (extendedContextBenchedUntil.size < BENCH_MAX_ENTRIES) return
+  for (const [key, until] of extendedContextBenchedUntil) {
+    if (until <= now) extendedContextBenchedUntil.delete(key)
+  }
+  while (extendedContextBenchedUntil.size >= BENCH_MAX_ENTRIES) {
+    // Everything left is live; drop whichever frees up soonest.
+    let soonestKey: string | undefined
+    let soonest = Infinity
+    for (const [key, until] of extendedContextBenchedUntil) {
+      if (until < soonest) { soonest = until; soonestKey = key }
+    }
+    if (soonestKey === undefined) return
+    extendedContextBenchedUntil.delete(soonestKey)
+  }
+}
+
 /**
- * Bench a profile's [1m] access until `until`.
+ * Bench one scope's [1m] access until `until`.
  *
  * A later mark extends an earlier one; an earlier mark never shortens a longer
  * bench. Two concurrent failures must not un-learn the longer reset — the same
  * rule `ProfileExhaustion.mark` follows, and for the same reason.
  */
-function benchExtendedContext(profileId: string | undefined, until: number): void {
-  if (until <= Date.now()) return
-  const key = profileId || DEFAULT_BENCH_KEY
+function benchExtendedContext(key: string, until: number): void {
+  const now = Date.now()
+  if (until <= now) return
   const existing = extendedContextBenchedUntil.get(key)
   if (existing !== undefined && existing >= until) return
+  pruneBenchEntries(now)
   extendedContextBenchedUntil.set(key, until)
+}
+
+function benchActive(key: string, now: number): boolean {
+  const until = extendedContextBenchedUntil.get(key)
+  if (until === undefined) return false
+  if (until <= now) {
+    extendedContextBenchedUntil.delete(key)
+    return false
+  }
+  return true
 }
 
 /**
@@ -270,9 +337,14 @@ function benchExtendedContext(profileId: string | undefined, until: number): voi
  * directly — no failed [1m] attempt per request. After the cooldown
  * the next request probes [1m] once; if Extra Usage was enabled in the
  * meantime it succeeds and the flag is never set again.
+ *
+ * Profile-wide on purpose: entitlement is a property of the account, not of
+ * the conversation that happened to discover it. Every session on this profile
+ * would fail identically, so making each one prove that costs N failed
+ * requests and buys nothing.
  */
 export function recordExtendedContextUnavailable(profileId?: string): void {
-  benchExtendedContext(profileId, Date.now() + EXTRA_USAGE_RETRY_MS)
+  benchExtendedContext(profileBenchKey(profileId), Date.now() + EXTRA_USAGE_RETRY_MS)
 }
 
 /**
@@ -283,32 +355,47 @@ export function recordExtendedContextUnavailable(profileId?: string): void {
  * makes the next request map straight back to [1m]: the conversation then
  * flaps between two models and pays a cold prompt cache in BOTH directions,
  * which routinely costs more than the rate limit it was routing around (#862).
+ *
+ * Scoped to `sessionKey` when the client has a session identity, so a harness
+ * running N children through one account no longer downgrades — and cold-caches
+ * — every sibling because one child hit the limit (#901). Without a session
+ * key there is nothing narrower to scope to, so the bench stays profile-wide.
  */
-export function recordExtendedContextRateLimited(profileId: string | undefined, until: number): void {
-  benchExtendedContext(profileId, until)
+export function recordExtendedContextRateLimited(
+  profileId: string | undefined,
+  until: number,
+  sessionKey?: string,
+): void {
+  benchExtendedContext(
+    sessionKey ? sessionBenchKey(profileId, sessionKey) : profileBenchKey(profileId),
+    until,
+  )
 }
 
 /**
- * Returns true while this profile's [1m] access is benched. Expired marks are
- * dropped on read, so the next request probes [1m] once — and if the window
- * has genuinely reset, it simply succeeds.
+ * Returns true while [1m] is benched for this profile, or for this session on
+ * it. Expired marks are dropped on read, so the next request probes [1m] once —
+ * and if the window has genuinely reset, it simply succeeds.
  */
-export function isExtendedContextKnownUnavailable(profileId?: string): boolean {
-  const key = profileId || DEFAULT_BENCH_KEY
-  const until = extendedContextBenchedUntil.get(key)
-  if (until === undefined) return false
-  if (until <= Date.now()) {
-    extendedContextBenchedUntil.delete(key)
-    return false
-  }
-  return true
+export function isExtendedContextKnownUnavailable(profileId?: string, sessionKey?: string): boolean {
+  const now = Date.now()
+  if (benchActive(profileBenchKey(profileId), now)) return true
+  return sessionKey ? benchActive(sessionBenchKey(profileId, sessionKey), now) : false
 }
 
-/** Clear extended-context benches — for testing only. Clears every profile
- *  when no id is given. */
+/** Clear extended-context benches — for testing only. Clearing a profile also
+ *  clears every session benched under it. Clears everything when no id is
+ *  given. */
 export function resetExtendedContextUnavailable(profileId?: string): void {
-  if (profileId) extendedContextBenchedUntil.delete(profileId)
-  else extendedContextBenchedUntil.clear()
+  if (!profileId) {
+    extendedContextBenchedUntil.clear()
+    return
+  }
+  const prefix = `${profileBenchKey(profileId)}\u0000`
+  extendedContextBenchedUntil.delete(profileBenchKey(profileId))
+  for (const key of extendedContextBenchedUntil.keys()) {
+    if (key.startsWith(prefix)) extendedContextBenchedUntil.delete(key)
+  }
 }
 
 /**

--- a/src/proxy/oauthUsage.ts
+++ b/src/proxy/oauthUsage.ts
@@ -21,6 +21,7 @@
  */
 
 import { claudeLog } from "../logger"
+import { parseRetryAfterMs } from "./retryAfter"
 import { createPlatformCredentialStore, refreshOAuthToken, type CredentialStore } from "./tokenRefresh"
 
 const OAUTH_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
@@ -146,14 +147,6 @@ function normalizeUtilization(raw: number | null | undefined): number | null {
   if (typeof raw !== "number" || !Number.isFinite(raw)) return null
   // OAuth returns 0..100. Normalize to 0..1 to match SDK rate_limit_event.
   return Math.max(0, raw / 100)
-}
-
-function parseRetryAfterMs(raw: string | null): number | null {
-  if (!raw) return null
-  const seconds = Number(raw)
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
-  const retryAt = Date.parse(raw)
-  return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : null
 }
 
 function modelScopedWindowType(limit: RawOAuthLimit): string | null {

--- a/src/proxy/retryAfter.ts
+++ b/src/proxy/retryAfter.ts
@@ -1,0 +1,141 @@
+/**
+ * `Retry-After` computation for the throttle-shaped responses Meridian returns.
+ *
+ * Pure leaf module — no I/O, no state, no imports from `server.ts` or
+ * `session/`. Everything here is a function of its arguments.
+ *
+ * Why it exists: a harness that runs N concurrent children against one account
+ * has nothing to coordinate against when every 429 arrives bare. Each child
+ * backs off on its own schedule, they all wake together, and the account is
+ * re-hammered at the exact moment the window is still spent. A single number on
+ * the response is what turns N independent retry loops into one.
+ */
+
+/** Statuses that carry a `Retry-After`. 529 is Anthropic's overloaded code,
+ *  which Meridian mirrors on the cross-process turn timeout. */
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([429, 503, 529])
+
+/**
+ * Overload is a transient upstream condition measured in seconds, not a spent
+ * quota window. A long hint here would idle a client through a blip that has
+ * already cleared.
+ */
+export const OVERLOADED_RETRY_AFTER_SECONDS = 5
+
+/**
+ * Fallback for a rate limit whose reset we cannot name. Deliberately
+ * conservative: too short re-hammers a spent window, and the cost of being a
+ * little long is one idle minute on a request that was already refused.
+ */
+export const RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS = 60
+
+/** Never emit less than a second — `Retry-After: 0` is the bare-429 behavior
+ *  this module exists to replace. */
+export const RETRY_AFTER_MIN_SECONDS = 1
+
+/** A weekly cap can reset days out. Clients treat a huge `Retry-After` as
+ *  "never", so bound it and let them re-probe; the account state is in
+ *  `/v1/usage/quota` for anything that needs the real boundary. */
+export const RETRY_AFTER_MAX_SECONDS = 24 * 60 * 60
+
+/**
+ * Parse an upstream `Retry-After` header value into milliseconds.
+ *
+ * Accepts both RFC 9110 forms: delta-seconds and an HTTP-date. Returns null
+ * when the value is absent or unparseable, so callers can fall through to a
+ * computed hint rather than inventing one from `NaN`.
+ */
+export function parseRetryAfterMs(raw: string | null | undefined, now: number = Date.now()): number | null {
+  if (!raw) return null
+  const seconds = Number(raw)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+  const retryAt = Date.parse(raw)
+  return Number.isFinite(retryAt) ? Math.max(0, retryAt - now) : null
+}
+
+/**
+ * Pull a retry hint out of raw upstream error text.
+ *
+ * The `/v1/messages` path talks to the Claude CLI subprocess, which surfaces
+ * the API's error as a string rather than a response object — so when upstream
+ * *did* say how long to wait, the only place that number survives is inside the
+ * message. Matches the JSON-ish and header-ish spellings the CLI has been
+ * observed to echo (`"retry-after": 30`, `retry_after=30`, `Retry-After: 30`).
+ *
+ * Deliberately narrow: only a bare integer count of seconds directly attached
+ * to a retry-after key. Anything looser starts matching line numbers and
+ * unrelated digits, which is how a wrong hint would reach every client.
+ */
+export function extractRetryAfterSeconds(errMsg: string | null | undefined): number | null {
+  if (!errMsg) return null
+  const match = errMsg.match(/retry[-_ ]?after"?\s*[:=]\s*"?(\d+)/i)
+  if (!match?.[1]) return null
+  const seconds = Number(match[1])
+  return Number.isFinite(seconds) ? seconds : null
+}
+
+export interface RetryAfterInput {
+  /** HTTP status Meridian is about to return. */
+  status: number
+  /** Verbatim upstream `Retry-After` header value, when one was observed. */
+  upstreamRetryAfter?: string | null
+  /** Raw upstream error text, scanned for an embedded retry hint. */
+  errorMessage?: string | null
+  /** Epoch ms at which the exhausted window is known to reset. Null when
+   *  nothing proves a window is actually spent — a healthy account always has
+   *  a future five-hour boundary, and that boundary is not a wait instruction. */
+  resetAtMs?: number | null
+  now?: number
+}
+
+/**
+ * Seconds to put in `Retry-After`, or null when the status does not take one.
+ *
+ * Precedence is "most authoritative first": what upstream said, then what
+ * upstream's error text said, then the account's own observed reset, then a
+ * per-status constant. Every branch is clamped, so no source can produce a 0
+ * (retry immediately, the bug) or a multi-day value (retry never).
+ */
+export function retryAfterSeconds(input: RetryAfterInput): number | null {
+  if (!RETRYABLE_STATUSES.has(input.status)) return null
+  const now = input.now ?? Date.now()
+
+  const upstreamMs = parseRetryAfterMs(input.upstreamRetryAfter, now)
+  if (upstreamMs !== null) return clamp(Math.ceil(upstreamMs / 1000))
+
+  const embedded = extractRetryAfterSeconds(input.errorMessage)
+  if (embedded !== null) return clamp(embedded)
+
+  if (input.resetAtMs != null && input.resetAtMs > now) {
+    return clamp(Math.ceil((input.resetAtMs - now) / 1000))
+  }
+
+  return input.status === 429
+    ? RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS
+    : OVERLOADED_RETRY_AFTER_SECONDS
+}
+
+/**
+ * Header bag to spread into a `Response`. Empty when there is nothing to say,
+ * so call sites stay a single spread rather than a conditional.
+ */
+export function retryAfterHeaders(seconds: number | null): Record<string, string> {
+  return seconds === null ? {} : { "Retry-After": String(seconds) }
+}
+
+/**
+ * The same hint as a body field, for SSE.
+ *
+ * A streaming turn's headers are on the wire long before the rate limit that
+ * kills it is known, so the header cannot carry this and the error frame is the
+ * only channel left. Emitted on the JSON path too so one field name means one
+ * thing on both.
+ */
+export function retryAfterBodyFields(seconds: number | null): Record<string, number> {
+  return seconds === null ? {} : { retry_after: seconds }
+}
+
+function clamp(seconds: number): number {
+  if (!Number.isFinite(seconds)) return RATE_LIMIT_DEFAULT_RETRY_AFTER_SECONDS
+  return Math.min(RETRY_AFTER_MAX_SECONDS, Math.max(RETRY_AFTER_MIN_SECONDS, Math.round(seconds)))
+}

--- a/src/proxy/routing.ts
+++ b/src/proxy/routing.ts
@@ -316,11 +316,28 @@ export function resolveCooldownUntil(
   now: number,
   defaultMs: number,
 ): number {
+  return findCooldownReset(windows, now) ?? now + defaultMs
+}
+
+/**
+ * The capped reset of the longest genuinely exhausted window, or null when
+ * nothing here proves a window is spent.
+ *
+ * Split out of `resolveCooldownUntil` so a caller can tell "the account told us
+ * when it frees up" from "we invented a conservative default" — a distinction
+ * `resolveCooldownUntil` erases by design. `Retry-After` needs it (#901): a
+ * real reset is worth sending, a fabricated one dressed as an observation is
+ * not.
+ */
+export function findCooldownReset(
+  windows: readonly CooldownWindow[],
+  now: number,
+): number | null {
   for (const type of COOLDOWN_WINDOWS) {
     const match = windows.find(w => w.type === type && w.exhausted && (w.resetsAt ?? 0) > now)
     if (match?.resetsAt) {
       return Math.min(match.resetsAt, now + cooldownCapMs(type))
     }
   }
-  return now + defaultMs
+  return null
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -93,8 +93,16 @@ import {
   ProfileExhaustion,
   AssignmentStore,
   resolveCooldownUntil,
+  findCooldownReset,
+  type CooldownWindow,
   type PriorityAssignment,
 } from "./routing"
+import {
+  retryAfterSeconds,
+  retryAfterHeaders,
+  retryAfterBodyFields,
+  OVERLOADED_RETRY_AFTER_SECONDS,
+} from "./retryAfter"
 import { getSetting, setSetting } from "./settings"
 import { filterBetasForProfile, getBetaPolicyFromEnv } from "./betas"
 import { createFileChangeHook, extractFileChangesFromMessages, formatFileChangeSummary, type FileChange } from "./fileChanges"
@@ -774,6 +782,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       ? { type: "error", error: { type, message } }
       : { error: { type, message, code: null } }
   const DRAIN_MESSAGE = "Meridian is shutting down and is not accepting new requests. Retry against another instance."
+  /** Every transient 503/529 Meridian raises itself — drain, unavailable
+   *  durable state, a contended cross-process turn — clears in seconds rather
+   *  than at a quota boundary, so they share one short hint (#901). */
+  const TRANSIENT_RETRY_AFTER_HEADERS = retryAfterHeaders(OVERLOADED_RETRY_AFTER_SECONDS)
   // Each route answers in its own envelope. /v1/responses reports every other
   // error (both 400s below it) in the OpenAI shape, so handing it the
   // Anthropic one here would make the drain 503 the single reply on that route
@@ -781,7 +793,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   const drainingResponse = (shape: ErrorShape = "anthropic"): Response =>
     new Response(JSON.stringify(errorEnvelope(shape, "overloaded_error", DRAIN_MESSAGE)), {
       status: 503,
-      headers: { "Content-Type": "application/json", "x-meridian-draining": "1" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-meridian-draining": "1",
+        // A drain is a restart, not a spent quota. Tell the client how long to
+        // hold rather than leaving it to guess (#901).
+        ...TRANSIENT_RETRY_AFTER_HEADERS,
+      },
     })
 
   /**
@@ -810,6 +828,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const headers: Record<string, string> = { "Content-Type": "application/json" }
     const drainingHeader = internalRes.headers.get("x-meridian-draining")
     if (drainingHeader) headers["x-meridian-draining"] = drainingHeader
+    // A compat client is throttled by the same window as an Anthropic-shaped
+    // one; dropping the hint here would leave /v1/responses and
+    // /v1/chat/completions callers with nothing to back off against (#901).
+    const innerRetryAfter = internalRes.headers.get("retry-after")
+    if (innerRetryAfter) headers["Retry-After"] = innerRetryAfter
     return new Response(JSON.stringify(payload), { status: internalRes.status, headers })
   }
 
@@ -939,26 +962,38 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     return Array.isArray(setting) && setting.length > 0 ? setting : undefined
   }
 
-  /** Tier 1 + 3: this profile's own observed five_hour reset, else a
-   *  conservative default so a mis-mark self-heals. Never blocks.
+  /** This profile's usage windows, normalized for the cooldown resolvers.
    *
-   *  Gated the same way as tier 2's `refinePriorityCooldown`: a healthy
-   *  account always has a `five_hour` window with a future `resetsAt` —
-   *  that boundary exists regardless of consumption, so a scoped entry's
-   *  mere presence doesn't prove the five-hour window caused THIS failure
-   *  (it could be a seven_day cap, or a transient upstream error). Only
-   *  trust the entry's `resetsAt` when it says the window was actually
-   *  exhausted (`status === "rejected"`, or `utilization >= 1` for older
-   *  entries that predate the `status` field); otherwise fall through to
-   *  the conservative default so tier 2 isn't left refining a wrong mark
-   *  it has no way to challenge. */
-  function priorityCooldownUntil(profileId: string, now: number): number {
-    const windows = rateLimitStore.getAll(profileId).map(e => ({
+   *  `exhausted` is deliberately strict: a healthy account always has a
+   *  `five_hour` window with a future `resetsAt` — that boundary exists
+   *  regardless of consumption, so a scoped entry's mere presence doesn't
+   *  prove the five-hour window caused THIS failure (it could be a seven_day
+   *  cap, or a transient upstream error). Only an entry that says the window
+   *  was actually spent (`status === "rejected"`, or `utilization >= 1` for
+   *  older entries that predate the `status` field) may be trusted. */
+  function profileCooldownWindows(profileId: string): CooldownWindow[] {
+    return rateLimitStore.getAll(profileId).map(e => ({
       type: e.rateLimitType ?? "",
       resetsAt: e.resetsAt,
       exhausted: e.status === "rejected" || (e.utilization ?? 0) >= 1,
     }))
-    return resolveCooldownUntil(windows, now, PRIORITY_DEFAULT_COOLDOWN_MS)
+  }
+
+  /** Tier 1 + 3: this profile's own observed five_hour reset, else a
+   *  conservative default so a mis-mark self-heals. Never blocks. Falling
+   *  through to the default is what keeps tier 2 from being left refining a
+   *  wrong mark it has no way to challenge. */
+  function priorityCooldownUntil(profileId: string, now: number): number {
+    return resolveCooldownUntil(profileCooldownWindows(profileId), now, PRIORITY_DEFAULT_COOLDOWN_MS)
+  }
+
+  /** When this account's own usage windows say it frees up, or null when
+   *  nothing proves a window is spent. Feeds `Retry-After` (#901) — telling a
+   *  client to wait until a boundary that was never the problem is worse than
+   *  the conservative constant. */
+  function observedResetAtMs(profileId: string | undefined, now: number): number | null {
+    if (!profileId) return null
+    return findCooldownReset(profileCooldownWindows(profileId), now)
   }
 
   /** Tier 2: the authoritative per-account reset from Anthropic's usage
@@ -1129,7 +1164,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           return options.context.json({
             type: "error",
             error: { type: "overloaded_error", message: "Durable priority attempt state is unavailable" },
-          }, 503)
+          }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
         }
         attemptOwnerToken = claim.ownerToken
       } catch (error) {
@@ -1140,7 +1175,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         return options.context.json({
           type: "error",
           error: { type: "overloaded_error", message: "Durable priority attempt state is unavailable" },
-        }, 503)
+        }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
       }
     }
     const settleAttempt = (disposition: "release" | "block"): boolean => {
@@ -1161,12 +1196,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const unavailableAttemptResponse = (): Response => options.context.json({
       type: "error",
       error: { type: "overloaded_error", message: "Durable priority attempt state is unavailable" },
-    }, 503)
+    }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
 
     let lastError: unknown = null
     let lastStatus = 429
     let previous: string | null = null
     let previousReason = "rate_limit_error"
+    // When every candidate is spent, the honest wait is until the FIRST one
+    // frees up, not the last one tried. Tracked across the loop so the caller's
+    // Retry-After names the pool's earliest opening (#901).
+    let earliestPoolReset: number | null = null
     for (const [attempt, candidate] of options.candidateIds.entries()) {
       const exposure: PriorityAttemptExposure = { committed: false }
       const priorityPublication = options.durableRoute && options.publicationTurn
@@ -1216,6 +1255,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         ? priorityCooldownUntil(candidate, Date.now())
         : Date.now() + PRIORITY_DEFAULT_COOLDOWN_MS
       priorityExhaustion.mark(candidate, cooldownUntil, reason)
+      if (earliestPoolReset === null || cooldownUntil < earliestPoolReset) {
+        earliestPoolReset = cooldownUntil
+      }
       claudeLog("priority.exhausted", { profile: candidate, until: cooldownUntil, reason })
       if (quotaRefusal) refinePriorityCooldown(candidate)
       lastError = sniffed.errorPayload
@@ -1237,13 +1279,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     if (!settleAttempt("release")) return unavailableAttemptResponse()
     // Surface the LAST tried profile's error (owner decision). Stream sniff
     // consumed the inner body, so reconstruct the exact frame for SSE requests.
+    // The SSE frame carries its own `retry_after` field, relayed verbatim from
+    // whichever attempt produced it — headers are unavailable to a stream.
     if (options.wantsStream) {
       return new Response(`event: error\ndata: ${JSON.stringify(lastError)}\n\n`, {
         status: 200,
         headers: { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache" },
       })
     }
-    return new Response(JSON.stringify(lastError), { status: lastStatus, headers: { "content-type": "application/json" } })
+    // The wait belongs to the POOL, not to the last account tried: the caller
+    // can proceed as soon as ANY candidate frees up. `earliestPoolReset` is a
+    // real observed boundary when a quota refusal supplied one and the
+    // conservative default otherwise, so it is always safe to say (#901).
+    const poolRetryAfter = retryAfterSeconds({
+      status: lastStatus,
+      resetAtMs: earliestPoolReset,
+    })
+    return new Response(JSON.stringify(lastError), {
+      status: lastStatus,
+      headers: { "content-type": "application/json", ...retryAfterHeaders(poolRetryAfter) },
+    })
   }
 
   app.use("/auth/*", requireAuth)
@@ -1460,6 +1515,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         priorityTerminalCommitted = true
       }
 
+      // The outer catch runs outside the profile's scope but still has to
+      // answer 429/503, and a Retry-After derived from this account's own
+      // observed reset beats a constant (#901). Stays undefined when the
+      // failure fired before the profile resolved.
+      let resolvedProfileId: string | undefined
+
       try {
         const body = options.body
         const markPriorityAttemptExposure = (reason: string): void => {
@@ -1571,7 +1632,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   return c.json({
                     type: "error",
                     error: { type: "overloaded_error", message: "Durable priority routing state is unavailable" },
-                  }, 503)
+                  }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
                 }
                 if (routeResult.status === "found") {
                   durableRoute = { routeKey, expectedGeneration: routeResult.generation }
@@ -1613,7 +1674,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     return c.json({
                       type: "error",
                       error: { type: "overloaded_error", message: "Durable priority session state is unavailable" },
-                    }, 503)
+                    }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
                   }
                   routeMappingIsCurrent = mapped.status === "found"
                     && mapped.generation === routeResult.assignment.mappingGeneration
@@ -1625,7 +1686,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       return c.json({
                         type: "error",
                         error: { type: "overloaded_error", message: "Durable priority session state is unavailable" },
-                      }, 503)
+                      }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
                     }
                     durableRoute = { ...durableRoute, forceFreshReplay: true }
                   }
@@ -1635,7 +1696,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   return c.json({
                     type: "error",
                     error: { type: "overloaded_error", message: "Durable priority attempt state is unavailable" },
-                  }, 503)
+                  }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
                 } else if (trustedTurn) {
                   durableRoute = { routeKey, expectedGeneration: routeResult.generation }
                   publicationTurn = trustedTurn
@@ -1672,7 +1733,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 return c.json({
                   type: "error",
                   error: { type: "overloaded_error", message: "Durable priority routing state is unavailable" },
-                }, 503)
+                }, 503, TRANSIENT_RETRY_AFTER_HEADERS)
               }
               const pick = choosePriorityProfile(order, id => priorityExhaustion.isExhausted(id))
               const first = retainOnlyProfile
@@ -1712,6 +1773,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             ? { routingMode, stickySessionKey: adapter.getSessionId(c, body) }
             : undefined
         )
+        resolvedProfileId = profile.id
 
         const authStatus = await getClaudeAuthStatusAsync(
           profile.id !== "default" ? profile.id : undefined,
@@ -1735,7 +1797,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           declaredAgentMode === "subagent" || requestSource?.startsWith("subagent-") === true
         const agentMode = isSubagentRequest ? "subagent" : declaredAgentMode
         const requestedModel = typeof body.model === "string" ? body.model : "sonnet"
-        let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode, profile.id)
+        // A rate-limit bench on [1m] is scoped to the session that earned it
+        // (#901), so model mapping needs the conversation identity. Resolved
+        // here rather than reusing `agentSessionId` below because that one is
+        // read after the transform pipeline: recording and reading a bench must
+        // agree, and this is the value both sides see. Undefined for clients
+        // with no session identity — those fall back to the profile-wide bench,
+        // exactly as before.
+        const benchSessionKey = adapter.getSessionId(c, body) || undefined
+        let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode, profile.id, benchSessionKey)
         // Explicitly versioned ids override their tier's canonical pin for
         // this request (spread last in query.ts env, so they also beat
         // operator env) — a proxy must never substitute models. Bare aliases
@@ -3339,11 +3409,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     if (hasExtendedContext(model)) {
                       const from = model
                       model = stripExtendedContext(model)
-                      // Bench [1m] for this profile until its window resets. Without
-                      // this the next request maps straight back to [1m], so one rate
-                      // limit costs TWO model switches and a cold prompt cache in both
-                      // directions — routinely more than the rate limit itself (#862).
-                      recordExtendedContextRateLimited(profile.id, priorityCooldownUntil(profile.id, Date.now()))
+                      // Bench [1m] until the window resets. Without this the next
+                      // request maps straight back to [1m], so one rate limit costs
+                      // TWO model switches and a cold prompt cache in both directions
+                      // — routinely more than the rate limit itself (#862).
+                      //
+                      // Benched for THIS SESSION, not the whole profile (#901): a
+                      // harness running N children through one account had every
+                      // sibling downgraded the instant one child was limited, and the
+                      // switch cold-caches each of them. Extra Usage exhaustion is
+                      // still profile-wide — that one really is account-scoped.
+                      recordExtendedContextRateLimited(profile.id, priorityCooldownUntil(profile.id, Date.now()), benchSessionKey)
                       claudeLog("upstream.context_fallback", {
                         mode: "non_stream",
                         from,
@@ -4358,11 +4434,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       if (hasExtendedContext(model)) {
                         const from = model
                         model = stripExtendedContext(model)
-                        // Bench [1m] for this profile until its window resets. Without
-                        // this the next request maps straight back to [1m], so one rate
-                        // limit costs TWO model switches and a cold prompt cache in both
-                        // directions — routinely more than the rate limit itself (#862).
-                        recordExtendedContextRateLimited(profile.id, priorityCooldownUntil(profile.id, Date.now()))
+                        // Bench [1m] until the window resets. Without this the next
+                        // request maps straight back to [1m], so one rate limit costs
+                        // TWO model switches and a cold prompt cache in both directions
+                        // — routinely more than the rate limit itself (#862).
+                        //
+                        // Benched for THIS SESSION, not the whole profile (#901): a
+                        // harness running N children through one account had every
+                        // sibling downgraded the instant one child was limited, and the
+                        // switch cold-caches each of them. Extra Usage exhaustion is
+                        // still profile-wide — that one really is account-scoped.
+                        recordExtendedContextRateLimited(profile.id, priorityCooldownUntil(profile.id, Date.now()), benchSessionKey)
                         claudeLog("upstream.context_fallback", {
                           mode: "stream",
                           from,
@@ -5687,6 +5769,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 : classifyError(errMsg, model)
               claudeLog("proxy.anthropic.error", { error: errMsg, classified: streamErr.type })
 
+              // How long the client should wait before retrying. A streaming
+              // turn's response headers went out with `message_start`, long
+              // before this failure existed, so the error frame is the only
+              // place a hint can still reach the client (#901).
+              const streamRetryAfter = retryAfterSeconds({
+                status: streamErr.status,
+                errorMessage: errMsg,
+                resetAtMs: observedResetAtMs(profile.id, Date.now()),
+              })
+
               // Surface the SDK termination reason (max_turns / process_exit / aborted)
               // and stderr tail to /telemetry/logs?category=error so failures are
               // visible without trawling raw log files.
@@ -6062,7 +6154,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // client at all.
                 safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
                   type: "error",
-                  error: { type: streamErr.type, message: streamErr.message }
+                  error: { type: streamErr.type, message: streamErr.message, ...retryAfterBodyFields(streamRetryAfter) }
                 })}\n\n`), "error_event_before_stop")
                 safeEnqueue(encoder.encode(
                   `event: message_stop\ndata: {"type":"message_stop"}\n\n`
@@ -6072,7 +6164,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // close — the error event is the whole response.
                 safeEnqueue(encoder.encode(`event: error\ndata: ${JSON.stringify({
                   type: "error",
-                  error: { type: streamErr.type, message: streamErr.message }
+                  error: { type: streamErr.type, message: streamErr.message, ...retryAfterBodyFields(streamRetryAfter) }
                 })}\n\n`), "error_event")
               }
               if (!streamClosed) {
@@ -6135,6 +6227,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? { status: 499, type: "request_cancelled", message: "The request was cancelled" }
           : classifyError(errMsg)
 
+        // Non-streaming failures still own their headers here, so the hint goes
+        // out as a real `Retry-After` (#901). `resolvedProfileId` is undefined
+        // when the request died before profile resolution, which just means the
+        // per-status default stands.
+        const retryAfter = retryAfterSeconds({
+          status: classified.status,
+          errorMessage: errMsg,
+          resetAtMs: observedResetAtMs(resolvedProfileId, Date.now()),
+        })
+
         claudeLog("proxy.error", { error: errMsg, classified: classified.type })
 
         // Surface the SDK termination reason. Outer-catch context is limited —
@@ -6179,8 +6281,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         })
 
         return new Response(
-          JSON.stringify({ type: "error", error: { type: classified.type, message: classified.message } }),
-          { status: classified.status, headers: { "Content-Type": "application/json" } }
+          JSON.stringify({
+            type: "error",
+            error: {
+              type: classified.type,
+              message: classified.message,
+              // Mirrored in the body so one field name means one thing on both
+              // the JSON and SSE paths; the header above is the contract.
+              ...retryAfterBodyFields(retryAfter),
+            },
+          }),
+          {
+            status: classified.status,
+            headers: { "Content-Type": "application/json", ...retryAfterHeaders(retryAfter) },
+          }
         )
       } finally {
         if (!streamOwnsAbortLink) {
@@ -6354,7 +6468,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   type: "overloaded_error",
                   message: "Timed out waiting for another process to finish this session turn",
                 },
-              }), { status: 529, headers: { "Content-Type": "application/json" } })
+              }), { status: 529, headers: { "Content-Type": "application/json", ...TRANSIENT_RETRY_AFTER_HEADERS } })
             }
             throw error
           }


### PR DESCRIPTION
## Problem

Prime Agent's RLM harness runs N concurrent children against one Max account through Meridian. Meridian returned 429/503 with no `Retry-After`, so every child backed off on its own schedule, woke at the same time, and re-hammered a window that was still spent. Worse, a rate limit on an extended-context request benched `[1m]` for the *whole profile*: one child's 429 downgraded every concurrent sibling to the 200k model at the same instant, and the model switch cold-caches each of them, because their cached prefixes were built on the 1M model.

## The fix

**Retry-After on every throttle-shaped response.** A new pure leaf module, `src/proxy/retryAfter.ts`, computes the number in "most authoritative first" order: upstream's own `Retry-After` when it survived into the error, then a hint embedded in the upstream error text (`"retry-after": 30`, `Retry-After: 30`, `retry_after=30`), then the account's own observed window reset from `rateLimitStore`, then a per-status constant — 60s for a rate limit, 5s for overload. Every branch is clamped to `[1s, 24h]`, so no source can produce "retry immediately" or "retry never".

It is wired wherever an error response is built:

- non-streaming failures get a real `Retry-After` header (and a mirrored `error.retry_after` field);
- SSE turns get `error.retry_after` in the error frame — a stream's headers went out with `message_start`, long before the failure existed, so the header cannot reach the client there;
- priority routing's pool-exhausted response names the *pool's* earliest opening, not the last account tried;
- the drain 503, the durable-priority-state 503s, and the cross-process turn 529 all carry the short constant;
- `relayInnerError` forwards the header, so `/v1/responses` and `/v1/chat/completions` callers get it too.

`oauthUsage.ts`'s private `parseRetryAfterMs` moved into the new module rather than being duplicated.

**Bench scoping decision: split by trigger, not blanket session-scoping.** The two reasons to bench `[1m]` have genuinely different blast radii, and the original profile-wide choice was right for one of them:

- **Extra Usage exhaustion stays profile-wide.** `recordExtendedContextUnavailable` fires on "extra usage is required for 1M context" / "out of extra usage". That is an entitlement fact about the *subscription*: every session on the account would fail identically, so making each one prove it costs N failed requests and buys nothing.
- **A plain rate limit is now session-scoped.** `recordExtendedContextRateLimited` benches only the session that earned the 429, keyed by the client's session identity namespaced under its profile. If the account's window really is spent, every session still discovers that — one extra refused attempt each, once — instead of N simultaneous cache misses.

Clients with no session identity (fingerprint-based adapters) still bench profile-wide; there is nothing narrower to scope to, so their behavior is unchanged. Session entries are bounded and self-expiring.

**Item 3 (session-limit vs account-limit in the error body) was skipped.** The Claude CLI's "You've hit your session limit · resets <time>" wording does not mean a per-conversation cap — it is the account's five-hour usage window, which resets. Labeling it "session" in the error body would tell a harness the opposite of the truth, and the thing it actually needs (how long to wait) is now on the response. The genuinely unfixable class, out-of-usage-credits, already classifies distinctly.

## Verification

- `npm test` — exit 0. 3159 tests across the 13 invocations (`npm test` isolates the module-mocking files into their own `bun test` runs): 3158 pass, 0 fail.
- `npm run typecheck` — clean.

New tests: `src/__tests__/retry-after-unit.test.ts` (precedence, clamping, per-status defaults, parse forms, statuses that take no hint), Retry-After integration cases in `proxy-error-handling.test.ts` (header on 429/503, upstream propagation, silence on 402/500/504, SSE frame), session-scope cases in `models.test.ts`, and bench-scope assertions in `proxy-extra-usage-fallback.test.ts`.

Closes nothing on its own — see #901 for the remaining item.

---

Model: Claude Opus. Harness: Claude Agent SDK.
