### PR TITLE
feat(models): add Claude Fable 5.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "opencode-claude-code-provider",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-        "@anthropic-ai/claude-code": "^2.1.198",
+        "@anthropic-ai/claude-code": "^2.1.257",
         "cross-spawn": "7.0.6",
         "jsonc-parser": "^3.3.1",
         "libsql": "^0.5.29",
@@ -46,23 +46,23 @@
 
     "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119", "", { "os": "win32", "cpu": "x64" }, "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA=="],
 
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.198", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.198", "@anthropic-ai/claude-code-darwin-x64": "2.1.198", "@anthropic-ai/claude-code-linux-arm64": "2.1.198", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.198", "@anthropic-ai/claude-code-linux-x64": "2.1.198", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.198", "@anthropic-ai/claude-code-win32-arm64": "2.1.198", "@anthropic-ai/claude-code-win32-x64": "2.1.198" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-5f4w6RcMQhGVo9ya53nIrmqPmeQxT5/mfZ3S6quJDvoJOGm8KClkRGDi9WAVz/CKbOMB7alRmDuIry1NbqkffA=="],
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.259", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.259", "@anthropic-ai/claude-code-darwin-x64": "2.1.259", "@anthropic-ai/claude-code-linux-arm64": "2.1.259", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.259", "@anthropic-ai/claude-code-linux-x64": "2.1.259", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.259", "@anthropic-ai/claude-code-win32-arm64": "2.1.259", "@anthropic-ai/claude-code-win32-x64": "2.1.259" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-kzhz+R36GgL5aouAkeMO9nI1BEIVaRx1NGu0wTTn/H315l61uiLRo13yvva7H10Pfv0PGgzqJ4m+EKv9BzIRXQ=="],
 
-    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.198", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6omNnK8MblrYGHs8I0B7wwl8mGXBH9+ilBYK6Jl1WJnA8SpFAqomwmZO2wmaR18pcueaSD56J3W8tTBaNtx7Eg=="],
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.259", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yAMbgvi5pVt2fBO0Sg9n+2WJ0vJTd6ykafaRq1DL/8/hb314zDwyJuP7OewFBgHthYm3szTPi7CSe0vmeTxz3g=="],
 
-    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.198", "", { "os": "darwin", "cpu": "x64" }, "sha512-R1jzAJnr+6TzPrER3hSJafuCGBy6Zvt+RnDslKCK5Hu4fSjpeoE1JwUy1PI4ZX7JamfNvickg4myVGccRUZB3w=="],
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.259", "", { "os": "darwin", "cpu": "x64" }, "sha512-Q70pOwpAmbuRFmEh+L3FPU3BHYcGf9nr8COtJDewjjnK8w9RZK8vs9k6TGvujhRjaQGAdKOwL5lgVI69xW4VEw=="],
 
-    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.198", "", { "os": "linux", "cpu": "arm64" }, "sha512-+7i3CtYtmrcnJQpxP0Jh98Tj6bo2EV98Ip3HViVPPPrf3ZRoseXvacafjlrw8IB0vOYGhp65wKuQ6li4iKLN3A=="],
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.259", "", { "os": "linux", "cpu": "arm64" }, "sha512-9NzlP79GXZcnaHmVbZO8pIPPafRTJzfSRAZeHbDyCAHnsMQWmkIbW2kOsDl1KpV93za+3Kdn6RuKIs+JRp0rag=="],
 
-    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.198", "", { "os": "linux", "cpu": "arm64" }, "sha512-n3ivLvvwEE/Z9VC6IP3K31lnrJwBXppTCq8pmKApydQNOWODo1t65BHY+loFJeaDA3xf2LRQ+hrHKeb0W1lYnA=="],
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.259", "", { "os": "linux", "cpu": "arm64" }, "sha512-kJia3BfDa1Tbfr3nLqinsE72Q9Pt6ovFMamKHkkircGW/xrZIlOtk4tXr6egEx07isp3ERhggYauRD6e+tgb7A=="],
 
-    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.198", "", { "os": "linux", "cpu": "x64" }, "sha512-/gFaLosxKKIfIJVoiNlkBBIvnaLcC7LuczPyc+wZzbwDOd80Lhmqeh5sb8FqNl0un/kQwprxaRcJ0n834eA4CA=="],
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.259", "", { "os": "linux", "cpu": "x64" }, "sha512-Uh2OEu5DVvndwosVXfjUpahQVjNqxZeCO7ehrG0JBd+xo/iWz38LfwCGsbgPiGNI+ZioIl3vwenD+6BjpOi8nQ=="],
 
-    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.198", "", { "os": "linux", "cpu": "x64" }, "sha512-4oHEh+7jdvx4KwUk8CfwAN06NgWReZ7VyGlpz35NDSrN44kMoiu2y8z+26xcFuNLqM5xgW/Z0UVG6xoXY17TyA=="],
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.259", "", { "os": "linux", "cpu": "x64" }, "sha512-zZSsED8WvQqH1JV7/8YkNRi8ZT7jZSQ1JWPQljDZTb1+Gf956fx8VT2JeD/r/nklScLoU8vVH+som11faSnRJQ=="],
 
-    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.198", "", { "os": "win32", "cpu": "arm64" }, "sha512-t2BuAP8DFhdp3Q9GUAypJP5wnk8fIZeqM5Q0jLzDg4XazUZt0lql5pBSlzjxuLw2CfES7nXFUKPJoV6ewaqlXw=="],
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.259", "", { "os": "win32", "cpu": "arm64" }, "sha512-VOuejZqTPuZyIYZP1LNqcZrlV/KYaj5Uinp3yQ2UNcyRye12oJiaV9EHqU2oySBAtQ+3apxzvs4rBajO8aMNsQ=="],
 
-    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.198", "", { "os": "win32", "cpu": "x64" }, "sha512-UStQl408M7sWbxkp4GUdrUfpC+IisWXfEmdNBpWihDzA2XxPIf9zfd8L5uZtkJjikkIvKsiHTZrGJHCkrPkIKQ=="],
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.259", "", { "os": "win32", "cpu": "x64" }, "sha512-NybMrZjP/AZTpxZtes5VDi6NeEt6PRxYR2A4+pdwl1id5R9jSWmpm9POXasdgMhwPKCYUCBIMbtwsU0Jx3PeDw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.81.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -53,41 +53,41 @@
     url = "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz";
     hash = "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==";
   };
-  "@anthropic-ai/claude-code-darwin-arm64@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.198.tgz";
-    hash = "sha512-6omNnK8MblrYGHs8I0B7wwl8mGXBH9+ilBYK6Jl1WJnA8SpFAqomwmZO2wmaR18pcueaSD56J3W8tTBaNtx7Eg==";
+  "@anthropic-ai/claude-code-darwin-arm64@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.259.tgz";
+    hash = "sha512-yAMbgvi5pVt2fBO0Sg9n+2WJ0vJTd6ykafaRq1DL/8/hb314zDwyJuP7OewFBgHthYm3szTPi7CSe0vmeTxz3g==";
   };
-  "@anthropic-ai/claude-code-darwin-x64@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.198.tgz";
-    hash = "sha512-R1jzAJnr+6TzPrER3hSJafuCGBy6Zvt+RnDslKCK5Hu4fSjpeoE1JwUy1PI4ZX7JamfNvickg4myVGccRUZB3w==";
+  "@anthropic-ai/claude-code-darwin-x64@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.259.tgz";
+    hash = "sha512-Q70pOwpAmbuRFmEh+L3FPU3BHYcGf9nr8COtJDewjjnK8w9RZK8vs9k6TGvujhRjaQGAdKOwL5lgVI69xW4VEw==";
   };
-  "@anthropic-ai/claude-code-linux-arm64-musl@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.198.tgz";
-    hash = "sha512-n3ivLvvwEE/Z9VC6IP3K31lnrJwBXppTCq8pmKApydQNOWODo1t65BHY+loFJeaDA3xf2LRQ+hrHKeb0W1lYnA==";
+  "@anthropic-ai/claude-code-linux-arm64-musl@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.259.tgz";
+    hash = "sha512-kJia3BfDa1Tbfr3nLqinsE72Q9Pt6ovFMamKHkkircGW/xrZIlOtk4tXr6egEx07isp3ERhggYauRD6e+tgb7A==";
   };
-  "@anthropic-ai/claude-code-linux-arm64@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.198.tgz";
-    hash = "sha512-+7i3CtYtmrcnJQpxP0Jh98Tj6bo2EV98Ip3HViVPPPrf3ZRoseXvacafjlrw8IB0vOYGhp65wKuQ6li4iKLN3A==";
+  "@anthropic-ai/claude-code-linux-arm64@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.259.tgz";
+    hash = "sha512-9NzlP79GXZcnaHmVbZO8pIPPafRTJzfSRAZeHbDyCAHnsMQWmkIbW2kOsDl1KpV93za+3Kdn6RuKIs+JRp0rag==";
   };
-  "@anthropic-ai/claude-code-linux-x64-musl@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.198.tgz";
-    hash = "sha512-4oHEh+7jdvx4KwUk8CfwAN06NgWReZ7VyGlpz35NDSrN44kMoiu2y8z+26xcFuNLqM5xgW/Z0UVG6xoXY17TyA==";
+  "@anthropic-ai/claude-code-linux-x64-musl@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.259.tgz";
+    hash = "sha512-zZSsED8WvQqH1JV7/8YkNRi8ZT7jZSQ1JWPQljDZTb1+Gf956fx8VT2JeD/r/nklScLoU8vVH+som11faSnRJQ==";
   };
-  "@anthropic-ai/claude-code-linux-x64@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.198.tgz";
-    hash = "sha512-/gFaLosxKKIfIJVoiNlkBBIvnaLcC7LuczPyc+wZzbwDOd80Lhmqeh5sb8FqNl0un/kQwprxaRcJ0n834eA4CA==";
+  "@anthropic-ai/claude-code-linux-x64@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.259.tgz";
+    hash = "sha512-Uh2OEu5DVvndwosVXfjUpahQVjNqxZeCO7ehrG0JBd+xo/iWz38LfwCGsbgPiGNI+ZioIl3vwenD+6BjpOi8nQ==";
   };
-  "@anthropic-ai/claude-code-win32-arm64@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.198.tgz";
-    hash = "sha512-t2BuAP8DFhdp3Q9GUAypJP5wnk8fIZeqM5Q0jLzDg4XazUZt0lql5pBSlzjxuLw2CfES7nXFUKPJoV6ewaqlXw==";
+  "@anthropic-ai/claude-code-win32-arm64@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.259.tgz";
+    hash = "sha512-VOuejZqTPuZyIYZP1LNqcZrlV/KYaj5Uinp3yQ2UNcyRye12oJiaV9EHqU2oySBAtQ+3apxzvs4rBajO8aMNsQ==";
   };
-  "@anthropic-ai/claude-code-win32-x64@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.198.tgz";
-    hash = "sha512-UStQl408M7sWbxkp4GUdrUfpC+IisWXfEmdNBpWihDzA2XxPIf9zfd8L5uZtkJjikkIvKsiHTZrGJHCkrPkIKQ==";
+  "@anthropic-ai/claude-code-win32-x64@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.259.tgz";
+    hash = "sha512-NybMrZjP/AZTpxZtes5VDi6NeEt6PRxYR2A4+pdwl1id5R9jSWmpm9POXasdgMhwPKCYUCBIMbtwsU0Jx3PeDw==";
   };
-  "@anthropic-ai/claude-code@2.1.198" = fetchurl {
-    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.198.tgz";
-    hash = "sha512-5f4w6RcMQhGVo9ya53nIrmqPmeQxT5/mfZ3S6quJDvoJOGm8KClkRGDi9WAVz/CKbOMB7alRmDuIry1NbqkffA==";
+  "@anthropic-ai/claude-code@2.1.259" = fetchurl {
+    url = "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.259.tgz";
+    hash = "sha512-kzhz+R36GgL5aouAkeMO9nI1BEIVaRx1NGu0wTTn/H315l61uiLRo13yvva7H10Pfv0PGgzqJ4m+EKv9BzIRXQ==";
   };
   "@anthropic-ai/sdk@0.81.0" = fetchurl {
     url = "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz";

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -128,6 +128,7 @@ Add a provider to `~/.config/crush/crush.json`:
       "base_url": "http://127.0.0.1:3456",
       "api_key": "dummy",
       "models": [
+        { "id": "claude-fable-5-1",  "name": "Claude Fable 5.1 (1M)",   "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
         { "id": "claude-fable-5",    "name": "Claude Fable 5 (1M)",     "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
         { "id": "claude-opus-5",     "name": "Claude Opus 5 (1M)",      "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
         { "id": "claude-opus-4-8",   "name": "Claude Opus 4.8 (1M)",    "context_window": 1000000, "default_max_tokens": 32768, "can_reason": true, "supports_attachments": true },
@@ -155,6 +156,7 @@ Add Meridian as a custom model provider in `~/.factory/settings.json`:
 ```json
 {
   "customModels": [
+    { "model": "claude-fable-5-1",        "name": "Fable 5.1 (Meridian)",  "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-fable-5",          "name": "Fable 5 (Meridian)",    "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-opus-5",           "name": "Opus 5 (Meridian)",     "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },
     { "model": "claude-opus-4-8",         "name": "Opus 4.8 (Meridian)",   "provider": "anthropic", "baseUrl": "http://127.0.0.1:3456", "apiKey": "x" },

--- a/flake.lock
+++ b/flake.lock
@@ -134,11 +134,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784120854,
-        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
         "type": "github"
       },
       "original": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-        "@anthropic-ai/claude-code": "^2.1.198",
+        "@anthropic-ai/claude-code": "^2.1.257",
         "cross-spawn": "7.0.6",
         "jsonc-parser": "^3.3.1",
         "libsql": "^0.5.29",
@@ -180,9 +180,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.247.tgz",
-      "integrity": "sha512-2Z2UQKom3x6GBQDYlFFi00KbRciqsuGL9CpK+IN3fXmmJb7IXVitrRZ6HZyUw0ixnckr814GIp0FUaXwDEbBrw==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.257.tgz",
+      "integrity": "sha512-JzpBQDzbEV+IKV9lIs/SSRIdHGrAmQXhNScoz9PZgdjnatrVnbsBXRDrF26qBBBph38pA/39d+BhDpf+7RwkwA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
@@ -192,20 +192,20 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.247",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.247",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.247",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.247",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.247",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.247",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.247",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.247"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.257",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.257",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.257",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.257",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.257",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.257",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.257",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.257"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.247.tgz",
-      "integrity": "sha512-PgInuhsq1LONloSE6puAPzQUakRDDkX8fYPz+k7CCJK8uvfsxtSwA19T1l3ebVuZauPcss+E4abk+WFwGlY3Cg==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.257.tgz",
+      "integrity": "sha512-VQQfNs9fiSmtDK4kgK18gQ9cXE8Nw44BogYYLZ3mGxWASplyYWhORMs+loNilBDmspBWhyVxVA4iGBPEpgxkmQ==",
       "cpu": [
         "arm64"
       ],
@@ -216,9 +216,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.247.tgz",
-      "integrity": "sha512-CAMN8THavM7V0qhX6JwvfXIAMuQHxQf8XYP2ztMR2MsIT1Vrac1bmXav/tmlVFmA2UaRBHImGIHO+4oiyaziTA==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.257.tgz",
+      "integrity": "sha512-QvIHitd4srhkdImuKQ5BBk2kPX8rTHBJ7nwbmRchYkCa3zpAQgxS3M176pFhsAW5o4PuYzKQ0NIARJMOrCJqxw==",
       "cpu": [
         "x64"
       ],
@@ -229,11 +229,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.247.tgz",
-      "integrity": "sha512-oz5zSpSHY3WBaajo70L61YVM0efGxhoguOhz2DjbVy/Q6EvXoDaAj6813IzIHHsRugLYQ36D1B32GDSL63mz6Q==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.257.tgz",
+      "integrity": "sha512-O/UyW9dHp0+wXKBvdg8TqoRMecedvwjQQou2hP4GCcRjjE/GD/9g64pCcmUgjrgbACA+LejuC7kiBxTg1TSbUg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -242,11 +245,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.247.tgz",
-      "integrity": "sha512-894hf5lB/+nBIHkzWwo4iDFzTCaJxKqLMfZRmiEj4FMoToepNXRr+jROwuXTAdWE7wKqZjUGi7SDbykfLR40Jw==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.257.tgz",
+      "integrity": "sha512-uTKbWiVg+6szOqbogZLsQXlo3Iqxz4cyVjDfAPWSjg6mnhUGck889D7FJPHrRJYARQGwwyRhZXoazCCe5KmciA==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -255,11 +261,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.247.tgz",
-      "integrity": "sha512-ZHjg+YRpBDKmTzIWtVF7ofABjwz387bCjDCUyO89ttuOwlUvh1zmCVwTlL6BdJO/v9uCTbQOrM7GUIDqzmPAoA==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.257.tgz",
+      "integrity": "sha512-Mue9ytQXYqkPYZfVnum5kxLirKdwxrU27VHykpzZ6ZOM9NNf7IEHmZ4a4eX0sRlYptJ0FACEc0HxgFdDnL7pgQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -268,11 +277,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.247.tgz",
-      "integrity": "sha512-/2ZS9KFUxvXlO4z1byS4BJExUfh51IbtrUVuF4QbdkAMBirnNF16ACJyorzcKfvQR8+aLoPuznMuIZd2yltRXQ==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.257.tgz",
+      "integrity": "sha512-vbmzXTj1gwqg8t1R5Bcn1VIBRXu9jQJZnhwg0rLkOmrjATygHl59H0N1cz/GvB32jzmNbX0808LoA9Erb8Jwdw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -281,9 +293,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.247.tgz",
-      "integrity": "sha512-vN73B/ofkhj939CN5aEW84wuJKWJ7t7Ecn0u1tu59zcUfuIjIllliTjnuVmmYolaR8mncLjK81d1dXMqHhbb7w==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.257.tgz",
+      "integrity": "sha512-BwKX60U0948hA/ukT0Q4ZFBFIy3mhkkp4c8DXpaRNZgPC6IkzvMzsImN2s/mahF5O8OP4MHhybLrAu6PtmfMHw==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +306,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.247",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.247.tgz",
-      "integrity": "sha512-nCg+StYkQjcZh4cWUwwD4ECTj/9jfWlNMxpsFvg2BgWkEtoA/q6bX+1NyYw9FRibbdD6MUfi7dtvK36koWqL2w==",
+      "version": "2.1.257",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.257.tgz",
+      "integrity": "sha512-Tb0/MaJ9nI3VGEP3Wo/LGjrapT1yzTUwTaC7Sa21VPCvjk7WWKyKNjNn6JWWsphthu6UM0nW/3wSi7F8eA3ihg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.117",
-    "@anthropic-ai/claude-code": "^2.1.198",
+    "@anthropic-ai/claude-code": "^2.1.257",
     "cross-spawn": "7.0.6",
     "jsonc-parser": "^3.3.1",
     "libsql": "^0.5.29",

--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test"
 
 // ---------- unit: explicitModelPin + canonical bump ----------
 
-const { explicitModelPin, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
+const { explicitModelPin, CANONICAL_FABLE_MODEL, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
 
 describe("explicitModelPin (#631)", () => {
   it("pins fully-versioned sonnet ids", () => {
@@ -29,6 +29,7 @@ describe("explicitModelPin (#631)", () => {
 
   it("routes mythos ids through the fable tier pin", () => {
     expect(explicitModelPin("claude-mythos-5")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-mythos-5" })
+    expect(explicitModelPin("claude-fable-5-1")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-fable-5-1" })
     expect(explicitModelPin("claude-fable-5")).toEqual({ ANTHROPIC_DEFAULT_FABLE_MODEL: "claude-fable-5" })
   })
 
@@ -55,6 +56,12 @@ describe("canonical sonnet pin (#631)", () => {
 describe("canonical opus pin", () => {
   it("bare opus means the current Opus", () => {
     expect(CANONICAL_OPUS_MODEL).toBe("claude-opus-5")
+  })
+})
+
+describe("canonical fable pin", () => {
+  it("bare fable means the current Fable", () => {
+    expect(CANONICAL_FABLE_MODEL).toBe("claude-fable-5-1")
   })
 })
 

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -126,6 +126,14 @@ describe("mapModelToClaudeModel", () => {
       expect(mapModelToClaudeModel("fable", "max", "subagent")).toBe("fable")
     })
 
+    // Every fable generation rides the one SDK alias, so a newer id must route
+    // identically — the version only reaches the SDK via the explicit pin.
+    it("routes claude-fable-5-1 through the same tier as claude-fable-5", () => {
+      expect(mapModelToClaudeModel("claude-fable-5-1")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("claude-fable-5-1", "max", "primary")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("claude-fable-5-1", "max", "subagent")).toBe("fable")
+    })
+
     it("downgrades fable[1m] to fable during the Extra Usage cooldown", () => {
       recordExtendedContextUnavailable()
       expect(mapModelToClaudeModel("claude-fable-5", "max")).toBe("fable")
@@ -167,6 +175,11 @@ describe("mapModelToClaudeModel", () => {
     it("downgrades to base fable when MERIDIAN_1M_CONTEXT_SUPPORT=0", () => {
       process.env.MERIDIAN_1M_CONTEXT_SUPPORT = "0"
       expect(mapModelToClaudeModel("claude-mythos-5", "max")).toBe("fable")
+    })
+
+    it("routes claude-mythos-5-1 through the fable tier too", () => {
+      expect(mapModelToClaudeModel("claude-mythos-5-1")).toBe("fable[1m]")
+      expect(mapModelToClaudeModel("claude-mythos-5-1", "max", "subagent")).toBe("fable")
     })
   })
 

--- a/src/__tests__/openai.test.ts
+++ b/src/__tests__/openai.test.ts
@@ -1320,14 +1320,15 @@ describe("createSseTranslator", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildModelList", () => {
-  it("returns 8 models", () => {
-    expect(buildModelList(true).length).toBe(8)
-    expect(buildModelList(false).length).toBe(8)
+  it("returns 9 models", () => {
+    expect(buildModelList(true).length).toBe(9)
+    expect(buildModelList(false).length).toBe(9)
   })
 
-  it("includes sonnet-5, fable-5, opus-5, opus-4-6, opus-4-7, and opus-4-8 for UI pickers", () => {
+  it("includes current and legacy Fable plus the supported Sonnet and Opus models for UI pickers", () => {
     const ids = buildModelList(true).map(m => m.id)
     expect(ids).toContain("claude-sonnet-5")
+    expect(ids).toContain("claude-fable-5-1")
     expect(ids).toContain("claude-fable-5")
     expect(ids).toContain("claude-opus-5")
     expect(ids).toContain("claude-opus-4-6")
@@ -1335,11 +1336,13 @@ describe("buildModelList", () => {
     expect(ids).toContain("claude-opus-4-8")
   })
 
-  it("Max subscription gets 1M context for fable, 200k otherwise", () => {
-    const fableMax = buildModelList(true).find(m => m.id === "claude-fable-5")!
-    const fableFree = buildModelList(false).find(m => m.id === "claude-fable-5")!
-    expect(fableMax.context_window).toBe(1_000_000)
-    expect(fableFree.context_window).toBe(200_000)
+  it("Max subscription gets 1M context for every Fable version, 200k otherwise", () => {
+    for (const id of ["claude-fable-5-1", "claude-fable-5"]) {
+      const fableMax = buildModelList(true).find(m => m.id === id)!
+      const fableFree = buildModelList(false).find(m => m.id === id)!
+      expect(fableMax.context_window).toBe(1_000_000)
+      expect(fableFree.context_window).toBe(200_000)
+    }
   })
 
   it("Max subscription gets 1M context for all opus variants, 200k for sonnet", () => {

--- a/src/__tests__/pricing-unit.test.ts
+++ b/src/__tests__/pricing-unit.test.ts
@@ -47,6 +47,7 @@ describe("resolveModelPricing", () => {
     expect(resolveModelPricing("claude-sonnet-4-6")).toMatchObject({ inputPerMTok: 3 })
     expect(resolveModelPricing("claude-fable-5-1")).toMatchObject({ inputPerMTok: 10 })
     expect(resolveModelPricing("claude-fable-5")).toMatchObject({ inputPerMTok: 10 })
+    expect(resolveModelPricing("claude-mythos-5-1")).toMatchObject({ inputPerMTok: 10 })
   })
 
   it("falls back to family pricing for dated snapshot IDs", () => {

--- a/src/__tests__/pricing-unit.test.ts
+++ b/src/__tests__/pricing-unit.test.ts
@@ -45,6 +45,7 @@ describe("resolveModelPricing", () => {
   it("resolves concrete API model IDs", () => {
     expect(resolveModelPricing("claude-opus-4-8")).toMatchObject({ inputPerMTok: 5, outputPerMTok: 25 })
     expect(resolveModelPricing("claude-sonnet-4-6")).toMatchObject({ inputPerMTok: 3 })
+    expect(resolveModelPricing("claude-fable-5-1")).toMatchObject({ inputPerMTok: 10 })
     expect(resolveModelPricing("claude-fable-5")).toMatchObject({ inputPerMTok: 10 })
   })
 

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -220,7 +220,7 @@ describe("SDK model pin injection (fixes #419)", () => {
     const app = createTestApp()
     // Bare alias: no envOverride kicks in, so the canonical pin is exercised.
     await post(app, { ...BASIC_REQUEST, model: "sonnet" })
-    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5-1")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe("claude-opus-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe("claude-sonnet-5")
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe("claude-haiku-4-5")
@@ -238,9 +238,15 @@ describe("SDK model pin injection (fixes #419)", () => {
     expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5")
   })
 
+  it("explicit claude-fable-5-1 requests pin the SDK env to Fable 5.1", async () => {
+    const app = createTestApp()
+    await post(app, { ...BASIC_REQUEST, model: "claude-fable-5-1" })
+    expect(capturedQueryOptions.env.ANTHROPIC_DEFAULT_FABLE_MODEL).toBe("claude-fable-5-1")
+  })
+
   // Mythos has no SDK alias of its own — it resolves through the fable alias,
   // so an explicit claude-mythos-* request must pin ANTHROPIC_DEFAULT_FABLE_MODEL
-  // to the requested id (not Meridian's canonical claude-fable-5 pin).
+  // to the requested id (not Meridian's canonical claude-fable-5-1 pin).
   it("explicit claude-mythos-5 requests pin the SDK env to mythos via the fable alias", async () => {
     const app = createTestApp()
     await post(app, { ...BASIC_REQUEST, model: "claude-mythos-5" })

--- a/src/__tests__/proxy-health-build.test.ts
+++ b/src/__tests__/proxy-health-build.test.ts
@@ -94,6 +94,7 @@ describe("/v1/models profile auth context", () => {
       envOverrides: { CLAUDE_CONFIG_DIR: "/profiles/work" },
     }])
     expect(models.get("claude-opus-4-6")?.context_window).toBe(1_000_000)
+    expect(models.get("claude-fable-5-1")?.context_window).toBe(1_000_000)
     expect(models.get("claude-fable-5")?.context_window).toBe(1_000_000)
   })
 

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -76,8 +76,8 @@ export function resolveSdkModelDefaults(
  *
  * Bare aliases ("sonnet", "opus[1m]") and unversioned family names return
  * undefined and keep the canonical pins. Mythos rides the fable tier
- * (claude-mythos-5 shares it — see mapModelToClaudeModel). A trailing [1m]
- * suffix is stripped; extended context stays alias-level.
+ * (claude-mythos-5/-5-1 share it — see mapModelToClaudeModel). A trailing
+ * [1m] suffix is stripped; extended context stays alias-level.
  */
 export function explicitModelPin(requestedModel: string): Record<string, string> | undefined {
   const base = requestedModel.trim().toLowerCase().replace(/\[1m\]$/, "")
@@ -165,18 +165,21 @@ export function mapModelToClaudeModel(model: string, subscriptionType?: string |
   // Using the base model preserves rate limit budget for the primary agent.
   const isSubagent = agentMode === "subagent"
 
-  // Fable [1m]: Fable 5 supports the 1M extended context window and, like Opus,
-  // is included on Max with no Extra Usage charge (verified on Max — a
-  // fable[1m] request returns normally, no Extra Usage error). Mirrors the opus
-  // handling: [1m] for primary agents, base model for subagents, honoring the
-  // shared Extra Usage cooldown so a future billing change auto-downgrades.
+  // Fable [1m]: the fable tier supports the 1M extended context window and,
+  // like Opus, is included on Max with no Extra Usage charge (verified on Max —
+  // a fable[1m] request returns normally, no Extra Usage error). Mirrors the
+  // opus handling: [1m] for primary agents, base model for subagents, honoring
+  // the shared Extra Usage cooldown so a future billing change auto-downgrades.
+  // Every fable generation rides the one alias, so this covers Fable 5.1
+  // (the canonical pin) and Fable 5 alike.
   //
-  // Mythos rides the fable tier: Claude Mythos 5 (claude-mythos-5, Project
-  // Glasswing) shares Fable 5's underlying model, context window, and API
-  // surface, and the Claude Agent SDK has no separate "mythos" alias. Routing
-  // it here (instead of the sonnet fallthrough) keeps explicit mythos requests
-  // on the right tier; server.ts pins ANTHROPIC_DEFAULT_FABLE_MODEL to the
-  // requested claude-mythos-* id so the concrete model passes through verbatim.
+  // Mythos rides the fable tier: Claude Mythos 5 / 5.1 (claude-mythos-5,
+  // claude-mythos-5-1, Project Glasswing) share the matching Fable model's
+  // context window and API surface, and the Claude Agent SDK has no separate
+  // "mythos" alias. Routing it here (instead of the sonnet fallthrough) keeps
+  // explicit mythos requests on the right tier; server.ts pins
+  // ANTHROPIC_DEFAULT_FABLE_MODEL to the requested claude-mythos-* id so the
+  // concrete model passes through verbatim.
   //
   // Per-tier opt-out (#702). Fable 1M is included at no Extra Usage cost on
   // Max and Team (verified live), so [1m] stays the default — but on plans

--- a/src/proxy/models.ts
+++ b/src/proxy/models.ts
@@ -40,7 +40,7 @@ export type ClaudeModel = "sonnet" | "sonnet[1m]" | "opus" | "opus[1m]" | "haiku
  * override via MERIDIAN_DEFAULT_{TYPE}_MODEL (proxy-side) or
  * ANTHROPIC_DEFAULT_{TYPE}_MODEL (shell env, wins over Meridian's pin).
  */
-export const CANONICAL_FABLE_MODEL = "claude-fable-5"
+export const CANONICAL_FABLE_MODEL = "claude-fable-5-1"
 export const CANONICAL_OPUS_MODEL = "claude-opus-5"
 export const CANONICAL_SONNET_MODEL = "claude-sonnet-5"
 export const CANONICAL_HAIKU_MODEL = "claude-haiku-4-5"

--- a/src/proxy/openai.ts
+++ b/src/proxy/openai.ts
@@ -1065,6 +1065,15 @@ export function buildModelList(extendedContextIncluded: boolean, now = Math.floo
       capabilities: FULL_CAPABILITIES,
     },
     {
+      id: "claude-fable-5-1",
+      object: "model",
+      created: now,
+      owned_by: "anthropic",
+      display_name: "Claude Fable 5.1",
+      context_window: extendedContextIncluded ? 1_000_000 : 200_000,
+      capabilities: FULL_CAPABILITIES,
+    },
+    {
       id: "claude-fable-5",
       object: "model",
       created: now,

--- a/src/telemetry/pricing.ts
+++ b/src/telemetry/pricing.ts
@@ -72,7 +72,9 @@ const HAIKU_3 = rates(0.25, 1.25)
  */
 export const BUILTIN_MODEL_PRICING: Record<string, ModelPricing> = {
   fable: FABLE,
+  "claude-fable-5-1": FABLE,
   "claude-fable-5": FABLE,
+  "claude-mythos-5-1": FABLE,
   "claude-mythos-5": FABLE,
   opus: OPUS,
   "claude-opus-5": OPUS,


### PR DESCRIPTION
Adds Claude Fable 5.1 (`claude-fable-5-1`) support.

Supersedes #921 by @emaadshamsi, cherry-picked here to satisfy `main`'s
signed-commit requirement (fork PRs sit at `BLOCKED` regardless of CI).
Their commit is preserved as-is; the second commit adds what it missed.

## From #921

- `claude-fable-5-1` becomes the canonical fable pin; `claude-fable-5`
  stays available as an explicit per-request pin
- `/v1/models` advertises Fable 5.1 with Max 1M context metadata
- bumps `@anthropic-ai/claude-code` — the older CLI rejects the model

## Added here

**`bun.lock` / `bun.nix` were never updated.** #921 bumped `package.json`
and `package-lock.json` only, but CI installs with `bun install` from
`bun.lock`, and `bun-nix-sync.yml` verifies `bun.nix` matches it. That
workflow only triggers on `bun.lock` changes, so it was skipped entirely
on #921 — and CI's non-frozen `bun install` resolved the new version
anyway, so green checks hid a stale lockfile. `bun install
--frozen-lockfile` would have broken on `main` after merge.

- pricing: `claude-fable-5-1` and `claude-mythos-5-1` as exact keys. The
  family fallback already priced them, but the settings page derives its
  overridable model list from the exact-key table, so both were missing there.
- tests: tier-mapping coverage for `claude-fable-5-1` and
  `claude-mythos-5-1` — neither id had any. Mythos 5.1 shipped alongside
  Fable 5.1 and rides the same alias.
- `docs/agents.md`: Fable 5.1 in the Crush and Droid example configs.
- comments: the fable branch describes a tier with several generations on
  one SDK alias, not just Fable 5.

## The CLI bump is load-bearing

Not taken on faith. The 2.1.198 binary contains no `claude-fable-5-1`
string; 2.1.259 does. At runtime the old CLI returns:

```
API Error: 400 Claude Code 2.1.198 does not support this model;
version 2.1.251 or newer is required.
```

while `claude-fable-5` still returns 200 on that same binary — so the
failure is model-specific, not a broken setup. **The true floor is
2.1.251**; `^2.1.257` clears it.

## Not affected: forced tool choice

Fable 5.1 returns 400 on `tool_choice` `any`/`tool`. Meridian only reads
`tool_choice` client-side (the `forceSingleToolUse` capture-dedup
heuristic in `server.ts`) and never forwards it upstream — tools reach
Claude through the passthrough MCP server. Verified live below.

## Testing

`npm test`: 2983 pass / 0 fail across 178 files, plus all 12 isolated
files green. `npm run typecheck` clean. (#921 reported a pre-existing
`proxy-stale-uuid-retry` failure; it does not reproduce here.)

Live E2E against Claude Max, proxy running the bundled 2.1.259 CLI:

| Check | Result |
|---|---|
| `/v1/models` | 9 models; `claude-fable-5-1` at 1M ctx |
| Fable 5.1 non-streaming | 200, `model=fable[1m]` |
| Fable 5.1 streaming | clean SSE envelope |
| Fable 5.1 tool call | `stop_reason=tool_use`, valid block |
| Tool result round-trip | `end_turn`, `lineage=continuation` |
| Legacy `claude-fable-5` | 200 — no regression |
| Subagent mode | `model=fable agent=subagent` (no `[1m]`) |
| `MERIDIAN_FABLE_MODEL=fable` | `model=fable` on a 5.1 request |
| `claude-mythos-5-1` | routes `fable[1m]`, gated by account access |
| Bogus `claude-fable-5-99` | **rejected** — see below |

The bogus-version check is the one that proves the feature is real: a
nonexistent fable version is rejected rather than silently served by
another model, which means the per-request pin genuinely reaches the SDK
and determines model selection. That is what makes `claude-fable-5-1`
succeeding evidence that Fable 5.1 actually served the request — the
failure mode this guards against is #529, where fable requests silently
answered as Sonnet.

## Unrelated pre-existing issue (not fixed here)

An unavailable model returns HTTP 500 `api_error` rather than a 400 —
applies to `claude-fable-5-99`, `claude-mythos-5-1`, and the old-CLI
rejection alike. 500 is retryable, so clients will retry a permanently
invalid model. Adjacent to #919; worth a follow-up issue.

Closes #921.
