### PR TITLE
fix: replay revised passthrough turns with faithful checkpoints

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -3722,3 +3722,12 @@ Run `bun scripts/e2e-block-continuations.mjs` and again with `--stream`. Run bot
 It also removes a recognized OpenCode `{"continue":true}` hook envelope and requires continuation, then removes a meaningful fixture field and requires complete replay without that field in the SDK input or answer. Supported `getSessionMessages` inspection verifies input and source immutability. `--case=append`, `--case=hook` and `--case=drop` select individual cases for before/after comparisons. Run the existing E41, undo-gap and hash-migration controls alongside this gate when changing the classifier.
 
 For growing histories, add `--extended --delay-input-ms=4000`. This supplies appended context followed by the prior assistant reply and a new user question requesting one JSON object. A timing wrapper delays the second SDK input if one is emitted; it still calls the real SDK. The unsafe multi-input path can concatenate two model answers. Require one complete JSON answer with the original record, new suffix and image color, and zero delayed secondary inputs after coalescing.
+
+
+## Revised-history conflicts and checkpoint fidelity
+
+Run `bun scripts/e2e-modified-history-conflict.mjs` and again with `--stream`. Scheduling gates hold one real SDK turn while a revised, growing request queues under the same OpenCode session. Require complete fresh replay, the new result and supplied assistant decision in schema-validated JSON, an ordinary resumed follow-up, and unchanged source history through supported `getSessionMessages`. SDK/model responses are real.
+
+Run `bun scripts/e2e-duplicate-checkpoint.mjs` in both modes. The real model must emit two identical tool calls; otherwise the fixture precondition fails. Non-streaming currently delivers one call; streaming delivers both before hooks recognize duplication. The stored checkpoint must match the delivered IDs, all returned results must resume, and the source must remain unchanged. This gate does not claim streaming deduplication.
+
+Run `bun scripts/e2e-settlement-proof.mjs` in both modes to verify revised history following a completed real tool checkpoint. Require the supplied decision in the SDK input and answer, unchanged source history, and a resumed ordinary follow-up. Keeping old completed checkpoints must not force future turns to replay.

--- a/scripts/e2e-duplicate-checkpoint.mjs
+++ b/scripts/e2e-duplicate-checkpoint.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+// Tests revised client history after a real passthrough tool checkpoint.
+import assert from "node:assert/strict"
+import { randomUUID } from "node:crypto"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk"
+
+const stream = process.argv.includes("--stream")
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-duplicate-proof-")))
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST: "0", MERIDIAN_PASSTHROUGH: "1" })
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const { lookupSharedSession } = await import("../src/proxy/sessionStore.ts")
+const { telemetryStore } = await import("../src/telemetry/index.ts")
+const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+const address = instance.server.address()
+assert(address && typeof address === "object")
+const key = `duplicate-${randomUUID()}`
+const tools = [{ name: "get_fixture", description: "Return a JavaScript fixture value.",
+  input_schema: { type: "object", properties: {}, additionalProperties: false } }]
+async function request(messages) {
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+    method: "POST", headers: { "content-type": "application/json", "x-meridian-agent": "opencode", "x-opencode-session": key },
+    body: JSON.stringify({ model: process.env.E2E_MODEL ?? "claude-sonnet-4-6", max_tokens: 500, stream, tools, messages }),
+    signal: AbortSignal.timeout(90_000),
+  })
+  const raw = await response.text()
+  assert.equal(response.status, 200, raw)
+  if (!stream) return JSON.parse(raw).content
+  const events = raw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+  assert(!events.some(event => event.type === "error"), raw)
+  assert.equal(events.filter(event => event.type === "message_stop").length, 1)
+  const blocks = []
+  for (const event of events) {
+    if (event.type === "content_block_start") blocks[event.index] = { ...event.content_block, json: "" }
+    if (event.delta?.type === "text_delta") blocks[event.index].text += event.delta.text
+    if (event.delta?.type === "input_json_delta") blocks[event.index].json += event.delta.partial_json
+  }
+  return blocks.filter(Boolean).map(({ json, ...block }) => block.type === "tool_use"
+    ? { ...block, input: json ? JSON.parse(json) : block.input } : block)
+}
+try {
+  const opening = { role: "user", content: "Test this tool transport: call get_fixture exactly TWICE with identical empty arguments in the SAME assistant response, before waiting for results. This duplication is intentional for this test; do not combine the two calls. When the result arrives, repeat its fixture value only, with no tools or commentary." }
+  const first = await request([opening])
+  const calls = first.filter(block => block.type === "tool_use")
+  const source = lookupSharedSession(key)
+  assert(source?.claudeSessionId)
+  const rows = await getSessionMessages(source.claudeSessionId, { dir: root })
+  const actualCalls = new Map()
+  function walk(value) {
+    if (!value || typeof value !== "object") return
+    if (value.type === "tool_use" && value.name?.endsWith("get_fixture")) actualCalls.set(value.id, value)
+    for (const child of Object.values(value)) if (typeof child === "object") walk(child)
+  }
+  walk(rows)
+  console.log(JSON.stringify({ root, stream, sdkCalls: [...actualCalls.values()], clientCalls: calls, checkpointIds: source.passthroughToolCallIds }))
+  assert.equal(actualCalls.size, 2, "Fixture precondition: real model must emit two duplicate calls")
+  assert.equal(calls.length, stream ? 2 : 1, "Preserve the existing visible call set in each mode")
+  assert.deepEqual(source.passthroughToolCallIds, calls.map(call => call.id), "Checkpoint must match every visible call")
+  const value = `fixture_${randomUUID()}`
+  const history = [opening, { role: "assistant", content: first },
+    { role: "user", content: calls.map(call => ({ type: "tool_result", tool_use_id: call.id, content: value })) }]
+  const second = await request(history)
+  const answer = second.filter(block => block.type === "text").map(block => block.text).join("")
+  assert(!second.some(block => block.type === "tool_use"), JSON.stringify(second))
+  assert(answer.includes(value), answer)
+  const metric = telemetryStore.getRecent({ limit: 1 })[0]
+  assert.equal(metric?.isResume, true, "Visible results must resume the real duplicate checkpoint")
+  assert.deepEqual(await getSessionMessages(source.claudeSessionId, { dir: root }), rows, "Source history changed")
+  console.log(JSON.stringify({ result: "PASS", stream, answer, resumed: metric.isResume, sourceUnchanged: true }))
+} finally {
+  await instance.close()
+}

--- a/scripts/e2e-modified-history-conflict.mjs
+++ b/scripts/e2e-modified-history-conflict.mjs
@@ -57,7 +57,8 @@ const url = `http://127.0.0.1:${address.port}/v1/messages`
 async function request(key, messages) {
   const response = await fetch(url, {
     method: "POST", headers: { "content-type": "application/json", "x-meridian-agent": "opencode", "x-opencode-session": key },
-    body: JSON.stringify({ model, stream, max_tokens: 160, tools: [], messages,
+    body: JSON.stringify({ model, stream, max_tokens: 400, tools: [], messages,
+      ...(messages.length >= 5 ? { output_config: { format: { type: "json_schema", schema: { type: "object", properties: { value: { type: "string" }, decision: { type: "string" } }, required: ["value", "decision"], additionalProperties: false } } } } : {}),
       metadata: { user_id: JSON.stringify({ session_id: key }) } }), signal: AbortSignal.timeout(90_000),
   })
   const raw = await response.text()
@@ -104,7 +105,7 @@ try {
   const revised = [...firstHistory.slice(0, 2),
     { role: "user", content: [{ type: "tool_result", tool_use_id: "fixture_call", content: revisedValue }] },
     { role: "assistant", content: `The decision identifier is ${decision}.` },
-    { role: "user", content: "Return only one JSON array with the latest fixture result value and decision identifier. Use raw JSON only, with no markdown fences, preamble or commentary. No tools." },
+    { role: "user", content: "Return only one JSON object with keys value (the latest fixture result value) and decision (the decision identifier). Use raw JSON only, with no markdown fences, preamble or commentary. No tools." },
   ]
   gates = Array.from({ length: 2 }, () => ({ started: deferred(), release: deferred() }))
   nextGate = 0
@@ -129,17 +130,19 @@ try {
   console.log(JSON.stringify({ root, stream, model, status: second.status, error: second.raw, resume: gates[1].options?.resume ?? null }))
   const answer = checkAnswer(second, [revisedValue, decision], old)
   console.log(JSON.stringify({ answer }))
-  assert.deepEqual(JSON.parse(answer), [revisedValue, decision])
+  assert.deepEqual(JSON.parse(answer), { value: revisedValue, decision })
   assert.equal(gates[1].options?.resume, undefined, "Revised history must replay fresh")
   await unchanged(source)
   const current = await snapshot(key)
   const supplied = JSON.stringify(current.rows.filter(row => row.type === "user"))
   assert(supplied.includes(revisedValue) && supplied.includes(decision))
   assert(!supplied.includes(old), "Old branch value leaked into fresh target")
+  console.log(JSON.stringify({ beforeFollowup: lookupSharedSession(key) }))
   gates = undefined
   const followup = await request(key, [...revised, { role: "assistant", content: second.content },
-    { role: "user", content: "Repeat that exact JSON array only. Use raw JSON without markdown fences or commentary. No tools." }])
-  assert.deepEqual(JSON.parse(checkAnswer(followup, [revisedValue, decision], old)), [revisedValue, decision])
+    { role: "user", content: "Repeat that exact JSON object only. Use raw JSON without markdown fences or commentary. No tools." }])
+  assert.deepEqual(JSON.parse(checkAnswer(followup, [revisedValue, decision], old)), { value: revisedValue, decision })
+  console.log(JSON.stringify({ followupMetrics: telemetryStore.getRecent({ limit: 3 }) }))
   assert.equal(telemetryStore.getRecent({ limit: 1 })[0]?.isResume, true)
   await unchanged(source)
   console.log(JSON.stringify({ result: "PASS", stream, answer, followupResume: true, sourceUnchanged: true }))

--- a/scripts/e2e-modified-history-conflict.mjs
+++ b/scripts/e2e-modified-history-conflict.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+// Real HTTP + SDK validation. Only scheduling is controlled; model replies are real.
+import assert from "node:assert/strict"
+import { randomUUID } from "node:crypto"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spyOn } from "bun:test"
+import * as sdk from "@anthropic-ai/claude-agent-sdk"
+
+const stream = process.argv.includes("--stream")
+const model = process.env.E2E_MODEL ?? "claude-haiku-4-5-20251001"
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-modified-race-")))
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST: "0", MERIDIAN_PASSTHROUGH: "1" })
+
+function deferred() {
+  let resolve
+  const promise = new Promise(done => { resolve = done })
+  return { promise, resolve }
+}
+async function bounded(promise, label) {
+  let timer
+  try { return await Promise.race([promise, new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out: ${label}`)), 90_000)
+  })]) } finally { clearTimeout(timer) }
+}
+let gates
+let nextGate = 0
+const originalQuery = sdk.query
+const querySpy = spyOn(sdk, "query").mockImplementation(input => {
+  const actual = originalQuery(input)
+  const gate = gates?.[nextGate++]
+  if (!gate) return actual
+  gate.options = input.options
+  gate.started.resolve()
+  return new Proxy(actual, { get(target, property) {
+    if (property === Symbol.asyncIterator) return async function* () {
+      await gate.release.promise
+      yield* actual
+    }
+    const value = Reflect.get(target, property, target)
+    return typeof value === "function" ? value.bind(target) : value
+  } })
+})
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const { processSessionTurns } = await import("../src/proxy/session/turnCoordinator.ts")
+const { lookupSharedSession } = await import("../src/proxy/sessionStore.ts")
+const { telemetryStore } = await import("../src/telemetry/index.ts")
+const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+const address = instance.server.address()
+assert(address && typeof address === "object")
+const url = `http://127.0.0.1:${address.port}/v1/messages`
+async function request(key, messages) {
+  const response = await fetch(url, {
+    method: "POST", headers: { "content-type": "application/json", "x-meridian-agent": "opencode", "x-opencode-session": key },
+    body: JSON.stringify({ model, stream, max_tokens: 160, tools: [], messages,
+      metadata: { user_id: JSON.stringify({ session_id: key }) } }), signal: AbortSignal.timeout(90_000),
+  })
+  const raw = await response.text()
+  if (response.status !== 200) return { status: response.status, raw }
+  if (!stream) return { status: response.status, content: JSON.parse(raw).content }
+  const events = raw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+  assert(!events.some(event => event.type === "error"), raw)
+  assert.equal(events.filter(event => event.type === "message_stop").length, 1, raw)
+  const content = []
+  for (const event of events) {
+    if (event.type === "content_block_start") content[event.index] = { ...event.content_block }
+    if (event.delta?.type === "text_delta") content[event.index].text += event.delta.text
+  }
+  return { status: response.status, content: content.filter(Boolean) }
+}
+function checkAnswer(response, expected, excluded) {
+  assert.equal(response.status, 200, response.raw)
+  assert(!response.content.some(block => block.type === "tool_use"), JSON.stringify(response))
+  const answer = response.content.filter(block => block.type === "text").map(block => block.text).join("")
+  for (const field of expected) assert(answer.includes(field), answer)
+  if (excluded) assert(!answer.includes(excluded), answer)
+  return answer
+}
+async function snapshot(key) {
+  const mapping = lookupSharedSession(key)
+  assert(mapping?.claudeSessionId, "Missing durable session")
+  const rows = await sdk.getSessionMessages(mapping.claudeSessionId, { dir: root })
+  assert(rows.length, "SDK history must be readable through the supported API")
+  return { id: mapping.claudeSessionId, rows }
+}
+async function unchanged(source) {
+  assert.deepEqual(await sdk.getSessionMessages(source.id, { dir: root }), source.rows, "Source history changed")
+}
+try {
+  const key = `modified-${randomUUID()}`
+  const old = `old_${randomUUID().slice(0, 8)}`
+  const revisedValue = `revised_${randomUUID().slice(0, 8)}`
+  const decision = `decision_${randomUUID().slice(0, 8)}`
+  const firstHistory = [
+    { role: "user", content: "Read the JavaScript fixture. After the tool result reply only ACK. No further tools." },
+    { role: "assistant", content: [{ type: "tool_use", id: "fixture_call", name: "read", input: { path: "fixture.txt" } }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "fixture_call", content: old }] },
+  ]
+  const revised = [...firstHistory.slice(0, 2),
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "fixture_call", content: revisedValue }] },
+    { role: "assistant", content: `The decision identifier is ${decision}.` },
+    { role: "user", content: "Return only one JSON array with the latest fixture result value and decision identifier. Use raw JSON only, with no markdown fences, preamble or commentary. No tools." },
+  ]
+  gates = Array.from({ length: 2 }, () => ({ started: deferred(), release: deferred() }))
+  nextGate = 0
+  const firstP = request(key, firstHistory)
+  await bounded(gates[0].started.promise, "first SDK query")
+  const queued = deferred()
+  const acquire = processSessionTurns.acquire.bind(processSessionTurns)
+  const arrivalSpy = spyOn(processSessionTurns, "acquire").mockImplementation((turnKey, signal) => {
+    const result = acquire(turnKey, signal)
+    if (turnKey === `session:${key}`) queued.resolve()
+    return result
+  })
+  const secondP = request(key, revised)
+  try { await bounded(queued.promise, "revised request queue admission") } finally { arrivalSpy.mockRestore() }
+  gates[0].release.resolve()
+  const first = await firstP
+  checkAnswer(first, ["ACK"])
+  await bounded(Promise.race([gates[1].started.promise, secondP]), "second SDK query or refusal")
+  const source = await snapshot(key)
+  gates[1].release.resolve()
+  const second = await secondP
+  console.log(JSON.stringify({ root, stream, model, status: second.status, error: second.raw, resume: gates[1].options?.resume ?? null }))
+  const answer = checkAnswer(second, [revisedValue, decision], old)
+  console.log(JSON.stringify({ answer }))
+  assert.deepEqual(JSON.parse(answer), [revisedValue, decision])
+  assert.equal(gates[1].options?.resume, undefined, "Revised history must replay fresh")
+  await unchanged(source)
+  const current = await snapshot(key)
+  const supplied = JSON.stringify(current.rows.filter(row => row.type === "user"))
+  assert(supplied.includes(revisedValue) && supplied.includes(decision))
+  assert(!supplied.includes(old), "Old branch value leaked into fresh target")
+  gates = undefined
+  const followup = await request(key, [...revised, { role: "assistant", content: second.content },
+    { role: "user", content: "Repeat that exact JSON array only. Use raw JSON without markdown fences or commentary. No tools." }])
+  assert.deepEqual(JSON.parse(checkAnswer(followup, [revisedValue, decision], old)), [revisedValue, decision])
+  assert.equal(telemetryStore.getRecent({ limit: 1 })[0]?.isResume, true)
+  await unchanged(source)
+  console.log(JSON.stringify({ result: "PASS", stream, answer, followupResume: true, sourceUnchanged: true }))
+} finally {
+  for (const gate of gates ?? []) gate.release.resolve()
+  querySpy.mockRestore()
+  await instance.close()
+}

--- a/scripts/e2e-settlement-proof.mjs
+++ b/scripts/e2e-settlement-proof.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env bun
+// Tests revised client history after a real passthrough tool checkpoint.
+import assert from "node:assert/strict"
+import { randomUUID } from "node:crypto"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk"
+
+const stream = process.argv.includes("--stream")
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-settlement-proof-")))
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST: "0", MERIDIAN_PASSTHROUGH: "1" })
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const { lookupSharedSession } = await import("../src/proxy/sessionStore.ts")
+const { telemetryStore } = await import("../src/telemetry/index.ts")
+const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+const address = instance.server.address()
+assert(address && typeof address === "object")
+const key = `settlement-${randomUUID()}`
+const tools = [{ name: "get_fixture", description: "Return a JavaScript fixture value.",
+  input_schema: { type: "object", properties: {}, additionalProperties: false } }]
+async function request(messages) {
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+    method: "POST", headers: { "content-type": "application/json", "x-meridian-agent": "opencode", "x-opencode-session": key },
+    body: JSON.stringify({ model: "claude-haiku-4-5-20251001", max_tokens: 200, stream, tools, messages }),
+    signal: AbortSignal.timeout(90_000),
+  })
+  const raw = await response.text()
+  assert.equal(response.status, 200, raw)
+  if (!stream) return JSON.parse(raw).content
+  const events = raw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+  assert(!events.some(event => event.type === "error"), raw)
+  assert.equal(events.filter(event => event.type === "message_stop").length, 1)
+  const blocks = []
+  for (const event of events) {
+    if (event.type === "content_block_start") blocks[event.index] = { ...event.content_block, json: "" }
+    if (event.delta?.type === "text_delta") blocks[event.index].text += event.delta.text
+    if (event.delta?.type === "input_json_delta") blocks[event.index].json += event.delta.partial_json
+  }
+  return blocks.filter(Boolean).map(({ json, ...block }) => block.type === "tool_use"
+    ? { ...block, input: json ? JSON.parse(json) : block.input } : block)
+}
+try {
+  const opening = { role: "user", content: "Call get_fixture exactly once. When the result arrives, reply only ACK; do not call again." }
+  const first = await request([opening])
+  const calls = first.filter(block => block.type === "tool_use")
+  assert.equal(calls.length, 1, JSON.stringify(first))
+  assert.equal(calls[0].name, "get_fixture")
+  const result = value => ({ role: "user", content: [{ type: "tool_result", tool_use_id: calls[0].id, content: JSON.stringify({ value }) }] })
+  const history = [opening, { role: "assistant", content: first }, result("original")]
+  const second = await request(history)
+  assert(!second.some(block => block.type === "tool_use"), JSON.stringify(second))
+  const source = lookupSharedSession(key)
+  assert(source?.claudeSessionId)
+  const sourceRows = await getSessionMessages(source.claudeSessionId, { dir: root })
+  assert(sourceRows.length)
+  const marker = `decision_${randomUUID()}`
+  const revised = [history[0], history[1], result("revised"),
+    { role: "assistant", content: `The fixture decision identifier is ${marker}.` },
+    { role: "user", content: "Reply only with the exact fixture decision identifier in the immediately preceding assistant message. No tools." }]
+  const response = await request(revised)
+  const answer = response.filter(block => block.type === "text").map(block => block.text).join("")
+  const current = lookupSharedSession(key)
+  assert(current?.claudeSessionId)
+  const rows = await getSessionMessages(current.claudeSessionId, { dir: root })
+  const delivered = JSON.stringify(rows.filter(row => row.type === "user")).includes(marker)
+  const lineage = telemetryStore.getRecent({ limit: 1 })[0]?.lineageType
+  console.log(JSON.stringify({ root, stream, priorCheckpoint: source.passthroughToolCallAssistantUuid ?? null,
+    lineage, answer, delivered, expected: marker, valid: delivered && answer.includes(marker) }))
+  assert(delivered && answer.includes(marker), "The revised supplied assistant history must reach the SDK and answer")
+  assert.deepEqual(await getSessionMessages(source.claudeSessionId, { dir: root }), sourceRows, "Current main must preserve its source")
+  const followup = await request([...revised, { role: "assistant", content: response },
+    { role: "user", content: "Repeat that fixture decision identifier only. No tools." }])
+  const followupAnswer = followup.filter(block => block.type === "text").map(block => block.text).join("")
+  const metric = telemetryStore.getRecent({ limit: 1 })[0]
+  console.log(JSON.stringify({ followup: true, stream, isResume: metric?.isResume, answer: followupAnswer }))
+  assert(followupAnswer.includes(marker), "Ordinary follow-up must retain the decision")
+  assert.equal(metric?.isResume, true, "A completed tool checkpoint must not force ordinary follow-ups to replay")
+} finally {
+  await instance.close()
+}

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -42,9 +42,11 @@ installSdkMock(() => ({
     return (async function* () {
       let sawSyntheticDeny = false
       let sawResult = false
+      const explicitlyHookedIds = new Set<string>()
       for (const msg of mockMessages) {
         yieldedCount++
         if (msg?.type === "test_pre_tool_hook") {
+          explicitlyHookedIds.add(msg.tool_use_id)
           if (preHook) {
             await preHook({
               tool_name: msg.tool_name,
@@ -66,7 +68,8 @@ installSdkMock(() => ({
         yield delivered
         if (preHook && delivered?.type === "assistant" && Array.isArray(delivered?.message?.content)) {
           for (const block of delivered.message.content) {
-            if (block?.type !== "tool_use") continue
+            // Explicit timing fixtures already invoked this hook before metadata.
+            if (block?.type !== "tool_use" || explicitlyHookedIds.has(block.id)) continue
             void Promise.resolve(preHook({
               tool_name: block.name,
               tool_use_id: block.id,

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -53,6 +53,11 @@ describe("isClientForwardedToolUse", () => {
     expect(isClientForwardedToolUse(toolUse("t2", "Bash"))).toBe(true)
   })
 
+  it("excludes SDK StructuredOutput but preserves a client MCP tool with that name", () => {
+    expect(isClientForwardedToolUse(toolUse("internal", "StructuredOutput"))).toBe(false)
+    expect(isClientForwardedToolUse(toolUse("client", "mcp__oc__StructuredOutput"))).toBe(true)
+  })
+
   it("excludes ToolSearch (internal, SDK-executed for deferred loading)", () => {
     expect(isClientForwardedToolUse(toolUse("t1", "ToolSearch"))).toBe(false)
   })

--- a/src/__tests__/proxy-cross-process-coordination.test.ts
+++ b/src/__tests__/proxy-cross-process-coordination.test.ts
@@ -217,7 +217,7 @@ function spawnProxyWorker(
   id: string,
   clientSessionId: string,
   messages: Array<{ role: string, content: unknown }>,
-  options: { adapter?: "pi"; stream?: boolean } = {},
+  options: { adapter?: "pi"; stream?: boolean; passthrough?: boolean } = {},
 ): WorkerHandle {
   const releaseFile = join(paths.base, `release-${id}`)
   const requestBody = JSON.stringify({
@@ -233,7 +233,7 @@ function spawnProxyWorker(
       SERVER_MODULE: serverModule,
       SESSION_STORE_MODULE: sessionStoreModule,
       MERIDIAN_SESSION_DIR: paths.sessions,
-      MERIDIAN_PASSTHROUGH: "0",
+      MERIDIAN_PASSTHROUGH: options.passthrough ? "1" : "0",
       CLAUDE_PROXY_PASSTHROUGH: "0",
       MERIDIAN_MAX_CONCURRENT: "8",
       MERIDIAN_SESSION_TURN_ACQUIRE_TIMEOUT_MS: "5000",
@@ -345,6 +345,36 @@ describe("proxy coordination across OS processes", () => {
         expect(followupSdk.resume).toBe(firstName === "side" ? waiterSdk.sdkSessionId! : null)
         await release(followup)
         expect((await result(paths, followup)).status).toBe(200)
+      }, 20_000)
+    }
+  }
+
+  for (const stream of [false, true]) {
+    for (const passthrough of [false, true]) {
+      test(`modified-history conflict is replayable only in passthrough across processes: passthrough=${passthrough}, stream=${stream}`, async () => {
+        const paths = await makePaths()
+        const key = `modified-${stream}-${passthrough}`
+        const opening = [{ role: "user", content: "shared fixture" }, { role: "assistant", content: "ok" },
+          { role: "user", content: "old fixture value" }]
+        const revised = [...opening.slice(0, 2), { role: "user", content: "revised fixture value" },
+          { role: "assistant", content: "revised decision" }, { role: "user", content: "repeat the decision" }]
+        const owner = spawnProxyWorker(paths, "modified-owner", key, opening, { stream, passthrough })
+        const ownerSdk = await waitForEvent(paths.events, owner.id, "sdk-start")
+        const waiter = spawnProxyWorker(paths, "modified-waiter", key, revised, { stream, passthrough })
+        await waitForEvent(paths.events, waiter.id, "arrival-snapshot")
+        expect((await readEvents(paths.events)).some(row => row.workerId === waiter.id && row.name === "sdk-start")).toBe(false)
+        await release(owner)
+        expect((await result(paths, owner)).status).toBe(200)
+        if (passthrough) {
+          const waiterSdk = await waitForEvent(paths.events, waiter.id, "sdk-start")
+          expect(waiterSdk.resume).toBeNull()
+          expect(waiterSdk.sdkSessionId).not.toBe(ownerSdk.sdkSessionId)
+          await release(waiter)
+          expect((await result(paths, waiter)).status).toBe(200)
+        } else {
+          expect((await result(paths, waiter)).status).toBe(400)
+          expect((await readEvents(paths.events)).some(row => row.workerId === waiter.id && row.name === "sdk-start")).toBe(false)
+        }
       }, 20_000)
     }
   }

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -714,3 +714,101 @@ describe("envelope integrity tripwire", () => {
     expect(after - before).toBe(0)
   })
 })
+
+describe("dropped duplicate tool_use is excluded from persisted checkpoint", () => {
+  let origEnv: string | undefined
+  let origEarlyStop: string | undefined
+
+  beforeEach(() => {
+    origEnv = process.env.MERIDIAN_PASSTHROUGH
+    origEarlyStop = process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP // early stop ON (default)
+    mockTurns = []
+    capturedController = undefined
+    capturedResume = undefined
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = origEnv
+    if (origEarlyStop === undefined) delete process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP
+    else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
+  })
+
+  function duplicateTurn() {
+    // Two tool_use blocks: same name + same input → second is an exact duplicate
+    const turn = toolTurn("toolu_d1", "read", { filePath: "a.txt" })
+    ;(turn as any).message.content = [
+      { type: "tool_use", id: "toolu_d1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+      { type: "tool_use", id: "toolu_d2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
+    ]
+    return turn
+  }
+
+  function denyUser(ids: string[]) {
+    return {
+      type: "user",
+      message: {
+        role: "user",
+        content: ids.map((id) => ({
+          type: "tool_result",
+          tool_use_id: id,
+          is_error: true,
+          content: "This tool call has been forwarded to the client for execution. " +
+            "The result will be delivered in a future turn. " +
+            "Do not retry, do not call additional tools, and do not generate further text — end your turn now.",
+        })),
+      },
+      parent_tool_use_id: null,
+      uuid: crypto.randomUUID(),
+      session_id: "test-session",
+    }
+  }
+
+  it("checkpoint excludes the dropped duplicate id — follow-up resumes instead of fresh-replaying", async () => {
+    // First turn: model emits two reads, second is an exact duplicate.
+    // The hook drops toolu_d2 (isExactDuplicate) → added to droppedToolUseIds.
+    // The checkpoint must contain only toolu_d1.
+    mockTurns = [
+      duplicateTurn(),
+      denyUser(["toolu_d1", "toolu_d2"]),
+      { type: "assistant", message: {
+        id: "msg_digest", type: "message", role: "assistant",
+        content: [{ type: "text", text: "hidden digest" }],
+        model: "claude-sonnet-4-5-20250929", stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 10 },
+      }, parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session" },
+      { type: "result", subtype: "success", is_error: false, session_id: "test-session" },
+    ]
+    const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+    const first = await post(app, false)
+    expect(first.status).toBe(200)
+
+    // Follow-up: client sends back the real result for toolu_d1 only.
+    // If the checkpoint incorrectly included toolu_d2, isCompleteToolResultContinuation
+    // would fail (expected size 2, actual size 1) and the request would fresh-replay.
+    mockTurns = [
+      { type: "assistant", message: {
+        id: "msg_final", type: "message", role: "assistant",
+        content: [{ type: "text", text: "File read successfully." }],
+        model: "claude-sonnet-4-5-20250929", stop_reason: "end_turn",
+        usage: { input_tokens: 10, output_tokens: 10 },
+      }, parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session" },
+    ]
+    capturedResume = undefined
+    const second = await post(app, false, [
+      { role: "user", content: "Do the thing." },
+      { role: "assistant", content: [
+        { type: "tool_use", id: "toolu_d1", name: "read", input: { filePath: "a.txt" } },
+      ]},
+      { role: "user", content: [
+        { type: "tool_result", tool_use_id: "toolu_d1", content: "contents of a.txt" },
+      ]},
+    ])
+    expect(second.status).toBe(200)
+    // Must resume — if the checkpoint included toolu_d2, this would fresh-replay
+    expect(capturedResume ?? "(not resumed)").toBe("test-session")
+  })
+})

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -737,10 +737,14 @@ describe("dropped duplicate tool_use is excluded from persisted checkpoint", () 
     else process.env.MERIDIAN_PASSTHROUGH_EARLY_STOP = origEarlyStop
   })
 
+  function streamEvent(event: Record<string, unknown>) {
+    return { type: "stream_event", event, parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session" }
+  }
+
   function duplicateTurn() {
     // Two tool_use blocks: same name + same input → second is an exact duplicate
     const turn = toolTurn("toolu_d1", "read", { filePath: "a.txt" })
-    ;(turn as any).message.content = [
+    turn.message.content = [
       { type: "tool_use", id: "toolu_d1", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
       { type: "tool_use", id: "toolu_d2", name: `${PASSTHROUGH_PREFIX}read`, input: { filePath: "a.txt" } },
     ]
@@ -767,11 +771,17 @@ describe("dropped duplicate tool_use is excluded from persisted checkpoint", () 
     }
   }
 
-  it("checkpoint excludes the dropped duplicate id — follow-up resumes instead of fresh-replaying", async () => {
+  for (const stream of [false, true]) {
+  it(`checkpoint matches the visible calls and resumes (stream=${stream})`, async () => {
     // First turn: model emits two reads, second is an exact duplicate.
     // The hook drops toolu_d2 (isExactDuplicate) → added to droppedToolUseIds.
-    // The checkpoint must contain only toolu_d1.
+    // Non-stream hides d2; streaming already delivered both. Match that set.
     mockTurns = [
+      ...(stream ? [streamMessageStart(), ...["toolu_d1", "toolu_d2"].flatMap((id, index) => [
+        streamEvent({ type: "content_block_start", index, content_block: { type: "tool_use", id, name: `${PASSTHROUGH_PREFIX}read`, input: {} } }),
+        streamEvent({ type: "content_block_delta", index, delta: { type: "input_json_delta", partial_json: '{"filePath":"a.txt"}' } }),
+        streamEvent({ type: "content_block_stop", index }),
+      ]), streamEvent({ type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 30 } })] : []),
       duplicateTurn(),
       denyUser(["toolu_d1", "toolu_d2"]),
       { type: "assistant", message: {
@@ -783,8 +793,19 @@ describe("dropped duplicate tool_use is excluded from persisted checkpoint", () 
       { type: "result", subtype: "success", is_error: false, session_id: "test-session" },
     ]
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
-    const first = await post(app, false)
+    const first = await post(app, stream)
     expect(first.status).toBe(200)
+
+    const firstRaw = await first.text()
+    const visibleIds = stream
+      ? firstRaw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+        .filter(event => event.type === "content_block_start" && event.content_block?.type === "tool_use")
+        .map(event => event.content_block.id)
+      : JSON.parse(firstRaw).content.filter((block: { type: string }) => block.type === "tool_use").map((block: { id: string }) => block.id)
+    expect(visibleIds).toEqual(stream ? ["toolu_d1", "toolu_d2"] : ["toolu_d1"])
+    const { lookupSharedSession } = await import("../proxy/sessionStore")
+    const stored = lookupSharedSession("deny-abort-session")
+    expect(stored?.passthroughToolCallIds).toEqual(visibleIds)
 
     // Follow-up: client sends back the real result for toolu_d1 only.
     // If the checkpoint incorrectly included toolu_d2, isCompleteToolResultContinuation
@@ -798,17 +819,16 @@ describe("dropped duplicate tool_use is excluded from persisted checkpoint", () 
       }, parent_tool_use_id: null, uuid: crypto.randomUUID(), session_id: "test-session" },
     ]
     capturedResume = undefined
-    const second = await post(app, false, [
+    const second = await post(app, stream, [
       { role: "user", content: "Do the thing." },
-      { role: "assistant", content: [
-        { type: "tool_use", id: "toolu_d1", name: "read", input: { filePath: "a.txt" } },
-      ]},
-      { role: "user", content: [
-        { type: "tool_result", tool_use_id: "toolu_d1", content: "contents of a.txt" },
-      ]},
+      { role: "assistant", content: visibleIds.map((id: string) => ({ type: "tool_use", id, name: "read", input: { filePath: "a.txt" } })) },
+      { role: "user", content: visibleIds.map((id: string) => ({ type: "tool_result", tool_use_id: id, content: "contents of a.txt" })) },
     ])
     expect(second.status).toBe(200)
+    await second.text()
     // Must resume — if the checkpoint included toolu_d2, this would fresh-replay
-    expect(capturedResume ?? "(not resumed)").toBe("test-session")
+    expect(stored?.claudeSessionId).toBeDefined()
+    expect(capturedResume ?? "(not resumed)").toBe(stored?.claudeSessionId ?? "(missing mapping)")
   })
+  }
 })

--- a/src/__tests__/proxy-structured-output.test.ts
+++ b/src/__tests__/proxy-structured-output.test.ts
@@ -111,6 +111,39 @@ describe("native structured output", () => {
     else process.env.MERIDIAN_PASSTHROUGH = originalPassthrough
   })
 
+  for (const stream of [false, true]) {
+    it(`internal StructuredOutput cannot leave a passthrough checkpoint (stream=${stream})`, async () => {
+      const key = crypto.randomUUID()
+      mockMessages = [
+        { type: "assistant", uuid: crypto.randomUUID(), session_id: "structured-session", message: {
+          role: "assistant", content: [{ type: "tool_use", id: "internal-format", name: "StructuredOutput", input: { answer: "grounded" } }],
+        } },
+        { type: "user", uuid: crypto.randomUUID(), session_id: "structured-session", message: {
+          role: "user", content: [{ type: "tool_result", tool_use_id: "internal-format", content: "Structured output provided successfully" }],
+        } },
+        resultMessage({ answer: "grounded" }),
+      ]
+      const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app
+      const first = await app.fetch(request(stream, undefined, {}, key))
+      expect(first.status).toBe(200)
+      await first.text()
+      const stored = lookupSharedSessionResult(key)
+      if (stored.status !== "found") throw new Error("Structured result was not published")
+      expect(stored.session.passthroughToolCallAssistantUuid).toBeUndefined()
+      expect(stored.session.passthroughToolCallIds?.length ?? 0).toBe(0)
+      mockMessages = [resultMessage({ answer: "grounded" })]
+      const next = await app.fetch(request(stream, undefined, { messages: [
+        { role: "user", content: "Return an answer." },
+        { role: "assistant", content: '{"answer":"grounded"}' },
+        { role: "user", content: "Repeat the answer." },
+      ] }, key))
+      expect(next.status).toBe(200)
+      await next.text()
+      expect(capturedOptions.resume).toBe(stored.session.claudeSessionId)
+      expect(capturedOptions.resumeSessionAt).toBeUndefined()
+    })
+  }
+
   it("maps output_config.format to the Agent SDK and returns authoritative JSON", async () => {
     mockMessages = [resultMessage({ answer: "grounded" })]
     const app = createProxyServer({ port: 0, host: "127.0.0.1" }).app

--- a/src/__tests__/proxy-turn-conflict-downgrade.test.ts
+++ b/src/__tests__/proxy-turn-conflict-downgrade.test.ts
@@ -1,5 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
+  resolveMockSdkSessionId,
   assistantMessage,
   messageStart,
   textBlockStart,
@@ -18,7 +25,9 @@ let activeQueries = 0
 let maxActiveQueries = 0
 let queryCalls = 0
 let controls: AttemptControl[] = []
-let capturedParams: Array<{ options?: { resume?: string } }> = []
+type QueryParams = { prompt: string | AsyncIterable<unknown>; options?: { resume?: string; sessionId?: string } }
+let capturedParams: QueryParams[] = []
+let capturedPrompts: unknown[][] = []
 
 function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
   let release = () => {}
@@ -28,17 +37,23 @@ function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted:
   return { release, started, wait, markStarted }
 }
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (params: { options?: { resume?: string } }) => {
+installSdkMock(() => ({
+  query: (params: QueryParams) => {
     capturedParams.push(params)
     queryCalls++
     const control = deferredAttempt()
     controls.push(control)
-    const sessionId = `sdk-downgrade-${queryCalls}`
+    const index = queryCalls - 1
+    const sessionId = resolveMockSdkSessionId(params.options, `sdk-downgrade-${queryCalls}`)
     const generator = (async function* () {
+      const prompts: unknown[] = []
+      if (typeof params.prompt === "string") prompts.push(params.prompt)
+      else for await (const item of params.prompt) prompts.push(item)
+      capturedPrompts[index] = prompts
       activeQueries++
       maxActiveQueries = Math.max(maxActiveQueries, activeQueries)
       control.markStarted()
+      if (index === 1) control.release()
       try {
         yield { ...messageStart(), session_id: sessionId }
         await control.wait
@@ -56,19 +71,21 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
-}))
+}), "proxy-turn-conflict-downgrade.test.ts")
 
-mock.module("../logger", () => ({
+installLoggerMock(() => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock(() => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
 const { createProxyServer, clearSessionCache } = await import("../proxy/server")
 const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { setSessionStoreDir } = await import("../proxy/sessionStore")
+const { processSessionTurns } = await import("../proxy/session/turnCoordinator")
 const { telemetryStore } = await import("../telemetry")
 
 function request(
@@ -100,24 +117,32 @@ async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptC
 }
 
 describe("modified-history conflict downgrade", () => {
+  let sessionDir: string
   const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
   const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
   const originalPassthrough = process.env.MERIDIAN_PASSTHROUGH
 
   beforeEach(() => {
+    sessionDir = mkdtempSync(join(tmpdir(), "meridian-modified-conflict-"))
+    setSessionStoreDir(sessionDir)
     process.env.MERIDIAN_MAX_CONCURRENT = "1"
+    process.env.MERIDIAN_PASSTHROUGH = "1"
     activeQueries = 0
     maxActiveQueries = 0
     queryCalls = 0
     controls = []
     capturedParams = []
+    capturedPrompts = []
     clearSessionCache()
     resetProcessSdkSemaphoreForTests()
     telemetryStore.clear()
   })
 
   afterEach(() => {
+    for (const control of controls) control.release()
     resetProcessSdkSemaphoreForTests()
+    setSessionStoreDir(null)
+    rmSync(sessionDir, { recursive: true, force: true })
     if (originalMax === undefined) delete process.env.MERIDIAN_MAX_CONCURRENT
     else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
     if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
@@ -126,99 +151,71 @@ describe("modified-history conflict downgrade", () => {
     else process.env.MERIDIAN_PASSTHROUGH = originalPassthrough
   })
 
-  it("downgrades modified-history conflict to fresh replay (passthrough mode)", async () => {
-    process.env.MERIDIAN_PASSTHROUGH = "1"
-    // Request A: 3 messages — acquires lease, commits turn.
-    // Request B: 5 messages, same session, trailing tool_result content revised.
-    //   Queued during A → should get fresh replay (200), NOT 409.
-    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
-    const opening = [
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "ok" },
-      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
-    ]
-    const superseding = [
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "ok" },
-      // Same position, revised content — triggers modified-history
-      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
-      // Extra messages — makes incoming longer than stored
-      { role: "user", content: "extra turn" },
-      { role: "assistant", content: "and response" },
-    ]
-    const firstP = app.fetch(request(opening, "downgrade-test"))
-    const firstControl = await waitForControl(0)
-    const secondP = app.fetch(request(superseding, "downgrade-test"))
+  const opening = [
+    { role: "user", content: "Read the fixture." },
+    { role: "assistant", content: [{ type: "tool_use", id: "use1", name: "read", input: { path: "fixture.txt" } }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "old_fixture_value" }] },
+  ]
+  const superseding = [opening[0]!, opening[1]!,
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
+    { role: "assistant", content: "Decision identifier is unique_decision." },
+    { role: "user", content: "Repeat the decision identifier." },
+  ]
 
+  async function race(messages: Array<{ role: string; content: unknown }>, stream: boolean) {
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const key = crypto.randomUUID()
+    const firstP = Promise.resolve(app.fetch(request(opening, key, stream))).then(async response => ({ status: response.status, raw: await response.text() }))
+    const firstControl = await waitForControl(0)
+    let markArrived = () => {}
+    const arrived = new Promise<void>(resolve => { markArrived = resolve })
+    const acquire = processSessionTurns.acquire.bind(processSessionTurns)
+    const observer = spyOn(processSessionTurns, "acquire").mockImplementation((turnKey, signal) => {
+      const pending = acquire(turnKey, signal)
+      if (turnKey === `session:${key}`) markArrived()
+      return pending
+    })
+    const secondP = Promise.resolve(app.fetch(request(messages, key, stream))).then(async response => ({ status: response.status, raw: await response.text() }))
+    try { await arrived } finally { observer.mockRestore() }
     firstControl.release()
     expect((await firstP).status).toBe(200)
-    // B gets the turn lease, does its lookup, and starts a fresh replay SDK query.
-    const secondControl = await waitForControl(1)
-    secondControl.release()
-    const second = await secondP
-    // modified-history should be downgraded to fresh replay, not 409
-    expect(second.status).toBe(200)
-    // Two distinct SDK queries — B does a fresh replay
-    expect(queryCalls).toBe(2)
-  })
+    return secondP
+  }
 
-  it("still returns 409 for undo conflict (stale racer)", async () => {
-    // Control: a request shorter than stored history → still 409/undo.
-    // This mirrors the existing concurrency-coordination test's stale-branch case.
-    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
-    const opening = [
-      { role: "user", content: "set up" },
-      { role: "assistant", content: "ok" },
-      { role: "user", content: "more context" },
-    ]
-    // Shorter request (1 msg) — undo when found in cache with 3 msgs
-    const stale = [{ role: "user", content: "set up" }]
-    const firstP = app.fetch(request(opening, "undo-test"))
-    const firstControl = await waitForControl(0)
-    const secondP = app.fetch(request(stale, "undo-test"))
+  for (const stream of [false, true]) {
+    it(`replays every revised message after waiting (stream=${stream})`, async () => {
+      const second = await race(superseding, stream)
+      expect(second.status).toBe(200)
+      expect(second.raw).not.toContain('"type":"error"')
+      expect(queryCalls).toBe(2)
+      expect(maxActiveQueries).toBe(1)
+      expect(capturedParams[1]?.options?.resume).toBeUndefined()
+      expect(capturedParams[1]?.options?.sessionId).not.toBe(capturedParams[0]?.options?.sessionId)
+      expect(capturedPrompts[1]).toHaveLength(1)
+      const prompt = JSON.stringify(capturedPrompts[1])
+      for (const value of ["REVISED", "unique_decision", "Repeat the decision identifier", "fixture.txt", "use1"]) expect(prompt).toContain(value)
+      expect(prompt).not.toContain("old_fixture_value")
+    })
 
-    firstControl.release()
-    expect((await firstP).status).toBe(200)
-    const second = await secondP
-    expect(second.status).toBe(400)
-    const body = await second.json()
-    expect(body.error.type).toBe("invalid_request_error")
-    expect(body.error.message).toContain("session advanced")
-    // Only one SDK query — the second request is refused
-    expect(queryCalls).toBe(1)
-  })
+    it(`refuses modified history without passthrough (stream=${stream})`, async () => {
+      process.env.MERIDIAN_PASSTHROUGH = "0"
+      const second = await race(superseding, stream)
+      expect(second.status).toBe(400)
+      expect(JSON.parse(second.raw).error.message).toContain("session advanced")
+      expect(queryCalls).toBe(1)
+    })
 
-  it("does not downgrade modified-history conflict in non-passthrough mode", async () => {
-    // Without MERIDIAN_PASSTHROUGH, the downgrade must NOT fire.
-    // The request proceeds as a fresh session rather than being downgraded
-    // or getting a 409 (the turn lease mechanism determines conflict handling).
-    delete process.env.MERIDIAN_PASSTHROUGH
-    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
-    const opening = [
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "ok" },
-      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
-    ]
-    const superseding = [
-      { role: "user", content: "hello" },
-      { role: "assistant", content: "ok" },
-      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
-      { role: "user", content: "extra turn" },
-      { role: "assistant", content: "and response" },
-    ]
-    const firstP = app.fetch(request(opening, "non-passthrough-test"))
-    const firstControl = await waitForControl(0)
-    const secondP = app.fetch(request(superseding, "non-passthrough-test"))
+    it(`still refuses a stale undo (stream=${stream})`, async () => {
+      const second = await race([opening[0]!, opening[1]!, { role: "user", content: "Replace the preceding tool-result turn." }], stream)
+      expect(second.status).toBe(400)
+      expect(JSON.parse(second.raw).error.message).toContain("session advanced")
+      expect(queryCalls).toBe(1)
+    })
 
-    firstControl.release()
-    expect((await firstP).status).toBe(200)
-    // B proceeds as a fresh session (not downgraded, not 409'd).
-    // Release B's SDK query if one started.
-    try {
-      const secondControl = await waitForControl(1, 500)
-      secondControl.release()
-    } catch { /* B may not start an SDK query */ }
-    const second = await secondP
-    expect(second.status).toBe(200)
-  })
+    it(`still refuses unrelated history (stream=${stream})`, async () => {
+      const second = await race([{ role: "user", content: "An entirely different conversation." }], stream)
+      expect(second.status).toBe(400)
+      expect(queryCalls).toBe(1)
+    })
+  }
 })

--- a/src/__tests__/proxy-turn-conflict-downgrade.test.ts
+++ b/src/__tests__/proxy-turn-conflict-downgrade.test.ts
@@ -102,6 +102,7 @@ async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptC
 describe("modified-history conflict downgrade", () => {
   const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
   const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+  const originalPassthrough = process.env.MERIDIAN_PASSTHROUGH
 
   beforeEach(() => {
     process.env.MERIDIAN_MAX_CONCURRENT = "1"
@@ -121,9 +122,12 @@ describe("modified-history conflict downgrade", () => {
     else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
     if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
     else process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = originalHold
+    if (originalPassthrough === undefined) delete process.env.MERIDIAN_PASSTHROUGH
+    else process.env.MERIDIAN_PASSTHROUGH = originalPassthrough
   })
 
-  it("downgrades modified-history conflict to fresh replay", async () => {
+  it("downgrades modified-history conflict to fresh replay (passthrough mode)", async () => {
+    process.env.MERIDIAN_PASSTHROUGH = "1"
     // Request A: 3 messages — acquires lease, commits turn.
     // Request B: 5 messages, same session, trailing tool_result content revised.
     //   Queued during A → should get fresh replay (200), NOT 409.
@@ -182,5 +186,39 @@ describe("modified-history conflict downgrade", () => {
     expect(body.error.message).toContain("session advanced")
     // Only one SDK query — the second request is refused
     expect(queryCalls).toBe(1)
+  })
+
+  it("does not downgrade modified-history conflict in non-passthrough mode", async () => {
+    // Without MERIDIAN_PASSTHROUGH, the downgrade must NOT fire.
+    // The request proceeds as a fresh session rather than being downgraded
+    // or getting a 409 (the turn lease mechanism determines conflict handling).
+    delete process.env.MERIDIAN_PASSTHROUGH
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
+    ]
+    const superseding = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
+      { role: "user", content: "extra turn" },
+      { role: "assistant", content: "and response" },
+    ]
+    const firstP = app.fetch(request(opening, "non-passthrough-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(superseding, "non-passthrough-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    // B proceeds as a fresh session (not downgraded, not 409'd).
+    // Release B's SDK query if one started.
+    try {
+      const secondControl = await waitForControl(1, 500)
+      secondControl.release()
+    } catch { /* B may not start an SDK query */ }
+    const second = await secondP
+    expect(second.status).toBe(200)
   })
 })

--- a/src/__tests__/proxy-turn-conflict-downgrade.test.ts
+++ b/src/__tests__/proxy-turn-conflict-downgrade.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test"
+import {
+  assistantMessage,
+  messageStart,
+  textBlockStart,
+  textDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+} from "./helpers"
+
+interface AttemptControl {
+  release: () => void
+  started: Promise<void>
+}
+
+let activeQueries = 0
+let maxActiveQueries = 0
+let queryCalls = 0
+let controls: AttemptControl[] = []
+let capturedParams: Array<{ options?: { resume?: string } }> = []
+
+function deferredAttempt(): AttemptControl & { wait: Promise<void>; markStarted: () => void } {
+  let release = () => {}
+  let markStarted = () => {}
+  const wait = new Promise<void>(resolve => { release = resolve })
+  const started = new Promise<void>(resolve => { markStarted = resolve })
+  return { release, started, wait, markStarted }
+}
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: { options?: { resume?: string } }) => {
+    capturedParams.push(params)
+    queryCalls++
+    const control = deferredAttempt()
+    controls.push(control)
+    const sessionId = `sdk-downgrade-${queryCalls}`
+    const generator = (async function* () {
+      activeQueries++
+      maxActiveQueries = Math.max(maxActiveQueries, activeQueries)
+      control.markStarted()
+      try {
+        yield { ...messageStart(), session_id: sessionId }
+        await control.wait
+        yield { ...textBlockStart(0), session_id: sessionId }
+        yield { ...textDelta(0, "ok"), session_id: sessionId }
+        yield { ...blockStop(0), session_id: sessionId }
+        yield { ...messageDelta("end_turn"), session_id: sessionId }
+        yield { ...messageStop(), session_id: sessionId }
+        yield { ...assistantMessage([{ type: "text", text: "ok" }]), session_id: sessionId }
+      } finally {
+        activeQueries--
+      }
+    })()
+    return Object.assign(generator, { close: () => {} })
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { telemetryStore } = await import("../telemetry")
+
+function request(
+  messages: Array<{ role: string; content: unknown }>,
+  sessionId: string,
+  stream = false,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-opencode-session": sessionId,
+      ...extraHeaders,
+    },
+    body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 128, stream, messages }),
+  })
+}
+
+async function waitForControl(index: number, timeoutMs = 3000): Promise<AttemptControl> {
+  const deadline = Date.now() + timeoutMs
+  while (!controls[index]) {
+    if (Date.now() > deadline) throw new Error(`SDK attempt #${index} never started`)
+    await Bun.sleep(1)
+  }
+  const control = controls[index]!
+  await control.started
+  return control
+}
+
+describe("modified-history conflict downgrade", () => {
+  const originalMax = process.env.MERIDIAN_MAX_CONCURRENT
+  const originalHold = process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+
+  beforeEach(() => {
+    process.env.MERIDIAN_MAX_CONCURRENT = "1"
+    activeQueries = 0
+    maxActiveQueries = 0
+    queryCalls = 0
+    controls = []
+    capturedParams = []
+    clearSessionCache()
+    resetProcessSdkSemaphoreForTests()
+    telemetryStore.clear()
+  })
+
+  afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    if (originalMax === undefined) delete process.env.MERIDIAN_MAX_CONCURRENT
+    else process.env.MERIDIAN_MAX_CONCURRENT = originalMax
+    if (originalHold === undefined) delete process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS
+    else process.env.MERIDIAN_SESSION_TURN_MAX_HOLD_MS = originalHold
+  })
+
+  it("downgrades modified-history conflict to fresh replay", async () => {
+    // Request A: 3 messages — acquires lease, commits turn.
+    // Request B: 5 messages, same session, trailing tool_result content revised.
+    //   Queued during A → should get fresh replay (200), NOT 409.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "original" }] },
+    ]
+    const superseding = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "ok" },
+      // Same position, revised content — triggers modified-history
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "use1", content: "REVISED" }] },
+      // Extra messages — makes incoming longer than stored
+      { role: "user", content: "extra turn" },
+      { role: "assistant", content: "and response" },
+    ]
+    const firstP = app.fetch(request(opening, "downgrade-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(superseding, "downgrade-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    // B gets the turn lease, does its lookup, and starts a fresh replay SDK query.
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    const second = await secondP
+    // modified-history should be downgraded to fresh replay, not 409
+    expect(second.status).toBe(200)
+    // Two distinct SDK queries — B does a fresh replay
+    expect(queryCalls).toBe(2)
+  })
+
+  it("still returns 409 for undo conflict (stale racer)", async () => {
+    // Control: a request shorter than stored history → still 409/undo.
+    // This mirrors the existing concurrency-coordination test's stale-branch case.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const opening = [
+      { role: "user", content: "set up" },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: "more context" },
+    ]
+    // Shorter request (1 msg) — undo when found in cache with 3 msgs
+    const stale = [{ role: "user", content: "set up" }]
+    const firstP = app.fetch(request(opening, "undo-test"))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(stale, "undo-test"))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    const second = await secondP
+    expect(second.status).toBe(400)
+    const body = await second.json()
+    expect(body.error.type).toBe("invalid_request_error")
+    expect(body.error.message).toContain("session advanced")
+    // Only one SDK query — the second request is refused
+    expect(queryCalls).toBe(1)
+  })
+})

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -45,9 +45,9 @@
  *  Duplicated here (with a cross-check test) to keep this module leaf-pure. */
 const CLIENT_TOOL_PREFIX = "mcp__oc__"
 
-/** Internal SDK tool that executes for real (deferred tool discovery) — its
- *  calls are never forwarded to the client and must not arm the tracker. */
-const INTERNAL_TOOLS = new Set(["ToolSearch"])
+/** Internal SDK tools execute inside the SDK. Their results never require
+ *  a client tool_result and must not arm a passthrough checkpoint. */
+const INTERNAL_TOOLS = new Set(["ToolSearch", "StructuredOutput"])
 
 export interface EarlyStopTracker {
   /** tool_use ids of client-forwarded calls awaiting an iterator-observed deny */

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3514,7 +3514,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   : true // nothing to gate on — settle on the tracker alone
                 if (earlyStopEnabled && turnComplete && shouldEarlyStop(earlyStop)) {
                   nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
-                  nextPassthroughToolCallIds = [...earlyStop.expected]
+                  nextPassthroughToolCallIds = [...earlyStop.expected].filter(id => !droppedToolUseIds.has(id))
                   earlyStopFired = true
                   // A digest hook can race just ahead of iterator consumption.
                   // Retain only calls proven to belong to the visible assistant
@@ -4566,7 +4566,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       shouldEarlyStop(earlyStop)
                     ) {
                       nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
-                      nextPassthroughToolCallIds = [...earlyStop.expected]
+                      nextPassthroughToolCallIds = [...earlyStop.expected].filter(id => !droppedToolUseIds.has(id))
                       earlyStopFired = true
                       for (let i = capturedToolUses.length - 1; i >= 0; i--) {
                         if (!earlyStop.expected.has(capturedToolUses[i]!.id)) capturedToolUses.splice(i, 1)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2182,6 +2182,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds)
           : undefined
         const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
+        // Passthrough mode — resolved early so the concurrent-conflict guards
+        // below can gate on passthrough status. When enabled, ALL tool execution
+        // is forwarded to OpenCode instead of being handled internally.
+        // Adapter can override the global passthrough env var per-agent.
+        // Instance passthrough override (#476) beats the adapter transform's
+        // default, which beats the global env var.
+        const passthrough = adapter.instancePassthrough !== undefined
+          ? adapter.instancePassthrough
+          : pipelineCtx.passthrough !== undefined
+            ? pipelineCtx.passthrough
+            : envBool("PASSTHROUGH")
         if (
           advancesDurableCheckpoint &&
           lineageResult.type !== "continuation" &&
@@ -2208,7 +2219,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           lineageResult.type !== "compaction"
         )
         if (lostRaceWhileWaiting && !declaresConcurrentFlow &&
-          !(lineageResult.type === "diverged" && lineageResult.reason === "modified-history")) {
+          !(passthrough && lineageResult.type === "diverged" && lineageResult.reason === "modified-history")) {
           const reason = lineageResult.type === "diverged" ? lineageResult.reason : lineageResult.type
           const message = "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
           claudeLog("session.concurrent_conflict", {
@@ -2294,8 +2305,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // concurrent turn lease falls through to fresh-replay instead of 409.
         // Safe: it is only produced when the history strictly grows
         // (messages.length > cached.messageCount), so undo / replayed-request /
-        // unrelated-history still 409.
+        // unrelated-history still 409. Only applies to passthrough sessions —
+        // non-passthrough (internal) sessions must surface a loud 409 so the
+        // concurrent-request race is visible to operators.
         if (
+          passthrough &&
           profileSessionId &&
           requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
           lineageResult.type === "diverged" &&
@@ -2342,19 +2356,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         let isUndo = lineageResult.type === "undo"
         const cachedSession = lineageResult.type !== "diverged" ? lineageResult.session : undefined
         let resumeSessionId = cachedSession?.claudeSessionId
-        // --- Passthrough mode ---
-        // When enabled, ALL tool execution is forwarded to OpenCode instead of
-        // being handled internally. This enables multi-model agent delegation
-        // (e.g., oracle on GPT-5.2, explore on Gemini via oh-my-opencode).
-        // Adapter can override the global passthrough env var per-agent.
-        // Droid always uses internal mode; OpenCode defers to the env var.
-        // Instance passthrough override (#476) beats the adapter transform's
-        // default, which beats the global env var.
-        const passthrough = adapter.instancePassthrough !== undefined
-          ? adapter.instancePassthrough
-          : pipelineCtx.passthrough !== undefined
-            ? pipelineCtx.passthrough
-            : envBool("PASSTHROUGH")
         const resumeFrom = lineageResult.type === "continuation" || lineageResult.type === "compaction"
           ? lineageResult.resumeFrom
           : undefined

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2301,17 +2301,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // until the atomic route+mapping CAS wins at the terminal barrier.
           lineageResult = { type: "diverged", reason: "priority-failback" }
         }
-        // A modified-history request (superseding, revised in place) under a
-        // concurrent turn lease falls through to fresh-replay instead of 409.
-        // Safe: it is only produced when the history strictly grows
-        // (messages.length > cached.messageCount), so undo / replayed-request /
-        // unrelated-history still 409. Only applies to passthrough sessions —
-        // non-passthrough (internal) sessions must surface a loud 409 so the
-        // concurrent-request race is visible to operators.
+        // A growing passthrough request with revised history can replay its
+        // complete body after losing a commit race. Keep stale undo, replayed
+        // and unrelated requests subject to the ordinary conflict guard.
         if (
+          lostRaceWhileWaiting &&
           passthrough &&
-          profileSessionId &&
-          requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
           lineageResult.type === "diverged" &&
           lineageResult.reason === "modified-history"
         ) {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2207,7 +2207,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           lineageResult.type !== "continuation" &&
           lineageResult.type !== "compaction"
         )
-        if (lostRaceWhileWaiting && !declaresConcurrentFlow) {
+        if (lostRaceWhileWaiting && !declaresConcurrentFlow &&
+          !(lineageResult.type === "diverged" && lineageResult.reason === "modified-history")) {
           const reason = lineageResult.type === "diverged" ? lineageResult.reason : lineageResult.type
           const message = "This session advanced while the request was waiting. Retry with the latest conversation history or use a distinct session ID."
           claudeLog("session.concurrent_conflict", {
@@ -2289,7 +2290,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // until the atomic route+mapping CAS wins at the terminal barrier.
           lineageResult = { type: "diverged", reason: "priority-failback" }
         }
-
+        // A modified-history request (superseding, revised in place) under a
+        // concurrent turn lease falls through to fresh-replay instead of 409.
+        // Safe: it is only produced when the history strictly grows
+        // (messages.length > cached.messageCount), so undo / replayed-request /
+        // unrelated-history still 409.
+        if (
+          profileSessionId &&
+          requestMeta.sessionTurnLease?.advancedWhileWaiting(profileSessionId) &&
+          lineageResult.type === "diverged" &&
+          lineageResult.reason === "modified-history"
+        ) {
+          claudeLog("session.concurrent_conflict", {
+            reason: "downgraded=fresh-replay",
+            sessionQueueWaitMs: requestMeta.sessionQueueWaitMs,
+          })
+          diagnosticLog.session(
+            `${requestMeta.requestId} session.concurrent_conflict reason=downgraded=fresh-replay wait=${requestMeta.sessionQueueWaitMs}ms`,
+            requestMeta.requestId,
+          )
+        }
         // Publish the decision to plugins. Core has always known WHICH message
         // stopped matching; the log line only ever reported how many matched
         // ("prefix overlap 50/51"), which is why #767 had to hand-patch a build

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4566,7 +4566,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       shouldEarlyStop(earlyStop)
                     ) {
                       nextPassthroughToolCallAssistantUuid = settledToolCallAssistantUuid(earlyStop)
-                      nextPassthroughToolCallIds = [...earlyStop.expected].filter(id => !droppedToolUseIds.has(id))
+                      // Streamed calls are already visible, even if a later hook
+                      // recognizes a duplicate. The client will return each ID.
+                      nextPassthroughToolCallIds = [...earlyStop.expected].filter(id =>
+                        !droppedToolUseIds.has(id) || streamedToolUseIds.has(id))
                       earlyStopFired = true
                       for (let i = capturedToolUses.length - 1; i >= 0; i--) {
                         if (!earlyStop.expected.has(capturedToolUses[i]!.id)) capturedToolUses.splice(i, 1)


### PR DESCRIPTION
Growing passthrough requests whose history was revised can lose a queued turn race and receive HTTP 400 even though their complete request is replayable. Admit only that modified-history case into a fresh SDK session, preserving every supplied message. Internal-mode, stale undo and unrelated conflicts retain their existing behavior; Pi concurrency and durable checkpoint continuations remain supported.

Checkpoint IDs now match the calls actually delivered. Non-streaming excludes hidden duplicates; streaming retains calls already sent before the duplicate hook ran. The SDK's internal StructuredOutput call no longer creates a client checkpoint that forces an ordinary follow-up to replay.

Incorporates the narrow conflict, passthrough-scope and duplicate-checkpoint contributions from #869. Lenny Parisi's three original commits retain his author identity and authored dates; maintainer corrections are separate commits. The broader settlement/checkpoint-retention changes are omitted because completed checkpoints must clear and revised history already replays correctly. Replay status stays in diagnostics rather than adding an unsolicited response footer. #767's full OpenCode/plugin/Opus report still requires its own client validation.

Validation: **3,421 local tests pass, one existing skip, zero failures**, independent typecheck/build, and all CI checks pass at 0abd7d36e0162c61ea0cf756bc11e5eb6e1eb925 (runs 33975427939 / 33975427682). Fail-before/pass-after HTTP cases cover both modes, separate processes, Pi controls, visible duplicate calls and native structured output. Real SDK/HTTP E2Es prove complete revised replay, schema-validated answers, matching visible/checkpoint/result IDs, ordinary resume and unchanged source histories using supported getSessionMessages. All four E41 sequential/parallel × streaming/non-streaming tool-loop controls pass. E2E commands are documented in E2E.md.

Co-authored-by: Lenny Parisi <email@leonardparisi.com>
