### PR TITLE
fix(session): preserve admission during reconciliation

### DIFF
--- a/src/__tests__/session-lifecycle.test.ts
+++ b/src/__tests__/session-lifecycle.test.ts
@@ -236,6 +236,23 @@ describe("session transcript lifecycle", () => {
     expect(readSidecar(bounded.storeDir).resources[getTranscriptResourceKey(stillLive)]?.state).toBe("live")
   })
 
+  it("leaves admission capacity while retiring live resources after a profile switch", async () => {
+    const bounded = { ...options, storeDir: join(storeDir, "retirement-headroom"), maxPending: 2 }
+    const firstStale = locator("first-stale-after-profile-switch")
+    const secondStale = locator("second-stale-after-profile-switch")
+    const fresh = locator("fresh-after-profile-switch")
+    await registerLiveTranscript(firstStale, bounded)
+    await registerLiveTranscript(secondStale, bounded)
+
+    expect((await reconcile([], bounded)).liveRetired).toBe(1)
+    await prepareFork(fresh, bounded)
+
+    const resources = readSidecar(bounded.storeDir).resources
+    expect(resources[getTranscriptResourceKey(fresh)]?.state).toBe("prepared")
+    expect(Object.values(resources).filter((resource) => resource.state === "retired")).toHaveLength(1)
+    expect(Object.values(resources).filter((resource) => resource.state === "live")).toHaveLength(1)
+  })
+
   it("never lets a delayed publisher recreate a deleted locator after tombstone pruning", async () => {
     const bounded = { ...options, maxTombstones: 1, deleter: async () => undefined }
     const stale = locator("stale-publisher")

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -557,6 +557,12 @@ export async function reconcile(
     }
     let pending = pendingResourceCount(sidecar)
     const maxPending = option(options.maxPending, DEFAULT_MAX_PENDING, "maxPending")
+    // Passive retirement must leave room for one active preallocation. Without
+    // that headroom, a profile switch can unpin enough live transcripts to fill
+    // the backlog and block every fresh request until the quarantine expires.
+    // A one-slot configuration cannot reserve capacity without disabling
+    // passive cleanup entirely, so preserve its existing behavior.
+    const passiveRetirementLimit = maxPending > 1 ? maxPending - 1 : maxPending
 
     // A deletion claim is recoverable only after the exact persisted executor
     // is provably dead. Before the executor handshake, authoritative death of
@@ -612,7 +618,7 @@ export async function reconcile(
         resource.nextAttemptAt = now + retiredGraceMs(options)
         result.preparedRetired++
         changed = true
-      } else if (resource.state === "live" && pending < maxPending) {
+      } else if (resource.state === "live" && pending < passiveRetirementLimit) {
         resource.state = "retired"
         resource.updatedAt = now
         resource.nextAttemptAt = now + retiredGraceMs(options)


### PR DESCRIPTION
## Summary

- reserve one pending lifecycle slot for active transcript preallocation
- prevent passive reconciliation from filling the backlog after a profile switch
- cover fresh-request admission at the pending-limit boundary

## Root cause

Switching profiles clears session mappings, so transcripts from the previous profile become unpinned. Reconciliation could retire live transcripts up to the configured pending limit, leaving no capacity for a new request until cleanup advanced.

## Verification

- `bun test src/__tests__/session-lifecycle.test.ts`
- `npm run typecheck`
- `npm run build`
