### PR TITLE
fix: preserve fresh-request admission after passive retirement

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -21,6 +21,24 @@ curl -s http://127.0.0.1:3456/health | jq .status   # → "healthy"
 kill $(lsof -ti :3456)
 ```
 
+### Profile-switch retirement admission (#923)
+
+```bash
+bun scripts/e2e-retirement-admission.mjs
+bun scripts/e2e-retirement-admission.mjs --stream
+```
+
+With a two-slot pending budget and a long retirement quarantine, seed two real
+sessions, switch profiles through HTTP, sweep GC and require a fresh request and
+its follow-up to answer correctly. Supported SDK history inspection verifies both
+old histories remain unchanged and the new mapping contains the expected token.
+Both profile aliases use the existing authentication; this does not validate two
+distinct billing accounts. Meridian state and SDK working directory are isolated.
+The one-slot configuration retains its existing behavior; reserving its only slot
+would disable passive cleanup. At limit two, passive retirement can pause while a
+publication is in flight, then resume after it completes. Capacity and cleanup
+progress are covered by the lifecycle tests.
+
 ### Fresh replay with completed tool calls (#888 / #858)
 
 ```bash

--- a/scripts/e2e-retirement-admission.mjs
+++ b/scripts/e2e-retirement-admission.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env bun
+// Real HTTP/profile-switch/SDK gate. Both aliases use existing authentication.
+import assert from "node:assert/strict"
+import { randomUUID } from "node:crypto"
+import { mkdtempSync, readFileSync, realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import * as sdk from "@anthropic-ai/claude-agent-sdk"
+
+const stream = process.argv.includes("--stream")
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-retirement-e2e-")))
+// Preserve an unset config directory: explicitly setting ~/.claude changes
+// Claude Code's macOS Keychain lookup key (see query.ts).
+const authDir = process.env.CLAUDE_CONFIG_DIR
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, {
+  MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_TELEMETRY_PERSIST: "0", MERIDIAN_ROUTING: "manual",
+  MERIDIAN_SESSION_GC_MAX_PENDING: "2", MERIDIAN_SESSION_GC_GRACE_MS: "3600000",
+})
+const { createProxyServer } = await import("../src/proxy/server.ts")
+const { readSessionStoreSnapshot } = await import("../src/proxy/sessionStore.ts")
+const proxy = createProxyServer({
+  port: 0, host: "127.0.0.1", defaultProfile: "personal", silent: true,
+  profiles: ["personal", "work"].map(id => ({ id, claudeConfigDir: authDir })),
+})
+const server = Bun.serve({ hostname: "127.0.0.1", port: 0, idleTimeout: 120, fetch: proxy.app.fetch })
+const base = `http://127.0.0.1:${server.port}`
+function mappings() { return Object.values(readSessionStoreSnapshot()) }
+function resources() {
+  return Object.values(JSON.parse(readFileSync(join(root, "sessions", "session-gc.json"), "utf8")).resources)
+}
+async function request(key, messages) {
+  const response = await fetch(`${base}/v1/messages`, {
+    method: "POST", headers: { "content-type": "application/json", "x-opencode-session": key },
+    body: JSON.stringify({ model: "haiku", stream, max_tokens: 128, messages }),
+    signal: AbortSignal.timeout(90_000),
+  })
+  const raw = await response.text()
+  assert.equal(response.status, 200, raw)
+  if (!stream) return JSON.parse(raw).content
+  const events = raw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+  assert(!events.some(event => event.type === "error"), raw)
+  assert.equal(events.filter(event => event.type === "message_stop").length, 1, raw)
+  const content = []
+  for (const event of events) {
+    if (event.type === "content_block_start") content[event.index] = { ...event.content_block }
+    if (event.delta?.type === "text_delta") content[event.index].text += event.delta.text
+    if (event.delta?.type === "thinking_delta") content[event.index].thinking += event.delta.thinking
+    if (event.delta?.type === "signature_delta") content[event.index].signature = (content[event.index].signature ?? "") + event.delta.signature
+  }
+  return content.filter(Boolean)
+}
+function answer(content, expected) {
+  assert(!content.some(block => block.type === "tool_use"), "Unexpected tool call")
+  assert.equal(content.filter(block => block.type === "text").map(block => block.text).join("").trim(), expected)
+}
+async function history(id) {
+  const rows = await sdk.getSessionMessages(id, { dir: root })
+  assert(rows.length > 0, `No supported SDK history for ${id}`)
+  return rows
+}
+try {
+  console.log(JSON.stringify({ root, stream, profileAliasesShareAuthentication: true }))
+  for (const key of ["old-a", "old-b"]) {
+    answer(await request(key, [{ role: "user", content: `Reply with exactly ${key}. Do not use tools.` }]), key)
+  }
+  const oldMappings = mappings()
+  assert.equal(oldMappings.length, 2)
+  const sources = await Promise.all(oldMappings.map(async row => ({ id: row.claudeSessionId, rows: await history(row.claudeSessionId) })))
+  await proxy.sweepSessionGc()
+  const switched = await fetch(`${base}/profiles/active`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ profile: "work" }),
+  })
+  assert.equal(switched.status, 200, await switched.text())
+  assert.equal(mappings().length, 0)
+  await proxy.sweepSessionGc()
+  const retired = resources().filter(row => row.state === "retired").length
+  assert(retired > 0, "The post-switch sweep must retire real old transcripts")
+  const token = `BUG-${randomUUID().slice(0, 8)}`
+  const initial = [{ role: "user", content: `For this software test project, the bug ticket identifier is ${token}. What is the exact bug ticket identifier? Reply with the identifier only; no tools are needed.` }]
+  const first = await request("new-work", initial)
+  answer(first, token)
+  assert.equal(retired, 1, "Passive cleanup must reserve one slot")
+  const newMapping = mappings()[0]
+  assert.equal(mappings().length, 1)
+  assert.deepEqual(Object.keys(readSessionStoreSnapshot()), ["work:new-work"])
+  assert(!sources.some(row => row.id === newMapping.claudeSessionId))
+  const newHistory = await history(newMapping.claudeSessionId)
+  assert(JSON.stringify(newHistory).includes(token))
+  const followup = await request("new-work", [...initial, { role: "assistant", content: first },
+    { role: "user", content: "What is this project's bug ticket identifier? Reply with the identifier only; no tools are needed." }])
+  answer(followup, token)
+  assert.equal(mappings().length, 1)
+  assert.deepEqual(Object.keys(readSessionStoreSnapshot()), ["work:new-work"])
+  assert(JSON.stringify(await history(mappings()[0].claudeSessionId)).includes(token))
+  for (const source of sources) assert.deepEqual(await history(source.id), source.rows, "Old profile history changed")
+  await proxy.sweepSessionGc()
+  assert(resources().filter(row => ["prepared", "retired", "deleting"].includes(row.state)).length <= 2)
+  console.log(JSON.stringify({ result: "PASS", stream, oldHistoriesUnchanged: 2, freshAndFollowupCorrect: true }))
+} finally {
+  proxy.beginDrain()
+  await proxy.sweepSessionGc()
+  await server.stop(true)
+}

--- a/src/__tests__/proxy-retirement-admission.test.ts
+++ b/src/__tests__/proxy-retirement-admission.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test"
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+import {
+  assistantMessage, withMockSdkSessionId, parseSSE, messageStart,
+  textBlockStart, textDelta, blockStop, messageDelta, messageStop,
+} from "./helpers"
+
+const queryProfiles: Array<string | undefined> = []
+installSdkMock(() => ({
+  query: (params: { options?: { sessionId?: string; resume?: string; includePartialMessages?: boolean; env?: Record<string, string | undefined> } }) => (async function* () {
+    queryProfiles.push(params.options?.env?.CLAUDE_CONFIG_DIR)
+    if (params.options?.includePartialMessages) {
+      for (const event of [messageStart(), textBlockStart(), textDelta(0, "ok"), blockStop(0), messageDelta(), messageStop()]) {
+        yield withMockSdkSessionId(event, params.options)
+      }
+    }
+    yield withMockSdkSessionId(assistantMessage([{ type: "text", text: "ok" }]), params.options)
+  })(),
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}), "proxy-retirement-admission.test.ts")
+installLoggerMock(() => ({ claudeLog: () => {}, withClaudeLogContext: (_ctx, fn) => fn() }))
+installMcpToolsMock(() => ({ createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }) }))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetActiveProfile } = await import("../proxy/profiles")
+const { setSessionStoreDir, readSessionStoreSnapshot } = await import("../proxy/sessionStore")
+
+let root: string
+let proxy: ReturnType<typeof createProxyServer> | undefined
+const savedEnv: Record<string, string | undefined> = {}
+const overrides = {
+  MERIDIAN_SESSION_GC_MAX_PENDING: "2",
+  MERIDIAN_SESSION_GC_GRACE_MS: "3600000",
+  MERIDIAN_ROUTING: "manual",
+  MERIDIAN_PASSTHROUGH: "0",
+}
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-retirement-http-")))
+  for (const key of [...Object.keys(overrides), "MERIDIAN_WORKDIR", "MERIDIAN_CONFIG_DIR"]) savedEnv[key] = process.env[key]
+  Object.assign(process.env, overrides, { MERIDIAN_WORKDIR: root, MERIDIAN_CONFIG_DIR: join(root, "config") })
+  setSessionStoreDir(join(root, "sessions"))
+  resetActiveProfile()
+  clearSessionCache()
+  queryProfiles.length = 0
+  for (const id of ["personal", "work"]) mkdirSync(join(root, id))
+  proxy = createProxyServer({
+    port: 0, host: "127.0.0.1", defaultProfile: "personal",
+    profiles: ["personal", "work"].map(id => ({ id, claudeConfigDir: join(root, id) })),
+  })
+})
+
+afterEach(async () => {
+  await proxy?.sweepSessionGc?.()
+  proxy = undefined
+  clearSessionCache()
+  resetActiveProfile()
+  setSessionStoreDir(null)
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  rmSync(root, { recursive: true, force: true })
+})
+
+async function request(key: string, stream: boolean) {
+  if (!proxy) throw new Error("test proxy not initialized")
+  return await proxy.app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST", headers: { "content-type": "application/json", "x-opencode-session": key },
+    body: JSON.stringify({ model: "haiku", stream, messages: [{ role: "user", content: key }] }),
+  }))
+}
+
+async function sweep() {
+  if (!proxy?.sweepSessionGc) throw new Error("SDK proxy GC not initialized")
+  await proxy.sweepSessionGc()
+}
+
+describe("profile switch admission with bounded retirement", () => {
+  it.each([false, true])("admits a fresh request after clearing old profile mappings (stream=%s)", async (stream) => {
+    for (const key of ["old-a", "old-b"]) {
+      const response = await request(key, false)
+      expect(response.status, await response.clone().text()).toBe(200)
+    }
+    expect(Object.values(readSessionStoreSnapshot())).toHaveLength(2)
+    if (!proxy) throw new Error("test proxy not initialized")
+    // Drain a sweep started by the completed request before changing its pins.
+    await sweep()
+    const switched = await proxy.app.fetch(new Request("http://localhost/profiles/active", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ profile: "work" }),
+    }))
+    expect(switched.status).toBe(200)
+    expect(Object.values(readSessionStoreSnapshot())).toHaveLength(0)
+    await sweep()
+    const sidecar = JSON.parse(readFileSync(join(root, "sessions", "session-gc.json"), "utf8")) as {
+      resources: Record<string, { state: string }>
+    }
+    expect(Object.values(sidecar.resources).some(resource => resource.state === "retired")).toBe(true)
+    const response = await request("new-work", stream)
+    const text = await response.text()
+    expect(response.status, text).toBe(200)
+    if (stream) {
+      const events = parseSSE(text)
+      expect(events.some(event => event.event === "error"), text).toBe(false)
+      expect(events.filter(event => event.event === "message_stop")).toHaveLength(1)
+      expect(text).toContain("ok")
+    } else {
+      expect(JSON.parse(text).content).toEqual([{ type: "text", text: "ok" }])
+    }
+    expect(queryProfiles).toEqual([join(root, "personal"), join(root, "personal"), join(root, "work")])
+    expect(Object.values(readSessionStoreSnapshot())).toHaveLength(1)
+    expect(Object.values(sidecar.resources).filter(resource => resource.state === "retired")).toHaveLength(1)
+  })
+})

--- a/src/__tests__/session-lifecycle.test.ts
+++ b/src/__tests__/session-lifecycle.test.ts
@@ -259,6 +259,23 @@ describe("session transcript lifecycle", () => {
     expect(readSidecar(bounded.storeDir).resources[getTranscriptResourceKey(stillLive)]?.state).toBe("live")
   })
 
+  it("leaves admission capacity while retiring live resources after a profile switch", async () => {
+    const bounded = { ...options, storeDir: join(storeDir, "retirement-headroom"), maxPending: 2 }
+    const firstStale = locator("first-stale-after-profile-switch")
+    const secondStale = locator("second-stale-after-profile-switch")
+    const fresh = locator("fresh-after-profile-switch")
+    await registerLiveTranscript(firstStale, bounded)
+    await registerLiveTranscript(secondStale, bounded)
+
+    expect((await reconcile([], bounded)).liveRetired).toBe(1)
+    await prepareFork(fresh, bounded)
+
+    const resources = readSidecar(bounded.storeDir).resources
+    expect(resources[getTranscriptResourceKey(fresh)]?.state).toBe("prepared")
+    expect(Object.values(resources).filter((resource) => resource.state === "retired")).toHaveLength(1)
+    expect(Object.values(resources).filter((resource) => resource.state === "live")).toHaveLength(1)
+  })
+
   it("never lets a delayed publisher recreate a deleted locator after tombstone pruning", async () => {
     const bounded = { ...options, maxTombstones: 1, deleter: async () => undefined }
     const stale = locator("stale-publisher")

--- a/src/__tests__/session-lifecycle.test.ts
+++ b/src/__tests__/session-lifecycle.test.ts
@@ -25,6 +25,7 @@ import {
   getSessionGcNodeExecutable,
   getTranscriptResourceKey,
   prepareFork,
+  prepareForkForPublication,
   publishPinnedTranscript,
   reconcile,
   registerLiveTranscript,
@@ -274,6 +275,59 @@ describe("session transcript lifecycle", () => {
     expect(resources[getTranscriptResourceKey(fresh)]?.state).toBe("prepared")
     expect(Object.values(resources).filter((resource) => resource.state === "retired")).toHaveLength(1)
     expect(Object.values(resources).filter((resource) => resource.state === "live")).toHaveLength(1)
+  })
+
+  it.each([2, 4])("continues bounded passive cleanup with a reserved admission slot (limit=%s)", async maxPending => {
+    const deleted: string[] = []
+    const bounded = { ...options, maxPending, maxDeletesPerRun: 1,
+      deleter: async (resource: TranscriptLocator) => { deleted.push(resource.sessionId) } }
+    const stale = Array.from({ length: 5 }, (_, index) => locator(`passive-${index}`))
+    for (const resource of stale) await registerLiveTranscript(resource, bounded)
+    const active = await prepareForkForPublication(locator("active-publication"), bounded)
+    await reconcile([], bounded)
+    // At limit two an in-flight publication occupies the passive budget.
+    // Cleanup must resume after it publishes, while keeping its mapping pinned.
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(active)]?.state).toBe("prepared")
+    await commitFork(active, bounded)
+    for (let iteration = 0; iteration < stale.length; iteration++) {
+      const result = await runGc([active], bounded)
+      expect(result.deleted).toBe(1)
+      const resources = Object.values(readSidecar(storeDir).resources)
+      expect(resources.filter(resource => ["prepared", "retired", "deleting"].includes(resource.state)).length)
+        .toBeLessThanOrEqual(maxPending)
+      expect(readSidecar(storeDir).resources[getTranscriptResourceKey(active)]?.state).toBe("live")
+    }
+    expect(new Set(deleted)).toEqual(new Set(stale.map(resource => resource.sessionId)))
+    expect(deleted).not.toContain(active.sessionId)
+  })
+
+  it("does not overbook reserved capacity when two publication requests race", async () => {
+    const bounded = { ...options, maxPending: 2 }
+    for (const id of ["stale-a", "stale-b"]) await registerLiveTranscript(locator(id), bounded)
+    await reconcile([], bounded)
+    const attempts = await Promise.allSettled([
+      prepareForkForPublication(locator("racing-a"), bounded),
+      prepareForkForPublication(locator("racing-b"), bounded),
+    ])
+    expect(attempts.filter(result => result.status === "fulfilled")).toHaveLength(1)
+    const failures = attempts.filter(result => result.status === "rejected")
+    expect(failures).toHaveLength(1)
+    expect(failures[0]?.reason).toBeInstanceOf(SessionLifecycleBacklogError)
+    const resources = Object.values(readSidecar(storeDir).resources)
+    expect(resources.filter(resource => ["prepared", "retired", "deleting"].includes(resource.state))).toHaveLength(2)
+  })
+
+  it("still enforces total ownership when passive retirement leaves pending capacity", async () => {
+    const bounded = { ...options, maxPending: 2, maxOwned: 3 }
+    for (const id of ["owned-a", "owned-b"]) await registerLiveTranscript(locator(id), bounded)
+    await reconcile([], bounded)
+    const active = await prepareForkForPublication(locator("owned-new"), bounded)
+    await commitFork(active, bounded)
+    await expect(prepareForkForPublication(locator("owned-overflow"), bounded))
+      .rejects.toBeInstanceOf(SessionLifecycleBacklogError)
+    const resources = Object.values(readSidecar(storeDir).resources)
+    expect(resources).toHaveLength(3)
+    expect(resources.filter(resource => resource.state === "retired")).toHaveLength(1)
   })
 
   it("never lets a delayed publisher recreate a deleted locator after tombstone pruning", async () => {

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -595,6 +595,12 @@ export async function reconcile(
     }
     let pending = pendingResourceCount(sidecar)
     const maxPending = option(options.maxPending, DEFAULT_MAX_PENDING, "maxPending")
+    // Passive retirement must leave room for one active preallocation. Without
+    // that headroom, a profile switch can unpin enough live transcripts to fill
+    // the backlog and block every fresh request until the quarantine expires.
+    // A one-slot configuration cannot reserve capacity without disabling
+    // passive cleanup entirely, so preserve its existing behavior.
+    const passiveRetirementLimit = maxPending > 1 ? maxPending - 1 : maxPending
 
     // A deletion claim is recoverable only after the exact persisted executor
     // is provably dead. Before the executor handshake, authoritative death of
@@ -650,7 +656,7 @@ export async function reconcile(
         resource.nextAttemptAt = now + retiredGraceMs(options)
         result.preparedRetired++
         changed = true
-      } else if (resource.state === "live" && pending < maxPending) {
+      } else if (resource.state === "live" && pending < passiveRetirementLimit) {
         resource.state = "retired"
         resource.updatedAt = now
         resource.nextAttemptAt = now + retiredGraceMs(options)


### PR DESCRIPTION
After a profile switch clears session mappings, passive reconciliation can fill the retirement backlog and make every fresh request return HTTP 500 until quarantine expires. Reserve one pending slot for active transcript preallocation when the configured limit exceeds one. Incorporates #923, preserving WarGloom's original author and authored date in a separate commit; maintainer HTTP, capacity and real-SDK validation follows it.

The hard pending and total-ownership limits remain enforced. Two competing preallocations cannot overbook the reserved slot. At limit two, passive retirement can pause during an in-flight publication and resumes after it completes. The one-slot configuration retains its existing behavior: reserving its only slot would disable passive cleanup. This improves admission after passive retirement; it does not guarantee admission against an already-full active or failed-request backlog.

Validation:

- Real HTTP profile-switch regression: main returns 500 with ownership-backlog-full in both response modes; candidate passes with the correct profile and durable mapping.
- Real Claude SDK profile-switch gate: fresh request and follow-up give the exact ticket identifier in both modes, with both old histories unchanged through supported getSessionMessages inspection. Both aliases share existing authentication; this does not test separate billing accounts. The baseline reproduces backlog rejection.
- 37 focused lifecycle/HTTP tests pass, including concurrent admission, bounded cleanup progress, active-target protection, total ownership, and existing one-slot behavior. Typecheck and build pass. Full suite passes 3,501 tests with one existing skip and zero failures. All four real E41 modes pass, retaining exact tool batching, supported active history and the existing cache threshold. Exact-head CI, Windows smoke and container smoke/build pass.

This preallocation failure is separate from the unexplained post-SDK concurrent 500 tracked in #917/#933. Those issues remain open.
