### PR TITLE
fix: fail closed on blank trailing reminders and scope the gate to the feature

### DIFF
--- a/src/__tests__/passthrough-early-stop-integration.test.ts
+++ b/src/__tests__/passthrough-early-stop-integration.test.ts
@@ -1286,6 +1286,92 @@ describe("Integration: passthrough early stop", () => {
     })
   }
 
+  // Fail-closed twin: a second trailing system breaks the one-reminder
+  // contract, so the continuation must fall back to a fresh replay.
+  it("stream: two trailing system reminders fail closed to a fresh replay", async () => {
+    const sessionId = `cc-delta-fc-${TEST_RUN_ID}`
+    const headers = { "x-meridian-agent": "claude-code", "x-opencode-session": sessionId }
+    const initialSystemText = "You are Claude Code, Anthropic's official CLI for Claude."
+    const firstReminder = "<system-reminder>Total tokens: 4151</system-reminder>"
+    const secondReminder = "<system-reminder>Context low</system-reminder>"
+    const toolTurn = assistantMessage([
+      { type: "tool_use", id: "cc-delta-fc-tu1", name: "read", input: { file_path: "x" } },
+    ])
+
+    // Turn 1 mirrors the parametrized accepted case: arm the checkpoint.
+    mockMessages = [
+      messageStart("msg_cc_delta_fc_1"),
+      toolUseBlockStart(0, "read", "cc-delta-fc-tu1"),
+      inputJsonDelta(0, '{"file_path":"x"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      toolTurn,
+      userDenyMessage("cc-delta-fc-tu1"),
+      assistantMessage([{ type: "text", text: "CC_DELTA_FC_GARBAGE_DIGEST" }]),
+    ]
+    const first = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: [{ type: "text", text: initialSystemText, cache_control: { type: "ephemeral" } }] },
+      ],
+    }, sessionId, headers)
+    expect(first.status).toBe(200)
+    await first.text()
+    let stored: any
+    for (let i = 0; i < 500 && !stored?.passthroughToolCallAssistantUuid; i++) {
+      stored = lookupSharedSession(sessionId)
+      if (!stored?.passthroughToolCallAssistantUuid) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(stored?.passthroughToolCallIds).toEqual(["cc-delta-fc-tu1"])
+
+    // Turn 2: the accepted delta, but with TWO trailing system messages.
+    mockMessages = [
+      messageStart("msg_cc_delta_fc_2"),
+      textBlockStart(0),
+      textDelta(0, "fresh replay answer"),
+      blockStop(0),
+      messageDelta("end_turn"),
+      messageStop(),
+      assistantMessage([{ type: "text", text: "fresh replay answer" }]),
+    ]
+    const requestId = `cc-delta-fc-turn2-${TEST_RUN_ID}`
+    const second = await postClaudeCode(app, {
+      model: "claude-sonnet-4-5",
+      max_tokens: 400,
+      stream: true,
+      tools: [READ_TOOL],
+      messages: [
+        { role: "user", content: "read x" },
+        { role: "system", content: initialSystemText },
+        { role: "assistant", content: [{ type: "tool_use", id: "cc-delta-fc-tu1", name: "read", input: { file_path: "x" } }] },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: "cc-delta-fc-tu1", content: "hi" }] },
+        { role: "system", content: [{ type: "text", text: firstReminder }] },
+        { role: "system", content: [{ type: "text", text: secondReminder }] },
+      ],
+    }, sessionId, { ...headers, "x-request-id": requestId })
+    expect(second.status).toBe(200)
+    expect(await second.text()).toContain("message_stop")
+
+    // Rejected checkpoint: fresh replay, no resume options, reminders kept out of the system prompt.
+    const replayed = capturedQueryParamsAll[1]
+    expect(replayed.options.resume).toBeUndefined()
+    expect(replayed.options.resumeSessionAt).toBeUndefined()
+    expect(JSON.stringify(replayed.options.systemPrompt ?? "")).not.toContain(firstReminder)
+    expect(JSON.stringify(replayed.options.systemPrompt ?? "")).not.toContain(secondReminder)
+
+    let row: any
+    for (let i = 0; i < 500 && !row; i++) {
+      row = telemetryStore.getRecent({ limit: 200 }).find((m: any) => m.requestId === requestId)
+      if (!row) await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    expect(row).toBeDefined()
+    expect(row!.isResume).toBe(false)
+  })
+
   it("stream: waits for late parallel assistant metadata before freezing the checkpoint", async () => {
     const firstFragment = assistantMessage([
       { type: "tool_use", id: "late-tu-1", name: "read", input: { file_path: "a" } },

--- a/src/__tests__/passthrough-early-stop.test.ts
+++ b/src/__tests__/passthrough-early-stop.test.ts
@@ -407,8 +407,7 @@ describe("claude-code trailing system delta", () => {
 
   it("accepts the captured delta: complete expected-ID echo, results, trailing reminder", () => {
     const results = [result("t1"), result("t2")]
-    // String and text-block-with-cache_control reminder forms pass through
-    // as-is; cache_control is stripped by the caller's existing strip path.
+    // cache_control is kept here; the caller strips it before the SDK.
     const cases: Array<[{ role: string; content: unknown }, unknown]> = [
       [{ role: "system", content: "<total_tokens> 4151" }, { type: "text", text: "<total_tokens> 4151" }],
       [reminder("<total_tokens> 4151", true), { type: "text", text: "<total_tokens> 4151", cache_control: { type: "ephemeral" } }],
@@ -460,8 +459,7 @@ describe("claude-code trailing system delta", () => {
     const cases: Array<[Array<{ role?: unknown; content?: unknown }>, string[]]> = [
       [[{ role: "user", content: [result("t1")], }, reminder("r")], ["t1"]], // missing echo
       [[echo(["t1", "t2"]), { role: "user", content: [result("t1")] }, reminder("r")], ["t1", "t2"]], // partial results
-      // Split echo across assistant messages: find never binds it, and the
-      // reminder-gated coalesce must reject it too.
+      // split echo: coalesce must reject it even though find never binds it
       [[echo(["t1"]), echo(["t2"]), { role: "user", content: [result("t1"), result("t2")] }, reminder("r")], ["t1", "t2"]],
     ]
     for (const [messages, ids] of cases) {
@@ -478,8 +476,91 @@ describe("claude-code trailing system delta", () => {
     ]
     expect(findCompleteToolResultCheckpoint(body, ["a"], opts))
       .toEqual([{ role: "user", content: [result("a"), { type: "text", text: "reminder", cache_control: { type: "ephemeral" } }] }])
-    // Without the opt-in the trailing reminder is a generic rejection — the
-    // observed staging transition to a full fresh replay.
     expect(findCompleteToolResultCheckpoint(body, ["a"])).toBeUndefined()
+  })
+
+  it("rejects a system message between two result turns", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        echo(["t1", "t2"]),
+        { role: "user", content: [result("t1")] },
+        reminder("mid-conversation"),
+        { role: "user", content: [result("t2")] },
+      ],
+      ["t1", "t2"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("rejects whitespace-only reminders in string and text-block form", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: "   " }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: [{ type: "text", text: "   " }] }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("accepts one reminder carrying two text blocks, both delivered in order", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        echo(["t1"]),
+        { role: "user", content: [result("t1")] },
+        { role: "system", content: [{ type: "text", text: "first" }, { type: "text", text: "second" }] },
+      ],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), { type: "text", text: "first" }, { type: "text", text: "second" }] }])
+  })
+
+  it("rejects object and number reminder content", () => {
+    const delta = [echo(["t1"]), { role: "user", content: [result("t1")] }]
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: { text: "shaped" } }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+    expect(coalesceCompleteToolResultContinuation(
+      [...delta, { role: "system", content: 42 }],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("rejects an echo carrying an extra unknown tool_use id alongside a valid reminder", () => {
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        { role: "assistant", content: [
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+          { type: "tool_use", id: "unknown-x", name: "read", input: {} },
+        ] },
+        { role: "user", content: [result("t1")] },
+        reminder("valid reminder"),
+      ],
+      ["t1"],
+      opts,
+    )).toBeUndefined()
+  })
+
+  it("tolerates adjacent thinking/text blocks in the echoing assistant message", () => {
+    // only tool_use blocks bind the echo; thinking/text neither reject nor reach the output
+    expect(coalesceCompleteToolResultContinuation(
+      [
+        { role: "assistant", content: [
+          { type: "thinking", thinking: "hmm", signature: "sig" },
+          { type: "tool_use", id: "t1", name: "read", input: {} },
+          { type: "text", text: "Reading the file." },
+        ] },
+        { role: "user", content: [result("t1")] },
+        reminder("r"),
+      ],
+      ["t1"],
+      opts,
+    )).toEqual([{ role: "user", content: [result("t1"), { type: "text", text: "r" }] }])
   })
 })

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -164,19 +164,13 @@ export function allForwardedCallsResolved(tracker: EarlyStopTracker): boolean {
  */
 export interface CompleteToolResultContinuationOptions {
   /**
-   * NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
-   * mid-conversation-system enabled closes its tool-result delta with a
-   * trailing `system` reminder turn (`assistant[tool_use] ->
-   * user[tool_result] -> system[text]`, a `<total_tokens>`-style message).
-   * The generic Anthropic contract has no system role in `messages`, so
-   * that captured shape is admitted only under this explicit opt-in, only
-   * as the final message of the delta, and only with a single assistant
-   * echo carrying the complete exact expected ID set. The reminder is
-   * delivered as unprivileged user text after the results and any queued
-   * user content — never dropped, never escalated to an SDK system prompt.
-   * Newer clients (observed on 2.1.261) fold the reminder into the user
-   * tool_result instead and need no system-role opt-in — which is why this
-   * stays scoped to the captured shape.
+   * NOTE: agent-specific (claude-code) — with its `mid-conversation-system`
+   * feature on (beta `mid-conversation-system-2026-04-07`; seen on 2.1.259
+   * and 2.1.261), claude-cli ends a tool-result delta with one trailing
+   * `system` reminder turn. The Messages contract has no system role, so the
+   * turn is admitted only here, only as the final message, only behind a
+   * single echo of the complete expected ID set, and is delivered as
+   * unprivileged user text after the results — never as an SDK system prompt.
    */
   allowClaudeCodeSystemDelta?: boolean
 }
@@ -204,26 +198,20 @@ export function coalesceCompleteToolResultContinuation(
   let echoMessages = 0
 
   for (const message of messages) {
-    // NOTE: agent-specific (claude-code) — the captured 2.1.259 shape
-    // carries exactly one trailing system reminder AFTER the result batch;
-    // nothing may follow it, and leading/late/repeated reminders fail
-    // closed. Without the opt-in this branch is dead and the generic
-    // rejection below applies.
     if (message.role === "system") {
       if (!options?.allowClaudeCodeSystemDelta) return undefined
       if (!sawUser || sawTrailingSystem) return undefined
       sawTrailingSystem = true
       if (typeof message.content === "string") {
-        if (message.content.length === 0) return undefined
+        if (message.content.trim().length === 0) return undefined
         systemTextBlocks.push({ type: "text", text: message.content })
         continue
       }
       if (Array.isArray(message.content)) {
         for (const rawBlock of message.content) {
           const block = rawBlock as { type?: unknown; text?: unknown } | null | undefined
-          if (block?.type !== "text" || typeof block.text !== "string" || block.text.length === 0) return undefined
-          // Pass blocks through untouched; cache_control is stripped by the
-          // caller's existing strip path before the SDK sees the prompt.
+          if (block?.type !== "text" || typeof block.text !== "string" || block.text.trim().length === 0) return undefined
+          // cache_control survives here; the caller's strip path removes it before the SDK.
           systemTextBlocks.push(block)
         }
         if (systemTextBlocks.length === 0) return undefined
@@ -278,13 +266,10 @@ export function coalesceCompleteToolResultContinuation(
     actual.size !== expected.size ||
     (echoedCalls.size !== 0 && echoedCalls.size !== expected.size)
   ) return undefined
-  // A system reminder is a captured 2.1.259 delta only with a single
-  // assistant echo carrying the complete expected ID set; a split, partial,
-  // or absent echo proves nothing causal and the replay must stay fresh.
-  // (Adjacent thinking/text blocks stay tolerated, as without the reminder.)
+  // With a reminder the echo must be exactly one message carrying the full ID
+  // set: a split, partial, or absent echo does not prove the checkpoint.
   if (sawTrailingSystem && (echoMessages !== 1 || echoedCalls.size !== expected.size)) return undefined
-  // Delivered after the results and any queued user content, matching the
-  // wire order; nothing ever follows the reminder on the wire.
+  // Reminder last, as on the wire.
   if (systemTextBlocks.length > 0) content.push(...systemTextBlocks)
   return [{ role: "user", content }]
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -2178,14 +2178,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         const durableCheckpointIds = durableMappingAtTurn.status === "found"
           ? durableMappingAtTurn.session.passthroughToolCallIds
           : undefined
-        // NOTE: agent-specific (claude-code) — claude-cli 2.1.259 with
-        // mid-conversation-system enabled closes its tool-result delta with
-        // a trailing system-role reminder turn (`assistant[tool_use] ->
-        // user[tool_result] -> system[text]`). The generic checkpoint
-        // helpers reject every role=system message, which turned each such
-        // continuation into a full fresh replay. The opt-in admits that
-        // captured shape for this adapter only, gated on the single
-        // complete expected-ID echo.
+        // NOTE: agent-specific (claude-code) — trailing system reminder of its mid-conversation-system feature; see allowClaudeCodeSystemDelta.
         const claudeCodeSystemDeltaOptions = adapterBase === "claude-code"
           ? { allowClaudeCodeSystemDelta: true }
           : undefined


### PR DESCRIPTION
## Summary

Follow-up to #949, which incorporated #947. Three small things from the later revisions of that branch that #949 does not carry:

- **whitespace-only trailing reminders fail closed** — they passed the gate and would reach the API as blank text blocks, which it rejects with 400 on the resumed turn
- **comments state the actual gate** — the trailing-system shape comes from Claude Code's `mid-conversation-system` feature (beta `mid-conversation-system-2026-04-07`), not from a client version. Verified live on the real Agent SDK: claude-cli 2.1.261 with the feature on emits the same `assistant[thinking,tool_use] -> user[tool_result] -> system[text]` delta as 2.1.259 and resumes through this path; with the feature off both fold the reminder into the `tool_result`. The "newer clients (2.1.261) fold the reminder … and need no opt-in" sentence was an artifact of a probe run with the feature off
- **tests pin the remaining fail-closed edges** — a system message between two result turns, blank and non-string reminder content, an extra unknown tool_use id in the echo, two trailing reminders through HTTP (`resume` undefined, telemetry `isResume=false`), thinking/text blocks in the echo tolerated, two text blocks delivered in order

No behaviour change other than rejecting blank reminders. The option keeps its name.

## Validation

- focused unit + HTTP suites: `123 pass, 0 fail`; full `npm test`: 0 failures
- `npm run typecheck`, `git diff --check`
- live evidence for the feature-gate claim is in the description of #947 (real Agent SDK 0.2.119 and 0.3.261, clients 2.1.259 and 2.1.261, clean main vs fix)
