### PR TITLE
docs: codify upstream review and agent handoff workflow

### DIFF
--- a/.agents/skills/meridian-upstream-review/SKILL.md
+++ b/.agents/skills/meridian-upstream-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: meridian-upstream-review
+description: Review and incorporate Meridian contributor PRs and issues, validate maintainer fixes with real E2E, prepare authorized releases, and resume the review backlog from its checked-in handoff.
+---
+
+# Meridian upstream review
+
+Use this workflow for Meridian PR/issue review and incorporation, an authorized release, or resuming that work. For unrelated tasks, follow AGENTS.md without starting this queue. This skill defines how to perform authorized work; it does not authorize extra merges, releases, messages, delegation or concurrent agents.
+
+Read [AGENTS.md](../../../AGENTS.md) for repository constraints. When continuing earlier work, read [REVIEW_HANDOFF.md](../../../docs/maintenance/REVIEW_HANDOFF.md) first, then refresh live GitHub state. Current user instructions override older memory and checkpoint text. Do not require a private chat, Codex goal, or personal memory directory to proceed.
+
+## Decide whether the change belongs
+
+1. Refresh origin/main and the live PR/issue inventory before selecting work. Record base SHA, contributor head SHA, linked issue, author and authored date. Read the full diff and neighboring code. CI status and PR descriptions are evidence inputs, not approval.
+2. Confirm the reported behavior on current main and explain the desired behavior. Assess scope, architecture, stable API compatibility, session/history integrity, cache behavior, error handling, concurrency, affected clients and platforms. A requested feature is not automatically a desirable change.
+3. Give each item an explicit disposition: accept as proposed, accept with maintainer corrections, superseded with linked evidence, defer pending a decision/environment, or decline with a concrete reason. Do not merge merely to clear the queue.
+
+## Preserve authorship while fixing it ourselves
+
+- Use a fresh isolated worktree and a `codex/` feature branch based on fetched origin/main unless the owner explicitly chose another branch name. Do not switch or reset the user's checkout, reuse an old delivery branch blindly, or disturb existing worktrees.
+- Cherry-pick the contributor's actual commits, preserving Author and AuthorDate; use the repository's signing setup. Record original-to-incorporated SHA mappings. Resolve conflicts against current behavior, then put maintainer corrections in separate commits. Never retype the contribution and claim it as new maintainer work.
+- Create a maintainer integration PR targeting main that credits the original author, links the source PR and issue, explains the final behavior and provides validation evidence. Follow Conventional Commits; no AI attribution.
+- Normal implementation PRs use squash merging to keep Release Please's changelog to one entry per PR. Confirm the original contributor receives credit on the resulting commit; preserve the source/cherry-pick authorship evidence in the review ledger. Do not assume an unrelated maintainer PR necessarily auto-generates every needed human co-author trailer. If explicit human credit is needed, use only verified contributor identities and avoid conventional-commit subjects in the squash body.
+- Repository settings verified 2026-09-08: PR_TITLE / BLANK. Do not bypass checks with routine `--admin`, force-push a contributor branch, push directly to main, or change those settings.
+
+## Prove the fix and protect existing behavior
+
+- Reproduce the actual defect before changing it whenever possible. Retain failed-before and passed-after evidence for the same meaningful assertion. A changed fixture or reduced assertion must be explained; an unreproduced bug stays explicitly unproven.
+- Run targeted pure/unit tests and HTTP integration tests through the mocked SDK where appropriate. The full gate is `npm test`, not a bare all-files `bun test`: the npm script isolates process-global SDK/module mocks. Also run `npm run typecheck` and `npm run build`.
+- Every accepted behavior change requires live E2E with the real SDK/model and affected client flow before it is called complete. Mocks alone do not prove a fix. Consult current [E2E.md](../../../E2E.md); use the exact installed client/SDK/CLI versions and record them, flags, model, workdir, artifact, exit status and log path.
+- For changes to passthrough, lineage, resume, tool hooks, or request identity, run all four E41 modes: sequential/parallel × streaming/nonstreaming. Check exact call/result pairing, durable resume/fork history, unchanged source history and cache continuity. For relevant V2 changes run E42 with each supported pinned beta, live extended flows and separate client/proxy working directories. Test both source and independently installed package when packaging/plugin behavior is involved.
+- Include adversarial controls: ordinary success, invalid inputs, retry bounds, cancellation, concurrent sessions, changed requests and retained tool results as relevant. Test the actual implicated model and platform; Haiku success is not Opus validation, and POSIX path fixtures are not a real Windows run.
+- Use isolated ports, config/session directories and fixture workdirs. Keep credentials and customer transcripts out of logs. Inspect SDK sessions only through supported APIs such as getSessionMessages/listSessions; never read or edit private SDK transcript files. Preserve failed logs as well as passing logs.
+- Do not call a flaky failure fixed because a rerun passes. Establish causality, otherwise retain an unresolved status and its limitation. If actual E2E is unavailable, record the missing requirement and leave the item incomplete rather than substituting mocks.
+- Aim for no regressions and only useful improvements; state the evidence and remaining uncertainty instead of promising universal absence of bugs.
+
+## Merge only what was validated
+
+- Finish all local required gates, push the integration branch and wait for all relevant final-head CI checks. Any source change, rebase or changed base requires impact-appropriate revalidation; obsolete green runs do not validate a new head.
+- Immediately before merge, re-read PR head/base and merge state. Use `--match-head-commit` with the verified head. Normal PRs use `--squash`; Release Please PRs use `--merge`. Confirm the merged tree corresponds to the validated tree.
+- After successful integration, recheck the original contributor PR head before closing it as incorporated. Do not discard new contributor commits that arrived during review. Close linked issues only when the evidence supports their resolution.
+- Do not post GitHub comments, email, Slack or other messages to people without explicit authorization. Draft any explanation locally. PR creation/editing and authorized integration are separate from permission to send community messages.
+
+## Release
+
+For an authorized release, read [references/release.md](references/release.md).
+A backlog review does not itself authorize a release.
+
+## Checkpoint and hand off
+
+Update [docs/maintenance/REVIEW_HANDOFF.md](../../../docs/maintenance/REVIEW_HANDOFF.md) as the portable checkpoint and keep per-item evidence in the PR or a linked review record. Local logs can supplement these records but must not be the only way another agent learns the status. Record item/disposition, original and delivery commits, author mapping, worktree, changes, commands, before/after failures, E2E versions, CI links, merge/closure status, known limitations and the next action. Keep historical logs, but replace contradictory status in the current handoff.
+
+The owner may pause after the current ticket. Finish only that ticket, save a checkpoint and stop. A handoff to another agent is not authority for two agents to resume the same queue concurrently. On continuation, the receiving agent refreshes GitHub and chooses one bounded item using this process. Do not treat a release as completion of the whole backlog.

--- a/.agents/skills/meridian-upstream-review/references/release.md
+++ b/.agents/skills/meridian-upstream-review/references/release.md
@@ -1,0 +1,9 @@
+# Release validation
+
+
+A release needs owner authorization; do not publish simply because a batch finished. Verify the previous tag/changelog range and the release PR's exact diff. Run the full suite, type/build, relevant real E2E and independently installed npm-pack gates. Wait for candidate CI, then merge the exact release head with `gh pr merge <N> --merge --match-head-commit <SHA>`.
+
+Never run manual npm version, tag pushes or npm publish. Do not routinely use --admin or publish_only. If automation fails, investigate the actual failure rather than treating E403 as proof that the correct artifact shipped. After merging, verify Release Please, the GitHub release/tag and commit, npm version/latest/integrity/provenance, a fresh registry install with real affected flow, and Docker version tags/architectures. Keep publication evidence.
+
+
+Record the exact candidate and merge SHAs, test/E2E versions and logs, workflow URLs, registry integrity/provenance and final publication outcome in the handoff or linked review record. A stopped agent must be able to distinguish “PR merged,” “publication running,” and “published and installed-package validated.”

--- a/.claude/skills/meridian-upstream-review/SKILL.md
+++ b/.claude/skills/meridian-upstream-review/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: meridian-upstream-review
+description: Review Meridian contributor PRs and issues, validate fixes with real E2E, prepare authorized releases, and resume the checked-in review handoff.
+---
+
+# Meridian upstream review
+
+Read and follow the canonical repository skill at
+[.agents/skills/meridian-upstream-review/SKILL.md](../../../.agents/skills/meridian-upstream-review/SKILL.md)
+before acting. Resolve its supporting references relative to that canonical file.
+It is the shared workflow for Claude, Codex and other repository agents; do not
+maintain a second copy here or substitute private memory for it.

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,15 @@ context.md
 apps/desktop/src-tauri/target/
 apps/desktop/src-tauri/target/
 
-# Local agent tooling (per-developer; never commit)
-.claude/
+# Share only the repository skill entrypoint; keep local agent state private.
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/meridian-upstream-review/
+.claude/skills/meridian-upstream-review/*
+!.claude/skills/meridian-upstream-review/SKILL.md
+
+# Other local agent tooling (per-developer; never commit)
 .pylon/
 .junie/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,21 @@
 
 Project guidelines for AI agents working in this codebase.
 
+## Repository skills and continuation
+
+For contributor PR/issue reviews, maintainer fixes to those contributions,
+authorized releases, or resuming this backlog, read and follow
+[meridian-upstream-review](.agents/skills/meridian-upstream-review/SKILL.md)
+before acting. Claude also has a discovery entrypoint in `.claude/skills/`;
+both use the same canonical instructions.
+
+For continuation, read [the current review handoff](docs/maintenance/REVIEW_HANDOFF.md),
+then refresh GitHub and origin/main. Update that handoff at a meaningful stop or
+handoff point. Do not rely on personal memories, old chat summaries, or a goal
+runner's status to decide what shipped or what remains. User instructions take
+precedence; this workflow does not start the backlog or authorize external
+actions by itself.
+
 ## What This Is
 
 A proxy that bridges OpenCode (Anthropic API format) to Claude Max (Agent SDK). See `ARCHITECTURE.md` for the full module map and dependency rules.
@@ -9,10 +24,14 @@ A proxy that bridges OpenCode (Anthropic API format) to Claude Max (Agent SDK). 
 ## Commands
 
 ```bash
-npm test          # Run all tests (bun test)
-npm run build     # Build with tsup
+npm test          # Full suite with process-global mocks isolated
+npm run build     # Bundle with Bun, emit declarations and check Node entrypoints
 npm start         # Start the proxy server
+npm run typecheck # tsc --noEmit; tests do not typecheck
 ```
+
+Use `npm test` for the full suite, not bare `bun test`: the npm script runs
+process-global mock users in separate Bun invocations.
 
 ## Code Rules
 
@@ -38,7 +57,7 @@ OpenCode-specific behavior is documented in `ARCHITECTURE.md` under "Agent-Speci
 - Integration tests go through the HTTP layer with mocked SDK
 - **All tests must pass before any change is considered complete**
 - New test files go in `src/__tests__/`
-- **E2E tests** are documented in [`E2E.md`](./E2E.md) — run manually before releases or after major refactors (requires Claude Max subscription)
+- **Live E2E is required for every accepted behavior change and before releases**, using the real SDK/model and affected client flow. See [`E2E.md`](./E2E.md) and the upstream-review skill. Mock-only tests, a different model/platform, or a green rerun do not prove the reported problem fixed.
 
 ### Style
 
@@ -102,41 +121,42 @@ If you need to modify any of these, open an issue first — breaking changes aff
 
 ### Development workflow — NEVER push directly to main
 
-All changes go through this process, no exceptions:
+1. Use a feature branch from current main, preferably in a fresh isolated
+   worktree, preserving the user's checkout. For upstream reviews, use the
+   repository skill above to assess desirability and preserve contributor
+   Author/AuthorDate through cherry-picks and separate maintainer corrections.
+2. Commit, push the feature branch, and create a PR targeting main. Use
+   Conventional Commits and describe the final behavior and validation.
+3. Run the required local checks and affected-flow live E2E, then wait for all
+   relevant final-head CI checks, including `test`. Recheck the head, base and
+   merge state immediately before merging; a changed head invalidates old checks.
+4. Normal PRs use `gh pr merge <N> --squash --match-head-commit <verified-SHA>`.
+   Delete only branches owned by this workflow after they are no longer needed.
+   Release Please PRs use `--merge` instead.
+5. Verify the merged tree and contributor credit. Recheck an incorporated
+   original PR's head before closing it, so newer contributor work is not lost.
+   Only close an issue when the validated behavior actually resolves it.
 
-1. **Create a feature branch** from `main`:
-   ```bash
-   git checkout -b feat/my-feature main
-   ```
+Squash keeps changelog entries one per PR. Preserve repository settings
+`squash_merge_commit_title=PR_TITLE` and `squash_merge_commit_message=BLANK`;
+do not paste intermediate conventional-commit subjects into the squash body.
+Verify human contributor credit instead of assuming every maintainer integration
+PR automatically receives all needed co-author trailers. No AI attribution.
 
-2. **Make changes, commit, push the branch:**
-   ```bash
-   git add -A && git commit -m "feat: my feature"
-   git push origin feat/my-feature
-   ```
+Signed-commit requirements can block a contributor PR. Inspect the actual block;
+use an authored cherry-pick in a maintainer integration PR when needed, with
+separate maintainer fixes. Never retype a contribution under your own authorship.
+Do not routinely use `--admin` or bypass checks.
 
-3. **Create a PR** targeting `main`:
-   ```bash
-   gh pr create --title "feat: my feature" --base main
-   ```
-
-4. **Wait for CI** — the `test` job must pass before merging:
-   ```bash
-   gh pr checks <PR_NUMBER>
-   ```
-
-5. **Merge the PR** (squash merge preferred):
-   ```bash
-   gh pr merge <PR_NUMBER> --squash --delete-branch
-   ```
-
-6. **Never** run `git push origin main` directly — all code reaches `main` through merged PRs only.
+Do not post comments or send messages to others without explicit authorization;
+draft explanations locally. Never run `git push origin main` directly.
 
 ## Releasing
 
 **Do NOT run `npm version`, `git push --tags`, or `npm publish` manually.**
 
-Releases are handled automatically by [Release Please](https://github.com/googleapis/release-please):
+For release validation and publication verification, follow the repository skill
+above and its release reference. Releases are handled automatically by [Release Please](https://github.com/googleapis/release-please):
 
 1. Merge PRs to `main` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
 2. Release Please auto-creates/updates a release PR that batches all unreleased changes
@@ -155,8 +175,8 @@ Multiple PRs get batched into a single release. Never publish manually.
 ### Troubleshooting releases
 
 - **Changelog shows entire history?** — Release Please can't find the previous release tag. Check that `meridian-v<version>` tags exist for recent releases: `git tag -l 'meridian-v*' | tail -5`
-- **Release PR not updating?** — It only updates on `push` to `main`. If you closed it, push any commit to main to regenerate.
-- **Publish failed with E403?** — The version was already published. This is safe to ignore; the release is already on npm.
+- **Release PR not updating?** — Inspect the Release Please run and PR state. Changes still reach main through normal PRs; never push directly to main to trigger the bot.
+- **Publish failed with E403?** — Check the actual registry version, release commit and provenance before deciding an existing publication is correct; do not blindly ignore the error.
 - **`publish_only` workflow dispatch** — Emergency escape hatch to publish the current version without Release Please. Only use when the normal flow is broken.
 
 ### Release config files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 Project guidelines for AI agents working in this codebase.
 
+## Repository skills and continuation
+
+For contributor PR/issue reviews, maintainer fixes to those contributions,
+authorized releases, or resuming this backlog, read and follow
+[meridian-upstream-review](.agents/skills/meridian-upstream-review/SKILL.md)
+before acting. Claude also has a discovery entrypoint in `.claude/skills/`;
+both use the same canonical instructions.
+
+For continuation, read [the current review handoff](docs/maintenance/REVIEW_HANDOFF.md),
+then refresh GitHub and origin/main. Update that handoff at a meaningful stop or
+handoff point. Do not rely on personal memories, old chat summaries, or a goal
+runner's status to decide what shipped or what remains. User instructions take
+precedence; this workflow does not start the backlog or authorize external
+actions by itself.
+
 ## What This Is
 
 A proxy that bridges OpenCode (Anthropic API format) to Claude Max (Agent SDK). See `ARCHITECTURE.md` for the full module map and dependency rules.
@@ -10,19 +25,15 @@ A proxy that bridges OpenCode (Anthropic API format) to Claude Max (Agent SDK). 
 
 ```bash
 npm test          # Run all tests — ALWAYS use this, never bare `bun test`
-npm run build     # Build with tsup
+npm run build     # Bundle with Bun, emit declarations and check Node entrypoints
 npm start         # Start the proxy server
 npm run typecheck # tsc --noEmit (CI runs this separately; tests do not typecheck)
 ```
 
-**`npm test` is not a thin wrapper around `bun test`.** Ten test files mock
-modules with `mock.module`, which is process-global in bun and leaks across
-files, so `npm test` runs each of them in its own `bun test` invocation and
-excludes them from the main pass. Running bare `bun test` puts them back in one
-process and produces ~11 failures that look pre-existing and have nothing to do
-with your change. If you see failures in `models-auth-status`, `mcpTools grep
-tool`, `models.test`, or the session-store files, check which command you ran
-before investigating anything else.
+**`npm test` is not a thin wrapper around `bun test`.** Some files use
+process-global mocks; the npm script excludes those from the main pass and runs
+them in separate Bun invocations. Use that script for the full suite. Targeted
+`bun test <file>` runs are useful during development but do not replace it.
 
 ## Code Rules
 
@@ -48,7 +59,7 @@ OpenCode-specific behavior is documented in `ARCHITECTURE.md` under "Agent-Speci
 - Integration tests go through the HTTP layer with mocked SDK
 - **All tests must pass before any change is considered complete**
 - New test files go in `src/__tests__/`
-- **E2E tests** are documented in [`E2E.md`](./E2E.md) — run manually before releases or after major refactors (requires Claude Max subscription)
+- **Live E2E is required for every accepted behavior change and before releases**, using the real SDK/model and affected client flow. See [`E2E.md`](./E2E.md) and the upstream-review skill. Mock-only tests, a different model/platform, or a green rerun do not prove the reported problem fixed.
 
 ### Style
 
@@ -121,107 +132,42 @@ If you need to modify any of these, open an issue first — breaking changes aff
 
 ### Development workflow — NEVER push directly to main
 
-All changes go through this process, no exceptions:
+1. Use a feature branch from current main, preferably in a fresh isolated
+   worktree, preserving the user's checkout. For upstream reviews, use the
+   repository skill above to assess desirability and preserve contributor
+   Author/AuthorDate through cherry-picks and separate maintainer corrections.
+2. Commit, push the feature branch, and create a PR targeting main. Use
+   Conventional Commits and describe the final behavior and validation.
+3. Run the required local checks and affected-flow live E2E, then wait for all
+   relevant final-head CI checks, including `test`. Recheck the head, base and
+   merge state immediately before merging; a changed head invalidates old checks.
+4. Normal PRs use `gh pr merge <N> --squash --match-head-commit <verified-SHA>`.
+   Delete only branches owned by this workflow after they are no longer needed.
+   Release Please PRs use `--merge` instead.
+5. Verify the merged tree and contributor credit. Recheck an incorporated
+   original PR's head before closing it, so newer contributor work is not lost.
+   Only close an issue when the validated behavior actually resolves it.
 
-1. **Create a feature branch** from `main`:
-   ```bash
-   git checkout -b feat/my-feature main
-   ```
+Squash keeps changelog entries one per PR. Preserve repository settings
+`squash_merge_commit_title=PR_TITLE` and `squash_merge_commit_message=BLANK`;
+do not paste intermediate conventional-commit subjects into the squash body.
+Verify human contributor credit instead of assuming every maintainer integration
+PR automatically receives all needed co-author trailers. No AI attribution.
 
-2. **Make changes, commit, push the branch:**
-   ```bash
-   git add -A && git commit -m "feat: my feature"
-   git push origin feat/my-feature
-   ```
+Signed-commit requirements can block a contributor PR. Inspect the actual block;
+use an authored cherry-pick in a maintainer integration PR when needed, with
+separate maintainer fixes. Never retype a contribution under your own authorship.
+Do not routinely use `--admin` or bypass checks.
 
-3. **Create a PR** targeting `main`:
-   ```bash
-   gh pr create --title "feat: my feature" --base main
-   ```
-
-4. **Wait for CI** — the `test` job must pass before merging:
-   ```bash
-   gh pr checks <PR_NUMBER>
-   ```
-
-5. **Merge the PR** (squash merge preferred):
-   ```bash
-   gh pr merge <PR_NUMBER> --squash --delete-branch
-   ```
-
-   Squash is the default because Release Please parses every commit on `main`
-   for the changelog — squashing keeps changelog entries 1:1 with PRs, whereas
-   merge commits leak every intermediate `fix:`/`feat:` commit into the release
-   notes.
-
-   **Use `--squash` for external contributions too.** `--merge` was tried in
-   #693 and #700 and produced *duplicate* changelog entries, not merely an
-   extra one: GitHub's merge commit carries the branch commit's subject in its
-   body, so Release Please parses both and emits the same line twice.
-
-   Squash still credits the contributor. GitHub auto-generates a
-   `Co-authored-by:` trailer, which counts toward their contribution graph and
-   renders both avatars on the commit. The only thing lost is sole `Author` on
-   the commit, which is not worth a changelog that repeats itself every release.
-
-   **The duplicate-entry trap is closed by repo settings, not by remembering.**
-   The same failure reaches squash whenever a branch has 2+ conventional
-   commits: GitHub would paste each commit subject into the squash body and
-   Release Please would parse them all. The repository is configured so that
-   cannot happen:
-
-   | Setting | Value | Why |
-   |---|---|---|
-   | `squash_merge_commit_title` | `PR_TITLE` | the changelog line is the PR title, never a branch commit's subject |
-   | `squash_merge_commit_message` | `BLANK` | the body carries no commit subjects, so there is nothing extra to parse |
-
-   Verified 2026-08-03 on a throwaway PR: the resulting squash body contained
-   *only* `Co-authored-by:`, which GitHub still appends under `BLANK`. So
-   contributor credit and a 1:1 changelog both hold with no flags.
-
-   **Therefore: plain `gh pr merge <N> --squash --delete-branch` is correct for
-   every PR, single- or multi-commit.** Do not hand-craft `--subject`/`--body`
-   to work around the old trap; that was only needed before these settings, and
-   a hand-written body can reintroduce the duplicate. Do not change these two
-   settings back. Check them with:
-
-   ```bash
-   gh api repos/rynfar/meridian --jq '{t: .squash_merge_commit_title, m: .squash_merge_commit_message}'
-   # expect {"t":"PR_TITLE","m":"BLANK"}
-   ```
-
-   `--admin` is **not** routinely required. `main` requires signed commits, and
-   `commit.gpgsign` is enabled locally, so normal work merges `CLEAN`. Reach for
-   `--admin` only when a PR is genuinely `BLOCKED`, and check
-   `gh pr view <N> --json mergeStateStatus` first rather than adding it by habit.
-
-   **`main` requires signed commits, so fork PRs can never be merged directly.**
-   An external PR sits at `mergeStateStatus: BLOCKED` with every check green and
-   no indication why — `gh pr view <N> --json mergeStateStatus` is the only
-   signal. This is not something the contributor can fix from their side.
-
-   The path in, for any outside contribution:
-
-   ```bash
-   git checkout -b fix/their-thing-merged origin/main
-   git cherry-pick <their-sha>     # re-signs with your key, keeps them as Author
-   # your own changes go in a separate commit on top
-   gh pr create --base main
-   gh pr merge <N> --squash --delete-branch
-   ```
-
-   - **Never retype a contributor's change as your own commit.** Cherry-pick it;
-     that is what preserves them as `Author` through to the squash trailer.
-   - Close their original PR with a comment explaining the signing constraint,
-     so it does not read as a rejection.
-
-6. **Never** run `git push origin main` directly — all code reaches `main` through merged PRs only.
+Do not post comments or send messages to others without explicit authorization;
+draft explanations locally. Never run `git push origin main` directly.
 
 ## Releasing
 
 **Do NOT run `npm version`, `git push --tags`, or `npm publish` manually.**
 
-Releases are handled automatically by [Release Please](https://github.com/googleapis/release-please):
+For release validation and publication verification, follow the repository skill
+above and its release reference. Releases are handled automatically by [Release Please](https://github.com/googleapis/release-please):
 
 1. Merge PRs to `main` using [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
 2. Release Please auto-creates/updates a release PR that batches all unreleased changes
@@ -240,8 +186,8 @@ Multiple PRs get batched into a single release. Never publish manually.
 ### Troubleshooting releases
 
 - **Changelog shows entire history?** — Release Please can't find the previous release tag. Check that `meridian-v<version>` tags exist for recent releases: `git tag -l 'meridian-v*' | tail -5`
-- **Release PR not updating?** — It only updates on `push` to `main`. If you closed it, push any commit to main to regenerate.
-- **Publish failed with E403?** — The version was already published. This is safe to ignore; the release is already on npm.
+- **Release PR not updating?** — Inspect the Release Please run and PR state. Changes still reach main through normal PRs; never push directly to main to trigger the bot.
+- **Publish failed with E403?** — Check the actual registry version, release commit and provenance before deciding an existing publication is correct; do not blindly ignore the error.
 - **`publish_only` workflow dispatch** — Emergency escape hatch to publish the current version without Release Please. Only use when the normal flow is broken.
 
 ### Release config files

--- a/docs/maintenance/REVIEW_HANDOFF.md
+++ b/docs/maintenance/REVIEW_HANDOFF.md
@@ -1,0 +1,114 @@
+# Upstream review handoff
+
+Checkpoint: 2026-09-08, before the workflow-documentation PR. Refresh GitHub and
+origin/main before continuing; this is a dated checkpoint, not a live queue.
+The owner requested portable skills and agent instructions so either Claude,
+Codex, or another repository agent can resume this work.
+
+## Read first
+
+Follow [meridian-upstream-review](../../.agents/skills/meridian-upstream-review/SKILL.md)
+and [AGENTS.md](../../AGENTS.md). The prior review run stopped after its current
+ticket and an authorized release. No new backlog fix is in progress. Continue
+when the owner asks; this document does not start background work or authorize
+two agents to work the same queue. A prior agent's paused/blocked goal is not a
+claim that the backlog is complete.
+
+Keep this checkpoint current after a delivered ticket or meaningful pause.
+Record the item, disposition, original/delivery/base SHAs, author mapping,
+worktree/branch, before/after proof, tests and E2E versions, CI URLs, merge and
+closure status, limitations, and the exact next action. Put portable evidence in
+the PR or linked review record; optional private local logs are not prerequisites
+for discovering the workflow. Never invent test evidence if those logs are absent.
+
+## Completed checkpoint
+
+[Meridian 1.68.0](https://github.com/rynfar/meridian/releases/tag/meridian-v1.68.0)
+shipped through [release PR #937](https://github.com/rynfar/meridian/pull/937).
+Its release/main commit at this checkpoint was
+`58f8a70402fce471712cd4650f721afcb80f05d7`, tree
+`427fbc82761e163d6fbf9621a8fb2e88ac260081`. Do not republish it.
+
+- [Release Please, npm and semver Docker publication](https://github.com/rynfar/meridian/actions/runs/33998609223): successful.
+- [Post-merge CI](https://github.com/rynfar/meridian/actions/runs/33998609125),
+  [Docker latest](https://github.com/rynfar/meridian/actions/runs/33998609160) and
+  [Nix builds/cache uploads](https://github.com/rynfar/meridian/actions/runs/33998609115): successful, including the formerly pending cache uploads (rechecked September 8).
+- Recorded release validation: 3601 tests passed, one existing skip, no failures;
+  typecheck/build; all four real E41 modes; installed-package OpenCode V1 and
+  extended V2 flows; structured output and package-integrity gates; published
+  package live V2; verified registry signatures and SLSA provenance matching the
+  release commit. This is historical evidence for that candidate, not a substitute
+  for tests on future changes.
+- Frozen install used SDK0.2.141/Claude Code2.1.259; fresh npm package gates used
+  SDK0.2.141/Claude Code2.1.261. Actual clients: V1 1.18.11 and V2 beta18866
+  (extended live, separate working directories), plus beta18314 scripted package
+  compatibility. Do not describe the beta18314 release check as extended live.
+
+Last completed implementation: [#961](https://github.com/rynfar/meridian/pull/961),
+merged `1ae1810dc2a24250c4a3f4d21546b03e56b9b388`, incorporating original #836 and
+resolving #829. Original `57e3091c` retained as
+`abd410192cfcb706c7649ce3e0f65f5fa73e6008` with Trevor Walker's author/date;
+maintainer corrections `25b895a6ccb9e1182257bd3089d7b055d4085132`. The final tree
+`19ecf09794f9545b93f5119af35255ab9fecd99d` matched the merge. Actual SDK billing
+refusal/failover and account/model telemetry were verified in both response modes.
+Original #836 and issue #829 are closed.
+
+Immediately preceding it, [#960](https://github.com/rynfar/meridian/pull/960)
+incorporated #868 and merged `6365ae0ed5445fbf6ea5c89055919570a7c76406`.
+Actual V1/beta18866 idle retry bounds and recovery, beta18314 compatibility,
+four E41 modes and full tests passed. Original #868 is closed.
+
+Earlier delivered integration PRs in this review run: #938, #939, #940, #941,
+#944, #945, #948, #949, #950, #952, #953, #954, #955, #956, #957, #958 and #959.
+Inspect their final diffs and linked original PRs before redoing overlapping
+work. In particular, #953 did **not** establish that #917/#933 were fixed.
+The already-merged structured-output implementation #930 was validated and
+released; original #898 was closed as superseded.
+
+## Next item to triage on resumption
+
+The September 8 snapshot had **32 open PRs and 18 open issues** before the
+workflow-documentation PR. Refresh both lists; do not act solely on this count.
+
+Prioritize bounded triage of [issue #967](https://github.com/rynfar/meridian/issues/967),
+which reports a growing headless-background-job respawn loop on Meridian1.68.0.
+The reporter's environment is OpenCode1.18.29, opencode-with-claude1.10.1,
+Claude Code2.1.263 and a resumed Opus session. Headless jobs reportedly receive
+client-tool forwarding stubs without a client able to return the result.
+
+This is a report, **not a verified root cause, a proven regression, or an approved
+implementation**. Reproduce with bounded attempts and isolated fixtures, establish
+which component owns the behavior, and validate the affected model/client versions.
+Their fresh Haiku attempts passed; earlier Haiku validation neither disproves the
+report nor resolves it. Do not read private SDK transcript files referenced in
+an issue; use supported APIs and controlled reproduction.
+
+New unreviewed contributor PRs since the prior checkpoint:
+
+| PR | Proposed change |
+|---|---|
+| [#962](https://github.com/rynfar/meridian/pull/962) | Per-tier refusal ending in prose |
+| [#963](https://github.com/rynfar/meridian/pull/963) | Disable auto-defer for Codex requests |
+| [#964](https://github.com/rynfar/meridian/pull/964) | Codex namespace/custom tool forwarding |
+| [#965](https://github.com/rynfar/meridian/pull/965) | Codex thread session identity |
+| [#966](https://github.com/rynfar/meridian/pull/966) | Mid-conversation developer messages |
+
+Existing unresolved priorities: #896/#895 (Windows session GC), #765 (Nix plugin
+inputs; its head changed after the prior snapshot), #917/#933 (historical
+concurrency failures), #767 (Opus-specific resume divergence), #905 (container
+incarnation) and #889 (missing client environment). The full live backlog also
+contains feature proposals and other issues; these lists do not approve them.
+
+## Restart safely
+
+Fetch origin/main and refresh the selected PR/issue, its exact head and related
+merged work. Preserve the user's current checkout; use a new isolated worktree
+from current main. Existing worktrees may be completed deliveries or deliberate
+before-code baselines. Do not reset or delete them on the assumption they are
+abandoned. Verify current tool/client versions and use the current E2E.md.
+
+Then work one bounded item through the skill: decide whether we want the behavior,
+reproduce, retain contributor authorship, correct separately, run real affected-flow
+E2E plus npm test/typecheck/build, inspect exact-head CI and finish only within the
+owner's authorized scope. If the required model/platform/environment or product
+decision is missing, record the precise blocker and leave that item incomplete.


### PR DESCRIPTION
Agents resuming upstream reviews currently depend on private memories and contradictory historical checkpoints. Add a shared repository skill, a Claude discovery entrypoint, and explicit links from AGENTS.md and CLAUDE.md so a fresh agent can find the same review and continuation process.

The workflow requires checking that each change belongs, preserving contributor authorship with separate maintainer corrections, real affected-flow E2E, full tests/typecheck/build, and final-head CI before completion. It distinguishes normal squash integration from Release Please merges, preserves authorization boundaries, and verifies publication instead of assuming a merged release PR shipped. The portable handoff records the completed 1.68.0 release and the unreviewed queue; it does not declare #967's reported cause proven or resume the backlog automatically.

Only the shared Claude skill entrypoint is allowlisted; private agent settings and worktrees remain ignored. Runtime source, dependencies and release metadata are unchanged.

Validation: both skill validators passed; all local documentation links resolve without personal paths; git-ignore checks confirm skill discovery and private-state exclusion; typecheck/build passed; actual Claude Max E41 sequential nonstreaming tool/resume/cache check passed (Haiku 4.5). Full npm test passed: 3601 passed, one existing skip, zero failures. No rerun was needed. No claim is made that this documentation update fixes a runtime issue.
