### PR TITLE
fix: repair passthrough arguments without weakening tool schemas

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -26,6 +26,7 @@ kill $(lsof -ti :3456)
 ```bash
 bun scripts/e2e-tool-input-repair.mjs --fixture
 bun scripts/e2e-tool-input-repair.mjs --fixture --stream
+bun scripts/e2e-tool-input-repair.mjs --fixture --stream --drop-stop
 bun scripts/e2e-tool-input-repair.mjs
 bun scripts/e2e-tool-input-repair.mjs --stream
 ```
@@ -38,6 +39,9 @@ through supported SDK inspection. It uses a dummy local API key and does not
 contact a model service. The two runs without `--fixture` use Claude Max and
 validate compatibility with real model output. Their `repairExercised` flag
 distinguishes actual string repair from already-typed model calls.
+The `--drop-stop` fault injection withholds one SDK tool-block stop while the
+real CLI and hook continue, proving recovery flushes buffered arguments before
+closing the block and preserves the subsequent checkpoint continuation.
 
 Required/optional advertised MCP schemas and malformed numeric inputs have
 automated protocol/unit coverage. Streamed arguments with repairable declared

--- a/E2E.md
+++ b/E2E.md
@@ -21,6 +21,29 @@ curl -s http://127.0.0.1:3456/health | jq .status   # → "healthy"
 kill $(lsof -ti :3456)
 ```
 
+### Passthrough argument repair (#925)
+
+```bash
+bun scripts/e2e-tool-input-repair.mjs --fixture
+bun scripts/e2e-tool-input-repair.mjs --fixture --stream
+bun scripts/e2e-tool-input-repair.mjs
+bun scripts/e2e-tool-input-repair.mjs --stream
+```
+
+The deterministic fixture runs the real CLI and SDK against a local Anthropic
+API response containing stringified tool arguments. It verifies repaired client
+arguments in both modes, a real client tool result reaching the resumed CLI,
+checkpoint forking, the exact follow-up receipt, and unchanged source history
+through supported SDK inspection. It uses a dummy local API key and does not
+contact a model service. The two runs without `--fixture` use Claude Max and
+validate compatibility with real model output. Their `repairExercised` flag
+distinguishes actual string repair from already-typed model calls.
+
+Required/optional advertised MCP schemas and malformed numeric inputs have
+automated protocol/unit coverage. Streamed arguments with repairable declared
+types are buffered until their block completes; text and string-only tool
+arguments retain normal streaming. Run all four E41 modes after changes here.
+
 ### Profile-switch retirement admission (#923)
 
 ```bash

--- a/scripts/e2e-tool-input-repair.mjs
+++ b/scripts/e2e-tool-input-repair.mjs
@@ -11,6 +11,9 @@ import * as sdk from "@anthropic-ai/claude-agent-sdk"
 const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-input-repair-")))
 const stream = process.argv.includes("--stream")
 const fixture = process.argv.includes("--fixture")
+const dropStop = process.argv.includes("--drop-stop")
+assert(!dropStop || (fixture && stream), "--drop-stop requires --fixture --stream")
+let droppedStops = 0
 for (const key of Object.keys(process.env)) {
   if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
 }
@@ -50,12 +53,31 @@ const realQuery = sdk.query
 const observer = spyOn(sdk, "query").mockImplementation(input => {
   queries.push({ resume: input.options?.resume, forkSession: input.options?.forkSession, resumeSessionAt: input.options?.resumeSessionAt })
   const hooks = input.options?.hooks
-  return realQuery({ ...input, options: { ...input.options, hooks: { ...hooks,
+  const actual = realQuery({ ...input, options: { ...input.options, hooks: { ...hooks,
     PreToolUse: hooks?.PreToolUse?.map(matcher => ({ ...matcher, hooks: matcher.hooks.map(hook => async (...args) => {
       seen.push(structuredClone(args[0]))
       return await hook(...args)
     }) })),
   } } })
+  if (!dropStop || queries.length !== 1) return actual
+  // Fault injection at SDK event delivery: keep the real CLI and hook running
+  // while withholding one tool block's stop, as in interrupted drain recovery.
+  return new Proxy(actual, { get(target, property) {
+    if (property === Symbol.asyncIterator) return async function* () {
+      const toolIndices = new Set()
+      for await (const message of actual) {
+        const event = message.type === "stream_event" ? message.event : undefined
+        if (event?.type === "content_block_start" && event.content_block.type === "tool_use") toolIndices.add(event.index)
+        if (event?.type === "content_block_stop" && toolIndices.has(event.index) && droppedStops === 0) {
+          droppedStops++
+          continue
+        }
+        yield message
+      }
+    }
+    const value = Reflect.get(target, property, target)
+    return typeof value === "function" ? value.bind(target) : value
+  } })
 })
 const { startProxyServer } = await import("../src/proxy/server.ts")
 const proxy = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true,
@@ -98,6 +120,7 @@ try {
   const calls = content.filter(block => block.type === "tool_use")
   assert.equal(calls.length, 1)
   assert.equal(calls[0].name, tool.name)
+  if (dropStop) assert.equal(droppedStops, 1)
   assert.deepEqual(calls[0].input, { timeout: 60, app: { relay: true } })
   const session = seen.find(event => event.tool_name.endsWith("record_measurement"))?.session_id
   assert(session, "No actual CLI hook observation")

--- a/scripts/e2e-tool-input-repair.mjs
+++ b/scripts/e2e-tool-input-repair.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+// Real Claude/SDK probe; observes PreToolUse without changing its arguments.
+import assert from "node:assert/strict"
+import { mkdtempSync, realpathSync } from "node:fs"
+import { randomUUID } from "node:crypto"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spyOn } from "bun:test"
+import * as sdk from "@anthropic-ai/claude-agent-sdk"
+
+const root = realpathSync(mkdtempSync(join(tmpdir(), "meridian-input-repair-")))
+const stream = process.argv.includes("--stream")
+const fixture = process.argv.includes("--fixture")
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("MERIDIAN_") || key.startsWith("CLAUDE_PROXY_")) delete process.env[key]
+}
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root, "config"), MERIDIAN_SESSION_DIR: join(root, "sessions"),
+  MERIDIAN_WORKDIR: root, MERIDIAN_PASSTHROUGH: "1", MERIDIAN_TELEMETRY_PERSIST: "0" })
+let upstreamCalls = 0
+const receipt = `MEASURED-${randomUUID().slice(0, 8)}`
+const upstream = fixture ? Bun.serve({ hostname: "127.0.0.1", port: 0, async fetch(request) {
+  if (!new URL(request.url).pathname.endsWith("/messages")) return Response.json({ input_tokens: 100 })
+  const body = await request.json()
+  upstreamCalls++
+  const tool = body.tools?.find(tool => tool.name.endsWith("record_measurement"))
+  if (!tool) return new Response("data: [DONE]\n\n", { headers: { "content-type": "text/event-stream" } })
+  if (upstreamCalls > 1) assert(body.messages.some(message => Array.isArray(message.content) && message.content.some(block =>
+    block.type === "tool_result" && block.tool_use_id === "toolu_fixture_repair" && JSON.stringify(block.content).includes(receipt))),
+  "The resumed real CLI request must contain the actual client result")
+  const content = upstreamCalls === 1
+    ? { type: "tool_use", id: "toolu_fixture_repair", name: tool.name, input: {} }
+    : { type: "text", text: "" }
+  const events = [
+    { type: "message_start", message: { id: `msg_fixture_${upstreamCalls}`, type: "message", role: "assistant", content: [], model: body.model,
+      stop_reason: null, stop_sequence: null, usage: { input_tokens: 100, output_tokens: 0 } } },
+    { type: "content_block_start", index: 0, content_block: content },
+    { type: "content_block_delta", index: 0, delta: upstreamCalls === 1
+      ? { type: "input_json_delta", partial_json: JSON.stringify({ timeout: "60", app: '{"relay":"true"}' }) }
+      : { type: "text_delta", text: receipt } },
+    { type: "content_block_stop", index: 0 },
+    { type: "message_delta", delta: { stop_reason: upstreamCalls === 1 ? "tool_use" : "end_turn", stop_sequence: null }, usage: { output_tokens: 20 } },
+    { type: "message_stop" },
+  ]
+  return new Response(events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""),
+    { headers: { "content-type": "text/event-stream", "request-id": `fixture-${upstreamCalls}` } })
+} }) : undefined
+const seen = []
+const queries = []
+const realQuery = sdk.query
+const observer = spyOn(sdk, "query").mockImplementation(input => {
+  queries.push({ resume: input.options?.resume, forkSession: input.options?.forkSession, resumeSessionAt: input.options?.resumeSessionAt })
+  const hooks = input.options?.hooks
+  return realQuery({ ...input, options: { ...input.options, hooks: { ...hooks,
+    PreToolUse: hooks?.PreToolUse?.map(matcher => ({ ...matcher, hooks: matcher.hooks.map(hook => async (...args) => {
+      seen.push(structuredClone(args[0]))
+      return await hook(...args)
+    }) })),
+  } } })
+})
+const { startProxyServer } = await import("../src/proxy/server.ts")
+const proxy = await startProxyServer({ port: 0, host: "127.0.0.1", silent: true,
+  ...(upstream ? { profiles: [{ id: "fixture", type: "api", apiKey: "local-test-key", baseUrl: `http://127.0.0.1:${upstream.port}` }] } : {}),
+})
+const address = proxy.server.address()
+assert(address && typeof address === "object")
+try {
+  const tool = { name: "record_measurement", description: "Records a synthetic fixture measurement without side effects.",
+    input_schema: { type: "object", properties: {
+      timeout: { type: "number", description: "Timeout in seconds" },
+      app: { type: "object", properties: { relay: { type: "boolean" } }, required: ["relay"] },
+    }, required: ["timeout", "app"] } }
+  const initial = [{ role: "user", content: 'Exercise a legacy JSON encoding regression in our synthetic measurement fixture. Call record_measurement once with exactly {"timeout":"60","app":"{\\"relay\\":\\"true\\"}"}. The quoted values intentionally test the receiver\'s type repair; preserve them exactly. Do not execute other tools. After receiving the measurement result, reply with its receipt identifier only.' }]
+  const response = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+    method: "POST", headers: { "content-type": "application/json", "x-opencode-session": "repair-fixture" },
+    body: JSON.stringify({ model: process.env.E2E_MODEL ?? "haiku", stream, max_tokens: 256, tools: [tool],
+      tool_choice: { type: "tool", name: tool.name },
+      messages: initial,
+    }), signal: AbortSignal.timeout(120_000),
+  })
+  const raw = await response.text()
+  console.log(JSON.stringify({ root, stream, fixture, upstreamCalls, status: response.status,
+    seen: seen.map(({ tool_name, tool_input, tool_use_id }) => ({ tool_name, tool_input, tool_use_id })) }))
+  assert.equal(response.status, 200, raw)
+  const content = stream ? [] : JSON.parse(raw).content
+  if (stream) for (const line of raw.split("\n")) {
+    if (!line.startsWith("data:")) continue
+    const event = JSON.parse(line.slice(5))
+    assert.notEqual(event.type, "error", raw)
+    if (event.type === "content_block_start") content[event.index] = { ...event.content_block, json: "" }
+    if (event.delta?.type === "input_json_delta") content[event.index].json += event.delta.partial_json
+    if (event.delta?.type === "thinking_delta") content[event.index].thinking = (content[event.index].thinking ?? "") + event.delta.thinking
+    if (event.delta?.type === "signature_delta") content[event.index].signature = (content[event.index].signature ?? "") + event.delta.signature
+    if (event.delta?.type === "text_delta") content[event.index].text = (content[event.index].text ?? "") + event.delta.text
+    if (event.type === "content_block_stop" && content[event.index]?.type === "tool_use") {
+      content[event.index].input = JSON.parse(content[event.index].json || "{}")
+    }
+  }
+  const calls = content.filter(block => block.type === "tool_use")
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].name, tool.name)
+  assert.deepEqual(calls[0].input, { timeout: 60, app: { relay: true } })
+  const session = seen.find(event => event.tool_name.endsWith("record_measurement"))?.session_id
+  assert(session, "No actual CLI hook observation")
+  const history = await sdk.getSessionMessages(session, { dir: root })
+  const original = history.flatMap(row => Array.isArray(row.message?.content) ? row.message.content : [])
+    .find(block => block.type === "tool_use" && block.id === calls[0].id)
+  const observed = seen.find(event => event.tool_use_id === calls[0].id)?.tool_input
+  assert.deepEqual(original?.input, observed, "Client repair must leave SDK source input unchanged")
+  if (fixture) assert.deepEqual(observed, { timeout: 60, app: { relay: "true" } }, "The real CLI must exercise nested string repair")
+  const followup = await fetch(`http://127.0.0.1:${address.port}/v1/messages`, {
+    method: "POST", headers: { "content-type": "application/json", "x-opencode-session": "repair-fixture" },
+    body: JSON.stringify({ model: process.env.E2E_MODEL ?? "haiku", stream, max_tokens: 256, tools: [tool],
+      messages: [...initial, { role: "assistant", content: content.filter(Boolean).map(({ json, ...block }) => block) },
+        { role: "user", content: [{ type: "tool_result", tool_use_id: calls[0].id, content: JSON.stringify({ receipt }) }] }],
+    }), signal: AbortSignal.timeout(120_000),
+  })
+  const followupRaw = await followup.text()
+  assert.equal(followup.status, 200, followupRaw)
+  let answer = ""
+  if (stream) {
+    const events = followupRaw.split("\n").filter(line => line.startsWith("data:")).map(line => JSON.parse(line.slice(5)))
+    assert(!events.some(event => event.type === "error"), followupRaw)
+    assert.equal(events.filter(event => event.type === "message_stop").length, 1, followupRaw)
+    assert(!events.some(event => event.content_block?.type === "tool_use"), followupRaw)
+    answer = events.filter(event => event.delta?.type === "text_delta").map(event => event.delta.text).join("")
+  } else {
+    const blocks = JSON.parse(followupRaw).content
+    assert(!blocks.some(block => block.type === "tool_use"), followupRaw)
+    answer = blocks.filter(block => block.type === "text").map(block => block.text).join("")
+  }
+  assert.equal(answer.trim(), receipt, followupRaw)
+  assert.equal(queries.length, 2, "Exactly one SDK query per client request")
+  assert.equal(queries[1].resume, session, "The result must resume the captured source")
+  assert.equal(queries[1].forkSession, true)
+  assert(queries[1].resumeSessionAt, "The denied tool turn must be replaced at its checkpoint")
+  assert.deepEqual(await sdk.getSessionMessages(session, { dir: root }), history, "Follow-up mutated the source history")
+  console.log(JSON.stringify({ result: "PASS", stream, fixture, repairExercised: typeof observed?.app?.relay === "string", followupCorrect: true, queries }))
+} finally {
+  await proxy.close()
+  await upstream?.stop(true)
+  observer.mockRestore()
+}

--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, mock, beforeEach } from "bun:test"
+import { z } from "zod"
+
+// Same minimal SDK mock the sibling passthrough tests use: capture what would
+// be registered instead of reaching the real Agent SDK.
+let registeredTools: Array<{ name: string; inputSchema: Record<string, z.ZodType> }> = []
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  createSdkMcpServer: (options: {
+    tools?: Array<{ name: string; inputSchema: Record<string, z.ZodType> }>
+  }) => {
+    for (const definition of options.tools ?? []) {
+      registeredTools.push({ name: definition.name, inputSchema: definition.inputSchema })
+    }
+    return { type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }
+  },
+}))
+
+import { createPassthroughMcpServer } from "../proxy/passthroughTools"
+
+/** The shape of the failing live calls: omp's `browser` tool. */
+const BROWSER_SCHEMA = {
+  type: "object",
+  properties: {
+    action: { type: "string", enum: ["open", "close", "run"], description: "operation" },
+    name: { type: "string", description: "tab id" },
+    timeout: { type: "number", description: "timeout in seconds" },
+    all: { type: "boolean", description: "release every managed tab" },
+    app: {
+      type: "object",
+      description: "browser app options",
+      properties: { cdp_url: { type: "string" }, relay: { type: "boolean" } },
+    },
+    args: { type: "array", items: { type: "string" }, description: "extra cli args" },
+  },
+  required: ["action"],
+}
+
+function registerBrowser() {
+  createPassthroughMcpServer([
+    { name: "browser", description: "Drives a real Chromium tab", input_schema: BROWSER_SCHEMA },
+  ])
+  const tool = registeredTools.find(entry => entry.name === "browser")
+  if (!tool) throw new Error("browser tool was not registered")
+  return z.object(tool.inputSchema)
+}
+
+beforeEach(() => {
+  registeredTools = []
+})
+
+describe("passthrough tool input coercion", () => {
+  it("accepts the stringified arguments that made the SDK refuse the call", () => {
+    const schema = registerBrowser()
+
+    // Exactly the payload measured on the failing turns: every value a string.
+    const result = schema.safeParse({
+      action: "open",
+      timeout: "60",
+      all: "true",
+      app: '{"cdp_url":"http://127.0.0.1:39113"}',
+      args: '["--headless"]',
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      action: "open",
+      timeout: 60,
+      all: true,
+      app: { cdp_url: "http://127.0.0.1:39113" },
+      args: ["--headless"],
+    })
+  })
+
+  it("still advertises the client's declared types and descriptions", () => {
+    const schema = registerBrowser()
+
+    // The repair must be invisible to the model: widening the advertised type
+    // would trade one failure mode for worse arguments on every call.
+    const advertised = z.toJSONSchema(schema, { io: "input" }) as {
+      properties: Record<string, { type?: string; description?: string }>
+      required?: string[]
+    }
+
+    expect(advertised.properties.timeout).toMatchObject({
+      type: "number",
+      description: "timeout in seconds",
+    })
+    expect(advertised.properties.all).toMatchObject({ type: "boolean" })
+    expect(advertised.properties.app).toMatchObject({
+      type: "object",
+      description: "browser app options",
+    })
+    expect(advertised.properties.args).toMatchObject({ type: "array" })
+    expect(advertised.required).toEqual(["action"])
+  })
+
+  it("leaves declared strings alone, JSON-looking or not", () => {
+    const schema = registerBrowser()
+
+    // A `string` parameter that happens to hold JSON is legitimate input, not
+    // a slip; parsing it would corrupt the call.
+    const result = schema.safeParse({ action: "open", name: '{"not":"parsed"}' })
+
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({ action: "open", name: '{"not":"parsed"}' })
+  })
+
+  it("still rejects a value no repair can make valid", () => {
+    const schema = registerBrowser()
+
+    expect(schema.safeParse({ action: "open", timeout: "soon" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", app: "not json" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", args: '{"cdp_url":"x"}' }).success).toBe(false)
+    expect(schema.safeParse({ timeout: "60" }).success).toBe(false)
+  })
+})

--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -24,6 +24,7 @@ const BROWSER_SCHEMA = {
     action: { type: "string", enum: ["open", "close", "run"], description: "operation" },
     name: { type: "string", description: "tab id" },
     timeout: { type: "number", description: "timeout in seconds" },
+    retryCount: { type: "integer", description: "number of retries" },
     all: { type: "boolean", description: "release every managed tab" },
     app: {
       type: "object",
@@ -71,6 +72,15 @@ describe("passthrough tool input coercion", () => {
     })
   })
 
+  it("repairs integer strings only when they are integral", () => {
+    const schema = registerBrowser()
+
+    const accepted = schema.safeParse({ action: "open", retryCount: "2" })
+    expect(accepted.success).toBe(true)
+    if (accepted.success) expect(accepted.data.retryCount).toBe(2)
+
+    expect(schema.safeParse({ action: "open", retryCount: "1.5" }).success).toBe(false)
+  })
   it("still advertises the client's declared types and descriptions", () => {
     const schema = registerBrowser()
 
@@ -84,6 +94,10 @@ describe("passthrough tool input coercion", () => {
     expect(advertised.properties.timeout).toMatchObject({
       type: "number",
       description: "timeout in seconds",
+    })
+    expect(advertised.properties.retryCount).toMatchObject({
+      type: "integer",
+      description: "number of retries",
     })
     expect(advertised.properties.all).toMatchObject({ type: "boolean" })
     expect(advertised.properties.app).toMatchObject({

--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -80,6 +80,7 @@ describe("passthrough tool input coercion", () => {
     if (accepted.success) expect(accepted.data.retryCount).toBe(2)
 
     expect(schema.safeParse({ action: "open", retryCount: "1.5" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", retryCount: "9007199254740993" }).success).toBe(false)
   })
   it("still advertises the client's declared types and descriptions", () => {
     const schema = registerBrowser()

--- a/src/__tests__/passthrough-input-coercion.test.ts
+++ b/src/__tests__/passthrough-input-coercion.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, mock, beforeEach } from "bun:test"
+import { describe, expect, it, beforeEach } from "bun:test"
 import { z } from "zod"
+import { installSdkMock } from "./sdkMock"
 
 // Same minimal SDK mock the sibling passthrough tests use: capture what would
 // be registered instead of reaching the real Agent SDK.
 let registeredTools: Array<{ name: string; inputSchema: Record<string, z.ZodType> }> = []
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+installSdkMock(() => ({
   createSdkMcpServer: (options: {
     tools?: Array<{ name: string; inputSchema: Record<string, z.ZodType> }>
   }) => {
@@ -13,7 +14,7 @@ mock.module("@anthropic-ai/claude-agent-sdk", () => ({
     }
     return { type: "sdk", name: "test", instance: { tool: () => {}, registerTool: () => ({}) } }
   },
-}))
+}), "passthrough-input-coercion.test.ts")
 
 import { createPassthroughMcpServer } from "../proxy/passthroughTools"
 
@@ -50,6 +51,57 @@ beforeEach(() => {
 })
 
 describe("passthrough tool input coercion", () => {
+  it("preserves requiredness and validation over the real SDK MCP protocol", () => {
+    // A child isolates the real SDK from the suite's process-global mocks.
+    const moduleUrl = new URL("../proxy/passthroughTools.ts", import.meta.url).href
+    const script = `
+      import assert from "node:assert/strict";
+      import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+      import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+      import { createPassthroughMcpServer } from ${JSON.stringify(moduleUrl)};
+      const properties = {
+        count: { type: "integer" }, timeout: { type: "number", description: "Seconds" },
+        enabled: { type: "boolean" }, names: { type: "array", items: { type: "string" } },
+        app: { type: "object", properties: { relay: { type: "boolean" } }, required: ["relay"] },
+        label: { type: "string", description: "Optional label" },
+      };
+      const required = ["count", "timeout", "enabled", "names", "app"];
+      const { server } = createPassthroughMcpServer([{ name: "test", input_schema: { type: "object", properties, required } }]);
+      const client = new Client({ name: "test", version: "1" });
+      const [a, b] = InMemoryTransport.createLinkedPair();
+      await server.instance.connect(b); await client.connect(a);
+      try {
+        const schema = (await client.listTools()).tools[0].inputSchema;
+        assert.deepEqual(schema.required, required);
+        assert.deepEqual(schema.properties.app.required, ["relay"]);
+        assert.equal(schema.properties.timeout.type, "number");
+        assert.equal(schema.properties.timeout.description, "Seconds");
+        assert.equal(schema.properties.label.description, "Optional label");
+        const args = { count: "2", timeout: "60", enabled: "true", names: '["first"]', app: '{"relay":"false"}' };
+        assert(!(await client.callTool({ name: "test", arguments: args })).isError);
+        assert((await client.callTool({ name: "test", arguments: { ...args, timeout: "soon" } })).isError);
+        delete args.timeout;
+        assert((await client.callTool({ name: "test", arguments: args })).isError);
+      } finally { await client.close(); await server.instance.close(); }
+    `
+    const child = Bun.spawnSync({ cmd: [process.execPath, "-e", script], stdout: "pipe", stderr: "pipe" })
+    expect(child.exitCode, child.stderr.toString()).toBe(0)
+  })
+
+  it("advertises required repaired fields and nested required fields", () => {
+    createPassthroughMcpServer([{ name: "required", input_schema: {
+      type: "object", properties: {
+        ...BROWSER_SCHEMA.properties,
+        app: { ...BROWSER_SCHEMA.properties.app, required: ["relay"] },
+      },
+      required: Object.keys(BROWSER_SCHEMA.properties),
+    } }])
+    const tool = registeredTools.find(entry => entry.name === "required")
+    if (!tool) throw new Error("required tool missing")
+    const advertised = z.toJSONSchema(z.object(tool.inputSchema), { io: "input" })
+    expect(advertised.required).toEqual(Object.keys(BROWSER_SCHEMA.properties))
+    expect(advertised.properties?.app).toMatchObject({ required: ["relay"] })
+  })
   it("accepts the stringified arguments that made the SDK refuse the call", () => {
     const schema = registerBrowser()
 
@@ -81,6 +133,16 @@ describe("passthrough tool input coercion", () => {
 
     expect(schema.safeParse({ action: "open", retryCount: "1.5" }).success).toBe(false)
     expect(schema.safeParse({ action: "open", retryCount: "9007199254740993" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", retryCount: "1.0000000000000001" }).success).toBe(false)
+    expect(schema.safeParse({ action: "open", retryCount: "2.0" }).success).toBe(true)
+    expect(schema.safeParse({ action: "open", retryCount: "2e1" }).success).toBe(true)
+  })
+  it("only repairs JSON numeric syntax", () => {
+    const schema = registerBrowser()
+    for (const value of ["0x10", "0b10", "+2", "01", "", " ", "Infinity", "NaN"]) {
+      expect(schema.safeParse({ action: "open", timeout: value }).success).toBe(false)
+    }
+    expect(schema.safeParse({ action: "open", timeout: " 1.25e2 " }).data?.timeout).toBe(125)
   })
   it("still advertises the client's declared types and descriptions", () => {
     const schema = registerBrowser()

--- a/src/__tests__/passthrough-param-normalization.test.ts
+++ b/src/__tests__/passthrough-param-normalization.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, it } from "bun:test"
-import { normalizeToolInput } from "../proxy/passthroughTools"
+import { normalizeToolInput, hasRepairableToolInput } from "../proxy/passthroughTools"
 
 describe("normalizeToolInput", () => {
+  it("only buffers streams with declared repairable fields", () => {
+    expect(hasRepairableToolInput(undefined)).toBe(false)
+    expect(hasRepairableToolInput({ properties: { path: { type: "string" } } })).toBe(false)
+    for (const type of ["number", "integer", "boolean", "object", "array"]) {
+      expect(hasRepairableToolInput({ properties: { input: { type } } })).toBe(true)
+    }
+  })
+  it("repairs nested values delivered by the real CLI hook without losing unknown fields", () => {
+    const input = { timeout: 60, app: { relay: "true", extra: "kept" }, label: '{"literal":true}' }
+    const schema = { properties: {
+      timeout: { type: "number" },
+      app: { type: "object", properties: { relay: { type: "boolean" } } },
+      label: { type: "string" },
+    }, required: ["timeout", "app"] }
+    expect(normalizeToolInput(input, schema)).toEqual({ timeout: 60, app: { relay: true, extra: "kept" }, label: '{"literal":true}' })
+    expect(input.app.relay).toBe("true")
+  })
+
   it("returns input unchanged when all required fields are present", () => {
     const input = { filePath: "/src/app.ts", offset: 0 }
     const schema = {

--- a/src/__tests__/proxy-passthrough-deny-abort.test.ts
+++ b/src/__tests__/proxy-passthrough-deny-abort.test.ts
@@ -38,7 +38,7 @@ afterEach(async () => {
   await Bun.sleep(25)
   rmSync(isolatedSessionDir, { recursive: true, force: true })
 })
-import { makeRequest, parseSSE, resolveMockSdkSessionId } from "./helpers"
+import { makeRequest, parseSSE, resolveMockSdkSessionId, streamEvent } from "./helpers"
 
 const PASSTHROUGH_PREFIX = "mcp__oc__"
 
@@ -273,6 +273,30 @@ describe("Passthrough deny aborts the nested SDK session on loop detection", () 
       .filter((e: any) => e.event === "content_block_start" && e.data?.content_block?.type === "tool_use")
       .map((e: any) => e.data.content_block.id)
     expect(toolStartIds).toEqual(["toolu_s1"])
+  })
+
+  it("retains buffered numeric arguments when recovery closes a dangling tool block", async () => {
+    mockTurns = [
+      streamMessageStart(),
+      streamEvent({ type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_buffered", name: `${PASSTHROUGH_PREFIX}measure`, input: {} } }),
+      streamEvent({ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"timeout":60}' } }),
+      toolTurn("toolu_buffered", "measure", { timeout: 60 }),
+      toolTurn("toolu_repeat", "measure", { timeout: 30 }),
+    ]
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+    const response = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify(makeRequest({ stream: true, tools: [{ name: "measure", input_schema: {
+        type: "object", properties: { timeout: { type: "number" } }, required: ["timeout"],
+      } }] })),
+    }))
+    const events = await readSSE(response)
+    expect(events.some(event => event.event === "error")).toBe(false)
+    const args = events.filter(event => event.event === "content_block_delta")
+      .map(event => (event.data.delta as { partial_json: string }).partial_json).join("")
+    expect(JSON.parse(args || "{}")).toEqual({ timeout: 60 })
+    expect(events.filter(event => event.event === "content_block_stop")).toHaveLength(1)
+    expect(events.filter(event => event.event === "message_stop")).toHaveLength(1)
   })
 
   it("closes a dangling tool_use content block before the recovery message_stop (#552 red reads)", async () => {

--- a/src/__tests__/proxy-passthrough-tool-use.test.ts
+++ b/src/__tests__/proxy-passthrough-tool-use.test.ts
@@ -132,6 +132,34 @@ describe("Passthrough streaming: early termination on tool_use stop", () => {
     }
   })
 
+  it("repairs complete split JSON arguments independently for parallel streamed calls", async () => {
+    const tool = { name: "measure", input_schema: { type: "object", properties: {
+      timeout: { type: "number" },
+      app: { type: "object", properties: { relay: { type: "boolean" } } },
+      label: { type: "string" },
+    }, required: ["timeout"] } }
+    const expected = [
+      { timeout: 60, app: { relay: true, extra: "kept" }, label: '{"keep":"string"}' },
+      { timeout: 30, app: { relay: false }, label: "second" },
+    ]
+    mockMessages = [messageStart()]
+    for (const [index, value] of expected.entries()) {
+      const raw = JSON.stringify({ ...value, timeout: String(value.timeout), app: JSON.stringify({ ...value.app, relay: String(value.app.relay) }) })
+      mockMessages.push(toolUseBlockStart(index, `${PASSTHROUGH_PREFIX}measure`, `toolu_measure_${index}`),
+        inputJsonDelta(index, raw.slice(0, 19)), inputJsonDelta(index, raw.slice(19)), blockStop(index))
+    }
+    mockMessages.push(messageDelta("tool_use"), messageStop())
+    const events = parseSSE(await postStream(createTestApp(), [tool]))
+    expect(events.filter(event => event.event === "error")).toHaveLength(0)
+    expect(events.filter(event => event.event === "message_stop")).toHaveLength(1)
+    for (const [index, value] of expected.entries()) {
+      const json = events.filter(event => event.event === "content_block_delta" && event.data.index === index)
+        .map(event => (event.data.delta as { partial_json: string }).partial_json).join("")
+      expect(JSON.parse(json)).toEqual(value)
+      expect(events.filter(event => event.event === "content_block_stop" && event.data.index === index)).toHaveLength(1)
+    }
+  })
+
   it("stream ends with message_stop immediately after message_delta(stop_reason:tool_use)", async () => {
     // Simulate: model streams a passthrough tool_use, then the SDK would
     // normally continue (turn 2) — but we should break before that happens.

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -35,14 +35,10 @@ interface JsonSchemaNode {
  * emits every argument as a string, so a declared `number` arrives as `"60"`
  * and a declared object as `'{"cdp_url":"..."}'`.
  *
- * That has to be repaired HERE, before validation, because a rejected call
- * never reaches the PreToolUse hook — so the proxy captures nothing, has
- * nothing to forward to the client, and the passthrough turn cap (maxTurns=1,
- * see query.ts) leaves the model no turn to correct itself. The SDK then ends
- * the query with `error_max_turns`, which server.ts can only report as a 500:
- * a hard, user-visible stream error for a call the client would have executed
- * fine. Measured live: every failing call carried `timeout: "60"` where the
- * client's schema says `number`.
+ * Use this at MCP validation and client capture. Current Claude Code repairs
+ * some top-level fields before PreToolUse, but nested values can remain strings.
+ * The hook precedes the MCP handler, and streamed arguments precede the hook:
+ * repairing only the handler cannot correct what the client receives.
  *
  * Only slips whose declared type makes the intent unambiguous are repaired,
  * and only from a string. A declared `string` is never JSON-parsed: that would
@@ -51,16 +47,21 @@ interface JsonSchemaNode {
 function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
   if (typeof value !== "string") return value
 
-  if (schema.type === "integer") {
-    if (value.trim() === "") return value
+  if (schema.type === "number" || schema.type === "integer") {
+    const match = /^(-?)(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/.exec(value.trim())
+    if (!match) return value
     const parsed = Number(value)
-    return Number.isSafeInteger(parsed) ? parsed : value
-  }
-
-  if (schema.type === "number") {
-    if (value.trim() === "") return value
-    const parsed = Number(value)
-    return Number.isFinite(parsed) ? parsed : value
+    if (!Number.isFinite(parsed)) return value
+    if (schema.type === "integer") {
+      if (!Number.isSafeInteger(parsed)) return value
+      // Number() can round a non-integral decimal such as 1.0000000000000001
+      // to an integer. Check the decimal's fractional digits before accepting.
+      const fraction = match[3] ?? ""
+      const digits = `${match[2]}${fraction}`.replace(/^0+/, "")
+      const scale = Number(match[4] ?? 0) - fraction.length
+      if (digits && scale < 0 && (-scale > digits.length || /[1-9]/.test(digits.slice(scale)))) return value
+    }
+    return parsed
   }
 
   if (schema.type === "boolean") {
@@ -83,6 +84,37 @@ function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
   return value
 }
 
+/** Repair capture input too: CLI PreToolUse precedes the MCP handler parser. */
+function repairCapturedValue(schema: unknown, value: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return value
+  const node = schema as JsonSchemaNode
+  const repaired = repairTypeSlip(node, value)
+  if (node.type === "array" && Array.isArray(repaired)) {
+    return repaired.map(item => repairCapturedValue(node.items, item))
+  }
+  if (node.type === "object" && repaired && typeof repaired === "object" && !Array.isArray(repaired) && node.properties) {
+    return repairCapturedObject(repaired as Record<string, unknown>, node.properties)
+  }
+  return repaired
+}
+
+function repairCapturedObject(input: Record<string, unknown>, properties: Record<string, unknown>): Record<string, unknown> {
+  // Preserve every key, including fields outside the simplified schema subset.
+  // Parsing through a ZodObject here would strip unknown client arguments.
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [key,
+    repairCapturedValue(Object.hasOwn(properties, key) ? properties[key] : undefined, value),
+  ]))
+}
+
+/** Only buffer streamed arguments whose declared fields can need type repair. */
+export function hasRepairableToolInput(schema: { properties?: Record<string, unknown> } | undefined): boolean {
+  return Object.values(schema?.properties ?? {}).some(property => {
+    if (!property || typeof property !== "object" || Array.isArray(property)) return false
+    const type = (property as { type?: unknown }).type
+    return type === "number" || type === "integer" || type === "boolean" || type === "object" || type === "array"
+  })
+}
+
 /**
  * The MCP schema converter reads `description` from the OUTERMOST node only —
  * an inner `.describe()` under `.optional()` or a `preprocess` pipe is dropped
@@ -97,7 +129,10 @@ function withDescription(node: z.ZodTypeAny, schema: JsonSchemaNode): z.ZodTypeA
 
 /** Wrap a validating node so a repairable slip is fixed instead of rejected. */
 function repairing(schema: JsonSchemaNode, node: z.ZodTypeAny): z.ZodTypeAny {
-  return z.preprocess(value => repairTypeSlip(schema, value), node)
+  // A preprocess pipe accepts unknown input at the type level. MCP's input
+  // schema converter otherwise drops required fields, despite runtime rejection
+  // of undefined. Optional properties are wrapped explicitly by the caller.
+  return z.preprocess(value => repairTypeSlip(schema, value), node).nonoptional()
 }
 
 /**
@@ -319,14 +354,15 @@ export function normalizeToolInput(
   input: Record<string, unknown> | undefined,
   clientSchema: { properties?: Record<string, unknown>; required?: string[] } | undefined,
 ): Record<string, unknown> | undefined {
-  if (!input || !clientSchema?.properties) return input
+  if (!input || typeof input !== "object" || Array.isArray(input) || !clientSchema?.properties) return input
 
   const schemaKeys = new Set(Object.keys(clientSchema.properties))
   const required = new Set(clientSchema.required ?? [])
 
-  // Fast path: all required fields are present, no normalization needed
+  // Name normalization is only needed for missing required fields. Type repair
+  // also applies when every field is present, including optional/nested fields.
   const missingRequired = [...required].filter(k => input[k] === undefined)
-  if (missingRequired.length === 0) return input
+  if (missingRequired.length === 0) return repairCapturedObject(input, clientSchema.properties)
 
   const normalized = { ...input }
 
@@ -349,5 +385,5 @@ export function normalizeToolInput(
     }
   }
 
-  return normalized
+  return repairCapturedObject(normalized, clientSchema.properties)
 }

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -51,7 +51,13 @@ interface JsonSchemaNode {
 function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
   if (typeof value !== "string") return value
 
-  if (schema.type === "number" || schema.type === "integer") {
+  if (schema.type === "integer") {
+    if (value.trim() === "") return value
+    const parsed = Number(value)
+    return Number.isInteger(parsed) ? parsed : value
+  }
+
+  if (schema.type === "number") {
     if (value.trim() === "") return value
     const parsed = Number(value)
     return Number.isFinite(parsed) ? parsed : value
@@ -110,7 +116,10 @@ function buildZodNode(schema: JsonSchemaNode): z.ZodTypeAny {
     if (schema.enum) return z.enum(schema.enum as [string, ...string[]])
     return z.string()
   }
-  if (schema.type === "number" || schema.type === "integer") {
+  if (schema.type === "integer") {
+    return repairing(schema, z.number().int())
+  }
+  if (schema.type === "number") {
     return repairing(schema, z.number())
   }
   if (schema.type === "boolean") return repairing(schema, z.boolean())

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -54,7 +54,7 @@ function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
   if (schema.type === "integer") {
     if (value.trim() === "") return value
     const parsed = Number(value)
-    return Number.isInteger(parsed) ? parsed : value
+    return Number.isSafeInteger(parsed) ? parsed : value
   }
 
   if (schema.type === "number") {

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -17,39 +17,129 @@ export const PASSTHROUGH_MCP_NAME = "oc"
 export const PASSTHROUGH_MCP_PREFIX = `mcp__${PASSTHROUGH_MCP_NAME}__`
 
 /**
- * Convert a JSON Schema object to a Zod schema (simplified).
+ * The JSON Schema subset a client's tool definitions actually use. Anything
+ * richer (`anyOf`, `$ref`, tuple `items`, …) falls through to `z.any()` below,
+ * exactly as before.
+ */
+interface JsonSchemaNode {
+  type?: string
+  description?: string
+  enum?: string[]
+  items?: JsonSchemaNode
+  properties?: Record<string, JsonSchemaNode>
+  required?: string[]
+}
+
+/**
+ * Repair the one tool-input slip the model makes often enough to matter: it
+ * emits every argument as a string, so a declared `number` arrives as `"60"`
+ * and a declared object as `'{"cdp_url":"..."}'`.
+ *
+ * That has to be repaired HERE, before validation, because a rejected call
+ * never reaches the PreToolUse hook — so the proxy captures nothing, has
+ * nothing to forward to the client, and the passthrough turn cap (maxTurns=1,
+ * see query.ts) leaves the model no turn to correct itself. The SDK then ends
+ * the query with `error_max_turns`, which server.ts can only report as a 500:
+ * a hard, user-visible stream error for a call the client would have executed
+ * fine. Measured live: every failing call carried `timeout: "60"` where the
+ * client's schema says `number`.
+ *
+ * Only slips whose declared type makes the intent unambiguous are repaired,
+ * and only from a string. A declared `string` is never JSON-parsed: that would
+ * corrupt legitimate input which merely looks like JSON.
+ */
+function repairTypeSlip(schema: JsonSchemaNode, value: unknown): unknown {
+  if (typeof value !== "string") return value
+
+  if (schema.type === "number" || schema.type === "integer") {
+    if (value.trim() === "") return value
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : value
+  }
+
+  if (schema.type === "boolean") {
+    if (value === "true") return true
+    if (value === "false") return false
+    return value
+  }
+
+  if (schema.type === "object" || schema.type === "array") {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      return value
+    }
+    if (schema.type === "array") return Array.isArray(parsed) ? parsed : value
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : value
+  }
+
+  return value
+}
+
+/**
+ * The MCP schema converter reads `description` from the OUTERMOST node only —
+ * an inner `.describe()` under `.optional()` or a `preprocess` pipe is dropped
+ * from the advertised schema. Apply it last so the model keeps seeing what the
+ * client wrote, optional parameters included.
+ */
+function withDescription(node: z.ZodTypeAny, schema: JsonSchemaNode): z.ZodTypeAny {
+  return typeof schema.description === "string" && schema.description
+    ? node.describe(schema.description)
+    : node
+}
+
+/** Wrap a validating node so a repairable slip is fixed instead of rejected. */
+function repairing(schema: JsonSchemaNode, node: z.ZodTypeAny): z.ZodTypeAny {
+  return z.preprocess(value => repairTypeSlip(schema, value), node)
+}
+
+/**
+ * Convert a JSON Schema node to a Zod schema (simplified).
  * Handles the common types OpenCode sends. Falls back to z.any() for complex types.
  */
-function jsonSchemaToZod(schema: any): z.ZodTypeAny {
+function jsonSchemaToZod(schema: unknown): z.ZodTypeAny {
   if (!schema || typeof schema !== "object") return z.any()
+  const node = schema as JsonSchemaNode
+  return withDescription(buildZodNode(node), node)
+}
+
+function buildZodNode(schema: JsonSchemaNode): z.ZodTypeAny {
 
   if (schema.type === "string") {
-    let s = z.string()
-    if (schema.description) s = s.describe(schema.description)
     if (schema.enum) return z.enum(schema.enum as [string, ...string[]])
-    return s
+    return z.string()
   }
   if (schema.type === "number" || schema.type === "integer") {
-    let n = z.number()
-    if (schema.description) n = n.describe(schema.description)
-    return n
+    return repairing(schema, z.number())
   }
-  if (schema.type === "boolean") return z.boolean()
+  if (schema.type === "boolean") return repairing(schema, z.boolean())
   if (schema.type === "array") {
     const items = schema.items ? jsonSchemaToZod(schema.items) : z.any()
-    return z.array(items)
+    return repairing(schema, z.array(items))
   }
   if (schema.type === "object" && schema.properties) {
-    const shape: Record<string, z.ZodTypeAny> = {}
-    const required = new Set(schema.required || [])
-    for (const [key, propSchema] of Object.entries(schema.properties)) {
-      const zodProp = jsonSchemaToZod(propSchema as any)
-      shape[key] = required.has(key) ? zodProp : zodProp.optional()
-    }
-    return z.object(shape)
+    return repairing(schema, z.object(objectShapeFromJsonSchema(schema)))
   }
 
   return z.any()
+}
+
+/**
+ * The property shape of a JSON Schema object, with optionality applied.
+ *
+ * Kept separate from `jsonSchemaToZod` because the MCP registration needs the
+ * root as a raw shape, and the root arguments object is never a slip candidate
+ * — the protocol always delivers it as an object.
+ */
+function objectShapeFromJsonSchema(schema: JsonSchemaNode): Record<string, z.ZodType> {
+  const shape: Record<string, z.ZodType> = {}
+  const required = new Set<string>(schema.required ?? [])
+  for (const [key, propSchema] of Object.entries(schema.properties ?? {})) {
+    const prop = jsonSchemaToZod(propSchema)
+    shape[key] = required.has(key) ? prop : withDescription(prop.optional(), propSchema)
+  }
+  return shape
 }
 
 /** Default threshold: auto-defer when tool count exceeds this.
@@ -73,7 +163,7 @@ export function getAutoDeferThreshold(): number {
  * Client-provided defer_loading: true also triggers deferral for specific tools.
  */
 export function createPassthroughMcpServer(
-  tools: Array<{ name: string; description?: string; input_schema?: any; defer_loading?: boolean }>,
+  tools: Array<{ name: string; description?: string; input_schema?: JsonSchemaNode; defer_loading?: boolean }>,
   coreToolNames?: readonly string[]
 ) {
   // Auto-defer: if tool count exceeds threshold and adapter provides core tools
@@ -101,12 +191,13 @@ export function createPassthroughMcpServer(
       // Register through the Agent SDK helper so its Zod 4 peer owns the MCP
       // compatibility boundary. Registering through the nested MCP instance
       // instead couples this module to that package's separate Zod version.
-      const zodSchema = passthroughTool.input_schema?.properties
-        ? jsonSchemaToZod(passthroughTool.input_schema)
-        : z.object({})
-      const shape: Record<string, z.ZodType> = zodSchema instanceof z.ZodObject
-        ? zodSchema.shape
-        : { input: z.any() }
+      //
+      // The root is built as a raw shape rather than a converted object: the
+      // arguments object always arrives as an object over the protocol, so it
+      // is never a repair candidate, and the SDK wants the shape anyway.
+      const shape = passthroughTool.input_schema?.properties
+        ? objectShapeFromJsonSchema(passthroughTool.input_schema)
+        : {}
       return defineTool(shape)
     } catch {
       const fallbackShape: Record<string, z.ZodType> = { input: z.string().optional() }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -4202,6 +4202,33 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // path closes these explicitly before its final frames.
             const openClientBlocks = new Set<number>()
 
+            // Keep argument buffers alive across drain/abort recovery, which can
+            // close a block even when its SDK content_block_stop never arrived.
+            const pendingToolArguments = new Map<number, { name: string; json: string }>()
+            const flushToolArguments = (clientIdx: number): void => {
+              const buffered = pendingToolArguments.get(clientIdx)
+              pendingToolArguments.delete(clientIdx)
+              if (!buffered?.json) return
+              let fixed = buffered.json
+              try {
+                const clientTool = requestTools.find((tool: { name: string; input_schema?: Parameters<typeof normalizeToolInput>[1] }) => tool.name === buffered.name)
+                const parsed = normalizeToolInput(JSON.parse(buffered.json), clientTool?.input_schema)
+                // NOTE: agent-specific — preserve Task alias normalization.
+                if (buffered.name.toLowerCase() === "task" && typeof parsed?.subagent_type === "string") {
+                  parsed.subagent_type = resolveAgentAlias(parsed.subagent_type, validAgentNames)
+                }
+                fixed = JSON.stringify(parsed)
+              } catch {
+                // Malformed JSON retains the original wire payload.
+              }
+              safeEnqueue(encoder.encode(
+                `event: content_block_delta\ndata: ${JSON.stringify({
+                  type: "content_block_delta", index: clientIdx,
+                  delta: { type: "input_json_delta", partial_json: fixed },
+                })}\n\n`
+              ), "passthrough_tool_fixed_delta")
+            }
+
             // Envelope integrity: every path that ends the client stream must
             // first terminate any content block whose start was forwarded but
             // whose stop hasn't been — an unterminated block renders
@@ -4223,6 +4250,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               })))
               claudeLog("stream.dangling_blocks_closed", { source, count: openClientBlocks.size })
               for (const idx of openClientBlocks) {
+                flushToolArguments(idx)
                 safeEnqueue(encoder.encode(
                   `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: idx })}\n\n`
                 ), `${source}_close_dangling`)
@@ -4518,7 +4546,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // Complete JSON is needed to repair typed client arguments. Keep
               // text streaming normally and flush each tool's arguments at its stop.
               const passthroughToolBlockNames = new Map<number, string>()
-              const passthroughToolJsonBuffer = new Map<number, string>()
 
               // Block index remapping: the SDK resets indices on each turn, but
               // we skip intermediate message_start/stop so the client sees one
@@ -4771,6 +4798,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       // Assign a monotonic client index for this forwarded block
                       if (eventIndex !== undefined) {
                         sdkToClientIndex.set(eventIndex, nextClientBlockIndex++)
+                        const toolName = passthroughToolBlockNames.get(eventIndex)
+                        if (toolName) {
+                          pendingToolArguments.set(sdkToClientIndex.get(eventIndex)!, { name: toolName, json: "" })
+                        }
                       }
                     }
 
@@ -4804,42 +4835,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       eventIndex !== undefined &&
                       passthroughToolBlockNames.has(eventIndex)
                     ) {
+                      const clientIdx = sdkToClientIndex.get(eventIndex) ?? eventIndex
+                      const buffered = pendingToolArguments.get(clientIdx)
                       if (eventType === "content_block_delta") {
-                        const delta = (event as any).delta
-                        if (delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
-                          const prev = passthroughToolJsonBuffer.get(eventIndex) ?? ""
-                          passthroughToolJsonBuffer.set(eventIndex, prev + delta.partial_json)
-                          continue // Don't forward — emit complete JSON at block_stop
+                        const delta = (event as { delta?: { type?: string; partial_json?: string } }).delta
+                        if (buffered && delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
+                          buffered.json += delta.partial_json
+                          continue
                         }
                       }
                       if (eventType === "content_block_stop") {
-                        const buffered = passthroughToolJsonBuffer.get(eventIndex)
-                        if (buffered) {
-                          let fixed = buffered
-                          try {
-                            const toolName = passthroughToolBlockNames.get(eventIndex)
-                            const clientTool = requestTools.find((tool: { name: string; input_schema?: Parameters<typeof normalizeToolInput>[1] }) => tool.name === toolName)
-                            const parsed = normalizeToolInput(JSON.parse(buffered), clientTool?.input_schema)
-                            // NOTE: agent-specific — preserve Task alias normalization.
-                            if (toolName?.toLowerCase() === "task" && typeof parsed?.subagent_type === "string") {
-                              parsed.subagent_type = resolveAgentAlias(parsed.subagent_type, validAgentNames)
-                            }
-                            fixed = JSON.stringify(parsed)
-                          } catch {
-                            // Malformed JSON — forward buffer unchanged rather than drop the block
-                          }
-                          const clientIdx = sdkToClientIndex.get(eventIndex) ?? eventIndex
-                          safeEnqueue(encoder.encode(
-                            `event: content_block_delta\ndata: ${JSON.stringify({
-                              type: "content_block_delta",
-                              index: clientIdx,
-                              delta: { type: "input_json_delta", partial_json: fixed }
-                            })}\n\n`
-                          ), "passthrough_tool_fixed_delta")
-                          passthroughToolJsonBuffer.delete(eventIndex)
-                        }
+                        flushToolArguments(clientIdx)
                         passthroughToolBlockNames.delete(eventIndex)
-                        // Fall through to forward content_block_stop normally
                       }
                     }
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -44,7 +44,7 @@ import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
-import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
@@ -4515,12 +4515,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               }, 15_000)
 
               const skipBlockIndices = new Set<number>()
-              // NOTE: agent-specific — track block indices for "task" tool_use blocks
-              // so we can normalize subagent_type in streamed input_json_delta events.
-              // Deltas are buffered because input_json_delta sends JSON in chunks —
-              // the key-value pair may span multiple deltas, preventing regex match.
-              const taskToolBlockIndices = new Set<number>()
-              const taskToolJsonBuffer = new Map<number, string>()
+              // Complete JSON is needed to repair typed client arguments. Keep
+              // text streaming normally and flush each tool's arguments at its stop.
+              const passthroughToolBlockNames = new Map<number, string>()
+              const passthroughToolJsonBuffer = new Map<number, string>()
 
               // Block index remapping: the SDK resets indices on each turn, but
               // we skip intermediate message_start/stop so the client sees one
@@ -4762,10 +4760,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           // condition fires correctly.
                           streamedToolUseIds.add(block.id)
                         }
-                        // NOTE: agent-specific — track "task" tool blocks so we can
-                        // normalize subagent_type in their streamed input_json_delta.
-                        if (passthrough && eventIndex !== undefined && block.name.toLowerCase() === "task") {
-                          taskToolBlockIndices.add(eventIndex)
+                        if (passthrough && eventIndex !== undefined) {
+                          const clientTool = requestTools.find((tool: { name: string }) => tool.name === block.name)
+                          // NOTE: agent-specific — Task still buffers for alias normalization.
+                          if (block.name.toLowerCase() === "task" || hasRepairableToolInput(clientTool?.input_schema)) {
+                            passthroughToolBlockNames.set(eventIndex, block.name)
+                          }
                         }
                       }
                       // Assign a monotonic client index for this forwarded block
@@ -4796,32 +4796,32 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       }
                     }
 
-                    // NOTE: agent-specific — buffer input_json_delta for Task tool blocks.
-                    // Claude sends PascalCase subagent_type (e.g., "Explore") and aliases
-                    // like "general-purpose" that OpenCode rejects. input_json_delta sends
-                    // JSON in chunks so we can't normalize individual deltas — buffer
-                    // all chunks, parse the complete JSON, and emit the fixed version
-                    // at content_block_stop.
+                    // The stream precedes PreToolUse capture, so it needs the
+                    // same argument repair before the client can execute a call.
+                    // JSON strings can span chunks; flush once the block is complete.
                     if (
                       passthrough &&
                       eventIndex !== undefined &&
-                      taskToolBlockIndices.has(eventIndex)
+                      passthroughToolBlockNames.has(eventIndex)
                     ) {
                       if (eventType === "content_block_delta") {
                         const delta = (event as any).delta
                         if (delta?.type === "input_json_delta" && typeof delta.partial_json === "string") {
-                          const prev = taskToolJsonBuffer.get(eventIndex) ?? ""
-                          taskToolJsonBuffer.set(eventIndex, prev + delta.partial_json)
+                          const prev = passthroughToolJsonBuffer.get(eventIndex) ?? ""
+                          passthroughToolJsonBuffer.set(eventIndex, prev + delta.partial_json)
                           continue // Don't forward — emit complete JSON at block_stop
                         }
                       }
                       if (eventType === "content_block_stop") {
-                        const buffered = taskToolJsonBuffer.get(eventIndex)
+                        const buffered = passthroughToolJsonBuffer.get(eventIndex)
                         if (buffered) {
                           let fixed = buffered
                           try {
-                            const parsed = JSON.parse(buffered) as Record<string, unknown>
-                            if (typeof parsed.subagent_type === "string") {
+                            const toolName = passthroughToolBlockNames.get(eventIndex)
+                            const clientTool = requestTools.find((tool: { name: string; input_schema?: Parameters<typeof normalizeToolInput>[1] }) => tool.name === toolName)
+                            const parsed = normalizeToolInput(JSON.parse(buffered), clientTool?.input_schema)
+                            // NOTE: agent-specific — preserve Task alias normalization.
+                            if (toolName?.toLowerCase() === "task" && typeof parsed?.subagent_type === "string") {
                               parsed.subagent_type = resolveAgentAlias(parsed.subagent_type, validAgentNames)
                             }
                             fixed = JSON.stringify(parsed)
@@ -4835,9 +4835,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                               index: clientIdx,
                               delta: { type: "input_json_delta", partial_json: fixed }
                             })}\n\n`
-                          ), "task_tool_fixed_delta")
-                          taskToolJsonBuffer.delete(eventIndex)
+                          ), "passthrough_tool_fixed_delta")
+                          passthroughToolJsonBuffer.delete(eventIndex)
                         }
+                        passthroughToolBlockNames.delete(eventIndex)
                         // Fall through to forward content_block_stop normally
                       }
                     }


### PR DESCRIPTION
Stringified nested tool arguments can reach the client with the wrong types. MCP-handler preprocessing alone cannot fix passthrough delivery: Claude Code invokes PreToolUse before the handler, and streams arguments before the hook. Apply the same schema-directed repair to captured calls and complete streamed argument blocks. Preserve unknown fields and declared strings, and retain text/string-only tool streaming.

Preserve required fields and descriptions in the actual MCP tools/list schema, including nested fields. Reject non-JSON numeric syntax and non-integral decimals that Number() rounds to integers. Keep argument buffers alive through normal completion and recovery so a missing block-stop event cannot discard a tool's arguments. Existing Task alias normalization stays in its agent-specific location. The existing simplified JSON Schema support remains; this is not a full schema validator.

Incorporates #925 with all three Mate Remias author commits preserved separately, followed by two maintainer correction commits.

Validation:

- 3,513 tests pass with one existing skip and zero failures; typecheck, build, exact-head CI, Windows smoke and container smoke/build pass.
- Required-field, nested capture, parallel split-JSON and numeric-boundary regressions fail before and pass after. An isolated real MCP client/server test checks advertised required/optional fields and validation.
- A deterministic local API response drives the real Claude CLI/SDK with stringified arguments. Both response modes deliver typed arguments, pass the actual client result into a resumed checkpoint, return the exact receipt and preserve source history through supported getSessionMessages.
- Withholding one SDK tool-block stop reproduces lost arguments on the earlier candidate; the correction passes with the same real CLI, hook and follow-up. The fixture uses local model responses and explicitly controlled SDK-event loss.
- Real Claude Max calls and tool-result follow-ups pass in both modes; four E41 modes pass with existing cache/history assertions. One live streaming run exercised nested string repair, while final compatibility reruns emitted typed arguments. No claim is made that every model run reproduced the slip.

The contributor's historic 500 is not independently reproduced on current CLI 2.1.259; wrong nested client arguments and the schema regression are demonstrated. Fields with repairable types are emitted when their JSON block completes so clients receive consistent arguments.
