### PR TITLE
fix(passthrough): repair stringified tool arguments instead of failing the turn

### DIFF
--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test"
+import { z } from "zod"
+
+// Same minimal SDK mock the sibling passthrough tests use: capture what would
+// be registered instead of reaching the real Agent SDK.
+let registeredTools: Array<{ name: string; inputSchema: Record<string, z.ZodType> }> = []
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  createSdkMcpServer: (options: {
+    tools?: Array<{ name: string; inputSchema: Record<string, z.ZodType> }>
+  }) => {
+    for (const definition of options.tools ?? []) {
+      registeredTools.push({ name: definition.name, inputSchema: definition.inputSchema })
+    }
+    return { type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }
+  },
+}))
+
+import { createPassthroughMcpServer } from "../proxy/passthroughTools"
+
+/** The shape of the failing live calls: omp's `browser` tool. */
+const BROWSER_SCHEMA = {
+  type: "object",
+  properties: {
+    action: { type: "string", enum: ["open", "close", "run"], description: "operation" },
+    name: { type: "string", description: "tab id" },
+    timeout: { type: "number", description: "timeout in seconds" },
+    all: { type: "boolean", description: "release every managed tab" },
+    app: {
+      type: "object",
+      description: "browser app options",
+      properties: { cdp_url: { type: "string" }, relay: { type: "boolean" } },
+    },
+    args: { type: "array", items: { type: "string" }, description: "extra cli args" },
+  },
+  required: ["action"],
+}
+
+function registerBrowser() {
+  createPassthroughMcpServer([
+    { name: "browser", description: "Drives a real Chromium tab", input_schema: BROWSER_SCHEMA },
+  ])
+  const tool = registeredTools.find(entry => entry.name === "browser")
+  if (!tool) throw new Error("browser tool was not registered")
+  return z.object(tool.inputSchema)
+}
+
+beforeEach(() => {
+  registeredTools = []
+})
+
+describe("passthrough tool input coercion", () => {
+  it("accepts the stringified arguments that made the SDK refuse the call", () => {
+    const schema = registerBrowser()
+
+    // Exactly the payload measured on the failing turns: every value a string.
+    const result = schema.safeParse({
+      action: "open",
+      timeout: "60",
+      all: "true",
+      app: '{"cdp_url":"http://127.0.0.1:39113"}',
+      args: '["--headless"]',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      action: "open",
+      timeout: 60,
+      all: true,
+      app: { cdp_url: "http://127.0.0.1:39113" },
+      args: ["--headless"],
+    })
+  })
+
+  it("still advertises the client's declared types and descriptions", () => {
+    const schema = registerBrowser()
+
+    // The repair must be invisible to the model: widening the advertised type
+    // would trade one failure mode for worse arguments on every call.
+    const advertised = z.toJSONSchema(schema, { io: "input" }) as {
+      properties: Record<string, { type?: string; description?: string }>
+      required?: string[]
+    }
+
+    expect(advertised.properties.timeout).toMatchObject({
+      type: "number",
+      description: "timeout in seconds",
+    })
+    expect(advertised.properties.all).toMatchObject({ type: "boolean" })
+    expect(advertised.properties.app).toMatchObject({
+      type: "object",
+      description: "browser app options",
+    })
+    expect(advertised.properties.args).toMatchObject({ type: "array" })
+    expect(advertised.required).toEqual(["action"])
+  })
+
+  it("leaves declared strings alone, JSON-looking or not", () => {
+    const schema = registerBrowser()
+
+    // A `string` parameter that happens to hold JSON is legitimate input, not
+    // a slip; parsing it would corrupt the call.
+    const result = schema.safeParse({ action: "open", name: '{"not":"parsed"}' })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({ action: "open", name: '{"not":"parsed"}' })
+  })
+
+  it("still rejects a value no repair can make valid", () => {
+    const schema = registerBrowser()
+
+    expect(schema.safeParse({ action: "open", timeout: "soon" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", app: "not json" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", args: '{"cdp_url":"x"}' }).success).toBe(false)
+    expect(schema.safeParse({ timeout: "60" }).success).toBe(false)
+  })
+})

--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -24,6 +24,7 @@ const BROWSER_SCHEMA = {
     action: { type: "string", enum: ["open", "close", "run"], description: "operation" },
     name: { type: "string", description: "tab id" },
     timeout: { type: "number", description: "timeout in seconds" },
+    retryCount: { type: "integer", description: "number of retries" },
     all: { type: "boolean", description: "release every managed tab" },
     app: {
       type: "object",
@@ -71,6 +72,15 @@ describe("passthrough tool input coercion", () => {
     })
   })
 
+  it("repairs integer strings only when they are integral", () => {
+    const schema = registerBrowser()
+
+    const accepted = schema.safeParse({ action: "open", retryCount: "2" })
+    expect(accepted.success).toBe(true)
+    if (accepted.success) expect(accepted.data.retryCount).toBe(2)
+
+    expect(schema.safeParse({ action: "open", retryCount: "1.5" }).success).toBe(false)
+  })
   it("still advertises the client's declared types and descriptions", () => {
     const schema = registerBrowser()
 
@@ -84,6 +94,10 @@ describe("passthrough tool input coercion", () => {
     expect(advertised.properties.timeout).toMatchObject({
       type: "number",
       description: "timeout in seconds",
+    })
+    expect(advertised.properties.retryCount).toMatchObject({
+      type: "integer",
+      description: "number of retries",
     })
     expect(advertised.properties.all).toMatchObject({ type: "boolean" })
     expect(advertised.properties.app).toMatchObject({

--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -80,6 +80,7 @@ describe("passthrough tool input coercion", () => {
     if (accepted.success) expect(accepted.data.retryCount).toBe(2)
 
     expect(schema.safeParse({ action: "open", retryCount: "1.5" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", retryCount: "9007199254740993" }).success).toBe(false)
   })
   it("still advertises the client's declared types and descriptions", () => {
     const schema = registerBrowser()

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -51,7 +51,13 @@ interface JsonSchemaNode {
 function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
   if (typeof value !== "string") return value
 
-  if (schema.type === "number" || schema.type === "integer") {
+  if (schema.type === "integer") {
+    if (value.trim() === "") return value
+    const parsed = Number(value)
+    return Number.isInteger(parsed) ? parsed : value
+  }
+
+  if (schema.type === "number") {
     if (value.trim() === "") return value
     const parsed = Number(value)
     return Number.isFinite(parsed) ? parsed : value
@@ -110,7 +116,10 @@ function buildZodNode(schema: JsonSchemaNode): z.ZodTypeAny {
     if (schema.enum) return z.enum(schema.enum as [string, ...string[]])
     return z.string()
   }
-  if (schema.type === "number" || schema.type === "integer") {
+  if (schema.type === "integer") {
+    return repairing(schema, z.number().int())
+  }
+  if (schema.type === "number") {
     return repairing(schema, z.number())
   }
   if (schema.type === "boolean") return repairing(schema, z.boolean())

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -54,7 +54,7 @@ function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
   if (schema.type === "integer") {
     if (value.trim() === "") return value
     const parsed = Number(value)
-    return Number.isInteger(parsed) ? parsed : value
+    return Number.isSafeInteger(parsed) ? parsed : value
   }
 
   if (schema.type === "number") {

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -17,39 +17,129 @@ export const PASSTHROUGH_MCP_NAME = "oc"
 export const PASSTHROUGH_MCP_PREFIX = `mcp__${PASSTHROUGH_MCP_NAME}__`
 
 /**
- * Convert a JSON Schema object to a Zod schema (simplified).
+ * The JSON Schema subset a client's tool definitions actually use. Anything
+ * richer (`anyOf`, `$ref`, tuple `items`, …) falls through to `z.any()` below,
+ * exactly as before.
+ */
+interface JsonSchemaNode {
+  type?: string
+  description?: string
+  enum?: string[]
+  items?: JsonSchemaNode
+  properties?: Record<string, JsonSchemaNode>
+  required?: string[]
+}
+
+/**
+ * Repair the one tool-input slip the model makes often enough to matter: it
+ * emits every argument as a string, so a declared `number` arrives as `"60"`
+ * and a declared object as `'{"cdp_url":"..."}'`.
+ *
+ * That has to be repaired HERE, before validation, because a rejected call
+ * never reaches the PreToolUse hook — so the proxy captures nothing, has
+ * nothing to forward to the client, and the passthrough turn cap (maxTurns=1,
+ * see query.ts) leaves the model no turn to correct itself. The SDK then ends
+ * the query with `error_max_turns`, which server.ts can only report as a 500:
+ * a hard, user-visible stream error for a call the client would have executed
+ * fine. Measured live: every failing call carried `timeout: "60"` where the
+ * client's schema says `number`.
+ *
+ * Only slips whose declared type makes the intent unambiguous are repaired,
+ * and only from a string. A declared `string` is never JSON-parsed: that would
+ * corrupt legitimate input which merely looks like JSON.
+ */
+function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
+  if (typeof value !== "string") return value
+
+  if (schema.type === "number" || schema.type === "integer") {
+    if (value.trim() === "") return value
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : value
+  }
+
+  if (schema.type === "boolean") {
+    if (value === "true") return true
+    if (value === "false") return false
+    return value
+  }
+
+  if (schema.type === "object" || schema.type === "array") {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      return value
+    }
+    if (schema.type === "array") return Array.isArray(parsed) ? parsed : value
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : value
+  }
+
+  return value
+}
+
+/**
+ * The MCP schema converter reads `description` from the OUTERMOST node only —
+ * an inner `.describe()` under `.optional()` or a `preprocess` pipe is dropped
+ * from the advertised schema. Apply it last so the model keeps seeing what the
+ * client wrote, optional parameters included.
+ */
+function withDescription(node: z.ZodTypeAny, schema: JsonSchemaNode): z.ZodTypeAny {
+  return typeof schema.description === "string" && schema.description
+    ? node.describe(schema.description)
+    : node
+}
+
+/** Wrap a validating node so a repairable slip is fixed instead of rejected. */
+function repairing(schema: JsonSchemaNode, node: z.ZodTypeAny): z.ZodTypeAny {
+  return z.preprocess(value => repairTypeSlip(schema, value), node)
+}
+
+/**
+ * Convert a JSON Schema node to a Zod schema (simplified).
  * Handles the common types OpenCode sends. Falls back to z.any() for complex types.
  */
-function jsonSchemaToZod(schema: any): z.ZodTypeAny {
+function jsonSchemaToZod(schema: unknown): z.ZodTypeAny {
   if (!schema || typeof schema !== "object") return z.any()
+  const node = schema as JsonSchemaNode
+  return withDescription(buildZodNode(node), node)
+}
+
+function buildZodNode(schema: JsonSchemaNode): z.ZodTypeAny {
 
   if (schema.type === "string") {
-    let s = z.string()
-    if (schema.description) s = s.describe(schema.description)
     if (schema.enum) return z.enum(schema.enum as [string, ...string[]])
-    return s
+    return z.string()
   }
   if (schema.type === "number" || schema.type === "integer") {
-    let n = z.number()
-    if (schema.description) n = n.describe(schema.description)
-    return n
+    return repairing(schema, z.number())
   }
-  if (schema.type === "boolean") return z.boolean()
+  if (schema.type === "boolean") return repairing(schema, z.boolean())
   if (schema.type === "array") {
     const items = schema.items ? jsonSchemaToZod(schema.items) : z.any()
-    return z.array(items)
+    return repairing(schema, z.array(items))
   }
   if (schema.type === "object" && schema.properties) {
-    const shape: Record<string, z.ZodTypeAny> = {}
-    const required = new Set(schema.required || [])
-    for (const [key, propSchema] of Object.entries(schema.properties)) {
-      const zodProp = jsonSchemaToZod(propSchema as any)
-      shape[key] = required.has(key) ? zodProp : zodProp.optional()
-    }
-    return z.object(shape)
+    return repairing(schema, z.object(objectShapeFromJsonSchema(schema)))
   }
 
   return z.any()
+}
+
+/**
+ * The property shape of a JSON Schema object, with optionality applied.
+ *
+ * Kept separate from `jsonSchemaToZod` because the MCP registration needs the
+ * root as a raw shape, and the root arguments object is never a slip candidate
+ * — the protocol always delivers it as an object.
+ */
+function objectShapeFromJsonSchema(schema: JsonSchemaNode): Record<string, z.ZodType> {
+  const shape: Record<string, z.ZodType> = {}
+  const required = new Set<string>(schema.required ?? [])
+  for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
+    const prop = jsonSchemaToZod(propSchema)
+    shape[key] = required.has(key) ? prop : withDescription(prop.optional(), propSchema)
+  }
+  return shape
 }
 
 /** Default threshold: auto-defer when tool count exceeds this.
@@ -73,7 +163,7 @@ export function getAutoDeferThreshold(): number {
  * Client-provided defer_loading: true also triggers deferral for specific tools.
  */
 export function createPassthroughMcpServer(
-  tools: Array<{ name: string; description?: string; input_schema?: any; defer_loading?: boolean }>,
+  tools: Array<{ name: string; description?: string; input_schema?: JsonSchemaNode; defer_loading?: boolean }>,
   coreToolNames?: readonly string[]
 ) {
   // Auto-defer: if tool count exceeds threshold and adapter provides core tools
@@ -101,12 +191,13 @@ export function createPassthroughMcpServer(
       // Register through the Agent SDK helper so its Zod 4 peer owns the MCP
       // compatibility boundary. Registering through the nested MCP instance
       // instead couples this module to that package's separate Zod version.
-      const zodSchema = passthroughTool.input_schema?.properties
-        ? jsonSchemaToZod(passthroughTool.input_schema)
-        : z.object({})
-      const shape: Record<string, z.ZodType> = zodSchema instanceof z.ZodObject
-        ? zodSchema.shape
-        : { input: z.any() }
+      //
+      // The root is built as a raw shape rather than a converted object: the
+      // arguments object always arrives as an object over the protocol, so it
+      // is never a repair candidate, and the SDK wants the shape anyway.
+      const shape = passthroughTool.input_schema?.properties
+        ? objectShapeFromJsonSchema(passthroughTool.input_schema)
+        : {}
       return defineTool(shape)
     } catch {
       const fallbackShape: Record<string, z.ZodType> = { input: z.string().optional() }


### PR DESCRIPTION
## The bug

A client's tool schema declares `timeout: number`. The model sometimes emits every argument as a string, so `"60"` arrives where a number is required, and a declared object arrives as `'{"cdp_url":"..."}'`.

In passthrough mode that is fatal rather than recoverable. The SDK's MCP layer rejects the call during validation, so:

- the call never reaches the PreToolUse hook, so the proxy captures nothing;
- there is nothing to forward to the client, so the client cannot execute it;
- the single-turn cap (`maxTurns: 1`, `src/proxy/query.ts`) leaves the model no turn to correct itself.

The query ends `error_max_turns` and `server.ts` can only report a 500. The client sees a hard stream error for a call it would have executed fine.

Measured on one machine: every failing `browser` call carried `timeout: "60"` where the schema says `number`, sometimes plus a stringified `app` object. The two successful calls in the same session omitted those fields.

## The fix

Repair the unambiguous slips in `src/proxy/passthroughTools.ts`, before validation.

A declared `number`, `integer`, `boolean`, `object` or `array` is parsed from a string. Anything that fails to parse, or parses to the wrong shape, is passed through unchanged and still rejected. A declared `string` is never JSON-parsed, so legitimate input that merely looks like JSON is untouched.

The advertised schema does not change: `z.preprocess` keeps the declared output type, so the model still sees `number`, not a widened union.

Because the wrapper is a pipe rather than a `ZodObject`, the registration site now builds the root arguments shape directly instead of converting an object and reading `.shape`. The root is never a repair candidate - the protocol always delivers it as an object - and the SDK wants the raw shape anyway. That also restores the client's `description` on optional and enum properties, which the previous ordering dropped from the advertised schema.

## Verification

New test `src/__tests__/passthrough-input-coercion.test.ts` drives the real `createPassthroughMcpServer` output through Zod's validation:

- the stringified arguments that made the SDK refuse the call now parse;
- declared strings are left alone, JSON-looking or not;
- the advertised schema still carries the client's declared types and descriptions.

All four fail on the parent commit (verified in a clean worktree at `1ea97d0`). `tsc --noEmit` clean; full suite clean.
