### PR TITLE
fix: resume Claude Code trailing system turns

### DIFF
--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -165,6 +165,25 @@ async function post(app: any, body: any, sessionHeader = "es-session", extraHead
   }))
 }
 
+/** Live Claude Code request: session identity in metadata.user_id, claude-cli
+ * UA, and no x-opencode-session header. */
+async function postClaudeCode(app: any, body: any, sessionId: string, extraHeaders: Record<string, string> = {}) {
+  usedSessionKeys.add(sessionId)
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "user-agent": "claude-cli/2.1.259",
+      ...extraHeaders,
+    },
+    body: JSON.stringify({
+      metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+      ...body,
+    }),
+  }))
+}
+
 describe("Integration: passthrough early stop", () => {
   let app: any
   let savedPassthrough: string | undefined
@@ -1130,6 +1149,112 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resumeSessionAt).toBe(visibleToolTurn.uuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(hiddenDigestTurn.uuid)
     expect(capturedQueryParams.options.forkSession).toBe(true)
+  })
+
+  // Live claude-cli 2.1.259 closes its tool-result delta with a trailing
+  // system-role reminder turn (assistant[tool_use] -> user[tool_result] ->
+  // system[text], a <total_tokens>-style message). The generic helpers
+  // reject role=system, which forced a full fresh replay; the claude-code
+  // opt-in must resume the checkpoint and deliver the reminder as
+  // unprivileged user text.
+  it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
+    const sessionId = `cc-delta-${TEST_RUN_ID}`
+    const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
+    const trailingSystemText = "<system-reminder>Total tokens: 4151</system-reminder>"
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1: initial user turn plus the system prompt as a text block with
+    // cache_control — the captured request1 shape.
+    mockMessages = [
+      messageStart("msg_cc_delta_1"),
+      toolUseBlockStart(0, "read", "cc-delta-tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("cc-delta-tu1"),
+      assistantMessage([{ type: "text", text: "CC_DELTA_GARBAGE_DIGEST" }]),
+    ]
+    const first = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId)
+    expect(first.status).toBe(200)
+    expect(await first.text()).not.toContain("CC_DELTA_GARBAGE_DIGEST")
+    let stored: any
+    for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
+      stored = lookupSharedSession(sessionId)
+      if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-tu1"])
+    expect(stored?.passthroughToolCallAssistantUuid).toBe(toolTurn.uuid)
+
+    // Turn 2: same prefix with the SAME system as an equivalent plain string
+    // (the representation flip lineage canonicalizes), then the exact live
+    // delta: echoed tool_use, real tool_result, trailing system reminder.
+    mockMessages = [
+      messageStart("msg_cc_delta_2"),
+      textBlockStart(0),
+      textDelta(0, "the file says hi"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "the file says hi" }]),
+    ]
+    const requestId = `cc-delta-turn2-${TEST_RUN_ID}`
+    const second = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: initialSystemText },
+        { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: trailingSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId, { "x-request-id": requestId })
+    expect(second.status).toBe(200)
+    const secondBody = await second.text()
+    expect(secondBody).toContain("message_stop")
+    expect(secondBody).toContain("the file says hi")
+    expect(secondBody).not.toContain("CC_DELTA_GARBAGE_DIGEST")
+
+    // Resumed at the exact assistant checkpoint — not a fresh replay.
+    const resumed = capturedQueryParamsAll[1]
+    expect(resumed.options.resume).toBe(initialManagedSessionId())
+    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+    expect(resumed.options.forkSession).toBe(true)
+    // No fresh-replay framing; the reminder never reaches the SDK system prompt.
+    expect(secondBody).not.toContain("conversation_history")
+    expect(JSON.stringify(resumed.options.systemPrompt ?? "")).not.toContain(trailingSystemText)
+    // SDK prompt is exactly the native tool_result then the reminder as
+    // ordinary user text, with cache_control stripped.
+    expect(typeof resumed.prompt).not.toBe("string")
+    const promptMessages: any[] = []
+    for await (const message of resumed.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "cc-delta-tu1", content: "hi" },
+      { type: "text", text: trailingSystemText },
+    ])
+
+    let row: any
+    for (let i = 0; i < 500 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
+      if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(row).toBeDefined()
+    expect(row!.isResume).toBe(true)
   })
 
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1151,13 +1151,12 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
-  // Captured claude-cli 2.1.259 with mid-conversation-system enabled closes
-  // its tool-result delta with a trailing system-role reminder turn
-  // (assistant[tool_use] -> user[tool_result] -> system[text]). Newer
-  // clients (2.1.261) embed the reminder in the user tool_result and need
-  // no opt-in. The generic helpers reject role=system, which forced a full
-  // fresh replay; the opt-in must resume the checkpoint and deliver the
-  // reminder as unprivileged user text.
+  // Captured from claude-cli with mid-conversation-system enabled (2.1.259
+  // in staging; reproduced on 2.1.261): the client closes its tool-result
+  // delta with a trailing system-role reminder turn (assistant[tool_use] ->
+  // user[tool_result] -> system[text]). The generic helpers reject
+  // role=system, which forced a full fresh replay; the opt-in must resume
+  // the checkpoint and deliver the reminder as unprivileged user text.
   it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
     const sessionId = `cc-delta-${TEST_RUN_ID}`
     const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
@@ -1256,6 +1255,134 @@ describe("Integration: passthrough early stop", () => {
     }
     expect(row).toBeDefined()
     expect(row!.isResume).toBe(true)
+  })
+
+  // Fail-closed twin of the accepted shape above: a SECOND trailing system
+  // message breaks the one-reminder contract, so the whole continuation
+  // must fail closed to a fresh replay — no resume options at all.
+  it("stream: two trailing system reminders fail closed to a fresh replay", async () => {
+    const sessionId = `cc-delta-fc-${TEST_RUN_ID}`
+    const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
+    const firstReminder = "<system-reminder>Total tokens: 4151</system-reminder>"
+    const secondReminder = "<system-reminder>Context low</system-reminder>"
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "cc-delta-fc-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1 mirrors the accepted test: arm the checkpoint.
+    mockMessages = [
+      messageStart("msg_cc_delta_fc_1"),
+      toolUseBlockStart(0, "read", "cc-delta-fc-tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("cc-delta-fc-tu1"),
+      assistantMessage([{ type: "text", text: "CC_DELTA_FC_GARBAGE_DIGEST" }]),
+    ]
+    const first = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId)
+    expect(first.status).toBe(200)
+    await first.text()
+    let stored: any
+    for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
+      stored = lookupSharedSession(sessionId)
+      if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-fc-tu1"])
+
+    // Turn 2: the accepted delta, but with TWO trailing system messages.
+    mockMessages = [
+      messageStart("msg_cc_delta_fc_2"),
+      textBlockStart(0),
+      textDelta(0, "fresh replay answer"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "fresh replay answer" }]),
+    ]
+    const requestId = `cc-delta-fc-turn2-${TEST_RUN_ID}`
+    const second = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: initialSystemText },
+        { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-fc-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-fc-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: firstReminder }] },
+        { role: "system", content: [{ type: "text", text: secondReminder }] },
+      ],
+    }, sessionId, { "x-request-id": requestId })
+    expect(second.status).toBe(200)
+    expect(await second.text()).toContain("message_stop")
+
+    // Checkpoint rejected → fresh structured replay: no resume options at all,
+    // and neither reminder reaches the SDK system prompt.
+    const replayed = capturedQueryParamsAll[1]
+    expect(replayed.options.resume).toBeUndefined()
+    expect(replayed.options.resumeSessionAt).toBeUndefined()
+    expect(JSON.stringify(replayed.options.systemPrompt ?? "")).not.toContain(firstReminder)
+    expect(JSON.stringify(replayed.options.systemPrompt ?? "")).not.toContain(secondReminder)
+
+    let row: any
+    for (let i = 0; i < 500 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
+      if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(row).toBeDefined()
+    expect(row!.isResume).toBe(false)
+  })
+
+  // The gate lives in server.ts, not in the helper default: the exact wire
+  // shape the claude-code adapter accepts must stay a fresh replay on any
+  // other adapter, which never passes the opt-in.
+  it("stream: non-claude-code adapters never opt in — reminder shape stays a fresh replay", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "oc-gate-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1 through the generic OpenCode adapter: arm the checkpoint.
+    mockMessages = [toolTurn, userDenyMessage("oc-gate-tu1")]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read gate x" }],
+    }, "es-oc-gate")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    // Turn 2: the exact accepted shape (echo, result, one trailing system
+    // reminder) — but the x-opencode-session adapter carries no opt-in.
+    mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read gate x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "oc-gate-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "oc-gate-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: "<system-reminder>Tokens: 4151</system-reminder>" }] },
+      ],
+    }, "es-oc-gate")
+    expect(second.status).toBe(200)
+    await second.text()
+    expect(capturedQueryParamsAll[1].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
   })
 
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1151,12 +1151,13 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
-  // Live claude-cli 2.1.259 closes its tool-result delta with a trailing
-  // system-role reminder turn (assistant[tool_use] -> user[tool_result] ->
-  // system[text], a <total_tokens>-style message). The generic helpers
-  // reject role=system, which forced a full fresh replay; the claude-code
-  // opt-in must resume the checkpoint and deliver the reminder as
-  // unprivileged user text.
+  // Captured claude-cli 2.1.259 with mid-conversation-system enabled closes
+  // its tool-result delta with a trailing system-role reminder turn
+  // (assistant[tool_use] -> user[tool_result] -> system[text]). Newer
+  // clients (2.1.261) embed the reminder in the user tool_result and need
+  // no opt-in. The generic helpers reject role=system, which forced a full
+  // fresh replay; the opt-in must resume the checkpoint and deliver the
+  // reminder as unprivileged user text.
   it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
     const sessionId = `cc-delta-${TEST_RUN_ID}`
     const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1151,12 +1151,10 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
-  // Captured from claude-cli with mid-conversation-system enabled (2.1.259
-  // in staging; reproduced on 2.1.261): the client closes its tool-result
-  // delta with a trailing system-role reminder turn (assistant[tool_use] ->
-  // user[tool_result] -> system[text]). The generic helpers reject
-  // role=system, which forced a full fresh replay; the opt-in must resume
-  // the checkpoint and deliver the reminder as unprivileged user text.
+  // claude-cli with mid-conversation-system on ends a tool-result delta with a
+  // trailing system reminder (assistant[tool_use] -> user[tool_result] ->
+  // system[text]); the generic helpers reject role=system and forced a fresh
+  // replay. The opt-in must resume and deliver the reminder as user text.
   it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
     const sessionId = `cc-delta-${TEST_RUN_ID}`
     const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
@@ -1165,8 +1163,7 @@ describe("Integration: passthrough early stop", () => {
       { type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } },
     ])
 
-    // Turn 1: initial user turn plus the system prompt as a text block with
-    // cache_control — the captured request1 shape.
+    // Turn 1: system prompt as a cached text block, as claude-cli sends it.
     mockMessages = [
       messageStart("msg_cc_delta_1"),
       toolUseBlockStart(0, "read", "cc-delta-tu1"),
@@ -1197,9 +1194,8 @@ describe("Integration: passthrough early stop", () => {
     expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-tu1"])
     expect(stored?.passthroughToolCallAssistantUuid).toBe(toolTurn.uuid)
 
-    // Turn 2: same prefix with the SAME system as an equivalent plain string
-    // (the representation flip lineage canonicalizes), then the exact live
-    // delta: echoed tool_use, real tool_result, trailing system reminder.
+    // Turn 2: the same system prompt as a plain string (lineage canonicalizes
+    // the flip), then echo, tool_result, trailing reminder.
     mockMessages = [
       messageStart("msg_cc_delta_2"),
       textBlockStart(0),
@@ -1237,8 +1233,7 @@ describe("Integration: passthrough early stop", () => {
     // No fresh-replay framing; the reminder never reaches the SDK system prompt.
     expect(secondBody).not.toContain("conversation_history")
     expect(JSON.stringify(resumed.options.systemPrompt ?? "")).not.toContain(trailingSystemText)
-    // SDK prompt is exactly the native tool_result then the reminder as
-    // ordinary user text, with cache_control stripped.
+    // SDK input: native tool_result, then the reminder as plain user text, cache_control stripped.
     expect(typeof resumed.prompt).not.toBe("string")
     const promptMessages: any[] = []
     for await (const message of resumed.prompt) promptMessages.push(message)
@@ -1257,9 +1252,8 @@ describe("Integration: passthrough early stop", () => {
     expect(row!.isResume).toBe(true)
   })
 
-  // Fail-closed twin of the accepted shape above: a SECOND trailing system
-  // message breaks the one-reminder contract, so the whole continuation
-  // must fail closed to a fresh replay — no resume options at all.
+  // Fail-closed twin: a second trailing system breaks the one-reminder
+  // contract, so the continuation must fall back to a fresh replay.
   it("stream: two trailing system reminders fail closed to a fresh replay", async () => {
     const sessionId = `cc-delta-fc-${TEST_RUN_ID}`
     const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
@@ -1327,8 +1321,7 @@ describe("Integration: passthrough early stop", () => {
     expect(second.status).toBe(200)
     expect(await second.text()).toContain("message_stop")
 
-    // Checkpoint rejected → fresh structured replay: no resume options at all,
-    // and neither reminder reaches the SDK system prompt.
+    // Rejected checkpoint: fresh replay, no resume options, reminders kept out of the system prompt.
     const replayed = capturedQueryParamsAll[1]
     expect(replayed.options.resume).toBeUndefined()
     expect(replayed.options.resumeSessionAt).toBeUndefined()
@@ -1344,9 +1337,8 @@ describe("Integration: passthrough early stop", () => {
     expect(row!.isResume).toBe(false)
   })
 
-  // The gate lives in server.ts, not in the helper default: the exact wire
-  // shape the claude-code adapter accepts must stay a fresh replay on any
-  // other adapter, which never passes the opt-in.
+  // The gate is the adapter check in server.ts: the same wire shape on any
+  // other adapter gets no opt-in and stays a fresh replay.
   it("stream: non-claude-code adapters never opt in — reminder shape stays a fresh replay", async () => {
     const toolTurn = assistantMessage([
       { type: "tool_use", id: "oc-gate-tu1", name: "read", input: { file_path: "x" } },
@@ -1364,8 +1356,7 @@ describe("Integration: passthrough early stop", () => {
     expect(first.status).toBe(200)
     await first.text()
 
-    // Turn 2: the exact accepted shape (echo, result, one trailing system
-    // reminder) — but the x-opencode-session adapter carries no opt-in.
+    // Turn 2: the accepted shape, but this adapter carries no opt-in.
     mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
     const second = await post(app, {
       model: "claude-sonnet-4-5",

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -400,7 +400,7 @@ describe("claude-code trailing system delta", () => {
   })
   const opts = { allowClaudeCodeSystemDelta: true }
 
-  it("accepts the live delta: complete expected-ID echo, results, trailing reminder", () => {
+  it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
     // String and text-block-with-cache_control reminder forms pass through
     // as-is; cache_control is stripped by the caller's existing strip path.

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -387,3 +387,94 @@ describe("findCompleteToolResultCheckpoint", () => {
     expect(findCompleteToolResultCheckpoint([assistant, { role: "assistant", content: [result("a"), result("b")] }], ["a", "b"])).toBeUndefined()
   })
 })
+
+describe("claude-code trailing system delta", () => {
+  const result = (id: string, content: unknown = "ok") => ({ type: "tool_result", tool_use_id: id, content })
+  const echo = (ids: string[]) => ({
+    role: "assistant",
+    content: ids.map((id) => ({ type: "tool_use", id, name: "read", input: {} })),
+  })
+  const reminder = (text: string, cacheControl = false) => ({
+    role: "system",
+    content: [{ type: "text", text, ...(cacheControl ? { cache_control: { type: "ephemeral" } } : {}) }],
+  })
+  const opts = { allowClaudeCodeSystemDelta: true }
+
+  it("accepts the live delta: complete expected-ID echo, results, trailing reminder", () => {
+    const results = [result("t1"), result("t2")]
+    // String and text-block-with-cache_control reminder forms pass through
+    // as-is; cache_control is stripped by the caller's existing strip path.
+    const cases: Array<[{ role: string; content: unknown }, unknown]> = [
+      [{ role: "system", content: "<total_tokens> 4151" }, { type: "text", text: "<total_tokens> 4151" }],
+      [reminder("<total_tokens> 4151", true), { type: "text", text: "<total_tokens> 4151", cache_control: { type: "ephemeral" } }],
+    ]
+    for (const [tail, expectedBlock] of cases) {
+      expect(coalesceCompleteToolResultContinuation(
+        [echo(["t1", "t2"]), { role: "user", content: results }, tail],
+        ["t1", "t2"],
+        opts,
+      )).toEqual([{ role: "user", content: [...results, expectedBlock] }])
+    }
+  })
+
+  it("delivers the reminder after results and queued user content, in wire order", () => {
+    const queuedText = { type: "text", text: "continue" }
+    const queuedImage = { type: "image", source: { type: "base64", data: "abc" } }
+    expect(coalesceCompleteToolResultContinuation(
+      [echo(["t1"]), { role: "user", content: [result("t1")] }, { role: "user", content: [queuedText, queuedImage] }, reminder("reminder")],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), queuedText, queuedImage, { type: "text", text: "reminder" }] }])
+  })
+
+  it("rejects the reminder-bearing delta without the opt-in (generic default)", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [echo(["t1"]), { role: "user", content: [result("t1")], }, reminder("reminder")],
+      ["t1"],
+    )).toBeUndefined()
+  })
+
+  it("rejects leading, non-final, repeated, non-text, and empty reminders", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    for (const body of [
+      [reminder("leading"), ...delta], // leading (undemonstrated form)
+      [echo(["t1"]), reminder("non-final"), { role: "user", content: [result("t1")] }], // before results
+      [...delta, reminder("one"), reminder("two")], // repeated
+      [...delta, reminder("final"), { role: "user", content: "after" }], // message after reminder
+      [...delta, { role: "system", content: [{ type: "image", source: { type: "base64", data: "x" } }] }], // non-text block
+      [...delta, { role: "system", content: [{ type: "tool_result", tool_use_id: "t1", content: "x" }] }], // tool_result block
+      [...delta, { role: "system", content: [] }], // empty array
+      [...delta, { role: "system", content: [{ type: "text", text: "" }] }], // empty text
+      [...delta, { role: "system", content: "" }], // empty string
+    ]) {
+      expect(coalesceCompleteToolResultContinuation(body, ["t1"], opts)).toBeUndefined()
+    }
+  })
+
+  it("fails on incomplete or split echoes even with a trailing reminder", () => {
+    const cases: Array<[Array<{ role?: unknown; content?: unknown }>, string[]]> = [
+      [[{ role: "user", content: [result("t1")], }, reminder("r")], ["t1"]], // missing echo
+      [[echo(["t1", "t2"]), { role: "user", content: [result("t1")] }, reminder("r")], ["t1", "t2"]], // partial results
+      // Split echo across assistant messages: find never binds it, and the
+      // reminder-gated coalesce must reject it too.
+      [[echo(["t1"]), echo(["t2"]), { role: "user", content: [result("t1"), result("t2")] }, reminder("r")], ["t1", "t2"]],
+    ]
+    for (const [messages, ids] of cases) {
+      expect(coalesceCompleteToolResultContinuation(messages, ids, opts)).toBeUndefined()
+    }
+  })
+
+  it("find accepts the actual suffix under the opt-in; default stays rejected", () => {
+    const body = [
+      { role: "user", content: "history" },
+      echo(["a"]),
+      { role: "user", content: [result("a")] },
+      reminder("reminder", true),
+    ]
+    expect(findCompleteToolResultCheckpoint(body, ["a"], opts))
+      .toEqual([{ role: "user", content: [result("a"), { type: "text", text: "reminder", cache_control: { type: "ephemeral" } }] }])
+    // Without the opt-in the trailing reminder is a generic rejection — the
+    // observed staging transition to a full fresh replay.
+    expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
+  })
+})

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -402,8 +402,7 @@ describe("claude-code trailing system delta", () => {
 
   it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
-    // String and text-block-with-cache_control reminder forms pass through
-    // as-is; cache_control is stripped by the caller's existing strip path.
+    // cache_control is kept here; the caller strips it before the SDK.
     const cases: Array<[{ role: string; content: unknown }, unknown]> = [
       [{ role: "system", content: "<total_tokens> 4151" }, { type: "text", text: "<total_tokens> 4151" }],
       [reminder("<total_tokens> 4151", true), { type: "text", text: "<total_tokens> 4151", cache_control: { type: "ephemeral" } }],
@@ -455,8 +454,7 @@ describe("claude-code trailing system delta", () => {
     const cases: Array<[Array<{ role?: unknown; content?: unknown }>, string[]]> = [
       [[{ role: "user", content: [result("t1")], }, reminder("r")], ["t1"]], // missing echo
       [[echo(["t1", "t2"]), { role: "user", content: [result("t1")] }, reminder("r")], ["t1", "t2"]], // partial results
-      // Split echo across assistant messages: find never binds it, and the
-      // reminder-gated coalesce must reject it too.
+      // split echo: coalesce must reject it even though find never binds it
       [[echo(["t1"]), echo(["t2"]), { role: "user", content: [result("t1"), result("t2")] }, reminder("r")], ["t1", "t2"]],
     ]
     for (const [messages, ids] of cases) {
@@ -473,8 +471,6 @@ describe("claude-code trailing system delta", () => {
     ]
     expect(findCompleteToolResultCheckpoint(body, ["a"], opts))
       .toEqual([{ role: "user", content: [result("a"), { type: "text", text: "reminder", cache_control: { type: "ephemeral" } }] }])
-    // Without the opt-in the trailing reminder is a generic rejection — the
-    // observed staging transition to a full fresh replay.
     expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
   })
 
@@ -547,8 +543,7 @@ describe("claude-code trailing system delta", () => {
   })
 
   it("tolerates adjacent thinking/text blocks in the echoing assistant message", () => {
-    // Pins the echo-gate comment: only tool_use blocks bind the echo, so
-    // surrounding thinking/text blocks neither reject nor reach the output.
+    // only tool_use blocks bind the echo; thinking/text neither reject nor reach the output
     expect(coalesceCompleteToolResultContinuation(
       [
         { role: "assistant", content: [

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -398,7 +398,7 @@ describe("claude-code trailing system delta", () => {
     role: "system",
     content: [{ type: "text", text, ...(cacheControl ? { cache_control: { type: "ephemeral" } } : {}) }],
   })
-  const opts = { allowClaudeCodeSystemDelta: true }
+  const opts = { allowTrailingSystemReminder: true }
 
   it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
@@ -476,5 +476,91 @@ describe("claude-code trailing system delta", () => {
     // Without the opt-in the trailing reminder is a generic rejection — the
     // observed staging transition to a full fresh replay.
     expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
+  })
+
+  it("rejects a system message between two result turns", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        echo(["t1", "t2"]),
+        { role: "user", content: [result("t1")] },
+        reminder("mid-conversation"),
+        { role: "user", content: [result("t2")] },
+      ],
+      ["t1", "t2"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("rejects whitespace-only reminders in string and text-block form", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: "   " }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: [{ type: "text", text: "   " }] }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("accepts one reminder carrying two text blocks, both delivered in order", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        echo(["t1"]),
+        { role: "user", content: [result("t1")] },
+        { role: "system", content: [{ type: "text", text: "first" }, { type: "text", text: "second" }] },
+      ],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), { type: "text", text: "first" }, { type: "text", text: "second" }] }])
+  })
+
+  it("rejects object and number reminder content", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: { text: "shaped" } }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: 42 }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("rejects an echo carrying an extra unknown tool_use id alongside a valid reminder", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        { role: "assistant", content: [
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+          { type: "tool_use", id: "unknown-x", name: "read", input: {} },
+        ] },
+        { role: "user", content: [result("t1")] },
+        reminder("valid reminder"),
+      ],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("tolerates adjacent thinking/text blocks in the echoing assistant message", () => {
+    // Pins the echo-gate comment: only tool_use blocks bind the echo, so
+    // surrounding thinking/text blocks neither reject nor reach the output.
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", signature: "sig" },
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+          { type: "text", text: "Reading the file." },
+        ] },
+        { role: "user", content: [result("t1")] },
+        reminder("r"),
+      ],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), { type: "text", text: "r" }] }])
   })
 })

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -160,6 +160,25 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
 }
 
 /**
+ * Opt-in flags for the checkpoint continuation validators.
+ */
+export interface CompleteToolResultContinuationOptions {
+  /**
+   * NOTE: agent-specific (claude-code) — live claude-cli closes its
+   * tool-result delta with a trailing `system` reminder turn
+   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
+   * `<total_tokens>`-style mid-conversation-system message). The generic
+   * Anthropic contract has no system role in `messages`, so that shape is
+   * admitted only under this explicit opt-in, only as the final message of
+   * the delta, and only with a single assistant echo carrying the complete
+   * exact expected ID set. The reminder is delivered as unprivileged user
+   * text after the results and any queued user content — never dropped,
+   * never escalated to an SDK system prompt.
+   */
+  allowClaudeCodeSystemDelta?: boolean
+}
+
+/**
  * Verify that a resumed tool-result delta settles exactly the tool calls at the
  * stored assistant checkpoint, then coalesce queued user turns into one SDK
  * input. Tool results must precede any ordinary user content, matching the
@@ -167,7 +186,8 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export function coalesceCompleteToolResultContinuation(
   messages: Array<{ role?: unknown; content?: unknown }>,
-  expectedIds: readonly string[]
+  expectedIds: readonly string[],
+  options?: CompleteToolResultContinuationOptions,
 ): Array<{ role: "user"; content: unknown[] }> | undefined {
   if (expectedIds.length === 0 || messages.length === 0) return undefined
   const expected = new Set(expectedIds)
@@ -176,8 +196,39 @@ export function coalesceCompleteToolResultContinuation(
   const content: unknown[] = []
   let sawUser = false
   let sawNonToolResult = false
+  let sawTrailingSystem = false
+  let systemTextBlocks: unknown[] = []
+  let echoMessages = 0
 
   for (const message of messages) {
+    // NOTE: agent-specific (claude-code) — the captured live shape carries
+    // exactly one trailing system reminder AFTER the result batch; nothing
+    // may follow it, and leading/late/repeated reminders fail closed.
+    // Without the opt-in this branch is dead and the generic rejection
+    // below applies.
+    if (message.role === "system") {
+      if (!options?.allowClaudeCodeSystemDelta) return undefined
+      if (!sawUser || sawTrailingSystem) return undefined
+      sawTrailingSystem = true
+      if (typeof message.content === "string") {
+        if (message.content.length === 0) return undefined
+        systemTextBlocks.push({ type: "text", text: message.content })
+        continue
+      }
+      if (Array.isArray(message.content)) {
+        for (const rawBlock of message.content) {
+          const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
+          if (block?.type !== "text" || typeof block.text !== "string" || block.text.length === 0) return undefined
+          // Pass blocks through untouched; cache_control is stripped by the
+          // caller's existing strip path before the SDK sees the prompt.
+          systemTextBlocks.push(block)
+        }
+        if (systemTextBlocks.length === 0) return undefined
+        continue
+      }
+      return undefined
+    }
+    if (sawTrailingSystem) return undefined
     // The client echoes the just-produced assistant tool_use before its user
     // result. That assistant turn already exists at resumeSessionAt, so the
     // structured SDK delta below intentionally filters it out.
@@ -193,6 +244,7 @@ export function coalesceCompleteToolResultContinuation(
         }
       }
       if (!sawToolUse) return undefined
+      echoMessages++
       continue
     }
     if (message.role !== "user") return undefined
@@ -223,6 +275,14 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
+  // A system reminder is a live Claude Code delta only with a single
+  // assistant echo carrying the complete expected ID set; a split, partial,
+  // or absent echo proves nothing causal and the replay must stay fresh.
+  // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)
+  if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
+  // Delivered after the results and any queued user content, matching the
+  // wire order; nothing ever follows the reminder on the wire.
+  if (systemTextBlocks.length > 0) content.push(...systemTextBlocks)
   return [{ role: "user", content }]
 }
 
@@ -230,6 +290,7 @@ export function coalesceCompleteToolResultContinuation(
 export function findCompleteToolResultCheckpoint(
   messages: Array<{ role?: unknown; content?: unknown }>,
   expectedIds: readonly string[],
+  options?: CompleteToolResultContinuationOptions,
 ): Array<{ role: "user"; content: unknown[] }> | undefined {
   if (expectedIds.length === 0) return undefined
   const expected = new Set(expectedIds)
@@ -247,7 +308,7 @@ export function findCompleteToolResultCheckpoint(
     }
     if (malformed || ids.length !== expected.size || new Set(ids).size !== ids.length) continue
     if (!ids.every((id) => expected.has(id))) continue
-    return coalesceCompleteToolResultContinuation(messages.slice(index), expectedIds)
+    return coalesceCompleteToolResultContinuation(messages.slice(index), expectedIds, options)
   }
   return undefined
 }

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,16 +164,19 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — live claude-cli closes its
-   * tool-result delta with a trailing `system` reminder turn
-   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
-   * `<total_tokens>`-style mid-conversation-system message). The generic
-   * Anthropic contract has no system role in `messages`, so that shape is
-   * admitted only under this explicit opt-in, only as the final message of
-   * the delta, and only with a single assistant echo carrying the complete
-   * exact expected ID set. The reminder is delivered as unprivileged user
-   * text after the results and any queued user content — never dropped,
-   * never escalated to an SDK system prompt.
+   * NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
+   * mid-conversation-system enabled closes its tool-result delta with a
+   * trailing `system` reminder turn (`assistant[tool_use] ->
+   * user[tool_result] -> system[text]`, a `<total_tokens>`-style message).
+   * The generic Anthropic contract has no system role in `messages`, so
+   * that captured shape is admitted only under this explicit opt-in, only
+   * as the final message of the delta, and only with a single assistant
+   * echo carrying the complete exact expected ID set. The reminder is
+   * delivered as unprivileged user text after the results and any queued
+   * user content — never dropped, never escalated to an SDK system prompt.
+   * Newer clients (observed on 2.1.261) fold the reminder into the user
+   * tool_result instead and need no system-role opt-in — which is why this
+   * stays scoped to the captured shape.
    */
   allowClaudeCodeSystemDelta?: boolean
 }
@@ -201,11 +204,11 @@ export function coalesceCompleteToolResultContinuation(
   let echoMessages = 0
 
   for (const message of messages) {
-    // NOTE: agent-specific (claude-code) — the captured live shape carries
-    // exactly one trailing system reminder AFTER the result batch; nothing
-    // may follow it, and leading/late/repeated reminders fail closed.
-    // Without the opt-in this branch is dead and the generic rejection
-    // below applies.
+    // NOTE: agent-specific (claude-code) — the captured 2.1.259 shape
+    // carries exactly one trailing system reminder AFTER the result batch;
+    // nothing may follow it, and leading/late/repeated reminders fail
+    // closed. Without the opt-in this branch is dead and the generic
+    // rejection below applies.
     if (message.role === "system") {
       if (!options?.allowClaudeCodeSystemDelta) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
@@ -275,7 +278,7 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A system reminder is a live Claude Code delta only with a single
+  // A system reminder is a captured 2.1.259 delta only with a single
   // assistant echo carrying the complete expected ID set; a split, partial,
   // or absent echo proves nothing causal and the replay must stay fresh.
   // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,21 +164,23 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
-   * mid-conversation-system enabled closes its tool-result delta with a
-   * trailing `system` reminder turn (`assistant[tool_use] ->
-   * user[tool_result] -> system[text]`, a `<total_tokens>`-style message).
-   * The generic Anthropic contract has no system role in `messages`, so
-   * that captured shape is admitted only under this explicit opt-in, only
-   * as the final message of the delta, and only with a single assistant
-   * echo carrying the complete exact expected ID set. The reminder is
-   * delivered as unprivileged user text after the results and any queued
-   * user content — never dropped, never escalated to an SDK system prompt.
-   * Newer clients (observed on 2.1.261) fold the reminder into the user
-   * tool_result instead and need no system-role opt-in — which is why this
-   * stays scoped to the captured shape.
+   * NOTE: agent-specific (claude-code) — with Claude Code's
+   * `mid-conversation-system` feature enabled (beta
+   * `mid-conversation-system-2026-04-07`), claude-cli closes its
+   * tool-result delta with a trailing `system` reminder turn
+   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
+   * `<total_tokens>`-style message); observed on 2.1.259 and 2.1.261.
+   * With the feature off the same clients fold the reminder into the
+   * user tool_result and need no opt-in — the gate is the feature, not
+   * the version. The generic Anthropic contract has no system role in
+   * `messages`, so that shape is admitted only under this explicit
+   * opt-in, only as the final message of the delta, and only with a
+   * single assistant echo carrying the complete exact expected ID set.
+   * The reminder is delivered as unprivileged user text after the
+   * results and any queued user content — never dropped, never
+   * escalated to an SDK system prompt.
    */
-  allowClaudeCodeSystemDelta?: boolean
+  allowTrailingSystemReminder?: boolean
 }
 
 /**
@@ -200,28 +202,24 @@ export function coalesceCompleteToolResultContinuation(
   let sawUser = false
   let sawNonToolResult = false
   let sawTrailingSystem = false
-  let systemTextBlocks: unknown[] = []
+  const systemTextBlocks: unknown[] = []
   let echoMessages = 0
 
   for (const message of messages) {
-    // NOTE: agent-specific (claude-code) — the captured 2.1.259 shape
-    // carries exactly one trailing system reminder AFTER the result batch;
-    // nothing may follow it, and leading/late/repeated reminders fail
-    // closed. Without the opt-in this branch is dead and the generic
-    // rejection below applies.
+    // Opt-in trailing reminder: the admitted shape lives on the allowTrailingSystemReminder JSDoc above; without the opt-in this branch is dead and the generic rejection below applies.
     if (message.role === "system") {
-      if (!options?.allowClaudeCodeSystemDelta) return undefined
+      if (!options?.allowTrailingSystemReminder) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
       sawTrailingSystem = true
       if (typeof message.content === "string") {
-        if (message.content.length === 0) return undefined
+        if (message.content.trim().length === 0) return undefined
         systemTextBlocks.push({ type: "text", text: message.content })
         continue
       }
       if (Array.isArray(message.content)) {
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
-          if (block?.type !== "text" || typeof block.text !== "string" || block.text.length === 0) return undefined
+          if (block?.type !== "text" || typeof block.text !== "string" || block.text.trim().length === 0) return undefined
           // Pass blocks through untouched; cache_control is stripped by the
           // caller's existing strip path before the SDK sees the prompt.
           systemTextBlocks.push(block)
@@ -278,10 +276,10 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A system reminder is a captured 2.1.259 delta only with a single
-  // assistant echo carrying the complete expected ID set; a split, partial,
-  // or absent echo proves nothing causal and the replay must stay fresh.
-  // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)
+  // A reminder-bearing delta is admitted only behind a single assistant echo
+  // carrying the complete expected ID set; a split, partial, or absent echo
+  // proves nothing causal and the replay must stay fresh. (Adjacent
+  // thinking/text blocks stay tolerated, as without the reminder.)
   if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
   // Delivered after the results and any queued user content, matching the
   // wire order; nothing ever follows the reminder on the wire.

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,21 +164,13 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — with Claude Code's
-   * `mid-conversation-system` feature enabled (beta
-   * `mid-conversation-system-2026-04-07`), claude-cli closes its
-   * tool-result delta with a trailing `system` reminder turn
-   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
-   * `<total_tokens>`-style message); observed on 2.1.259 and 2.1.261.
-   * With the feature off the same clients fold the reminder into the
-   * user tool_result and need no opt-in — the gate is the feature, not
-   * the version. The generic Anthropic contract has no system role in
-   * `messages`, so that shape is admitted only under this explicit
-   * opt-in, only as the final message of the delta, and only with a
-   * single assistant echo carrying the complete exact expected ID set.
-   * The reminder is delivered as unprivileged user text after the
-   * results and any queued user content — never dropped, never
-   * escalated to an SDK system prompt.
+   * NOTE: agent-specific (claude-code) — with its `mid-conversation-system`
+   * feature on (beta `mid-conversation-system-2026-04-07`; seen on 2.1.259
+   * and 2.1.261), claude-cli ends a tool-result delta with one trailing
+   * `system` reminder turn. The Messages contract has no system role, so the
+   * turn is admitted only here, only as the final message, only behind a
+   * single echo of the complete expected ID set, and is delivered as
+   * unprivileged user text after the results — never as an SDK system prompt.
    */
   allowTrailingSystemReminder?: boolean
 }
@@ -206,7 +198,6 @@ export function coalesceCompleteToolResultContinuation(
   let echoMessages = 0
 
   for (const message of messages) {
-    // Opt-in trailing reminder: the admitted shape lives on the allowTrailingSystemReminder JSDoc above; without the opt-in this branch is dead and the generic rejection below applies.
     if (message.role === "system") {
       if (!options?.allowTrailingSystemReminder) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
@@ -220,8 +211,7 @@ export function coalesceCompleteToolResultContinuation(
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
           if (block?.type !== "text" || typeof block.text !== "string" || block.text.trim().length === 0) return undefined
-          // Pass blocks through untouched; cache_control is stripped by the
-          // caller's existing strip path before the SDK sees the prompt.
+          // cache_control survives here; the caller's strip path removes it before the SDK.
           systemTextBlocks.push(block)
         }
         if (systemTextBlocks.length === 0) return undefined
@@ -276,13 +266,10 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A reminder-bearing delta is admitted only behind a single assistant echo
-  // carrying the complete expected ID set; a split, partial, or absent echo
-  // proves nothing causal and the replay must stay fresh. (Adjacent
-  // thinking/text blocks stay tolerated, as without the reminder.)
+  // With a reminder the echo must be exactly one message carrying the full ID
+  // set: a split, partial, or absent echo does not prove the checkpoint.
   if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
-  // Delivered after the results and any queued user content, matching the
-  // wire order; nothing ever follows the reminder on the wire.
+  // Reminder last, as on the wire.
   if (systemTextBlocks.length > 0) content.push(...systemTextBlocks)
   return [{ role: "user", content }]
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,8 +2178,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
+        // NOTE: agent-specific (claude-code) — live claude-cli closes its
+        // tool-result delta with a trailing system-role reminder turn
+        // (`assistant[tool_use] -> user[tool_result] -> system[text]`). The
+        // generic checkpoint helpers reject every role=system message, which
+        // turned each such continuation into a full fresh replay. The opt-in
+        // admits that exact shape for this adapter only, gated on the single
+        // complete expected-ID echo.
+        const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
+          ? { allowClaudeCodeSystemDelta: true }
+          : undefined
         const durableCheckpointContinuation = durableCheckpointIds?.length
-          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds)
+          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds, claudeCodeSystemDeltaOptions)
           : undefined
         const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
         if (
@@ -2493,7 +2503,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // turns so multimodal tool results remain on the final SDK input.
         const checkpointContinuation = coalesceCompleteToolResultContinuation(
           messagesToConvert,
-          passthroughToolCallIds ?? []
+          passthroughToolCallIds ?? [],
+          claudeCodeSystemDeltaOptions,
         )
         if (checkpointContinuation) {
           messagesToConvert = checkpointContinuation

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,19 +2178,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
-        // NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
-        // mid-conversation-system enabled closes its tool-result delta with
-        // a trailing system-role reminder turn (`assistant[tool_use] ->
-        // user[tool_result] -> system[text]`). The generic checkpoint
-        // helpers reject every role=system message, which turned each such
-        // continuation into a full fresh replay. The opt-in admits that
-        // captured shape for this adapter only, gated on the single
-        // complete expected-ID echo.
-        const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
-          ? { allowClaudeCodeSystemDelta: true }
+        // NOTE: agent-specific (claude-code) — the shape comes from Claude Code's mid-conversation-system feature (seen on claude-cli 2.1.259 and 2.1.261), admitted only for this adapter; rationale: the allowTrailingSystemReminder JSDoc in passthroughEarlyStop.
+        const trailingSystemReminderOptions = adapterBase === "claude-code"
+          ? { allowTrailingSystemReminder: true }
           : undefined
         const durableCheckpointContinuation = durableCheckpointIds?.length
-          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds, claudeCodeSystemDeltaOptions)
+          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds, trailingSystemReminderOptions)
           : undefined
         const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
         if (
@@ -2505,7 +2498,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const checkpointContinuation = coalesceCompleteToolResultContinuation(
           messagesToConvert,
           passthroughToolCallIds ?? [],
-          claudeCodeSystemDeltaOptions,
+          trailingSystemReminderOptions,
         )
         if (checkpointContinuation) {
           messagesToConvert = checkpointContinuation

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,12 +2178,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
-        // NOTE: agent-specific (claude-code) — live claude-cli closes its
-        // tool-result delta with a trailing system-role reminder turn
-        // (`assistant[tool_use] -> user[tool_result] -> system[text]`). The
-        // generic checkpoint helpers reject every role=system message, which
-        // turned each such continuation into a full fresh replay. The opt-in
-        // admits that exact shape for this adapter only, gated on the single
+        // NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
+        // mid-conversation-system enabled closes its tool-result delta with
+        // a trailing system-role reminder turn (`assistant[tool_use] ->
+        // user[tool_result] -> system[text]`). The generic checkpoint
+        // helpers reject every role=system message, which turned each such
+        // continuation into a full fresh replay. The opt-in admits that
+        // captured shape for this adapter only, gated on the single
         // complete expected-ID echo.
         const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
           ? { allowClaudeCodeSystemDelta: true }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,7 +2178,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
-        // NOTE: agent-specific (claude-code) — the shape comes from Claude Code's mid-conversation-system feature (seen on claude-cli 2.1.259 and 2.1.261), admitted only for this adapter; rationale: the allowTrailingSystemReminder JSDoc in passthroughEarlyStop.
+        // NOTE: agent-specific (claude-code) — trailing system reminder of its mid-conversation-system feature; see allowTrailingSystemReminder.
         const trailingSystemReminderOptions = adapterBase === "claude-code"
           ? { allowTrailingSystemReminder: true }
           : undefined


### PR DESCRIPTION
## Summary

- preserve passthrough checkpoint resume when Claude Code closes a complete tool-result delta with a trailing `system` reminder turn
- deliver the reminder as ordinary user text after the native `tool_result`, never as an SDK system prompt
- keep the exception scoped to the `claude-code` adapter and fail closed for leading, repeated, non-final, non-text, blank, partial, unknown, and split-echo forms

## Root cause

With Claude Code's `mid-conversation-system` feature enabled (beta `mid-conversation-system-2026-04-07`), the CLI sends the next tool continuation as a semantically stable prefix plus three messages:

```text
assistant[tool_use] -> user[tool_result] -> system[text]
```

The final message is a `<total_tokens>`-style mid-conversation system reminder. Lineage correctly classified the request as a continuation, but the later checkpoint validator rejected every `role=system` message, cleared `resume`, and replayed the complete history in a fresh SDK session.

## Client scope

The shape is gated by the **feature**, not by the client version: reproduced with the real CLI on 2.1.259 and 2.1.261 with the feature enabled. With the feature off the same clients fold the reminder into the user `tool_result` and the generic path resumes without any opt-in. The exception therefore stays limited to this exact shape rather than treating all Claude Code system messages as resumable.

## Live verification (real Agent SDK, real Claude Max)

A throwaway Meridian built from this branch's `dist/` on a Linux host, passthrough mode, one live Max profile, driven by the real `claude -p` (`ANTHROPIC_BASE_URL` at the proxy, `--allowedTools "Bash(printf:*)"`, Haiku, `mid-conversation-system` forced by env). Turn 2 on the wire was the same in every run: `user[string] → system[string] → assistant[thinking,tool_use] → user[tool_result] → system[text]` (the echo carries a thinking block; the grammar tolerates it and a unit test pins that). Verdict read from `/telemetry/requests`.

| build | runtime `claude-agent-sdk` / bundled `claude-code` | client CLI | turn 2 lineage | `isResume` | SDK session | answer |
|---|---|---|---|---|---|---|
| clean `upstream/main` | 0.2.119 / 2.1.259 | 2.1.259 | continuation | **false** | new (full replay) | confused by replay framing, fixture missing |
| this branch | 0.2.119 / 2.1.259 | 2.1.259 | continuation | **true** | resumed at checkpoint | exact fixture |
| this branch | 0.3.261 / 2.1.261 | 2.1.259 | continuation | **true** | resumed at checkpoint | exact fixture |
| this branch | 0.3.261 / 2.1.261 | 2.1.261 | continuation | **true** | resumed at checkpoint | exact fixture |

## Validation

- clean `upstream/main` with the test-only diff: the HTTP regression fails because `options.resume` is `undefined`
- focused unit and HTTP integration suites: `100 pass, 0 fail`; full `npm test`: `3166 pass, 0 fail`
- `npm run typecheck`, `npm run build`, `git diff --check`
- Linux CI, Windows smoke, Docker smoke/build
- independent review of adapter scoping, content ordering, and fail-closed guards; follow-ups landed: agent-neutral option name `allowTrailingSystemReminder` in the leaf helper (the `claude-code` gate lives only in `server.ts`), whitespace-only reminders fail closed, and new tests for a system message between two result turns, blank/non-string reminder content, an extra unknown tool_use id in the echo, two trailing reminders (fresh replay, `isResume=false`), and the same shape under a non-claude-code adapter (no opt-in)

This is related to the full-history replay symptom in #946, but it is a distinct direct Claude Code adapter failure and does not claim to fix that issue's OpenCode/Orca cross-tool session ownership case.
