### PR TITLE
fix: finish Claude Code reminder validation

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -3618,6 +3618,8 @@ PROBE_PARALLEL=1 bun scripts/e2e-passthrough-turns.mjs --stream
 - Every continuation, including the follow-up, reads at least 95% of the prior
   turn's `cache_read_input_tokens + cache_creation_input_tokens`.
 
+The fixture uses a disposable SDK working directory: edits to the checkout must not change the SDK's per-query git-status context during this cache benchmark. A git-status change can invalidate the prompt cache even when the session resumes correctly.
+
 The gate resolves Meridian's published session from its own durable store and
 uses the supported Agent SDK `getSessionMessages()` API for the history check.
 It does not inspect Claude's private persistence format.

--- a/E2E.md
+++ b/E2E.md
@@ -3739,6 +3739,8 @@ Run `bun scripts/e2e-claude-code-system-delta.mjs` in both modes (`--stream`); r
 
 Repeat the direct gate with `--revise-history` and separately with `--insert-history` in text/image and streaming/non-streaming modes. Edited or inserted user history must replay fresh and deliver its revised or inserted identifier, with no removed identifier, no assistant attribution on the reminder, and the replay history boundary preserved. Matching pending tool IDs alone must never discard earlier edits.
 
+Run the direct gate with `--blank-reminder` in both response modes, with and without `--image`. Whitespace-only text does not qualify for the narrow reminder exception: require fresh replay, the correct tool value/context and optional image color, and unchanged source history.
+
 Run `bun scripts/e2e-claude-code-client.mjs` for the full installed Claude Code 2.1.259 → Meridian → real SDK loop. `E2E_CLAUDE_CLIENT` can name that exact client binary. The fixture isolates the outer client's settings and enables its `CLAUDE_CODE_FORCE_MID_CONVERSATION_SYSTEM` flag; `--bare` suppresses the shape and is unsuitable. The real CLI reads a disposable fixture, sends its native `<total_tokens>` system reminder, then resumes for an ordinary follow-up. Require both proxy continuations to resume, delivery of both reminders to SDK user history, correct answers, and unchanged source history.
 
 `--capture` runs only the real client's wire-format probe against a scripted local endpoint. It does not contact the SDK and is not a substitute for the full E2E gate. The fixture checks the exact client version; newer versions are separate compatibility targets. This case does not validate OpenCode/Orca cross-tool session ownership (#946).

--- a/scripts/e2e-claude-code-system-delta.mjs
+++ b/scripts/e2e-claude-code-system-delta.mjs
@@ -31,7 +31,8 @@ const stream = process.argv.includes("--stream")
 const image = process.argv.includes("--image")
 const reviseHistory = process.argv.includes("--revise-history")
 const insertHistory = process.argv.includes("--insert-history")
-const expectResume = !reviseHistory && !insertHistory
+const blankReminder = process.argv.includes("--blank-reminder")
+const expectResume = !reviseHistory && !insertHistory && !blankReminder
 const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-cc-system-delta-")))
 for (const key of Object.keys(process.env)) {
   if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
@@ -100,19 +101,19 @@ try {
   assert(sourceRows.length)
   const value = `value_${randomUUID()}`
   const marker = `reminder_${randomUUID()}`
-  const reminder = `<system-reminder>The reminder identifier is ${marker}. Include it with the fixture value and the fixture context identifier from the opening user message in your response. If the tool result includes an image, also name its predominant color. Include any extra identifier supplied in a user message before the call. No more tools.</system-reminder>`
+  const reminder = blankReminder ? " \n\t " : `<system-reminder>The reminder identifier is ${marker}. Include it with the fixture value and the fixture context identifier from the opening user message in your response. If the tool result includes an image, also name its predominant color. Include any extra identifier supplied in a user message before the call. No more tools.</system-reminder>`
   const history = [{ ...opening, content: opening.content.replace(originalContext, revisedContext) },
     ...(insertHistory ? [{ role: "user", content: `The extra identifier is ${insertedIdentifier}. Include it in the final answer.` }] : []), { role: "assistant", content: first },
     { role: "user", content: [{ type: "tool_result", tool_use_id: calls[0].id, content: image ? [{ type: "text", text: value }, blueImage()] : value },
-      { type: "text", text: "The requested tool has completed. Report its supplied value, the fixture context identifier from the opening message, and the accompanying reminder identifier. Use the recorded result; no further tool calls are needed." }] },
+      { type: "text", text: blankReminder ? "Report the completed tool value and opening context identifier. If there is an image, name its predominant color. No further calls are needed." : "The requested tool has completed. Report its supplied value, the fixture context identifier from the opening message, and the accompanying reminder identifier. Use the recorded result; no further tool calls are needed." }] },
     { role: "system", content: [{ type: "text", text: reminder, cache_control: { type: "ephemeral" } }] }]
   const second = await request(history)
   const answer = second.filter(block => block.type === "text").map(block => block.text).join("")
   const metric = telemetryStore.getRecent({ limit: 1 })[0]
-  console.log(JSON.stringify({ root, stream, image, reviseHistory, insertHistory, answer, expected: [value, marker], isResume: metric?.isResume,
+  console.log(JSON.stringify({ root, stream, image, reviseHistory, insertHistory, blankReminder, answer, expected: [value, marker], isResume: metric?.isResume,
     blocks: second.map(block => ({ type: block.type, name: block.name, text: block.text })), sdkResults, freshPrompt: textPrompts[1], resumeAt: queryOptions[1]?.resumeSessionAt ?? null, expectedCheckpoint: source.passthroughToolCallAssistantUuid }))
   assert.equal(second.filter(block => block.type === "tool_use").length, 0, "A completed result must not cause another tool request")
-  assert(answer.includes(value) && answer.includes(marker), "Both real result and system-reminder text must reach the answer")
+  assert(answer.includes(value) && (blankReminder || answer.includes(marker)), "Both real result and system-reminder text must reach the answer")
   if (image) assert(answer.toLowerCase().includes("blue"), "Tool-result image must reach the model")
   assert(answer.includes(revisedContext), "Revised opening context must reach the answer")
   if (reviseHistory) assert(!answer.includes(originalContext), "Removed opening context leaked into the answer")
@@ -124,7 +125,7 @@ try {
   assert(current?.claudeSessionId)
   const rows = await getSessionMessages(current.claudeSessionId, { dir: root })
   const users = JSON.stringify(rows.filter(row => row.type === "user"))
-  assert(users.includes(value) && users.includes(marker))
+  assert(users.includes(value) && (blankReminder || users.includes(marker)))
   assert(!users.includes("[Assistant: <system-reminder>"), "Reminder was attributed to the assistant during replay")
   if (insertHistory) assert(users.includes(insertedIdentifier))
   if (reviseHistory) {
@@ -132,7 +133,7 @@ try {
     assert(users.includes("</conversation_history>"), "Fresh history must retain its context boundary")
   }
   assert.deepEqual(await getSessionMessages(source.claudeSessionId, { dir: root }), sourceRows)
-  console.log(JSON.stringify({ result: "PASS", stream, reminderDelivered: true, sourceUnchanged: true }))
+  console.log(JSON.stringify({ result: "PASS", stream, reminderDelivered: !blankReminder, sourceUnchanged: true }))
 } finally {
   querySpy.mockRestore()
   await instance.close()

--- a/scripts/e2e-passthrough-turns.mjs
+++ b/scripts/e2e-passthrough-turns.mjs
@@ -12,7 +12,7 @@
  *
  *   bun scripts/e2e-passthrough-turns.mjs [--stream]
  */
-import { mkdtempSync, writeFileSync, readFileSync } from "node:fs"
+import { mkdtempSync, realpathSync, writeFileSync, readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { getSessionMessages } from "@anthropic-ai/claude-agent-sdk"
@@ -28,7 +28,10 @@ const PORT = Number(process.env.PROBE_PORT ?? 3522)
 const MODEL = process.env.PROBE_MODEL ?? "claude-sonnet-5"
 const MAX_TURNS = Number(process.env.PROBE_TURNS ?? 6)
 
-const WORKDIR = mkdtempSync(join(tmpdir(), "meridian-probe-proxy-"))
+const WORKDIR = realpathSync(mkdtempSync(join(tmpdir(), "meridian-probe-proxy-")))
+// The SDK recomputes git status each query. Keep this cache-continuity
+// fixture outside the checkout so concurrent review edits cannot change it.
+process.env.MERIDIAN_WORKDIR = WORKDIR
 setSessionStoreDir(join(WORKDIR, "meridian-store"))
 const CONTENT = { "a.txt": "alpha", "b.txt": "bravo", "c.txt": "charlie" }
 const FILES = Object.keys(CONTENT).map(f => join(WORKDIR, f))
@@ -190,7 +193,7 @@ const activeStoredSession = Object.entries(storedSessions).find(([key]) =>
 )?.[1]
 const activeSessionId = activeStoredSession?.claudeSessionId
 const activeMessages = activeSessionId
-  ? await getSessionMessages(activeSessionId)
+  ? await getSessionMessages(activeSessionId, { dir: WORKDIR })
   : []
 
 say(`\n=== verdict (stream=${STREAM}, parallel=${PARALLEL}) ===`)
@@ -240,7 +243,7 @@ const pass = quotes.length === 3 &&
   activeMessages.length > 0 &&
   activeAnswerProblems.length === 0 &&
   cacheMisses.length === 0
-say(`  ${pass ? "PASS" : "FAIL"}: active history has one real answer per delivered call`)
+say(`  ${pass ? "PASS" : "FAIL"}: tool batching, active history, and prompt-cache continuity`)
 if (!pass) {
   say("\n  recent proxy diagnostics:")
   for (const line of proxyLog.slice(-30)) say(`    ${line}`)

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1151,13 +1151,10 @@ describe("Integration: passthrough early stop", () => {
     expect(capturedQueryParams.options.forkSession).toBe(true)
   })
 
-  // Captured claude-cli 2.1.259 with mid-conversation-system enabled closes
-  // its tool-result delta with a trailing system-role reminder turn
-  // (assistant[tool_use] -> user[tool_result] -> system[text]). Newer
-  // clients (2.1.261) embed the reminder in the user tool_result and need
-  // no opt-in. The generic helpers reject role=system, which forced a full
-  // fresh replay; the opt-in must resume the checkpoint and deliver the
-  // reminder as unprivileged user text.
+  // claude-cli with mid-conversation-system on ends a tool-result delta with a
+  // trailing system reminder (assistant[tool_use] -> user[tool_result] ->
+  // system[text]); the generic helpers reject role=system and forced a fresh
+  // replay. The opt-in must resume and deliver the reminder as user text.
   const reminderCases = [false, true].flatMap(stream =>
     ["claude-code", "opencode"].flatMap(adapter =>
       ["unchanged", "revised", "inserted"].flatMap(historyChange =>
@@ -1286,9 +1283,8 @@ describe("Integration: passthrough early stop", () => {
     })
   }
 
-  // Fail-closed twin of the accepted shape above: a SECOND trailing system
-  // message breaks the one-reminder contract, so the whole continuation
-  // must fail closed to a fresh replay — no resume options at all.
+  // Fail-closed twin: a second trailing system breaks the one-reminder
+  // contract, so the continuation must fall back to a fresh replay.
   it("stream: two trailing system reminders fail closed to a fresh replay", async () => {
     const sessionId = `cc-delta-fc-${TEST_RUN_ID}`
     const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
@@ -1356,8 +1352,7 @@ describe("Integration: passthrough early stop", () => {
     expect(second.status).toBe(200)
     expect(await second.text()).toContain("message_stop")
 
-    // Checkpoint rejected → fresh structured replay: no resume options at all,
-    // and neither reminder reaches the SDK system prompt.
+    // Rejected checkpoint: fresh replay, no resume options, reminders kept out of the system prompt.
     const replayed = capturedQueryParamsAll[1]
     expect(replayed.options.resume).toBeUndefined()
     expect(replayed.options.resumeSessionAt).toBeUndefined()
@@ -1373,9 +1368,8 @@ describe("Integration: passthrough early stop", () => {
     expect(row!.isResume).toBe(false)
   })
 
-  // The gate lives in server.ts, not in the helper default: the exact wire
-  // shape the claude-code adapter accepts must stay a fresh replay on any
-  // other adapter, which never passes the opt-in.
+  // The gate is the adapter check in server.ts: the same wire shape on any
+  // other adapter gets no opt-in and stays a fresh replay.
   it("stream: non-claude-code adapters never opt in — reminder shape stays a fresh replay", async () => {
     const toolTurn = assistantMessage([
       { type: "tool_use", id: "oc-gate-tu1", name: "read", input: { file_path: "x" } },
@@ -1393,8 +1387,7 @@ describe("Integration: passthrough early stop", () => {
     expect(first.status).toBe(200)
     await first.text()
 
-    // Turn 2: the exact accepted shape (echo, result, one trailing system
-    // reminder) — but the x-opencode-session adapter carries no opt-in.
+    // Turn 2: the accepted shape, but this adapter carries no opt-in.
     mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
     const second = await post(app, {
       model: "claude-sonnet-4-5",

--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1286,6 +1286,134 @@ describe("Integration: passthrough early stop", () => {
     })
   }
 
+  // Fail-closed twin of the accepted shape above: a SECOND trailing system
+  // message breaks the one-reminder contract, so the whole continuation
+  // must fail closed to a fresh replay — no resume options at all.
+  it("stream: two trailing system reminders fail closed to a fresh replay", async () => {
+    const sessionId = `cc-delta-fc-${TEST_RUN_ID}`
+    const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
+    const firstReminder = "<system-reminder>Total tokens: 4151</system-reminder>"
+    const secondReminder = "<system-reminder>Context low</system-reminder>"
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "cc-delta-fc-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1 mirrors the accepted test: arm the checkpoint.
+    mockMessages = [
+      messageStart("msg_cc_delta_fc_1"),
+      toolUseBlockStart(0, "read", "cc-delta-fc-tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("cc-delta-fc-tu1"),
+      assistantMessage([{ type: "text", text: "CC_DELTA_FC_GARBAGE_DIGEST" }]),
+    ]
+    const first = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId)
+    expect(first.status).toBe(200)
+    await first.text()
+    let stored: any
+    for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
+      stored = lookupSharedSession(sessionId)
+      if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-fc-tu1"])
+
+    // Turn 2: the accepted delta, but with TWO trailing system messages.
+    mockMessages = [
+      messageStart("msg_cc_delta_fc_2"),
+      textBlockStart(0),
+      textDelta(0, "fresh replay answer"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "fresh replay answer" }]),
+    ]
+    const requestId = `cc-delta-fc-turn2-${TEST_RUN_ID}`
+    const second = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: initialSystemText },
+        { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-fc-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-fc-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: firstReminder }] },
+        { role: "system", content: [{ type: "text", text: secondReminder }] },
+      ],
+    }, sessionId, { "x-request-id": requestId })
+    expect(second.status).toBe(200)
+    expect(await second.text()).toContain("message_stop")
+
+    // Checkpoint rejected → fresh structured replay: no resume options at all,
+    // and neither reminder reaches the SDK system prompt.
+    const replayed = capturedQueryParamsAll[1]
+    expect(replayed.options.resume).toBeUndefined()
+    expect(replayed.options.resumeSessionAt).toBeUndefined()
+    expect(JSON.stringify(replayed.options.systemPrompt ?? "")).not.toContain(firstReminder)
+    expect(JSON.stringify(replayed.options.systemPrompt ?? "")).not.toContain(secondReminder)
+
+    let row: any
+    for (let i = 0; i < 500 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
+      if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(row).toBeDefined()
+    expect(row!.isResume).toBe(false)
+  })
+
+  // The gate lives in server.ts, not in the helper default: the exact wire
+  // shape the claude-code adapter accepts must stay a fresh replay on any
+  // other adapter, which never passes the opt-in.
+  it("stream: non-claude-code adapters never opt in — reminder shape stays a fresh replay", async () => {
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "oc-gate-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1 through the generic OpenCode adapter: arm the checkpoint.
+    mockMessages = [toolTurn, userDenyMessage("oc-gate-tu1")]
+    const first = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [{ role: "user", content: "read gate x" }],
+    }, "es-oc-gate")
+    expect(first.status).toBe(200)
+    await first.text()
+
+    // Turn 2: the exact accepted shape (echo, result, one trailing system
+    // reminder) — but the x-opencode-session adapter carries no opt-in.
+    mockMessages = [assistantMessage([{ type: "text", text: "continued" }])]
+    const second = await post(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: false,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read gate x" },
+        { role: "assistant", content: [{ type: "tool_use", id: "oc-gate-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "oc-gate-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: "<system-reminder>Tokens: 4151</system-reminder>" }] },
+      ],
+    }, "es-oc-gate")
+    expect(second.status).toBe(200)
+    await second.text()
+    expect(capturedQueryParamsAll[1].options.resume).toBeUndefined()
+    expect(capturedQueryParamsAll[1].options.resumeSessionAt).toBeUndefined()
+  })
+
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
     const firstFragment = assistantMessage([
       { type: "tool_use", id: "late-tu-1", name: "read", input: { file_path: "a" } },

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -403,7 +403,7 @@ describe("claude-code trailing system delta", () => {
     role: "system",
     content: [{ type: "text", text, ...(cacheControl ? { cache_control: { type: "ephemeral" } } : {}) }],
   })
-  const opts = { allowClaudeCodeSystemDelta: true }
+  const opts = { allowTrailingSystemReminder: true }
 
   it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
@@ -481,5 +481,91 @@ describe("claude-code trailing system delta", () => {
     // Without the opt-in the trailing reminder is a generic rejection — the
     // observed staging transition to a full fresh replay.
     expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
+  })
+
+  it("rejects a system message between two result turns", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        echo(["t1", "t2"]),
+        { role: "user", content: [result("t1")] },
+        reminder("mid-conversation"),
+        { role: "user", content: [result("t2")] },
+      ],
+      ["t1", "t2"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("rejects whitespace-only reminders in string and text-block form", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: "   " }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: [{ type: "text", text: "   " }] }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("accepts one reminder carrying two text blocks, both delivered in order", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        echo(["t1"]),
+        { role: "user", content: [result("t1")] },
+        { role: "system", content: [{ type: "text", text: "first" }, { type: "text", text: "second" }] },
+      ],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), { type: "text", text: "first" }, { type: "text", text: "second" }] }])
+  })
+
+  it("rejects object and number reminder content", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: { text: "shaped" } }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: 42 }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("rejects an echo carrying an extra unknown tool_use id alongside a valid reminder", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        { role: "assistant", content: [
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+          { type: "tool_use", id: "unknown-x", name: "read", input: {} },
+        ] },
+        { role: "user", content: [result("t1")] },
+        reminder("valid reminder"),
+      ],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("tolerates adjacent thinking/text blocks in the echoing assistant message", () => {
+    // Pins the echo-gate comment: only tool_use blocks bind the echo, so
+    // surrounding thinking/text blocks neither reject nor reach the output.
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", signature: "sig" },
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+          { type: "text", text: "Reading the file." },
+        ] },
+        { role: "user", content: [result("t1")] },
+        reminder("r"),
+      ],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), { type: "text", text: "r" }] }])
   })
 })

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -407,8 +407,7 @@ describe("claude-code trailing system delta", () => {
 
   it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
-    // String and text-block-with-cache_control reminder forms pass through
-    // as-is; cache_control is stripped by the caller's existing strip path.
+    // cache_control is kept here; the caller strips it before the SDK.
     const cases: Array<[{ role: string; content: unknown }, unknown]> = [
       [{ role: "system", content: "<total_tokens> 4151" }, { type: "text", text: "<total_tokens> 4151" }],
       [reminder("<total_tokens> 4151", true), { type: "text", text: "<total_tokens> 4151", cache_control: { type: "ephemeral" } }],
@@ -460,8 +459,7 @@ describe("claude-code trailing system delta", () => {
     const cases: Array<[Array<{ role?: unknown; content?: unknown }>, string[]]> = [
       [[{ role: "user", content: [result("t1")], }, reminder("r")], ["t1"]], // missing echo
       [[echo(["t1", "t2"]), { role: "user", content: [result("t1")] }, reminder("r")], ["t1", "t2"]], // partial results
-      // Split echo across assistant messages: find never binds it, and the
-      // reminder-gated coalesce must reject it too.
+      // split echo: coalesce must reject it even though find never binds it
       [[echo(["t1"]), echo(["t2"]), { role: "user", content: [result("t1"), result("t2")] }, reminder("r")], ["t1", "t2"]],
     ]
     for (const [messages, ids] of cases) {
@@ -478,8 +476,6 @@ describe("claude-code trailing system delta", () => {
     ]
     expect(findCompleteToolResultCheckpoint(body, ["a"], opts))
       .toEqual([{ role: "user", content: [result("a"), { type: "text", text: "reminder", cache_control: { type: "ephemeral" } }] }])
-    // Without the opt-in the trailing reminder is a generic rejection — the
-    // observed staging transition to a full fresh replay.
     expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
   })
 
@@ -552,8 +548,7 @@ describe("claude-code trailing system delta", () => {
   })
 
   it("tolerates adjacent thinking/text blocks in the echoing assistant message", () => {
-    // Pins the echo-gate comment: only tool_use blocks bind the echo, so
-    // surrounding thinking/text blocks neither reject nor reach the output.
+    // only tool_use blocks bind the echo; thinking/text neither reject nor reach the output
     expect(coalesceCompleteToolResultContinuation(
       [
         { role: "assistant", content: [

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,21 +164,23 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
-   * mid-conversation-system enabled closes its tool-result delta with a
-   * trailing `system` reminder turn (`assistant[tool_use] ->
-   * user[tool_result] -> system[text]`, a `<total_tokens>`-style message).
-   * The generic Anthropic contract has no system role in `messages`, so
-   * that captured shape is admitted only under this explicit opt-in, only
-   * as the final message of the delta, and only with a single assistant
-   * echo carrying the complete exact expected ID set. The reminder is
-   * delivered as unprivileged user text after the results and any queued
-   * user content — never dropped, never escalated to an SDK system prompt.
-   * Newer clients (observed on 2.1.261) fold the reminder into the user
-   * tool_result instead and need no system-role opt-in — which is why this
-   * stays scoped to the captured shape.
+   * NOTE: agent-specific (claude-code) — with Claude Code's
+   * `mid-conversation-system` feature enabled (beta
+   * `mid-conversation-system-2026-04-07`), claude-cli closes its
+   * tool-result delta with a trailing `system` reminder turn
+   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
+   * `<total_tokens>`-style message); observed on 2.1.259 and 2.1.261.
+   * With the feature off the same clients fold the reminder into the
+   * user tool_result and need no opt-in — the gate is the feature, not
+   * the version. The generic Anthropic contract has no system role in
+   * `messages`, so that shape is admitted only under this explicit
+   * opt-in, only as the final message of the delta, and only with a
+   * single assistant echo carrying the complete exact expected ID set.
+   * The reminder is delivered as unprivileged user text after the
+   * results and any queued user content — never dropped, never
+   * escalated to an SDK system prompt.
    */
-  allowClaudeCodeSystemDelta?: boolean
+  allowTrailingSystemReminder?: boolean
 }
 
 /**
@@ -204,24 +206,20 @@ export function coalesceCompleteToolResultContinuation(
   let echoMessages = 0
 
   for (const message of messages) {
-    // NOTE: agent-specific (claude-code) — the captured 2.1.259 shape
-    // carries exactly one trailing system reminder AFTER the result batch;
-    // nothing may follow it, and leading/late/repeated reminders fail
-    // closed. Without the opt-in this branch is dead and the generic
-    // rejection below applies.
+    // Opt-in trailing reminder: the admitted shape lives on the allowTrailingSystemReminder JSDoc above; without the opt-in this branch is dead and the generic rejection below applies.
     if (message.role === "system") {
-      if (!options?.allowClaudeCodeSystemDelta) return undefined
+      if (!options?.allowTrailingSystemReminder) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
       sawTrailingSystem = true
       if (typeof message.content === "string") {
-        if (message.content.length === 0) return undefined
+        if (message.content.trim().length === 0) return undefined
         systemTextBlocks.push({ type: "text", text: message.content })
         continue
       }
       if (Array.isArray(message.content)) {
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
-          if (block?.type !== "text" || typeof block.text !== "string" || block.text.length === 0) return undefined
+          if (block?.type !== "text" || typeof block.text !== "string" || block.text.trim().length === 0) return undefined
           // Pass blocks through untouched; cache_control is stripped by the
           // caller's existing strip path before the SDK sees the prompt.
           systemTextBlocks.push(block)
@@ -278,10 +276,10 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A system reminder is a captured 2.1.259 delta only with a single
-  // assistant echo carrying the complete expected ID set; a split, partial,
-  // or absent echo proves nothing causal and the replay must stay fresh.
-  // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)
+  // A reminder-bearing delta is admitted only behind a single assistant echo
+  // carrying the complete expected ID set; a split, partial, or absent echo
+  // proves nothing causal and the replay must stay fresh. (Adjacent
+  // thinking/text blocks stay tolerated, as without the reminder.)
   if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
   // Delivered after the results and any queued user content, matching the
   // wire order; nothing ever follows the reminder on the wire.

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,21 +164,13 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — with Claude Code's
-   * `mid-conversation-system` feature enabled (beta
-   * `mid-conversation-system-2026-04-07`), claude-cli closes its
-   * tool-result delta with a trailing `system` reminder turn
-   * (`assistant[tool_use] -> user[tool_result] -> system[text]`, a
-   * `<total_tokens>`-style message); observed on 2.1.259 and 2.1.261.
-   * With the feature off the same clients fold the reminder into the
-   * user tool_result and need no opt-in — the gate is the feature, not
-   * the version. The generic Anthropic contract has no system role in
-   * `messages`, so that shape is admitted only under this explicit
-   * opt-in, only as the final message of the delta, and only with a
-   * single assistant echo carrying the complete exact expected ID set.
-   * The reminder is delivered as unprivileged user text after the
-   * results and any queued user content — never dropped, never
-   * escalated to an SDK system prompt.
+   * NOTE: agent-specific (claude-code) — with its `mid-conversation-system`
+   * feature on (beta `mid-conversation-system-2026-04-07`; seen on 2.1.259
+   * and 2.1.261), claude-cli ends a tool-result delta with one trailing
+   * `system` reminder turn. The Messages contract has no system role, so the
+   * turn is admitted only here, only as the final message, only behind a
+   * single echo of the complete expected ID set, and is delivered as
+   * unprivileged user text after the results — never as an SDK system prompt.
    */
   allowTrailingSystemReminder?: boolean
 }
@@ -206,7 +198,6 @@ export function coalesceCompleteToolResultContinuation(
   let echoMessages = 0
 
   for (const message of messages) {
-    // Opt-in trailing reminder: the admitted shape lives on the allowTrailingSystemReminder JSDoc above; without the opt-in this branch is dead and the generic rejection below applies.
     if (message.role === "system") {
       if (!options?.allowTrailingSystemReminder) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
@@ -220,8 +211,7 @@ export function coalesceCompleteToolResultContinuation(
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
           if (block?.type !== "text" || typeof block.text !== "string" || block.text.trim().length === 0) return undefined
-          // Pass blocks through untouched; cache_control is stripped by the
-          // caller's existing strip path before the SDK sees the prompt.
+          // cache_control survives here; the caller's strip path removes it before the SDK.
           systemTextBlocks.push(block)
         }
         if (systemTextBlocks.length === 0) return undefined
@@ -276,13 +266,10 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A reminder-bearing delta is admitted only behind a single assistant echo
-  // carrying the complete expected ID set; a split, partial, or absent echo
-  // proves nothing causal and the replay must stay fresh. (Adjacent
-  // thinking/text blocks stay tolerated, as without the reminder.)
+  // With a reminder the echo must be exactly one message carrying the full ID
+  // set: a split, partial, or absent echo does not prove the checkpoint.
   if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
-  // Delivered after the results and any queued user content, matching the
-  // wire order; nothing ever follows the reminder on the wire.
+  // Reminder last, as on the wire.
   if (systemTextBlocks.length > 0) content.push(...systemTextBlocks)
   return [{ role: "user", content }]
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,14 +2178,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
-        // NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
-        // mid-conversation-system enabled closes its tool-result delta with
-        // a trailing system-role reminder turn (`assistant[tool_use] ->
-        // user[tool_result] -> system[text]`). The generic checkpoint
-        // helpers reject every role=system message, which turned each such
-        // continuation into a full fresh replay. The opt-in admits that
-        // captured shape for this adapter only, gated on the single
-        // complete expected-ID echo.
+        // NOTE: agent-specific (claude-code) — trailing system reminder of its mid-conversation-system feature; see allowTrailingSystemReminder.
         const trailingSystemReminderOptions = adapterBase === "claude-code"
           ? { allowTrailingSystemReminder: true }
           : undefined

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2186,8 +2186,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // continuation into a full fresh replay. The opt-in admits that
         // captured shape for this adapter only, gated on the single
         // complete expected-ID echo.
-        const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
-          ? { allowClaudeCodeSystemDelta: true }
+        const trailingSystemReminderOptions = adapterBase === "claude-code"
+          ? { allowTrailingSystemReminder: true }
           : undefined
         const durableCheckpointContinuation = durableCheckpointIds?.length
           && durableMappingAtTurn.status === "found"
@@ -2195,7 +2195,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           ? coalesceCompleteToolResultContinuation(
             (body.messages || []).slice(durableMappingAtTurn.session.messageCount),
             durableCheckpointIds,
-            claudeCodeSystemDeltaOptions,
+            trailingSystemReminderOptions,
           )
           : undefined
         const advancesDurableCheckpoint = Boolean(durableCheckpointContinuation)
@@ -2526,7 +2526,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const checkpointContinuation = coalesceCompleteToolResultContinuation(
           messagesToConvert,
           passthroughToolCallIds ?? [],
-          claudeCodeSystemDeltaOptions,
+          trailingSystemReminderOptions,
         )
         if (checkpointContinuation) {
           messagesToConvert = checkpointContinuation


### PR DESCRIPTION
Finish the late #947 updates following #949: whitespace-only system reminders must use fresh replay, matching already-rejected empty reminders. Rename the leaf helper's option to allowTrailingSystemReminder, retain the Claude Code adapter gate, and correct the comments to describe feature-controlled client behavior. The complete-prefix and whole-delta history checks from #949 remain intact.

Preserves Aleksey Proshutinskiy's two additional commits as 1eaf7fe4 and d9c5f135, with their original author and dates. Separate maintainer commits add real SDK validation and isolate E41's SDK cwd from checkout edits.

Validation:

- Author's blank-reminder leaf test fails on main; real SDK before resumes that malformed shape. Corrected text/image cases pass in both response modes, replay fresh, return the actual value/context and image color, and preserve source history.
- 3,462 tests pass, one existing skip, zero failures; typecheck/build pass. Focused checkpoint/concurrency suite: 139 pass.
- Actual Claude Code 2.1.259 Read loop and ordinary follow-up pass; revised and inserted history controls pass.
- All four E41 batching/response-mode combinations pass, retaining exact tool-result history and the 95% cache threshold.

The first E41 runs failed cache continuity while E2E.md changed in their SDK working directory. A controlled experiment on unchanged main passes with stable Git status and fails when a tracked file changes between SDK turns. E41 now uses its disposable directory as SDK cwd; the same external Git mutation no longer changes its cache input, and the isolated experiment passes. Earlier failures remain recorded. This corrects benchmark isolation; it does not claim to eliminate the SDK's cache invalidation when a real project's Git status changes.

This completes the reviewed #947 scope when merged. It does not resolve #946's OpenCode/Orca ownership report or certify a separately installed 2.1.261 runtime. All applicable CI checks passed at final head 59077b98 before merge.
