### PR TITLE
feat: add Claude Fable 5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-        "@anthropic-ai/claude-code": "^2.1.198",
+        "@anthropic-ai/claude-code": "^2.1.257",
         "cross-spawn": "7.0.6",
         "jsonc-parser": "^3.3.1",
         "libsql": "^0.5.29",
@@ -180,9 +180,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.247.tgz",
-      "integrity": "sha512-2Z2UQKom3x6GBQDYlFFi00KbRciqsuGL9CpK+IN3fXmmJb7IXVitrRZ6HZyUw0ixnckr814GIp0FUaXwDEbBrw==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.257.tgz",
+      "integrity": "sha512-JzpBQDzbEV+IKV9lIs/SSRIdHGrAmQXhNScoz9PZgdjnatrVnbsBXRDrF26qBBBph38pA/39d+BhDpf+7RwkwA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
@@ -192,20 +192,20 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.247",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.247",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.247",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.247",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.247",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.247",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.247",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.247"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.257",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.257",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.257",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.257",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.257",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.257",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.257",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.257"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.247.tgz",
-      "integrity": "sha512-PgInuhsq1LONloSE6puAPzQUakRDDkX8fYPz+k7CCJK8uvfsxtSwA19T1l3ebVuZauPcss+E4abk+WFwGlY3Cg==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.257.tgz",
+      "integrity": "sha512-VQQfNs9fiSmtDK4kgK18gQ9cXE8Nw44BogYYLZ3mGxWASplyYWhORMs+loNilBDmspBWhyVxVA4iGBPEpgxkmQ==",
       "cpu": [
         "arm64"
       ],
@@ -216,9 +216,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.247.tgz",
-      "integrity": "sha512-CAMN8THavM7V0qhX6JwvfXIAMuQHxQf8XYP2ztMR2MsIT1Vrac1bmXav/tmlVFmA2UaRBHImGIHO+4oiyaziTA==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.257.tgz",
+      "integrity": "sha512-QvIHitd4srhkdImuKQ5BBk2kPX8rTHBJ7nwbmRchYkCa3zpAQgxS3M176pFhsAW5o4PuYzKQ0NIARJMOrCJqxw==",
       "cpu": [
         "x64"
       ],
@@ -229,11 +229,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.247.tgz",
-      "integrity": "sha512-oz5zSpSHY3WBaajo70L61YVM0efGxhoguOhz2DjbVy/Q6EvXoDaAj6813IzIHHsRugLYQ36D1B32GDSL63mz6Q==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.257.tgz",
+      "integrity": "sha512-O/UyW9dHp0+wXKBvdg8TqoRMecedvwjQQou2hP4GCcRjjE/GD/9g64pCcmUgjrgbACA+LejuC7kiBxTg1TSbUg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -242,11 +245,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.247.tgz",
-      "integrity": "sha512-894hf5lB/+nBIHkzWwo4iDFzTCaJxKqLMfZRmiEj4FMoToepNXRr+jROwuXTAdWE7wKqZjUGi7SDbykfLR40Jw==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.257.tgz",
+      "integrity": "sha512-uTKbWiVg+6szOqbogZLsQXlo3Iqxz4cyVjDfAPWSjg6mnhUGck889D7FJPHrRJYARQGwwyRhZXoazCCe5KmciA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -255,11 +261,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.247.tgz",
-      "integrity": "sha512-ZHjg+YRpBDKmTzIWtVF7ofABjwz387bCjDCUyO89ttuOwlUvh1zmCVwTlL6BdJO/v9uCTbQOrM7GUIDqzmPAoA==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.257.tgz",
+      "integrity": "sha512-Mue9ytQXYqkPYZfVnum5kxLirKdwxrU27VHykpzZ6ZOM9NNf7IEHmZ4a4eX0sRlYptJ0FACEc0HxgFdDnL7pgQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -268,11 +277,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.247.tgz",
-      "integrity": "sha512-/2ZS9KFUxvXlO4z1byS4BJExUfh51IbtrUVuF4QbdkAMBirnNF16ACJyorzcKfvQR8+aLoPuznMuIZd2yltRXQ==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.257.tgz",
+      "integrity": "sha512-vbmzXTj1gwqg8t1R5Bcn1VIBRXu9jQJZnhwg0rLkOmrjATygHl59H0N1cz/GvB32jzmNbX0808LoA9Erb8Jwdw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -281,9 +293,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.247.tgz",
-      "integrity": "sha512-vN73B/ofkhj939CN5aEW84wuJKWJ7t7Ecn0u1tu59zcUfuIjIllliTjnuVmmYolaR8mncLjK81d1dXMqHhbb7w==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.257.tgz",
+      "integrity": "sha512-BwKX60U0948hA/ukT0Q4ZFBFIy3mhkkp4c8DXpaRNZgPC6IkzvMzsImN2s/mahF5O8OP4MHhybLrAu6PtmfMHw==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +306,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.247.tgz",
-      "integrity": "sha512-nCg+StYkQjcZh4cWUwwD4ECTj/9jfWlNMxpsFvg2BgWkEtoA/q6bX+1NyYw9FRibbdD6MUfi7dtvK36koWqL2w==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.257.tgz",
+      "integrity": "sha512-Tb0/MaJ9nI3VGEP3Wo/LGjrapT1yzTUwTaC7Sa21VPCvjk7WWKyKNjNn6JWWsphthu6UM0nW/3wSi7F8eA3ihg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-    "@anthropic-ai/claude-code": "^2.1.198",
+    "@anthropic-ai/claude-code": "^2.1.257",
     "cross-spawn": "7.0.6",
     "jsonc-parser": "^3.3.1",
     "libsql": "^0.5.29",

--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test"
 
 // ---------- unit: explicitModelPin + canonical bump ----------
 
-const { explicitModelPin, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
+const { explicitModelPin, CANONICAL_FABLE_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
 
 describe("explicitModelPin (#631)", () => {
   it("pins fully-versioned sonnet ids", () => {
@@ -29,6 +29,7 @@ describe("explicitModelPin (#631)", () => {
 
   it("routes mythos ids through the fable tier pin", () => {
     expect(explicitModelPin("claude-mythos-5")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-mythos-5" })
+    expect(explicitModelPin("claude-fable-5-1")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-fable-5-1" })
     expect(explicitModelPin("claude-fable-5")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-fable-5" })
   })
 
@@ -55,6 +56,12 @@ describe("canonical sonnet pin (#631)", () => {
 describe("canonical opus pin", () => {
   it("bare opus means the current Opus", () => {
     expect(CANONICAL_OPUS_MODEL).toBe("claude-opus-5")
+  })
+})
+
+describe("canonical fable pin", () => {
+  it("bare fable means the current Fable", () => {
+    expect(CANONICAL_FABLE_MODEL).toBe("claude-fable-5-1")
   })
 })
 

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1320,14 +1320,15 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 8 models", () => {
-    expect(buildModelList(true).length).toBe(8)
-    expect(buildModelList(false).length).toBe(8)
+  it("returns 9 models", () => {
+    expect(buildModelList(true).length).toBe(9)
+    expect(buildModelList(false).length).toBe(9)
   })
 
-  it("includes sonnet-5, fable-5, opus-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes current and legacy Fable plus the supported Sonnet and Opus models for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
     expect(ids).toContain("claude-sonnet-5")
+    expect(ids).toContain("claude-fable-5-1")
     expect(ids).toContain("claude-fable-5")
     expect(ids).toContain("claude-opus-5")
     expect(ids).toContain("claude-opus-4-6")
@@ -1335,11 +1336,13 @@ describe("buildModelList", () => {
     expect(ids).toContain("claude-opus-4-8")
   })
 
-  it("Max subscription gets 1M context for fable, 200k otherwise", () => {
-    const fableMax = buildModelList(true).find(m => m.id === "claude-fable-5")!
-    const fableFree = buildModelList(false).find(m => m.id === "claude-fable-5")!
-    expect(fableMax.context_window).toBe(1_000_000)
-    expect(fableFree.context_window).toBe(200_000)
+  it("Max subscription gets 1M context for every Fable version, 200k otherwise", () => {
+    for (const id of ["claude-fable-5-1", "claude-fable-5"]) {
+      const fableMax = buildModelList(true).find(m => m.id === id)!
+      const fableFree = buildModelList(false).find(m => m.id === id)!
+      expect(fableMax.context_window).toBe(1_000_000)
+      expect(fableFree.context_window).toBe(200_000)
+    }
   })
 
   it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {

--- a/src/__tests__/pricing-unit.test.ts
+++ b/src/__tests__/pricing-unit.test.ts
@@ -45,6 +45,7 @@ describe("resolveModelPricing", () => {
   it("resolves concrete API model IDs", () => {
     expect(resolveModelPricing("claude-opus-4-8")).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
     expect(resolveModelPricing("claude-sonnet-4-6")).toMatchObject({ inputPerMTok: 3 })
+    expect(resolveModelPricing("claude-fable-5-1")).toMatchObject({ inputPerMTok: 10 })
     expect(resolveModelPricing("claude-fable-5")).toMatchObject({ inputPerMTok: 10 })
   })
 

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -220,7 +220,7 @@ describe("SDK model pin injection (fixes #419)", () => {
     const app = createTestApp()
     // Bare alias: no envOverride kicks in, so the canonical pin is exercised.
     await post(app, { ...BASIC_REQUEST, model: "sonnet" })
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5-1")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
@@ -238,9 +238,15 @@ describe("SDK model pin injection (fixes #419)", () => {
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
   })
 
+  it("explicit claude-fable-5-1 requests pin the SDK env to Fable 5.1", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-fable-5-1" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5-1")
+  })
+
   // Mythos has no SDK alias of its own — it resolves through the fable alias,
   // so an explicit claude-mythos-* request must pin ANTHROPIC_DEFAULT_FABLE_MODEL
-  // to the requested id (not Meridian's canonical claude-fable-5 pin).
+  // to the requested id (not Meridian's canonical claude-fable-5-1 pin).
   it("explicit claude-mythos-5 requests pin the SDK env to mythos via the fable alias", async () => {
     const app = createTestApp()
     await post(app, { ...BASIC_REQUEST, model: "claude-mythos-5" })

--- a/src/__tests__/proxy-health-build.test.ts
+++ b/src/__tests__/proxy-health-build.test.ts
@@ -94,6 +94,7 @@ describe("/v1/models profile auth context", () => {
       envOverrides: { CLAUDE_CONFIG_DIR: "/profiles/work" },
     }])
     expect(models.get("claude-opus-4-6")?.context_window).toBe(1_000_000)
+    expect(models.get("claude-fable-5-1")?.context_window).toBe(1_000_000)
     expect(models.get("claude-fable-5")?.context_window).toBe(1_000_000)
   })
 

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -40,7 +40,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * override via MERIDIAN_DEFAULT_{TYPE}_MODEL (proxy-side) or
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
-export const CANONICAL_FABLE_MODEL = "claude-fable-5"
+export const CANONICAL_FABLE_MODEL = "claude-fable-5-1"
 export const CANONICAL_OPUS_MODEL = "claude-opus-5"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-5"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -1065,6 +1065,15 @@ export function buildModelList(extendedContextIncluded: boolean, now = Math.floo
       capabilities: FULL_CAPABILITIES,
     },
     {
+      id: "claude-fable-5-1",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Fable 5.1",
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
+      capabilities: FULL_CAPABILITIES,
+    },
+    {
       id: "claude-fable-5",
       object: "model",
       created: now,


### PR DESCRIPTION
## Summary
- make `claude-fable-5-1` the canonical Fable model while retaining `claude-fable-5` as an explicit legacy pin
- advertise both Fable versions through `/v1/models` with Max 1M context metadata and pricing coverage
- bump the bundled Claude Code dependency to 2.1.257 because earlier builds reject Fable 5.1

## Validation
- `npm run build`
- `bun test src/__tests__/openai.test.ts src/__tests__/proxy-health-build.test.ts src/__tests__/proxy-env-stripping.test.ts src/__tests__/explicit-model-pins.test.ts src/__tests__/pricing-unit.test.ts` (173 passed)
- live Claude Max qualification through Meridian succeeded for `claude-fable-5-1`; legacy `claude-fable-5` still succeeds

## Known unrelated test issue
- the full `npm test` run still has the existing `proxy-stale-uuid-retry.test.ts` expectation mismatch (expected 500, received 499)
- reproduced the same failure on a clean `origin/main` worktree at `1ea97d0`