### PR TITLE
test(rate-limit): stop sleeping 3 real seconds per retry test

### DIFF
--- a/src/__tests__/proxy-rate-limit-retry.test.ts
+++ b/src/__tests__/proxy-rate-limit-retry.test.ts
@@ -8,7 +8,7 @@
  * 4. No retry happens after partial output has been sent
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 import {
   messageStart,
   textBlockStart,
@@ -118,6 +118,17 @@ describe("Rate-limit retry with backoff", () => {
     queryCalls = []
     queryCallCount = 0
     mockBehavior = "succeed"
+    // The backoff sleeps for real. At the production default (1s + 2s) these
+    // seven tests spend ~18s asleep, and the exhaust-all-retries cases land at
+    // ~3.1s against bun's 5s per-test timeout — ~1.5s of headroom, which a
+    // loaded CI runner eats. That is what made this file the single largest
+    // source of intermittent CI failures. The delay is behaviour under test
+    // only in its *ordering*, not its duration, so collapse it here.
+    process.env.MERIDIAN_RATE_LIMIT_BASE_DELAY_MS = "1"
+  })
+
+  afterEach(() => {
+    delete process.env.MERIDIAN_RATE_LIMIT_BASE_DELAY_MS
   })
 
   describe("Non-streaming", () => {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3177,7 +3177,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             //   1. Strip [1m] context (immediate, different model tier)
             //   2. Backoff retries on base model (1s, 2s — exponential)
             const MAX_RATE_LIMIT_RETRIES = 2
-            const RATE_LIMIT_BASE_DELAY_MS = 1000
+            const RATE_LIMIT_BASE_DELAY_MS = envInt("RATE_LIMIT_BASE_DELAY_MS", 1000)
 
             const response = (async function* () {
               let rateLimitRetries = 0
@@ -4233,7 +4233,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               //   1. Strip [1m] context (immediate, different model tier)
               //   2. Backoff retries on base model (1s, 2s — exponential)
               const MAX_RATE_LIMIT_RETRIES = 2
-              const RATE_LIMIT_BASE_DELAY_MS = 1000
+              const RATE_LIMIT_BASE_DELAY_MS = envInt("RATE_LIMIT_BASE_DELAY_MS", 1000)
 
               const response = (async function* () {
                 let rateLimitRetries = 0


### PR DESCRIPTION
The rate-limit retry tests sleep for real. That is the single largest source of intermittent CI failures on `main`, and it blocked the 1.66.0 npm publish **twice** today.

## What was happening

`RATE_LIMIT_BASE_DELAY_MS` was hardcoded at 1000ms, so every test exercising the retry path waited through the real 1s + 2s backoff:

- 7 tests, **18.4 seconds**, nearly all of it asleep
- the exhaust-all-retries cases land at ~3.1s against bun's **5s** per-test timeout
- that leaves ~1.5s of headroom, which a loaded CI runner eats

The signature is unmistakable — failures at exactly `5002.97ms`, `5003.01ms`, `5005.06ms`.

I confirmed these tests have *always* taken 3.1–3.5s, including in old passing runs, so this is a long-standing latent problem rather than something recently introduced. Runner variance decides whether a given run fails.

## Why it matters beyond CI noise

The `publish` job re-runs `npm test` before `npm publish`. A flake there stops the release even when the same commit passed CI — which is exactly what happened to 1.66.0: tagged, GitHub Release published, Docker published, npm stuck on 1.65.2.

## The fix

```ts
const RATE_LIMIT_BASE_DELAY_MS = envInt("RATE_LIMIT_BASE_DELAY_MS", 1000)
```

Tests set it to `1`. **Production default is unchanged.**

This is not a new pattern. The neighbouring retry constant is already `parseInt(process.env.MERIDIAN_BUSY_RETRY_DELAY_MS ?? "500", 10)`, and both tests exercising that path already override it. The rate-limit constant was simply missed when that pattern was established.

The duration is not the behaviour under test — the retry *ordering* and *count* are, and those assertions are untouched.

## Result

| | before | after |
|---|---|---|
| rate-limit file | 18.4s | **0.84s** |
| slowest test in suite | 5139ms | **684ms** |
| headroom under bun's 5s timeout | ~1.5s | ~4.3s |
| suite wall time | 89s | 72s |

Full suite: **3211 pass, 0 fail**. `tsc --noEmit` clean.

## What this does not fix

Several other intermittent failures are **not** timeouts and are untouched by this:

```
MCP server per-request lifecycle     919ms
Plugin integration end-to-end       2197ms
Concurrent subagent requests         119ms
Fingerprint resume cross-project      89ms
queue telemetry under cancellation   226ms
```

Those are mostly concurrency tests failing fast, which suggests genuine races under CPU contention rather than slowness. Not diagnosed here — worth a separate issue. This PR removes the largest and most clearly-understood category.
