### PR TITLE
fix(errors): classify the credits-era per-tier limit refusal

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -730,6 +730,7 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["Opus tier", "You've reached your Opus limit"],
     ["versioned Sonnet tier", "You've reached your Sonnet 4.6 limit"],
     ["Claude-prefixed tier", "You've reached your Claude Opus 4.6 limit"],
+    ["space-separated model command", "You've reached your Fable 5 limit /model to switch models."],
     ["multiline subprocess stderr", "Claude Code process exited with code 1\nSubprocess stderr: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
@@ -749,6 +750,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["documentation sentence suffix", "Error: You've reached your Fable 5 limit. This is only a documentation example"],
     ["false assertion suffix", "You've reached your Fable 5 limit is false"],
     ["possessive threshold suffix", "You've reached your Fable 5 limit's configured warning threshold"],
+    ["joined run command", "You've reached your Fable 5 limitRun /usage-credits"],
+    ["joined usage command", "You've reached your Fable 5 limit/usage-credits"],
+    ["unspaced punctuated command", "You've reached your Fable 5 limit.Run /usage-credits"],
     ["generic error newline", "Error:\nYou've reached your Fable 5 limit."],
     ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
     ["unrelated appended stderr", "You've reached your Fable 5 limit.\nSubprocess stderr: unrelated tool output"],

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -738,6 +738,10 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["configured tool qualifier", "You've reached your Fable configured tool limit"],
     ["limitations suffix", "You've reached your Fable 5 limitations"],
     ["unlabelled multiline quote", "MCP server failed:\nYou've reached your Fable 5 limit (quoted from docs)"],
+    ["parenthetical documentation suffix", "You've reached your Fable 5 limit (quoted from docs, account healthy)"],
+    ["documentation sentence suffix", "Error: You've reached your Fable 5 limit. This is only a documentation example"],
+    ["false assertion suffix", "You've reached your Fable 5 limit is false"],
+    ["possessive threshold suffix", "You've reached your Fable 5 limit's configured warning threshold"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -708,6 +708,35 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(classifyError(msg).type).not.toBe("rate_limit_error")
   })
 
+  it("maps the CLI's per-tier limit refusal to rate_limit_error without a same-profile retry", () => {
+    const msg = "Claude Code returned an error result: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+    expect(isRateLimitError(msg)).toBe(false)
+    expect(isAccountFailoverError(r.type)).toBe(true)
+  })
+
+  it.each([
+    ["bare banner", "You've reached your Fable 5 limit."],
+    ["nested SDK wrappers", "Error: API Error: You’ve reached your Fable 5 limit! /model to switch models."],
+    ["Opus tier", "You've reached your Opus limit"],
+    ["versioned Sonnet tier", "You've reached your Sonnet 4.6 limit"],
+  ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  it.each([
+    ["specified limit", "You've reached your specified limit"],
+    ["quoted banner", "The docs say ‘You've reached your Fable 5 limit.’"],
+    ["negated banner", "You've not reached your Fable 5 limit"],
+    ["filename prefix", "Claude Code returned an error result: usage-credits.ts says You've reached your Fable 5 limit."],
+  ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
+    expect(classifyError(msg).type).toBe("api_error")
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -717,6 +717,13 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(isAccountFailoverError(r.type)).toBe(true)
   })
 
+  it("maps the live per-tier refusal with appended beta-warning stderr to rate_limit_error", () => {
+    const msg = "Claude Code returned an error result: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.\nSubprocess stderr: Warning: Custom betas are only available for API key users. Ignoring provided betas."
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it.each([
     ["bare banner", "You've reached your Fable 5 limit."],
     ["nested SDK wrappers", "Error: API Error: You’ve reached your Fable 5 limit! /model to switch models."],
@@ -742,6 +749,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["documentation sentence suffix", "Error: You've reached your Fable 5 limit. This is only a documentation example"],
     ["false assertion suffix", "You've reached your Fable 5 limit is false"],
     ["possessive threshold suffix", "You've reached your Fable 5 limit's configured warning threshold"],
+    ["generic error newline", "Error:\nYou've reached your Fable 5 limit."],
+    ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
+    ["unrelated appended stderr", "You've reached your Fable 5 limit.\nSubprocess stderr: unrelated tool output"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -722,6 +722,8 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["nested SDK wrappers", "Error: API Error: You’ve reached your Fable 5 limit! /model to switch models."],
     ["Opus tier", "You've reached your Opus limit"],
     ["versioned Sonnet tier", "You've reached your Sonnet 4.6 limit"],
+    ["Claude-prefixed tier", "You've reached your Claude Opus 4.6 limit"],
+    ["multiline subprocess stderr", "Claude Code process exited with code 1\nSubprocess stderr: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
@@ -733,6 +735,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["quoted banner", "The docs say ‘You've reached your Fable 5 limit.’"],
     ["negated banner", "You've not reached your Fable 5 limit"],
     ["filename prefix", "Claude Code returned an error result: usage-credits.ts says You've reached your Fable 5 limit."],
+    ["configured tool qualifier", "You've reached your Fable configured tool limit"],
+    ["limitations suffix", "You've reached your Fable 5 limitations"],
+    ["unlabelled multiline quote", "MCP server failed:\nYou've reached your Fable 5 limit (quoted from docs)"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -43,6 +43,12 @@ afterEach(async () => {
     for (let i = 0; i < 100 && proxyServer.getInFlightCount!() !== 0; i++) {
       await Bun.sleep(1)
     }
+    if (proxyServer.getInFlightCount!() !== 0) {
+      proxyServer.forceAbortInFlight!()
+      for (let i = 0; i < 1000 && proxyServer.getInFlightCount!() !== 0; i++) {
+        await Bun.sleep(1)
+      }
+    }
   }
   const drained = !proxyServer || proxyServer.getInFlightCount!() === 0
   if (drained) {

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -31,11 +31,19 @@ import {
 
 let isolatedSessionDir = ""
 beforeEach(() => {
+  proxyServer = undefined
   isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-subagent-support-"))
   setSessionStoreDir(isolatedSessionDir)
 })
 afterEach(async () => {
-  await Bun.sleep(25)
+  if (proxyServer) {
+    for (let i = 0; i < 100 && proxyServer.getInFlightCount!() !== 0; i++) {
+      await Bun.sleep(1)
+    }
+    expect(proxyServer.getInFlightCount!()).toBe(0)
+    await proxyServer.sweepSessionGc!()
+  }
+  setSessionStoreDir(null)
   rmSync(isolatedSessionDir, { recursive: true, force: true })
 })
 
@@ -72,10 +80,11 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer } = await import("../proxy/server")
+let proxyServer: ReturnType<typeof createProxyServer> | undefined
 
 function createTestApp() {
-  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
-  return app
+  proxyServer = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return proxyServer.app
 }
 
 async function postMessages(app: any, body: Record<string, unknown>) {

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -8,7 +8,11 @@
  * 4. Multiple tool calls in a single response
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
 import {
   messageStart,
   textBlockStart,
@@ -24,6 +28,16 @@ import {
   parseSSE,
   withMockSdkSessionId,
 } from "./helpers"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-subagent-support-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
 
 // --- Capture SDK calls ---
 let mockMessages: any[] = []
@@ -140,6 +154,9 @@ describe("Phase 3: Concurrent request support", () => {
       postMessages(app, makeRequest({ stream: false })),
       postMessages(app, makeRequest({ stream: false })),
     ])
+
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
 
     const [b1, b2] = await Promise.all([
       r1.json() as Promise<any>,

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -31,6 +31,9 @@ import {
 
 let isolatedSessionDir = ""
 beforeEach(() => {
+  if (proxyServer && proxyServer.getInFlightCount!() !== 0) {
+    throw new Error("Previous proxy did not drain; refusing to switch the process-global session store")
+  }
   proxyServer = undefined
   isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-subagent-support-"))
   setSessionStoreDir(isolatedSessionDir)
@@ -40,11 +43,14 @@ afterEach(async () => {
     for (let i = 0; i < 100 && proxyServer.getInFlightCount!() !== 0; i++) {
       await Bun.sleep(1)
     }
-    expect(proxyServer.getInFlightCount!()).toBe(0)
-    await proxyServer.sweepSessionGc!()
   }
-  setSessionStoreDir(null)
-  rmSync(isolatedSessionDir, { recursive: true, force: true })
+  const drained = !proxyServer || proxyServer.getInFlightCount!() === 0
+  if (drained) {
+    if (proxyServer) await proxyServer.sweepSessionGc!()
+    setSessionStoreDir(null)
+    rmSync(isolatedSessionDir, { recursive: true, force: true })
+  }
+  expect(drained).toBe(true)
 })
 
 // --- Capture SDK calls ---

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -110,7 +110,7 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * Accept only known CLI command suffixes and anchor the whole banner: a false
  * positive exhausts a healthy profile pool-wide. New tier names must be added
  * to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!][ \t]*)?(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)?\.?(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)\.?|[.!]?)(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -104,9 +104,10 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
  * versions without arbitrary words, while an explicit subprocess label admits
- * the observed multiline exit shape without treating any quoted line as
- * account state. New tier names must be added to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit\b/
+ * the observed multiline exit shape. Accept only known CLI command suffixes
+ * and anchor the whole banner: a false positive exhausts a healthy profile
+ * pool-wide. New tier names must be added to the known-tier enumeration. */
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!]\s*)?(?:(?:run\s+)?\/usage-credits(?:\s+to\s+continue)?(?:\s+or\s+switch\s+models\s+with\s+\/model)?|\/model\s+to\s+switch\s+models)?\.?\s*$/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -101,11 +101,12 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
 
 /** Credits-era per-tier banner uses "reached", not the "hit" wording from
  * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
- * CLI also emits "reached your specified ...", which is not account quota
- * exhaustion (#909). The two-word tail covers "Fable 5" and similar versions;
- * anchoring after known SDK wrappers, like HIT_YOUR_SPEND_LIMIT, prevents
- * quoted banner prose from exhausting a healthy profile. */
-const REACHED_YOUR_TIER_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:fable|mythos|opus|sonnet|haiku)(?: [\w'’.\d-]+){0,2} limit/m
+ * CLI also emits "reached your specified/configured ..." prose that is not
+ * account quota exhaustion (#909). A numeric version suffix accepts real tier
+ * versions without arbitrary words, while an explicit subprocess label admits
+ * the observed multiline exit shape without treating any quoted line as
+ * account state. New tier names must be added to the known-tier enumeration. */
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit\b/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -104,10 +104,13 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
  * versions without arbitrary words, while an explicit subprocess label admits
- * the observed multiline exit shape. Accept only known CLI command suffixes
- * and anchor the whole banner: a false positive exhausts a healthy profile
- * pool-wide. New tier names must be added to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!]\s*)?(?:(?:run\s+)?\/usage-credits(?:\s+to\s+continue)?(?:\s+or\s+switch\s+models\s+with\s+\/model)?|\/model\s+to\s+switch\s+models)?\.?\s*$/
+ * the observed multiline exit shape. The known trailing beta warning is
+ * accepted because the server appends captured stderr to `Error.message`; all
+ * other cross-line entry requires an explicit banner-bearing subprocess label.
+ * Accept only known CLI command suffixes and anchor the whole banner: a false
+ * positive exhausts a healthy profile pool-wide. New tier names must be added
+ * to the known-tier enumeration. */
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!][ \t]*)?(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)?\.?(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -99,6 +99,14 @@ const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
  *  in the first place. */
 const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/m
 
+/** Credits-era per-tier banner uses "reached", not the "hit" wording from
+ * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
+ * CLI also emits "reached your specified ...", which is not account quota
+ * exhaustion (#909). The two-word tail covers "Fable 5" and similar versions;
+ * anchoring after known SDK wrappers, like HIT_YOUR_SPEND_LIMIT, prevents
+ * quoted banner prose from exhausting a healthy profile. */
+const REACHED_YOUR_TIER_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:fable|mythos|opus|sonnet|haiku)(?: [\w'’.\d-]+){0,2} limit/m
+
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
  * cannot exhaust every profile in a priority pool. */
@@ -156,7 +164,7 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // variants seen so far and the daily/monthly/5-hour ones that would
   // otherwise be the next report.
   if (HTTP_429.test(lower) || lower.includes("rate limit") || lower.includes("too many requests")
-    || HIT_YOUR_LIMIT.test(lower) || HIT_YOUR_SPEND_LIMIT.test(lower)
+    || HIT_YOUR_LIMIT.test(lower) || HIT_YOUR_SPEND_LIMIT.test(lower) || REACHED_YOUR_TIER_LIMIT.test(lower)
     || lower.includes("usage limit reached")
     || OUT_OF_USAGE_CREDITS.test(lower)) {
     const hint = lower.includes("1m") || lower.includes("context")


### PR DESCRIPTION
Fixes #909.

`You've reached your Fable 5 limit` currently falls through as `500 api_error`. This change classifies it as `429 rate_limit_error`, so priority routing marks the profile exhausted and fails over to the next account.

`isRateLimitError` remains unchanged: retrying the same account cannot help.

The matcher is intentionally narrow:

- known model tiers, with an optional numeric version and `Claude` prefix;
- only the observed `/usage-credits` and `/model` suffixes;
- multiline banners only under an explicit `Subprocess stderr:` label;
- the known appended beta-warning line produced by captured stderr;
- full-message anchoring to reject quoted, negated, configured, or otherwise incidental prose.

The concurrent proxy test now drains request finalization and instance GC before changing its process-global session store. Requests remain headerless, so the test still covers weak-fingerprint CAS. The target file passed 500 fresh-process stress runs.

Known trade-off: exhaustion is currently profile-wide rather than model-tier-scoped, so a Fable refusal cools the profile for all models. Tier-scoped exhaustion is separate work.
