### PR TITLE
fix(codex): keep auto-defer off for Codex requests

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/aleksei/dev/meridian/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/aleksei/dev/meridian/node_modules

--- a/src/__tests__/codex-transform-core-tools.test.ts
+++ b/src/__tests__/codex-transform-core-tools.test.ts
@@ -1,0 +1,28 @@
+/**
+ * The codex transform must name Codex's own built-ins as core tools: the
+ * inherited OpenCode list matches nothing Codex sends, so auto-defer deferred
+ * every tool (exec_command included) and each turn paid a discovery round.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { codexTransforms } from "../proxy/transforms/codex"
+import { openCodeTransforms } from "../proxy/transforms/opencode"
+import type { RequestContext } from "../proxy/transform"
+
+function runCodexPipeline(body: Record<string, unknown>): RequestContext {
+  let ctx = { body, adapter: "codex" } as unknown as RequestContext
+  for (const t of [...openCodeTransforms, ...codexTransforms]) {
+    if ((t.adapters === undefined || t.adapters.includes("codex")) && t.onRequest) ctx = t.onRequest(ctx)
+  }
+  return ctx
+}
+
+describe("codex transform core tools", () => {
+  it("forces passthrough and names Codex built-ins as the always-loaded set", () => {
+    const ctx = runCodexPipeline({ model: "m", messages: [], tools: [{ name: "exec_command" }, { name: "mcp__iskron_bridge__iskron_orient" }] })
+    expect(ctx.passthrough).toBe(true)
+    expect(ctx.coreToolNames).toContain("exec_command")
+    expect(ctx.coreToolNames).toContain("apply_patch")
+    expect(ctx.coreToolNames).not.toContain("bash")
+  })
+})

--- a/src/__tests__/codex-transform-core-tools.test.ts
+++ b/src/__tests__/codex-transform-core-tools.test.ts
@@ -1,13 +1,17 @@
 /**
- * The codex transform must name Codex's own built-ins as core tools: the
- * inherited OpenCode list matches nothing Codex sends, so auto-defer deferred
- * every tool (exec_command included) and each turn paid a discovery round.
+ * The codex transform must switch auto-defer off: it inherits OpenCode's core
+ * tool list, which names nothing Codex sends, so a Codex request past the
+ * defer threshold deferred every tool (exec_command included) and each
+ * tool-calling turn paid the SDK's digest turn on the full context. With no
+ * core set the passthrough MCP server never defers and the single-turn cap
+ * holds.
  */
 
 import { describe, it, expect } from "bun:test"
 import { codexTransforms } from "../proxy/transforms/codex"
 import { openCodeTransforms } from "../proxy/transforms/opencode"
 import type { RequestContext } from "../proxy/transform"
+import { createPassthroughMcpServer } from "../proxy/passthroughTools"
 
 function runCodexPipeline(body: Record<string, unknown>): RequestContext {
   let ctx = { body, adapter: "codex" } as unknown as RequestContext
@@ -17,12 +21,13 @@ function runCodexPipeline(body: Record<string, unknown>): RequestContext {
   return ctx
 }
 
-describe("codex transform core tools", () => {
-  it("forces passthrough and names Codex built-ins as the always-loaded set", () => {
-    const ctx = runCodexPipeline({ model: "m", messages: [], tools: [{ name: "exec_command" }, { name: "mcp__iskron_bridge__iskron_orient" }] })
+describe("codex transform auto-defer", () => {
+  it("forces passthrough and leaves no core set so nothing is deferred", () => {
+    const tools = Array.from({ length: 40 }, (_, i) => ({ name: i === 0 ? "exec_command" : `mcp__iskron_bridge__tool_${i}` }))
+    const ctx = runCodexPipeline({ model: "m", messages: [], tools })
     expect(ctx.passthrough).toBe(true)
-    expect(ctx.coreToolNames).toContain("exec_command")
-    expect(ctx.coreToolNames).toContain("apply_patch")
-    expect(ctx.coreToolNames).not.toContain("bash")
+    expect(ctx.coreToolNames).toBeUndefined()
+    const mcp = createPassthroughMcpServer(tools, ctx.coreToolNames ? [...ctx.coreToolNames] : undefined)
+    expect(mcp.hasDeferredTools).toBe(false)
   })
 })

--- a/src/proxy/transforms/codex.ts
+++ b/src/proxy/transforms/codex.ts
@@ -10,28 +10,23 @@ import type { Transform, RequestContext } from "../transform"
  * leave Codex waiting for tool calls that never come back.
  */
 /**
- * Codex's built-in tools — the ones it sends as top-level `function`/`custom`
- * entries rather than inside an MCP `namespace`. These stay loaded on every
- * turn; everything else (MCP servers, apps) is deferred behind the SDK's tool
- * search when the request crosses the auto-defer threshold. The OpenCode list
- * (read/write/edit/bash/…) names nothing Codex sends, so inheriting it deferred
- * every tool including `exec_command` and cost every turn a discovery round.
- * Mirrors Codex's own native behaviour: MCP tools deferred, built-ins direct.
+ * Codex sends every MCP server as a `namespace` entry with the tool
+ * definitions inline, so a desktop session easily carries 250+ tools and
+ * crosses the auto-defer threshold. Deferring them is a net loss here: the
+ * deferred budget lifts the single-turn cap (see computePassthroughMaxTurns),
+ * so every tool-calling turn also generates the SDK's discarded digest turn —
+ * one or two extra reads of the full context, measured 2-3x cache reads per
+ * turn on a 680k-token session — while the alternative, loading the schemas,
+ * costs ~125k cached tokens once. Codex never sets `defer_loading` itself, so
+ * with no core set auto-defer stays off, the cap stays at 1, and a tool turn
+ * is one model call again.
  */
-const CODEX_CORE_TOOL_NAMES: readonly string[] = [
-  "exec_command", "write_stdin", "shell", "shell_command", "local_shell",
-  "apply_patch", "view_image",
-  "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
-  "request_user_input", "request_plugin_install",
-  "get_goal", "create_goal", "update_goal",
-]
-
 export const codexTransforms: Transform[] = [
   {
     name: "codex-force-passthrough",
     adapters: ["codex"],
     onRequest(ctx: RequestContext): RequestContext {
-      return { ...ctx, passthrough: true, coreToolNames: CODEX_CORE_TOOL_NAMES }
+      return { ...ctx, passthrough: true, coreToolNames: undefined }
     },
   },
 ]

--- a/src/proxy/transforms/codex.ts
+++ b/src/proxy/transforms/codex.ts
@@ -9,12 +9,29 @@ import type { Transform, RequestContext } from "../transform"
  * global MERIDIAN_PASSTHROUGH setting. Internal mode (SDK executes tools) would
  * leave Codex waiting for tool calls that never come back.
  */
+/**
+ * Codex's built-in tools — the ones it sends as top-level `function`/`custom`
+ * entries rather than inside an MCP `namespace`. These stay loaded on every
+ * turn; everything else (MCP servers, apps) is deferred behind the SDK's tool
+ * search when the request crosses the auto-defer threshold. The OpenCode list
+ * (read/write/edit/bash/…) names nothing Codex sends, so inheriting it deferred
+ * every tool including `exec_command` and cost every turn a discovery round.
+ * Mirrors Codex's own native behaviour: MCP tools deferred, built-ins direct.
+ */
+const CODEX_CORE_TOOL_NAMES: readonly string[] = [
+  "exec_command", "write_stdin", "shell", "shell_command", "local_shell",
+  "apply_patch", "view_image",
+  "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
+  "request_user_input", "request_plugin_install",
+  "get_goal", "create_goal", "update_goal",
+]
+
 export const codexTransforms: Transform[] = [
   {
     name: "codex-force-passthrough",
     adapters: ["codex"],
     onRequest(ctx: RequestContext): RequestContext {
-      return { ...ctx, passthrough: true }
+      return { ...ctx, passthrough: true, coreToolNames: CODEX_CORE_TOOL_NAMES }
     },
   },
 ]


### PR DESCRIPTION
## Problem

`codexTransforms` runs after the shared OpenCode transform and inherits its `coreToolNames` (`read, write, edit, bash, glob, grep`). Codex never sends tools with those names, so as soon as a Codex request crosses the auto-defer threshold (default 15 — trivially, once MCP namespaces are carried through, see #964) the core set matches nothing and **every** tool is deferred, `exec_command` and `apply_patch` included. Observed with Codex Desktop 0.153.4: `deferred=283/283 tools (core: read,write,edit,bash,glob,grep)`.

Deferral has a second, larger cost in passthrough: `computePassthroughMaxTurns` lifts the single-turn cap when `hasDeferredTools` is set (a ToolSearch discovery needs a turn), so every tool-calling turn also generates the SDK's discarded digest turn on the full context. Measured on a 680k-token Codex session: cache reads of 1×/2×/3× the context per turn (683k / 1349k / 2022k) with a 97–100% hit rate, versus one read per turn before MCP tools arrived. The SDK transcripts contain no `ToolSearch` call at all — the extra reads are digest turns, not discovery.

## Fix

The codex transform sets `coreToolNames: undefined`, which per `AgentAdapter.getCoreToolNames` disables auto-defer for this agent. Codex never sets `defer_loading` itself, so `hasDeferredTools` stays false, the cap stays at 1, and a tool turn is one model call again. Loading the ~250 namespace tool schemas costs ~125k cached tokens once (437k chars in the captured request) — far less than one extra full-context read per turn.

An earlier revision of this PR named Codex's built-ins as the core set instead; that kept `exec_command` loaded but still paid the digest turn on every tool call, so it was replaced.

## Tests

`src/__tests__/codex-transform-core-tools.test.ts` runs the OpenCode + codex transform pipeline with 40 tools and asserts passthrough is forced, no core set is exposed, and `createPassthroughMcpServer` reports `hasDeferredTools === false`. `bun test` and `tsc --noEmit` green.

Independent of, but most useful together with, #964.