### PR TITLE
test: protect operator telemetry and remove recovery timeout race

### DIFF
--- a/src/__tests__/preload-isolation.test.ts
+++ b/src/__tests__/preload-isolation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import { createSqliteStores } from "../telemetry/sqlite"
+
+describe("test preload operator isolation (#927)", () => {
+  for (const prefix of ["MERIDIAN_", "CLAUDE_PROXY_"]) {
+    it(`protects operator telemetry and configuration inherited through ${prefix}`, () => {
+      const root = mkdtempSync(join(tmpdir(), "meridian-preload-check-"))
+      const dbPath = join(root, "operator.db")
+      const stores = createSqliteStores(dbPath, 7)
+      try {
+        stores.telemetry.record({
+          requestId: "operator-request", timestamp: Date.now(), model: "sonnet",
+          mode: "non-stream", isResume: false, isPassthrough: false, status: 200,
+          queueWaitMs: 0, proxyOverheadMs: 0, ttfbMs: null, upstreamDurationMs: 0,
+          totalDurationMs: 0, contentBlocks: 1, textEvents: 1, error: null,
+        })
+        stores.diagnostics.session("operator diagnostic")
+        expect(stores.telemetry.size).toBe(1)
+        expect(stores.diagnostics.getRecent()).toHaveLength(1)
+
+        const fixture = join(root, "operator-isolation.test.ts")
+        const telemetryUrl = pathToFileURL(resolve(import.meta.dir, "../telemetry/index.ts")).href
+        const envUrl = pathToFileURL(resolve(import.meta.dir, "../env.ts")).href
+        // Run the real test runner and preload in a fresh process: an in-process
+        // import cannot prove that isolation happens before singleton creation.
+        writeFileSync(fixture, `
+          import { expect, test } from "bun:test"
+          import { telemetryStore, diagnosticLog, MemoryTelemetryStore, MemoryDiagnosticLogStore } from ${JSON.stringify(telemetryUrl)}
+          import { env } from ${JSON.stringify(envUrl)}
+          test("test cleanup is isolated from operator state", () => {
+            telemetryStore.clear()
+            diagnosticLog.clear()
+            expect(telemetryStore).toBeInstanceOf(MemoryTelemetryStore)
+            expect(diagnosticLog).toBeInstanceOf(MemoryDiagnosticLogStore)
+            expect(env("NO_FILE_CHANGES")).toBeUndefined()
+            expect(env("API_KEY")).toBeUndefined()
+            expect(env("CONFIG_DIR")).not.toBe(${JSON.stringify(join(root, "operator-config"))})
+            expect(env("SESSION_DIR")).not.toBe(${JSON.stringify(join(root, "operator-sessions"))})
+            expect(env("TEST_DISABLE_SDK_PROCESS_GATE")).toBe("1")
+            process.env.MERIDIAN_NO_FILE_CHANGES = "1"
+            expect(env("NO_FILE_CHANGES")).toBe("1")
+          })
+        `)
+        const childEnv = { ...process.env }
+        for (const key of Object.keys(childEnv)) {
+          if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete childEnv[key]
+        }
+        Object.assign(childEnv, {
+          // Even a broken preload can only touch this throwaway HOME/database.
+          HOME: root, USERPROFILE: root, TMPDIR: root, TMP: root, TEMP: root,
+          [`${prefix}TELEMETRY_PERSIST`]: "1",
+          [`${prefix}TELEMETRY_DB`]: dbPath,
+          [`${prefix}NO_FILE_CHANGES`]: "1",
+          [`${prefix}API_KEY`]: "test-only-key",
+          [`${prefix}CONFIG_DIR`]: join(root, "operator-config"),
+          [`${prefix}SESSION_DIR`]: join(root, "operator-sessions"),
+          [`${prefix}TEST_DISABLE_SDK_PROCESS_GATE`]: "0",
+        })
+        const result = spawnSync(process.execPath, [
+          "test", "--preload", resolve(import.meta.dir, "preload.ts"), fixture,
+        ], { cwd: root, env: childEnv, encoding: "utf8", timeout: 10_000 })
+
+        // Check the user's rows first: this must fail on the old preload even
+        // though the child successfully performed its usual clear() cleanup.
+        expect(stores.telemetry.getRecent().map(row => row.requestId)).toEqual(["operator-request"])
+        expect(stores.diagnostics.getRecent().map(row => row.message)).toEqual(["operator diagnostic"])
+        if (result.error) throw result.error
+        expect({ status: result.status, output: result.stdout + result.stderr }).toMatchObject({ status: 0 })
+      } finally {
+        stores.close()
+        rmSync(root, { recursive: true, force: true })
+      }
+    }, 15_000)
+  }
+})

--- a/src/__tests__/preload.ts
+++ b/src/__tests__/preload.ts
@@ -7,8 +7,25 @@ import { mkdirSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-// Auth middleware reads this at request time; clear it so tests don't need API keys
-delete process.env.MERIDIAN_API_KEY
+// Take the operator's whole configuration namespace away from the suite.
+//
+// Every runtime knob is read through `env()`, i.e. `MERIDIAN_<X>` with a
+// `CLAUDE_PROXY_<X>` fallback, so anything a developer exports to run their own
+// proxy silently reconfigures the code under test. Two real examples from this
+// machine: `MERIDIAN_NO_FILE_CHANGES=1` turns off the PostToolUse hook and
+// fails the three "other adapters still track" cases in
+// proxy-file-changes.test.ts, and `MERIDIAN_TELEMETRY_PERSIST=1` makes the
+// global telemetry store the real ~/.config/meridian/telemetry.db — which the
+// suite then DELETEs, because tests call `telemetryStore.clear()` and
+// `diagnosticLog.clear()`. (Redirecting the config dir does not save it:
+// telemetry resolves its path from `env("TELEMETRY_DB")` alone.)
+//
+// CI runs with none of these set, so stripping the namespace is what makes a
+// local run mean the same thing as a CI run. Tests that need a knob set it
+// themselves, in-process, after this point.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
 
 // Point settings.ts at a throwaway directory so the suite never reads the
 // developer's real ~/.config/meridian/settings.json. A live

--- a/src/__tests__/proxy-stale-uuid-retry.test.ts
+++ b/src/__tests__/proxy-stale-uuid-retry.test.ts
@@ -42,6 +42,7 @@ let queryParams: any[] = []
 let queryCallCount = 0
 let queryMutation: ((options: Record<string, any>) => void) | undefined
 let forcedQueryError: Error | undefined
+let forcedQueryDelayMs = 0
 
 installSdkMock(() => ({
   query: (opts: any) => {
@@ -53,7 +54,10 @@ installSdkMock(() => ({
 
     return (async function* () {
       queryMutation?.(opts.options || {})
-      if (forcedQueryError) throw forcedQueryError
+      if (forcedQueryError) {
+        if (forcedQueryDelayMs > 0) await Bun.sleep(forcedQueryDelayMs)
+        throw forcedQueryError
+      }
       // First call with resumeSessionAt: simulate stale UUID error
       if (callIndex === 1 && opts.options?.resumeSessionAt) {
         throw new Error(
@@ -124,6 +128,7 @@ describe("Stale UUID retry", () => {
     queryCallCount = 0
     queryMutation = undefined
     forcedQueryError = undefined
+    forcedQueryDelayMs = 0
   })
 
   it("retries as fresh session when undo hits stale UUID (non-streaming)", async () => {
@@ -344,17 +349,26 @@ describe("Stale UUID retry", () => {
     expect(failed.status).toBe(500)
     expect(queryCallCount).toBe(1)
 
+    // Processing may legitimately take longer than 50ms on a busy runner.
+    // Keep a slow SDK response in the test so a short client-abort timer can
+    // never masquerade as the expected upstream error (#917/#933).
+    forcedQueryDelayMs = 75
     const abort = new AbortController()
-    const timer = setTimeout(() => abort.abort(), 50)
-    const blocked = await app.fetch(new Request("http://localhost/v1/messages", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "x-opencode-session": sessionId },
-      body: JSON.stringify({ model: "sonnet", stream: false, messages: continuation }),
-      signal: abort.signal,
-    }))
-    clearTimeout(timer)
-    expect(blocked.status).toBe(500)
-    expect(queryCallCount).toBe(2)
+    // This is a hang guard, not a latency requirement. A quarantined source
+    // still fails the assertions below (499 or no second SDK call).
+    const timer = setTimeout(() => abort.abort(), 2_000)
+    try {
+      const blocked = await app.fetch(new Request("http://localhost/v1/messages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-opencode-session": sessionId },
+        body: JSON.stringify({ model: "sonnet", stream: false, messages: continuation }),
+        signal: abort.signal,
+      }))
+      expect(blocked.status).toBe(500)
+      expect(queryCallCount).toBe(2)
+    } finally {
+      clearTimeout(timer)
+    }
   })
 
   it("propagates non-stale errors normally", async () => {


### PR DESCRIPTION
Two test-environment problems make the suite unsafe or unreliable: inherited operator configuration can send test cleanup to the operator’s real telemetry database, and the stale-session CAS test cancels its own request after 50 ms while expecting an upstream 500 response.

This preserves Mate Remias’s original #927 fix and authorship in its own commit, then adds two separate maintainer commits:

- A fresh-process regression test launches the real Bun test runner/preload with operator configuration under both `MERIDIAN_*` and `CLAUDE_PROXY_*`. After the child clears test telemetry, the parent verifies that seeded operator metrics and diagnostics survive. Every potentially affected path is disposable. The test also checks suite-owned settings and per-test overrides.
- The stale-session test uses a 2-second hang guard with guaranteed timer cleanup. A deliberate 75 ms mock response fails with the old 50 ms timer (499) and passes with the corrected guard (500), while preserving the assertion that a second SDK call occurs. This removes a latency race without accepting cancellation or a quarantined source.

Validation at `cace2af3`:

- Full local `npm test`: **3,297 pass, 1 existing skip, 0 fail**; typecheck and build pass.
- Before/after telemetry regression: old preload deletes seeded metrics under both prefixes; fixed preload preserves metrics and diagnostics.
- Before/after delayed stale-session regression: old timer returns 499; corrected test returns the required 500 and observes two SDK calls.
- Real Claude Max E41 chain E2E, streaming and non-streaming: both pass, including three tool calls, exact results, durable fork progression, follow-up resume, and cached-prefix continuity. Repeated after the final test correction.
- Linux CI test/typecheck/build, Windows smoke, container smoke, and container build all pass.

One separate full-suite run returned 500 for a concurrent priority request after mock SDK completion. Thirty repetitions of the affected file (90 tests) did not reproduce it. This change fixes the demonstrated stale-session timing race, but does **not** claim that all of #917/#933 is resolved. Kept as a draft first review batch; no runtime code changes.
