### PR TITLE
fix(responses): carry Codex namespace and custom tools through to Claude

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/aleksei/dev/meridian/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/aleksei/dev/meridian/node_modules

--- a/src/__tests__/openai-responses-namespaces.test.ts
+++ b/src/__tests__/openai-responses-namespaces.test.ts
@@ -185,3 +185,46 @@ describe("createResponsesSseTranslator with aliases", () => {
     expect(done).toEqual({ type: "custom_tool_call", id: "fc_toolu_p", call_id: "toolu_p", name: "apply_patch", input: "*** Begin Patch\n*** End Patch\n", status: "completed" })
   })
 })
+
+describe("function_call_output content items", () => {
+  // MCP tool results come back from Codex as content items, not a string
+  // (FunctionCallOutputBody::ContentItems); a verbatim pass-through reached
+  // Anthropic as `tool_result.content[0].type = "input_text"` → 400.
+  it("maps input_text and data-URL input_image items to tool_result blocks", () => {
+    const png = "data:image/png;base64,iVBORw0KGgo="
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      tools,
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", arguments: "{}", call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: [
+          { type: "input_text", text: "ГРАФ: merkazim [60]" },
+          { type: "input_image", image_url: png },
+          { type: "encrypted_content", encrypted_content: "opaque" },
+        ] },
+      ] as never,
+    })!
+    const result = (r.messages.at(-1)!.content as unknown as Array<Record<string, unknown>>).find((b) => b.type === "tool_result")!
+    expect(result.tool_use_id).toBe("call_1")
+    expect(result.content).toEqual([
+      { type: "text", text: "ГРАФ: merkazim [60]" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } },
+      { type: "text", text: "[Unsupported encrypted_content tool output part omitted]" },
+    ])
+  })
+
+  it("keeps string outputs as strings and turns an empty item list into an empty string", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "function_call", name: "shell", arguments: "{}", call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: "a.txt" },
+        { type: "function_call", name: "shell", arguments: "{}", call_id: "call_2" },
+        { type: "function_call_output", call_id: "call_2", output: [] },
+      ] as never,
+    })!
+    const results = r.messages.flatMap((m) => m.content as unknown as Array<Record<string, unknown>>).filter((b) => b.type === "tool_result")
+    expect(results.map((b) => b.content)).toEqual(["a.txt", ""])
+  })
+})

--- a/src/__tests__/openai-responses-namespaces.test.ts
+++ b/src/__tests__/openai-responses-namespaces.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Namespaced (MCP) and custom tools on the Responses API — Codex 0.153 ships
+ * every MCP server as one `{type:"namespace", tools:[…]}` entry and its
+ * freeform `apply_patch` as `{type:"custom"}`; a translator that keeps only
+ * `type:"function"` silently loses all of them. Wire shapes mirror a request
+ * captured from Codex Desktop 0.153.4 (25 tools, 12 namespaces).
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  translateResponsesToAnthropic,
+  translateAnthropicToResponses,
+  createResponsesSseTranslator,
+  buildResponsesToolAliases,
+  responsesToolAlias,
+  RESPONSES_TOOL_ALIAS_MAX,
+} from "../proxy/openaiResponses"
+import { PASSTHROUGH_MCP_PREFIX } from "../proxy/passthroughTools"
+
+const iskronNamespace = {
+  type: "namespace",
+  name: "mcp__iskron-bridge",
+  description: "Graph tools.",
+  tools: [
+    { type: "function", name: "iskron_orient", description: "Orient in a realm.", strict: false, parameters: { type: "object", properties: { realm: { type: "string" } }, required: ["realm"] } },
+    { type: "function", name: "iskron_look", description: "Read one node.", strict: false, parameters: { type: "object", properties: { node_id: { type: "string" } } } },
+  ],
+}
+const applyPatch = {
+  type: "custom",
+  name: "apply_patch",
+  description: "The `apply_patch` tool can be used to edit files.",
+  format: { type: "grammar", syntax: "lark", definition: "start: begin_patch hunk+ end_patch" },
+}
+const tools = [
+  { type: "function", name: "shell", description: "run", strict: false, parameters: { type: "object", properties: {} } },
+  applyPatch,
+  iskronNamespace,
+  { type: "web_search", external_web_access: true } as unknown as { type: string; name: string },
+]
+
+describe("responsesToolAlias", () => {
+  it("leaves the alias budget for the passthrough MCP prefix", () => {
+    expect(RESPONSES_TOOL_ALIAS_MAX).toBe(64 - PASSTHROUGH_MCP_PREFIX.length)
+  })
+
+  it("joins namespace and name, sanitizing characters Claude rejects", () => {
+    expect(responsesToolAlias("mcp__iskron-bridge", "iskron_orient")).toBe("mcp__iskron-bridge__iskron_orient")
+    expect(responsesToolAlias("mcp__a.b", "x y")).toBe("mcp__a_b__x_y")
+    expect(responsesToolAlias(undefined, "apply_patch")).toBe("apply_patch")
+  })
+
+  it("hashes names over the budget deterministically", () => {
+    const long = responsesToolAlias("mcp__codex_apps__codex_document_control", "codex_document_control_list_sections")
+    expect(long.length).toBeLessThanOrEqual(RESPONSES_TOOL_ALIAS_MAX)
+    expect(long).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(long).toBe(responsesToolAlias("mcp__codex_apps__codex_document_control", "codex_document_control_list_sections"))
+    expect(long).not.toBe(responsesToolAlias("mcp__codex_apps__codex_document_control", "codex_document_control_list_section"))
+  })
+})
+
+describe("buildResponsesToolAliases", () => {
+  it("lists nested and custom tools, not top-level functions", () => {
+    const aliases = buildResponsesToolAliases(tools)
+    expect([...aliases.keys()].sort()).toEqual(["apply_patch", "mcp__iskron-bridge__iskron_look", "mcp__iskron-bridge__iskron_orient"])
+    expect(aliases.get("mcp__iskron-bridge__iskron_orient")).toEqual({ namespace: "mcp__iskron-bridge", name: "iskron_orient", kind: "function" })
+    expect(aliases.get("apply_patch")).toEqual({ name: "apply_patch", kind: "custom" })
+  })
+})
+
+describe("translateResponsesToAnthropic with namespaces", () => {
+  it("flattens namespace tools and exposes custom tools as a single-string function", () => {
+    const r = translateResponsesToAnthropic({ model: "m", input: "x", tools })!
+    expect(r.tools!.map((t) => t.name)).toEqual(["shell", "apply_patch", "mcp__iskron-bridge__iskron_orient", "mcp__iskron-bridge__iskron_look"])
+    const orient = r.tools!.find((t) => t.name === "mcp__iskron-bridge__iskron_orient")!
+    expect(orient.description).toBe("[mcp__iskron-bridge] Orient in a realm.")
+    expect(orient.input_schema).toEqual({ type: "object", properties: { realm: { type: "string" } }, required: ["realm"] })
+    const patch = r.tools!.find((t) => t.name === "apply_patch")!
+    expect(patch.description).toContain("edit files")
+    expect(patch.description).toContain("Input grammar (lark)")
+    expect((patch.input_schema as { required: string[] }).required).toEqual(["input"])
+  })
+
+  it("replays namespaced and custom calls from history under the same aliases", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      tools,
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", arguments: '{"realm":"r60"}', call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: "ГРАФ: merkazim [60]" },
+        { type: "custom_tool_call", name: "apply_patch", input: "*** Begin Patch\n*** End Patch\n", call_id: "call_2" },
+        { type: "custom_tool_call_output", call_id: "call_2", output: "Done!" },
+      ] as never,
+    })!
+    const assistant = r.messages.filter((m) => m.role === "assistant").flatMap((m) => m.content as unknown as Array<Record<string, unknown>>)
+    expect(assistant).toEqual([
+      { type: "tool_use", id: "call_1", name: "mcp__iskron-bridge__iskron_orient", input: { realm: "r60" } },
+      { type: "tool_use", id: "call_2", name: "apply_patch", input: { input: "*** Begin Patch\n*** End Patch\n" } },
+    ])
+    const results = r.messages.filter((m) => m.role === "user").flatMap((m) => m.content as unknown as Array<Record<string, unknown>>).filter((b) => b.type === "tool_result")
+    expect(results.map((b) => b.tool_use_id)).toEqual(["call_1", "call_2"])
+  })
+})
+
+describe("translateAnthropicToResponses with aliases", () => {
+  const ctx = { responseId: "resp_1", model: "m", created: 1, toolAliases: buildResponsesToolAliases(tools) }
+
+  it("turns an aliased tool_use into a namespaced function_call", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "tool_use", id: "toolu_1", name: "mcp__iskron-bridge__iskron_orient", input: { realm: "r60" } }],
+      stop_reason: "tool_use",
+    }, ctx)
+    expect((out.output as Array<Record<string, unknown>>)[0]).toEqual({
+      type: "function_call", id: "fc_toolu_1", call_id: "toolu_1", name: "iskron_orient", namespace: "mcp__iskron-bridge",
+      arguments: '{"realm":"r60"}', status: "completed",
+    })
+  })
+
+  it("turns a custom tool_use into a custom_tool_call carrying the raw input", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "tool_use", id: "toolu_2", name: "apply_patch", input: { input: "*** Begin Patch\n*** End Patch\n" } }],
+      stop_reason: "tool_use",
+    }, ctx)
+    expect((out.output as Array<Record<string, unknown>>)[0]).toEqual({
+      type: "custom_tool_call", id: "fc_toolu_2", call_id: "toolu_2", name: "apply_patch",
+      input: "*** Begin Patch\n*** End Patch\n", status: "completed",
+    })
+  })
+
+  it("leaves top-level function tools untouched", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "tool_use", id: "toolu_3", name: "shell", input: { command: ["ls"] } }],
+      stop_reason: "tool_use",
+    }, ctx)
+    const item = (out.output as Array<Record<string, unknown>>)[0]!
+    expect(item.type).toBe("function_call")
+    expect(item.name).toBe("shell")
+    expect("namespace" in item).toBe(false)
+  })
+})
+
+describe("createResponsesSseTranslator with aliases", () => {
+  const ctx = { responseId: "resp_s", model: "m", created: 1, toolAliases: buildResponsesToolAliases(tools) }
+  function run(events: Array<Record<string, unknown>>) {
+    const translate = createResponsesSseTranslator(ctx)
+    return events.flatMap((e) => translate(e as never))
+  }
+  const start = { type: "message_start", message: { id: "m1", usage: { input_tokens: 1 } } }
+  const end = [
+    { type: "content_block_stop", index: 0 },
+    { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } },
+    { type: "message_stop" },
+  ]
+
+  it("streams a namespaced function_call with argument deltas", () => {
+    const out = run([
+      start,
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_9", name: "mcp__iskron-bridge__iskron_orient", input: {} } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"realm":"r60"}' } },
+      ...end,
+    ])
+    const added = out.find((e) => e.event === "response.output_item.added")!.data.item as Record<string, unknown>
+    expect(added).toMatchObject({ type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", call_id: "toolu_9" })
+    expect(out.filter((e) => e.event === "response.function_call_arguments.delta")).toHaveLength(1)
+    const done = out.find((e) => e.event === "response.output_item.done")!.data.item as Record<string, unknown>
+    expect(done).toMatchObject({ type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", arguments: '{"realm":"r60"}', status: "completed" })
+    const completed = out.find((e) => e.event === "response.completed")!.data.response as { output: Array<Record<string, unknown>> }
+    expect(completed.output[0]).toMatchObject({ type: "function_call", namespace: "mcp__iskron-bridge" })
+  })
+
+  it("streams a custom tool as one custom_tool_call item without argument deltas", () => {
+    const out = run([
+      start,
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_p", name: "apply_patch", input: {} } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"input":"*** Begin ' } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: 'Patch\\n*** End Patch\\n"}' } },
+      ...end,
+    ])
+    const added = out.find((e) => e.event === "response.output_item.added")!.data.item as Record<string, unknown>
+    expect(added).toMatchObject({ type: "custom_tool_call", name: "apply_patch", call_id: "toolu_p", status: "in_progress" })
+    expect(out.some((e) => e.event === "response.function_call_arguments.delta")).toBe(false)
+    expect(out.some((e) => e.event === "response.function_call_arguments.done")).toBe(false)
+    const done = out.find((e) => e.event === "response.output_item.done")!.data.item as Record<string, unknown>
+    expect(done).toEqual({ type: "custom_tool_call", id: "fc_toolu_p", call_id: "toolu_p", name: "apply_patch", input: "*** Begin Patch\n*** End Patch\n", status: "completed" })
+  })
+})

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -53,10 +53,20 @@ interface ResponsesFunctionCallItem {
   arguments: string
   call_id: string
 }
+/**
+ * `function_call_output.output` is a plain string for shell-style tools and an
+ * array of content items for MCP tools (Codex's FunctionCallOutputBody is an
+ * untagged Text | ContentItems); custom tool outputs are always strings.
+ */
+interface ResponsesOutputContentItem {
+  type: "input_text" | "input_image" | "input_audio" | "encrypted_content" | string
+  text?: string
+  image_url?: string
+}
 interface ResponsesFunctionCallOutputItem {
   type: "function_call_output"
   call_id: string
-  output: string
+  output: string | ResponsesOutputContentItem[]
 }
 /** A freeform (`type:"custom"`) tool call — Codex's `apply_patch`. */
 interface ResponsesCustomToolCallItem {
@@ -315,6 +325,32 @@ function partsToBlocks(content: ResponsesContentPart[] | string | undefined): An
 }
 
 /**
+ * Anthropic `tool_result.content` for a Responses tool output. Content items
+ * are mapped part by part — `input_text` → text, data-URL `input_image` →
+ * image — and anything else becomes an omission note, so an MCP tool that
+ * answered with structured content never reaches the API as an unknown tag.
+ */
+function toolOutputToContent(output: string | ResponsesOutputContentItem[] | undefined): string | AnthropicContentBlock[] {
+  if (output === undefined || output === null) return ""
+  if (typeof output === "string") return output
+  if (!Array.isArray(output)) return typeof output === "object" ? JSON.stringify(output) : String(output)
+  const blocks: AnthropicContentBlock[] = []
+  for (const part of output) {
+    if (!part || typeof part !== "object") continue
+    if (typeof part.text === "string") {
+      blocks.push({ type: "text", text: part.text })
+    } else if (part.type === "input_image") {
+      const image = typeof part.image_url === "string" ? parseDataUrlImage(part.image_url) : null
+      blocks.push(image ?? { type: "text", text: "[Unsupported input_image omitted: only data URLs are currently supported]" })
+    } else {
+      blocks.push({ type: "text", text: `[Unsupported ${String(part.type)} tool output part omitted]` })
+    }
+  }
+  // Anthropic rejects an empty content array; an empty string is fine.
+  return blocks.length > 0 ? blocks : ""
+}
+
+/**
  * Map a Responses `tool_choice` to Anthropic's. Codex sends `"auto"`,
  * `"required"`, `"none"`, or `{type:"function", name}`. `"none"` maps to
  * undefined (Anthropic has no explicit none — omitting lets the model decide,
@@ -391,7 +427,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
       }
       case "function_call_output": {
         const fo = item as ResponsesFunctionCallOutputItem
-        pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: fo.output })
+        pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: toolOutputToContent(fo.output) })
         break
       }
       case "custom_tool_call": {
@@ -402,7 +438,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
       }
       case "custom_tool_call_output": {
         const co = item as ResponsesCustomToolCallOutputItem
-        pushBlock("user", { type: "tool_result", tool_use_id: co.call_id, content: co.output })
+        pushBlock("user", { type: "tool_result", tool_use_id: co.call_id, content: toolOutputToContent(co.output) })
         break
       }
       case "reasoning":

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -26,6 +26,7 @@ import type {
   AnthropicUsage,
 } from "./openai"
 import { mergeAnthropicUsage, parseDataUrlImage, totalAnthropicInputTokens } from "./openai"
+import { createHash } from "node:crypto"
 
 // ---------------------------------------------------------------------------
 // Responses request types (subset Codex actually sends)
@@ -47,11 +48,26 @@ interface ResponsesMessageItem {
 interface ResponsesFunctionCallItem {
   type: "function_call"
   name: string
+  /** Set when the tool lives in a `namespace` tool entry (an MCP server). */
+  namespace?: string
   arguments: string
   call_id: string
 }
 interface ResponsesFunctionCallOutputItem {
   type: "function_call_output"
+  call_id: string
+  output: string
+}
+/** A freeform (`type:"custom"`) tool call — Codex's `apply_patch`. */
+interface ResponsesCustomToolCallItem {
+  type: "custom_tool_call"
+  name: string
+  namespace?: string
+  input: string
+  call_id: string
+}
+interface ResponsesCustomToolCallOutputItem {
+  type: "custom_tool_call_output"
   call_id: string
   output: string
 }
@@ -63,14 +79,20 @@ type ResponsesInputItem =
   | ResponsesMessageItem
   | ResponsesFunctionCallItem
   | ResponsesFunctionCallOutputItem
+  | ResponsesCustomToolCallItem
+  | ResponsesCustomToolCallOutputItem
   | ResponsesReasoningItem
 
-interface ResponsesTool {
-  type: "function" | string
+export interface ResponsesTool {
+  type: "function" | "custom" | "namespace" | string
   name: string
   description?: string
   strict?: boolean
   parameters?: unknown
+  /** `custom` tools: the freeform grammar Codex expects the input to follow. */
+  format?: unknown
+  /** `namespace` tools: the nested function/custom tools of one MCP server. */
+  tools?: ResponsesTool[]
 }
 
 export interface ResponsesRequest {
@@ -86,6 +108,150 @@ export interface ResponsesRequest {
   reasoning?: { effort?: string }
   stream?: boolean
   [k: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// Tool aliasing: namespaced and custom tools
+// ---------------------------------------------------------------------------
+
+/**
+ * Codex (0.15x) ships every MCP server as one `{type:"namespace", name,
+ * tools:[…]}` entry with the tool definitions nested inside, and its freeform
+ * `apply_patch` as `{type:"custom"}`. Claude sees one flat list of function
+ * tools, so each nested or custom tool is exposed under an alias, and the alias
+ * table maps Claude's call back onto the exact `{namespace, name}` pair Codex's
+ * router resolves (`ToolName::new(namespace, name)` — a flattened name without
+ * `namespace` never matches a namespaced tool).
+ */
+export interface ResponsesToolAlias {
+  namespace?: string
+  name: string
+  kind: "function" | "custom"
+}
+export type ResponsesToolAliases = Map<string, ResponsesToolAlias>
+
+/**
+ * Claude tool names are `[A-Za-z0-9_-]{1,64}`, and the passthrough MCP server
+ * prepends its own `mcp__oc__` (PASSTHROUGH_MCP_PREFIX in passthroughTools.ts;
+ * a test pins the two in sync), so an alias gets the remainder.
+ */
+const PASSTHROUGH_PREFIX_LENGTH = "mcp__oc__".length
+export const RESPONSES_TOOL_ALIAS_MAX = 64 - PASSTHROUGH_PREFIX_LENGTH
+
+/**
+ * The Claude-visible name of a tool. Deterministic on (namespace, name): the
+ * history Codex replays next turn carries the same pair and must land on the
+ * same alias, or the replayed `tool_use` names no longer match the tool set.
+ */
+export function responsesToolAlias(namespace: string | undefined, name: string): string {
+  const raw = namespace ? `${namespace}__${name}` : name
+  const safe = raw.replace(/[^A-Za-z0-9_-]/g, "_")
+  if (safe.length <= RESPONSES_TOOL_ALIAS_MAX) return safe
+  const digest = createHash("sha256").update(raw).digest("hex").slice(0, 8)
+  return `${safe.slice(0, RESPONSES_TOOL_ALIAS_MAX - digest.length - 1)}_${digest}`
+}
+
+/**
+ * Alias table for a request's tools. Pure and deterministic, so the route can
+ * rebuild it for the response side without threading state through the
+ * request translator. Top-level function tools keep their own names and are
+ * not listed.
+ */
+export function buildResponsesToolAliases(tools: ResponsesTool[] | undefined): ResponsesToolAliases {
+  const aliases: ResponsesToolAliases = new Map()
+  for (const tool of tools ?? []) {
+    if (tool.type === "custom") {
+      aliases.set(responsesToolAlias(undefined, tool.name), { name: tool.name, kind: "custom" })
+    } else if (tool.type === "namespace") {
+      for (const nested of tool.tools ?? []) {
+        if (nested.type !== "function" && nested.type !== "custom") continue
+        aliases.set(responsesToolAlias(tool.name, nested.name), {
+          namespace: tool.name,
+          name: nested.name,
+          kind: nested.type,
+        })
+      }
+    }
+  }
+  return aliases
+}
+
+/**
+ * A freeform tool has no JSON arguments: Claude gets a single `input` string
+ * and the whole payload is passed through verbatim as `custom_tool_call.input`.
+ */
+const CUSTOM_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    input: { type: "string", description: "The complete freeform payload, exactly as the tool's format requires." },
+  },
+  required: ["input"],
+  additionalProperties: false,
+}
+
+function customToolDescription(tool: ResponsesTool): string {
+  const parts = [tool.description ?? "", "Freeform tool: put the entire payload in the `input` string; do not wrap it in JSON."]
+  const format = tool.format && typeof tool.format === "object" ? (tool.format as { syntax?: unknown; definition?: unknown }) : undefined
+  if (typeof format?.definition === "string") {
+    parts.push(`Input grammar${typeof format.syntax === "string" ? ` (${format.syntax})` : ""}:\n${format.definition}`)
+  }
+  return parts.filter((s) => s.length > 0).join("\n\n")
+}
+
+function translateResponsesTools(tools: ResponsesTool[]): AnthropicTool[] {
+  const out: AnthropicTool[] = []
+  const push = (namespace: string | undefined, tool: ResponsesTool) => {
+    if (tool.type === "function") {
+      out.push({
+        name: namespace ? responsesToolAlias(namespace, tool.name) : tool.name,
+        description: namespace ? `[${namespace}] ${tool.description ?? ""}`.trimEnd() : tool.description ?? "",
+        input_schema: tool.parameters ?? { type: "object", properties: {} },
+      })
+    } else if (tool.type === "custom") {
+      out.push({
+        name: responsesToolAlias(namespace, tool.name),
+        description: customToolDescription(tool),
+        input_schema: CUSTOM_TOOL_INPUT_SCHEMA,
+      })
+    }
+    // Server-side tool kinds (`web_search`, …) have no Claude counterpart here.
+  }
+  for (const tool of tools) {
+    if (tool.type === "namespace") {
+      for (const nested of tool.tools ?? []) push(tool.name, nested)
+    } else {
+      push(undefined, tool)
+    }
+  }
+  return out
+}
+
+/** The Responses item for a Claude `tool_use`, resolved through the alias table. */
+function toolCallItem(
+  ctx: ResponsesCtx,
+  id: string,
+  callId: string,
+  name: string,
+  argsJson: string,
+  status: "in_progress" | "completed"
+): Record<string, unknown> {
+  const alias = ctx.toolAliases?.get(name)
+  const namespace = alias?.namespace ? { namespace: alias.namespace } : {}
+  if (alias?.kind === "custom") {
+    let input = argsJson
+    try {
+      const parsed: unknown = JSON.parse(argsJson || "{}")
+      if (parsed && typeof parsed === "object" && typeof (parsed as { input?: unknown }).input === "string") {
+        input = (parsed as { input: string }).input
+      } else if (argsJson === "" || argsJson === "{}") {
+        input = ""
+      }
+    } catch {
+      // Not JSON: Claude may already have emitted the freeform payload itself.
+    }
+    return { type: "custom_tool_call", id, call_id: callId, name: alias.name, ...namespace, input, status }
+  }
+  return { type: "function_call", id, call_id: callId, name: alias?.name ?? name, ...namespace, arguments: argsJson, status }
 }
 
 // ---------------------------------------------------------------------------
@@ -219,12 +385,24 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         const fc = item as ResponsesFunctionCallItem
         let input: Record<string, unknown> = {}
         try { input = fc.arguments ? JSON.parse(fc.arguments) : {} } catch { input = {} }
-        pushBlock("assistant", { type: "tool_use", id: fc.call_id, name: fc.name, input })
+        const name = fc.namespace ? responsesToolAlias(fc.namespace, fc.name) : fc.name
+        pushBlock("assistant", { type: "tool_use", id: fc.call_id, name, input })
         break
       }
       case "function_call_output": {
         const fo = item as ResponsesFunctionCallOutputItem
         pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: fo.output })
+        break
+      }
+      case "custom_tool_call": {
+        const ct = item as ResponsesCustomToolCallItem
+        const name = responsesToolAlias(ct.namespace, ct.name)
+        pushBlock("assistant", { type: "tool_use", id: ct.call_id, name, input: { input: ct.input ?? "" } })
+        break
+      }
+      case "custom_tool_call_output": {
+        const co = item as ResponsesCustomToolCallOutputItem
+        pushBlock("user", { type: "tool_result", tool_use_id: co.call_id, content: co.output })
         break
       }
       case "reasoning":
@@ -244,13 +422,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   }
   if (systemParts.length > 0) result.system = systemParts.join("\n\n")
   if (Array.isArray(body.tools) && body.tools.length > 0) {
-    result.tools = body.tools
-      .filter((t) => t.type === "function")
-      .map((t): AnthropicTool => ({
-        name: t.name,
-        description: t.description ?? "",
-        input_schema: t.parameters ?? { type: "object", properties: {} },
-      }))
+    result.tools = translateResponsesTools(body.tools)
   }
   const tc = mapToolChoice(body.tool_choice)
   if (tc) result.tool_choice = tc
@@ -277,6 +449,11 @@ export interface ResponsesCtx {
    * satisfy its state machine. Set from `reasoningRequested(body)`.
    */
   reasoningRequested?: boolean
+  /**
+   * Alias table from `buildResponsesToolAliases(request.tools)`: maps Claude's
+   * tool_use names back onto Codex's `{namespace, name}` and custom tools.
+   */
+  toolAliases?: ResponsesToolAliases
 }
 
 /** Did the Responses request ask for reasoning output? */
@@ -329,14 +506,8 @@ export function translateAnthropicToResponses(res: AnthropicResponseLike, ctx: R
     if (block.type === "text" && typeof block.text === "string") {
       textParts.push({ type: "output_text", text: block.text, annotations: [] })
     } else if (block.type === "tool_use") {
-      output.push({
-        type: "function_call",
-        id: `fc_${block.id}`,
-        call_id: block.id,
-        name: block.name,
-        arguments: JSON.stringify(block.input ?? {}),
-        status: "completed",
-      })
+      const callId = String(block.id)
+      output.push(toolCallItem(ctx, `fc_${callId}`, callId, String(block.name), JSON.stringify(block.input ?? {}), "completed"))
     }
     // thinking: dropped (phase 1)
   }
@@ -419,6 +590,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
     args: string          // accumulated JSON (tool blocks)
     callId?: string
     name?: string
+    custom?: boolean      // freeform tool: no argument deltas, one done item
   }
   const blocks = new Map<number, BlockState>()
   // Completed items collected for the terminal response.completed.
@@ -489,10 +661,13 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
         } else if (cb.type === "tool_use") {
           const oi = outputIndex++
           const itemId = `fc_${cb.id}`
-          blocks.set(idx, { kind: "tool", outputIndex: oi, itemId, text: "", args: "", callId: cb.id, name: cb.name })
+          const callId = String(cb.id ?? "")
+          const name = String(cb.name ?? "")
+          const custom = ctx.toolAliases?.get(name)?.kind === "custom"
+          blocks.set(idx, { kind: "tool", outputIndex: oi, itemId, text: "", args: "", callId, name, custom })
           out.push(emit("response.output_item.added", {
             output_index: oi,
-            item: { type: "function_call", id: itemId, call_id: cb.id, name: cb.name, arguments: "", status: "in_progress" },
+            item: toolCallItem(ctx, itemId, callId, name, "", "in_progress"),
           }))
         } else {
           // thinking / unknown → skip, but track so deltas/stop are ignored.
@@ -512,9 +687,14 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
           }))
         } else if (st.kind === "tool" && event.delta?.type === "input_json_delta" && typeof event.delta.partial_json === "string") {
           st.args += event.delta.partial_json
-          out.push(emit("response.function_call_arguments.delta", {
-            item_id: st.itemId, output_index: st.outputIndex, delta: event.delta.partial_json,
-          }))
+          // A custom tool's payload is the `input` string inside Claude's JSON
+          // — it cannot be streamed as freeform deltas; Codex takes the whole
+          // item from response.output_item.done.
+          if (!st.custom) {
+            out.push(emit("response.function_call_arguments.delta", {
+              item_id: st.itemId, output_index: st.outputIndex, delta: event.delta.partial_json,
+            }))
+          }
         }
         break
       }
@@ -538,13 +718,12 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
           finalOutput.push(item)
           out.push(emit("response.output_item.done", { output_index: st.outputIndex, item }))
         } else if (st.kind === "tool") {
-          out.push(emit("response.function_call_arguments.done", {
-            item_id: st.itemId, output_index: st.outputIndex, arguments: st.args,
-          }))
-          const item = {
-            type: "function_call", id: st.itemId, call_id: st.callId, name: st.name,
-            arguments: st.args, status: "completed",
+          if (!st.custom) {
+            out.push(emit("response.function_call_arguments.done", {
+              item_id: st.itemId, output_index: st.outputIndex, arguments: st.args,
+            }))
           }
+          const item = toolCallItem(ctx, st.itemId, st.callId ?? "", st.name ?? "", st.args, "completed")
           finalOutput.push(item)
           out.push(emit("response.output_item.done", { output_index: st.outputIndex, item }))
         }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -74,7 +74,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDef
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
-import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
+import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, buildResponsesToolAliases, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { flattenAssistantContent, normalizeStructuredUserContent, replayToolResultHeader, frameStructuredReplay, coalesceStructuredUserMessages } from "./replay"
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, MULTIMODAL_TYPES, buildToolUseIndex, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
@@ -7548,7 +7548,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const responseId = `resp_${randomUUID().replace(/-/g, "")}`
     const created = Math.floor(Date.now() / 1000)
     const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : CANONICAL_SONNET_MODEL
-    const ctx = { responseId, model, created, reasoningRequested: reasoningRequested(rawBody) }
+    // Namespaced (MCP) and custom tools reach Claude under aliases; the same
+    // table turns its calls back into Codex's `{namespace, name}` items.
+    const toolAliases = buildResponsesToolAliases(rawBody.tools)
+    const ctx = { responseId, model, created, reasoningRequested: reasoningRequested(rawBody), toolAliases }
 
     if (!anthropicBody.stream) {
       const anthropicRes = await internalRes.json() as Record<string, unknown>


### PR DESCRIPTION
## Problem

Codex 0.15x (Desktop 0.153.4 captured) no longer sends MCP tools as flat `function` entries. Every MCP server arrives as one `{type:"namespace", name:"mcp__<server>", description, tools:[…]}` entry with the tool definitions nested inside, and its freeform `apply_patch` as `{type:"custom", format:{grammar}}`. `translateResponsesToAnthropic` keeps only `type:"function"`, so all of them are dropped silently: a Codex session on a Claude model sees none of its MCP servers (in the captured request, 25 top-level tools, 12 of them namespaces holding ~250 tools) and no `apply_patch`. The design spec scoped Phase 1 to function tools and this shape did not exist when it was verified against Codex 0.144.

Two more gaps surface as soon as an MCP tool is actually called:

- Codex expects the call back as `function_call {name, namespace}` (its router resolves `ToolName::new(namespace, name)`; a flattened name without `namespace` never matches), and `custom_tool_call {name, input}` for custom tools.
- `function_call_output.output` is a string for shell-style tools but an **array of content items** for MCP tools (`FunctionCallOutputBody` is an untagged `Text | ContentItems`). Passed verbatim it reaches Anthropic as `tool_result.content[0].type = "input_text"` → `400`, killing every turn after an MCP call.

## Fix

- Nested and custom tools are exposed to Claude under deterministic aliases (`<namespace>__<name>`, sanitized to `[A-Za-z0-9_-]`, hashed past Claude's 64-char limit minus the `mcp__oc__` passthrough prefix — a test pins the two constants together). Custom tools become a function with a single `input` string carrying the freeform payload; the grammar is folded into the description.
- `buildResponsesToolAliases(request.tools)` is pure and deterministic; the route builds it once and passes it in `ResponsesCtx`. Both emitters (non-stream and SSE) map an aliased `tool_use` back to `function_call {name, namespace}` or `custom_tool_call {name, namespace?, input}`; custom tools emit no `function_call_arguments.*` events (Codex takes the item from `output_item.done`). Replayed history items with a `namespace`, and `custom_tool_call` / `custom_tool_call_output`, land on the same aliases so the next turn's tool set matches its history.
- `function_call_output` content items map to `tool_result` blocks: `input_text` → text, data-URL `input_image` → image (reusing `parseDataUrlImage`), anything else → an omission note; an empty list → `""`.
- Server-side tool kinds (`web_search`) are still dropped — Claude has no client-side counterpart here.

## Verification

- `src/__tests__/openai-responses-namespaces.test.ts` (new): alias budget/sanitizing/hashing, alias table, request flattening, history replay, non-stream and SSE emitters for namespaced and custom tools, content-item outputs. Full `bun test` and `tsc --noEmit` green.
- Live: Codex Desktop 0.153.4 → Meridian → Claude calls an MCP tool (`iskron_realm` on a stdio server) and the turn completes; before the change the model had no MCP tools, and with only the first half of the change the turn after the call died with the `input_text` 400.

Deployed on a fork build since 2026-09-06. Pairs with #963 (Codex core tools for auto-defer) — without it, a Codex request with ~260 tools crosses the defer threshold with an empty core set.