### PR TITLE
fix(responses): keep a mid-conversation developer message out of the system prompt

### DIFF
--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -40,6 +40,66 @@ describe("translateResponsesToAnthropic", () => {
     expect(r.messages[0]!.role).toBe("user")
   })
 
+  // Anthropic caches the prompt as one prefix, tools → system → messages.
+  // A developer message that appears mid-conversation and gets folded into
+  // `system` rewrites the system block on the turn it first shows up and
+  // invalidates the entire cached history behind it. Observed live with
+  // Codex's `<image_resize_notice>`: 240k–584k tokens re-written per image.
+  it("keeps a mid-conversation developer message in the history, not in system", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      instructions: "You are Codex.",
+      input: [
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "House rules." }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "look at the picture" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "Looking." }] },
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "<image_resize_notice>resized</image_resize_notice>" }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "and now?" }] },
+      ],
+    })!
+    expect(r.system).toBe("You are Codex.\n\nHouse rules.")
+    expect(r.system).not.toContain("image_resize_notice")
+    expect(r.messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "look at the picture" }] },
+      { role: "assistant", content: [{ type: "text", text: "Looking." }] },
+      { role: "user", content: [
+        { type: "text", text: "<image_resize_notice>resized</image_resize_notice>" },
+        { type: "text", text: "and now?" },
+      ] },
+    ])
+  })
+
+  it("files a tool result ahead of a developer note that landed between two outputs", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "function_call", name: "a", arguments: "{}", call_id: "c1" },
+        { type: "function_call", name: "b", arguments: "{}", call_id: "c2" },
+        { type: "function_call_output", call_id: "c1", output: "one" },
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "<image_resize_notice/>" }] },
+        { type: "function_call_output", call_id: "c2", output: "two" },
+      ],
+    })!
+    const last = r.messages[r.messages.length - 1]!
+    expect(last.role).toBe("user")
+    const blocks = Array.isArray(last.content) ? last.content : []
+    expect(blocks.map((b) => b.type)).toEqual(["tool_result", "tool_result", "text"])
+  })
+
+  it("still folds a system-role item that opens the conversation", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { role: "system", content: "Be terse." },
+        { role: "developer", content: "And polite." },
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    })!
+    expect(r.system).toBe("Be terse.\n\nAnd polite.")
+    expect(r.messages).toHaveLength(1)
+  })
+
   // Bare `{role, content}` items are spec-valid and sent by the Vercel AI SDK.
   it("treats input items without a type as messages", () => {
     const r = translateResponsesToAnthropic({

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -178,8 +178,10 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
       ? [{ type: "message", role: "user", content: [{ type: "input_text", text: body.input }] }]
       : body.input
 
-  // System: instructions + any developer/system-role messages folded in
-  // (Codex's harness rules arrive as developer turns).
+  // System: instructions + the developer/system-role messages that PRECEDE
+  // the conversation (Codex's harness rules arrive as leading developer
+  // turns). A developer message that arrives mid-history stays in the
+  // history — see the `message` case for why.
   const systemParts: string[] = []
   if (body.instructions) systemParts.push(body.instructions)
 
@@ -187,11 +189,25 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   const pushBlock = (role: "user" | "assistant", block: AnthropicContentBlock) => {
     const last = messages[messages.length - 1]
     if (last && last.role === role && Array.isArray(last.content)) {
-      last.content.push(block)
+      // A tool_result must lead its user message. An inlined developer note
+      // can land between two tool outputs of one batch, so a result arriving
+      // after text is filed ahead of the text rather than behind it.
+      if (block.type === "tool_result") {
+        const firstText = last.content.findIndex(b => b.type !== "tool_result")
+        if (firstText === -1) last.content.push(block)
+        else last.content.splice(firstText, 0, block)
+      } else {
+        last.content.push(block)
+      }
     } else {
       messages.push({ role, content: [block] })
     }
   }
+
+  // Whether a conversation item (user, assistant, tool call or result) has
+  // been seen yet; developer/system items before that are the harness
+  // preamble, developer items after it are events inside the conversation.
+  let conversationStarted = false
 
   for (const item of items) {
     // NOTE: this switches on a COMPUTED discriminator, not on `item.type`, so
@@ -202,9 +218,28 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         const msg = item as ResponsesMessageItem
         if (msg.role === "developer" || msg.role === "system") {
           const t = partsToText(msg.content)
-          if (t) systemParts.push(t)
+          if (!t) break
+          if (!conversationStarted) {
+            systemParts.push(t)
+            break
+          }
+          // Anthropic caches the prompt as one prefix in the order
+          // tools → system → messages. Folding a developer message that
+          // appeared mid-conversation into `system` rewrites the system
+          // block on the turn it first shows up, which invalidates every
+          // cached token past the tools — the entire history. Codex emits
+          // exactly such messages as ordinary events: `<image_resize_notice>`
+          // after every image, `<model_switch>` on a model change,
+          // `<app-context>` when the app refreshes. Observed live: every
+          // cache collapse in a long thread (14 of 14, 240k–584k tokens
+          // re-written each) followed one of these by one to three seconds,
+          // with the tools block the only part still hitting. Kept in the
+          // history at its own position, the note is just another message:
+          // the prefix before it stays cached and the turn costs its size.
+          pushBlock("user", { type: "text", text: t })
           break
         }
+        conversationStarted = true
         const role = msg.role === "assistant" ? "assistant" : "user"
         const imageBlocks = partsToBlocks(msg.content)
         if (imageBlocks) {
@@ -216,6 +251,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         break
       }
       case "function_call": {
+        conversationStarted = true
         const fc = item as ResponsesFunctionCallItem
         let input: Record<string, unknown> = {}
         try { input = fc.arguments ? JSON.parse(fc.arguments) : {} } catch { input = {} }
@@ -223,6 +259,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         break
       }
       case "function_call_output": {
+        conversationStarted = true
         const fo = item as ResponsesFunctionCallOutputItem
         pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: fo.output })
         break


### PR DESCRIPTION
## What breaks today

Anthropic caches the prompt as one prefix in the order **tools → system → messages**. `/v1/responses` folds every `developer`/`system` item into the Anthropic `system` prompt, wherever it sits in the input. So a developer message that first appears mid-conversation rewrites the system block on that turn and invalidates every cached token behind the tools — the entire history.

Codex emits exactly such messages as ordinary conversation events: `<image_resize_notice>` after every `view_image`, `<model_switch>` and `<collaboration_mode>` on a model change, `<app-context>` when the app refreshes. On a long Codex Desktop thread against a Claude Max pool, every cache collapse over a day — 14 of 14 — followed one of these by one to three seconds, with the tools block (~125k) the only part still hitting and 240k–584k tokens re-written each time:

```
20:16:18  b5701fe5  msgs=343  cache=100%  read=697k  write=434
20:16:26  d7eb087d  msgs=345  cache=18%   read=125k  write=575k   <-- 2s after <image_resize_notice>
20:16:57  0e068f2a  msgs=347  cache=100%  read=700k  write=1k
```

An A/B through the proxy reproduces it: two identical conversations, the second turn of one carrying a developer note in the history.

```
A control      msgs=3  continuation  cache_read=30k  cache_write=58   cache=100%
B developer    msgs=3  continuation  cache_write=30k                  cache=0%
```

## The fix

A developer/system item that **precedes** the conversation is still the harness preamble and still folds into `system`. One that arrives **after** the conversation has started stays in the history as a user text block at its own position — the prefix before it remains cached and the turn costs only the note's own size. Codex replays the item at the same position on every later turn, so the placement is stable.

A tool result that lands in the same user message is filed ahead of the note, since tool results must lead their message (a developer note can fall between two outputs of one batch).

After the change the same A/B hits 100% on both sides.

## Tests

`openai-responses.test.ts`: leading developer/system items still fold (existing tests unchanged); a mid-conversation developer item is inlined at its position and absent from `system`; a tool result arriving after an inlined note is filed ahead of it.
