### PR TITLE
test: validate fallback ownership across GC reconciliation

### DIFF
--- a/src/__tests__/proxy-concurrency-limiter.test.ts
+++ b/src/__tests__/proxy-concurrency-limiter.test.ts
@@ -72,8 +72,8 @@ function createTestApp(maxConcurrent: string) {
   return app
 }
 
-async function post(app: any, content: string) {
-  return app.fetch(new Request("http://localhost/v1/messages", {
+async function post(app: ReturnType<typeof createTestApp>, content: string): Promise<Response> {
+  const response = await app.fetch(new Request("http://localhost/v1/messages", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -83,6 +83,12 @@ async function post(app: any, content: string) {
       messages: [{ role: "user", content }],
     }),
   }))
+  if (response.status !== 200) {
+    console.error("[concurrency failure]", JSON.stringify({
+      content, status: response.status, body: await response.clone().text(),
+    }))
+  }
+  return response
 }
 
 /**

--- a/src/__tests__/proxy-extra-usage-fallback.test.ts
+++ b/src/__tests__/proxy-extra-usage-fallback.test.ts
@@ -13,7 +13,8 @@ import { installLoggerMock } from "./loggerMock"
 import { installMcpToolsMock } from "./mcpToolsMock"
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { getSessionStoreDir } from "../proxy/sessionStore"
+import { getSessionStoreDir, readSessionStoreSnapshot } from "../proxy/sessionStore"
+import { reconcile, type TranscriptLocator } from "../proxy/sessionLifecycle"
 import {
   messageStart,
   textBlockStart,
@@ -27,8 +28,10 @@ import {
 
 // Track query calls to verify retry behavior
 interface LifecycleResourceSnapshot {
-  locator?: { sessionId?: string }
-  state?: string
+  locator: TranscriptLocator
+  generation: string
+  state: string
+  activeLeases?: Record<string, { purpose?: "publication"; owner: { pid: number } }>
 }
 
 let queryCalls: Array<{ model: string; callIndex: number; resume?: string; sessionId?: string }> = []
@@ -36,7 +39,47 @@ let queryCallCount = 0
 /** Benches recorded when a [1m] model is stripped after a rate limit (#862),
  *  with the session scope they were recorded against (#901). */
 let rateLimitBenches: Array<{ profileId: string | undefined; until: number; sessionKey?: string }> = []
-let lifecycleStateAtSpawn: Array<{ sessionId: string; state: string | undefined }> = []
+let lifecycleAtQuery: Array<LifecycleResourceSnapshot | undefined> = []
+let lifecycleBeforeSdkEvents: Array<LifecycleResourceSnapshot | undefined> = []
+let reconcileBeforeSdkEvents = false
+
+function readLifecycleResource(sessionId: string): LifecycleResourceSnapshot | undefined {
+  const sidecar = JSON.parse(readFileSync(join(getSessionStoreDir(), "session-gc.json"), "utf8")) as {
+    resources: Record<string, LifecycleResourceSnapshot>
+  }
+  return Object.values(sidecar.resources).find((resource) => resource.locator.sessionId === sessionId)
+}
+
+/** Check ownership and publication, not a transient GC state label (#917/#933). */
+function expectSafeFallbackTargets(reconciled: boolean) {
+  expect(queryCalls.map((call) => call.model)).toEqual(["sonnet[1m]", "sonnet"])
+  expect(lifecycleAtQuery).toHaveLength(2)
+  expect(lifecycleBeforeSdkEvents).toHaveLength(2)
+  const expectedIds = queryCalls.map((call) => call.sessionId)
+  expect(expectedIds.every((id) => typeof id === "string" && id.length > 0)).toBe(true)
+  expect(new Set(expectedIds).size).toBe(2)
+  for (const snapshots of [lifecycleAtQuery, lifecycleBeforeSdkEvents]) {
+    expect(snapshots.map((resource) => resource?.locator.sessionId)).toEqual(expectedIds)
+    for (const resource of snapshots) {
+      expect(resource).toBeDefined()
+      // The same proxy's sweep rescues pinned prepared targets to live before
+      // SDK startup. Both states are safe only with their ownership still intact.
+      expect(["prepared", "live"]).toContain(resource?.state ?? "missing")
+      expect(resource?.generation).toMatch(/^r:[0-9a-f]{64}:[1-9][0-9]*$/)
+      const leases = Object.values(resource?.activeLeases ?? {})
+      expect(leases.some((lease) => lease.purpose === "publication" && lease.owner.pid === process.pid)).toBe(true)
+      expect(leases.some((lease) => lease.purpose === undefined && lease.owner.pid === process.pid)).toBe(true)
+    }
+  }
+  expect(lifecycleBeforeSdkEvents.map((resource) => resource?.generation))
+    .toEqual(lifecycleAtQuery.map((resource) => resource?.generation))
+  if (reconciled) {
+    expect(lifecycleBeforeSdkEvents.map((resource) => resource?.state)).toEqual(["live", "live"])
+  }
+  const publishedIds = Object.values(readSessionStoreSnapshot()).map((entry) => entry.claudeSessionId)
+  expect(publishedIds).toContain(expectedIds[1] ?? "missing")
+  expect(publishedIds).not.toContain(expectedIds[0] ?? "missing")
+}
 
 // Control what the mock does
 let mockBehavior: "extra_usage_then_succeed" | "always_extra_usage" | "out_of_extra_usage_then_succeed" | "resume_extra_usage_then_succeed" | "succeed" | "error_assistant_then_ratelimit" = "succeed"
@@ -73,15 +116,23 @@ installSdkMock(() => ({
       const sessionId = opts.options?.sessionId
       queryCalls.push({ model, callIndex, resume: opts.options?.resume, sessionId })
       const returnedSessionId = resolveMockSdkSessionId(opts.options, `sdk-session-${callIndex}`)
-      if (sessionId) {
-        const sidecar = JSON.parse(readFileSync(join(getSessionStoreDir(), "session-gc.json"), "utf8"))
-        const resource = Object.values(sidecar.resources as Record<string, LifecycleResourceSnapshot>)
-          .find((candidate) => candidate.locator?.sessionId === sessionId)
-        lifecycleStateAtSpawn.push({ sessionId, state: resource?.state })
-      }
+      if (sessionId) lifecycleAtQuery.push(readLifecycleResource(sessionId))
       const isStreaming = opts.options?.includePartialMessages === true
 
     return (async function* () {
+      if (sessionId) {
+        if (reconcileBeforeSdkEvents) {
+          const resource = readLifecycleResource(sessionId)
+          if (!resource) throw new Error(`SDK target ${sessionId} was not journaled`)
+          // Force the same legal transition as the background sweep between
+          // target preparation and the first SDK event, without relying on timing.
+          await reconcile([{ ...resource.locator, lifecycleGeneration: resource.generation }], {
+            maxPending: 1_000_000,
+          })
+        }
+        const resource = readLifecycleResource(sessionId)
+        lifecycleBeforeSdkEvents.push(resource)
+      }
       if (mockBehavior === "always_extra_usage") {
         throw new Error(EXTRA_USAGE_ERROR)
       }
@@ -186,13 +237,16 @@ describe("Extra usage required fallback", () => {
     clearSessionCache()
     queryCalls = []
     rateLimitBenches = []
-    lifecycleStateAtSpawn = []
+    lifecycleAtQuery = []
+    lifecycleBeforeSdkEvents = []
+    reconcileBeforeSdkEvents = false
     queryCallCount = 0
     mockBehavior = "succeed"
   })
 
   describe("Non-streaming", () => {
-    it("falls back from [1m] to base model on extra usage error", async () => {
+    it.each([false, true])("falls back from [1m] to base model on extra usage error (reconcile=%s)", async (reconcileFirst) => {
+      reconcileBeforeSdkEvents = reconcileFirst
       mockBehavior = "extra_usage_then_succeed"
       const app = createTestApp()
 
@@ -205,9 +259,8 @@ describe("Extra usage required fallback", () => {
       // Should succeed after fallback (no backoff delay)
       expect(response.status).toBe(200)
       const body = await response.json()
-      expect(body.content).toBeDefined()
-      expect(lifecycleStateAtSpawn.map((entry) => entry.state)).toEqual(["prepared", "prepared"])
-      expect(new Set(lifecycleStateAtSpawn.map((entry) => entry.sessionId)).size).toBe(2)
+      expect(body.content).toEqual([{ type: "text", text: "response-2" }])
+      expectSafeFallbackTargets(reconcileFirst)
     })
 
     it("propagates error when model is already base (no [1m] to strip)", async () => {
@@ -243,7 +296,8 @@ describe("Extra usage required fallback", () => {
   })
 
   describe("Streaming", () => {
-    it("falls back from [1m] to base model on extra usage error", async () => {
+    it.each([false, true])("falls back from [1m] to base model on extra usage error (reconcile=%s)", async (reconcileFirst) => {
+      reconcileBeforeSdkEvents = reconcileFirst
       mockBehavior = "extra_usage_then_succeed"
       const app = createTestApp()
 
@@ -257,8 +311,10 @@ describe("Extra usage required fallback", () => {
       const text = await response.text()
       // Should contain successful stream content after fallback
       expect(text).toContain("event: message_start")
-      expect(lifecycleStateAtSpawn.map((entry) => entry.state)).toEqual(["prepared", "prepared"])
-      expect(new Set(lifecycleStateAtSpawn.map((entry) => entry.sessionId)).size).toBe(2)
+      expect(text).toContain("response-2")
+      expect(text).toContain("event: message_stop")
+      expect(parseSSE(text).some((event) => event.event === "error")).toBe(false)
+      expectSafeFallbackTargets(reconcileFirst)
     })
 
     it("returns error event when model is already base", async () => {


### PR DESCRIPTION
The extra-usage fallback fixture intermittently fails when the proxy's GC sweep promotes its pinned retry target from prepared to live before SDK startup. Both are valid active states; requiring only prepared caused main CI runs 33910999030 and 33980447251 to fail after successful responses.

Force reconciliation before the mock SDK emits its first event, and check the actual ownership contract at query invocation and after reconciliation: journaled targets, publication and writer leases, unchanged generations, distinct retry IDs, and publication of only the successful target. Keep exact response and error-free terminal SSE assertions. Add response-body diagnostics to the still-unexplained concurrent-priority HTTP 500 fixture without changing its assertions or deadlines.

Validation:

- Forced reconciliation fails both original state assertions (11 pass / 2 fail); corrected lifecycle/fallback/concurrency suite passes 46 tests.
- Real Claude Max E41 passes all four sequential/parallel and streaming/non-streaming combinations, checking answers, tool batching, supported active transcript history and unchanged prompt-cache threshold. This is real lifecycle/replay validation; the quota refusal itself remains a mocked HTTP regression case.
- Full suite: 3,490 pass / one existing skip / zero fail, exit 0. Typecheck and build pass. All applicable CI checks pass at 2477996c (33982358617 / 33982358462).

Partially addresses #917 and #933. Keep both issues open: 300 focused concurrency tests did not reproduce the separate HTTP 500, and a green rerun does not identify its cause. No runtime behavior or release workflow changes.
