### PR TITLE
fix: preserve account attribution and SDK billing failover

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -21,6 +21,28 @@ curl -s http://127.0.0.1:3456/health | jq .status   # → "healthy"
 kill $(lsof -ti :3456)
 ```
 
+### Error telemetry and SDK billing refusals (#836 / #829)
+
+```bash
+bun scripts/e2e-error-telemetry.mjs
+```
+
+The real CLI and SDK call a local Anthropic API fixture that refuses billing.
+Its normalized `Credit balance is too low` error must classify as a billing
+refusal. Pinned requests fail with the correct account/model telemetry in both
+response modes. Unpinned priority requests must fail over to real Claude Max,
+return a visible recovery receipt, and record the refusing and serving accounts
+under the same request id, in both modes. No SDK query is mocked.
+
+Each case uses a fresh proxy instance so a preceding case's expected account
+cooldown cannot skip the refusal being tested. Configuration, session metadata
+and working directory are disposable; Claude Max retains its normal authentication.
+The local API uses a dummy key. `E2E_MERIDIAN_ROOT` selects source from another
+checkout for before/after comparisons; `--failover-only` selects one failure case.
+This verifies actual SDK refusal handling and live recovery, not two separate
+paid accounts. Run the full priority-routing suite and all four E41 modes to
+retain the barrier against failover after real content, tools or structured output.
+
 ### Consecutive idle stalls (#868)
 
 ```bash

--- a/scripts/e2e-error-telemetry.mjs
+++ b/scripts/e2e-error-telemetry.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+// Actual proxy + SDK + CLI: local API billing refusal, then real Claude Max.
+import assert from 'node:assert/strict'
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+const repo = resolve(process.env.E2E_MERIDIAN_ROOT ?? '.')
+const root = realpathSync(mkdtempSync(join(tmpdir(), 'meridian-error-telemetry-')))
+for (const key of Object.keys(process.env)) if (key.startsWith('MERIDIAN_') || key.startsWith('CLAUDE_PROXY_')) delete process.env[key]
+Object.assign(process.env, { MERIDIAN_CONFIG_DIR: join(root, 'config'), MERIDIAN_SESSION_DIR: join(root, 'sessions'), MERIDIAN_WORKDIR: root,
+  MERIDIAN_TELEMETRY_PERSIST: '0', MERIDIAN_ROUTING: 'priority', MERIDIAN_PROFILE_ORDER: 'refused,working' })
+let refusedCalls = 0
+const upstream = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch(request) {
+  if (!new URL(request.url).pathname.endsWith('/messages')) return Response.json({ input_tokens: 100 })
+  refusedCalls++
+  return Response.json({ type: 'error', error: { type: 'billing_error', message: 'Credit balance is too low to access the Anthropic API.' } },
+    { status: 400, headers: { 'x-should-retry': 'false', 'request-id': 'fixture-billing-refusal' } })
+} })
+const { startProxyServer } = await import(pathToFileURL(join(repo, 'src/proxy/server.ts')).href)
+const { telemetryStore } = await import(pathToFileURL(join(repo, 'src/telemetry/index.ts')).href)
+const { rateLimitStore } = await import(pathToFileURL(join(repo, 'src/proxy/rateLimitStore.ts')).href)
+const start = () => startProxyServer({ port: 0, host: '127.0.0.1', silent: true, profiles: [
+  { id: 'refused', type: 'api', apiKey: 'local-fixture-key', baseUrl: `http://127.0.0.1:${upstream.port}` },
+  { id: 'working', type: 'claude-max' },
+], defaultProfile: 'refused' })
+let proxy = await start()
+const cases = process.argv.includes('--failover-only') ? ['failover'] : ['pinned', 'pinned-stream', 'failover', 'failover-stream']
+try {
+  for (const mode of cases) {
+    // Each mode must exercise a fresh refusal, not reuse the preceding case's
+    // expected account-exhaustion cooldown and skip directly to the fallback.
+    if (mode !== cases[0]) { await proxy.close(); proxy = await start() }
+    const port = proxy.server.address().port
+    rateLimitStore.clear()
+    const requestId = crypto.randomUUID()
+    const receipt = `RECOVERED_${crypto.randomUUID()}`
+    const isFailover = mode.startsWith('failover')
+    const stream = mode.endsWith('-stream')
+    const callsBefore = refusedCalls
+    const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+      method: 'POST', headers: { 'content-type': 'application/json', 'x-request-id': requestId, 'x-opencode-session': requestId,
+        ...(!isFailover ? { 'x-meridian-profile': 'refused' } : {}) },
+      body: JSON.stringify({ model: 'claude-haiku-4-5-20251001', max_tokens: 128, stream,
+        messages: [{ role: 'user', content: `Reply with exactly ${receipt}.` }] }),
+      signal: AbortSignal.timeout(120000),
+    })
+    const body = await response.text()
+    const rows = telemetryStore.getRecent({ limit: 100 }).filter(row => row.requestId === requestId)
+    const failures = rows.filter(row => row.error !== null)
+    let reply = ''
+    if (stream) {
+      for (const line of body.split('\n')) if (line.startsWith('data:')) {
+        const event = JSON.parse(line.slice(5))
+        if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') reply += event.delta.text
+      }
+    } else {
+      reply = (JSON.parse(body).content ?? []).filter(block => block.type === 'text').map(block => block.text).join('')
+    }
+    console.log(JSON.stringify({ mode, status: response.status, refusedCalls, rows: rows.map(row => ({ profile: row.profileId, model: row.model, requestModel: row.requestModel, status: row.status, error: row.error })), reply }))
+    assert(refusedCalls > callsBefore, 'The real CLI must reach the local refusal API for this case')
+    assert.equal(failures.length, 1)
+    assert.equal(failures[0].profileId, 'refused')
+    assert.notEqual(failures[0].model, 'unknown')
+    assert.equal(failures[0].requestModel, 'claude-haiku-4-5-20251001')
+    if (isFailover) {
+      assert.equal(response.status, 200)
+      assert(reply.includes(receipt), 'Real Claude Max fallback must answer the prompt with visible text')
+      const served = rows.filter(row => row.error === null)
+      assert.equal(served.length, 1)
+      assert.equal(served[0].profileId, 'working')
+    } else {
+      assert(body.includes('billing_error'))
+      assert.equal(rows.length, 1)
+    }
+  }
+  console.log(JSON.stringify({ result: 'PASS', root, refusedCalls, cases }))
+} finally {
+  await proxy.close()
+  upstream.stop(true)
+}

--- a/src/__tests__/error-telemetry-profile.test.ts
+++ b/src/__tests__/error-telemetry-profile.test.ts
@@ -1,0 +1,149 @@
+/**
+ * A refusal recorded on the error path must name the account that refused.
+ *
+ * Priority routing tries each profile in turn. Since #825 stopped forking
+ * `requestId` per attempt, every attempt files under the caller's id and
+ * `profileId` is the only thing that distinguishes them. The error-path
+ * telemetry row wrote `model: "unknown"` and no `profileId` at all, so
+ * "which account rate-limited me?" was unanswerable from telemetry. See #829.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
+import { assistantMessage } from "./helpers"
+
+let failingDirs = new Set<string>()
+
+mock.module("@anthropic-ai/claude-agent-sdk", () => ({
+  query: (params: any) => {
+    const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
+    return (async function* () {
+      if ([...failingDirs].some(f => dir.includes(f))) {
+        throw new Error("429 rate limit reached for this account")
+      }
+      yield assistantMessage([{ type: "text", text: "ok from " + dir }])
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}))
+
+mock.module("../logger", () => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+mock.module("../mcpTools", () => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetProcessSdkSemaphoreForTests } = await import("../proxy/concurrency")
+const { resetActiveProfile } = await import("../proxy/profiles")
+const { rateLimitStore } = await import("../proxy/rateLimitStore")
+const { telemetryStore } = await import("../telemetry")
+
+const PROFILES = [
+  { id: "work", claudeConfigDir: "/tmp/meridian-errtel-work" },
+  { id: "personal", claudeConfigDir: "/tmp/meridian-errtel-personal" },
+]
+
+const savedEnv: Record<string, string | undefined> = {}
+
+describe("error-path telemetry records the profile that failed", () => {
+  beforeEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    clearSessionCache()
+    resetActiveProfile()
+    rateLimitStore.clear?.()
+    failingDirs = new Set()
+    savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
+    savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
+    process.env.MERIDIAN_ROUTING = "priority"
+    process.env.MERIDIAN_PROFILE_ORDER = "work,personal"
+  })
+
+  afterEach(() => {
+    resetProcessSdkSemaphoreForTests()
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  })
+
+  it("names the refusing profile on the failover refusal row", async () => {
+    failingDirs.add("meridian-errtel-work")
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
+    })
+
+    const clientId = `errtel-failover-${Date.now()}`
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-request-id": clientId },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+
+    const mine = telemetryStore.getRecent({ limit: 500 }).filter(m => m.requestId === clientId)
+    expect(mine.length).toBeGreaterThanOrEqual(2)
+
+    // The bug: this row had no profileId, so the only account named anywhere
+    // in telemetry was the one that succeeded.
+    const refusals = mine.filter(m => m.error !== null)
+    expect(refusals).toHaveLength(1)
+    expect(refusals[0]!.profileId).toBe("work")
+
+    // ...and the served row still names the account that answered, unchanged.
+    const served = mine.filter(m => m.error === null)
+    expect(served).toHaveLength(1)
+    expect(served[0]!.profileId).toBe("personal")
+  })
+
+  it("records the dispatched model instead of a bare \"unknown\"", async () => {
+    failingDirs.add("meridian-errtel-work")
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
+    })
+
+    const clientId = `errtel-model-${Date.now()}`
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-request-id": clientId },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-5",
+        max_tokens: 128,
+        stream: false,
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    }))
+    expect(res.status).toBe(200)
+
+    const refusal = telemetryStore.getRecent({ limit: 500 })
+      .find(m => m.requestId === clientId && m.error !== null)
+    expect(refusal).toBeDefined()
+    expect(refusal!.model).not.toBe("unknown")
+    expect(refusal!.requestModel).toBe("claude-sonnet-4-5")
+  })
+
+  it("still records a row when the request fails before profile resolution", async () => {
+    const { app } = createProxyServer({
+      port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
+    })
+
+    const clientId = `errtel-early-${Date.now()}`
+    const res = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-request-id": clientId },
+      body: "{ not json",
+    }))
+    expect(res.status).toBe(400)
+    // No profile was ever chosen, so there is genuinely nothing to name — the
+    // fix must not fabricate one.
+    const rows = telemetryStore.getRecent({ limit: 500 }).filter(m => m.requestId === clientId)
+    for (const row of rows) expect(row.profileId).toBeUndefined()
+  })
+})

--- a/src/__tests__/error-telemetry-profile.test.ts
+++ b/src/__tests__/error-telemetry-profile.test.ts
@@ -7,31 +7,43 @@
  * telemetry row wrote `model: "unknown"` and no `profileId` at all, so
  * "which account rate-limited me?" was unanswerable from telemetry. See #829.
  */
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test"
-import { assistantMessage } from "./helpers"
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { assistantMessage, withMockSdkSessionId } from "./helpers"
+
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
 
 let failingDirs = new Set<string>()
+let sdkErrorAssistant = false
 
-mock.module("@anthropic-ai/claude-agent-sdk", () => ({
-  query: (params: any) => {
+installSdkMock( () => ({
+  query: (params: { options?: { env?: Record<string, string>; sessionId?: string; resume?: string } }) => {
     const dir = params.options?.env?.CLAUDE_CONFIG_DIR ?? "default"
     return (async function* () {
       if ([...failingDirs].some(f => dir.includes(f))) {
+        if (sdkErrorAssistant) {
+          const message = assistantMessage([{ type: "text", text: "Credit balance is too low" }])
+          if (message.type === "assistant") {
+            yield withMockSdkSessionId({ ...message, error: "billing_error" }, params.options)
+          }
+          throw new Error("Claude Code returned an error result: Credit balance is too low")
+        }
         throw new Error("429 rate limit reached for this account")
       }
-      yield assistantMessage([{ type: "text", text: "ok from " + dir }])
+      yield withMockSdkSessionId(assistantMessage([{ type: "text", text: "ok from " + dir }]), params.options)
     })()
   },
   createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
   tool: () => ({}),
 }))
 
-mock.module("../logger", () => ({
+installLoggerMock( () => ({
   claudeLog: () => {},
   withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
 }))
 
-mock.module("../mcpTools", () => ({
+installMcpToolsMock( () => ({
   createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
 }))
 
@@ -55,6 +67,7 @@ describe("error-path telemetry records the profile that failed", () => {
     resetActiveProfile()
     rateLimitStore.clear?.()
     failingDirs = new Set()
+    sdkErrorAssistant = false
     savedEnv.MERIDIAN_ROUTING = process.env.MERIDIAN_ROUTING
     savedEnv.MERIDIAN_PROFILE_ORDER = process.env.MERIDIAN_PROFILE_ORDER
     process.env.MERIDIAN_ROUTING = "priority"
@@ -103,7 +116,7 @@ describe("error-path telemetry records the profile that failed", () => {
     expect(served[0]!.profileId).toBe("personal")
   })
 
-  it("records the dispatched model instead of a bare \"unknown\"", async () => {
+  it("records the initially resolved model instead of a bare \"unknown\"", async () => {
     failingDirs.add("meridian-errtel-work")
     const { app } = createProxyServer({
       port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
@@ -129,7 +142,7 @@ describe("error-path telemetry records the profile that failed", () => {
     expect(refusal!.requestModel).toBe("claude-sonnet-4-5")
   })
 
-  it("still records a row when the request fails before profile resolution", async () => {
+  it("does not fabricate account telemetry for rejected malformed JSON", async () => {
     const { app } = createProxyServer({
       port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work",
     })
@@ -144,6 +157,57 @@ describe("error-path telemetry records the profile that failed", () => {
     // No profile was ever chosen, so there is genuinely nothing to name — the
     // fix must not fabricate one.
     const rows = telemetryStore.getRecent({ limit: 500 }).filter(m => m.requestId === clientId)
-    for (const row of rows) expect(row.profileId).toBeUndefined()
+    expect(rows).toHaveLength(0)
+  })
+
+  it.each([false, true])("keeps a pinned failure attributed without failover, stream=%s", async (stream) => {
+    failingDirs.add("meridian-errtel-work")
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work" })
+    const requestId = crypto.randomUUID()
+    const response = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-request-id": requestId, "x-meridian-profile": "work" },
+      body: JSON.stringify({ model: "claude-sonnet-4-5", max_tokens: 128, stream, messages: [{ role: "user", content: "hello" }] }),
+    }))
+    expect(response.status).toBe(stream ? 200 : 429)
+    expect(await response.text()).toContain("rate_limit_error")
+    const rows = telemetryStore.getRecent({ limit: 500 }).filter(row => row.requestId === requestId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.profileId).toBe("work")
+    expect(rows[0]?.model).not.toBe("unknown")
+    expect(rows[0]?.requestModel).toBe("claude-sonnet-4-5")
+  })
+
+  it("distinguishes both failed profiles under the same request id", async () => {
+    failingDirs = new Set(["meridian-errtel-work", "meridian-errtel-personal"])
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work" })
+    const requestId = crypto.randomUUID()
+    const response = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST", headers: { "content-type": "application/json", "x-request-id": requestId },
+      body: JSON.stringify({ model: "claude-sonnet-4-5", max_tokens: 128, stream: false, messages: [{ role: "user", content: "hello" }] }),
+    }))
+    expect(response.status).toBe(429)
+    await response.text()
+    const rows = telemetryStore.getRecent({ limit: 500 }).filter(row => row.requestId === requestId)
+    expect(rows).toHaveLength(2)
+    expect(new Set(rows.map(row => row.profileId))).toEqual(new Set(["work", "personal"]))
+    expect(rows.every(row => row.error !== null)).toBe(true)
+  }, 15_000) // Two accounts each wait through the configured 1s + 2s retry delays.
+
+  it("does not mistake an SDK error assistant for committed user content", async () => {
+    sdkErrorAssistant = true
+    failingDirs.add("meridian-errtel-work")
+    const { app } = createProxyServer({ port: 0, host: "127.0.0.1", profiles: PROFILES, defaultProfile: "work" })
+    const requestId = crypto.randomUUID()
+    const response = await app.fetch(new Request("http://localhost/v1/messages", {
+      method: "POST", headers: { "content-type": "application/json", "x-request-id": requestId },
+      body: JSON.stringify({ model: "haiku", max_tokens: 128, stream: false, messages: [{ role: "user", content: "hello" }] }),
+    }))
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain("ok from")
+    const rows = telemetryStore.getRecent({ limit: 500 }).filter(row => row.requestId === requestId)
+    expect(rows).toHaveLength(2)
+    expect(rows.find(row => row.error !== null)?.profileId).toBe("work")
+    expect(rows.find(row => row.error === null)?.profileId).toBe("personal")
   })
 })

--- a/src/__tests__/sdk-credit-refusal.test.ts
+++ b/src/__tests__/sdk-credit-refusal.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test"
+import { classifyError, isAccountFailoverError, isQuotaRefusal } from "../proxy/errors"
+
+describe("SDK credit refusal", () => {
+  it.each([
+    "Credit balance is too low",
+    "Claude Code returned an error result: Credit balance is too low",
+    "Error: Claude Code returned an error result: Credit balance is too low.",
+  ])("recognizes the CLI's shortened refusal: %s", (message) => {
+    const error = classifyError(message)
+    expect(error.status).toBe(402)
+    expect(error.type).toBe("billing_error")
+    expect(isAccountFailoverError(error.type)).toBe(true)
+    expect(isQuotaRefusal(error.type)).toBe(false)
+  })
+
+  it.each([
+    "Tool failed while documenting Credit balance is too low",
+    "Credit balance is too low is an example error string",
+    "Claude Code returned an error result: could not find 'Credit balance is too low' in fixture.txt",
+    "Error: ENOENT: /repo/Credit balance is too low.txt",
+  ])("does not exhaust accounts for incidental text: %s", (message) => {
+    expect(isAccountFailoverError(classifyError(message).type)).toBe(false)
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -55,6 +55,9 @@ const BILLING_SIGNALS: readonly RegExp[] = [
   /update your payment/,
   /(?:out of|draw from|draws from) extra usage/,
   /insufficient (?:credit|funds|balance)/,
+  // The real CLI shortens an API billing refusal to this exact sentence.
+  // Anchor the whole line so incidental tool output does not exhaust a profile.
+  /^\s*(?:(?:error|api error|claude code returned an error result):\s*)*credit balance is too low[.!]?\s*$/m,
   // The credits-era entitlement cap: "Your group's usage limit is set to $0 ·
   // run /usage-credits to ask your admin for a higher limit" (#909, verbatim in
   // the CLI). billing_error rather than rate_limit_error: a provisioned cap is

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1493,6 +1493,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // failure fired before the profile resolved.
       let resolvedProfileId: string | undefined
 
+      // Hoisted for the same reason: the outer catch records a telemetry row,
+      // but `profile`/`model` are block-scoped inside the try. Without these,
+      // a priority-routing failover files its refusal row with no profileId,
+      // so the row cannot say WHICH account refused — and since #825 stopped
+      // forking requestId per attempt, profileId is what distinguishes the
+      // attempts. Assigned as soon as each value is known; still undefined
+      // when the request fails before that point (early validation), which is
+      // exactly when the row genuinely has nothing to report. See #829.
+      let attemptedProfileId: string | undefined
+      let attemptedModel: string | undefined
+      let attemptedRequestModel: string | undefined
       try {
         const body = options.body
         const idleRequestKey = idleStallRequestKey(body)
@@ -1747,6 +1758,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             : undefined
         )
         resolvedProfileId = profile.id
+        // Every routing mode funnels through this single resolveProfile call —
+        // the priority path re-enters handleMessages with forcedProfileId, so
+        // one assignment here covers failover attempts and direct requests.
+        attemptedProfileId = profile.id
 
         const authStatus = await getClaudeAuthStatusAsync(
           profile.id !== "default" ? profile.id : undefined,
@@ -1779,6 +1794,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // exactly as before.
         const benchSessionKey = adapter.getSessionId(c, body) || undefined
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode, profile.id, benchSessionKey)
+        // Captured for the outer catch's telemetry row (see #829): the model
+        // this attempt was dispatched with. Later [1m] fallbacks reassign the
+        // local `model` inside the retry loops and are deliberately not
+        // mirrored here — the dispatched model is what identifies the attempt,
+        // and mirroring would mean touching four sites in the retry control
+        // flow for no observability gain.
+        attemptedModel = model
+        attemptedRequestModel = typeof body.model === "string" ? body.model : undefined
         // Explicitly versioned ids override their tier's canonical pin for
         // this request (spread last in query.ts env, so they also beat
         // operator env) — a proxy must never substitute models. Bare aliases
@@ -6572,8 +6595,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           requestId: requestMeta.requestId,
           timestamp: Date.now(),
           adapter: adapter.name,
-          model: "unknown",
-          requestModel: undefined,
+          // #829: name the account that failed. On a priority-routing failover
+          // the refusal row is otherwise indistinguishable from any other
+          // attempt under the same requestId. Still "unknown"/absent when the
+          // request died before profile/model resolution.
+          profileId: attemptedProfileId,
+          model: attemptedModel ?? "unknown",
+          requestModel: attemptedRequestModel,
           mode: "non-stream",
           isResume: false,
           isPassthrough: envBool("PASSTHROUGH"),

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -1501,7 +1501,6 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       // attempts. Assigned as soon as each value is known; still undefined
       // when the request fails before that point (early validation), which is
       // exactly when the row genuinely has nothing to report. See #829.
-      let attemptedProfileId: string | undefined
       let attemptedModel: string | undefined
       let attemptedRequestModel: string | undefined
       try {
@@ -1514,7 +1513,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           exposure.reason = reason
         }
         const observePriorityAttemptMessage = (message: any): void => {
-          if (message?.type === "assistant" && Array.isArray(message.message?.content) && message.message.content.length > 0) {
+          // SDK error assistants describe a refusal, not content delivered to the
+          // client. They must not prevent failover before any real exposure.
+          if (message?.type === "assistant" && !message.error && Array.isArray(message.message?.content) && message.message.content.length > 0) {
             markPriorityAttemptExposure("assistant_content")
             return
           }
@@ -1757,11 +1758,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             ? { routingMode, stickySessionKey: adapter.getSessionId(c, body) }
             : undefined
         )
+        // Also identifies failure telemetry; priority retries resolve each account here.
         resolvedProfileId = profile.id
-        // Every routing mode funnels through this single resolveProfile call —
-        // the priority path re-enters handleMessages with forcedProfileId, so
-        // one assignment here covers failover attempts and direct requests.
-        attemptedProfileId = profile.id
 
         const authStatus = await getClaudeAuthStatusAsync(
           profile.id !== "default" ? profile.id : undefined,
@@ -1794,12 +1792,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // exactly as before.
         const benchSessionKey = adapter.getSessionId(c, body) || undefined
         let model = mapModelToClaudeModel(requestedModel, authStatus?.subscriptionType, agentMode, profile.id, benchSessionKey)
-        // Captured for the outer catch's telemetry row (see #829): the model
-        // this attempt was dispatched with. Later [1m] fallbacks reassign the
-        // local `model` inside the retry loops and are deliberately not
-        // mirrored here — the dispatched model is what identifies the attempt,
-        // and mirroring would mean touching four sites in the retry control
-        // flow for no observability gain.
+        // Error telemetry names the initially resolved model for this account
+        // attempt. Later context fallbacks do not rewrite that identity.
         attemptedModel = model
         attemptedRequestModel = typeof body.model === "string" ? body.model : undefined
         // Explicitly versioned ids override their tier's canonical pin for
@@ -6599,7 +6593,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           // the refusal row is otherwise indistinguishable from any other
           // attempt under the same requestId. Still "unknown"/absent when the
           // request died before profile/model resolution.
-          profileId: attemptedProfileId,
+          profileId: resolvedProfileId,
           model: attemptedModel ?? "unknown",
           requestModel: attemptedRequestModel,
           mode: "non-stream",


### PR DESCRIPTION
A real SDK billing refusal could lose its account identity in telemetry and stop priority routing before the healthy account was tried. This incorporates #836 and fixes two gaps exposed by actual SDK validation: the CLI shortens billing refusals to “Credit balance is too low,” and represents that refusal as an error assistant that must not count as committed user content.

Error rows now retain the resolved account, initially resolved model and requested model. The exact CLI credit message classifies as billing, and error assistants leave pre-content failover available. Earlier real content, tool activity and structured output still block failover. The original authored commit is retained with its date; maintainer corrections and stronger fixtures are separate.

Validation:
- Before/after HTTP tests reproduce missing profile/model attribution and the error-assistant failover barrier. Exact credit-refusal classifier tests fail before and pass after, with incidental-text negative cases.
- Actual SDK + CLI → local Anthropic API billing fixture: pinned streaming/non-streaming requests retain the refusing account; unpinned requests in both modes fail over to real Claude Max, return a visible recovery receipt, and record both accounts under the same request id. No SDK query is mocked. Each case uses a fresh proxy so the prior case’s cooldown cannot skip the tested refusal.
- All four live E41 tool-chain/parallel × streaming/non-streaming controls pass, including durable tool-result history and prompt-cache continuity.
- Full required suite: 3,601 pass, one existing skip, zero failures. Typecheck and build pass. Final-head CI must pass before merging.

The local refusal fixture uses a dummy API key and the successful account uses existing Claude Max authentication. This validates real SDK failure handling and live recovery; it does not simulate two paid accounts. The separate historical concurrent post-SDK 500 remains unresolved.

Fixes #829
