### PR TITLE
fix(responses): key a Codex turn by its thread, not the parent's cache key

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -10,6 +10,7 @@ import {
   translateResponsesToAnthropic,
   translateAnthropicToResponses,
   createResponsesSseTranslator,
+  resolveCodexThreadIdentity,
 } from "../proxy/openaiResponses"
 import type { AnthropicContentBlock } from "../proxy/openai"
 
@@ -539,5 +540,100 @@ describe("createResponsesSseTranslator (stream)", () => {
     for (const e of run(textStream)) {
       expect((e.data as any).type).toBe(e.event)
     }
+  })
+})
+
+describe("resolveCodexThreadIdentity", () => {
+  // Wire shapes below are a real capture: Codex Desktop 0.144.4 sends this
+  // metadata as both a header and a `client_metadata` entry, and a subagent's
+  // rollout records the same split — own `id`, parent's `session_id`.
+  const turnMetadata = (over: Record<string, unknown>) => JSON.stringify({
+    installation_id: "66bcfba4-e581-41e3-9487-57705ef35f60",
+    session_id: "01a07829-00b2-7c23-b950-26b07808dc26",
+    thread_id: "01a07829-00b2-7c23-b950-26b07808dc26",
+    turn_id: "01a07829-00f7-7a71-82d6-6b3a2626ebc8",
+    request_kind: "turn",
+    thread_source: "user",
+    ...over,
+  })
+
+  it("falls back to prompt_cache_key when no metadata is sent", () => {
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: "conv-a" })).toEqual({ sessionKey: "conv-a" })
+  })
+
+  it("carries no identity at all when neither is sent", () => {
+    expect(resolveCodexThreadIdentity({ model: "claude-sonnet-5" })).toEqual({})
+  })
+
+  it("keys a user thread the same way prompt_cache_key did", () => {
+    const key = "01a07829-00b2-7c23-b950-26b07808dc26"
+    const identity = resolveCodexThreadIdentity({ prompt_cache_key: key }, turnMetadata({}))
+    expect(identity).toEqual({ sessionKey: key })
+  })
+
+  it("keys a subagent by its own thread, not the parent's cache key", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "01a077c4-9c1c-73d1-bddb-7887bef18554" },
+      turnMetadata({
+        session_id: "01a077c4-9c1c-73d1-bddb-7887bef18554",
+        thread_id: "01a07806-a29d-79b3-af96-876d8fa1be83",
+        thread_source: "subagent",
+      }),
+    )
+    expect(identity).toEqual({
+      sessionKey: "01a07806-a29d-79b3-af96-876d8fa1be83",
+      requestSource: "fork-codex-subagent",
+    })
+  })
+
+  it("declares a concurrent flow even when the spawned thread reuses the id", () => {
+    const shared = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: shared },
+      turnMetadata({ session_id: shared, thread_id: shared, thread_source: "subagent" }),
+    )
+    expect(identity.sessionKey).toBe(shared)
+    expect(identity.requestSource).toBe("fork-codex-subagent")
+  })
+
+  it("reads the metadata from client_metadata when the header is absent", () => {
+    const identity = resolveCodexThreadIdentity({
+      prompt_cache_key: "parent",
+      client_metadata: {
+        "x-codex-turn-metadata": turnMetadata({ thread_id: "child", thread_source: "subagent" }),
+      },
+    })
+    expect(identity).toEqual({ sessionKey: "child", requestSource: "fork-codex-subagent" })
+  })
+
+  it("prefers the header over client_metadata", () => {
+    const identity = resolveCodexThreadIdentity(
+      {
+        prompt_cache_key: "parent",
+        client_metadata: { "x-codex-turn-metadata": turnMetadata({ thread_id: "from-body" }) },
+      },
+      turnMetadata({ thread_id: "from-header" }),
+    )
+    expect(identity.sessionKey).toBe("from-header")
+  })
+
+  it("keeps the cache-key path when the metadata is unparseable", () => {
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: "conv-a" }, "{not json")).toEqual({ sessionKey: "conv-a" })
+  })
+
+  it("sanitizes an unexpected thread_source into a header-safe source", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "parent" },
+      turnMetadata({ thread_id: "child", thread_source: "Cloud Task/2" }),
+    )
+    expect(identity.requestSource).toBe("fork-codex-cloud-task-2")
+  })
+
+  it("declares nothing for a thread_source that survives sanitizing as separators only", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "parent" },
+      turnMetadata({ thread_id: "child", thread_source: "///" }),
+    )
+    expect(identity.requestSource).toBeUndefined()
   })
 })

--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -636,4 +636,44 @@ describe("resolveCodexThreadIdentity", () => {
     )
     expect(identity.requestSource).toBeUndefined()
   })
+
+  // Codex runs compaction (and title/summary/review/memory) as a side request
+  // under the SAME thread id, with no tools and the whole history. Keyed on the
+  // thread alone it lands on the conversation's session as a rewrite of it.
+  it("keys a compaction beside the thread, not on it, and declares its flow", () => {
+    const thread = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: thread },
+      turnMetadata({ thread_id: thread, request_kind: "compact" }),
+    )
+    expect(identity).toEqual({ sessionKey: `${thread}:compact`, requestSource: "fork-codex-compact" })
+  })
+
+  it("leaves a plain turn exactly as before", () => {
+    const thread = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: thread }, turnMetadata({ thread_id: thread, request_kind: "turn" })))
+      .toEqual({ sessionKey: thread })
+  })
+
+  it("treats a missing request_kind as a turn", () => {
+    const meta = JSON.parse(turnMetadata({ thread_id: "t1" }))
+    delete meta.request_kind
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: "t1" }, JSON.stringify(meta))).toEqual({ sessionKey: "t1" })
+  })
+
+  it("lets the kind name the flow when a spawned thread compacts", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "parent" },
+      turnMetadata({ thread_id: "child", thread_source: "subagent", request_kind: "compact" }),
+    )
+    expect(identity).toEqual({ sessionKey: "child:compact", requestSource: "fork-codex-compact" })
+  })
+
+  it("handles a kind Codex has not sent yet the same way", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "t1" },
+      turnMetadata({ thread_id: "t1", request_kind: "Memory Extract" }),
+    )
+    expect(identity).toEqual({ sessionKey: "t1:memory-extract", requestSource: "fork-codex-memory-extract" })
+  })
 })

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -243,3 +243,80 @@ describe("/v1/responses session continuity via prompt_cache_key (#655)", () => {
     expect(capturedOptions[1].resume).toBeUndefined()
   })
 })
+
+describe("/v1/responses keeps a spawned Codex thread out of its parent's session", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedOptions = []
+  })
+
+  const parentKey = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+  const childThread = "01a07806-a29d-79b3-af96-876d8fa1be83"
+
+  const userItem = {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "Read data.txt and count the lines." }],
+  }
+  const loopTurnInput = [
+    userItem,
+    { type: "function_call", name: "exec_command", arguments: '{"cmd":"wc -l data.txt"}', call_id: "toolu_test_1" },
+    { type: "function_call_output", call_id: "toolu_test_1", output: "3 data.txt" },
+  ]
+
+  // Codex Desktop hands a spawned subagent the parent's prompt_cache_key, so
+  // the key alone cannot tell two live conversations apart. Its turn metadata
+  // can: the thread id is the subagent's own.
+  const clientMetadata = (thread: string, source: string) => ({
+    "x-codex-turn-metadata": JSON.stringify({
+      session_id: parentKey,
+      thread_id: thread,
+      turn_id: "01a07829-00f7-7a71-82d6-6b3a2626ebc8",
+      request_kind: "turn",
+      thread_source: source,
+    }),
+  })
+
+  it("gives the subagent its own SDK session and leaves the parent's resumable", async () => {
+    const app = createTestApp()
+    const parentTurn = (input: unknown) => postResponses(app, {
+      model: "claude-sonnet-5",
+      input,
+      stream: false,
+      prompt_cache_key: parentKey,
+      client_metadata: clientMetadata(parentKey, "user"),
+    })
+
+    expect((await parentTurn([userItem])).status).toBe(200)
+    const subagent = await postResponses(app, {
+      model: "claude-sonnet-5",
+      input: [userItem],
+      stream: false,
+      prompt_cache_key: parentKey,
+      client_metadata: clientMetadata(childThread, "subagent"),
+    })
+    expect(subagent.status).toBe(200)
+    expect((await parentTurn(loopTurnInput)).status).toBe(200)
+
+    expect(capturedOptions).toHaveLength(3)
+    // The subagent starts its own conversation rather than rebinding the key…
+    expect(capturedOptions[1].resume).toBeUndefined()
+    expect(capturedOptions[1].sessionId).not.toBe(capturedOptions[0].sessionId)
+    // …so the parent's next turn still resumes the session it left.
+    expect(capturedOptions[2].resume).toBe(capturedOptions[0].sessionId)
+  })
+
+  it("keeps resuming a user thread that sends turn metadata", async () => {
+    const app = createTestApp()
+    const body = (input: unknown) => ({
+      model: "claude-sonnet-5",
+      input,
+      stream: false,
+      prompt_cache_key: parentKey,
+      client_metadata: clientMetadata(parentKey, "user"),
+    })
+    await postResponses(app, body([userItem]))
+    await postResponses(app, body(loopTurnInput))
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
+  })
+})

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -89,6 +89,98 @@ export interface ResponsesRequest {
 }
 
 // ---------------------------------------------------------------------------
+// Codex thread identity
+// ---------------------------------------------------------------------------
+
+/** What one Codex turn says about the conversation it belongs to. */
+export interface CodexThreadIdentity {
+  /** Conversation key for session resume — the codex adapter's `x-codex-session`. */
+  sessionKey?: string
+  /** Concurrency declaration for a turn that is not the thread the user drives. */
+  requestSource?: string
+}
+
+/** The fields of Codex's turn metadata this route reads. */
+interface CodexTurnMetadata {
+  thread_id?: unknown
+  session_id?: unknown
+  thread_source?: unknown
+}
+
+/** Codex sends this both as a request header and inside `client_metadata`. */
+const CODEX_TURN_METADATA = "x-codex-turn-metadata"
+
+/** Longest `thread_source` tag echoed into a request source. */
+const CODEX_THREAD_SOURCE_MAX = 24
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function parseCodexTurnMetadata(value: unknown): CodexTurnMetadata | undefined {
+  if (value && typeof value === "object") return value as CodexTurnMetadata
+  const raw = nonEmptyString(value)
+  if (!raw) return undefined
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === "object" ? parsed as CodexTurnMetadata : undefined
+  } catch {
+    // A client that garbles its own metadata still gets the cache-key path.
+    return undefined
+  }
+}
+
+function codexTurnMetadataFromBody(body: ResponsesRequest): unknown {
+  const metadata = body.client_metadata
+  if (!metadata || typeof metadata !== "object") return undefined
+  return (metadata as Record<string, unknown>)[CODEX_TURN_METADATA]
+}
+
+/**
+ * Reads the conversation identity Codex attaches to a turn.
+ *
+ * `prompt_cache_key` was the only identity this route had (#655), and for the
+ * thread a user drives it is exactly that thread's id. A subagent is the case
+ * it cannot describe: Codex Desktop spawns one as its own thread, with its own
+ * instructions and its own tools, and hands it the *parent's*
+ * `prompt_cache_key`. Keyed on that alone two live conversations become one
+ * session — the subagent's first turn rebinds the key to its own SDK session,
+ * and the parent's next turn then reads as a rewrite of it: refused as a
+ * concurrent conflict when it loses the session-turn race, replayed from
+ * scratch when it wins.
+ *
+ * `x-codex-turn-metadata` names the thread itself, so the thread id is the
+ * honest key: identical to `prompt_cache_key` for a user thread — this
+ * re-anchors no existing session — and distinct for every spawned one.
+ * `thread_source` carries the same fact independently, so a turn from a
+ * spawned thread also declares a concurrent flow and is admitted rather than
+ * refused should a client ever reuse one id across flows. `fork-` and not
+ * `subagent-`: the tier a Codex subagent runs on is the client's choice, and
+ * a concurrency declaration must not silently rewrite it.
+ */
+export function resolveCodexThreadIdentity(
+  body: ResponsesRequest,
+  metadataHeader?: string,
+): CodexThreadIdentity {
+  const metadata = parseCodexTurnMetadata(metadataHeader)
+    ?? parseCodexTurnMetadata(codexTurnMetadataFromBody(body))
+  const identity: CodexThreadIdentity = {}
+
+  const sessionKey = nonEmptyString(metadata?.thread_id) ?? nonEmptyString(body.prompt_cache_key)
+  if (sessionKey) identity.sessionKey = sessionKey
+
+  const threadSource = nonEmptyString(metadata?.thread_source)
+  if (threadSource && threadSource !== "user") {
+    const tag = threadSource
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .slice(0, CODEX_THREAD_SOURCE_MAX)
+    if (tag.replace(/-/g, "")) identity.requestSource = `fork-codex-${tag}`
+  }
+
+  return identity
+}
+// ---------------------------------------------------------------------------
 // Request translation: Responses → Anthropic
 // ---------------------------------------------------------------------------
 

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -105,16 +105,26 @@ interface CodexTurnMetadata {
   thread_id?: unknown
   session_id?: unknown
   thread_source?: unknown
+  request_kind?: unknown
 }
 
 /** Codex sends this both as a request header and inside `client_metadata`. */
 const CODEX_TURN_METADATA = "x-codex-turn-metadata"
 
-/** Longest `thread_source` tag echoed into a request source. */
+/** Longest `thread_source` / `request_kind` tag echoed into a key or source. */
 const CODEX_THREAD_SOURCE_MAX = 24
+
+/** The one `request_kind` that IS the conversation; every other kind rides beside it. */
+const CODEX_TURN_KIND = "turn"
 
 function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+/** A Codex tag reduced to what a header and a session key may carry. */
+function codexTag(value: string): string | undefined {
+  const tag = value.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, CODEX_THREAD_SOURCE_MAX)
+  return tag.replace(/-/g, "") ? tag : undefined
 }
 
 function parseCodexTurnMetadata(value: unknown): CodexTurnMetadata | undefined {
@@ -157,6 +167,16 @@ function codexTurnMetadataFromBody(body: ResponsesRequest): unknown {
  * refused should a client ever reuse one id across flows. `fork-` and not
  * `subagent-`: the tier a Codex subagent runs on is the client's choice, and
  * a concurrency declaration must not silently rewrite it.
+ *
+ * `request_kind` is the third signal. Codex runs side requests against the
+ * same thread id — `compact` carries the whole history with no tools to
+ * summarise it, and the binary also names `title`, `summary`, `review`,
+ * `memory` — and none of them is the conversation: keyed on the thread alone
+ * a compaction lands on the conversation's session as a rewrite of it.
+ * Observed live: a 379-message `compact` under a live thread's key. Any kind
+ * other than `turn` therefore gets its own key beside the thread's and
+ * declares its own flow; a kind Codex has not sent yet is handled the same
+ * way, since the property that matters — not being the turn — is shared.
  */
 export function resolveCodexThreadIdentity(
   body: ResponsesRequest,
@@ -166,17 +186,17 @@ export function resolveCodexThreadIdentity(
     ?? parseCodexTurnMetadata(codexTurnMetadataFromBody(body))
   const identity: CodexThreadIdentity = {}
 
-  const sessionKey = nonEmptyString(metadata?.thread_id) ?? nonEmptyString(body.prompt_cache_key)
-  if (sessionKey) identity.sessionKey = sessionKey
+  const threadKey = nonEmptyString(metadata?.thread_id) ?? nonEmptyString(body.prompt_cache_key)
+
+  const kind = nonEmptyString(metadata?.request_kind)
+  const kindTag = kind && kind !== CODEX_TURN_KIND ? codexTag(kind) : undefined
+
+  if (threadKey) identity.sessionKey = kindTag ? `${threadKey}:${kindTag}` : threadKey
 
   const threadSource = nonEmptyString(metadata?.thread_source)
-  if (threadSource && threadSource !== "user") {
-    const tag = threadSource
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, "-")
-      .slice(0, CODEX_THREAD_SOURCE_MAX)
-    if (tag.replace(/-/g, "")) identity.requestSource = `fork-codex-${tag}`
-  }
+  const sourceTag = threadSource && threadSource !== "user" ? codexTag(threadSource) : undefined
+  const flow = kindTag ?? sourceTag
+  if (flow) identity.requestSource = `fork-codex-${flow}`
 
   return identity
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -74,7 +74,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDef
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
-import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
+import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, resolveCodexThreadIdentity, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { flattenAssistantContent, normalizeStructuredUserContent, replayToolResultHeader, frameStructuredReplay, coalesceStructuredUserMessages } from "./replay"
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, MULTIMODAL_TYPES, buildToolUseIndex, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
@@ -7518,15 +7518,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       "Content-Type": "application/json",
       "x-meridian-agent": "codex",
     }
-    // NOTE: agent-specific (Codex) — prompt_cache_key is Codex's stable
-    // per-conversation id (mirrored as session_id in its client_metadata).
-    // Forward it as the codex adapter's session header so consecutive turns
+    // NOTE: agent-specific (Codex) — the thread this turn belongs to.
+    // Forwarded as the codex adapter's session header so consecutive turns
     // resume the same SDK session: Claude's signed thinking then persists
-    // across turns natively and the prompt cache stays warm (#655).
-    const promptCacheKey = (rawBody as { prompt_cache_key?: unknown }).prompt_cache_key
-    if (typeof promptCacheKey === "string" && promptCacheKey.length > 0) {
-      internalHeaders["x-codex-session"] = promptCacheKey
-    }
+    // across turns natively and the prompt cache stays warm (#655). A turn
+    // from a spawned thread also declares its own concurrent flow, because a
+    // subagent inherits its parent's `prompt_cache_key` — see
+    // resolveCodexThreadIdentity for what each signal answers.
+    const codexThread = resolveCodexThreadIdentity(rawBody, c.req.header("x-codex-turn-metadata"))
+    if (codexThread.sessionKey) internalHeaders["x-codex-session"] = codexThread.sessionKey
+    if (codexThread.requestSource) internalHeaders["x-meridian-source"] = codexThread.requestSource
     const xApiKey = c.req.header("x-api-key")
     if (xApiKey) internalHeaders["x-api-key"] = xApiKey
     const authz = c.req.header("authorization")


### PR DESCRIPTION
## What breaks today

Codex Desktop spawns a subagent as its own thread — own instructions, own tools, own conversation — but hands it the **parent's `prompt_cache_key`**. Since #655 that key is the whole identity `/v1/responses` has, so two live conversations land on one session key: the subagent's first turn rebinds the key to its own SDK session, and the parent's next turn then reads as a rewrite of it.

Observed live on Codex Desktop 0.144.4 against a Claude Max pool:

```
18:40:51  c602aaff  lineage=continuation  tools=226  msgCount=137   (46s, ok)
18:41:38  17889774  lineage=new           tools=91   msgCount=1     sessionWait=483ms
18:41:38  17889774  SESSION RECOVERY: previous conversation available. Run: claude --resume 032a5a78
18:41:45  58dce5f6  lineage=diverged                 msgCount=139   sessionWait=6360ms → 400
```

The `msgCount=1`/`tools=91` turn is the subagent; `032a5a78` is the SDK session the parent had just used, which is how the shared key shows up server-side. The parent's next turn queued 6.4s behind it, lost the session-turn race and was refused with *"This session advanced while the request was waiting."* When it wins the race instead, the outcome is quieter but worse: each side replays the full conversation into a fresh session at 0% cache.

The same shape has a second door: Codex runs **compaction** (`request_kind: compact`) as a request against the same thread id, with the whole history and no tools — its binary also names `title`, `summary`, `review`, `memory`. Keyed on the thread alone, a compaction lands on the live conversation's session as a rewrite of it; the conversation's next real turn then reads as `undo` and starts a fresh session at 0% cache. Reproduced through the gateway with a compaction-shaped request between two turns.

## The fix

Codex sends `x-codex-turn-metadata` both as a request header and inside `client_metadata`, and it names the thread and the request:

```json
{"session_id":"01a077c4-…","thread_id":"01a07806-…","thread_source":"subagent","request_kind":"turn"}
```

Three signals, each independently sufficient for its case:

- **`thread_id` keys the session.** For a thread the user drives it equals `prompt_cache_key`, so no existing session is re-anchored by this change; for a spawned thread it is distinct, which is exactly the case the cache key cannot express.
- **`thread_source` declares a concurrent flow** (`x-meridian-source: fork-codex-<source>`), so a spawned turn is admitted rather than refused even if a client ever reuses one id across flows.
- **`request_kind` other than `turn` gets its own key beside the thread's** (`<thread>:<kind>`) and declares its own flow (`fork-codex-<kind>`), so a compaction neither queues on the conversation's lease nor rebinds its session. A kind Codex has not sent yet is handled identically — the property that matters, not being the turn, is shared. A plain turn is keyed exactly as before.

`fork-` and not `subagent-` is deliberate: which tier a Codex subagent runs on is the client's choice, and a concurrency declaration must not silently rewrite the model mapping.

Clients that send no metadata (Codex ≤ 0.14x, anything else on this route) keep the `prompt_cache_key` path unchanged.

## Tests

- `resolveCodexThreadIdentity` unit tests in `openai-responses.test.ts` — header/body precedence, user vs. subagent thread, unparseable metadata, `thread_source` sanitizing, `request_kind` compact/turn/missing/unknown.
- `proxy-responses-endpoint.test.ts` — parent turn, subagent turn, parent turn again: the subagent gets its own SDK session and the parent still resumes the one it left; a user thread that sends metadata keeps resuming as before.
