### PR TITLE
fix(session): stop refusing the loser of a declared concurrent race (#870)

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -323,6 +323,24 @@ Pi mimics Claude Code's User-Agent, so automatic detection isn't possible. The `
 
 Pi runs in passthrough mode by default — it executes its own tools and Meridian just forwards the `tool_use` blocks. Opt out with `MERIDIAN_PASSTHROUGH=0`.
 
+[Oh My Pi](https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent) (`omp`) is
+built on the same runtime and uses the Pi adapter. Its config lives in
+`~/.omp/agent/models.yml` and takes the same three keys:
+
+```yaml
+providers:
+  anthropic:
+    baseUrl: http://127.0.0.1:3456
+    apiKey: x
+    headers:
+      x-meridian-agent: pi
+```
+
+omp runs its main turn, title generation and mid-turn side questions
+concurrently under one session id. Meridian serializes them, and the turn that
+loses the commit race replays from its own history instead of resuming, which
+costs a prompt-cache hit but never fails the turn.
+
 ### Prime Agent
 
 [Prime Agent](https://www.npmjs.com/package/prime-agent) is a fork of Pi with a

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -338,8 +338,8 @@ providers:
 
 omp runs its main turn, title generation and mid-turn side questions
 concurrently under one session id. Meridian serializes them, and the turn that
-loses the commit race replays from its own history instead of resuming, which
-costs a prompt-cache hit but never fails the turn.
+loses the commit race replays from its own history instead of resuming, so it
+misses the prompt cache for that one turn but never fails.
 
 ### Prime Agent
 

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -108,12 +108,14 @@ function request(
 function piRequest(
   messages: Array<{ role: string; content: unknown }>,
   sessionId: string,
+  extraHeaders: Record<string, string> = {},
 ): Request {
   return new Request("http://localhost/v1/messages", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "x-meridian-agent": "pi",
+      ...extraHeaders,
     },
     body: JSON.stringify({
       model: "claude-sonnet-4-6",
@@ -339,6 +341,44 @@ describe("SDK and Session concurrency coordination", () => {
     // Neither resumed nor rolled back: the committed session is left alone.
     expect(capturedParams[0]?.options?.resume).toBeUndefined()
     expect(capturedParams[0]?.options?.resumeSessionAt).toBeUndefined()
+  })
+
+  it("keeps a per-request fork signal's undo when it loses the same race (#870)", async () => {
+    // The protocol-level declaration exists because pi cannot mark its own side
+    // calls, so an undo shape there is an accident of arrival order. A fork
+    // source is the opposite: that caller named the boundary itself, so its
+    // rollback is deliberate and must still be honoured after losing a race.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const sessionId = `omp-fork-${crypto.randomUUID()}`
+    const committed = [
+      { role: "user", content: "start the task" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "tool result for step 12" },
+    ]
+    const lease = await processSessionTurns.acquire(`session:${sessionId}`)
+    const forkP = app.fetch(piRequest(committed.slice(0, 2), sessionId, {
+      "x-meridian-source": "fork-memory-extract",
+    }))
+
+    // Same shape as the test above: nothing observable fires between the
+    // arrival snapshot and the queue grant, so the window has to be timed.
+    await Bun.sleep(20)
+    storeSharedSession(
+      sessionId,
+      "winner-sdk",
+      committed.length,
+      computeLineageHash(committed),
+      computeMessageHashes(committed),
+      ["winner-uuid-1", "winner-uuid-2", "winner-uuid-3"],
+    )
+    lease.markCommitted(sessionId)
+    lease.release()
+
+    const forkControl = await waitForControl(0)
+    forkControl.release()
+    expect((await forkP).status).toBe(200)
+    expect(capturedParams[0]?.options?.resume).toBe("winner-sdk")
+    expect(capturedParams[0]?.options?.resumeSessionAt).toBe("winner-uuid-2")
   })
 
   it("does not refuse a turn because a DIFFERENT profile advanced the same session id", async () => {

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -22,7 +22,7 @@ let activeQueries = 0
 let maxActiveQueries = 0
 let queryCalls = 0
 let controls: AttemptControl[] = []
-let capturedParams: Array<{ options?: { resume?: string; sessionId?: string; env?: Record<string, string> } }> = []
+let capturedParams: Array<{ options?: { resume?: string; resumeSessionAt?: string; sessionId?: string; env?: Record<string, string> } }> = []
 let rateLimitWorkQueries = false
 
 function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
@@ -78,8 +78,9 @@ mock.module("../mcpTools", () => ({
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
 const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
 const { telemetryStore } = await import("../telemetry")
-const { setSessionStoreDir, storeSharedSession } = await import("../proxy/sessionStore")
+const { setSessionStoreDir, storeSharedSession, readSessionStoreSnapshot } = await import("../proxy/sessionStore")
 const { processSessionTurns } = await import("../proxy/session/turnCoordinator")
+const { computeLineageHash, computeMessageHashes } = await import("../proxy/session/lineage")
 
 function request(
   messages: Array<{ role: string; content: unknown }>,
@@ -97,6 +98,30 @@ function request(
     },
     body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 128, stream, messages }),
     signal,
+  })
+}
+
+/**
+ * Oh My Pi has no per-flow header: every caller in one conversation, main turn
+ * and side calls alike, stamps the same id in `metadata.user_id`.
+ */
+function piRequest(
+  messages: Array<{ role: string; content: unknown }>,
+  sessionId: string,
+): Request {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-meridian-agent": "pi",
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      max_tokens: 128,
+      stream: false,
+      messages,
+      metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+    }),
   })
 }
 
@@ -236,6 +261,84 @@ describe("SDK and Session concurrency coordination", () => {
     expect(conflicts).toHaveLength(1)
     expect(conflicts[0]!.status).toBe(400)
     expect(conflicts[0]!.upstreamDurationMs).toBe(0)
+  })
+
+  it("answers, instead of refusing, the loser of a race an adapter declares (#870)", async () => {
+    // Reproduces the omp report: a side question asked mid-turn and the main
+    // tool loop reach the proxy under one session id, holding branches that
+    // share a prefix and differ at the last message. Serializing them is
+    // right; refusing the loser is not, because the 400 is a hard error that
+    // pushes the client onto a fallback model for a turn it could have run.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const shared = [
+      { role: "user", content: "start the task" },
+      { role: "assistant", content: "ok" },
+    ]
+    const sideQuestion = [...shared, { role: "user", content: "by the way, which branch is this?" }]
+    const mainLoop = [...shared, { role: "user", content: "tool result for step 12" }]
+
+    const sideP = app.fetch(piRequest(sideQuestion, "omp-session"))
+    const sideControl = await waitForControl(0)
+    const mainP = app.fetch(piRequest(mainLoop, "omp-session"))
+
+    sideControl.release()
+    expect((await sideP).status).toBe(200)
+    const mainControl = await waitForControl(1)
+    mainControl.release()
+    expect((await mainP).status).toBe(200)
+    // One session id still means one turn at a time: the second SDK query only
+    // started once the first had finished.
+    expect(maxActiveQueries).toBe(1)
+    expect(queryCalls).toBe(2)
+
+    // The loser carries a branch the winner never had, so it runs fresh rather
+    // than resuming the winner's session and merging two histories.
+    expect(capturedParams[1]?.options?.resume).toBeUndefined()
+    expect(telemetryStore.getRecent().filter(m => m.error === "session_turn_conflict")).toHaveLength(0)
+
+    // The mapping follows the turn that ran last, so the next main-loop request
+    // resumes instead of paying a second fresh replay.
+    const loserSessionId = capturedParams[1]?.options?.sessionId
+    expect(loserSessionId).toMatch(/^[0-9a-f-]{36}$/)
+    const stored = Object.values(readSessionStoreSnapshot()).map(s => s.claudeSessionId)
+    expect(stored).toContain(loserSessionId!)
+  })
+
+  it("replays a declared-flow loser instead of rewinding the turn it lost to (#870)", async () => {
+    // A side call carries a prefix of the main history, so once the main turn
+    // commits the loser reads as an undo against it. Honouring that would roll
+    // the winner's SDK session back to serve a turn that merely arrived late,
+    // so a declared flow is admitted on its own body, never on that lineage.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const sessionId = `omp-undo-${crypto.randomUUID()}`
+    const committed = [
+      { role: "user", content: "start the task" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "tool result for step 12" },
+    ]
+    const lease = await processSessionTurns.acquire(`session:${sessionId}`)
+    const sideP = app.fetch(piRequest(committed.slice(0, 2), sessionId))
+
+    // Let handleWithQueue take its coherent arrival snapshot, then commit the
+    // winning turn, UUIDs and all, before the queued side call is granted.
+    await Bun.sleep(20)
+    storeSharedSession(
+      sessionId,
+      "winner-sdk",
+      committed.length,
+      computeLineageHash(committed),
+      computeMessageHashes(committed),
+      ["winner-uuid-1", "winner-uuid-2", "winner-uuid-3"],
+    )
+    lease.markCommitted(sessionId)
+    lease.release()
+
+    const sideControl = await waitForControl(0)
+    sideControl.release()
+    expect((await sideP).status).toBe(200)
+    // Neither resumed nor rolled back: the committed session is left alone.
+    expect(capturedParams[0]?.options?.resume).toBeUndefined()
+    expect(capturedParams[0]?.options?.resumeSessionAt).toBeUndefined()
   })
 
   it("does not refuse a turn because a DIFFERENT profile advanced the same session id", async () => {

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -54,6 +54,19 @@ export interface AgentIdentity {
   getAgentMode?(c: Context, body?: unknown): string | undefined
 
   /**
+   * True when the client is known to run several turns concurrently under one
+   * session key. Turn coordination still serializes them; what changes is the
+   * loser of a commit race. It is reclassified (`diverged`) and answered from
+   * its own body instead of refused with a 400 (#870). The pattern predates
+   * turn coordination and the upstream API answers both turns.
+   *
+   * Set this only for clients whose protocol makes the sharing unavoidable.
+   * For everyone else, a key that advanced under a waiting request carries a
+   * stale branch, and refusing it is what stops two histories from merging.
+   */
+  readonly runsConcurrentTurnsPerSessionKey?: boolean
+
+  /**
    * Optional trusted identity for a visible human turn.
    *
    * This is deliberately a positive, normalized assertion. Callers must treat

--- a/src/proxy/adapters/pi.ts
+++ b/src/proxy/adapters/pi.ts
@@ -71,6 +71,17 @@ export const piAdapter: AgentAdapter = {
   name: "pi",
 
   /**
+   * Oh My Pi drives one conversation from several callers at once, the main
+   * turn, title generation, and side questions asked mid-turn, and they all
+   * carry the same `metadata.user_id.session_id`. Whichever one commits first
+   * advances the mapping, so the other arrives holding a branch that no longer
+   * matches and used to be refused with a 400 (#870). Its own history is
+   * complete, so it is answered by fresh replay: one prompt-cache miss instead
+   * of a failed turn that pushes the client onto a fallback model.
+   */
+  runsConcurrentTurnsPerSessionKey: true,
+
+  /**
    * Pi itself sends no session header — continuity normally comes from the
    * fingerprint cache. Orchestrators driving the pi runtime (pylon) can opt
    * into explicit, collision-proof session keys via x-session-affinity;

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2202,8 +2202,15 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // the keyed fork/subagent note above. Serializing them is still worth
         // doing, but a reclassification is their normal cost; refusing them
         // would break flows that worked before turn coordination existed.
+        //
+        // An adapter can declare the same fact for its whole protocol when the
+        // client has no per-flow signal to send: pi carries one session id for
+        // the main turn and its side calls alike, so the loser of that race is
+        // reclassified rather than refused. See runsConcurrentTurnsPerSessionKey.
         const declaresConcurrentFlow =
-          requestSource?.startsWith("fork-") === true || isSubagentRequest
+          requestSource?.startsWith("fork-") === true
+          || isSubagentRequest
+          || adapter.runsConcurrentTurnsPerSessionKey === true
         // NOTE: agent-specific (opencode) — OpenCode begins the tool-result
         // request as soon as the visible checkpoint closes, while Meridian is
         // still draining and committing that checkpoint. Its prompt envelope
@@ -2232,15 +2239,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             }
           }
         }
-        if (
+        // The account this turn holds was rewritten while it waited: it lost a
+        // commit race, so the branch its body carries is no longer authoritative.
+        const lostRaceWhileWaiting = Boolean(
           agentSessionId &&
           profileSessionId &&
-          !declaresConcurrentFlow &&
           !advancesDurableCheckpoint &&
           (requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) || advancedAcrossProcesses) &&
           lineageResult.type !== "continuation" &&
           lineageResult.type !== "compaction"
-        ) {
+        )
+        if (lostRaceWhileWaiting && !declaresConcurrentFlow) {
           const reason = lineageResult.type === "diverged" ? lineageResult.reason : lineageResult.type
           const message = "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
           claudeLog("session.concurrent_conflict", {
@@ -2297,6 +2306,20 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               headers: { "Content-Type": "application/json" },
             },
           )
+        }
+        // Admitting a protocol-declared flow is not the same as trusting its
+        // lineage. A loser holding a prefix of the committed history reads as an
+        // undo, and honouring that would rewind the session that just committed
+        // to serve a turn which merely arrived late — pi's title generation is
+        // exactly that shape. Replay its own body instead. Per-request fork and
+        // subagent signals keep their lineage: those callers name their own
+        // session boundary, so an undo from them is deliberate.
+        if (
+          lostRaceWhileWaiting &&
+          adapter.runsConcurrentTurnsPerSessionKey === true &&
+          lineageResult.type === "undo"
+        ) {
+          lineageResult = { type: "diverged", reason: "concurrent-race" }
         }
         if (options.forceFreshPriorityReplay) {
           if (!options.priorityPublication || !agentSessionId || !durableMappingKey) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2207,9 +2207,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // client has no per-flow signal to send: pi carries one session id for
         // the main turn and its side calls alike, so the loser of that race is
         // reclassified rather than refused. See runsConcurrentTurnsPerSessionKey.
-        const declaresConcurrentFlow =
+        const declaresPerRequestConcurrentFlow =
           requestSource?.startsWith("fork-") === true
           || isSubagentRequest
+        const declaresConcurrentFlow =
+          declaresPerRequestConcurrentFlow
           || adapter.runsConcurrentTurnsPerSessionKey === true
         // NOTE: agent-specific (opencode) — OpenCode begins the tool-result
         // request as soon as the visible checkpoint closes, while Meridian is
@@ -2310,12 +2312,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // Admitting a protocol-declared flow is not the same as trusting its
         // lineage. A loser holding a prefix of the committed history reads as an
         // undo, and honouring that would rewind the session that just committed
-        // to serve a turn which merely arrived late — pi's title generation is
-        // exactly that shape. Replay its own body instead. Per-request fork and
-        // subagent signals keep their lineage: those callers name their own
+        // to serve a turn which merely arrived late. Pi's title generation is
+        // exactly that shape. Replay its own body instead. A per-request fork
+        // or subagent signal keeps its lineage: those callers name their own
         // session boundary, so an undo from them is deliberate.
         if (
           lostRaceWhileWaiting &&
+          !declaresPerRequestConcurrentFlow &&
           adapter.runsConcurrentTurnsPerSessionKey === true &&
           lineageResult.type === "undo"
         ) {

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -130,6 +130,7 @@ export type LineageDivergenceReason =
   | "independent-request"
   | "priority-failback"
   | "missing-session-header"
+  | "concurrent-race"
 
 // --- Hashing ---
 


### PR DESCRIPTION
Fixes #870.

## The bug

Oh My Pi (`@oh-my-pi/pi-coding-agent`) drives one conversation from several callers at once: the main tool loop, title generation, and side questions asked mid-turn. All of them post to `/v1/messages` carrying the same `metadata.user_id.session_id`, because the Anthropic Messages protocol gives them no per-flow signal to send.

Turn coordination serializes them correctly. What breaks is the loser of the commit race: it arrives holding a branch the durable mapping has already moved past, `advancedWhileWaiting` fires, and `server.ts` refuses it with a 400 `invalid_request_error`.

That 400 is a hard error on the client side. In omp it trips the retry classifier into a model fallback, so a turn that could have run switched models and threw away the prompt cache instead. Reproduced here as `anthropic/claude-opus-5:high -> openai-codex/gpt-5.6-sol:high` mid-session, on the local proxy's own log:

```
12:18:15.272  7ab0cc98  adapter=pi  lineage=continuation  msgCount=357  sessionWait=9024ms  → published 5d5430ca
12:18:37.184  Undo detected (key=01a0610a…): prefix overlap 355/357, rollback UUID: none
12:18:37.184  08ae3291  session.concurrent_conflict reason=undo wait=21850ms
12:19:10.734  Stale session detected (key=01a0610a…): incoming 358 msgs. Starting fresh replay.
```

Two `adapter=pi` requests on one key, 357 messages each, diverging at index 355. The refused one is the main tool loop; it waited 21.8s in the queue and lost to a side call that arrived while it was waiting.

## The fix

`declaresConcurrentFlow` already exempts callers that name their own concurrency, `x-meridian-source: fork-*` and subagent requests. Those are per-request signals. Pi has no such signal to send, so the same fact is declared once for the protocol.

`AgentIdentity` gains an optional capability:

```ts
readonly runsConcurrentTurnsPerSessionKey?: boolean
```

`adapters/pi.ts` sets it, and `server.ts` folds it into `declaresConcurrentFlow`. Every other adapter still refuses a stale arrival, so the deliberate invariants in `proxy-cross-process-coordination.test.ts` and `priority-routing-integration.test.ts` stay green.

Second half, which matters as much: **admitting the turn is not the same as trusting its lineage.** A short side call carries a prefix of the main history, so once the main turn commits, the loser reads as an `undo` against it. Honouring that would resume and rewind the session that just committed, to serve a turn that merely arrived late. A loser admitted by the protocol declaration is therefore reclassified `diverged` with the new reason `concurrent-race` before the undo path derives `isUndo`, and is answered by replaying its own body.

The downgrade is scoped to the protocol declaration alone. A per-request `fork-*` source or subagent signal keeps its lineage, because those callers name their own session boundary, so an undo from them is deliberate. `priority-failback` is untouched.

Cost of the fix is one prompt-cache miss for the loser, instead of a refused turn.

## Tests

Three additions to `proxy-concurrency-coordination.test.ts`, each verified to fail without the corresponding change:

| test | failure without it |
|---|---|
| `answers, instead of refusing, the loser of a race an adapter declares (#870)` | the request never reaches the SDK; `SDK attempt #1 never started` |
| `replays a declared-flow loser instead of rewinding the turn it lost to (#870)` | `options.resume` points at the winner's session |
| `keeps a per-request fork signal's undo when it loses the same race (#870)` | the fork's rollback is dropped; `Expected: "winner-sdk" / Received: undefined` |

The first reproduces the reported shape: two branches sharing a prefix, differing at the last message. The second commits a winning turn carrying SDK message UUIDs while a prefix-holding side call waits, which is what makes the rollback path reachable, and pins that the loser neither resumes nor rewinds it. The third drives the same race with `x-meridian-source: fork-memory-extract` and pins that a named boundary still resumes and rolls back.

Project test sequence (`npm test`, run stepwise so the 12 isolated files are not cross-contaminated): **0 failures on this branch**. Clean `1ea97d0` shows one failure in the same environment, `Integration: Concurrent subagent requests > should handle 3 concurrent requests`, which passes 3/3 when its file is run alone. `tsc --noEmit` clean.

## Also

`docs/agents.md` § Pi gained a paragraph on the concurrency shape, which #870 asked for, and the config path there is `~/.omp/agent/models.yml` rather than the older `~/.pi/agent/models.json`.

## Precedent and scope

#848 shipped per-agent key scoping in `adapters/opencode.ts` for the structurally identical OpenCode title-generation race. #842 is still open, reporting that key scoping alone missed OpenCode's primary-mode side caller, which is the same gap this declaration closes rather than works around. #847 is the related session-start report.

Running this locally as a distro package patch since it was cut. The 400s are gone, and the patched proxy has recorded no `session_turn_conflict` rows since.
