### PR TITLE
fix: classify CLI model incompatibility without false client errors

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -3746,3 +3746,9 @@ Run the direct gate with `--blank-reminder` in both response modes, with and wit
 Run `bun scripts/e2e-claude-code-client.mjs` for the full installed Claude Code 2.1.259 → Meridian → real SDK loop. `E2E_CLAUDE_CLIENT` can name that exact client binary. The fixture isolates the outer client's settings and enables its `CLAUDE_CODE_FORCE_MID_CONVERSATION_SYSTEM` flag; `--bare` suppresses the shape and is unsuitable. The real CLI reads a disposable fixture, sends its native `<total_tokens>` system reminder, then resumes for an ordinary follow-up. Require both proxy continuations to resume, delivery of both reminders to SDK user history, correct answers, and unchanged source history.
 
 `--capture` runs only the real client's wire-format probe against a scripted local endpoint. It does not contact the SDK and is not a substitute for the full E2E gate. The fixture checks the exact client version; newer versions are separate compatibility targets. This case does not validate OpenCode/Orca cross-tool session ownership (#946).
+
+## CLI model-version rejection
+
+Run `E2E_CLAUDE_PATH=/path/to/old/claude bun scripts/e2e-cli-model-version.mjs --expect-rejection` and again with `--stream`. Use an old CLI that actually rejects the default `fable` model (2.1.177 was validated). Require HTTP 400/invalid_request_error or a single actionable SSE invalid_request_error without message_stop, the installed/required versions and override remedy, and exactly one proxy SDK query.
+
+Run the same old binary with `E2E_MODEL=claude-haiku-4-5-20251001`, omitting `--expect-rejection`, in both modes. Then omit both overrides to validate the bundled CLI with `fable` in both modes. Supported requests must return exactly READY. Each run isolates Meridian config, sessions and working directory; it does not change the installed CLI or subscription credentials.

--- a/scripts/e2e-cli-model-version.mjs
+++ b/scripts/e2e-cli-model-version.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env bun
+// Real CLI model compatibility through Meridian HTTP and SSE.
+import assert from "node:assert/strict"
+import { randomUUID } from "node:crypto"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import * as sdk from "@anthropic-ai/claude-agent-sdk"
+import { spyOn } from "bun:test"
+
+const stream = process.argv.includes("--stream")
+const expectRejection = process.argv.includes("--expect-rejection")
+const override = process.env.E2E_CLAUDE_PATH
+const model = process.env.E2E_MODEL ?? "fable"
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-cli-version-")))
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, {
+  MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST: "0",
+  ...(override ? { MERIDIAN_CLAUDE_PATH: override } : {}),
+})
+const { resolveClaudeExecutableAsync } = await import("../src/proxy/models.ts")
+const cli = await resolveClaudeExecutableAsync()
+const versionProcess = Bun.spawn([cli, "--version"], { stdout: "pipe", stderr: "pipe" })
+const versionTimer = setTimeout(() => versionProcess.kill(), 10_000)
+const [versionCode, versionOut, versionError] = await Promise.all([
+  versionProcess.exited, new Response(versionProcess.stdout).text(), new Response(versionProcess.stderr).text(),
+])
+clearTimeout(versionTimer)
+assert.equal(versionCode, 0, versionError)
+const version = versionOut.trim()
+let queryCount = 0
+const realQuery = sdk.query
+const querySpy = spyOn(sdk, "query").mockImplementation(input => {
+  queryCount++
+  return realQuery(input)
+})
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const instance = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true })
+try {
+  const address = instance.server.address()
+  assert(address && typeof address === "object")
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-opencode-session": `cli-model-${randomUUID()}` },
+    body: JSON.stringify({ model, max_tokens: 128, stream,
+      messages: [{ role: "user", content: "Reply with exactly READY. Do not use tools." }] }),
+    signal: AbortSignal.timeout(90_000),
+  })
+  const raw = await response.text()
+  const events = stream ? raw.split("\n").filter(line => line.startsWith("data:"))
+    .map(line => JSON.parse(line.slice(5))) : []
+  const body = stream ? undefined : JSON.parse(raw)
+  console.log(JSON.stringify({ root, cli, version, model, stream, expectRejection, status: response.status, queryCount }))
+  assert.equal(queryCount, 1, "A permanent model rejection must not cause a proxy SDK retry")
+  if (expectRejection) {
+    assert.equal(response.status, stream ? 200 : 400, raw)
+    const errorEvents = events.filter(event => event.type === "error")
+    if (stream) {
+      assert.equal(errorEvents.length, 1, raw)
+      assert(!events.some(event => event.type === "message_stop"), raw)
+    }
+    const error = stream ? errorEvents[0].error : body.error
+    assert.equal(error?.type, "invalid_request_error", raw)
+    assert.match(error.message, /Claude Code .* does not support this model/i)
+    assert(error.message.includes(version.split(" ")[0]), "Installed version must remain actionable")
+    assert.match(error.message, /version \d[\w.]* or newer is required/i)
+    assert(error.message.includes("MERIDIAN_CLAUDE_PATH"))
+    assert.equal(response.headers.get("Retry-After"), null)
+    console.log(JSON.stringify({ error }))
+  } else {
+    assert.equal(response.status, 200, raw)
+    assert(!events.some(event => event.type === "error"), raw)
+    if (stream) assert.equal(events.filter(event => event.type === "message_stop").length, 1, raw)
+    const answer = stream
+      ? events.filter(event => event.delta?.type === "text_delta").map(event => event.delta.text).join("")
+      : body.content.filter(block => block.type === "text").map(block => block.text).join("")
+    assert.equal(answer.trim(), "READY", raw)
+  }
+  console.log(JSON.stringify({ result: "PASS", version, model, stream, expectRejection }))
+} finally {
+  querySpy.mockRestore()
+  await instance.close()
+}

--- a/src/__tests__/cli-model-error-boundaries.test.ts
+++ b/src/__tests__/cli-model-error-boundaries.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test"
+import { classifyError } from "../proxy/errors"
+
+const rejection = "Claude Code 2.1.177 does not support this model; version 2.1.251 or newer is required."
+
+describe("CLI model rejection boundaries", () => {
+  for (const input of [
+    rejection,
+    `API Error: 400 ${rejection}`,
+    `Error: API Error: 400 ${rejection}`,
+    `Claude Code returned an error result: API Error: 400 ${rejection}`,
+    `Claude Code process exited with code 1\nSubprocess stderr: API Error: 400 ${rejection}`,
+    `Claude Code process exited with code 1\nSubprocess stderr:\nAPI Error: 400 ${rejection}`,
+    "API Error: 400 Claude Code 3.1.2-preview.1 does not support this model; version 4.0.0 is required.",
+  ]) {
+    it(`recognizes the actionable rejection: ${input}`, () => {
+      const result = classifyError(input)
+      expect(result.status).toBe(400)
+      expect(result.type).toBe("invalid_request_error")
+      expect(result.message).toContain(input)
+      expect(result.message).toContain("MERIDIAN_CLAUDE_PATH")
+    })
+  }
+
+  for (const [input, status] of [
+    [`Tool read failed: the file contains ${rejection}`, 500],
+    [`API Error: 503 Upstream overloaded; documentation mentions ${rejection}`, 503],
+    [`It is not true that ${rejection}`, 500],
+    [`Tool read failed; quoted documentation follows:\n${rejection}`, 500],
+    [`API Error: 503 Upstream overloaded\nDocumentation example:\n${rejection}`, 503],
+    ['Error: this tool does not support streaming input', 500],
+    ['API Error: 401 Invalid authentication credentials', 401],
+    ["You've hit your usage limit for claude-fable-5-1", 429],
+    ['Claude Code process exited with code 137', 502],
+  ] as const) {
+    it(`preserves unrelated error classification: ${input}`, () => {
+      const result = classifyError(input)
+      expect(result.status).toBe(status)
+      expect(result.message).not.toContain("MERIDIAN_CLAUDE_PATH")
+    })
+  }
+})

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -346,6 +346,51 @@ describe("classifyError", () => {
     })
   })
 
+  // The CLI rejects a model it is too old to know about. Captured verbatim from
+  // claude-code 2.1.198 asked for claude-fable-5-1 (#932). This is reachable via
+  // MERIDIAN_CLAUDE_PATH, which outranks the bundled binary the package.json
+  // floor governs, so the floor alone does not prevent it.
+  describe("CLI too old for the requested model (#932)", () => {
+    const REAL = "API Error: 400 Claude Code 2.1.198 does not support this model; version 2.1.251 or newer is required. Run 'claude update', or update the Claude desktop app, then try again."
+
+    it("classifies the CLI's verbatim wording as a client error", () => {
+      const r = classifyError(REAL)
+      expect(r.status).toBe(400)
+      expect(r.type).toBe("invalid_request_error")
+    })
+
+    // The whole point: a 500 reads as "transient" to every client retry policy,
+    // so an upgrade-or-nothing failure gets replayed forever at upstream cost.
+    it("is never retryable", () => {
+      expect(classifyError(REAL).status).toBeLessThan(500)
+    })
+
+    // The CLI names both the installed and required versions. Dropping them for
+    // generic prose would discard the only actionable part of the message.
+    it("preserves the version detail the CLI reported", () => {
+      const r = classifyError(REAL)
+      expect(r.message).toContain("2.1.198")
+      expect(r.message).toContain("2.1.251")
+    })
+
+    it("matches the shape, not one hardcoded version pair", () => {
+      const r = classifyError("API Error: 400 Claude Code 2.0.5 does not support this model; version 3.0.0 or newer is required.")
+      expect(r.status).toBe(400)
+    })
+
+    // Must not steal a genuine quota failure that happens to mention a model.
+    it("leaves a rate limit alone", () => {
+      expect(classifyError("You've hit your usage limit for claude-fable-5-1").status).toBe(429)
+    })
+
+    // "does not support" alone is too broad — an unsupported tool or flag is a
+    // different failure with a different remedy.
+    it("does not fire on an unrelated unsupported-feature error", () => {
+      const r = classifyError("Error: this tool does not support streaming input")
+      expect(r.status).not.toBe(400)
+    })
+  })
+
   describe("process crashes", () => {
     it("detects exit code with specific number", () => {
       const result = classifyError("exited with code 137")

--- a/src/__tests__/proxy-error-handling.test.ts
+++ b/src/__tests__/proxy-error-handling.test.ts
@@ -79,6 +79,36 @@ describe("Error classification", () => {
     clearSessionCache()
   })
 
+  for (const stream of [false, true]) {
+    for (const quoted of [false, true]) {
+      it(`keeps model rejection distinct from quoted overload text (stream=${stream}, quoted=${quoted})`, async () => {
+        const rejection = "Claude Code 2.1.177 does not support this model; version 2.1.251 or newer is required."
+        mockError = new Error(quoted
+          ? `API Error: 503 Upstream overloaded; documentation mentions ${rejection}`
+          : `Claude Code returned an error result: API Error: 400 ${rejection}`)
+        const response: Response = await post(createTestApp(), { ...BASIC_REQUEST, stream })
+        const raw = await response.text()
+        const expectedType = quoted ? "overloaded_error" : "invalid_request_error"
+        if (stream) {
+          expect(response.status).toBe(200)
+          const events = raw.split("\n").filter(line => line.startsWith("data:"))
+            .map(line => JSON.parse(line.slice(5)))
+          expect(events.find(event => event.type === "error")?.error.type).toBe(expectedType)
+          expect(events.some(event => event.type === "message_stop")).toBe(false)
+        } else {
+          expect(response.status).toBe(quoted ? 503 : 400)
+          expect(JSON.parse(raw).error.type).toBe(expectedType)
+          expect(response.headers.get("Retry-After")).toBe(quoted ? "5" : null)
+        }
+        if (!quoted) {
+          expect(raw).toContain("2.1.177")
+          expect(raw).toContain("2.1.251")
+          expect(raw).toContain("MERIDIAN_CLAUDE_PATH")
+        }
+      }, 15000)
+    }
+  }
+
   it("should return 401 for authentication errors", async () => {
     mockError = new Error("API Error: 401 authentication_error - Invalid authentication credentials")
     const app = createTestApp()

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -193,7 +193,16 @@ const OVERFLOW_PHRASES = [
  *  an unsupported *tool* or *flag* ("this tool does not support streaming
  *  input") cannot take the branch: that is a different failure with a
  *  different remedy. */
-const CLI_MODEL_UNSUPPORTED = /claude code(?: \d[\w.]*)? does not support this model/
+// Require an error-message opening, after only known SDK/CLI wrappers. A
+// quoted phrase in a tool error or overload diagnostic is not this rejection:
+// falsely returning 400 would prevent a legitimate retry. Only the observed
+// 400 wrapper is admitted. A bare phrase on a later diagnostic line is not
+// an error opening; only the server's explicit stderr marker reopens one.
+const CLI_MODEL_UNSUPPORTED = new RegExp(
+  String.raw`(?:^\s*|\r?\n[ \t]*subprocess stderr:\s*)`
+  + String.raw`(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*(?:400\s+)?)*`
+  + String.raw`claude code(?: \d[\w.+-]*)? does not support this model\b`,
+)
 
 /** Either the phrase opens a line (after the known SDK/CLI wrappers), or it
  *  opens the `message` value of an API error envelope — `API Error: 400

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -182,6 +182,19 @@ const OVERFLOW_PHRASES = [
   String.raw`context[_ ]length[_ ]exceeded`,
 ]
 
+/** The resolved CLI is older than the model that was asked for. Observed
+ *  verbatim from claude-code 2.1.198 asked for `claude-fable-5-1`:
+ *  `API Error: 400 Claude Code 2.1.198 does not support this model; version
+ *  2.1.251 or newer is required. Run 'claude update', ...`
+ *
+ *  Version-agnostic by design — pinning the observed pair would stop matching
+ *  at the next floor bump, which is the same trap #764/#787 sprang on the
+ *  rate-limit literals. `Claude Code` must sit adjacent to the phrase so that
+ *  an unsupported *tool* or *flag* ("this tool does not support streaming
+ *  input") cannot take the branch: that is a different failure with a
+ *  different remedy. */
+const CLI_MODEL_UNSUPPORTED = /claude code(?: \d[\w.]*)? does not support this model/
+
 /** Either the phrase opens a line (after the known SDK/CLI wrappers), or it
  *  opens the `message` value of an API error envelope — `API Error: 400
  *  {"type":"invalid_request_error","message":"prompt is too long: ..."}`, which
@@ -280,6 +293,28 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
       status: 400,
       type: "invalid_request_error",
       message: "Prompt exceeds the model's context window. Compact or trim the conversation before retrying — an identical retry fails the same way."
+    }
+  }
+
+  // The resolved CLI predates the requested model. A correct package.json floor
+  // does not prevent this: MERIDIAN_CLAUDE_PATH is step 0 of
+  // resolveClaudeExecutableWithSource, so an env-pointed CLI outranks the
+  // bundled binary the floor governs (#932).
+  //
+  // 400 for the same reason as context overflow above — upgrading the CLI is
+  // the only fix, so every retry fails identically, and the default 500 reads
+  // as "transient" to every client retry policy. Placed before the crash
+  // branch so the same error arriving as a code-1 exit with stderr attached
+  // does not get answered with `claude login`, which cannot help here.
+  //
+  // The CLI names both the installed and the required version; that is the
+  // only actionable part of the message, so it is carried through rather than
+  // replaced with generic prose.
+  if (CLI_MODEL_UNSUPPORTED.test(lower)) {
+    return {
+      status: 400,
+      type: "invalid_request_error",
+      message: `${errMsg.trim()} (Meridian: the Claude Code CLI it resolved is older than the requested model. If MERIDIAN_CLAUDE_PATH is set it overrides the bundled CLI, so update that binary or unset the variable.)`
     }
   }
 


### PR DESCRIPTION
When MERIDIAN_CLAUDE_PATH selects a CLI too old for the requested model, return an actionable 400/invalid_request_error. Streaming requests emit that error without a successful message_stop. Preserve the CLI's installed/required versions and explain the override remedy so callers can stop retrying an incompatible request.

Incorporates #936, preserving its original author and date in d52eff1b. The maintainer correction restricts matching to error-message openings and known SDK/CLI wrappers, including captured subprocess stderr. Quoted prose, even on a later diagnostic line, must not turn an unrelated tool error or retryable 503 into a permanent client error. Authentication, quota and process-crash classifications retain their existing behavior.

Validation:

- Real CLI 2.1.177 baseline returned HTTP 500 for the upstream model-version rejection. Corrected HTTP/SSE return the actionable invalid_request_error with exactly one SDK query.
- Six real CLI cases pass: old CLI rejected by Fable, old CLI successfully using Haiku, current bundled CLI 2.1.259 successfully using Fable; both response modes.
- Original proposal fails six new boundary/HTTP/SSE checks. Additional multiline quotation checks fail on a per-line matcher and pass after restricting the opening.
- 3,488 tests pass, one existing skip, zero failures; 228 focused error and HTTP tests pass; typecheck/build pass. Exact-head CI is the remaining merge gate.

Fixes #932. Diagnosis is provided where the request fails; this change does not add a startup subprocess or change the stable health/config interfaces.
