### PR TITLE
fix(errors): classify org spend-limit refusals as rate limits

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -639,16 +639,37 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
   it("does not treat a negated spend-limit sentence as a rate limit", () => {
     const r = classifyError("You have not hit your monthly spend limit yet, so this is unrelated.")
     expect(r.type).not.toBe("rate_limit_error")
+    expect(isAccountFailoverError(r.type)).toBe(false)
   })
 
   it("does not treat a quoted spend-limit phrase as a rate limit", () => {
     const r = classifyError("The docs say: when you've hit your monthly spend limit, ask your admin to raise it.")
     expect(r.type).not.toBe("rate_limit_error")
+    expect(isAccountFailoverError(r.type)).toBe(false)
   })
 
   it("does not treat a spend-limit phrase quoted inside tool stderr as a rate limit", () => {
     const r = classifyError("Subprocess stderr: helper printed \"You've hit your org's monthly spend limit\" and exited")
     expect(r.type).not.toBe("rate_limit_error")
+    expect(isAccountFailoverError(r.type)).toBe(false)
+  })
+
+  // The CLI surfaces a limit banner by exiting and appending it to stderr. A
+  // whole-message anchor missed that shape, and the fall-through was a 401
+  // telling the operator to run `claude login` for a quota refusal — while the
+  // session-limit banner in the identical shape classified correctly.
+  it("maps a spend-limit banner appended to subprocess stderr to rate_limit_error", () => {
+    const r = classifyError("Claude Code process exited with code 1\nSubprocess stderr: You've hit your org's monthly spend limit \u00b7 ask your admin to raise it")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+    expect(r.message).not.toContain("claude login")
+  })
+
+  it("classifies the stderr-appended spend and session banners the same way", () => {
+    const spend = classifyError("Claude Code process exited with code 1\nSubprocess stderr: You've hit your monthly spend limit")
+    const session = classifyError("Claude Code process exited with code 1\nSubprocess stderr: You've hit your session limit")
+    expect(spend.type).toBe(session.type)
+    expect(spend.status).toBe(session.status)
   })
 
   // Typographic apostrophes: the CLI renders these in some terminals.

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -620,6 +620,18 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  it("maps the CLI's 'You've hit your org's monthly spend limit' to rate_limit_error", () => {
+    const r = classifyError("Claude Code returned an error result: You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  it("maps the CLI's 'You've hit your monthly spend limit' to rate_limit_error", () => {
+    const r = classifyError("You've hit your monthly spend limit · raise it at claude.ai/settings/usage · your session limit resets 5pm (Europe/Warsaw)")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps the CLI's 'You're out of usage credits' to rate_limit_error without a same-profile retry", () => {
     const msg = "Claude Code returned an error result: You're out of usage credits. /model to switch models."
     const r = classifyError(msg)

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -632,6 +632,32 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(r.status).toBe(429)
   })
 
+  // The spend-limit pattern allows four qualifier words, which is a much wider
+  // net than the single-word HIT_YOUR_LIMIT. Unanchored it matched all three of
+  // these. Each would mark a healthy account exhausted and drop it out of a
+  // priority pool — the same outage this fix prevents, from the other side.
+  it("does not treat a negated spend-limit sentence as a rate limit", () => {
+    const r = classifyError("You have not hit your monthly spend limit yet, so this is unrelated.")
+    expect(r.type).not.toBe("rate_limit_error")
+  })
+
+  it("does not treat a quoted spend-limit phrase as a rate limit", () => {
+    const r = classifyError("The docs say: when you've hit your monthly spend limit, ask your admin to raise it.")
+    expect(r.type).not.toBe("rate_limit_error")
+  })
+
+  it("does not treat a spend-limit phrase quoted inside tool stderr as a rate limit", () => {
+    const r = classifyError("Subprocess stderr: helper printed \"You've hit your org's monthly spend limit\" and exited")
+    expect(r.type).not.toBe("rate_limit_error")
+  })
+
+  // Typographic apostrophes: the CLI renders these in some terminals.
+  it("maps the curly-apostrophe spend-limit wording to rate_limit_error", () => {
+    const r = classifyError("You\u2019ve hit your org\u2019s monthly spend limit \u00b7 ask your admin to raise it")
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it("maps the CLI's 'You're out of usage credits' to rate_limit_error without a same-profile retry", () => {
     const msg = "Claude Code returned an error result: You're out of usage credits. /model to switch models."
     const r = classifyError(msg)

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -84,11 +84,20 @@ const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
  *  "you've hit your" at the start of the message (after the known SDK error
  *  wrappers) keeps every live wording while rejecting all of them.
  *
+ *  `subprocess stderr` is in the wrapper list and the anchor is per-line (`m`)
+ *  because the CLI often surfaces a limit banner by exiting and appending it to
+ *  stderr. Anchoring to the start of the whole message missed that shape, and
+ *  the fall-through was not merely a missed failover: a bare code-1 exit reads
+ *  as an auth failure, so the operator was told to run `claude login` for a
+ *  quota refusal. The unanchored HIT_YOUR_LIMIT still matched there, so the
+ *  session-limit banner classified correctly while the spend-limit banner in
+ *  the identical shape returned 401.
+ *
  *  Known boundary: a message that genuinely *begins* "you've hit your <...>
  *  spend limit" from some unrelated billing tool would still match. Tightening
  *  further means enumerating qualifiers, which is what missed the org wording
  *  in the first place. */
-const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result):\s*)*you(?:'|’)ve hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/
+const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/m
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -72,8 +72,23 @@ const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
  *  swallow "you have hit your configured tool call depth limit", which is not a
  *  quota refusal. Anchor on the limit's *kind* instead — "spend" or "usage" —
  *  so any number of qualifier words is allowed without matching unrelated
- *  limits. Apostrophes are included for the possessive ("org's"). */
-const HIT_YOUR_SPEND_LIMIT = /hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/
+ *  limits. Apostrophes are included for the possessive ("org's").
+ *
+ *  Anchored to the start of the message, like OUT_OF_USAGE_CREDITS below and
+ *  for the same reason. Allowing four qualifier words is a much wider net than
+ *  HIT_YOUR_LIMIT's single word, and unanchored it matched negated and quoted
+ *  prose — "you have not hit your monthly spend limit yet", or the phrase
+ *  merely quoted inside MCP stderr. Each of those would mark a healthy profile
+ *  exhausted and pull it out of a priority pool: the exact failure this fix
+ *  exists to prevent, in the opposite direction. Requiring the possessive
+ *  "you've hit your" at the start of the message (after the known SDK error
+ *  wrappers) keeps every live wording while rejecting all of them.
+ *
+ *  Known boundary: a message that genuinely *begins* "you've hit your <...>
+ *  spend limit" from some unrelated billing tool would still match. Tightening
+ *  further means enumerating qualifiers, which is what missed the org wording
+ *  in the first place. */
+const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result):\s*)*you(?:'|’)ve hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -62,6 +62,19 @@ const BILLING_SIGNALS: readonly RegExp[] = [
  *  can't drift into unrelated text that happens to contain "limit". */
 const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
 
+/** The multi-word spend/usage variants: "You've hit your org's monthly spend
+ *  limit · ask your admin to raise it at claude.ai/settings/usage" was observed
+ *  live and matched none of the single-word shapes above, so the profile was
+ *  never marked exhausted and priority routing never failed over — the pool
+ *  sat on a dead account while a healthy one waited behind it.
+ *
+ *  Widening HIT_YOUR_LIMIT to a multi-word wildcard is not safe: it would also
+ *  swallow "you have hit your configured tool call depth limit", which is not a
+ *  quota refusal. Anchor on the limit's *kind* instead — "spend" or "usage" —
+ *  so any number of qualifier words is allowed without matching unrelated
+ *  limits. Apostrophes are included for the possessive ("org's"). */
+const HIT_YOUR_SPEND_LIMIT = /hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/
+
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
  * cannot exhaust every profile in a priority pool. */
@@ -119,7 +132,8 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // variants seen so far and the daily/monthly/5-hour ones that would
   // otherwise be the next report.
   if (HTTP_429.test(lower) || lower.includes("rate limit") || lower.includes("too many requests")
-    || HIT_YOUR_LIMIT.test(lower) || lower.includes("usage limit reached")
+    || HIT_YOUR_LIMIT.test(lower) || HIT_YOUR_SPEND_LIMIT.test(lower)
+    || lower.includes("usage limit reached")
     || OUT_OF_USAGE_CREDITS.test(lower)) {
     const hint = lower.includes("1m") || lower.includes("context")
       ? extendedContextHint(model)


### PR DESCRIPTION
Cherry-picks @StanChmielewski's fix from #900, plus two commits hardening it against false positives that review turned up.

## The bug

`HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/` allows exactly one qualifier word, so the live refusal

```
You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage
```

matched nothing. It fell through to a generic `api_error`, `isAccountFailoverError()` returned false, and the profile was never marked exhausted. Under `MERIDIAN_ROUTING=priority` that is the bad case: `/profiles/list` reports `exhausted: []` while every request fails, and the pool keeps serving a dead account with a healthy one waiting behind it.

Verified the whole chain, before and after:

| message | before | after |
|---|---|---|
| `You've hit your org's monthly spend limit …` | `500 api_error`, no failover | `429 rate_limit_error`, fails over |
| `You've hit your monthly spend limit …` | `500 api_error`, no failover | `429 rate_limit_error`, fails over |
| `you have hit your configured tool call depth limit` | not a rate limit | not a rate limit (unchanged) |

@StanChmielewski's reasoning for not simply widening `HIT_YOUR_LIMIT` holds up — I reproduced it. A multi-word wildcard also swallows the tool-call-depth wording that `errors.test.ts` already pins as a non-quota error. Anchoring on the limit's *kind* (`spend|usage`) is the right shape.

## What I added

**Anchoring (commit 2).** Four qualifier words is a much wider net than `HIT_YOUR_LIMIT`'s one, and unanchored it also matched:

```
you have not hit your monthly spend limit yet
The docs say: when you've hit your monthly spend limit, ask your admin
Subprocess stderr: helper printed "You've hit your ... spend limit" and exited
```

Each of those marks a *healthy* account exhausted and pulls it out of a priority pool — the same outage this fix prevents, from the other direction. The single-word pattern avoided them only by accident. `OUT_OF_USAGE_CREDITS` already anchors for exactly this reason; the spend pattern now does too.

**Stderr shape (commit 3).** Review caught that commit 2 overcorrected. The CLI most often surfaces a limit banner by exiting non-zero and appending it to stderr, and a whole-message anchor was blind to that. The fall-through was worse than a missed failover:

```
Subprocess stderr: You've hit your session limit       -> 429, fails over
Subprocess stderr: You've hit your monthly spend limit -> 401, "run claude login"
```

Same shape, opposite handling, because unanchored `HIT_YOUR_LIMIT` still matched the first. A quota refusal was telling the operator to re-authenticate. Fixed by allowing `subprocess stderr` as a wrapper and anchoring per-line. The tests originally asserted only `not.toBe("rate_limit_error")`, which passed while masking that 401 — they now assert the failover verdict too.

Every regression test was verified to fail against the version it guards.

## Not fixed here

Reading the banner strings out of the bundled CLI binary turned up two adjacent refusals that still fall through to `api_error` with no failover — same outage, different wording:

```
You've reached your Fable 5 limit.
Your group's usage limit is set to $0 · run /usage-credits to request more
```

Both are verbatim in the shipped binary. The first uses `reached`, not `hit`, and the binary also contains a templated `reached your specified …` whose noun I could not resolve from strings alone — so widening on that verb needs evidence I do not have yet. Filing separately rather than guessing inside someone else's PR.

`npm test` exits 0; `npm run typecheck` clean; `errors.test.ts` 124/124.

Closes #900
