### PR TITLE
fix(openai): profile-aware model catalog, SSE keepalives, cached-token usage

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -284,7 +284,32 @@ describe("translateAnthropicToResponses (non-stream)", () => {
     const msg = out.output.find((o: any) => o.type === "message")
     expect(msg.role).toBe("assistant")
     expect(msg.content).toEqual([{ type: "output_text", text: "Hello!", annotations: [] }])
-    expect(out.usage).toEqual({ input_tokens: 10, output_tokens: 5, total_tokens: 15 })
+    expect(out.usage).toEqual({
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })
+  })
+
+  it("includes cache reads and writes in input usage", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "text", text: "Cached answer" }],
+      stop_reason: "end_turn",
+      usage: {
+        input_tokens: 23,
+        output_tokens: 41,
+        cache_read_input_tokens: 900,
+        cache_creation_input_tokens: 77,
+      },
+    }, ctx)
+
+    expect(out.usage).toEqual({
+      input_tokens: 1000,
+      output_tokens: 41,
+      total_tokens: 1041,
+      input_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
   })
 
   it("maps tool_use blocks to function_call items", () => {
@@ -368,9 +393,48 @@ describe("createResponsesSseTranslator (stream)", () => {
     const completed = out.find((e) => e.event === "response.completed")!
     const resp = (completed.data as any).response
     expect(resp.status).toBe("completed")
-    expect(resp.usage).toEqual({ input_tokens: 12, output_tokens: 7, total_tokens: 19 })
+    expect(resp.usage).toEqual({
+      input_tokens: 12,
+      output_tokens: 7,
+      total_tokens: 19,
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })
     const msg = resp.output.find((o: any) => o.type === "message")
     expect(msg.content[0].text).toBe("Hello")
+  })
+
+  it("preserves start usage and applies only cumulative delta fields", () => {
+    const out = run([
+      {
+        type: "message_start",
+        message: {
+          id: "m1",
+          usage: {
+            input_tokens: 23,
+            output_tokens: 0,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 77,
+          },
+        },
+      },
+      { type: "message_delta", usage: { output_tokens: 17 } },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { input_tokens: 25, output_tokens: 41, cache_read_input_tokens: 910 },
+      },
+      { type: "message_stop" },
+    ])
+    const completed = out.find((event) => event.event === "response.completed")!
+
+    expect(completed.data.response).toEqual(expect.objectContaining({
+      usage: {
+        input_tokens: 1012,
+        output_tokens: 41,
+        total_tokens: 1053,
+        input_tokens_details: { cached_tokens: 910, cache_write_tokens: 77 },
+      },
+    }))
   })
 
   it("emits function_call items with argument deltas for tool_use blocks", () => {

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -758,6 +758,30 @@ describe("translateAnthropicToOpenAi", () => {
     expect(result.usage.prompt_tokens).toBe(10)
     expect(result.usage.completion_tokens).toBe(5)
     expect(result.usage.total_tokens).toBe(15)
+    expect(result.usage.prompt_tokens_details).toEqual({ cached_tokens: 0, cache_write_tokens: 0 })
+  })
+
+  it("includes cache reads and writes in prompt usage", () => {
+    const result = translateAnthropicToOpenAi(
+      {
+        content: [{ type: "text", text: "Cached answer" }],
+        stop_reason: "end_turn",
+        usage: {
+          input_tokens: 23,
+          output_tokens: 41,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 77,
+        },
+      },
+      ID, MODEL, CREATED,
+    )
+
+    expect(result.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 41,
+      total_tokens: 1041,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
   })
 
   it("maps max_tokens stop_reason to length finish_reason", () => {
@@ -1224,14 +1248,70 @@ describe("createSseTranslator", () => {
     const chunk = translate.buildUsageChunk()
     expect(chunk).not.toBeNull()
     expect(chunk!.choices).toEqual([])
-    expect(chunk!.usage).toEqual({ prompt_tokens: 132, completion_tokens: 37, total_tokens: 169 })
+    expect(chunk!.usage).toEqual({
+      prompt_tokens: 132,
+      completion_tokens: 37,
+      total_tokens: 169,
+      prompt_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+    })
   })
 
-  it("buildUsageChunk uses the latest message_delta.usage if multiple arrive", () => {
+  it("buildUsageChunk uses message_start usage when message_delta omits usage", () => {
     const translate = createSseTranslator({ ...CTX, includeUsage: true })
-    translate({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { input_tokens: 100, output_tokens: 10 } })
-    translate({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { input_tokens: 100, output_tokens: 42 } })
-    expect(translate.buildUsageChunk()!.usage).toEqual({ prompt_tokens: 100, completion_tokens: 42, total_tokens: 142 })
+    translate({
+      type: "message_start",
+      message: {
+        id: "msg_1",
+        usage: {
+          input_tokens: 23,
+          output_tokens: 3,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 77,
+        },
+      },
+    })
+    translate({ type: "message_delta", delta: { stop_reason: "end_turn" } })
+
+    expect(translate.buildUsageChunk()!.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 3,
+      total_tokens: 1003,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
+  })
+
+  it("buildUsageChunk preserves start fields and applies cumulative delta overrides", () => {
+    const translate = createSseTranslator({ ...CTX, includeUsage: true })
+    translate({
+      type: "message_start",
+      message: {
+        id: "msg_1",
+        usage: {
+          input_tokens: 23,
+          output_tokens: 0,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 77,
+        },
+      },
+    })
+    translate({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 17 } })
+    expect(translate.buildUsageChunk()!.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 17,
+      total_tokens: 1017,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
+    translate({
+      type: "message_delta",
+      delta: { stop_reason: "end_turn" },
+      usage: { input_tokens: 25, output_tokens: 41, cache_read_input_tokens: 910 },
+    })
+    expect(translate.buildUsageChunk()!.usage).toEqual({
+      prompt_tokens: 1012,
+      completion_tokens: 41,
+      total_tokens: 1053,
+      prompt_tokens_details: { cached_tokens: 910, cache_write_tokens: 77 },
+    })
   })
 })
 

--- a/src/__tests__/proxy-health-build.test.ts
+++ b/src/__tests__/proxy-health-build.test.ts
@@ -109,6 +109,10 @@ describe("/v1/models profile auth context", () => {
     const body = await response.json() as { data: Array<{ id: string; context_window: number }> }
 
     expect(response.status).toBe(200)
+    expect(authCalls).toEqual([{
+      profileId: "pro",
+      envOverrides: { CLAUDE_CONFIG_DIR: "/profiles/pro" },
+    }])
     expect(body.data.every((model) => model.context_window === 200_000)).toBe(true)
   })
 })

--- a/src/__tests__/proxy-health-build.test.ts
+++ b/src/__tests__/proxy-health-build.test.ts
@@ -19,13 +19,18 @@ import { describe, expect, it, mock, afterEach } from "bun:test"
 // crash somewhere unrelated.
 import * as realModels from "../proxy/models"
 
+const authCalls: Array<{ profileId?: string; envOverrides?: Record<string, string> }> = []
+
 mock.module("../proxy/models", () => ({
   ...realModels,
-  getClaudeAuthStatusAsync: async () => ({
-    loggedIn: true,
-    email: "test@example.com",
-    subscriptionType: "max",
-  }),
+  getClaudeAuthStatusAsync: async (profileId?: string, envOverrides?: Record<string, string>) => {
+    authCalls.push({ profileId, envOverrides })
+    return {
+      loggedIn: true,
+      email: "test@example.com",
+      subscriptionType: profileId === "pro" ? "pro" : "max",
+    }
+  },
   resolveClaudeExecutableAsync: async () => "claude",
 }))
 
@@ -57,7 +62,55 @@ const STAMPS = [
 
 afterEach(() => {
   for (const key of STAMPS) delete process.env[key]
+  authCalls.length = 0
   stopUpdateCheck()
+})
+
+describe("/v1/models profile auth context", () => {
+  it("uses the legacy auth context when no profiles are configured", async () => {
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+
+    const response = await app.fetch(new Request("http://localhost/v1/models"))
+
+    expect(response.status).toBe(200)
+    expect(authCalls).toEqual([{ profileId: undefined, envOverrides: undefined }])
+  })
+
+  it("advertises 1M Opus and Fable context from the configured Max profile", async () => {
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [{ id: "work", type: "claude-max", claudeConfigDir: "/profiles/work" }],
+      defaultProfile: "work",
+    })
+
+    const response = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await response.json() as { data: Array<{ id: string; context_window: number }> }
+    const models = new Map(body.data.map((model) => [model.id, model]))
+
+    expect(response.status).toBe(200)
+    expect(authCalls).toEqual([{
+      profileId: "work",
+      envOverrides: { CLAUDE_CONFIG_DIR: "/profiles/work" },
+    }])
+    expect(models.get("claude-opus-4-6")?.context_window).toBe(1_000_000)
+    expect(models.get("claude-fable-5")?.context_window).toBe(1_000_000)
+  })
+
+  it("keeps the 200k catalog for a non-Max profile", async () => {
+    const { app } = createProxyServer({
+      port: 0,
+      host: "127.0.0.1",
+      profiles: [{ id: "pro", type: "claude-max", claudeConfigDir: "/profiles/pro" }],
+      defaultProfile: "pro",
+    })
+
+    const response = await app.fetch(new Request("http://localhost/v1/models"))
+    const body = await response.json() as { data: Array<{ id: string; context_window: number }> }
+
+    expect(response.status).toBe(200)
+    expect(body.data.every((model) => model.context_window === 200_000)).toBe(true)
+  })
 })
 
 describe("/health build provenance", () => {

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -24,6 +24,7 @@ import {
   toolUseBlockStart,
   inputJsonDelta,
   resolveMockSdkSessionId,
+  streamEvent,
 } from "./helpers"
 
 let mockMessages: unknown[] = []
@@ -476,6 +477,55 @@ describe("POST /v1/chat/completions — streaming", () => {
 
     const text = await readStream(res)
     expect(text).toContain("data: [DONE]")
+  })
+
+  it("emits complete cached usage immediately before [DONE] when requested", async () => {
+    mockMessages = [
+      streamEvent({
+        type: "message_start",
+        message: {
+          id: "msg_usage",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-5-20250929",
+          stop_reason: null,
+          usage: {
+            input_tokens: 23,
+            output_tokens: 0,
+            cache_read_input_tokens: 900,
+            cache_creation_input_tokens: 77,
+          },
+        },
+      }),
+      textBlockStart(0),
+      textDelta(0, "cached"),
+      blockStop(0),
+      streamEvent({
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 41 },
+      }),
+      messageStop(),
+    ]
+    const app = createTestApp()
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: [{ role: "user", content: "Use the cached prompt" }],
+    })
+
+    const frames = (await readStream(res)).split("\n").filter(line => line.startsWith("data: "))
+    expect(frames.at(-1)).toBe("data: [DONE]")
+    const usageChunk = JSON.parse(frames.at(-2)!.slice(6)) as Record<string, unknown>
+    expect(usageChunk.choices).toEqual([])
+    expect(usageChunk.usage).toEqual({
+      prompt_tokens: 1000,
+      completion_tokens: 41,
+      total_tokens: 1041,
+      prompt_tokens_details: { cached_tokens: 900, cache_write_tokens: 77 },
+    })
   })
 
   it("all chunks share the same completion id", async () => {

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -501,6 +501,50 @@ describe("POST /v1/chat/completions — streaming", () => {
     expect([...uniqueIds][0]).toMatch(/^chatcmpl-/)
   })
 
+  it("forwards internal SSE keepalive comments to the client", async () => {
+    const app = createTestApp()
+    const originalFetch = app.fetch.bind(app)
+    const internalFrames = [
+      `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "claude-sonnet-5", stop_reason: null, usage: { input_tokens: 10, output_tokens: 0 } } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello" } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+      `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 5 } })}`,
+      `data: ${JSON.stringify({ type: "message_stop" })}`,
+    ]
+    app.fetch = (req, env, executionCtx) => {
+      if (req.url === "http://internal/v1/messages") {
+        return Promise.resolve(new Response(`${internalFrames.join("\n\n")}\n\n`, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }))
+      }
+      return originalFetch(req, env, executionCtx)
+    }
+
+    const res = await postChatCompletion(app, {
+      stream: true,
+      messages: [{ role: "user", content: "Hi" }],
+    })
+
+    const text = await readStream(res)
+    const pingLines = text.split("\n").filter(l => l === ": ping")
+    expect(pingLines).toHaveLength(2)
+
+    const contentChunks = text.split("\n")
+      .filter(l => l.startsWith("data: ") && l !== "data: [DONE]")
+      .map(l => JSON.parse(l.slice(6)) as Record<string, unknown>)
+      .map(c => {
+        const choices = c.choices as Array<Record<string, unknown>>
+        return (choices[0]!.delta as Record<string, unknown>).content
+      })
+      .filter((content): content is string => typeof content === "string" && content.length > 0)
+    expect(contentChunks.join("")).toBe("Hello")
+    expect(text).toContain("data: [DONE]")
+  })
+
   // --- tool_call_counter increment behavior ---
 
   type DeltaToolCall = {

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -151,6 +151,40 @@ describe("/v1/responses (#475)", () => {
     expect(lastCompleted).toContain("Hello from Codex")
   })
 
+  it("stream: forwards internal SSE keepalive comments to the client", async () => {
+    const app = createTestApp()
+    const originalFetch = app.fetch.bind(app)
+    const internalFrames = [
+      `data: ${JSON.stringify({ type: "message_start", message: { id: "msg_1", type: "message", role: "assistant", content: [], model: "claude-sonnet-5", stop_reason: null, usage: { input_tokens: 11, output_tokens: 0 } } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } })}`,
+      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello from Codex" } })}`,
+      ": ping",
+      `data: ${JSON.stringify({ type: "content_block_stop", index: 0 })}`,
+      `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 4 } })}`,
+      `data: ${JSON.stringify({ type: "message_stop" })}`,
+    ]
+    app.fetch = (req: Request, env?: any, executionCtx?: any) => {
+      if (req.url === "http://internal/v1/messages") {
+        return Promise.resolve(new Response(`${internalFrames.join("\n\n")}\n\n`, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }))
+      }
+      return originalFetch(req, env, executionCtx)
+    }
+
+    const res = await postResponses(app, { model: "claude-sonnet-5", input: "hi", stream: true })
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    const pingLines = text.split("\n").filter((l: string) => l === ": ping")
+    expect(pingLines).toHaveLength(2)
+    expect(text).toContain("event: response.output_text.delta")
+    expect(text).toContain("event: response.completed")
+    const lastCompleted = text.split("event: response.completed")[1] || ""
+    expect(lastCompleted).toContain("Hello from Codex")
+  })
+
   it("is advertised in the root endpoint list", async () => {
     const app = createTestApp()
     const res = await app.fetch(new Request("http://localhost/", { headers: { accept: "application/json" } }))

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -164,7 +164,7 @@ describe("/v1/responses (#475)", () => {
       `data: ${JSON.stringify({ type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 4 } })}`,
       `data: ${JSON.stringify({ type: "message_stop" })}`,
     ]
-    app.fetch = (req: Request, env?: any, executionCtx?: any) => {
+    app.fetch = (req, env, executionCtx) => {
       if (req.url === "http://internal/v1/messages") {
         return Promise.resolve(new Response(`${internalFrames.join("\n\n")}\n\n`, {
           status: 200,

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -134,6 +134,34 @@ export interface AnthropicRequestBody {
 export interface AnthropicUsage {
   input_tokens?: number
   output_tokens?: number
+  cache_read_input_tokens?: number
+  cache_creation_input_tokens?: number
+}
+
+const ANTHROPIC_USAGE_FIELDS = [
+  "input_tokens",
+  "output_tokens",
+  "cache_read_input_tokens",
+  "cache_creation_input_tokens",
+] as const
+
+/** Merge cumulative usage snapshots without erasing fields omitted by a delta. */
+export function mergeAnthropicUsage(
+  current: AnthropicUsage | undefined,
+  update: AnthropicUsage,
+): AnthropicUsage {
+  const merged = { ...current }
+  for (const field of ANTHROPIC_USAGE_FIELDS) {
+    if (typeof update[field] === "number") merged[field] = update[field]
+  }
+  return merged
+}
+
+/** Anthropic reports fresh, cache-read, and cache-written input separately. */
+export function totalAnthropicInputTokens(usage: AnthropicUsage | undefined): number {
+  return (usage?.input_tokens ?? 0)
+    + (usage?.cache_read_input_tokens ?? 0)
+    + (usage?.cache_creation_input_tokens ?? 0)
 }
 
 export interface AnthropicContentBlockText {
@@ -207,7 +235,15 @@ export interface OpenAiStreamChunk {
     }
     finish_reason: "stop" | "length" | "tool_calls" | null
   }>
-  usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+  usage?: {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+    prompt_tokens_details: {
+      cached_tokens: number
+      cache_write_tokens: number
+    }
+  }
 }
 
 export interface OpenAiCompletionFunctionToolCall {
@@ -247,6 +283,10 @@ export interface OpenAiCompletion {
     prompt_tokens: number
     completion_tokens: number
     total_tokens: number
+    prompt_tokens_details: {
+      cached_tokens: number
+      cache_write_tokens: number
+    }
   }
 }
 
@@ -630,7 +670,7 @@ export function translateAnthropicToOpenAi(
         .join("")
     : ""
 
-  const promptTokens = response.usage?.input_tokens ?? 0
+  const promptTokens = totalAnthropicInputTokens(response.usage)
   const completionTokens = response.usage?.output_tokens ?? 0
 
   return {
@@ -652,6 +692,10 @@ export function translateAnthropicToOpenAi(
       prompt_tokens: promptTokens,
       completion_tokens: completionTokens,
       total_tokens: promptTokens + completionTokens,
+      prompt_tokens_details: {
+        cached_tokens: response.usage?.cache_read_input_tokens ?? 0,
+        cache_write_tokens: response.usage?.cache_creation_input_tokens ?? 0,
+      },
     },
   }
 }
@@ -680,7 +724,7 @@ export interface AnthropicSseEvent {
     | { type: "text"; text?: string }
     | { type: "thinking"; thinking?: string }
     | AnthropicToolUseBlock
-  message?: { id?: string }
+  message?: { id?: string; usage?: AnthropicUsage }
   usage?: AnthropicUsage
 }
 
@@ -726,8 +770,12 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
       toolCallIndex++
     }
 
+    if (event.type === "message_start" && event.message?.usage) {
+      lastUsage = mergeAnthropicUsage(lastUsage, event.message.usage)
+    }
+
     if (event.type === "message_delta" && event.usage) {
-      lastUsage = event.usage
+      lastUsage = mergeAnthropicUsage(lastUsage, event.usage)
     }
 
     return translateAnthropicSseEvent(
@@ -742,7 +790,7 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
 
   translate.buildUsageChunk = () => {
     if (!ctx.includeUsage || !lastUsage) return null
-    const promptTokens = lastUsage.input_tokens ?? 0
+    const promptTokens = totalAnthropicInputTokens(lastUsage)
     const completionTokens = lastUsage.output_tokens ?? 0
     return {
       id: ctx.completionId,
@@ -754,6 +802,10 @@ export function createSseTranslator(ctx: SseTranslatorContext): SseTranslator {
         prompt_tokens: promptTokens,
         completion_tokens: completionTokens,
         total_tokens: promptTokens + completionTokens,
+        prompt_tokens_details: {
+          cached_tokens: lastUsage.cache_read_input_tokens ?? 0,
+          cache_write_tokens: lastUsage.cache_creation_input_tokens ?? 0,
+        },
       },
     }
   }

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -239,6 +239,11 @@ export interface OpenAiStreamChunk {
     prompt_tokens: number
     completion_tokens: number
     total_tokens: number
+    // `cached_tokens` is OpenAI's field. `cache_write_tokens` is NOT — it is a
+    // Meridian extension carrying Anthropic's cache_creation_input_tokens, which
+    // OpenAI has no equivalent for and which bills at a premium. Kept because a
+    // cost-tracking client cannot reconstruct it, deliberately named so it is
+    // obviously not spec. Clients that ignore unknown keys are unaffected.
     prompt_tokens_details: {
       cached_tokens: number
       cache_write_tokens: number
@@ -283,6 +288,11 @@ export interface OpenAiCompletion {
     prompt_tokens: number
     completion_tokens: number
     total_tokens: number
+    // `cached_tokens` is OpenAI's field. `cache_write_tokens` is NOT — it is a
+    // Meridian extension carrying Anthropic's cache_creation_input_tokens, which
+    // OpenAI has no equivalent for and which bills at a premium. Kept because a
+    // cost-tracking client cannot reconstruct it, deliberately named so it is
+    // obviously not spec. Clients that ignore unknown keys are unaffected.
     prompt_tokens_details: {
       cached_tokens: number
       cache_write_tokens: number

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -23,8 +23,9 @@ import type {
   AnthropicMessage,
   AnthropicContentBlock,
   AnthropicTool,
+  AnthropicUsage,
 } from "./openai"
-import { parseDataUrlImage } from "./openai"
+import { mergeAnthropicUsage, parseDataUrlImage, totalAnthropicInputTokens } from "./openai"
 
 // ---------------------------------------------------------------------------
 // Responses request types (subset Codex actually sends)
@@ -288,13 +289,21 @@ export function reasoningRequested(body: ResponsesRequest): boolean {
 interface AnthropicResponseLike {
   content?: Array<Record<string, unknown>>
   stop_reason?: string
-  usage?: { input_tokens?: number; output_tokens?: number }
+  usage?: AnthropicUsage
 }
 
-function mapUsage(usage: { input_tokens?: number; output_tokens?: number } | undefined) {
-  const input = usage?.input_tokens ?? 0
+function mapUsage(usage: AnthropicUsage | undefined) {
+  const input = totalAnthropicInputTokens(usage)
   const output = usage?.output_tokens ?? 0
-  return { input_tokens: input, output_tokens: output, total_tokens: input + output }
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    total_tokens: input + output,
+    input_tokens_details: {
+      cached_tokens: usage?.cache_read_input_tokens ?? 0,
+      cache_write_tokens: usage?.cache_creation_input_tokens ?? 0,
+    },
+  }
 }
 
 /**
@@ -377,10 +386,10 @@ export function translateAnthropicToResponses(res: AnthropicResponseLike, ctx: R
 export interface AnthropicSseEvent {
   type: string
   index?: number
-  message?: { id?: string; usage?: { input_tokens?: number } }
+  message?: { id?: string; usage?: AnthropicUsage }
   content_block?: { type?: string; id?: string; name?: string; input?: unknown }
   delta?: { type?: string; text?: string; partial_json?: string; thinking?: string; stop_reason?: string }
-  usage?: { output_tokens?: number }
+  usage?: AnthropicUsage
 }
 
 export interface ResponsesSseEmission {
@@ -395,8 +404,7 @@ export interface ResponsesSseEmission {
 export function createResponsesSseTranslator(ctx: ResponsesCtx) {
   let seq = 0
   let outputIndex = 0
-  let inputTokens = 0
-  let outputTokens = 0
+  let usage: AnthropicUsage | undefined
   let createdEmitted = false
   let stopReason: string | undefined
 
@@ -439,7 +447,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
 
     switch (event.type) {
       case "message_start": {
-        inputTokens = event.message?.usage?.input_tokens ?? 0
+        if (event.message?.usage) usage = mergeAnthropicUsage(usage, event.message.usage)
         if (!createdEmitted) {
           createdEmitted = true
           out.push(emit("response.created", { response: responseEnvelope("in_progress", { output: [] }) }))
@@ -542,7 +550,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
       }
 
       case "message_delta": {
-        if (typeof event.usage?.output_tokens === "number") outputTokens = event.usage.output_tokens
+        if (event.usage) usage = mergeAnthropicUsage(usage, event.usage)
         if (typeof event.delta?.stop_reason === "string") stopReason = event.delta.stop_reason
         break
       }
@@ -552,7 +560,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
         out.push(emit(status === "incomplete" ? "response.incomplete" : "response.completed", {
           response: responseEnvelope(status, {
             output: finalOutput,
-            usage: { input_tokens: inputTokens, output_tokens: outputTokens, total_tokens: inputTokens + outputTokens },
+            usage: mapUsage(usage),
             parallel_tool_calls: true,
             tool_choice: "auto",
             tools: [],

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -299,6 +299,8 @@ function mapUsage(usage: AnthropicUsage | undefined) {
     input_tokens: input,
     output_tokens: output,
     total_tokens: input + output,
+    // `cached_tokens` is OpenAI's field; `cache_write_tokens` is a Meridian
+    // extension — see the note on OpenAiCompletion in ./openai.
     input_tokens_details: {
       cached_tokens: usage?.cache_read_input_tokens ?? 0,
       cache_write_tokens: usage?.cache_creation_input_tokens ?? 0,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -7258,7 +7258,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // comparison here used to advertise 200k to Team accounts that Meridian was
   // already routing to opus[1m] (#826).
   app.get("/v1/models", async (c) => {
-    const authStatus = await getClaudeAuthStatusAsync()
+    const profile = resolveProfile(finalConfig.profiles, finalConfig.defaultProfile)
+    const profileEnvOverrides = Object.keys(profile.env).length > 0 ? profile.env : undefined
+    const authStatus = await getClaudeAuthStatusAsync(
+      profile.id !== "default" ? profile.id : undefined,
+      profileEnvOverrides,
+    )
     const extendedContext = subscriptionIncludesExtendedContext(authStatus?.subscriptionType)
     return c.json({ object: "list", data: buildModelList(extendedContext) })
   })

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -7086,6 +7086,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             buffer = lines.pop() ?? ""
 
             for (const line of lines) {
+              if (line.startsWith(":")) {
+                controller.enqueue(encoder.encode(`${line}\n\n`))
+                continue
+              }
               if (!line.startsWith("data: ")) continue
               const dataStr = line.slice(6).trim()
               if (!dataStr) continue
@@ -7214,6 +7218,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             const lines = buffer.split("\n")
             buffer = lines.pop() ?? ""
             for (const line of lines) {
+              if (line.startsWith(":")) {
+                controller.enqueue(encoder.encode(`${line}\n\n`))
+                continue
+              }
               if (!line.startsWith("data: ")) continue
               const dataStr = line.slice(6).trim()
               if (!dataStr) continue


### PR DESCRIPTION
Lands three OpenAI-compat fixes from @justprosh, cherry-picked so authorship is preserved. Fork PRs can't merge directly because `main` requires signed commits.

Closes #882
Closes #883
Closes #894

## What each one fixes

**#882 — `/v1/models` ignored the configured profile.**
It called `getClaudeAuthStatusAsync()` with no arguments, so with profiles configured it reported the *legacy* account's tier and advertised the wrong `context_window` (200k for an account already routed to `[1m]`). `/health` already resolved the profile — same server, two different answers.

**#883 — SSE heartbeats were dropped on the OpenAI path.**
`handleMessages` emits `: ping` to keep client idle-timeouts from firing. Both OpenAI-compat stream loops skipped every line that isn't `data: `, so the heartbeat never reached `/v1/chat/completions` or `/v1/responses` clients. Long thinking or tool pauses could time out — looking like a hang, not a bug.

**#894 — cached input tokens were dropped from usage.**
`prompt_tokens` used only `input_tokens`, which excludes cached tokens. On a 90k-cached turn the API reported **0**. `tokenUsage.ts` already documents the correct formula and `server.ts` already merges `message_start` + `message_delta` usage on the Anthropic path — the OpenAI path was the outlier. Also fixes usage being clobbered rather than merged.

## Follow-up commit (mine)

- `cache_write_tokens` is **not** an OpenAI field (spec is `cached_tokens` / `audio_tokens`). It carries Anthropic's premium-billed cache-creation count, which is worth exposing, so it's kept and documented as a deliberate Meridian extension rather than left looking like spec.
- Dropped two `any` annotations in the Responses test; the sibling test in the same PR leaves the identical override to inference and typechecks clean.

## Verification

- `tsc --noEmit` — exit 0
- `npm test` — 3211 pass / 0 fail (run twice, before and after my commit)
- Bug for each PR confirmed against current `main` by reading the code, not the PR description
- SSE comment handling probed for CRLF, chunk-split pings, ping+data interleaving, and colons inside JSON payloads

### Known edge, deliberately not patched

If `message_delta` ever reports `input_tokens: 0` explicitly, the merge overwrites the `message_start` value. `main` loses the value entirely and `server.ts`'s existing spread has the same flaw, so this is strictly better than both. Changing merge semantics on a wire shape I can't confirm would be speculative.
