### PR TITLE
fix(errors): classify an oversized prompt as a 400, not a retryable 500

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -237,6 +237,12 @@ describe("classifyError", () => {
       expect(canRecoverCapturedToolUses({ ...base, reason: "process_exit" })).toBe(false)
     })
 
+    // An overflow is rejected before generation, so there is nothing captured
+    // to deliver — and replaying the same oversized prompt cannot succeed.
+    it("does not recover a context overflow", () => {
+      expect(canRecoverCapturedToolUses({ ...base, reason: "context_overflow" })).toBe(false)
+    })
+
     // Without captured calls there is nothing to deliver, and outside
     // passthrough the client does not execute tools at all.
     it("requires captured tool calls", () => {
@@ -245,6 +251,55 @@ describe("classifyError", () => {
 
     it("requires passthrough", () => {
       expect(canRecoverCapturedToolUses({ ...base, reason: "max_turns", passthrough: false })).toBe(false)
+    })
+  })
+
+  describe("context overflow", () => {
+    it("classifies the CLI's bare wording", () => {
+      const r = classifyError("Claude Code returned an error result: Prompt is too long")
+      expect(r.status).toBe(400)
+      expect(r.type).toBe("invalid_request_error")
+    })
+
+    it("classifies the API's token-count wording", () => {
+      const r = classifyError('API Error: 400 {"type":"invalid_request_error","message":"prompt is too long: 215843 tokens > 200000 maximum"}')
+      expect(r.status).toBe(400)
+    })
+
+    it("classifies the max_tokens phrasing", () => {
+      const r = classifyError("input length and `max_tokens` exceed context limit: 197000 + 8192 > 200000")
+      expect(r.status).toBe(400)
+    })
+
+    it("classifies the OpenAI-compatible code", () => {
+      const r = classifyError("context_length_exceeded")
+      expect(r.status).toBe(400)
+    })
+
+    // The whole reason this branch sits above the crash branch. Without it the
+    // code-1 path returns 401 and tells the operator to run `claude login` —
+    // advice that cannot work here, for a cause it has hidden.
+    it("wins over a process exit carrying the overflow in stderr", () => {
+      const r = classifyError("Claude Code process exited with code 1\nSubprocess stderr: Prompt is too long")
+      expect(r.status).toBe(400)
+      expect(r.type).toBe("invalid_request_error")
+      expect(r.message).not.toContain("claude login")
+    })
+
+    // A 5xx reads as "transient, try again" to every client retry policy, which
+    // is what replays an unfixable request at full upstream cost.
+    it.each([
+      ["the CLI wording", "Prompt is too long"],
+      ["the OpenAI code", "context_length_exceeded"],
+    ])("never classifies %s as retryable", (_label, msg) => {
+      expect(classifyError(msg).status).toBeLessThan(500)
+    })
+
+    // Mirrors #796: the phrase is word-separated, so an identifier carrying the
+    // same words cannot steal the branch from the real cause.
+    it("ignores an incidental identifier", () => {
+      const r = classifyError("Error: ENOENT: no such file or directory, open '/repo/src/prompt-is-too-long.ts'")
+      expect(r.status).not.toBe(400)
     })
   })
 
@@ -465,6 +520,26 @@ describe("extractSdkTermination", () => {
       expect(t.reason).toBe("max_turns")
       expect(t.turns).toBe(3)
       expect(t.stderrTail).toContain("Custom betas")
+    })
+  })
+
+  describe("context_overflow", () => {
+    it("names an oversized prompt", () => {
+      const t = extractSdkTermination("Claude Code returned an error result: Prompt is too long")
+      expect(t.reason).toBe("context_overflow")
+    })
+
+    // Ordering guard: the overflow arrives as a process exit often enough that
+    // reading the exit first points the diagnostic log at the wrong thing.
+    it("wins over a process exit carrying the overflow in stderr", () => {
+      const t = extractSdkTermination("process exited with code 1\nSubprocess stderr: Prompt is too long")
+      expect(t.reason).toBe("context_overflow")
+      expect(t.stderrTail).toContain("Prompt is too long")
+    })
+
+    it("survives the round trip into a diagnostic log line", () => {
+      const t = extractSdkTermination("Prompt is too long")
+      expect(formatSdkTermination(t, { model: "sonnet" })).toContain("reason=context_overflow")
     })
   })
 

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -301,6 +301,49 @@ describe("classifyError", () => {
       const r = classifyError("Error: ENOENT: no such file or directory, open '/repo/src/prompt-is-too-long.ts'")
       expect(r.status).not.toBe(400)
     })
+
+    // A false 400 is the expensive direction: it tells the client the request is
+    // unfixable, so the retry is abandoned and legitimate work is silently
+    // dropped. Every case below classified as 400 before the pattern was
+    // anchored. Asserting the concrete status, not `not.toBe(400)` — the weaker
+    // form is what let an equivalent regression hide in #908.
+    it.each([
+      ["a negated sentence", "The prompt is too long check did not trigger; this is a network failure"],
+      ["the phrase quoted in prose", 'The assistant replied: "prompt is too long" is a common error message users see'],
+      ["the phrase quoted inside stderr", 'Subprocess stderr: user asked "why does it say prompt is too long?"'],
+      ["a tool_result echoing a grep hit", "tool_result: grep found 'context_length_exceeded' in errors.ts:114"],
+    ])("does not classify %s as an overflow", (_label, msg) => {
+      const r = classifyError(msg)
+      expect(r.status).toBe(500)
+      expect(r.type).toBe("api_error")
+    })
+
+    // The API envelope is the one non-line-anchored shape that must still match,
+    // so the phrase is accepted when it opens a `message` value. That is narrow
+    // on purpose: the same words inside any other field, or partway through the
+    // message, are prose rather than the error itself.
+    //
+    // Known boundary: a tool_result echoing a genuine overflow envelope verbatim
+    // still classifies as 400. Distinguishing it would mean parsing the message
+    // to see whose error it is, and an echoed envelope is a real overflow report
+    // either way — so it is left as the accepted edge rather than widened around.
+    it.each([
+      ["opens the message value", '{"message":"prompt is too long: 215843 tokens > 200000 maximum"}', 400],
+      ["sits in another field", '{"note":"prompt is too long is a common error users hit"}', 500],
+      ["sits partway through the message", '{"message":"the user asked why prompt is too long appears"}', 500],
+    ])("%s", (_label, msg, status) => {
+      expect(classifyError(msg).status).toBe(status)
+    })
+
+    // The overflow branch runs before the process-crash branch but after the
+    // HTTP-status branches, so a real refusal that merely mentions the phrase
+    // keeps its own classification rather than being downgraded to a 400.
+    it.each([
+      ["a rate limit", "429 rate limit exceeded — note: context length exceeded is a different error", 429],
+      ["an auth failure", "401 unauthorized. Docs mention context_length_exceeded elsewhere.", 401],
+    ])("lets %s keep its status", (_label, msg, status) => {
+      expect(classifyError(msg).status).toBe(status)
+    })
   })
 
   describe("process crashes", () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -124,12 +124,41 @@ const HTTP_503 = /(?:^|[^0-9a-f])503(?![0-9a-f]|:\d)/
  *  Wordings: the CLI's bare "Prompt is too long", the API's fuller
  *  "prompt is too long: N tokens > M maximum" (same prefix), its max_tokens
  *  phrasing (backtick-quoted upstream, matched loosely here), and the
- *  OpenAI-compatible code the openai adapter can surface. */
-const CONTEXT_OVERFLOW_SIGNALS: readonly RegExp[] = [
-  /prompt is too long/,
-  /input length and .?max_tokens.? exceed context limit/,
-  /context[_ ]length[_ ]exceeded/,
+ *  OpenAI-compatible code the openai adapter can surface.
+ *
+ *  Anchored per-line, tolerating the wrapper prefixes the CLI and SDK prepend —
+ *  the same shape as HIT_YOUR_SPEND_LIMIT above, for the same reason. Unanchored
+ *  these matched their own strings quoted inside arbitrary text: an assistant
+ *  turn discussing the error, a tool_result echoing a grep hit, and a plainly
+ *  negated sentence all classified as 400 before the anchor was added.
+ *
+ *  The asymmetry matters here more than it does for a quota refusal. A false 400
+ *  tells the client the request itself is unfixable, so the retry is abandoned
+ *  and legitimate work is silently dropped; a false 5xx only costs a retry.
+ *
+ *  `subprocess stderr` is in the wrapper list because the CLI surfaces an
+ *  oversized prompt by exiting and appending it to stderr — and without this
+ *  branch that shape reads as a bare code-1 exit, which the process-crash branch
+ *  below reports as an auth failure telling the operator to run `claude login`. */
+const OVERFLOW_PHRASES = [
+  String.raw`prompt is too long`,
+  String.raw`input length and .?max_tokens.? exceed context limit`,
+  String.raw`context[_ ]length[_ ]exceeded`,
 ]
+
+/** Either the phrase opens a line (after the known SDK/CLI wrappers), or it
+ *  opens the `message` value of an API error envelope — `API Error: 400
+ *  {"type":"invalid_request_error","message":"prompt is too long: ..."}`, which
+ *  is a real upstream shape and not line-anchored. Requiring the phrase to start
+ *  the message value is what separates it from the same words merely quoted
+ *  somewhere inside arbitrary prose. */
+const CONTEXT_OVERFLOW_SIGNALS: readonly RegExp[] = OVERFLOW_PHRASES.map(
+  phrase => new RegExp(
+    String.raw`(?:^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*|"message"\s*:\s*")`
+    + phrase,
+    "m",
+  ),
+)
 
 /**
  * Detect specific SDK errors and return helpful messages to the client.

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -114,6 +114,22 @@ const HTTP_401 = /(?:^|[^0-9a-f])401(?![0-9a-f]|:\d)/
 const HTTP_429 = /(?:^|[^0-9a-f])429(?![0-9a-f]|:\d)/
 const HTTP_500 = /(?:^|[^0-9a-f])500(?![0-9a-f]|:\d)/
 const HTTP_503 = /(?:^|[^0-9a-f])503(?![0-9a-f]|:\d)/
+/** A request whose input exceeds the model's context window.
+ *
+ *  Distinct from a rate limit in the one way that matters to a caller: waiting
+ *  does not fix it. An identical retry burns a whole upstream turn to fail
+ *  identically, so this must not classify as a 5xx — see the branch in
+ *  classifyError for why the status code is the actual fix.
+ *
+ *  Wordings: the CLI's bare "Prompt is too long", the API's fuller
+ *  "prompt is too long: N tokens > M maximum" (same prefix), its max_tokens
+ *  phrasing (backtick-quoted upstream, matched loosely here), and the
+ *  OpenAI-compatible code the openai adapter can surface. */
+const CONTEXT_OVERFLOW_SIGNALS: readonly RegExp[] = [
+  /prompt is too long/,
+  /input length and .?max_tokens.? exceed context limit/,
+  /context[_ ]length[_ ]exceeded/,
+]
 
 /**
  * Detect specific SDK errors and return helpful messages to the client.
@@ -181,6 +197,24 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
       status: 402,
       type: "billing_error",
       message: "Claude Max subscription issue. Check your subscription status at https://claude.ai/settings/subscription"
+    }
+  }
+
+  // Context overflow. Ordered before the process-crash branch deliberately:
+  // when the CLI surfaces an oversized prompt by exiting rather than returning
+  // a result, that branch reads a bare code-1 exit as an auth failure and tells
+  // the operator to run `claude login` — advice that cannot work and that hides
+  // the real cause.
+  //
+  // The status code is the fix, not the wording. The default 500 reads as
+  // "transient, try again" to every client retry policy, so an overflow that
+  // can only ever fail identically gets replayed at full upstream cost. 400
+  // says the request itself is the problem.
+  if (CONTEXT_OVERFLOW_SIGNALS.some(rx => rx.test(lower))) {
+    return {
+      status: 400,
+      type: "invalid_request_error",
+      message: "Prompt exceeds the model's context window. Compact or trim the conversation before retrying — an identical retry fails the same way."
     }
   }
 
@@ -403,7 +437,7 @@ export function isExtraUsageRequiredError(errMsg: string): boolean {
  * collapses into a generic api_error.
  */
 export interface SdkTermination {
-  reason: "max_turns" | "process_exit" | "aborted" | "upstream_idle" | "unknown"
+  reason: "max_turns" | "process_exit" | "aborted" | "upstream_idle" | "context_overflow" | "unknown"
   /** Turn count when reason=max_turns and parseable. */
   turns?: number
   /** Exit code when reason=process_exit and parseable. */
@@ -513,6 +547,16 @@ export function extractSdkTermination(errMsg: string): SdkTermination {
     return {
       reason: "max_turns",
       ...(m ? { turns: Number(m[1]) } : {}),
+      ...(stderrTail ? { stderrTail } : {}),
+    }
+  }
+
+  // Same ordering rationale as classifyError: an oversized prompt that arrives
+  // as a process exit must name the overflow, not the exit, or the diagnostic
+  // log points at the wrong thing.
+  if (CONTEXT_OVERFLOW_SIGNALS.some(rx => rx.test(lower))) {
+    return {
+      reason: "context_overflow",
       ...(stderrTail ? { stderrTail } : {}),
     }
   }


### PR DESCRIPTION
Lands @mpeter's context-overflow classification from #857, cherry-picked so authorship is preserved, with a follow-up commit hardening the patterns.

Closes #857
Closes #856

## The bug

An oversized prompt falls through to the process-crash branch. Verified against current `main` before touching anything:

| input | before |
|---|---|
| `Prompt is too long` | 500 `api_error` |
| `prompt is too long: 250000 tokens > 200000 maximum` | 500 `api_error` |
| `input length and \`max_tokens\` exceed context limit` | 500 `api_error` |
| `context_length_exceeded` | 500 `api_error` |
| **surfaced via process exit** | **401 — "try `claude login`"** |

The 500s are the reported problem: every client retry policy reads 5xx as "transient, try again", so an unfixable request is replayed at full upstream cost, forever.

The 401 is not in the issue and is arguably worse. When the CLI surfaces an oversized prompt by exiting, a bare code-1 exit reads as an auth failure — so the operator is told to re-authenticate for a prompt-size problem. Exactly the shape that made the spend-limit misclassification in #908 so hard to spot.

## Follow-up commit (mine)

The signals were unanchored, so they matched their own strings quoted inside arbitrary text. All four of these classified as **400** against the cherry-picked commit:

```
"The prompt is too long check did not trigger; this is a network failure"
'The assistant replied: "prompt is too long" is a common error message users see'
'Subprocess stderr: user asked "why does it say prompt is too long?"'
"tool_result: grep found 'context_length_exceeded' in errors.ts:114"
```

**A false 400 is the expensive direction.** It tells the client the request itself is unfixable, so the retry is abandoned and legitimate work is silently dropped; a false 5xx only costs a retry. Same failure class as #908, anchored the same way.

### The correction that mattered

Anchoring per-line alone was **too strict** — it rejected the API's own envelope:

```
API Error: 400 {"type":"invalid_request_error","message":"prompt is too long: 215843 tokens > 200000 maximum"}
```

That is a real upstream shape and is not line-anchored. @mpeter's existing test caught my regression immediately. The phrase is now also accepted when it *opens a `message` value*, which still rejects the same words in another field or partway through the message:

| shape | result |
|---|---|
| `{"message":"prompt is too long: 215843 tokens > 200000"}` | 400 |
| `{"note":"prompt is too long is a common error users hit"}` | 500 |
| `{"message":"the user asked why prompt is too long appears"}` | 500 |

### Known boundary, documented not papered over

A `tool_result` echoing a genuine overflow envelope verbatim still classifies as 400. Distinguishing it would mean parsing the message to work out whose error it is, and an echoed envelope is a real overflow report either way.

## Verification

- Bug confirmed on `main` by running `classifyError` directly, not from the PR description
- Every false positive above has a test asserting the **concrete status**, not `not.toBe(400)` — the weaker assertion is what let an equivalent regression hide in #908
- Ordering checked: a real 401/429 that merely mentions the phrase keeps its own status
- `errors.test.ts`: 145 pass, 0 fail
- Full suite: **3232 pass, 0 fail**. `tsc --noEmit` clean.

Thanks @mpeter — the diagnosis and the ordering argument were both right, and your token-count test is what caught my over-correction.
