### PR TITLE
test: isolate the suite from the operator's meridian environment

### DIFF
--- a/src/__tests__/preload.ts
+++ b/src/__tests__/preload.ts
@@ -7,8 +7,25 @@ import { mkdirSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-// Auth middleware reads this at request time; clear it so tests don't need API keys
-delete process.env.MERIDIAN_API_KEY
+// Take the operator's whole configuration namespace away from the suite.
+//
+// Every runtime knob is read through `env()`, i.e. `MERIDIAN_<X>` with a
+// `CLAUDE_PROXY_<X>` fallback, so anything a developer exports to run their own
+// proxy silently reconfigures the code under test. Two real examples from this
+// machine: `MERIDIAN_NO_FILE_CHANGES=1` turns off the PostToolUse hook and
+// fails the three "other adapters still track" cases in
+// proxy-file-changes.test.ts, and `MERIDIAN_TELEMETRY_PERSIST=1` makes the
+// global telemetry store the real ~/.config/meridian/telemetry.db — which the
+// suite then DELETEs, because tests call `telemetryStore.clear()` and
+// `diagnosticLog.clear()`. (Redirecting the config dir does not save it:
+// telemetry resolves its path from `env("TELEMETRY_DB")` alone.)
+//
+// CI runs with none of these set, so stripping the namespace is what makes a
+// local run mean the same thing as a CI run. Tests that need a knob set it
+// themselves, in-process, after this point.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
 
 // Point settings.ts at a throwaway directory so the suite never reads the
 // developer's real ~/.config/meridian/settings.json. A live


### PR DESCRIPTION
## Problem

Every runtime knob is read through `env()` — `MERIDIAN_<X>` with a `CLAUDE_PROXY_<X>` fallback — so anything a developer exports to run their own proxy silently reconfigures the code under test. The suite inherits it, and CI (which exports none of it) cannot see the difference.

Two cases observed on one machine, both from a normal operator environment:

- **`MERIDIAN_NO_FILE_CHANGES=1`** disables the PostToolUse file-change hook, so the three *"File change visibility: other adapters still track"* cases in `src/__tests__/proxy-file-changes.test.ts` fail on `main` — with no local change in sight.
- **`MERIDIAN_TELEMETRY_PERSIST=1`** makes the process-global telemetry store the real `~/.config/meridian/telemetry.db`. The suite is written against the in-memory store and calls `telemetryStore.clear()` / `diagnosticLog.clear()`, which issue `DELETE FROM metrics` / `DELETE FROM diagnostic_logs` — so running `npm test` **destroys every metric and diagnostic log the operator's own proxy has recorded**. Redirecting `MERIDIAN_CONFIG_DIR` does not help: `src/telemetry/index.ts` resolves its path from `env("TELEMETRY_DB")` and otherwise hard-codes `~/.config/meridian/telemetry.db`.

The second one is data loss, and it is silent.

## Fix

Strip the `MERIDIAN_*` / `CLAUDE_PROXY_*` namespace in `src/__tests__/preload.ts`, before any module import. The preload then sets the values the suite owns (config dir, session dir, SDK process gate) as it already did.

CI runs with none of these set, so this is precisely what makes a local run mean the same thing as a CI run. Tests that need a knob set it themselves, in-process, after the preload.

## Verification

`npm test` on this branch: all 13 invocations green (2982 + 251 tests, 0 fail). Before it, on the same machine, `main` reported 3 failures in `proxy-file-changes.test.ts` and wiped the local telemetry database.