### PR TITLE
DO NOT MERGE: temporary #917 diagnostic

### DIFF
--- a/src/__tests__/proxy-error-handling.test.ts
+++ b/src/__tests__/proxy-error-handling.test.ts
@@ -168,6 +168,10 @@ describe("Error classification", () => {
       const app = createTestApp()
       const res = await post(app, BASIC_REQUEST)
 
+      if (res.status !== 429) {
+        // TEMPORARY #917 DIAGNOSTIC — throwaway branch, never merged.
+        console.error("[917] status=", res.status, "body=", await res.clone().text())
+      }
       expect(res.status).toBe(429)
       expect(res.headers.get("Retry-After")).toBe("60")
       const body = await res.json()

--- a/src/__tests__/proxy-passthrough-tool-use.test.ts
+++ b/src/__tests__/proxy-passthrough-tool-use.test.ts
@@ -306,6 +306,10 @@ describe("Passthrough non-streaming: tool_use returned without HTTP 500", () => 
 
     const app = createTestApp()
     const response = await postNonStream(app)
+    if (response.status !== 200) {
+      // TEMPORARY #917 DIAGNOSTIC — throwaway branch, never merged.
+      console.error("[917] status=", response.status, "body=", await response.clone().text())
+    }
     expect(response.status).toBe(200)
 
     const body = await response.json() as any


### PR DESCRIPTION
Throwaway draft to get a Linux CI run that prints the body of the 500 the #917 cluster returns.

Two `console.error` calls in `proxy-error-handling.test.ts` and `proxy-passthrough-tool-use.test.ts`, fired only when the status is already wrong. No source changes. **Close without merging** once the log is captured.

Context: three hypotheses have failed to reproduce on macOS (SDK mock leakage — shipped as #931 and did not fix it; partial `../proxy/models` stubs; rate-limit store leakage). The `[PROXY]` log shows the retry starting but never what it failed with, so this captures that.