### PR TITLE
fix(errors): classify the per-tier refusal that ends in prose

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -910,6 +910,13 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
     ["trailing newline", "You've reached your Fable 5 limit.\n"],
     ["CRLF line ending", "You've reached your Fable 5 limit.\r\n"],
+    // The prose suffix, not a slash command. Observed live on 1.66.0 through a
+    // gateway fronting a Claude Max pool: every Fable turn came back in this
+    // exact shape, classified api_error, and failed nothing over while three
+    // other profiles in the pool had Fable window left.
+    ["prose switch suffix", "Claude Code returned an error result: You've reached your Fable limit. Switch to another model to continue."],
+    ["prose switch suffix, bare banner", "You've reached your Fable 5 limit. Switch to another model to continue."],
+    ["prose switch suffix without the trailing clause", "You've reached your Opus limit. Switch to another model."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
@@ -931,6 +938,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["joined run command", "You've reached your Fable 5 limitRun /usage-credits"],
     ["joined usage command", "You've reached your Fable 5 limit/usage-credits"],
     ["unspaced punctuated command", "You've reached your Fable 5 limit.Run /usage-credits"],
+    // The prose suffix is enumerated, not a licence for any tail: a sentence
+    // that merely starts like it must still fall through.
+    ["prose switch suffix continuing into documentation", "You've reached your Fable 5 limit. Switch to another model to continue, the docs say, but the account is healthy"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -122,10 +122,18 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
- * versions without arbitrary words, and only known CLI command suffixes are
+ * versions without arbitrary words, and only known CLI suffixes are
  * accepted: a false positive exhausts a healthy profile pool-wide, so the
  * banner must occupy its whole line rather than merely open one. New tier
  * names must be added to the enumeration.
+ *
+ * Not every accepted suffix is a slash command. The credits-era banner also
+ * ends in plain prose — "Switch to another model to continue." — which is the
+ * shape a Claude Max pool receives today, observed live through a gateway on
+ * 1.66.0 and still unmatched by this pattern as released in 1.68.0. It is
+ * enumerated like the others rather than admitted as a wildcard tail, because
+ * the negative cases below turn on exactly that distinction: a documentation
+ * sentence continuing past the banner must not exhaust a healthy profile.
  *
  * The bound is the LINE, not the message — `/m`, like HIT_YOUR_SPEND_LIMIT
  * above and CONTEXT_OVERFLOW_SIGNALS below. `server.ts` appends captured
@@ -136,7 +144,7 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * always, the harmless "custom betas" warning being emitted first. Both shapes
  * then fell through to the code-1 branch, which tells the operator to run
  * `claude login` for what is actually a quota refusal. */
-const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)\.?|[.!]?)[ \t\r]*$/m
+const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models|switch[ \t]+to[ \t]+another[ \t]+model(?:[ \t]+to[ \t]+continue)?)\.?|[.!]?)[ \t\r]*$/m
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose


### PR DESCRIPTION
`REACHED_YOUR_TIER_LIMIT` (1.67.0, the reimplementation of #920 that closed #909) accepts the banner only when the line ends at `limit.`, or continues with `/usage-credits` or `/model to switch models`. A Claude Max pool receives a fourth shape, and it is the only one that arrives there:

```
Claude Code returned an error result: You've reached your Fable limit. Switch to another model to continue.
```

The prefix is already anticipated; the suffix is prose rather than a slash command, so the refusal falls through to `500 api_error` and `ACCOUNT_FAILOVER_ERROR_TYPES` never sees it.

Observed live on 1.66.0 through a gateway fronting a pool of Claude Max profiles: five consecutive Fable turns, five identical refusals from the same profile, no failover — while three other profiles in the same pool still had Fable window left (29%, 79%, and one untouched). Re-checked against the pattern as released in 1.68.0 by lifting the regex out of the published bundle and running the real string through it:

```
false | Claude Code returned an error result: You've reached your Fable limit. Switch to another model to continue.
true  | You've reached your Fable 5 limit.
true  | You've reached your Fable 5 limit. /model to switch models.
```

The suffix is enumerated like the existing ones rather than admitted as a wildcard tail, because the negative cases turn on exactly that distinction: a documentation sentence continuing past the banner must not exhaust a healthy profile pool-wide. A new negative case pins that boundary next to the positives — `"...limit. Switch to another model to continue, the docs say, but the account is healthy"` still classifies as `api_error`.

The line anchor, the tier enumeration and the `/m` bound are untouched.

Verified: `bun test src/__tests__/errors.test.ts` — 194 pass, 0 fail; `tsc --noEmit` clean. The same patch was also built into a bundle and the released artifact re-checked, so the behaviour is confirmed on the compiled output, not only the source.
