### PR TITLE
fix(errors): classify the credits-era per-tier limit refusal

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -840,6 +840,8 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["nested SDK wrappers", "Error: API Error: You’ve reached your Fable 5 limit! /model to switch models."],
     ["Opus tier", "You've reached your Opus limit"],
     ["versioned Sonnet tier", "You've reached your Sonnet 4.6 limit"],
+    ["Claude-prefixed tier", "You've reached your Claude Opus 4.6 limit"],
+    ["multiline subprocess stderr", "Claude Code process exited with code 1\nSubprocess stderr: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
@@ -851,6 +853,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["quoted banner", "The docs say ‘You've reached your Fable 5 limit.’"],
     ["negated banner", "You've not reached your Fable 5 limit"],
     ["filename prefix", "Claude Code returned an error result: usage-credits.ts says You've reached your Fable 5 limit."],
+    ["configured tool qualifier", "You've reached your Fable configured tool limit"],
+    ["limitations suffix", "You've reached your Fable 5 limitations"],
+    ["unlabelled multiline quote", "MCP server failed:\nYou've reached your Fable 5 limit (quoted from docs)"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -848,6 +848,7 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["Opus tier", "You've reached your Opus limit"],
     ["versioned Sonnet tier", "You've reached your Sonnet 4.6 limit"],
     ["Claude-prefixed tier", "You've reached your Claude Opus 4.6 limit"],
+    ["space-separated model command", "You've reached your Fable 5 limit /model to switch models."],
     ["multiline subprocess stderr", "Claude Code process exited with code 1\nSubprocess stderr: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
@@ -867,6 +868,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["documentation sentence suffix", "Error: You've reached your Fable 5 limit. This is only a documentation example"],
     ["false assertion suffix", "You've reached your Fable 5 limit is false"],
     ["possessive threshold suffix", "You've reached your Fable 5 limit's configured warning threshold"],
+    ["joined run command", "You've reached your Fable 5 limitRun /usage-credits"],
+    ["joined usage command", "You've reached your Fable 5 limit/usage-credits"],
+    ["unspaced punctuated command", "You've reached your Fable 5 limit.Run /usage-credits"],
     ["generic error newline", "Error:\nYou've reached your Fable 5 limit."],
     ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
     ["unrelated appended stderr", "You've reached your Fable 5 limit.\nSubprocess stderr: unrelated tool output"],

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -850,6 +850,21 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["Claude-prefixed tier", "You've reached your Claude Opus 4.6 limit"],
     ["space-separated model command", "You've reached your Fable 5 limit /model to switch models."],
     ["multiline subprocess stderr", "Claude Code process exited with code 1\nSubprocess stderr: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."],
+    // server.ts appends captured stderr to Error.message before classification,
+    // so the banner is routinely NOT the last thing in the message. These are
+    // the shapes that reach classifyError in production; each returned 500
+    // api_error (or, with nothing else to go on, a 401 telling the operator to
+    // run `claude login`) until the bound became the line rather than the
+    // message. See REACHED_YOUR_TIER_LIMIT.
+    ["banner then unrelated appended stderr", "You've reached your Fable 5 limit.\nSubprocess stderr: unrelated tool output"],
+    // stderrLines.join("\n") labels only the first line, and on Team plans the
+    // harmless betas warning is always emitted first — so the real banner
+    // arrives on an unlabelled second line.
+    ["beta warning first, banner on an unlabelled line", "Claude Code process exited with code 1\nSubprocess stderr: Warning: Custom betas are only available for API key users. Ignoring provided betas.\nYou've reached your Fable 5 limit."],
+    ["generic error newline", "Error:\nYou've reached your Fable 5 limit."],
+    ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
+    ["trailing newline", "You've reached your Fable 5 limit.\n"],
+    ["CRLF line ending", "You've reached your Fable 5 limit.\r\n"],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
@@ -871,11 +886,33 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["joined run command", "You've reached your Fable 5 limitRun /usage-credits"],
     ["joined usage command", "You've reached your Fable 5 limit/usage-credits"],
     ["unspaced punctuated command", "You've reached your Fable 5 limit.Run /usage-credits"],
-    ["generic error newline", "Error:\nYou've reached your Fable 5 limit."],
-    ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
-    ["unrelated appended stderr", "You've reached your Fable 5 limit.\nSubprocess stderr: unrelated tool output"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
+  })
+
+  // The second refusal in #909. An entitlement cap, not a spent window, so it
+  // is billing_error: it still fails over via ACCOUNT_FAILOVER_ERROR_TYPES,
+  // but without isQuotaRefusal sending the cooldown to wait out a five-hour
+  // reset that will never arrive.
+  it.each([
+    ["group", "Your group's usage limit is set to $0 · run /usage-credits to request more"],
+    ["organization", "Your organization's usage limit is set to $250 · run /usage-credits to request more"],
+    ["typographic apostrophe", "Your group’s usage limit is set to $0"],
+    ["behind an SDK wrapper", "Claude Code returned an error result: Your group's usage limit is set to $0 · run /usage-credits to request more"],
+    ["on an unlabelled stderr line", "Claude Code process exited with code 1\nSubprocess stderr: Warning: ignoring provided betas.\nYour group's usage limit is set to $0"],
+  ])("maps the %s entitlement cap to a failover-eligible billing_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("billing_error")
+    expect(r.status).toBe(402)
+    expect(isAccountFailoverError(r.type)).toBe(true)
+    expect(isQuotaRefusal(r.type)).toBe(false)
+  })
+
+  it.each([
+    ["quoted mid-line", "The docs say your group's usage limit is set to $0"],
+    ["no amount", "Your group's usage limit is set to whatever the admin picked"],
+  ])("does not treat %s as an entitlement cap", (_label, msg) => {
+    expect(classifyError(msg).type).not.toBe("billing_error")
   })
 
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -915,6 +915,28 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(classifyError(msg).type).not.toBe("billing_error")
   })
 
+  // Verbatim from the refusal builder in the shipped CLI
+  // (@anthropic-ai/claude-code 2.1.198). It emits exactly these two suffixes —
+  // one per interactive/non-interactive copy branch — so these two strings are
+  // what actually reaches classifyError. Pinned so a copy change in a future
+  // CLI shows up here rather than as another silent 500 in a priority pool.
+  it.each([
+    ["interactive copy", "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."],
+    ["non-interactive copy", "You've reached your Fable 5 limit. /model to switch models."],
+  ])("maps the shipped CLI's %s to rate_limit_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+    expect(isAccountFailoverError(r.type)).toBe(true)
+  })
+
+  it("classifies the verbatim group entitlement cap as a failover-eligible billing_error", () => {
+    const r = classifyError("Your group's usage limit is set to $0 \u00b7 run /usage-credits to ask your admin for a higher limit")
+    expect(r.type).toBe("billing_error")
+    expect(isAccountFailoverError(r.type)).toBe(true)
+    expect(isQuotaRefusal(r.type)).toBe(false)
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -826,6 +826,35 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(classifyError(msg).type).not.toBe("rate_limit_error")
   })
 
+  it("maps the CLI's per-tier limit refusal to rate_limit_error without a same-profile retry", () => {
+    const msg = "Claude Code returned an error result: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model."
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+    expect(isRateLimitError(msg)).toBe(false)
+    expect(isAccountFailoverError(r.type)).toBe(true)
+  })
+
+  it.each([
+    ["bare banner", "You've reached your Fable 5 limit."],
+    ["nested SDK wrappers", "Error: API Error: You’ve reached your Fable 5 limit! /model to switch models."],
+    ["Opus tier", "You've reached your Opus limit"],
+    ["versioned Sonnet tier", "You've reached your Sonnet 4.6 limit"],
+  ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
+  it.each([
+    ["specified limit", "You've reached your specified limit"],
+    ["quoted banner", "The docs say ‘You've reached your Fable 5 limit.’"],
+    ["negated banner", "You've not reached your Fable 5 limit"],
+    ["filename prefix", "Claude Code returned an error result: usage-credits.ts says You've reached your Fable 5 limit."],
+  ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
+    expect(classifyError(msg).type).toBe("api_error")
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -856,6 +856,10 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["configured tool qualifier", "You've reached your Fable configured tool limit"],
     ["limitations suffix", "You've reached your Fable 5 limitations"],
     ["unlabelled multiline quote", "MCP server failed:\nYou've reached your Fable 5 limit (quoted from docs)"],
+    ["parenthetical documentation suffix", "You've reached your Fable 5 limit (quoted from docs, account healthy)"],
+    ["documentation sentence suffix", "Error: You've reached your Fable 5 limit. This is only a documentation example"],
+    ["false assertion suffix", "You've reached your Fable 5 limit is false"],
+    ["possessive threshold suffix", "You've reached your Fable 5 limit's configured warning threshold"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -835,6 +835,13 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(isAccountFailoverError(r.type)).toBe(true)
   })
 
+  it("maps the live per-tier refusal with appended beta-warning stderr to rate_limit_error", () => {
+    const msg = "Claude Code returned an error result: You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.\nSubprocess stderr: Warning: Custom betas are only available for API key users. Ignoring provided betas."
+    const r = classifyError(msg)
+    expect(r.type).toBe("rate_limit_error")
+    expect(r.status).toBe(429)
+  })
+
   it.each([
     ["bare banner", "You've reached your Fable 5 limit."],
     ["nested SDK wrappers", "Error: API Error: You’ve reached your Fable 5 limit! /model to switch models."],
@@ -860,6 +867,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["documentation sentence suffix", "Error: You've reached your Fable 5 limit. This is only a documentation example"],
     ["false assertion suffix", "You've reached your Fable 5 limit is false"],
     ["possessive threshold suffix", "You've reached your Fable 5 limit's configured warning threshold"],
+    ["generic error newline", "Error:\nYou've reached your Fable 5 limit."],
+    ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
+    ["unrelated appended stderr", "You've reached your Fable 5 limit.\nSubprocess stderr: unrelated tool output"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -43,6 +43,12 @@ afterEach(async () => {
     for (let i = 0; i < 100 && proxyServer.getInFlightCount!() !== 0; i++) {
       await Bun.sleep(1)
     }
+    if (proxyServer.getInFlightCount!() !== 0) {
+      proxyServer.forceAbortInFlight!()
+      for (let i = 0; i < 1000 && proxyServer.getInFlightCount!() !== 0; i++) {
+        await Bun.sleep(1)
+      }
+    }
   }
   const drained = !proxyServer || proxyServer.getInFlightCount!() === 0
   if (drained) {

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -31,11 +31,19 @@ import {
 
 let isolatedSessionDir = ""
 beforeEach(() => {
+  proxyServer = undefined
   isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-subagent-support-"))
   setSessionStoreDir(isolatedSessionDir)
 })
 afterEach(async () => {
-  await Bun.sleep(25)
+  if (proxyServer) {
+    for (let i = 0; i < 100 && proxyServer.getInFlightCount!() !== 0; i++) {
+      await Bun.sleep(1)
+    }
+    expect(proxyServer.getInFlightCount!()).toBe(0)
+    await proxyServer.sweepSessionGc!()
+  }
+  setSessionStoreDir(null)
   rmSync(isolatedSessionDir, { recursive: true, force: true })
 })
 
@@ -72,10 +80,11 @@ mock.module("../mcpTools", () => ({
 }))
 
 const { createProxyServer } = await import("../proxy/server")
+let proxyServer: ReturnType<typeof createProxyServer> | undefined
 
 function createTestApp() {
-  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
-  return app
+  proxyServer = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return proxyServer.app
 }
 
 async function postMessages(app: any, body: Record<string, unknown>) {

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -8,7 +8,11 @@
  * 4. Multiple tool calls in a single response
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../proxy/sessionStore"
 import {
   messageStart,
   textBlockStart,
@@ -24,6 +28,16 @@ import {
   parseSSE,
   withMockSdkSessionId,
 } from "./helpers"
+
+let isolatedSessionDir = ""
+beforeEach(() => {
+  isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-subagent-support-"))
+  setSessionStoreDir(isolatedSessionDir)
+})
+afterEach(async () => {
+  await Bun.sleep(25)
+  rmSync(isolatedSessionDir, { recursive: true, force: true })
+})
 
 // --- Capture SDK calls ---
 let mockMessages: any[] = []
@@ -140,6 +154,9 @@ describe("Phase 3: Concurrent request support", () => {
       postMessages(app, makeRequest({ stream: false })),
       postMessages(app, makeRequest({ stream: false })),
     ])
+
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
 
     const [b1, b2] = await Promise.all([
       r1.json() as Promise<any>,

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -31,6 +31,9 @@ import {
 
 let isolatedSessionDir = ""
 beforeEach(() => {
+  if (proxyServer && proxyServer.getInFlightCount!() !== 0) {
+    throw new Error("Previous proxy did not drain; refusing to switch the process-global session store")
+  }
   proxyServer = undefined
   isolatedSessionDir = mkdtempSync(join(tmpdir(), "meridian-subagent-support-"))
   setSessionStoreDir(isolatedSessionDir)
@@ -40,11 +43,14 @@ afterEach(async () => {
     for (let i = 0; i < 100 && proxyServer.getInFlightCount!() !== 0; i++) {
       await Bun.sleep(1)
     }
-    expect(proxyServer.getInFlightCount!()).toBe(0)
-    await proxyServer.sweepSessionGc!()
   }
-  setSessionStoreDir(null)
-  rmSync(isolatedSessionDir, { recursive: true, force: true })
+  const drained = !proxyServer || proxyServer.getInFlightCount!() === 0
+  if (drained) {
+    if (proxyServer) await proxyServer.sweepSessionGc!()
+    setSessionStoreDir(null)
+    rmSync(isolatedSessionDir, { recursive: true, force: true })
+  }
+  expect(drained).toBe(true)
 })
 
 // --- Capture SDK calls ---

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -55,6 +55,14 @@ const BILLING_SIGNALS: readonly RegExp[] = [
   /update your payment/,
   /(?:out of|draw from|draws from) extra usage/,
   /insufficient (?:credit|funds|balance)/,
+  // The credits-era entitlement cap: "Your group's usage limit is set to $0 ·
+  // run /usage-credits to request more" (#909). Deliberately billing_error and
+  // not rate_limit_error — it is a provisioned cap, not a spent window, so
+  // isQuotaRefusal must not send the cooldown looking up a five-hour reset that
+  // will never arrive. Line-anchored for the reason given at BILLING_SIGNALS:
+  // this branch can mark every profile in a pool exhausted (#796), so an MCP
+  // server echoing the sentence must not trigger it.
+  /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*your (?:group|organization|org)(?:'|’)s usage limit is set to \$\d/m,
 ]
 
 /** "hit your limit", "hit your session limit", "hit your weekly limit", and any
@@ -103,14 +111,21 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
- * versions without arbitrary words, while an explicit subprocess label admits
- * the observed multiline exit shape. The known trailing beta warning is
- * accepted because the server appends captured stderr to `Error.message`; all
- * other cross-line entry requires an explicit banner-bearing subprocess label.
- * Accept only known CLI command suffixes and anchor the whole banner: a false
- * positive exhausts a healthy profile pool-wide. New tier names must be added
- * to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)\.?|[.!]?)(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
+ * versions without arbitrary words, and only known CLI command suffixes are
+ * accepted: a false positive exhausts a healthy profile pool-wide, so the
+ * banner must occupy its whole line rather than merely open one. New tier
+ * names must be added to the enumeration.
+ *
+ * The bound is the LINE, not the message — `/m`, like HIT_YOUR_SPEND_LIMIT
+ * above and CONTEXT_OVERFLOW_SIGNALS below. `server.ts` appends captured
+ * stderr to `Error.message` before classification, so a message-final anchor
+ * is unreachable in production; and because `stderrLines.join("\n")` labels
+ * only its FIRST line with `Subprocess stderr:`, requiring a labelled line
+ * missed the banner whenever anything preceded it — which on Team plans is
+ * always, the harmless "custom betas" warning being emitted first. Both shapes
+ * then fell through to the code-1 branch, which tells the operator to run
+ * `claude login` for what is actually a quota refusal. */
+const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)\.?|[.!]?)[ \t\r]*$/m
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -110,7 +110,7 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * Accept only known CLI command suffixes and anchor the whole banner: a false
  * positive exhausts a healthy profile pool-wide. New tier names must be added
  * to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!][ \t]*)?(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)?\.?(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)\.?|[.!]?)(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -56,12 +56,20 @@ const BILLING_SIGNALS: readonly RegExp[] = [
   /(?:out of|draw from|draws from) extra usage/,
   /insufficient (?:credit|funds|balance)/,
   // The credits-era entitlement cap: "Your group's usage limit is set to $0 ·
-  // run /usage-credits to request more" (#909). Deliberately billing_error and
-  // not rate_limit_error — it is a provisioned cap, not a spent window, so
-  // isQuotaRefusal must not send the cooldown looking up a five-hour reset that
-  // will never arrive. Line-anchored for the reason given at BILLING_SIGNALS:
-  // this branch can mark every profile in a pool exhausted (#796), so an MCP
-  // server echoing the sentence must not trigger it.
+  // run /usage-credits to ask your admin for a higher limit" (#909, verbatim in
+  // the CLI). billing_error rather than rate_limit_error: a provisioned cap is
+  // not a spent window, so isQuotaRefusal must not send the cooldown looking up
+  // a five-hour reset that will never arrive.
+  //
+  // This only disambiguates the wordings that name the cap. The CLI's refusal
+  // builder returns the identical "You've reached your <tier> limit." text for
+  // group/member/seat_tier zero-credit caps as for a genuinely spent window, so
+  // those still classify 429 and still take the five-hour cooldown. Telling
+  // them apart needs a signal the message does not carry.
+  //
+  // Line-anchored for the reason given above: this branch can mark every
+  // profile in a pool exhausted (#796), so an MCP server or an assistant turn
+  // echoing the sentence mid-line must not trigger it.
   /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*your (?:group|organization|org)(?:'|’)s usage limit is set to \$\d/m,
 ]
 

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -99,6 +99,14 @@ const HIT_YOUR_LIMIT = /hit your (?:[\w-]+ )?limit/
  *  in the first place. */
 const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve hit your (?:[\w'’-]+ ){0,4}(?:spend|usage) limit/m
 
+/** Credits-era per-tier banner uses "reached", not the "hit" wording from
+ * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
+ * CLI also emits "reached your specified ...", which is not account quota
+ * exhaustion (#909). The two-word tail covers "Fable 5" and similar versions;
+ * anchoring after known SDK wrappers, like HIT_YOUR_SPEND_LIMIT, prevents
+ * quoted banner prose from exhausting a healthy profile. */
+const REACHED_YOUR_TIER_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:fable|mythos|opus|sonnet|haiku)(?: [\w'’.\d-]+){0,2} limit/m
+
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
  * cannot exhaust every profile in a priority pool. */
@@ -201,7 +209,7 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
   // variants seen so far and the daily/monthly/5-hour ones that would
   // otherwise be the next report.
   if (HTTP_429.test(lower) || lower.includes("rate limit") || lower.includes("too many requests")
-    || HIT_YOUR_LIMIT.test(lower) || HIT_YOUR_SPEND_LIMIT.test(lower)
+    || HIT_YOUR_LIMIT.test(lower) || HIT_YOUR_SPEND_LIMIT.test(lower) || REACHED_YOUR_TIER_LIMIT.test(lower)
     || lower.includes("usage limit reached")
     || OUT_OF_USAGE_CREDITS.test(lower)) {
     const hint = lower.includes("1m") || lower.includes("context")

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -104,9 +104,10 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
  * versions without arbitrary words, while an explicit subprocess label admits
- * the observed multiline exit shape without treating any quoted line as
- * account state. New tier names must be added to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit\b/
+ * the observed multiline exit shape. Accept only known CLI command suffixes
+ * and anchor the whole banner: a false positive exhausts a healthy profile
+ * pool-wide. New tier names must be added to the known-tier enumeration. */
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!]\s*)?(?:(?:run\s+)?\/usage-credits(?:\s+to\s+continue)?(?:\s+or\s+switch\s+models\s+with\s+\/model)?|\/model\s+to\s+switch\s+models)?\.?\s*$/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -101,11 +101,12 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
 
 /** Credits-era per-tier banner uses "reached", not the "hit" wording from
  * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
- * CLI also emits "reached your specified ...", which is not account quota
- * exhaustion (#909). The two-word tail covers "Fable 5" and similar versions;
- * anchoring after known SDK wrappers, like HIT_YOUR_SPEND_LIMIT, prevents
- * quoted banner prose from exhausting a healthy profile. */
-const REACHED_YOUR_TIER_LIMIT = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:fable|mythos|opus|sonnet|haiku)(?: [\w'’.\d-]+){0,2} limit/m
+ * CLI also emits "reached your specified/configured ..." prose that is not
+ * account quota exhaustion (#909). A numeric version suffix accepts real tier
+ * versions without arbitrary words, while an explicit subprocess label admits
+ * the observed multiline exit shape without treating any quoted line as
+ * account state. New tier names must be added to the known-tier enumeration. */
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit\b/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -104,10 +104,13 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
  * versions without arbitrary words, while an explicit subprocess label admits
- * the observed multiline exit shape. Accept only known CLI command suffixes
- * and anchor the whole banner: a false positive exhausts a healthy profile
- * pool-wide. New tier names must be added to the known-tier enumeration. */
-const REACHED_YOUR_TIER_LIMIT = /(?:^|\n\s*subprocess stderr:\s*)\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!]\s*)?(?:(?:run\s+)?\/usage-credits(?:\s+to\s+continue)?(?:\s+or\s+switch\s+models\s+with\s+\/model)?|\/model\s+to\s+switch\s+models)?\.?\s*$/
+ * the observed multiline exit shape. The known trailing beta warning is
+ * accepted because the server appends captured stderr to `Error.message`; all
+ * other cross-line entry requires an explicit banner-bearing subprocess label.
+ * Accept only known CLI command suffixes and anchor the whole banner: a false
+ * positive exhausts a healthy profile pool-wide. New tier names must be added
+ * to the known-tier enumeration. */
+const REACHED_YOUR_TIER_LIMIT = /(?:^|\n[ \t]*subprocess stderr:[ \t]*)[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:[.!][ \t]*)?(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)?\.?(?:\n[ \t]*subprocess stderr:[ \t]*warning:[ \t]*custom betas are only available for api key users\.[ \t]*ignoring provided betas\.)?[ \t]*$/
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose


### PR DESCRIPTION
Supersedes #920 (cherry-picked, @justprosh retained as author on all seven of their commits). Fixes #909.

`main` requires signed commits, so the fork PR sat at `mergeStateStatus: BLOCKED` with every check green. This branch carries justprosh's work plus two commits on top.

## What justprosh got right

Classifying `You've reached your <tier> limit` as `429 rate_limit_error` so priority routing marks the profile exhausted and fails over, with `isRateLimitError` left alone because retrying the same account cannot help. The tier enumeration is the right call too — the CLI also emits `reached your specified/configured …` prose that must not exhaust an account.

## What needed fixing

The matcher was anchored to the end of the **message**, but `server.ts:3721-3723` and `:5759-5761` append captured stderr to `Error.message` *before* classification. That anchor is unreachable in production. Two live shapes missed:

| shape | before |
|---|---|
| banner + any appended stderr other than the one whitelisted beta warning | `500 api_error`, no failover |
| beta warning first, banner on an unlabelled second line | `401 authentication_error` — *"try `claude login`"* |

The second is the common case, not a corner: `stderrLines.join("\n")` labels only its **first** line with `Subprocess stderr:`, and on Team plans the harmless "custom betas" warning is always emitted first. So the real banner lands unlabelled on line two, misses, and falls through to the code-1 branch — which reports a quota refusal as a broken login. `errors.ts:130-156` already documents this exact trap for context overflow.

The fix is to bound by **line** instead of by message (`/m`), matching the `HIT_YOUR_SPEND_LIMIT` and `CONTEXT_OVERFLOW_SIGNALS` idiom directly above and below it, and to tolerate CRLF. The suffix whitelist and tier enumeration are untouched, so **every negative case from #920 still misses** — verified individually.

## Second refusal from #909

`Your group's usage limit is set to $0 · run /usage-credits to ask your admin for a higher limit` matched nothing, so #920 would have auto-closed #909 half-fixed. Now `billing_error`: it fails over via `ACCOUNT_FAILOVER_ERROR_TYPES` without `isQuotaRefusal` waiting out a five-hour reset that never arrives, since an entitlement cap is not a spent window.

## Verification

Patterns checked against the refusal builder extracted from the shipped CLI (`@anthropic-ai/claude-code` 2.1.198) rather than against the reported strings. It emits exactly two tier-limit suffixes — one per interactive copy branch — and both are now pinned verbatim in tests, as is the group cap.

- `npm test` — 3271 pass, 0 fail
- `npm run typecheck` — clean

## Known limitation

The CLI returns the *identical* `You've reached your <tier> limit.` text for `group_zero_credit_limit`, `member_zero_credit_limit` and `seat_tier_zero_credit_limit` as for a genuinely spent window. Those still classify 429 and still take the five-hour cooldown; telling them apart needs a signal the message does not carry. Documented in the code rather than papered over.

Also unchanged from #920: exhaustion is profile-wide, not tier-scoped, so a Fable refusal cools the profile for all models. Separate work.