### PR TITLE
fix(errors): classify a too-old CLI's model rejection as 400, not 500

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -346,6 +346,51 @@ describe("classifyError", () => {
     })
   })
 
+  // The CLI rejects a model it is too old to know about. Captured verbatim from
+  // claude-code 2.1.198 asked for claude-fable-5-1 (#932). This is reachable via
+  // MERIDIAN_CLAUDE_PATH, which outranks the bundled binary the package.json
+  // floor governs, so the floor alone does not prevent it.
+  describe("CLI too old for the requested model (#932)", () => {
+    const REAL = "API Error: 400 Claude Code 2.1.198 does not support this model; version 2.1.251 or newer is required. Run 'claude update', or update the Claude desktop app, then try again."
+
+    it("classifies the CLI's verbatim wording as a client error", () => {
+      const r = classifyError(REAL)
+      expect(r.status).toBe(400)
+      expect(r.type).toBe("invalid_request_error")
+    })
+
+    // The whole point: a 500 reads as "transient" to every client retry policy,
+    // so an upgrade-or-nothing failure gets replayed forever at upstream cost.
+    it("is never retryable", () => {
+      expect(classifyError(REAL).status).toBeLessThan(500)
+    })
+
+    // The CLI names both the installed and required versions. Dropping them for
+    // generic prose would discard the only actionable part of the message.
+    it("preserves the version detail the CLI reported", () => {
+      const r = classifyError(REAL)
+      expect(r.message).toContain("2.1.198")
+      expect(r.message).toContain("2.1.251")
+    })
+
+    it("matches the shape, not one hardcoded version pair", () => {
+      const r = classifyError("API Error: 400 Claude Code 2.0.5 does not support this model; version 3.0.0 or newer is required.")
+      expect(r.status).toBe(400)
+    })
+
+    // Must not steal a genuine quota failure that happens to mention a model.
+    it("leaves a rate limit alone", () => {
+      expect(classifyError("You've hit your usage limit for claude-fable-5-1").status).toBe(429)
+    })
+
+    // "does not support" alone is too broad — an unsupported tool or flag is a
+    // different failure with a different remedy.
+    it("does not fire on an unrelated unsupported-feature error", () => {
+      const r = classifyError("Error: this tool does not support streaming input")
+      expect(r.status).not.toBe(400)
+    })
+  })
+
   describe("process crashes", () => {
     it("detects exit code with specific number", () => {
       const result = classifyError("exited with code 137")

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -182,6 +182,19 @@ const OVERFLOW_PHRASES = [
   String.raw`context[_ ]length[_ ]exceeded`,
 ]
 
+/** The resolved CLI is older than the model that was asked for. Observed
+ *  verbatim from claude-code 2.1.198 asked for `claude-fable-5-1`:
+ *  `API Error: 400 Claude Code 2.1.198 does not support this model; version
+ *  2.1.251 or newer is required. Run 'claude update', ...`
+ *
+ *  Version-agnostic by design — pinning the observed pair would stop matching
+ *  at the next floor bump, which is the same trap #764/#787 sprang on the
+ *  rate-limit literals. `Claude Code` must sit adjacent to the phrase so that
+ *  an unsupported *tool* or *flag* ("this tool does not support streaming
+ *  input") cannot take the branch: that is a different failure with a
+ *  different remedy. */
+const CLI_MODEL_UNSUPPORTED = /claude code(?: \d[\w.]*)? does not support this model/
+
 /** Either the phrase opens a line (after the known SDK/CLI wrappers), or it
  *  opens the `message` value of an API error envelope — `API Error: 400
  *  {"type":"invalid_request_error","message":"prompt is too long: ..."}`, which
@@ -280,6 +293,28 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
       status: 400,
       type: "invalid_request_error",
       message: "Prompt exceeds the model's context window. Compact or trim the conversation before retrying — an identical retry fails the same way."
+    }
+  }
+
+  // The resolved CLI predates the requested model. A correct package.json floor
+  // does not prevent this: MERIDIAN_CLAUDE_PATH is step 0 of
+  // resolveClaudeExecutableWithSource, so an env-pointed CLI outranks the
+  // bundled binary the floor governs (#932).
+  //
+  // 400 for the same reason as context overflow above — upgrading the CLI is
+  // the only fix, so every retry fails identically, and the default 500 reads
+  // as "transient" to every client retry policy. Placed before the crash
+  // branch so the same error arriving as a code-1 exit with stderr attached
+  // does not get answered with `claude login`, which cannot help here.
+  //
+  // The CLI names both the installed and the required version; that is the
+  // only actionable part of the message, so it is carried through rather than
+  // replaced with generic prose.
+  if (CLI_MODEL_UNSUPPORTED.test(lower)) {
+    return {
+      status: 400,
+      type: "invalid_request_error",
+      message: `${errMsg.trim()} (Meridian: the Claude Code CLI it resolved is older than the requested model. If MERIDIAN_CLAUDE_PATH is set it overrides the bundled CLI, so update that binary or unset the variable.)`
     }
   }
 


### PR DESCRIPTION
Fixes #932.

## The bug

`MERIDIAN_CLAUDE_PATH` is step 0 of `resolveClaudeExecutableWithSource`, so it outranks the bundled binary that the `package.json` floor governs. Point it at a CLI older than the requested model and the CLI returns a 400 — reproduced verbatim by running the 2.1.198 binary against `claude-fable-5-1`:

```
API Error: 400 Claude Code 2.1.198 does not support this model;
version 2.1.251 or newer is required. Run 'claude update', or update
the Claude desktop app, then try again.
```

That matched no branch in `classifyError`, so it fell through to the default:

```
{ "status": 500, "type": "api_error", ... }
```

A 5xx reads as "transient, try again" to every client retry policy, so a request that cannot succeed until the operator upgrades the CLI gets replayed indefinitely at full upstream cost. Same failure mode the context-overflow branch was added to fix.

## The fix

Classify it `400 / invalid_request_error`.

- **Shape-matched, not version-pinned.** `/claude code(?: \d[\w.]*)? does not support this model/` — hardcoding the observed `2.1.198 / 2.1.251` pair would stop matching at the next floor bump, which is the trap #764/#787 sprang on the rate-limit literals.
- **`Claude Code` must be adjacent to the phrase**, so an unsupported *tool* or *flag* ("this tool does not support streaming input") keeps its own classification — different failure, different remedy.
- **Placed before the process-crash branch**, so the same error arriving as a code-1 exit with stderr attached isn't answered with `claude login`, which cannot help here. Same ordering rationale as context overflow.
- **The CLI's own message is carried through**, since it names both the installed and required version — the only actionable part. A Meridian note about `MERIDIAN_CLAUDE_PATH` is appended, because that's the thing to check and nothing else surfaces it.

## Verification

Against the real captured message and the guards:

| Input | Status |
|---|---|
| the real 2.1.198 rejection | 400 |
| a future version pair (9.9.9 / 10.0.0) | 400 |
| same error as a code-1 exit with stderr | 400 (was 401 "run claude login") |
| rate limit naming a model | 429 (unchanged) |
| "this tool does not support streaming input" | 500 (unchanged) |

`npm test` passes (exit 0), `npm run typecheck` clean.

## Not included

#932 also floated surfacing the resolved CLI version in the startup banner. That needs a new `claude --version` spawn at startup — added latency and error paths — for something the error message now states directly at the point of failure, naming `MERIDIAN_CLAUDE_PATH`. Left out deliberately; happy to add it separately if you want the startup signal too.
