### PR TITLE
fix: replay undo histories that exceed the rollback boundary

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -264,6 +264,19 @@ curl -s http://127.0.0.1:3456/v1/messages \
 
 **Verifies:** When the message suffix changes (user edited/undid), proxy detects undo and emits rollback UUID.
 
+**Automated history-integrity gate (#817):** Run `bun scripts/e2e-undo-gap.mjs`
+and `bun scripts/e2e-undo-gap.mjs --stream`. The fixture creates a real SDK
+conversation with valid historical assistant UUIDs and publishes its matching
+Meridian mapping, representing a persisted session with available rollback
+points. Recent proxy forks invalidate older UUIDs, so simply growing a proxy
+conversation can mask this bug through the missing-UUID fresh-replay fallback.
+The gate proves ordinary undo uses a real fork, shortened history with edited
+intermediate turns reaches the SDK and the answer in full, and the source stays
+unchanged. A third case removes the adjacent UUID from the stored mapping and
+checks that fresh replay preserves facts after an older known checkpoint.
+It inspects history only through `getSessionMessages()` and isolates
+Meridian configuration/session storage in a temporary directory.
+
 **Prerequisite:** Run E4 first (builds a 3+ message session with `e2e-cont-001`).
 
 ```bash

--- a/scripts/e2e-undo-gap.mjs
+++ b/scripts/e2e-undo-gap.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env bun
+/**
+ * #817: a shortened history with edited intermediate turns must replay them.
+ * Uses real SDK queries to establish a source with valid historical rollback
+ * UUIDs, then installs its matching Meridian mapping (a persisted-session
+ * fixture). This matters: recent proxy forks invalidate old UUIDs and would
+ * mask the defective rollback path by falling back to fresh replay already.
+ * All transcript inspection uses the supported getSessionMessages API.
+ * Run: bun scripts/e2e-undo-gap.mjs [--stream]
+ */
+import assert from "node:assert/strict"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { homedir, tmpdir } from "node:os"
+import { join } from "node:path"
+import { randomUUID } from "node:crypto"
+import { query, getSessionMessages } from "@anthropic-ai/claude-agent-sdk"
+
+const stream = process.argv.includes("--stream")
+const model = process.env.E2E_MODEL ?? "claude-haiku-4-5-20251001"
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-undo-gap-")))
+// Isolate Meridian state without replacing the operator's SDK auth context.
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, {
+  MERIDIAN_CONFIG_DIR: join(root, "config"),
+  MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root,
+  MERIDIAN_TELEMETRY_PERSIST: "0",
+  MERIDIAN_PASSTHROUGH: "1",
+})
+const { resolveClaudeExecutableAsync } = await import("../src/proxy/models.ts")
+const { storeSession } = await import("../src/proxy/session/cache.ts")
+const { readSessionStoreSnapshot } = await import("../src/proxy/sessionStore.ts")
+const { telemetryStore } = await import("../src/telemetry/index.ts")
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const executable = await resolveClaudeExecutableAsync()
+const originalMarker = `ORIGINAL_${randomUUID()}`
+const changedMarker = `REVISED_${randomUUID()}`
+const secondaryMarker = `SECONDARY_${randomUUID()}`
+const history = []
+const uuids = []
+let sourceId
+for (let turn = 0; turn < 4; turn++) {
+  const prompt = turn === 0
+    ? `The marker is ${originalMarker}. Remember it and reply only ACK.`
+    : turn === 1
+      ? `The secondary marker is ${secondaryMarker}. Remember both markers and reply only ACK1.`
+      : `Keep remembering both markers. Reply only ACK${turn}.`
+  let assistant
+  let result
+  for await (const event of query({ prompt, options: {
+    model, cwd: root, resume: sourceId, tools: [], settingSources: [],
+    pathToClaudeCodeExecutable: executable, maxTurns: 1,
+    permissionMode: "bypassPermissions", allowDangerouslySkipPermissions: true,
+  } })) {
+    if (event.type === "assistant") assistant = event
+    if (event.type === "result") result = event
+  }
+  assert.equal(result?.subtype, "success", `SDK fixture turn ${turn} did not succeed`)
+  assert(assistant?.uuid && assistant.session_id, "SDK fixture lacks a real rollback point")
+  if (sourceId) assert.equal(assistant.session_id, sourceId, "fixture unexpectedly forked")
+  sourceId = assistant.session_id
+  history.push({ role: "user", content: prompt }, { role: "assistant", content: assistant.message.content })
+  uuids.push(null, assistant.uuid)
+}
+const sourceMessages = await getSessionMessages(sourceId, { dir: root })
+assert(sourceMessages.some(row => row.uuid === uuids[1]), "historical rollback UUID missing from real source")
+const storedHistory = history.slice(0, -1) // last request's seven supplied messages
+const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+const address = instance.server.address()
+assert(address && typeof address === "object")
+const problems = []
+try {
+  for (const mode of ["ordinary", "gap", "missing-adjacent"]) {
+    const gap = mode === "gap"
+    const missingAdjacent = mode === "missing-adjacent"
+    const rollbackUuids = [...uuids]
+    if (missingAdjacent) rollbackUuids[3] = null
+    const key = `e2e-undo-${mode}-${randomUUID()}`
+    assert(storeSession(key, storedHistory, sourceId, root, rollbackUuids, undefined, null, null, {
+      sessionId: sourceId,
+      configDir: process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude"),
+      projectDir: root,
+    }), "could not publish SDK fixture mapping")
+    const messages = gap
+      ? [...history.slice(0, 2),
+        { role: "user", content: `Correction: the marker is now ${changedMarker}.` },
+        { role: "assistant", content: "I acknowledge the corrected marker." },
+        { role: "user", content: "What is the marker now? Reply only with the marker." }]
+      : missingAdjacent
+        ? [...history.slice(0, 4), { role: "user", content: "What is the secondary marker? Reply only with that marker." }]
+        : [...history.slice(0, 2),
+          { role: "user", content: "What is the marker? Reply only with the marker." }]
+    const response = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-opencode-session": key, "x-meridian-agent": "opencode" },
+      body: JSON.stringify({ model, max_tokens: 256, stream, messages }),
+      signal: AbortSignal.timeout(90_000),
+    })
+    const raw = await response.text()
+    assert.equal(response.status, 200, raw)
+    let answer
+    if (stream) {
+      const events = raw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+      assert(!events.some(event => event.type === "error"), raw)
+      assert.equal(events.filter(event => event.type === "message_stop").length, 1)
+      assert.equal(events.filter(event => event.type === "message_delta").length, 1)
+      answer = events.filter(event => event.delta?.type === "text_delta").map(event => event.delta.text).join("")
+    } else {
+      answer = JSON.parse(raw).content.filter(block => block.type === "text").map(block => block.text).join("")
+    }
+    const metric = telemetryStore.getRecent({ limit: 1 })[0]
+    const active = readSessionStoreSnapshot()[key]
+    assert(active?.claudeSessionId, "response did not publish a durable mapping")
+    assert.notEqual(active.claudeSessionId, sourceId, "source transcript was reused in place")
+    const activeMessages = await getSessionMessages(active.claudeSessionId, { dir: root })
+    assert(activeMessages.length > 0, "supported SDK history is empty")
+    if (mode === "ordinary") assert(activeMessages.filter(row => row.type === "user").length >= 2, "ordinary undo fell back to a fresh replay; rollback control is invalid")
+    const marker = gap ? changedMarker : missingAdjacent ? secondaryMarker : originalMarker
+    const inputHasMarker = activeMessages.some(row => row.type === "user" && JSON.stringify(row.message).includes(marker))
+    const expectedLineage = gap ? "new" : "undo"
+    console.log(JSON.stringify({ case: mode, stream,
+      lineage: metric?.lineageType, inputHasMarker, answerHasMarker: answer.includes(marker), answer }))
+    if (metric?.lineageType !== expectedLineage || !inputHasMarker || !answer.includes(marker)) {
+      problems.push(`${mode}: expected ${expectedLineage} with supplied marker in both SDK input and answer`)
+    }
+  }
+  assert.deepEqual(await getSessionMessages(sourceId, { dir: root }), sourceMessages, "rollback mutated the source")
+  assert.deepEqual(problems, [], "undo history regression")
+  console.log(`PASS: ordinary undo, edited intermediate history, and missing adjacent checkpoint (stream=${stream})`)
+} finally {
+  await instance.close()
+}

--- a/src/__tests__/concurrency-hardening.test.ts
+++ b/src/__tests__/concurrency-hardening.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
 import { installSdkMock } from "./sdkMock"
 import { installLoggerMock } from "./loggerMock"
 import { installMcpToolsMock } from "./mcpToolsMock"
@@ -69,7 +69,7 @@ installMcpToolsMock(() => ({
 
 const { createProxyServer } = await import("../proxy/server")
 const { telemetryStore } = await import("../telemetry")
-const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { AbortableSemaphore, resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
 
 // The SDK semaphore is a process-wide singleton cached on first use, so a file
 // that leaves one behind silently overrides the next file's maxConcurrent.
@@ -234,6 +234,26 @@ describe("queue telemetry under cancellation", () => {
 
     const queuedId = `cancelled-permit-${Date.now()}`
     const abort = new AbortController()
+    let queuedSemaphore: InstanceType<typeof AbortableSemaphore> | undefined
+    const acquire = AbortableSemaphore.prototype.acquire
+    const acquireSpy = spyOn(AbortableSemaphore.prototype, "acquire").mockImplementation(function (this: InstanceType<typeof AbortableSemaphore>, signal) {
+      const pending = acquire.call(this, signal)
+      if (this.snapshot.queued > 0) queuedSemaphore = this
+      return pending
+    })
+    // Exercise setup taking longer than the former 40 ms cancellation timer.
+    // A slow request body must not be mistaken for time spent in the SDK queue.
+    const delayedBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        setTimeout(() => {
+          controller.enqueue(new TextEncoder().encode(JSON.stringify({
+            model: "claude-sonnet-4-6", max_tokens: 64,
+            messages: [{ role: "user", content: "queued" }],
+          })))
+          controller.close()
+        }, 75)
+      },
+    })
     const queued = proxy.app.fetch(new Request("http://localhost/v1/messages", {
       method: "POST",
       headers: {
@@ -241,26 +261,37 @@ describe("queue telemetry under cancellation", () => {
         "x-opencode-session": `queued-${Date.now()}`,
         "x-request-id": queuedId,
       },
-      body: JSON.stringify({
-        model: "claude-sonnet-4-6", max_tokens: 64,
-        messages: [{ role: "user", content: "queued" }],
-      }),
+      body: delayedBody,
       signal: abort.signal,
     }))
 
-    await new Promise(resolve => setTimeout(resolve, 40))
-    abort.abort()
-    await Promise.resolve(queued).catch(() => undefined)
+    try {
+      // Synchronize on the real queue, not a guessed request-setup duration.
+      const deadline = Date.now() + 3000
+      while (!queuedSemaphore && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 5))
+      }
+      expect(queuedSemaphore?.snapshot).toEqual({ active: 1, queued: 1, limit: 1 })
+      // Ensure this wait spans the millisecond clock used by the metric.
+      await new Promise(resolve => setTimeout(resolve, 10))
+      abort.abort()
+      const response = await queued
+      expect(response.status).toBe(499)
 
-    const metric = metricFor(queuedId)
-    expect(metric).toBeDefined()
-    // The bug: wait time was credited only from a lease that an aborted
-    // acquire never produces, so the entire wait landed in proxyOverheadMs —
-    // the one number that is supposed to mean "the proxy is the bottleneck".
-    expect(metric!.sdkQueueWaitMs ?? 0).toBeGreaterThan(0)
-
-    control.release()
-    const holderRes = await holder
-    await holderRes.text()
+      const metric = metricFor(queuedId)
+      expect(metric).toBeDefined()
+      // An aborted acquire never produces a lease, but its queue time must
+      // still be measured separately from request setup / proxy overhead.
+      expect(metric!.sdkQueueWaitMs ?? 0).toBeGreaterThan(0)
+      expect(queuedSemaphore?.snapshot.queued).toBe(0)
+      expect(controls).toHaveLength(1)
+    } finally {
+      abort.abort()
+      acquireSpy.mockRestore()
+      control.release()
+      await queued
+      const holderRes = await holder
+      await holderRes.text()
+    }
   })
 })

--- a/src/__tests__/lineage-safety.test.ts
+++ b/src/__tests__/lineage-safety.test.ts
@@ -213,9 +213,12 @@ describe("lineage safety: golden verdict matrix", () => {
       .join("\n")
 
     // R=continuation (resume)  C=compaction (resume)  U=undo (fork)  D=diverged (replay)
+    // These former undo cases either end with an edited assistant message or
+    // truncate to an unchanged prefix with no replacement user turn. Neither
+    // permits the last-user-only rollback delivery (#817).
     const expected = `stored=2 churn=none gap=0 => D
 stored=2 churn=@0 gap=0 => D
-stored=2 churn=@1 gap=0 => U
+stored=2 churn=@1 gap=0 => D
 stored=2 churn=none gap=1 => R
 stored=2 churn=@0 gap=1 => D
 stored=2 churn=@1 gap=1 => D
@@ -228,13 +231,13 @@ stored=2 churn=@1 gap=3 => D
 stored=2 churn=none gap=5 => R
 stored=2 churn=@0 gap=5 => D
 stored=2 churn=@1 gap=5 => D
-stored=2 shrink-to=1 => U
-stored=2 shrink-to=1 => U
+stored=2 shrink-to=1 => D
+stored=2 shrink-to=1 => D
 stored=4 churn=none gap=0 => D
 stored=4 churn=@0 gap=0 => D
 stored=4 churn=@1 gap=0 => D
 stored=4 churn=@2 gap=0 => D
-stored=4 churn=@3 gap=0 => U
+stored=4 churn=@3 gap=0 => D
 stored=4 churn=none gap=1 => R
 stored=4 churn=@0 gap=1 => D
 stored=4 churn=@1 gap=1 => D
@@ -255,15 +258,15 @@ stored=4 churn=@0 gap=5 => D
 stored=4 churn=@1 gap=5 => D
 stored=4 churn=@2 gap=5 => D
 stored=4 churn=@3 gap=5 => D
-stored=4 shrink-to=1 => U
-stored=4 shrink-to=2 => U
+stored=4 shrink-to=1 => D
+stored=4 shrink-to=2 => D
 stored=6 churn=none gap=0 => D
 stored=6 churn=@0 gap=0 => D
 stored=6 churn=@1 gap=0 => D
 stored=6 churn=@2 gap=0 => D
 stored=6 churn=@3 gap=0 => D
 stored=6 churn=@4 gap=0 => D
-stored=6 churn=@5 gap=0 => U
+stored=6 churn=@5 gap=0 => D
 stored=6 churn=none gap=1 => R
 stored=6 churn=@0 gap=1 => C
 stored=6 churn=@1 gap=1 => C
@@ -292,8 +295,8 @@ stored=6 churn=@2 gap=5 => C
 stored=6 churn=@3 gap=5 => C
 stored=6 churn=@4 gap=5 => D
 stored=6 churn=@5 gap=5 => D
-stored=6 shrink-to=1 => U
-stored=6 shrink-to=3 => U
+stored=6 shrink-to=1 => D
+stored=6 shrink-to=3 => D
 stored=6 compaction => D
 stored=8 churn=none gap=0 => D
 stored=8 churn=@0 gap=0 => D
@@ -303,7 +306,7 @@ stored=8 churn=@3 gap=0 => D
 stored=8 churn=@4 gap=0 => D
 stored=8 churn=@5 gap=0 => D
 stored=8 churn=@6 gap=0 => D
-stored=8 churn=@7 gap=0 => U
+stored=8 churn=@7 gap=0 => D
 stored=8 churn=none gap=1 => R
 stored=8 churn=@0 gap=1 => C
 stored=8 churn=@1 gap=1 => C
@@ -340,8 +343,8 @@ stored=8 churn=@4 gap=5 => C
 stored=8 churn=@5 gap=5 => C
 stored=8 churn=@6 gap=5 => D
 stored=8 churn=@7 gap=5 => D
-stored=8 shrink-to=1 => U
-stored=8 shrink-to=4 => U
+stored=8 shrink-to=1 => D
+stored=8 shrink-to=4 => D
 stored=8 compaction => D
 unrelated history => D`
 

--- a/src/__tests__/lineage-unit.test.ts
+++ b/src/__tests__/lineage-unit.test.ts
@@ -309,8 +309,8 @@ describe("verifyLineage", () => {
     expect(result.type).toBe("continuation")
   })
 
-  it("returns undo when same count but last message replaced", () => {
-    // Same message count with last message changed = user replaced last message (undo + retype)
+  it("replays a replacement assistant tail instead of dropping it", () => {
+    // An assistant-tail rewrite is not a new user turn to send after rollback.
     const msgs = [
       msg("user", "a"), msg("assistant", "b"),
       msg("user", "c"), msg("assistant", "d"),
@@ -322,13 +322,13 @@ describe("verifyLineage", () => {
       messageHashes: hashes,
       sdkMessageUuids: [null, "uuid-1", null, "uuid-2"],
     })
-    // Same count, but last message changed — this is undo + new message
+    // The replacement assistant content must survive the replay.
     const modified = [
       msg("user", "a"), msg("assistant", "b"),
       msg("user", "c"), msg("assistant", "d-modified"),
     ]
     const result = verifyLineage(session, modified)
-    expect(result.type).toBe("undo")
+    expect(result).toMatchObject({ type: "diverged", reason: "undo-gap" })
   })
 
   it("returns undo when fewer messages", () => {

--- a/src/__tests__/proxy-undo-gap.test.ts
+++ b/src/__tests__/proxy-undo-gap.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+import { assistantMessage, messageStart, textBlockStart, textDelta, blockStop, messageDelta, messageStop, withMockSdkSessionId } from "./helpers"
+
+type QueryInput = { prompt: unknown; options?: { sessionId?: string; resume?: string; resumeSessionAt?: string } }
+let captured: QueryInput[] = []
+installSdkMock(() => ({
+  query: (input: QueryInput) => {
+    captured.push(input)
+    return (async function* () {
+      for (const message of [messageStart(), textBlockStart(0), textDelta(0, "ok"), blockStop(0), messageDelta(), messageStop(), assistantMessage([{ type: "text", text: "ok" }])]) {
+        yield withMockSdkSessionId(message, input.options)
+      }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}), "proxy-undo-gap.test.ts")
+installLoggerMock(() => ({ claudeLog: () => {}, withClaudeLogContext: (_context: unknown, fn: () => unknown) => fn() }))
+installMcpToolsMock(() => ({ createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }) }))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { storeSession } = await import("../proxy/session/cache")
+const { diagnosticLog } = await import("../telemetry")
+const original = Array.from({ length: 9 }, (_, index) => ({
+  role: index % 2 === 0 ? "user" : "assistant", content: `original ${index}`,
+}))
+
+describe("undo gap delivery over HTTP (#817)", () => {
+  beforeEach(() => { captured = []; clearSessionCache(); diagnosticLog.clear() })
+  for (const stream of [false, true]) {
+    for (const gap of [false, true]) {
+      it(`${gap ? "replays the edited intermediate turns" : "keeps ordinary rollback tail-only"} (stream=${stream})`, async () => {
+        const key = `undo-gap-${crypto.randomUUID()}`
+        storeSession(key, original, "sdk-source", undefined,
+          original.map((message, index) => message.role === "assistant" ? `uuid-${index}` : null))
+        const tail = { role: "user", content: "What is the marker?" }
+        const messages = gap
+          ? [...original.slice(0, 4), { role: "user", content: "The new marker is INDIGO_817" },
+            { role: "assistant", content: "Acknowledged the replacement" }, tail]
+          : [...original.slice(0, 4), tail]
+        const { app } = createProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+        const response = await app.fetch(new Request("http://localhost/v1/messages", {
+          method: "POST", headers: { "Content-Type": "application/json", "x-opencode-session": key },
+          body: JSON.stringify({ model: "haiku", stream, messages }),
+        }))
+        expect(response.status).toBe(200)
+        const body = await response.text()
+        if (stream) {
+          expect(body).toContain("event: message_stop")
+          expect(body).not.toContain("event: error")
+        }
+        expect(captured).toHaveLength(1)
+        expect(typeof captured[0]!.prompt).toBe("string")
+        if (gap) {
+          expect(captured[0]!.options?.resume).toBeUndefined()
+          expect(captured[0]!.options?.resumeSessionAt).toBeUndefined()
+          expect(captured[0]!.prompt).toContain("INDIGO_817")
+          expect(captured[0]!.prompt).toContain("Acknowledged the replacement")
+          expect(captured[0]!.prompt).toContain("original 0")
+          const diagnostics = diagnosticLog.getRecent().map(entry => entry.message).join("\n")
+          expect(diagnostics).toContain("reason=undo-gap")
+          expect(diagnostics).not.toContain("INDIGO_817")
+        } else {
+          expect(captured[0]!.options?.resume).toBe("sdk-source")
+          expect(captured[0]!.options?.resumeSessionAt).toBe("uuid-3")
+          expect(captured[0]!.prompt).toBe(tail.content)
+        }
+      })
+    }
+  }
+})

--- a/src/__tests__/undo-gap.test.ts
+++ b/src/__tests__/undo-gap.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test"
+import { computeLineageHash, computeMessageHashes, verifyLineage, type SessionState } from "../proxy/session/lineage"
+
+const original = Array.from({ length: 9 }, (_, index) => ({
+  role: index % 2 === 0 ? "user" : "assistant",
+  content: `original ${index}`,
+}))
+const cached: SessionState = {
+  claudeSessionId: "source", lastAccess: 0, messageCount: original.length,
+  lineageHash: computeLineageHash(original), messageHashes: computeMessageHashes(original),
+  sdkMessageUuids: original.map((message, index) => message.role === "assistant" ? `uuid-${index}` : null),
+}
+
+describe("undo delivery proof (#817)", () => {
+  for (const count of [7, 9]) {
+    it(`replays ${count} messages when edits begin before the final user turn`, () => {
+      const incoming = [...original.slice(0, 4), ...original.slice(4, count).map(message => ({
+        ...message, content: `edited ${message.content}`,
+      }))]
+      expect(verifyLineage(cached, incoming)).toMatchObject({
+        type: "diverged", reason: "undo-gap", prefixOverlap: 4,
+        mismatch: { index: 4, storedCount: 9, incomingCount: count },
+      })
+    })
+  }
+
+  it("does not silently replace a final assistant turn with an earlier user turn", () => {
+    expect(verifyLineage(cached, [...original.slice(0, 2), { role: "assistant", content: "revised assistant" }]))
+      .toMatchObject({ type: "diverged", reason: "undo-gap" })
+  })
+
+  it("retains ordinary undo at the adjacent assistant checkpoint", () => {
+    expect(verifyLineage(cached, [...original.slice(0, 4), { role: "user", content: "replacement question" }]))
+      .toMatchObject({ type: "undo", prefixOverlap: 4, rollbackUuid: "uuid-3" })
+  })
+
+  it("does not roll back farther when the adjacent checkpoint UUID is missing", () => {
+    const missingAdjacent = { ...cached, sdkMessageUuids: [null, "uuid-1", null, null] }
+    expect(verifyLineage(missingAdjacent, [...original.slice(0, 4), { role: "user", content: "replacement question" }]))
+      .toMatchObject({ type: "undo", prefixOverlap: 4, rollbackUuid: undefined })
+  })
+})

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -256,11 +256,12 @@ function classifyLineage(
     const msg = `Undo detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap}/${state.messageCount}, rollback UUID: ${result.rollbackUuid || "none (legacy session)"}.`
     console.error(`[PROXY] ${msg}`)
     diagnosticLog.lineage(msg)
-  } else if (result.type === "diverged" && result.reason === "modified-history") {
+  } else if (result.type === "diverged" && (result.reason === "modified-history" || result.reason === "undo-gap")) {
     // The overlap count alone is not actionable — name the message that broke,
     // which verifyLineage already worked out to reach this branch.
     const detail = result.mismatch ? formatLineageMismatch(result.mismatch) : undefined
     const msg = `Stale session detected (key=${cacheKey.slice(0, 8)}…): prefix overlap ${result.prefixOverlap || 0}/${state.messageCount}, incoming ${messages.length} msgs. Starting fresh replay.`
+      + (result.reason === "undo-gap" ? " reason=undo-gap (rollback would omit supplied history)." : "")
       + (detail ? `\n  ${detail}` : "")
     console.error(`[PROXY] ${msg}`)
     diagnosticLog.lineage(msg)

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -117,14 +117,15 @@ export type LineageResult =
   | { type: "compaction";   session: SessionState; resumeFrom: number; suffixOverlap: number }
   | { type: "undo";         session: SessionState; prefixOverlap: number; rollbackUuid: string | undefined }
   | { type: "diverged";     reason: LineageDivergenceReason; prefixOverlap?: number;
-      /** Which message stopped matching. Present for modified-history, the
-       *  only divergence where the answer is both knowable and useful. */
+      /** Which message stopped matching, when available for a history rewrite
+       *  or an unsafe undo boundary. */
       mismatch?: LineageMismatch }
 
 export type LineageDivergenceReason =
   | "unverifiable"
   | "replayed-request"
   | "modified-history"
+  | "undo-gap"
   | "unrelated-history"
   | "not-found"
   | "independent-request"
@@ -531,16 +532,19 @@ export function verifyLineage(
   // after a cached message changed, the old SDK session cannot prove it has
   // the intervening history; that case is handled as divergence below.
   if (prefixOverlap > 0 && suffixOverlap === 0 && messages.length <= cached.messageCount) {
-    // Find the SDK UUID at the last matching position.
-    let rollbackUuid: string | undefined
-    if (cached.sdkMessageUuids) {
-      for (let i = prefixOverlap - 1; i >= 0; i--) {
-        if (cached.sdkMessageUuids[i]) {
-          rollbackUuid = cached.sdkMessageUuids[i]!
-          break
-        }
+    // Undo delivery sends only the final user message. Everything preceding
+    // it must therefore be covered by the preserved prefix; edited intermediate
+    // turns would otherwise be absent from both the fork and its input (#817).
+    if (prefixOverlap !== messages.length - 1 || messages.at(-1)?.role !== "user") {
+      return {
+        type: "diverged", reason: "undo-gap", prefixOverlap,
+        mismatch: describeLineageMismatch(cached, messages, incomingHashes),
       }
     }
+    // The UUID must cover that entire prefix too. An older checkpoint would
+    // silently omit the matching turns after it. With no adjacent UUID the
+    // existing undo-without-rollback path safely replays the full history.
+    const rollbackUuid = cached.sdkMessageUuids?.[prefixOverlap - 1] || undefined
     return { type: "undo", session: cached, prefixOverlap, rollbackUuid }
   }
 


### PR DESCRIPTION
Undo previously resumed at a matching prefix and delivered only the final user message even when the request contained edited intermediate turns. Those turns disappeared from the SDK input. Require the preserved prefix to cover every message before the final user turn, and replay the full request otherwise. If the adjacent rollback UUID is unavailable, use the existing full-replay fallback instead of an older checkpoint that omits intervening turns.

Adds content-free `undo-gap` diagnostics, five pure regression tests, four HTTP cases, and a repeatable real-SDK E2E gate. Ordinary undo retains its rollback behavior; unsafe boundaries incur a fresh replay to preserve the supplied history.

Validation:
- Before the fix, the canonical-path real-SDK fixture returned the original fact after the request supplied an edited intermediate fact; the revised fact was absent from SDK input. Four new pure regression cases also failed.
- After the fix, ordinary undo, edited intermediate history, and a missing adjacent UUID pass with real Claude Max in both streaming and non-streaming modes. The gate checks SDK input, model answers, an actual ordinary rollback, and source-session immutability. Its source session is created through supported SDK APIs and seeded into Meridian with valid historical UUIDs.
- All four E41 passthrough combinations pass: sequential/parallel tool calls, streaming/non-streaming.
- `npm test`: 3,306 passed, one existing skip, zero failures. `npm run typecheck` and `npm run build` passed.

CI also exposed an existing test race: the cancellation test assumed request setup finished within 40 ms. A separate test-only commit reproduces it with a 75 ms delayed body, waits for actual SDK queue admission before cancelling, and always releases the holder. The delayed case failed before that correction and passes afterward. The final full local suite again passes all 3,306 tests (one existing skip).

Fixes #817.
