### PR TITLE
fix: resume Claude Code reminders without losing history

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -3731,3 +3731,14 @@ Run `bun scripts/e2e-modified-history-conflict.mjs` and again with `--stream`. S
 Run `bun scripts/e2e-duplicate-checkpoint.mjs` in both modes. The real model must emit two identical tool calls; otherwise the fixture precondition fails. Non-streaming currently delivers one call; streaming delivers both before hooks recognize duplication. The stored checkpoint must match the delivered IDs, all returned results must resume, and the source must remain unchanged. This gate does not claim streaming deduplication.
 
 Run `bun scripts/e2e-settlement-proof.mjs` in both modes to verify revised history following a completed real tool checkpoint. Require the supplied decision in the SDK input and answer, unchanged source history, and a resumed ordinary follow-up. Keeping old completed checkpoints must not force future turns to replay.
+
+
+## Claude Code trailing system reminders
+
+Run `bun scripts/e2e-claude-code-system-delta.mjs` in both modes (`--stream`); repeat with `E2E_MODEL=claude-sonnet-4-6` and the `--image` flag to validate a native image tool result followed by a reminder. Require the actual tool result, reminder identifier and optional image color in the answer, checkpoint resume, no reminder promoted into the SDK system prompt, and unchanged source history through supported `getSessionMessages`.
+
+Repeat the direct gate with `--revise-history` and separately with `--insert-history` in text/image and streaming/non-streaming modes. Edited or inserted user history must replay fresh and deliver its revised or inserted identifier, with no removed identifier, no assistant attribution on the reminder, and the replay history boundary preserved. Matching pending tool IDs alone must never discard earlier edits.
+
+Run `bun scripts/e2e-claude-code-client.mjs` for the full installed Claude Code 2.1.259 → Meridian → real SDK loop. `E2E_CLAUDE_CLIENT` can name that exact client binary. The fixture isolates the outer client's settings and enables its `CLAUDE_CODE_FORCE_MID_CONVERSATION_SYSTEM` flag; `--bare` suppresses the shape and is unsuitable. The real CLI reads a disposable fixture, sends its native `<total_tokens>` system reminder, then resumes for an ordinary follow-up. Require both proxy continuations to resume, delivery of both reminders to SDK user history, correct answers, and unchanged source history.
+
+`--capture` runs only the real client's wire-format probe against a scripted local endpoint. It does not contact the SDK and is not a substitute for the full E2E gate. The fixture checks the exact client version; newer versions are separate compatibility targets. This case does not validate OpenCode/Orca cross-tool session ownership (#946).

--- a/scripts/e2e-claude-code-client.mjs
+++ b/scripts/e2e-claude-code-client.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+// Real Claude Code 2.1.259 → Meridian → SDK read loop and ordinary continuation.
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getSessionMessages } from '@anthropic-ai/claude-agent-sdk'
+import { realpathSync } from 'node:fs'
+const captureOnly = process.argv.includes('--capture')
+import assert from 'node:assert/strict'
+const root = realpathSync(mkdtempSync(join(tmpdir(), 'meridian-cc-client-')))
+for (const key of Object.keys(process.env)) if (key.startsWith('MERIDIAN_') || key.startsWith('CLAUDE_PROXY_')) delete process.env[key]
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root,'proxy-config'), MERIDIAN_SESSION_DIR: join(root,'proxy-sessions'), MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST:'0', MERIDIAN_PASSTHROUGH:'1' })
+const { startProxyServer } = await import('../src/proxy/server.ts')
+const { lookupSharedSession } = await import('../src/proxy/sessionStore.ts')
+const { telemetryStore } = await import('../src/telemetry/index.ts')
+const { resolveClaudeExecutableAsync } = await import('../src/proxy/models.ts')
+const client = process.env.E2E_CLAUDE_CLIENT ?? await resolveClaudeExecutableAsync()
+const versionProcess = Bun.spawn([client, '--version'], { stdout:'pipe', stderr:'pipe' })
+const version = (await new Response(versionProcess.stdout).text()).trim()
+const versionError = await new Response(versionProcess.stderr).text()
+assert.equal(await versionProcess.exited, 0, versionError)
+assert.equal(version, '2.1.259 (Claude Code)', 'This gate validates the captured 2.1.259 client')
+const instance = captureOnly ? undefined : await startProxyServer({port:0,host:'127.0.0.1',silent:true})
+const address = instance?.server.address()
+const proxyUrl = address && typeof address === 'object' ? `http://127.0.0.1:${address.port}` : undefined
+let source
+let sourceRows
+let key
+const value = `fixture_${crypto.randomUUID()}`
+const file = join(root, 'fixture.txt')
+writeFileSync(file, value)
+const captures=[]
+const server=Bun.serve({hostname:'127.0.0.1',port:0, async fetch(req){
+ const path=new URL(req.url).pathname
+ if(path.endsWith('/count_tokens'))return Response.json({input_tokens:4000})
+ if(!path.endsWith('/messages'))return proxyUrl ? fetch(proxyUrl+path,{method:req.method,headers:req.headers,body:req.body,duplex:'half'}) : Response.json({})
+ const body=await req.json();captures.push(body)
+ if(proxyUrl){
+  key=JSON.parse(body.metadata.user_id).session_id
+  if(captures.length===2){
+   source=lookupSharedSession(key)
+   assert(source?.claudeSessionId && source.passthroughToolCallAssistantUuid)
+   sourceRows=await getSessionMessages(source.claudeSessionId,{dir:root})
+  }
+  return fetch(proxyUrl+path,{method:'POST',headers:req.headers,body:JSON.stringify(body),signal:AbortSignal.timeout(120_000)})
+ }
+ const isResult=body.messages?.some(m=>Array.isArray(m.content)&&m.content.some(b=>b.type==='tool_result'))
+ const content=isResult?[{type:'text',text:value}]:[{type:'tool_use',id:'toolu_capture',name:'Read',input:{file_path:file}}]
+ const stop_reason=isResult?'end_turn':'tool_use'
+ const message={id:'msg_capture_'+captures.length,type:'message',role:'assistant',model:body.model,content,stop_reason,stop_sequence:null,usage:{input_tokens:4000,output_tokens:100}}
+ if(!body.stream)return Response.json(message)
+ const events=[{type:'message_start',message:{...message,content:[],stop_reason:null}}]
+ content.forEach((block,index)=>{events.push({type:'content_block_start',index,content_block:block.type==='text'?{type:'text',text:''}:{...block,input:{}}});events.push({type:'content_block_delta',index,delta:block.type==='text'?{type:'text_delta',text:block.text}:{type:'input_json_delta',partial_json:JSON.stringify(block.input)}});events.push({type:'content_block_stop',index})})
+ events.push({type:'message_delta',delta:{stop_reason,stop_sequence:null},usage:{output_tokens:100}},{type:'message_stop'})
+ return new Response(events.map(event=>`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(''),{headers:{'content-type':'text/event-stream'}})
+}})
+const env={...process.env,ANTHROPIC_BASE_URL:`http://127.0.0.1:${server.port}`,ANTHROPIC_API_KEY:'test-loopback-key',CLAUDE_CONFIG_DIR:join(root,'client-config'),CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:'1',CLAUDE_CODE_FORCE_MID_CONVERSATION_SYSTEM:'1'}
+for(const key of Object.keys(env))if(key.startsWith('MERIDIAN_')||key.startsWith('CLAUDE_PROXY_')||['CLAUDECODE','ANTHROPIC_AUTH_TOKEN','CLAUDE_CODE_OAUTH_TOKEN'].includes(key))delete env[key]
+let child
+try{
+ child=Bun.spawn([client,'--setting-sources','','--strict-mcp-config','--mcp-config','{"mcpServers":{}}','-p',`Read ${file} once and return its contents.`, '--model','claude-opus-4-7','--tools','Read','--allowedTools','Read','--max-turns','3','--output-format','json'],{cwd:root,env,stdout:'pipe',stderr:'pipe'})
+ const timer=setTimeout(()=>child.kill(),180_000)
+ const [code,out,err]=await Promise.all([child.exited,new Response(child.stdout).text(),new Response(child.stderr).text()]);clearTimeout(timer)
+ writeFileSync(join(root,'requests.json'),JSON.stringify(captures,null,2))
+ assert.equal(code, 0, JSON.stringify({out, err}))
+ console.log(JSON.stringify({root,code,err,version,mode:captureOnly?'capture':'live',result:JSON.parse(out).result,roles:captures.map(b=>b.messages.map(m=>m.role))}))
+ assert(captures.some(b=>b.messages.at(-1)?.role==='system'),'Captured client must emit trailing system message')
+ if(!captureOnly){
+  assert.equal(captures.length, 2, 'One read must complete in exactly two client requests')
+  assert(JSON.parse(out).result.includes(value),'Actual client must return the read fixture')
+  assert(source && sourceRows && key)
+  const metric=telemetryStore.getRecent({limit:1})[0]
+  assert.equal(metric?.isResume,true,'Real Claude Code continuation must resume')
+  const current=lookupSharedSession(key)
+  assert(current?.claudeSessionId)
+  const rows=await getSessionMessages(current.claudeSessionId,{dir:root})
+  const reminder=captures[1].messages.at(-1).content
+  const texts=typeof reminder==='string'?[reminder]:reminder.map(b=>b.text)
+  const userRows=JSON.stringify(rows.filter(row=>row.type==='user'))
+  for(const text of texts)assert(userRows.includes(text),'Reminder missing from SDK user content')
+  assert.deepEqual(await getSessionMessages(source.claudeSessionId,{dir:root}),sourceRows,'Source history changed')
+  child = Bun.spawn([client, '--setting-sources', '', '--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}',
+    '--resume', JSON.parse(out).session_id, '-p', 'Repeat the fixture value you just read. No tools.',
+    '--model', 'claude-opus-4-7', '--tools', 'Read', '--allowedTools', 'Read', '--max-turns', '3', '--output-format', 'json'],
+    { cwd:root, env, stdout:'pipe', stderr:'pipe' })
+  const followupTimer = setTimeout(() => child.kill(), 120_000)
+  const [followupCode, followupOut, followupErr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()])
+  clearTimeout(followupTimer)
+  writeFileSync(join(root,'requests.json'),JSON.stringify(captures,null,2))
+  const followupMetric = telemetryStore.getRecent({limit:1})[0]
+  assert.equal(followupCode, 0, JSON.stringify({followupOut, followupErr}))
+  console.log(JSON.stringify({followupCode, followupErr, followupResult:JSON.parse(followupOut).result, isResume:followupMetric?.isResume}))
+  assert.equal(captures.length, 3, 'The ordinary follow-up must not call another tool')
+  assert(JSON.parse(followupOut).result.includes(value))
+  assert.equal(followupMetric?.isResume, true, 'Ordinary real client continuation must also resume')
+  const finalMapping = lookupSharedSession(key)
+  const finalRows = await getSessionMessages(finalMapping.claudeSessionId, {dir:root})
+  const finalReminder = captures.at(-1).messages.at(-1).content
+  const finalTexts = typeof finalReminder === 'string' ? [finalReminder] : finalReminder.map(block => block.text)
+  const finalUsers = JSON.stringify(finalRows.filter(row => row.type === 'user'))
+  for (const text of finalTexts) assert(finalUsers.includes(text), 'Ordinary follow-up reminder missing from SDK user content')
+  assert.deepEqual(await getSessionMessages(source.claudeSessionId,{dir:root}),sourceRows)
+  console.log(JSON.stringify({result:'PASS',actualClient:true,resume:true,sourceUnchanged:true}))
+ }
+
+}finally{child?.kill();server.stop(true);await instance?.close()}

--- a/scripts/e2e-claude-code-system-delta.mjs
+++ b/scripts/e2e-claude-code-system-delta.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+// Real SDK/HTTP gate for Claude Code trailing-system checkpoint delivery.
+import assert from "node:assert/strict"
+import { randomUUID } from "node:crypto"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { deflateSync } from "node:zlib"
+import * as sdk from "@anthropic-ai/claude-agent-sdk"
+import { spyOn } from "bun:test"
+const { getSessionMessages } = sdk
+const queryOptions = []
+const textPrompts = []
+const sdkResults = []
+const realQuery = sdk.query
+const querySpy = spyOn(sdk, "query").mockImplementation(input => {
+  queryOptions.push(input.options)
+  textPrompts.push(typeof input.prompt === "string" ? input.prompt : null)
+  const query = realQuery(input)
+  const iterate = query[Symbol.asyncIterator].bind(query)
+  query[Symbol.asyncIterator] = async function* () {
+    for await (const event of { [Symbol.asyncIterator]: iterate }) {
+      if (event.type === "result") sdkResults.push({ subtype: event.subtype, errors: event.errors, is_error: event.is_error })
+      yield event
+    }
+  }
+  return query
+})
+
+const stream = process.argv.includes("--stream")
+const image = process.argv.includes("--image")
+const reviseHistory = process.argv.includes("--revise-history")
+const insertHistory = process.argv.includes("--insert-history")
+const expectResume = !reviseHistory && !insertHistory
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-cc-system-delta-")))
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST: "0", MERIDIAN_PASSTHROUGH: "1" })
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const { lookupSharedSession } = await import("../src/proxy/sessionStore.ts")
+const { telemetryStore } = await import("../src/telemetry/index.ts")
+function blueImage() {
+  function chunk(type, data) {
+    let crc = 0xffffffff
+    for (const byte of Buffer.concat([Buffer.from(type), data])) {
+      crc ^= byte
+      for (let bit = 0; bit < 8; bit++) crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1
+    }
+    const size = Buffer.alloc(4); size.writeUInt32BE(data.length)
+    const checksum = Buffer.alloc(4); checksum.writeUInt32BE((crc ^ 0xffffffff) >>> 0)
+    return Buffer.concat([size, Buffer.from(type), data, checksum])
+  }
+  const header = Buffer.alloc(13); header.writeUInt32BE(48); header.writeUInt32BE(48, 4); header[8] = 8; header[9] = 2
+  const row = Buffer.concat([Buffer.from([0]), Buffer.from(Array.from({ length: 48 }, () => [0, 0, 255]).flat())])
+  const data = Buffer.concat([Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]), chunk("IHDR", header),
+    chunk("IDAT", deflateSync(Buffer.concat(Array.from({ length: 48 }, () => row)))), chunk("IEND", Buffer.alloc(0))]).toString("base64")
+  return { type: "image", source: { type: "base64", media_type: "image/png", data } }
+}
+
+const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+const address = instance.server.address()
+assert(address && typeof address === "object")
+const key = `cc-system-${randomUUID()}`
+const tools = [{ name: "get_fixture", description: "Return a JavaScript fixture value.",
+  input_schema: { type: "object", properties: {}, additionalProperties: false } }]
+async function request(messages) {
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+    method: "POST", headers: { "content-type": "application/json", "user-agent": "claude-cli/2.1.259" },
+    body: JSON.stringify({ model: process.env.E2E_MODEL ?? "claude-haiku-4-5-20251001", max_tokens: 200, stream, tools, messages, metadata: { user_id: JSON.stringify({ session_id: key }) } }),
+    signal: AbortSignal.timeout(90_000),
+  })
+  const raw = await response.text()
+  assert.equal(response.status, 200, raw)
+  if (!stream) return JSON.parse(raw).content
+  const events = raw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+  assert(!events.some(event => event.type === "error"), raw)
+  assert.equal(events.filter(event => event.type === "message_stop").length, 1)
+  const blocks = []
+  for (const event of events) {
+    if (event.type === "content_block_start") blocks[event.index] = { ...event.content_block, json: "" }
+    if (event.delta?.type === "text_delta") blocks[event.index].text += event.delta.text
+    if (event.delta?.type === "input_json_delta") blocks[event.index].json += event.delta.partial_json
+  }
+  return blocks.filter(Boolean).map(({ json, ...block }) => block.type === "tool_use"
+    ? { ...block, input: json ? JSON.parse(json) : block.input } : block)
+}
+try {
+  const insertedIdentifier = `inserted_${randomUUID()}`
+  const originalContext = `context_${randomUUID()}`
+  const revisedContext = reviseHistory ? `context_${randomUUID()}` : originalContext
+  const opening = { role: "user", content: `The fixture context identifier is ${originalContext}. Call get_fixture exactly once. When the result arrives, reply with its value, the fixture context identifier, and the identifier in any accompanying system reminder. No more tools.` }
+  const first = await request([opening])
+  const calls = first.filter(block => block.type === "tool_use")
+  assert.equal(calls.length, 1, JSON.stringify(first))
+  const source = lookupSharedSession(key)
+  assert(source?.claudeSessionId && source.passthroughToolCallAssistantUuid)
+  const sourceRows = await getSessionMessages(source.claudeSessionId, { dir: root })
+  assert(sourceRows.length)
+  const value = `value_${randomUUID()}`
+  const marker = `reminder_${randomUUID()}`
+  const reminder = `<system-reminder>The reminder identifier is ${marker}. Include it with the fixture value and the fixture context identifier from the opening user message in your response. If the tool result includes an image, also name its predominant color. Include any extra identifier supplied in a user message before the call. No more tools.</system-reminder>`
+  const history = [{ ...opening, content: opening.content.replace(originalContext, revisedContext) },
+    ...(insertHistory ? [{ role: "user", content: `The extra identifier is ${insertedIdentifier}. Include it in the final answer.` }] : []), { role: "assistant", content: first },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: calls[0].id, content: image ? [{ type: "text", text: value }, blueImage()] : value },
+      { type: "text", text: "The requested tool has completed. Report its supplied value, the fixture context identifier from the opening message, and the accompanying reminder identifier. Use the recorded result; no further tool calls are needed." }] },
+    { role: "system", content: [{ type: "text", text: reminder, cache_control: { type: "ephemeral" } }] }]
+  const second = await request(history)
+  const answer = second.filter(block => block.type === "text").map(block => block.text).join("")
+  const metric = telemetryStore.getRecent({ limit: 1 })[0]
+  console.log(JSON.stringify({ root, stream, image, reviseHistory, insertHistory, answer, expected: [value, marker], isResume: metric?.isResume,
+    blocks: second.map(block => ({ type: block.type, name: block.name, text: block.text })), sdkResults, freshPrompt: textPrompts[1], resumeAt: queryOptions[1]?.resumeSessionAt ?? null, expectedCheckpoint: source.passthroughToolCallAssistantUuid }))
+  assert.equal(second.filter(block => block.type === "tool_use").length, 0, "A completed result must not cause another tool request")
+  assert(answer.includes(value) && answer.includes(marker), "Both real result and system-reminder text must reach the answer")
+  if (image) assert(answer.toLowerCase().includes("blue"), "Tool-result image must reach the model")
+  assert(answer.includes(revisedContext), "Revised opening context must reach the answer")
+  if (reviseHistory) assert(!answer.includes(originalContext), "Removed opening context leaked into the answer")
+  if (insertHistory) assert(answer.includes(insertedIdentifier), "Inserted user context must reach the answer")
+  assert.equal(metric?.isResume, expectResume, "Only unchanged history may resume its checkpoint")
+  assert.equal(queryOptions[1]?.resumeSessionAt, expectResume ? source.passthroughToolCallAssistantUuid : undefined)
+  assert(!JSON.stringify(queryOptions[1]?.systemPrompt).includes(marker), "Reminder was escalated into the SDK system prompt")
+  const current = lookupSharedSession(key)
+  assert(current?.claudeSessionId)
+  const rows = await getSessionMessages(current.claudeSessionId, { dir: root })
+  const users = JSON.stringify(rows.filter(row => row.type === "user"))
+  assert(users.includes(value) && users.includes(marker))
+  assert(!users.includes("[Assistant: <system-reminder>"), "Reminder was attributed to the assistant during replay")
+  if (insertHistory) assert(users.includes(insertedIdentifier))
+  if (reviseHistory) {
+    assert(users.includes(revisedContext) && !users.includes(originalContext))
+    assert(users.includes("</conversation_history>"), "Fresh history must retain its context boundary")
+  }
+  assert.deepEqual(await getSessionMessages(source.claudeSessionId, { dir: root }), sourceRows)
+  console.log(JSON.stringify({ result: "PASS", stream, reminderDelivered: true, sourceUnchanged: true }))
+} finally {
+  querySpy.mockRestore()
+  await instance.close()
+}

--- a/src/__tests__/lineage-checkpoint-prefix.test.ts
+++ b/src/__tests__/lineage-checkpoint-prefix.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { computeLineageHash, matchesStoredLineagePrefix } from "../proxy/session/lineage"
+
+describe("durable checkpoint prefix proof", () => {
+  const prefix = [{ role: "user", content: "original instruction" }, { role: "system", content: [{ type: "text", text: "reminder" }] }]
+  const stored = { messageCount: prefix.length, lineageHash: computeLineageHash(prefix) }
+
+  it("accepts complete unchanged prefixes and equivalent text representations", () => {
+    expect(matchesStoredLineagePrefix(stored, [...prefix, { role: "assistant", content: "new call" }])).toBe(true)
+    expect(matchesStoredLineagePrefix(stored, [prefix[0]!, { role: "system", content: "reminder" }])).toBe(true)
+  })
+
+  it("rejects edits, removals and role changes before the pending call", () => {
+    expect(matchesStoredLineagePrefix(stored, [{ role: "user", content: "revised instruction" }, prefix[1]!])).toBe(false)
+    expect(matchesStoredLineagePrefix(stored, [prefix[0]!])).toBe(false)
+    expect(matchesStoredLineagePrefix(stored, [prefix[0]!, { role: "user", content: "reminder" }])).toBe(false)
+  })
+
+  it("requires a valid nonempty stored count and current digest", () => {
+    for (const messageCount of [undefined, 0, -1, 1.5, Infinity, NaN]) {
+      expect(matchesStoredLineagePrefix({ ...stored, messageCount }, prefix)).toBe(false)
+    }
+    expect(matchesStoredLineagePrefix({ messageCount: 2 }, prefix)).toBe(false)
+    expect(matchesStoredLineagePrefix({ messageCount: 2, lineageHash: "legacy" }, prefix)).toBe(false)
+  })
+})

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -168,6 +168,25 @@ async function post(app: any, body: any, sessionHeader = "es-session", extraHead
   }))
 }
 
+/** Live Claude Code request: session identity in metadata.user_id, claude-cli
+ * UA, and no x-opencode-session header. */
+async function postClaudeCode(app: any, body: any, sessionId: string, extraHeaders: Record<string, string> = {}) {
+  usedSessionKeys.add(sessionId)
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "user-agent": "claude-cli/2.1.259",
+      ...extraHeaders,
+    },
+    body: JSON.stringify({
+      metadata: { user_id: JSON.stringify({ session_id: sessionId }) },
+      ...body,
+    }),
+  }))
+}
+
 describe("Integration: passthrough early stop", () => {
   let app: any
   let savedPassthrough: string | undefined
@@ -1133,6 +1152,112 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.resumeSessionAt).toBe(visibleToolTurn.uuid)
     expect(capturedQueryParams.options.resumeSessionAt).not.toBe(hiddenDigestTurn.uuid)
     expect(capturedQueryParams.options.forkSession).toBe(true)
+  })
+
+  // Live claude-cli 2.1.259 closes its tool-result delta with a trailing
+  // system-role reminder turn (assistant[tool_use] -> user[tool_result] ->
+  // system[text], a <total_tokens>-style message). The generic helpers
+  // reject role=system, which forced a full fresh replay; the claude-code
+  // opt-in must resume the checkpoint and deliver the reminder as
+  // unprivileged user text.
+  it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
+    const sessionId = `cc-delta-${TEST_RUN_ID}`
+    const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
+    const trailingSystemText = "<system-reminder>Total tokens: 4151</system-reminder>"
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1: initial user turn plus the system prompt as a text block with
+    // cache_control — the captured request1 shape.
+    mockMessages = [
+      messageStart("msg_cc_delta_1"),
+      toolUseBlockStart(0, "read", "cc-delta-tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("cc-delta-tu1"),
+      assistantMessage([{ type: "text", text: "CC_DELTA_GARBAGE_DIGEST" }]),
+    ]
+    const first = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId)
+    expect(first.status).toBe(200)
+    expect(await first.text()).not.toContain("CC_DELTA_GARBAGE_DIGEST")
+    let stored: any
+    for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
+      stored = lookupSharedSession(sessionId)
+      if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-tu1"])
+    expect(stored?.passthroughToolCallAssistantUuid).toBe(toolTurn.uuid)
+
+    // Turn 2: same prefix with the SAME system as an equivalent plain string
+    // (the representation flip lineage canonicalizes), then the exact live
+    // delta: echoed tool_use, real tool_result, trailing system reminder.
+    mockMessages = [
+      messageStart("msg_cc_delta_2"),
+      textBlockStart(0),
+      textDelta(0, "the file says hi"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "the file says hi" }]),
+    ]
+    const requestId = `cc-delta-turn2-${TEST_RUN_ID}`
+    const second = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: initialSystemText },
+        { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: trailingSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId, { "x-request-id": requestId })
+    expect(second.status).toBe(200)
+    const secondBody = await second.text()
+    expect(secondBody).toContain("message_stop")
+    expect(secondBody).toContain("the file says hi")
+    expect(secondBody).not.toContain("CC_DELTA_GARBAGE_DIGEST")
+
+    // Resumed at the exact assistant checkpoint — not a fresh replay.
+    const resumed = capturedQueryParamsAll[1]
+    expect(resumed.options.resume).toBe(initialManagedSessionId())
+    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+    expect(resumed.options.forkSession).toBe(true)
+    // No fresh-replay framing; the reminder never reaches the SDK system prompt.
+    expect(secondBody).not.toContain("conversation_history")
+    expect(JSON.stringify(resumed.options.systemPrompt ?? "")).not.toContain(trailingSystemText)
+    // SDK prompt is exactly the native tool_result then the reminder as
+    // ordinary user text, with cache_control stripped.
+    expect(typeof resumed.prompt).not.toBe("string")
+    const promptMessages: any[] = []
+    for await (const message of resumed.prompt) promptMessages.push(message)
+    expect(promptMessages).toHaveLength(1)
+    expect(promptMessages[0].message.content).toEqual([
+      { type: "tool_result", tool_use_id: "cc-delta-tu1", content: "hi" },
+      { type: "text", text: trailingSystemText },
+    ])
+
+    let row: any
+    for (let i = 0; i < 500 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
+      if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(row).toBeDefined()
+    expect(row!.isResume).toBe(true)
   })
 
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -370,7 +370,7 @@ describe("Integration: passthrough early stop", () => {
     ])
   })
 
-  it("non-stream: treats exact pending tool results as causal continuation despite envelope drift", async () => {
+  it("non-stream: replays changed earlier history even when pending tool IDs match", async () => {
     const assistantToolTurn = assistantMessage([
       { type: "tool_use", id: "tu-envelope", name: "read", input: { file_path: "x" } },
     ])
@@ -397,15 +397,12 @@ describe("Integration: passthrough early stop", () => {
       ],
     }, "es-envelope-drift")
     expect(second.status).toBe(200)
-    expect(capturedQueryParams.options.resume).toBe(initialManagedSessionId())
-    expect(capturedQueryParams.options.resumeSessionAt).toBe(assistantToolTurn.uuid)
-    expect(capturedQueryParams.options.forkSession).toBe(true)
-    const promptMessages: any[] = []
-    for await (const message of capturedQueryParams.prompt) promptMessages.push(message)
-    expect(promptMessages).toHaveLength(1)
-    expect(promptMessages[0].message.content).toEqual([
-      { type: "tool_result", tool_use_id: "tu-envelope", content: "hi" },
-    ])
+    expect(capturedQueryParams.options.resume).toBeUndefined()
+    expect(capturedQueryParams.options.resumeSessionAt).toBeUndefined()
+    expect(typeof capturedQueryParams.prompt).toBe("string")
+    expect(capturedQueryParams.prompt).toContain("inserted volatile prefix")
+    expect(capturedQueryParams.prompt).toContain("volatile envelope changed")
+    expect(capturedQueryParams.prompt).toContain("hi")
   })
 
   it("non-stream: keeps the checkpoint when queued user text follows tool results", async () => {
@@ -1161,105 +1158,133 @@ describe("Integration: passthrough early stop", () => {
   // no opt-in. The generic helpers reject role=system, which forced a full
   // fresh replay; the opt-in must resume the checkpoint and deliver the
   // reminder as unprivileged user text.
-  it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
-    const sessionId = `cc-delta-${TEST_RUN_ID}`
-    const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
-    const trailingSystemText = "<system-reminder>Total tokens: 4151</system-reminder>"
-    const toolTurn = assistantMessage([
-      { type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } },
-    ])
+  const reminderCases = [false, true].flatMap(stream =>
+    ["claude-code", "opencode"].flatMap(adapter =>
+      ["unchanged", "revised", "inserted"].flatMap(historyChange =>
+        [false, true].map(image => ({ stream, adapter, historyChange, image })))))
+  for (const { stream, adapter, historyChange, image } of reminderCases) {
+    it(`scopes trailing reminder checkpoint resume to Claude Code (adapter=${adapter}, stream=${stream}, historyChange=${historyChange}, image=${image})`, async () => {
+      const sessionId = `cc-delta-${adapter}-${stream}-${historyChange}-${image}-${TEST_RUN_ID}`
+      const resultContent = image
+        ? [{ type: "text", text: "hi" }, { type: "image", source: { type: "base64", media_type: "image/png", data: "test-image" } }]
+        : "hi"
+      const headers = { "x-meridian-agent": adapter, "x-opencode-session": sessionId }
+      const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
+      const trailingSystemText = "<system-reminder>Total tokens: 4151</system-reminder>"
+      const toolTurn = assistantMessage([
+        { type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } },
+      ])
 
-    // Turn 1: initial user turn plus the system prompt as a text block with
-    // cache_control — the captured request1 shape.
-    mockMessages = [
-      messageStart("msg_cc_delta_1"),
-      toolUseBlockStart(0, "read", "cc-delta-tu1"),
-      inputJsonDelta(0, '{"file_path":"x"}'),
-      blockStop(0),
-      messageDelta("tool_use"),
-      toolTurn,
-      userDenyMessage("cc-delta-tu1"),
-      assistantMessage([{ type: "text", text: "CC_DELTA_GARBAGE_DIGEST" }]),
-    ]
-    const first = await postClaudeCode(app, {
-      model: "claude-sonnet-4-5",
-      max_tokens: 400,
-      stream: true,
-      tools: [READ_TOOL],
-      messages: [
-        { role: "user", content: "read x" },
-        { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
-      ],
-    }, sessionId)
-    expect(first.status).toBe(200)
-    expect(await first.text()).not.toContain("CC_DELTA_GARBAGE_DIGEST")
-    let stored: any
-    for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
-      stored = lookupSharedSession(sessionId)
-      if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
-    }
-    expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-tu1"])
-    expect(stored?.passthroughToolCallAssistantUuid).toBe(toolTurn.uuid)
+      // Turn 1: initial user turn plus the system prompt as a text block with
+      // cache_control — the captured request1 shape.
+      mockMessages = [
+        messageStart("msg_cc_delta_1"),
+        toolUseBlockStart(0, "read", "cc-delta-tu1"),
+        inputJsonDelta(0, '{"file_path":"x"}'),
+        blockStop(0),
+        messageDelta("tool_use"),
+        toolTurn,
+        userDenyMessage("cc-delta-tu1"),
+        assistantMessage([{ type: "text", text: "CC_DELTA_GARBAGE_DIGEST" }]),
+      ]
+      const first = await postClaudeCode(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 400,
+        stream,
+        tools: [READ_TOOL],
+        messages: [
+          { role: "user", content: "read x" },
+          { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
+        ],
+      }, sessionId, headers)
+      expect(first.status).toBe(200)
+      expect(await first.text()).not.toContain("CC_DELTA_GARBAGE_DIGEST")
+      let stored: any
+      for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
+        stored = lookupSharedSession(sessionId)
+        if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-tu1"])
+      expect(stored?.passthroughToolCallAssistantUuid).toBe(toolTurn.uuid)
 
-    // Turn 2: same prefix with the SAME system as an equivalent plain string
-    // (the representation flip lineage canonicalizes), then the exact live
-    // delta: echoed tool_use, real tool_result, trailing system reminder.
-    mockMessages = [
-      messageStart("msg_cc_delta_2"),
-      textBlockStart(0),
-      textDelta(0, "the file says hi"),
-      blockStop(0),
-      messageDelta("end_turn"),
-      messageStop(),
-      assistantMessage([{ type: "text", text: "the file says hi" }]),
-    ]
-    const requestId = `cc-delta-turn2-${TEST_RUN_ID}`
-    const second = await postClaudeCode(app, {
-      model: "claude-sonnet-4-5",
-      max_tokens: 400,
-      stream: true,
-      tools: [READ_TOOL],
-      messages: [
-        { role: "user", content: "read x" },
-        { role: "system", content: initialSystemText },
-        { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } }] },
-        { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-tu1", content: "hi" }] },
-        { role: "system", content: [{ type: "text", text: trailingSystemText, cache_control: { type: "ephemeral" } }] },
-      ],
-    }, sessionId, { "x-request-id": requestId })
-    expect(second.status).toBe(200)
-    const secondBody = await second.text()
-    expect(secondBody).toContain("message_stop")
-    expect(secondBody).toContain("the file says hi")
-    expect(secondBody).not.toContain("CC_DELTA_GARBAGE_DIGEST")
+      // Turn 2: same prefix with the SAME system as an equivalent plain string
+      // (the representation flip lineage canonicalizes), then the exact live
+      // delta: echoed tool_use, real tool_result, trailing system reminder.
+      mockMessages = [
+        messageStart("msg_cc_delta_2"),
+        textBlockStart(0),
+        textDelta(0, "the file says hi"),
+        blockStop(0),
+        messageDelta("end_turn"),
+        messageStop(),
+        assistantMessage([{ type: "text", text: "the file says hi" }]),
+      ]
+      const requestId = `cc-delta-turn2-${TEST_RUN_ID}`
+      const second = await postClaudeCode(app, {
+        model: "claude-sonnet-4-5",
+        max_tokens: 400,
+        stream,
+        tools: [READ_TOOL],
+        messages: [
+          { role: "user", content: historyChange === "revised" ? "Read the fixture with revised earlier instructions." : "read x" },
+          { role: "system", content: initialSystemText },
+          ...(historyChange === "inserted" ? [{ role: "user", content: "Inserted instruction before the echoed call." }] : []),
+          { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-tu1", name: "read", input: { file_path: "x" } }] },
+          { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-tu1", content: resultContent }] },
+          { role: "system", content: [{ type: "text", text: trailingSystemText, cache_control: { type: "ephemeral" } }] },
+        ],
+      }, sessionId, { ...headers, "x-request-id": requestId })
+      expect(second.status).toBe(200)
+      const secondBody = await second.text()
+      expect(secondBody).toContain(stream ? "message_stop" : "end_turn")
+      expect(secondBody).toContain("the file says hi")
+      expect(secondBody).not.toContain("CC_DELTA_GARBAGE_DIGEST")
 
-    // Resumed at the exact assistant checkpoint — not a fresh replay.
-    const resumed = capturedQueryParamsAll[1]
-    expect(resumed.options.resume).toBe(initialManagedSessionId())
-    expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
-    expect(resumed.options.forkSession).toBe(true)
-    // No fresh-replay framing; the reminder never reaches the SDK system prompt.
-    expect(secondBody).not.toContain("conversation_history")
-    expect(JSON.stringify(resumed.options.systemPrompt ?? "")).not.toContain(trailingSystemText)
-    // SDK prompt is exactly the native tool_result then the reminder as
-    // ordinary user text, with cache_control stripped.
-    expect(typeof resumed.prompt).not.toBe("string")
-    const promptMessages: any[] = []
-    for await (const message of resumed.prompt) promptMessages.push(message)
-    expect(promptMessages).toHaveLength(1)
-    expect(promptMessages[0].message.content).toEqual([
-      { type: "tool_result", tool_use_id: "cc-delta-tu1", content: "hi" },
-      { type: "text", text: trailingSystemText },
-    ])
+      if (adapter !== "claude-code" || historyChange !== "unchanged") {
+        expect(capturedQueryParamsAll[1].options.resume).toBeUndefined()
+        expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
+        const fresh = capturedQueryParamsAll[1]
+        const inputs: unknown[] = []
+        if (typeof fresh.prompt === "string") inputs.push(fresh.prompt)
+        else for await (const message of fresh.prompt) inputs.push(message)
+        const delivered = JSON.stringify(inputs)
+        expect(delivered).toContain(trailingSystemText)
+        expect(delivered).not.toContain(`[Assistant: ${trailingSystemText}]`)
+        expect(delivered).toContain("</conversation_history>")
+        if (historyChange === "revised") expect(delivered).toContain("revised earlier instructions")
+        if (historyChange === "inserted") expect(delivered).toContain("Inserted instruction before the echoed call.")
+        expect(JSON.stringify(fresh.options.systemPrompt)).not.toContain(trailingSystemText)
+        return
+      }
 
-    let row: any
-    for (let i = 0; i < 500 && !row; i++) {
-      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
-      if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
-    }
-    expect(row).toBeDefined()
-    expect(row!.isResume).toBe(true)
-  })
+      // Resumed at the exact assistant checkpoint — not a fresh replay.
+      const resumed = capturedQueryParamsAll[1]
+      expect(resumed.options.resume).toBe(initialManagedSessionId())
+      expect(resumed.options.resumeSessionAt).toBe(toolTurn.uuid)
+      expect(resumed.options.forkSession).toBe(true)
+      // No fresh-replay framing; the reminder never reaches the SDK system prompt.
+      expect(secondBody).not.toContain("conversation_history")
+      expect(JSON.stringify(resumed.options.systemPrompt ?? "")).not.toContain(trailingSystemText)
+      // SDK prompt is exactly the native tool_result then the reminder as
+      // ordinary user text, with cache_control stripped.
+      expect(typeof resumed.prompt).not.toBe("string")
+      const promptMessages: any[] = []
+      for await (const message of resumed.prompt) promptMessages.push(message)
+      expect(promptMessages).toHaveLength(1)
+      expect(promptMessages[0].message.content).toEqual([
+        { type: "tool_result", tool_use_id: "cc-delta-tu1", content: resultContent },
+        { type: "text", text: trailingSystemText },
+      ])
+
+      let row: any
+      for (let i = 0; i < 500 && !row; i++) {
+        row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
+        if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      expect(row).toBeDefined()
+      expect(row!.isResume).toBe(true)
+    })
+  }
 
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
     const firstFragment = assistantMessage([

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1154,12 +1154,13 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
-  // Live claude-cli 2.1.259 closes its tool-result delta with a trailing
-  // system-role reminder turn (assistant[tool_use] -> user[tool_result] ->
-  // system[text], a <total_tokens>-style message). The generic helpers
-  // reject role=system, which forced a full fresh replay; the claude-code
-  // opt-in must resume the checkpoint and deliver the reminder as
-  // unprivileged user text.
+  // Captured claude-cli 2.1.259 with mid-conversation-system enabled closes
+  // its tool-result delta with a trailing system-role reminder turn
+  // (assistant[tool_use] -> user[tool_result] -> system[text]). Newer
+  // clients (2.1.261) embed the reminder in the user tool_result and need
+  // no opt-in. The generic helpers reject role=system, which forced a full
+  // fresh replay; the opt-in must resume the checkpoint and deliver the
+  // reminder as unprivileged user text.
   it("stream: resumes the checkpoint through the claude-code trailing system reminder", async () => {
     const sessionId = `cc-delta-${TEST_RUN_ID}`
     const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -405,7 +405,7 @@ describe("claude-code trailing system delta", () => {
   })
   const opts = { allowClaudeCodeSystemDelta: true }
 
-  it("accepts the live delta: complete expected-ID echo, results, trailing reminder", () => {
+  it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
     // String and text-block-with-cache_control reminder forms pass through
     // as-is; cache_control is stripped by the caller's existing strip path.

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -392,3 +392,94 @@ describe("findCompleteToolResultCheckpoint", () => {
     expect(findCompleteToolResultCheckpoint([assistant, { role: "assistant", content: [result("a"), result("b")] }], ["a", "b"])).toBeUndefined()
   })
 })
+
+describe("claude-code trailing system delta", () => {
+  const result = (id: string, content: unknown = "ok") => ({ type: "tool_result", tool_use_id: id, content })
+  const echo = (ids: string[]) => ({
+    role: "assistant",
+    content: ids.map((id) => ({ type: "tool_use", id, name: "read", input: {} })),
+  })
+  const reminder = (text: string, cacheControl = false) => ({
+    role: "system",
+    content: [{ type: "text", text, ...(cacheControl ? { cache_control: { type: "ephemeral" } } : {}) }],
+  })
+  const opts = { allowClaudeCodeSystemDelta: true }
+
+  it("accepts the live delta: complete expected-ID echo, results, trailing reminder", () => {
+    const results = [result("t1"), result("t2")]
+    // String and text-block-with-cache_control reminder forms pass through
+    // as-is; cache_control is stripped by the caller's existing strip path.
+    const cases: Array<[{ role: string; content: unknown }, unknown]> = [
+      [{ role: "system", content: "<total_tokens> 4151" }, { type: "text", text: "<total_tokens> 4151" }],
+      [reminder("<total_tokens> 4151", true), { type: "text", text: "<total_tokens> 4151", cache_control: { type: "ephemeral" } }],
+    ]
+    for (const [tail, expectedBlock] of cases) {
+      expect(coalesceCompleteToolResultContinuation(
+        [echo(["t1", "t2"]), { role: "user", content: results }, tail],
+        ["t1", "t2"],
+        opts,
+      )).toEqual([{ role: "user", content: [...results, expectedBlock] }])
+    }
+  })
+
+  it("delivers the reminder after results and queued user content, in wire order", () => {
+    const queuedText = { type: "text", text: "continue" }
+    const queuedImage = { type: "image", source: { type: "base64", data: "abc" } }
+    expect(coalesceCompleteToolResultContinuation(
+      [echo(["t1"]), { role: "user", content: [result("t1")] }, { role: "user", content: [queuedText, queuedImage] }, reminder("reminder")],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), queuedText, queuedImage, { type: "text", text: "reminder" }] }])
+  })
+
+  it("rejects the reminder-bearing delta without the opt-in (generic default)", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [echo(["t1"]), { role: "user", content: [result("t1")], }, reminder("reminder")],
+      ["t1"],
+    )).toBeUndefined()
+  })
+
+  it("rejects leading, non-final, repeated, non-text, and empty reminders", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    for (const body of [
+      [reminder("leading"), ...delta], // leading (undemonstrated form)
+      [echo(["t1"]), reminder("non-final"), { role: "user", content: [result("t1")] }], // before results
+      [...delta, reminder("one"), reminder("two")], // repeated
+      [...delta, reminder("final"), { role: "user", content: "after" }], // message after reminder
+      [...delta, { role: "system", content: [{ type: "image", source: { type: "base64", data: "x" } }] }], // non-text block
+      [...delta, { role: "system", content: [{ type: "tool_result", tool_use_id: "t1", content: "x" }] }], // tool_result block
+      [...delta, { role: "system", content: [] }], // empty array
+      [...delta, { role: "system", content: [{ type: "text", text: "" }] }], // empty text
+      [...delta, { role: "system", content: "" }], // empty string
+    ]) {
+      expect(coalesceCompleteToolResultContinuation(body, ["t1"], opts)).toBeUndefined()
+    }
+  })
+
+  it("fails on incomplete or split echoes even with a trailing reminder", () => {
+    const cases: Array<[Array<{ role?: unknown; content?: unknown }>, string[]]> = [
+      [[{ role: "user", content: [result("t1")], }, reminder("r")], ["t1"]], // missing echo
+      [[echo(["t1", "t2"]), { role: "user", content: [result("t1")] }, reminder("r")], ["t1", "t2"]], // partial results
+      // Split echo across assistant messages: find never binds it, and the
+      // reminder-gated coalesce must reject it too.
+      [[echo(["t1"]), echo(["t2"]), { role: "user", content: [result("t1"), result("t2")] }, reminder("r")], ["t1", "t2"]],
+    ]
+    for (const [messages, ids] of cases) {
+      expect(coalesceCompleteToolResultContinuation(messages, ids, opts)).toBeUndefined()
+    }
+  })
+
+  it("find accepts the actual suffix under the opt-in; default stays rejected", () => {
+    const body = [
+      { role: "user", content: "history" },
+      echo(["a"]),
+      { role: "user", content: [result("a")] },
+      reminder("reminder", true),
+    ]
+    expect(findCompleteToolResultCheckpoint(body, ["a"], opts))
+      .toEqual([{ role: "user", content: [result("a"), { type: "text", text: "reminder", cache_control: { type: "ephemeral" } }] }])
+    // Without the opt-in the trailing reminder is a generic rejection — the
+    // observed staging transition to a full fresh replay.
+    expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
+  })
+})

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -160,6 +160,25 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
 }
 
 /**
+ * Opt-in flags for the checkpoint continuation validators.
+ */
+export interface CompleteToolResultContinuationOptions {
+  /**
+   * NOTE: agent-specific (claude-code) — live claude-cli closes its
+   * tool-result delta with a trailing `system` reminder turn
+   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
+   * `<total_tokens>`-style mid-conversation-system message). The generic
+   * Anthropic contract has no system role in `messages`, so that shape is
+   * admitted only under this explicit opt-in, only as the final message of
+   * the delta, and only with a single assistant echo carrying the complete
+   * exact expected ID set. The reminder is delivered as unprivileged user
+   * text after the results and any queued user content — never dropped,
+   * never escalated to an SDK system prompt.
+   */
+  allowClaudeCodeSystemDelta?: boolean
+}
+
+/**
  * Verify that a resumed tool-result delta settles exactly the tool calls at the
  * stored assistant checkpoint, then coalesce queued user turns into one SDK
  * input. Tool results must precede any ordinary user content, matching the
@@ -167,7 +186,8 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export function coalesceCompleteToolResultContinuation(
   messages: Array<{ role?: unknown; content?: unknown }>,
-  expectedIds: readonly string[]
+  expectedIds: readonly string[],
+  options?: CompleteToolResultContinuationOptions,
 ): Array<{ role: "user"; content: unknown[] }> | undefined {
   if (expectedIds.length === 0 || messages.length === 0) return undefined
   const expected = new Set(expectedIds)
@@ -176,8 +196,39 @@ export function coalesceCompleteToolResultContinuation(
   const content: unknown[] = []
   let sawUser = false
   let sawNonToolResult = false
+  let sawTrailingSystem = false
+  let systemTextBlocks: unknown[] = []
+  let echoMessages = 0
 
   for (const message of messages) {
+    // NOTE: agent-specific (claude-code) — the captured live shape carries
+    // exactly one trailing system reminder AFTER the result batch; nothing
+    // may follow it, and leading/late/repeated reminders fail closed.
+    // Without the opt-in this branch is dead and the generic rejection
+    // below applies.
+    if (message.role === "system") {
+      if (!options?.allowClaudeCodeSystemDelta) return undefined
+      if (!sawUser || sawTrailingSystem) return undefined
+      sawTrailingSystem = true
+      if (typeof message.content === "string") {
+        if (message.content.length === 0) return undefined
+        systemTextBlocks.push({ type: "text", text: message.content })
+        continue
+      }
+      if (Array.isArray(message.content)) {
+        for (const rawBlock of message.content) {
+          const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
+          if (block?.type !== "text" || typeof block.text !== "string" || block.text.length === 0) return undefined
+          // Pass blocks through untouched; cache_control is stripped by the
+          // caller's existing strip path before the SDK sees the prompt.
+          systemTextBlocks.push(block)
+        }
+        if (systemTextBlocks.length === 0) return undefined
+        continue
+      }
+      return undefined
+    }
+    if (sawTrailingSystem) return undefined
     // The client echoes the just-produced assistant tool_use before its user
     // result. That assistant turn already exists at resumeSessionAt, so the
     // structured SDK delta below intentionally filters it out.
@@ -193,6 +244,7 @@ export function coalesceCompleteToolResultContinuation(
         }
       }
       if (!sawToolUse) return undefined
+      echoMessages++
       continue
     }
     if (message.role !== "user") return undefined
@@ -223,6 +275,14 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
+  // A system reminder is a live Claude Code delta only with a single
+  // assistant echo carrying the complete expected ID set; a split, partial,
+  // or absent echo proves nothing causal and the replay must stay fresh.
+  // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)
+  if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
+  // Delivered after the results and any queued user content, matching the
+  // wire order; nothing ever follows the reminder on the wire.
+  if (systemTextBlocks.length > 0) content.push(...systemTextBlocks)
   return [{ role: "user", content }]
 }
 
@@ -230,6 +290,7 @@ export function coalesceCompleteToolResultContinuation(
 export function findCompleteToolResultCheckpoint(
   messages: Array<{ role?: unknown; content?: unknown }>,
   expectedIds: readonly string[],
+  options?: CompleteToolResultContinuationOptions,
 ): Array<{ role: "user"; content: unknown[] }> | undefined {
   if (expectedIds.length === 0) return undefined
   const expected = new Set(expectedIds)
@@ -247,7 +308,7 @@ export function findCompleteToolResultCheckpoint(
     }
     if (malformed || ids.length !== expected.size || new Set(ids).size !== ids.length) continue
     if (!ids.every((id) => expected.has(id))) continue
-    return coalesceCompleteToolResultContinuation(messages.slice(index), expectedIds)
+    return coalesceCompleteToolResultContinuation(messages.slice(index), expectedIds, options)
   }
   return undefined
 }

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -200,7 +200,7 @@ export function coalesceCompleteToolResultContinuation(
   let sawUser = false
   let sawNonToolResult = false
   let sawTrailingSystem = false
-  let systemTextBlocks: unknown[] = []
+  const systemTextBlocks: unknown[] = []
   let echoMessages = 0
 
   for (const message of messages) {

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,16 +164,19 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — live claude-cli closes its
-   * tool-result delta with a trailing `system` reminder turn
-   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
-   * `<total_tokens>`-style mid-conversation-system message). The generic
-   * Anthropic contract has no system role in `messages`, so that shape is
-   * admitted only under this explicit opt-in, only as the final message of
-   * the delta, and only with a single assistant echo carrying the complete
-   * exact expected ID set. The reminder is delivered as unprivileged user
-   * text after the results and any queued user content — never dropped,
-   * never escalated to an SDK system prompt.
+   * NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
+   * mid-conversation-system enabled closes its tool-result delta with a
+   * trailing `system` reminder turn (`assistant[tool_use] ->
+   * user[tool_result] -> system[text]`, a `<total_tokens>`-style message).
+   * The generic Anthropic contract has no system role in `messages`, so
+   * that captured shape is admitted only under this explicit opt-in, only
+   * as the final message of the delta, and only with a single assistant
+   * echo carrying the complete exact expected ID set. The reminder is
+   * delivered as unprivileged user text after the results and any queued
+   * user content — never dropped, never escalated to an SDK system prompt.
+   * Newer clients (observed on 2.1.261) fold the reminder into the user
+   * tool_result instead and need no system-role opt-in — which is why this
+   * stays scoped to the captured shape.
    */
   allowClaudeCodeSystemDelta?: boolean
 }
@@ -201,11 +204,11 @@ export function coalesceCompleteToolResultContinuation(
   let echoMessages = 0
 
   for (const message of messages) {
-    // NOTE: agent-specific (claude-code) — the captured live shape carries
-    // exactly one trailing system reminder AFTER the result batch; nothing
-    // may follow it, and leading/late/repeated reminders fail closed.
-    // Without the opt-in this branch is dead and the generic rejection
-    // below applies.
+    // NOTE: agent-specific (claude-code) — the captured 2.1.259 shape
+    // carries exactly one trailing system reminder AFTER the result batch;
+    // nothing may follow it, and leading/late/repeated reminders fail
+    // closed. Without the opt-in this branch is dead and the generic
+    // rejection below applies.
     if (message.role === "system") {
       if (!options?.allowClaudeCodeSystemDelta) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
@@ -275,7 +278,7 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A system reminder is a live Claude Code delta only with a single
+  // A system reminder is a captured 2.1.259 delta only with a single
   // assistant echo carrying the complete expected ID set; a split, partial,
   // or absent echo proves nothing causal and the replay must stay fresh.
   // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -46,7 +46,7 @@ import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
 import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
-import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, findCompleteToolResultCheckpoint, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
+import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
 import { classifyTurnOutcome, createRecoveryLifter, shouldAttemptRecovery, shouldInjectSilentTurn, SILENT_TURN_NUDGE } from "./turnOutcome"
 import { resolveAgentAlias } from "./agentMatch"
@@ -113,6 +113,7 @@ import { computeCacheHitRate, formatUsageSummary } from "./tokenUsage"
 import { sanitizeTextContent } from "./sanitize"
 import {
   computeLineageHash,
+  matchesStoredLineagePrefix,
   hashMessage,
   computeMessageHashes,
   normalizeContextUsage,
@@ -427,7 +428,9 @@ function buildFreshPrompt(
   if (hasMultimodal) {
     const structured: Array<{ type: "user"; message: { role: string; content: any }; parent_tool_use_id: null }> = []
     for (const m of messages) {
-      if (m.role === "user") {
+      // Match text replay: only assistant turns carry assistant attribution.
+      // In-message reminders remain ordinary input, never SDK system prompts.
+      if (m.role !== "assistant") {
         structured.push({
           type: "user" as const,
           message: { role: "user" as const, content: normalizeStructuredUserContent(stripCacheControlDeep(m.content)) },
@@ -446,7 +449,7 @@ function buildFreshPrompt(
       }
     }
     // See #553 — consolidate earlier-turn multimodal onto the final user turn.
-    const prompt = frameStructuredReplay(structured, messages.at(-1)?.role === "user")
+    const prompt = frameStructuredReplay(structured, messages.at(-1)?.role !== "assistant")
     return (async function* () { for (const msg of prompt) yield msg })()
   }
 
@@ -2169,12 +2172,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const declaresConcurrentFlow =
           declaresPerRequestConcurrentFlow
           || adapter.runsConcurrentTurnsPerSessionKey === true
-        // NOTE: agent-specific (opencode) — OpenCode begins the tool-result
-        // request as soon as the visible checkpoint closes, while Meridian is
-        // still draining and committing that checkpoint. Its prompt envelope
-        // may change enough that hash lineage is "unrelated-history". Echoing
-        // every exact pending tool ID is nevertheless a causal continuation,
-        // not a stale competing branch.
+        // Exact pending tool IDs identify the batch, not the earlier history.
+        // Rebinding a checkpoint must also preserve its complete stored prefix;
+        // otherwise a revised user instruction would be silently discarded.
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
@@ -2190,7 +2190,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? { allowClaudeCodeSystemDelta: true }
           : undefined
         const durableCheckpointContinuation = durableCheckpointIds?.length
-          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds, claudeCodeSystemDeltaOptions)
+          && durableMappingAtTurn.status === "found"
+          && matchesStoredLineagePrefix(durableMappingAtTurn.session, lineageMessages)
+          ? coalesceCompleteToolResultContinuation(
+            (body.messages || []).slice(durableMappingAtTurn.session.messageCount),
+            durableCheckpointIds,
+            claudeCodeSystemDeltaOptions,
+          )
           : undefined
         const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
         // Passthrough mode — resolved early so the concurrent-conflict guards
@@ -2472,9 +2478,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       let messagesToConvert: typeof allMessages
 
       if (passthroughToolCallAssistantUuid && durableCheckpointContinuation) {
-        // Envelope drift can move the exact echoed checkpoint relative to the
-        // stored message count. Use the validated tail itself, never re-slice
-        // it through a stale lineage index.
+        // Use the complete delta following the verified stored prefix. Never
+        // search past intervening user turns to find a matching tool echo.
         messagesToConvert = durableCheckpointContinuation
       } else if ((isResume || isUndo) && cachedSession) {
         if (isUndo && undoRollbackUuid) {
@@ -2665,9 +2670,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             }
           }
         } else {
-          // First request: all messages (system context now passed via appendSystemPrompt)
+          // Fresh replay preserves the text path's role attribution. In-message
+          // reminders are ordinary input; only assistant turns get its marker.
           for (const m of messagesToConvert) {
-            if (m.role === "user") {
+            if (m.role !== "assistant") {
               structuredMessages.push({
                 type: "user" as const,
                 message: { role: "user" as const, content: normalizeStructuredUserContent(
@@ -2697,7 +2703,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (structuredMessages.length > 1) {
           structuredMessages = isResume
             ? coalesceStructuredUserMessages(structuredMessages)
-            : frameStructuredReplay(structuredMessages, messagesToConvert.at(-1)?.role === "user")
+            : frameStructuredReplay(structuredMessages, messagesToConvert.at(-1)?.role !== "assistant")
         }
 
       } else {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,12 +2178,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
-        // NOTE: agent-specific (claude-code) — live claude-cli closes its
-        // tool-result delta with a trailing system-role reminder turn
-        // (`assistant[tool_use] -> user[tool_result] -> system[text]`). The
-        // generic checkpoint helpers reject every role=system message, which
-        // turned each such continuation into a full fresh replay. The opt-in
-        // admits that exact shape for this adapter only, gated on the single
+        // NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
+        // mid-conversation-system enabled closes its tool-result delta with
+        // a trailing system-role reminder turn (`assistant[tool_use] ->
+        // user[tool_result] -> system[text]`). The generic checkpoint
+        // helpers reject every role=system message, which turned each such
+        // continuation into a full fresh replay. The opt-in admits that
+        // captured shape for this adapter only, gated on the single
         // complete expected-ID echo.
         const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
           ? { allowClaudeCodeSystemDelta: true }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,8 +2178,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
+        // NOTE: agent-specific (claude-code) — live claude-cli closes its
+        // tool-result delta with a trailing system-role reminder turn
+        // (`assistant[tool_use] -> user[tool_result] -> system[text]`). The
+        // generic checkpoint helpers reject every role=system message, which
+        // turned each such continuation into a full fresh replay. The opt-in
+        // admits that exact shape for this adapter only, gated on the single
+        // complete expected-ID echo.
+        const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
+          ? { allowClaudeCodeSystemDelta: true }
+          : undefined
         const durableCheckpointContinuation = durableCheckpointIds?.length
-          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds)
+          ? findCompleteToolResultCheckpoint(body.messages || [], durableCheckpointIds, claudeCodeSystemDeltaOptions)
           : undefined
         const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
         // Passthrough mode — resolved early so the concurrent-conflict guards
@@ -2509,7 +2519,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // turns so multimodal tool results remain on the final SDK input.
         const checkpointContinuation = coalesceCompleteToolResultContinuation(
           messagesToConvert,
-          passthroughToolCallIds ?? []
+          passthroughToolCallIds ?? [],
+          claudeCodeSystemDeltaOptions,
         )
         if (checkpointContinuation) {
           messagesToConvert = checkpointContinuation

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -185,6 +185,17 @@ export function computeLineageHash(messages: Array<{ role: string; content: any 
   return lineageDigest("history", messages.map(m => [m.role, semanticContent(m.content)]))
 }
 
+/** Matching tool IDs do not prove that the history before them is unchanged. */
+export function matchesStoredLineagePrefix(
+  stored: { messageCount?: number; lineageHash?: string },
+  messages: Array<{ role: string; content: unknown }>,
+): boolean {
+  const count = stored.messageCount
+  return typeof count === "number" && Number.isInteger(count) && count > 0
+    && messages.length >= count && typeof stored.lineageHash === "string"
+    && computeLineageHash(messages.slice(0, count)) === stored.lineageHash
+}
+
 /**
  * Compute a content hash for a single message (role + normalised content).
  * Used to build per-message hash arrays for precise diff-based verification.


### PR DESCRIPTION
Claude Code 2.1.259 can end a completed tool-result request with a system-role token reminder. Meridian previously replayed the whole conversation instead of resuming its tool checkpoint. Admit that captured shape only for the Claude Code adapter and deliver the reminder as ordinary SDK user content after the results.

Checkpoint recovery also verifies the complete stored history prefix and validates the entire subsequent delta. Matching tool IDs must not discard revised or newly inserted user instructions. Such histories replay in full. Fresh multimodal replay preserves reminder attribution and its context-only history boundary, matching text replay.

Incorporates #947 while preserving Aleksey Proshutinskiy's original author identity and dates in commits 9273c93e and 8f9c723c. Maintainer corrections and validation are separate in 723d548d. This does not resolve #946's OpenCode/Orca ownership report.

Validation:

- Original proposal fails real SDK checks for revised and inserted user history; corrected candidate preserves both in the SDK input and answer, with immutable source history.
- 3,454 tests pass, one existing skip, zero failures; typecheck/build pass. Focused checkpoint/concurrency suite: 131 pass.
- Twelve real SDK cases: unchanged/revised/inserted history × text/image × streaming/non-streaming, with actual tool results, distinct context/reminder identifiers, optional image color, correct resume decision and supported getSessionMessages inspection.
- Actual Claude Code 2.1.259 → Meridian → SDK Read loop and ordinary follow-up pass; all four E41 sequential/parallel × streaming/non-streaming controls pass, including supported session-history inspection and prompt-cache continuity.

The direct E2E fixture explicitly asks a user question after the completed tool result and rejects further calls. Earlier less explicit Haiku runs returned another tool call instead of final text. Supported SDK inspection of the exact published target confirms the full revised input and repeated call, including the initially unexplained no-text case. Those behavioral failures are retained in the review evidence and are not claimed fixed by reruns. These checks establish history delivery and the captured native-client compatibility, not a guarantee about every model response. CI at the exact candidate head must pass before merge.
