### PR TITLE
test: give every file its own module mocks instead of racing for one

### DIFF
--- a/src/__tests__/adapter-instances-integration.test.ts
+++ b/src/__tests__/adapter-instances-integration.test.ts
@@ -7,12 +7,15 @@
  *   - PASSTHROUGH override comes from the instance
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -23,14 +26,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "adapter-instances-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/concurrency-hardening.test.ts
+++ b/src/__tests__/concurrency-hardening.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   assistantMessage,
   messageStart,
@@ -32,7 +35,7 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
   return { release, started, wait, markStarted }
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     queryCalls++
     const control = deferredAttempt()
@@ -53,14 +56,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "concurrency-hardening.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/deferred-tool-loading.test.ts
+++ b/src/__tests__/deferred-tool-loading.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   toolUseBlockStart,
@@ -25,7 +28,7 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk"
 let mockMessages: SDKMessage[] = []
 let capturedQueryParams: any = {}
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedQueryParams = opts
     return (async function* () {
@@ -39,14 +42,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     name: "test",
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
-}))
+}), "deferred-tool-loading.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/design-endpoint.test.ts
+++ b/src/__tests__/design-endpoint.test.ts
@@ -8,22 +8,25 @@
  * exchanges a code and persists the token file. From #543 by @sittitep.
  */
 import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync, readFileSync, statSync, existsSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: () => (async function* () {})(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "design-endpoint.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/explicit-model-pins.test.ts
+++ b/src/__tests__/explicit-model-pins.test.ts
@@ -11,6 +11,9 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 // ---------- unit: explicitModelPin + canonical bump ----------
 
 const { explicitModelPin, CANONICAL_SONNET_MODEL, CANONICAL_OPUS_MODEL } = await import("../proxy/models")
@@ -64,7 +67,7 @@ let queryEnvs: Array<Record<string, string | undefined>> = []
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     queryEnvs.push(opts.options?.env || {})
     return (async function* () {
@@ -86,14 +89,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "explicit-model-pins.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/failover-request-id.test.ts
+++ b/src/__tests__/failover-request-id.test.ts
@@ -8,11 +8,14 @@
  * request unfindable by the id the client sent.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let failingDirs = new Set<string>()
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
     return (async function* () {
@@ -25,14 +28,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "failover-request-id.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/graceful-shutdown.test.ts
+++ b/src/__tests__/graceful-shutdown.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import type { AddressInfo } from "node:net"
 import { tmpdir } from "node:os"
@@ -31,7 +34,7 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
   return { release, started, wait, markStarted }
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     queryCalls++
     const control = deferredAttempt()
@@ -52,14 +55,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "graceful-shutdown.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { describe, it, expect, mock, beforeAll, afterAll, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -27,7 +30,7 @@ import {
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -42,14 +45,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: {},
   }),
   tool: () => ({}),
-}))
+}), "integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/loggerMock.ts
+++ b/src/__tests__/loggerMock.ts
@@ -1,0 +1,47 @@
+import { mock, beforeAll } from "bun:test"
+
+/**
+ * One process-global mock of `../logger`, shared by every test file.
+ *
+ * Same problem and same shape as `./sdkMock` — see that file for the full
+ * explanation of the load-phase last-wins race (#917).
+ *
+ * Deliberately its own module rather than part of `sdkMock`: importing a module
+ * is what registers its mock, so a file that never mocked the logger must not
+ * acquire one just by wanting the SDK mocked.
+ *
+ * With no implementation installed this is a silent no-op rather than an error.
+ * A test that never asked about logging still wants silence, not a crash from
+ * the first log line.
+ */
+
+type LogFn = (...args: never[]) => unknown
+
+export interface LoggerMockModule {
+  claudeLog?: LogFn
+  /** Method syntax deliberately: its parameters are bivariant, so a file may
+   *  narrow `fn` to its own handler's return type without a variance error. */
+  withClaudeLogContext?(ctx: unknown, fn: () => unknown): unknown
+}
+
+let active: LoggerMockModule | null = null
+
+mock.module("../logger", () => ({
+  claudeLog: (...args: never[]) => active?.claudeLog?.(...args),
+  withClaudeLogContext: (ctx: unknown, fn: () => unknown) =>
+    active?.withClaudeLogContext ? active.withClaudeLogContext(ctx, fn) : fn(),
+}))
+
+/** Install this file's logger mock. Call at module scope. */
+export function installLoggerMock(factory: () => LoggerMockModule): void {
+  beforeAll(() => { active = factory() })
+}
+
+/**
+ * Install an implementation immediately, for the rare file that swaps its mock
+ * from inside a test body. `installLoggerMock` cannot be used there — bun rejects a
+ * `beforeAll` registered inside a running test.
+ */
+export function setLoggerMock(factory: () => LoggerMockModule): void {
+  active = factory()
+}

--- a/src/__tests__/mcpToolsMock.ts
+++ b/src/__tests__/mcpToolsMock.ts
@@ -1,0 +1,48 @@
+import { mock, beforeAll } from "bun:test"
+
+/**
+ * One process-global mock of `../mcpTools`, shared by every test file.
+ *
+ * Same problem and same shape as `./sdkMock` — see that file for the full
+ * explanation of the load-phase last-wins race (#917). This module is the one
+ * that decides an adapter's MCP server name, so a stray winner renamed another
+ * adapter's tools and failed its entire file.
+ *
+ * Deliberately its own module rather than part of `sdkMock`: importing a module
+ * is what registers its mock, so a file that never mocked mcpTools must not
+ * acquire one just by wanting the SDK mocked.
+ *
+ * With no implementation installed this returns the default OpenCode stub —
+ * the shape 59 of the 70 mocking files used — rather than throwing. Before this
+ * harness those files were silently sharing one another's stub anyway, so
+ * failing here would be stricter than the behaviour being replaced.
+ */
+
+type McpFn = (...args: never[]) => unknown
+
+export interface McpToolsMockModule {
+  createOpencodeMcpServer?: McpFn
+}
+
+let active: McpToolsMockModule | null = null
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: (...args: never[]) =>
+    active?.createOpencodeMcpServer
+      ? active.createOpencodeMcpServer(...args)
+      : { type: "sdk", name: "opencode", instance: {} },
+}))
+
+/** Install this file's mcpTools mock. Call at module scope. */
+export function installMcpToolsMock(factory: () => McpToolsMockModule): void {
+  beforeAll(() => { active = factory() })
+}
+
+/**
+ * Install an implementation immediately, for the rare file that swaps its mock
+ * from inside a test body. `installMcpToolsMock` cannot be used there — bun rejects a
+ * `beforeAll` registered inside a running test.
+ */
+export function setMcpToolsMock(factory: () => McpToolsMockModule): void {
+  active = factory()
+}

--- a/src/__tests__/opencode-title-agent-collision.test.ts
+++ b/src/__tests__/opencode-title-agent-collision.test.ts
@@ -25,6 +25,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -56,7 +59,7 @@ let holdTitleUntil: Promise<void> | undefined
  *  not a sleep. */
 let onTitleEnteredQuery: (() => void) | undefined
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     const options = params.options || {}
     capturedOptions.push(options)
@@ -82,14 +85,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "opencode-title-agent-collision.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -7,6 +7,9 @@
  * known durable enough for resumeSessionAt.
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach, afterAll } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -28,7 +31,7 @@ let mockReturnedSessionIdOverride: string | undefined
 let mockOmitReturnedSessionId = false
 const initialManagedSessionId = () => capturedQueryParamsAll[0]?.options?.sessionId ?? mockBaseSessionId
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     capturedQueryParamsAll.push(params)
@@ -94,14 +97,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "passthrough-early-stop-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/passthrough-tool-sort.test.ts
+++ b/src/__tests__/passthrough-tool-sort.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
 // Provide a minimal SDK mock so createPassthroughMcpServer can register tools
 // without hitting the real SDK (which may not be available in CI or may have
 // been mocked differently by a sibling test file).
 let registeredTools: Array<{ name: string; config: any }> = []
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   createSdkMcpServer: (options: {
     tools?: Array<{
       name: string
@@ -29,7 +30,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
       instance: { tool: () => {}, registerTool: () => ({}) },
     }
   },
-}))
+}), "passthrough-tool-sort.test.ts")
 
 import { createPassthroughMcpServer, getAutoDeferThreshold } from "../proxy/passthroughTools"
 

--- a/src/__tests__/plugin-integration.test.ts
+++ b/src/__tests__/plugin-integration.test.ts
@@ -12,6 +12,8 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
@@ -28,7 +30,7 @@ interface CapturedParams {
 let capturedParams: CapturedParams | null = null
 function getCaptured(): CapturedParams | null { return capturedParams }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: unknown) => {
     capturedParams = params as CapturedParams
     return (async function* () {
@@ -42,9 +44,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "plugin-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
 }))

--- a/src/__tests__/pluginless-opencode-warning.test.ts
+++ b/src/__tests__/pluginless-opencode-warning.test.ts
@@ -26,6 +26,9 @@
  * exposed case.
  */
 import { describe, it, expect, beforeEach } from "bun:test"
+import { installSdkMock, setSdkMock } from "./sdkMock"
+import { installLoggerMock, setLoggerMock } from "./loggerMock"
+import { installMcpToolsMock, setMcpToolsMock } from "./mcpToolsMock"
 import { resolveMockSdkSessionId } from "./helpers"
 import { notePluginlessOpenCodeRequest, clearPluginlessWarnings } from "../proxy/setup"
 
@@ -140,7 +143,7 @@ describe("notePluginlessOpenCodeRequest", () => {
 describe("plugin-less warning through the HTTP path", () => {
   it("records a diagnostic for a plugin-less OpenCode request, and not for a plugin-ful one", async () => {
     const { mock } = await import("bun:test")
-    mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+    setSdkMock(() => ({
       query: (params: any) => (async function* () {
         yield {
           type: "assistant",
@@ -153,9 +156,9 @@ describe("plugin-less warning through the HTTP path", () => {
       })(),
       createSdkMcpServer: () => ({ type: "sdk", name: "t", instance: { tool: () => {}, registerTool: () => ({}) } }),
       tool: () => ({}),
-    }))
-    mock.module("../logger", () => ({ claudeLog: () => {}, withClaudeLogContext: (_c: unknown, f: () => unknown) => f() }))
-    mock.module("../mcpTools", () => ({
+    }), "pluginless-opencode-warning.test.ts")
+    setLoggerMock(() => ({ claudeLog: () => {}, withClaudeLogContext: (_c: unknown, f: () => unknown) => f() }))
+    setMcpToolsMock(() => ({
       createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
     }))
 

--- a/src/__tests__/pricing-routes.test.ts
+++ b/src/__tests__/pricing-routes.test.ts
@@ -4,11 +4,12 @@
  * HTTP contract: shapes, validation status codes, and the malformed-JSON 400.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installLoggerMock } from "./loggerMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))

--- a/src/__tests__/priority-routing-integration.test.ts
+++ b/src/__tests__/priority-routing-integration.test.ts
@@ -9,6 +9,9 @@
  * is byte-identical to today's behavior.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, resolveMockSdkSessionId } from "./helpers"
 import { createPriorityAttestation } from "../../plugin/priority-attestation"
 import type { PriorityFailbackPolicy } from "../proxy/routing"
@@ -86,7 +89,7 @@ const INCIDENTAL_BILLING_WORD =
   "Claude Code returned an error result: Reached maximum number of turns (3) while editing subscription.ts"
 let failureMessage = DEFAULT_FAILURE
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
     capturedEnvs.push(dir)
@@ -195,14 +198,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "priority-routing-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/profile-switch-integration.test.ts
+++ b/src/__tests__/profile-switch-integration.test.ts
@@ -5,12 +5,14 @@
  * and settings persistence contract.
  */
 import { describe, test, expect, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
 import { mock } from "bun:test"
 
 // Mock the SDK before importing server
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: { options?: { sessionId?: string } }) => {
     return (async function* () {
       yield {
@@ -24,9 +26,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "profile-switch-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))

--- a/src/__tests__/proxy-advisor-support.test.ts
+++ b/src/__tests__/proxy-advisor-support.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   assistantMessage,
   messageStart,
@@ -24,7 +27,7 @@ import {
 let capturedOptions: Record<string, unknown> = {}
 let mockMessages: unknown[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
     capturedOptions = params.options ?? {}
     return (async function* () {
@@ -35,14 +38,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-advisor-support.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-busy-session-retry.test.ts
+++ b/src/__tests__/proxy-busy-session-retry.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -49,7 +52,7 @@ let queryCallCount = 0
 /** Number of leading resume attempts that fail busy (0 = never busy). */
 let busyFailCount = 0
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     queryCallCount++
     const callIndex = queryCallCount
@@ -90,14 +93,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-busy-session-retry.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-cache-eviction.test.ts
+++ b/src/__tests__/proxy-cache-eviction.test.ts
@@ -1,4 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -13,7 +16,7 @@ type TestApp = { fetch: (req: Request) => Promise<Response> }
 let mockMessages: MockSdkMessage[] = []
 let capturedQueryParams: { options?: { resume?: string; sessionId?: string } } | null = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: unknown) => {
     const queryParams = params as { options?: { resume?: string; sessionId?: string } }
     capturedQueryParams = queryParams
@@ -27,14 +30,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-cache-eviction.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -33,7 +36,7 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
   return { release, started, wait, markStarted }
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { options?: { resume?: string; sessionId?: string; env?: Record<string, string> } }) => {
     capturedParams.push(params)
     queryCalls++
@@ -64,14 +67,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-concurrency-coordination.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-concurrency-limiter.test.ts
+++ b/src/__tests__/proxy-concurrency-limiter.test.ts
@@ -15,6 +15,9 @@
  * subprocesses run at once.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let sdkActive = 0
@@ -27,7 +30,7 @@ function gateClosed() {
   sdkGate = new Promise<void>((resolve) => { openGate = resolve })
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => (async function* () {
     sdkActive++
     sdkPeak = Math.max(sdkPeak, sdkActive)
@@ -41,14 +44,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-concurrency-limiter.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-context-usage-store.test.ts
+++ b/src/__tests__/proxy-context-usage-store.test.ts
@@ -11,26 +11,29 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => (async function* () {
     const message = assistantMessage([{ type: "text", text: "ok" }])
     yield withMockSdkSessionId(message, params.options)
   })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-context-usage-store.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-crush-integration.test.ts
+++ b/src/__tests__/proxy-crush-integration.test.ts
@@ -8,12 +8,15 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, toolUseBlockStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, messageStart, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -24,14 +27,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-crush-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-droid-integration.test.ts
+++ b/src/__tests__/proxy-droid-integration.test.ts
@@ -10,6 +10,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -38,7 +41,7 @@ let mockMessages: any[] = []
 let capturedQueryParams: any = null
 let savedPassthrough: string | undefined
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -56,14 +59,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "proxy-droid-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-env-stripping.test.ts
+++ b/src/__tests__/proxy-env-stripping.test.ts
@@ -11,13 +11,16 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 // Capture the env passed to query()
 let capturedQueryOptions: any = null
 const savedEnv: Record<string, string | undefined> = {}
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryOptions = params.options
     return (async function* () {
@@ -38,14 +41,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-env-stripping.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-error-handling.test.ts
+++ b/src/__tests__/proxy-error-handling.test.ts
@@ -7,12 +7,15 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 // Make the SDK throw specific errors
 let mockError: Error | null = null
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     if (mockError) {
       return (async function* () {
@@ -37,14 +40,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-error-handling.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { getSessionStoreDir } from "../proxy/sessionStore"
@@ -62,7 +65,7 @@ mock.module("../proxy/models", () => ({
   getAuthCacheInfo: () => ({ lastCheckedAt: 0, lastSuccessAt: 0, isFailure: false }),
 }))
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     queryCallCount++
       const callIndex = queryCallCount
@@ -149,14 +152,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-extra-usage-fallback.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-file-changes.test.ts
+++ b/src/__tests__/proxy-file-changes.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   assistantMessage,
   messageStart,
@@ -26,7 +29,7 @@ let mockMessages: any[] = []
 let capturedQueryParams: any = null
 let firePreToolUseHooks = false
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
 
@@ -100,14 +103,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     type: "sdk", name: "test", instance: { registerTool: () => ({}), tool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "proxy-file-changes.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-forgecode-integration.test.ts
+++ b/src/__tests__/proxy-forgecode-integration.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -33,7 +36,7 @@ mkdirSync(FORGECODE_PROJECT_DIR, { recursive: true })
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -44,14 +47,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-forgecode-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-mcp-filtering.test.ts
+++ b/src/__tests__/proxy-mcp-filtering.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -23,7 +26,7 @@ import {
 
 let mockMessages: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     return (async function* () {
       for (const msg of mockMessages) {
@@ -33,14 +36,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-mcp-filtering.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-mcp-server-per-request.test.ts
+++ b/src/__tests__/proxy-mcp-server-per-request.test.ts
@@ -12,13 +12,16 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 // Track how many times createOpencodeMcpServer is called and what's passed to query
 let mcpServerCreateCount = 0
 let capturedMcpServers: any[] = []
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     if (params.options?.mcpServers) {
       capturedMcpServers.push(params.options.mcpServers)
@@ -41,15 +44,15 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-mcp-server-per-request.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
 // Each call returns a unique object so we can verify they're different instances
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => {
     mcpServerCreateCount++
     return { type: "sdk", name: "opencode", instance: {}, _id: mcpServerCreateCount }

--- a/src/__tests__/proxy-multimodal.test.ts
+++ b/src/__tests__/proxy-multimodal.test.ts
@@ -6,11 +6,14 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -31,14 +34,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-multimodal.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-nonstream-deny-hold.test.ts
+++ b/src/__tests__/proxy-nonstream-deny-hold.test.ts
@@ -15,6 +15,9 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 let hook1SettledBeforeTurnEnd: boolean | undefined
 
 const tu = (id: string, path: string) => ({
@@ -34,7 +37,7 @@ const boundary = (type: string, sessionId = "sdk-ns-1") => ({
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     return (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
@@ -97,14 +100,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "proxy-nonstream-deny-hold.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-openai-compat.test.ts
+++ b/src/__tests__/proxy-openai-compat.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -32,7 +35,7 @@ let capturedPromptMessages: unknown[] = []
 let capturedOptions: Record<string, unknown> | null = null
 let capturedOptionHistory: Array<Record<string, unknown>> = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: ({ prompt, options }: { prompt: string | AsyncIterable<unknown>; options?: Record<string, unknown> }) => {
     capturedOptions = options ?? null
     capturedOptionHistory.push(options ?? {})
@@ -57,14 +60,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-openai-compat.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-output-tokens-aggregation.test.ts
+++ b/src/__tests__/proxy-output-tokens-aggregation.test.ts
@@ -18,9 +18,12 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => (async function* () {
     for (const m of mockMessages) {
       yield withMockSdkSessionId(m, params.options)
@@ -28,14 +31,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-output-tokens-aggregation.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -20,6 +20,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -110,7 +113,7 @@ function streamMessageStart() {
 // turn's PreToolUse hook fires after the turn is yielded, and an aborted
 // controller terminates the query with an abort-shaped error (the real
 // subprocess is SIGTERMed and surfaces "aborted by user").
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedController = opts?.options?.abortController
     capturedResume = opts?.options?.resume
@@ -143,14 +146,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "proxy-passthrough-deny-abort.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-passthrough-single-turn.test.ts
+++ b/src/__tests__/proxy-passthrough-single-turn.test.ts
@@ -25,6 +25,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { makeRequest, withMockSdkSessionId } from "./helpers"
 
 const PASSTHROUGH_PREFIX = "mcp__oc__"
@@ -52,7 +55,7 @@ function toolTurn(toolId: string, toolName: string, input: Record<string, unknow
   }
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) =>
     (async function* () {
       const preHook = opts?.options?.hooks?.PreToolUse?.[0]?.hooks?.[0]
@@ -76,14 +79,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     name: "test",
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
-}))
+}), "proxy-passthrough-single-turn.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-passthrough-thinking.test.ts
+++ b/src/__tests__/proxy-passthrough-thinking.test.ts
@@ -22,6 +22,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -56,7 +59,7 @@ const EDIT_TOOL = {
 // ─── SDK mock ────────────────────────────────────────────────────────────────
 let mockMessages: SDKMessage[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) =>
     (async function* () {
       for (const msg of mockMessages) {
@@ -68,14 +71,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     name: "test",
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
-}))
+}), "proxy-passthrough-thinking.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/proxy-passthrough-tool-use.test.ts
+++ b/src/__tests__/proxy-passthrough-tool-use.test.ts
@@ -15,6 +15,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -34,7 +37,7 @@ import {
 // --- Mock the Claude SDK ---
 let mockMessages: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) =>
     (async function* () {
       for (const msg of mockMessages) {
@@ -47,14 +50,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     // Provide a minimal instance that supports tool() registration
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
-}))
+}), "proxy-passthrough-tool-use.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-pretooluse-hook.test.ts
+++ b/src/__tests__/proxy-pretooluse-hook.test.ts
@@ -12,13 +12,16 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 let savedPassthrough: string | undefined
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -29,14 +32,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-pretooluse-hook.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-rate-limit-retry.test.ts
+++ b/src/__tests__/proxy-rate-limit-retry.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -27,7 +30,7 @@ let queryCallCount = 0
 // Control what the mock does
 let mockBehavior: "rate_limit_then_succeed" | "always_rate_limit" | "rate_limit_base_then_succeed" | "succeed" = "succeed"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     queryCallCount++
     const callIndex = queryCallCount
@@ -84,14 +87,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-rate-limit-retry.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-replay-envelope.test.ts
+++ b/src/__tests__/proxy-replay-envelope.test.ts
@@ -9,11 +9,14 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 let capturedPrompts: any[] = []
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedPrompts.push(opts.prompt)
     return (async function* () {
@@ -35,14 +38,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-replay-envelope.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-request-cancellation.test.ts
+++ b/src/__tests__/proxy-request-cancellation.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 type QueryMode = "complete" | "wait-for-abort"
 
 let mode: QueryMode = "complete"
@@ -26,7 +29,7 @@ function assistantMessage() {
 
 import { withMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { options?: { abortController?: AbortController; sessionId?: string } }) => {
     capturedController = params.options?.abortController
     notifyQueryStarted?.()
@@ -47,14 +50,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-request-cancellation.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -19,7 +22,7 @@ import {
 
 let capturedOptions: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedOptions.push(opts.options || {})
     const isStreaming = opts.options?.includePartialMessages === true
@@ -57,14 +60,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-responses-endpoint.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-responses-image.test.ts
+++ b/src/__tests__/proxy-responses-image.test.ts
@@ -7,6 +7,9 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 // A real, valid 1x1 red PNG (69 bytes).
 const RED_PNG_B64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
@@ -17,7 +20,7 @@ let capturedPrompt: any = null
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedPrompt = opts.prompt
     return (async function* () {
@@ -39,14 +42,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-responses-image.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-resume-refusal.test.ts
+++ b/src/__tests__/proxy-resume-refusal.test.ts
@@ -14,6 +14,9 @@
  * one-shot.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -43,7 +46,7 @@ let missingMessage = false
 /** Per-attempt wordings, when the refusal is not the same one every time. */
 let refusalScript: Array<"unresumable" | "busy"> = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     queryCallCount++
     const callIndex = queryCallCount
@@ -97,14 +100,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-resume-refusal.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/proxy-sdk-params.test.ts
+++ b/src/__tests__/proxy-sdk-params.test.ts
@@ -10,6 +10,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -26,7 +29,7 @@ import {
 let capturedOptions: Record<string, unknown> = {}
 let mockMessages: unknown[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
     capturedOptions = params.options ?? {}
     const sessionId = resolveMockSdkSessionId(params.options)
@@ -42,14 +45,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-sdk-params.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-session-resume.test.ts
+++ b/src/__tests__/proxy-session-resume.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   assistantMessage,
   messageStart,
@@ -28,7 +31,7 @@ let capturedQueryParams: any = null
 let queryCallCount = 0
 let firstCallerSelectedSessionId: string | undefined
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     queryCallCount++
@@ -48,14 +51,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: {},
   }),
   tool: () => ({}),
-}))
+}), "proxy-session-resume.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-session-tree-cancellation.test.ts
+++ b/src/__tests__/proxy-session-tree-cancellation.test.ts
@@ -13,6 +13,9 @@
  * disconnect aborts it.
  */
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { resolveMockSdkSessionId, withMockSdkSessionId } from "./helpers"
 
 type Behavior = "complete" | "hang"
@@ -45,7 +48,7 @@ function assistantMessage(sessionId: string) {
   }
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { options?: { abortController?: AbortController; resume?: string; sessionId?: string } }) => {
     const behavior = behaviors.shift() ?? "complete"
     const controller = params.options?.abortController
@@ -75,14 +78,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-session-tree-cancellation.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-silent-logging.test.ts
+++ b/src/__tests__/proxy-silent-logging.test.ts
@@ -8,11 +8,14 @@
  * while leaving the structured telemetry (claudeLog) and HTTP responses intact.
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => (async function* () {
     for (const msg of mockMessages) {
       yield withMockSdkSessionId(msg, params.options)
@@ -20,14 +23,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   })(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-silent-logging.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-source-header.test.ts
+++ b/src/__tests__/proxy-source-header.test.ts
@@ -13,12 +13,15 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -29,14 +32,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-source-header.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-source-keyed-session.test.ts
+++ b/src/__tests__/proxy-source-keyed-session.test.ts
@@ -15,12 +15,15 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedOptions: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     const options = params.options || {}
     capturedOptions.push(options)
@@ -31,14 +34,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-source-keyed-session.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-source-skip-cache.test.ts
+++ b/src/__tests__/proxy-source-skip-cache.test.ts
@@ -15,12 +15,15 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: unknown[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -31,14 +34,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-source-skip-cache.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-stale-uuid-retry.test.ts
+++ b/src/__tests__/proxy-stale-uuid-retry.test.ts
@@ -7,6 +7,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -40,7 +43,7 @@ let queryCallCount = 0
 let queryMutation: ((options: Record<string, any>) => void) | undefined
 let forcedQueryError: Error | undefined
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     queryCallCount++
     const callIndex = queryCallCount
@@ -84,14 +87,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-stale-uuid-retry.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -24,6 +24,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -92,7 +95,7 @@ const denyMsg = (ids: string[], sessionId: string) => {
 
 // CLI-faithful mock: per-block assistant messages, mid-stream hook dispatch,
 // CANCEL-ON-DENY when a deny resolves while generation is in flight.
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedController = opts?.options?.abortController
     capturedSessionId = opts?.options?.sessionId
@@ -163,13 +166,13 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-stream-deny-hold.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: (event: string) => { timeline.push(`log:${event}`) },
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-stream-error-recovery.test.ts
+++ b/src/__tests__/proxy-stream-error-recovery.test.ts
@@ -22,6 +22,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -34,7 +37,7 @@ import {
 let mockMessages: any[] = []
 let mockErrorAfter: number | null = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     return (async function* () {
       let yielded = 0
@@ -49,14 +52,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-stream-error-recovery.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-streaming-message.test.ts
+++ b/src/__tests__/proxy-streaming-message.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -29,7 +32,7 @@ import {
 
 let mockMessages: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     return (async function* () {
       for (const msg of mockMessages) {
@@ -39,14 +42,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-streaming-message.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-structured-output-hook.test.ts
+++ b/src/__tests__/proxy-structured-output-hook.test.ts
@@ -21,6 +21,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 let capturedOptions: Record<string, unknown> = {}
 let hookDeniedStructuredOutput: boolean | undefined
 
@@ -78,7 +81,7 @@ function resultMessage(withStructuredOutput: boolean) {
 
 import { withMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: { options?: Record<string, unknown> }) => {
     capturedOptions = opts.options ?? {}
     return (async function* () {
@@ -101,14 +104,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-structured-output-hook.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-structured-output.test.ts
+++ b/src/__tests__/proxy-structured-output.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 let capturedOptions: Record<string, unknown> = {}
 let mockMessages: unknown[] = []
 let queryCalls = 0
@@ -7,7 +10,7 @@ let waitBeforeMessages: Promise<void> | undefined
 
 import { withMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { options?: Record<string, unknown> }) => {
     queryCalls += 1
     capturedOptions = params.options ?? {}
@@ -20,14 +23,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "proxy-structured-output.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-subagent-model-selection.test.ts
+++ b/src/__tests__/proxy-subagent-model-selection.test.ts
@@ -8,12 +8,15 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
 
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 let capturedModel: string | null = null
 let capturedOptions: any = null
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedOptions = opts.options
     capturedModel = opts.options?.model ?? null
@@ -36,14 +39,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { registerTool: () => {} } }),
   tool: () => ({}),
-}))
+}), "proxy-subagent-model-selection.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-subagent-support.test.ts
+++ b/src/__tests__/proxy-subagent-support.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -64,7 +67,7 @@ let mockMessages: any[] = []
 let capturedQueryParams: any = null
 let queryCallCount = 0
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     queryCallCount++
@@ -80,14 +83,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: {},
   }),
   tool: () => ({}),
-}))
+}), "proxy-subagent-support.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-system-reminder-preservation.test.ts
+++ b/src/__tests__/proxy-system-reminder-preservation.test.ts
@@ -13,13 +13,16 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 let savedPassthrough: string | undefined
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -30,14 +33,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-system-reminder-preservation.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-thinking-setting.test.ts
+++ b/src/__tests__/proxy-thinking-setting.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 // ─── controllable sdk-features state ──────────────────────────────────────────
@@ -46,7 +49,7 @@ mock.module("../proxy/sdkFeatures", () => ({
 let capturedOptions: Record<string, unknown> = {}
 let mockMessages: unknown[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: { prompt: unknown; options: Record<string, unknown> }) => {
     capturedOptions = params.options ?? {}
     return (async function* () {
@@ -57,14 +60,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-thinking-setting.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-tool-blocking.test.ts
+++ b/src/__tests__/proxy-tool-blocking.test.ts
@@ -13,6 +13,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -21,7 +24,7 @@ import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
 let capturedQueryParams: any = null
 let mockMessages: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -32,14 +35,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-tool-blocking.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-tool-cache.test.ts
+++ b/src/__tests__/proxy-tool-cache.test.ts
@@ -5,12 +5,15 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, makeRequest, READ_TOOL, withMockSdkSessionId } from "./helpers"
 
 let capturedQueryParams: any = null
 let mockMessages: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -25,14 +28,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "proxy-tool-cache.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-tool-flattening-regression.test.ts
+++ b/src/__tests__/proxy-tool-flattening-regression.test.ts
@@ -11,6 +11,8 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -28,7 +30,7 @@ let capturedParams: CapturedParams | null = null
 let queuedSessionIds: string[] = []
 function getCaptured(): CapturedParams | null { return capturedParams }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: unknown) => {
     capturedParams = params as CapturedParams
     const options = (params as CapturedParams).options
@@ -42,9 +44,9 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-tool-flattening-regression.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
 }))

--- a/src/__tests__/proxy-tool-forwarding.test.ts
+++ b/src/__tests__/proxy-tool-forwarding.test.ts
@@ -12,6 +12,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -32,7 +35,7 @@ import {
 // --- Mock the Claude SDK ---
 let mockMessages: any[] = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     return (async function* () {
       for (const msg of mockMessages) {
@@ -46,16 +49,16 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: {},
   }),
   tool: () => ({}),
-}))
+}), "proxy-tool-forwarding.test.ts")
 
 // Mock the logger to avoid noise
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
 // Mock mcpTools
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-transparent-tools.test.ts
+++ b/src/__tests__/proxy-transparent-tools.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import {
   messageStart,
   textBlockStart,
@@ -31,7 +34,7 @@ import {
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -46,14 +49,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: {},
   }),
   tool: () => ({}),
-}))
+}), "proxy-transparent-tools.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-usage-quota-route.test.ts
+++ b/src/__tests__/proxy-usage-quota-route.test.ts
@@ -8,18 +8,21 @@
 
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+installSdkMock(() => ({
   query: () => (async function* () {})(),
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-usage-quota-route.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/proxy-working-directory.test.ts
+++ b/src/__tests__/proxy-working-directory.test.ts
@@ -12,13 +12,16 @@
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { tmpdir } from "node:os"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = null
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedQueryParams = params
     return (async function* () {
@@ -29,14 +32,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-working-directory.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/sdkMock.ts
+++ b/src/__tests__/sdkMock.ts
@@ -1,0 +1,99 @@
+import { mock, beforeAll } from "bun:test"
+
+/**
+ * One process-global mock of the Claude Agent SDK, shared by every test file.
+ *
+ * ## Why this exists (#917)
+ *
+ * `mock.module` is process-global in bun, and every test file is *loaded*
+ * before any test *runs*. When 75 files each called
+ * `mock.module("@anthropic-ai/claude-agent-sdk", ...)` at module scope, all 75
+ * registrations executed during the load phase and the last one won for the
+ * whole process. Every other file then ran its tests against a stranger's mock,
+ * which serves a different generator reading a different file's state — so
+ * requests that should have returned 200/429/503 returned 500 instead.
+ *
+ * That produced the signature in #917: whole files failing as a block, a
+ * failure set that is stable for a given file set but changes when the set or
+ * its order changes, and nothing reproducing when a file runs on its own. It
+ * is also why ten files are already split into their own `bun test`
+ * invocations in the `test` script — the same bug, worked around one file at a
+ * time.
+ *
+ * ## How this fixes it
+ *
+ * The registration happens exactly once, here. The exported functions are
+ * stable wrappers that resolve the active implementation *at call time*, so
+ * importers can bind to them once (as ESM does) and still reach whichever
+ * implementation the running file installed.
+ *
+ * Each file calls `installSdkMock(factory)` at module scope instead. That
+ * registers a file-scoped `beforeAll`, so the implementation is swapped in when
+ * that file's tests begin rather than during the load-phase free-for-all.
+ * Because bun runs files sequentially, exactly one implementation is ever
+ * active.
+ *
+ * A consequence worth knowing: the factory is invoked at `beforeAll` time, not
+ * at module scope, so it may safely close over `let` bindings declared further
+ * down the file.
+ */
+
+/** Any SDK export. `never[]` params make every concrete function assignable
+ *  (parameter contravariance) without reaching for `any`. */
+type SdkExport = (...args: never[]) => unknown
+
+/** All optional: a file mocks only the exports its subject actually reaches,
+ *  and `resolve` raises a named error if something else is called. */
+export interface SdkMockModule {
+  query?: SdkExport
+  createSdkMcpServer?: SdkExport
+  tool?: SdkExport
+}
+
+let active: SdkMockModule | null = null
+let activeOwner = "<none>"
+
+function resolve(name: keyof SdkMockModule): SdkExport {
+  if (!active) {
+    throw new Error(
+      `Claude Agent SDK mock: '${name}' was called before any test file installed an implementation. `
+      + "Call installSdkMock(() => ({ query, createSdkMcpServer, tool })) at module scope.",
+    )
+  }
+  const impl = active[name]
+  if (!impl) {
+    throw new Error(
+      `Claude Agent SDK mock: '${name}' is not provided by the implementation installed in ${activeOwner}.`,
+    )
+  }
+  return impl
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (...args: never[]) => resolve("query")(...args),
+  createSdkMcpServer: (...args: never[]) => resolve("createSdkMcpServer")(...args),
+  tool: (...args: never[]) => resolve("tool")(...args),
+}))
+
+/**
+ * Install this file's SDK mock for the duration of its tests.
+ *
+ * Call at module scope. `owner` is only used to name the file in error
+ * messages when an export is missing.
+ */
+export function installSdkMock(factory: () => SdkMockModule, owner?: string): void {
+  beforeAll(() => {
+    active = factory()
+    activeOwner = owner ?? "the current test file"
+  })
+}
+
+/**
+ * Install an implementation immediately, for the rare file that swaps its mock
+ * from inside a test body. `installSdkMock` cannot be used there — bun rejects a
+ * `beforeAll` registered inside a running test.
+ */
+export function setSdkMock(factory: () => SdkMockModule, owner?: string): void {
+  active = factory()
+  activeOwner = owner ?? "the current test file"
+}

--- a/src/__tests__/session-fingerprint-context.test.ts
+++ b/src/__tests__/session-fingerprint-context.test.ts
@@ -18,6 +18,9 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -42,7 +45,7 @@ function getCallerSelectedSessionId(label: string): string {
   return sessionId
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: unknown) => {
     capturedQueryParams = params as CapturedFPQueryParams
     const sessionLabel = queuedSessionLabels.shift()
@@ -60,14 +63,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "session-fingerprint-context.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/session-lineage.test.ts
+++ b/src/__tests__/session-lineage.test.ts
@@ -11,6 +11,9 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -36,7 +39,7 @@ function getCallerSelectedSessionId(label: string): string {
   return sessionId
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: unknown) => {
     capturedQueryParams = params as CapturedQueryParams
     const sessionLabel = queuedSessionLabels.shift()
@@ -54,14 +57,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "session-lineage.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => Promise<Response> | Response) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 

--- a/src/__tests__/session-tool-cache-eviction.test.ts
+++ b/src/__tests__/session-tool-cache-eviction.test.ts
@@ -16,12 +16,15 @@
  * into the map — an evicted session simply stops having its tools restored.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, makeRequest, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedQueryParams: any = {}
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (opts: any) => {
     capturedQueryParams = opts
     return (async function* () {
@@ -36,14 +39,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "session-tool-cache-eviction.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 

--- a/src/__tests__/silent-turn-recovery.test.ts
+++ b/src/__tests__/silent-turn-recovery.test.ts
@@ -10,6 +10,9 @@
  * recovery turn.
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -34,7 +37,7 @@ const initialManagedSessionId = () => queryCalls[0]?.options?.sessionId ?? mockB
 
 import { resolveMockSdkSessionId } from "./helpers"
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     queryCalls.push(params)
     queryMutation?.(params)
@@ -66,14 +69,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     instance: { tool: () => {}, registerTool: () => ({}) },
   }),
   tool: () => ({}),
-}))
+}), "silent-turn-recovery.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({
     type: "sdk", name: "opencode",
     instance: { tool: () => {}, registerTool: () => ({}) },

--- a/src/__tests__/sticky-routing-integration.test.ts
+++ b/src/__tests__/sticky-routing-integration.test.ts
@@ -4,12 +4,15 @@
  * SDK subprocess env (CLAUDE_CONFIG_DIR carries the profile's config dir).
  */
 import { describe, it, expect, mock, beforeAll, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 import { assistantMessage, withMockSdkSessionId } from "./helpers"
 
 let mockMessages: any[] = []
 let capturedEnvs: Array<Record<string, string | undefined>> = []
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   query: (params: any) => {
     capturedEnvs.push(params.options?.env ?? {})
     return (async function* () {
@@ -20,14 +23,14 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }),
   tool: () => ({}),
-}))
+}), "sticky-routing-integration.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: any, fn: any) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: { tool: () => {}, registerTool: () => ({}) } }),
 }))
 


### PR DESCRIPTION
Fixes #917.

## The bug

`mock.module` is process-global in bun, and **every test file is loaded before any test runs**. 75 files called `mock.module("@anthropic-ai/claude-agent-sdk", ...)` at module scope, so all 75 registrations executed during the load phase and **the last one won for the whole process**. Every other file then ran its tests against a stranger's mock — a different generator reading a different file's state — so requests that should have returned 200/429/503 returned 500 instead.

That accounts for every observation in #917:

- whole files failing as a block, not scattered singletons;
- a failure set that is **stable for a given file set** but changes when the set or its order changes;
- nothing reproducing when a file runs on its own;
- concrete status mismatches (`Expected: 429, Received: 500`) rather than timeouts.

It also explains the ten files already split into their own `bun test` invocations in the `test` script — the same bug, worked around one file at a time. `../logger` (74 files) and `../mcpTools` (70) had it too; mcpTools decides an adapter's MCP server name, so a stray winner renamed another adapter's tools and failed its whole file.

This settles #917's two candidate explanations: it is cross-file mock leakage, not CPU contention.

## The fix

Register each module exactly once — `sdkMock.ts`, `loggerMock.ts`, `mcpToolsMock.ts`. The exported functions are stable wrappers that resolve the active implementation **at call time**, so importers can bind to them once (as ESM does) and still reach whichever implementation the running file installed.

Files call `installSdkMock(...)` / `installLoggerMock(...)` / `installMcpToolsMock(...)` at module scope. Those register a file-scoped `beforeAll`, so the implementation swaps in when that file's tests begin rather than during the load-phase free-for-all. I verified bun scopes a top-level `beforeAll` to its own file, so exactly one implementation is ever active.

Three modules rather than one, deliberately: importing a module is what registers its mock, so a file that never mocked the logger must not acquire one just by wanting the SDK mocked. That was a real regression in an earlier cut of this change.

## Notes

- `setSdkMock` / `setLoggerMock` / `setMcpToolsMock` install immediately, for the one file that swaps its mock from inside a test body — `beforeAll` is rejected there.
- `mcpTools` with no implementation falls back to the default OpenCode stub (the shape 59 of 70 files used) and the logger to a no-op, matching what those files were already sharing accidentally. Throwing would be stricter than the behaviour being replaced.
- `proxy-cross-process-coordination.test.ts` keeps its `mock.module`: it lives inside the subprocess source string, and that worker has its own module graph.
- The factory now runs at `beforeAll` rather than module scope, so it may safely close over `let` bindings declared further down the file.

## Verification

- `npm test` — 3040 pass, 0 fail, exit 0
- `npm run typecheck` — clean
- Confirmed the `beforeAll` file-scoping assumption with a two-file scratch case rather than assuming it

## Not included

Bare `bun test` still fails, because `../proxy/models` (6 files) and `child_process` (1) have the same unresolved race. Folding those in — and then letting the ten excluded files rejoin the main pass, which would make CI faster — is worth doing as a follow-up, but it is a separate change from fixing the flake.