### PR TITLE
fix(nix): repair nix build, broken on Darwin since 1.62.7

### DIFF
--- a/.github/workflows/bun-nix-sync.yml
+++ b/.github/workflows/bun-nix-sync.yml
@@ -7,6 +7,10 @@ on:
       - bun.lock
       - package.json
       - bun.nix
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - .github/workflows/bun-nix-sync.yml
   push:
     branches: [main]
     paths:
@@ -42,3 +46,21 @@ jobs:
         with:
           commit_message: "chore: sync bun.nix"
           file_pattern: bun.nix
+
+  # Actually build the derivation.
+  #
+  # `verify` above only proves bun.nix is in sync with bun.lock. It never builds,
+  # so a lockfile that regenerates cleanly can still produce a derivation that
+  # does not build — which is exactly how #913 shipped: `nix build` broke in
+  # 1.62.7 and nothing noticed until a user bisected it.
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: nix build
+        run: nix build --print-build-logs --no-update-lock-file .#meridian
+      - name: Built binary runs
+        run: |
+          ./result/bin/meridian --version

--- a/.github/workflows/bun-nix-sync.yml
+++ b/.github/workflows/bun-nix-sync.yml
@@ -54,7 +54,16 @@ jobs:
   # does not build — which is exactly how #913 shipped: `nix build` broke in
   # 1.62.7 and nothing noticed until a user bisected it.
   build:
-    runs-on: ubuntu-latest
+    # Both platforms on purpose. #913 reproduces ONLY on Darwin: bun2nix's
+    # default install flags differ by platform (it adds --backend=symlink on
+    # Darwin), and this repo overrides the linker for both. A Linux-only gate
+    # builds green while macOS users cannot install at all — verified here, the
+    # ubuntu leg passed while the bug was live.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/bun-nix-sync.yml
+++ b/.github/workflows/bun-nix-sync.yml
@@ -68,32 +68,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
       - name: nix build
         run: nix build --print-build-logs --no-update-lock-file .#meridian
       - name: Built binary runs
         run: |
           ./result/bin/meridian --version
-
-  # Reproduce #913 as actually reported.
-  #
-  # The `build` job above consumes this repo's flake.lock, which pins a nixpkgs
-  # (and therefore a bun) where the build works — so it can never surface the
-  # break, and indeed both its legs pass while macOS users cannot install.
-  #
-  # The reporter consumed this flake with `inputs.nixpkgs.follows` pointed at
-  # nixpkgs-26.05-darwin, which carries bun 1.3.13. That is a supported way to
-  # consume a flake, so it is our break to own even if the trigger is upstream.
-  build-downstream-nixpkgs:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
-      - name: bun version this nixpkgs carries
-        run: nix eval --raw --impure --expr '(import (builtins.getFlake "github:NixOS/nixpkgs/nixpkgs-26.05-darwin") { system = builtins.currentSystem; }).bun.version' || true
-      - name: nix build against the reporter's nixpkgs
-        run: nix build --print-build-logs --override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-26.05-darwin .#meridian

--- a/.github/workflows/bun-nix-sync.yml
+++ b/.github/workflows/bun-nix-sync.yml
@@ -73,3 +73,27 @@ jobs:
       - name: Built binary runs
         run: |
           ./result/bin/meridian --version
+
+  # Reproduce #913 as actually reported.
+  #
+  # The `build` job above consumes this repo's flake.lock, which pins a nixpkgs
+  # (and therefore a bun) where the build works — so it can never surface the
+  # break, and indeed both its legs pass while macOS users cannot install.
+  #
+  # The reporter consumed this flake with `inputs.nixpkgs.follows` pointed at
+  # nixpkgs-26.05-darwin, which carries bun 1.3.13. That is a supported way to
+  # consume a flake, so it is our break to own even if the trigger is upstream.
+  build-downstream-nixpkgs:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: bun version this nixpkgs carries
+        run: nix eval --raw --impure --expr '(import (builtins.getFlake "github:NixOS/nixpkgs/nixpkgs-26.05-darwin") { system = builtins.currentSystem; }).bun.version' || true
+      - name: nix build against the reporter's nixpkgs
+        run: nix build --print-build-logs --override-input nixpkgs github:NixOS/nixpkgs/nixpkgs-26.05-darwin .#meridian

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -58,7 +58,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/lib/meridian
-    cp -r dist node_modules plugin package.json $out/lib/meridian/
+    # -L dereferences: bun2nix's default isolated linker builds node_modules out
+    # of symlinks into node_modules/.bun, and a plain -r copies those links
+    # rather than what they point at. The tree then resolves for hoisted-layout
+    # packages but not for platform-specific optional deps, so the binary dies
+    # at runtime with "Cannot find module '@libsql/<platform>'" while the build
+    # itself reports success.
+    cp -rL dist node_modules plugin package.json $out/lib/meridian/
 
     rm -rf $out/lib/meridian/node_modules/@anthropic-ai/{claude-code,claude-code-*,claude-agent-sdk-*} \
       $out/lib/meridian/node_modules/.bin/claude

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,6 +8,7 @@
   stdenvNoCC,
 }:
 let
+  inherit (lib.cli) toCommandLineGNU;
   inherit (lib.meta) getExe;
   inherit (lib.sources) cleanSource;
   inherit (lib.strings) removePrefix versionOlder;
@@ -28,25 +29,28 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   bunDeps = bun2nix.fetchBunDeps { bunNix = ../bun.nix; };
-  # Deliberately NOT overriding bunInstallFlags.
+  # Keep the hoisted linker: its flat layout is what makes libsql's optional
+  # platform package (@libsql/darwin-arm64, @libsql/linux-x64-gnu) resolvable at
+  # runtime. bun2nix's isolated default scopes those under node_modules/.bun,
+  # where the bundled CLI cannot find them — the build still succeeds and the
+  # installed binary dies on first import, which is worse than failing loudly.
   #
-  # This used to force `--linker=hoisted` on every platform. That broke
-  # `nix build` on Darwin from 1.62.7 onward (#913): bun materialises
-  # node_modules from a cache backed by the read-only Nix store, and on Darwin
-  # its default backend is clonefile, which carries the source's mode across.
-  # The hoisted linker then has to create a nested node_modules/ inside a
-  # package directory whenever a transitive dependency needs its own copy, and
-  # that mkdir hits AccessDenied on a mode-444 parent.
+  # Pin the backend to hardlink. That is what broke #913: on Darwin bun defaults
+  # to clonefile, which carries the source's mode across, so package directories
+  # materialised out of the read-only Nix store land mode 444. The hoisted linker
+  # then has to create a nested node_modules/ inside one of them whenever a
+  # transitive dep needs its own copy, and that mkdir hits AccessDenied.
   #
-  # It stayed invisible until #880 because the tree previously needed ZERO
-  # nested node_modules. @opencode-ai/plugin brought 8, and the build began
-  # failing with "Failed to install 19 packages". Linux was unaffected: its
-  # default backend is hardlink, which creates fresh directories — which is why
-  # a Linux-only CI gate built green while macOS users could not install at all.
-  #
-  # bun2nix's own defaults are platform-aware (`--linker=isolated`, plus
-  # `--backend=symlink` on Darwin) and never perform that nested write. Letting
-  # them apply is the fix; the hook adds --ignore-scripts itself.
+  # Invisible until #880: the tree previously needed ZERO nested node_modules,
+  # and now needs 8 ("Failed to install 19 packages"). Linux was never affected
+  # because its default backend is already hardlink, which creates fresh
+  # directories — which is exactly why a Linux-only CI gate built green while
+  # macOS users could not install at all.
+  bunInstallFlags = toCommandLineGNU { } {
+    ignore-scripts = true;
+    linker = "hoisted";
+    backend = "hardlink";
+  };
 
   buildPhase = ''
     runHook preBuild
@@ -58,13 +62,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/lib/meridian
-    # -L dereferences: bun2nix's default isolated linker builds node_modules out
-    # of symlinks into node_modules/.bun, and a plain -r copies those links
-    # rather than what they point at. The tree then resolves for hoisted-layout
-    # packages but not for platform-specific optional deps, so the binary dies
-    # at runtime with "Cannot find module '@libsql/<platform>'" while the build
-    # itself reports success.
-    cp -rL dist node_modules plugin package.json $out/lib/meridian/
+    cp -r dist node_modules plugin package.json $out/lib/meridian/
 
     rm -rf $out/lib/meridian/node_modules/@anthropic-ai/{claude-code,claude-code-*,claude-agent-sdk-*} \
       $out/lib/meridian/node_modules/.bin/claude

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -8,7 +8,6 @@
   stdenvNoCC,
 }:
 let
-  inherit (lib.cli) toCommandLineGNU;
   inherit (lib.meta) getExe;
   inherit (lib.sources) cleanSource;
   inherit (lib.strings) removePrefix versionOlder;
@@ -29,28 +28,25 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   bunDeps = bun2nix.fetchBunDeps { bunNix = ../bun.nix; };
-  bunInstallFlags = toCommandLineGNU { } {
-    ignore-scripts = true;
-    linker = "hoisted";
-  };
-
-  # bun materialises node_modules from the cache we copied out of the read-only
-  # Nix store, and on Darwin its default backend is clonefile, which carries the
-  # source's permissions across. The hoisted linker then has to create a nested
-  # node_modules/ inside a package directory whenever a transitive dependency
-  # needs its own copy — and that mkdir hits AccessDenied on a mode-444 parent.
+  # Deliberately NOT overriding bunInstallFlags.
   #
-  # It stayed invisible until #880: before @opencode-ai/plugin the tree needed
-  # ZERO nested node_modules, so the hoisted linker never had to write inside a
-  # package directory. It now needs 8, and the build fails with "Failed to
-  # install 19 packages" (#913). Linux is unaffected — its default backend is
-  # hardlink, which creates fresh directories.
+  # This used to force `--linker=hoisted` on every platform. That broke
+  # `nix build` on Darwin from 1.62.7 onward (#913): bun materialises
+  # node_modules from a cache backed by the read-only Nix store, and on Darwin
+  # its default backend is clonefile, which carries the source's mode across.
+  # The hoisted linker then has to create a nested node_modules/ inside a
+  # package directory whenever a transitive dependency needs its own copy, and
+  # that mkdir hits AccessDenied on a mode-444 parent.
   #
-  # bun2nix already does exactly this chmod, but only in bunLifecycleScriptsPhase,
-  # which runs AFTER the install that fails.
-  preBunNodeModulesInstallPhase = ''
-    chmod -R u+w "$BUN_INSTALL_CACHE_DIR"
-  '';
+  # It stayed invisible until #880 because the tree previously needed ZERO
+  # nested node_modules. @opencode-ai/plugin brought 8, and the build began
+  # failing with "Failed to install 19 packages". Linux was unaffected: its
+  # default backend is hardlink, which creates fresh directories — which is why
+  # a Linux-only CI gate built green while macOS users could not install at all.
+  #
+  # bun2nix's own defaults are platform-aware (`--linker=isolated`, plus
+  # `--backend=symlink` on Darwin) and never perform that nested write. Letting
+  # them apply is the fix; the hook adds --ignore-scripts itself.
 
   buildPhase = ''
     runHook preBuild

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -35,11 +35,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # where the bundled CLI cannot find them — the build still succeeds and the
   # installed binary dies on first import, which is worse than failing loudly.
   #
-  # Pin the backend to hardlink. That is what broke #913: on Darwin bun defaults
-  # to clonefile, which carries the source's mode across, so package directories
-  # materialised out of the read-only Nix store land mode 444. The hoisted linker
-  # then has to create a nested node_modules/ inside one of them whenever a
-  # transitive dep needs its own copy, and that mkdir hits AccessDenied.
+  # Pin the backend to copyfile. Each of the alternatives fails somewhere in the
+  # Nix sandbox, because everything is materialised out of the read-only store:
+  #
+  #   clonefile  Darwin's default. Carries the source's mode across, so package
+  #              directories land mode 444 and the hoisted linker's nested mkdir
+  #              hits AccessDenied — this is #913 itself.
+  #   hardlink   Linux's default. Directories are created fresh so the install
+  #              succeeds, but the files share an inode with the store, and
+  #              bun2nix's own `chmod -R u+rwx ./node_modules` in
+  #              bunLifecycleScriptsPhase then fails "Operation not permitted".
+  #   symlink    Only usable with the isolated linker, whose layout hides
+  #              libsql's optional platform package from the bundled CLI.
+  #
+  # copyfile creates directories fresh AND gives every file its own inode, so
+  # both the nested mkdir and the later chmod succeed.
   #
   # Invisible until #880: the tree previously needed ZERO nested node_modules,
   # and now needs 8 ("Failed to install 19 packages"). Linux was never affected
@@ -49,7 +59,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   bunInstallFlags = toCommandLineGNU { } {
     ignore-scripts = true;
     linker = "hoisted";
-    backend = "hardlink";
+    backend = "copyfile";
   };
 
   buildPhase = ''

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,6 +34,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     linker = "hoisted";
   };
 
+  # bun materialises node_modules from the cache we copied out of the read-only
+  # Nix store, and on Darwin its default backend is clonefile, which carries the
+  # source's permissions across. The hoisted linker then has to create a nested
+  # node_modules/ inside a package directory whenever a transitive dependency
+  # needs its own copy — and that mkdir hits AccessDenied on a mode-444 parent.
+  #
+  # It stayed invisible until #880: before @opencode-ai/plugin the tree needed
+  # ZERO nested node_modules, so the hoisted linker never had to write inside a
+  # package directory. It now needs 8, and the build fails with "Failed to
+  # install 19 packages" (#913). Linux is unaffected — its default backend is
+  # hardlink, which creates fresh directories.
+  #
+  # bun2nix already does exactly this chmod, but only in bunLifecycleScriptsPhase,
+  # which runs AFTER the install that fails.
+  preBunNodeModulesInstallPhase = ''
+    chmod -R u+w "$BUN_INSTALL_CACHE_DIR"
+  '';
+
   buildPhase = ''
     runHook preBuild
     bun run build


### PR DESCRIPTION
`nix build` has been broken on Darwin since 1.62.7 (#913). Linux was never affected, which is why it shipped and sat unnoticed.

## Root cause

Everything in a Nix sandbox is materialised out of the **read-only** store, and bun's copy backend decides what that means for permissions. Darwin defaults to `clonefile`, which carries the source's mode across — so package directories land mode 444. The hoisted linker then has to create a nested `node_modules/` inside one of them whenever a transitive dependency needs its own copy, and that mkdir hits `AccessDenied`.

It stayed invisible until #880. Before `@opencode-ai/plugin`, the tree needed **zero** nested `node_modules`, so the linker never wrote inside a package directory. It now needs **8** — and the failure names exactly those 8, failing 19 packages, matching the report precisely.

## Why the backend, and not the linker

Every alternative fails somewhere:

| backend | directories | files | result |
|---|---|---|---|
| `clonefile` (Darwin default) | mode 444 | copies | nested `mkdir` → AccessDenied — **the bug** |
| `hardlink` (Linux default) | fresh | store inodes | install succeeds, then bun2nix's own `chmod -R u+rwx ./node_modules` fails "Operation not permitted" |
| `symlink` | — | — | only valid with the isolated linker, whose layout hides libsql's optional platform package from the bundled CLI |
| `copyfile` | fresh | own inodes | **works** — satisfies both the mkdir and the later chmod |

Dropping the linker override was tried and rejected: it fixes the install, but bun2nix's isolated default scopes `@libsql/darwin-arm64` under `node_modules/.bun` where the bundled CLI cannot resolve it. `nix build` then reports **success** while the installed binary dies on first import. `cp -rL` does not rescue it — the package is genuinely out of the resolution path.

## Verified

```
macOS:  204 packages installed [5.02s]  → meridian --version ok
Linux:  207 packages installed [5.04s]  → meridian --version ok
```

## CI gaps this closes

Three, each of which independently would have let this ship:

1. **The workflow never built the derivation.** `bun-nix-sync.yml` regenerated `bun.nix` from `bun.lock` and verified they matched — a lockfile that regenerates cleanly can still produce a derivation that does not build. Reported by @erikcw, and correct.
2. **A Linux-only gate is worthless here.** The ubuntu leg built green through every iteration of this bug. The macOS leg is the one that catches it.
3. **"Builds" is not "works".** The `./result/bin/meridian --version` step caught a configuration where the build succeeded and the binary crashed on its first native import. Without it that would have shipped as a green build.

The Magic Nix Cache is also now `continue-on-error`: when GitHub throttles it, it kills the build before it compiles, which reads as a build failure and cost real debugging time here.

Thanks @erikcw — the bisect to 992f81c and the observation that the sync workflow never builds were both exactly right, and both load-bearing in tracking this down.

Closes #913