### PR TITLE
fix(passthrough): keep a client tool named mcp__oc__* callable

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -266,6 +266,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E40 | [Passthrough digest-turn cap](#e40-passthrough-digest-turn-cap) | **Automated**: `bun scripts/e2e-digest-turn-cap.mjs` — real SDK. Asserts the capped tool turn generates no digest text, costs materially less than uncapped on an identical prompt, still RESUMES at its captured checkpoint, leaves text-only turns returning `success`, and does not truncate parallel tool calls. **Run before any release touching the passthrough tool loop, `maxTurns`, or the early-stop checkpoint** | 2026-08-20 |
 | E41 | [Passthrough multi-turn: one call, one answer](#e41-passthrough-multi-turn-one-call-one-answer) | **Automated**: `bun scripts/e2e-passthrough-turns.mjs [--stream]` — real proxy + SDK + Claude Max. Chain and `PROBE_PARALLEL=1` modes assert exact tool-call batching, a distinct durable fork per result round, one real answer per delivered call in the active transcript, and full prompt-cache continuity. **Run all four chain/parallel × stream/non-stream combinations before releases touching passthrough resume or the deny hook** | 2026-08-26 |
 | E42 | [OpenCode V2 beta compatibility](#e42-opencode-v2-beta-compatibility) | **Automated**, exact betas `18314` and `18866`: run `e2e-opencode-v2-package.mjs --live --extended` with each pinned binary. Covers hidden title/summary isolation, process restart, passthrough tools, undo/fork/compaction and overlapping general children. Also test source and packed npm artifacts. **Run after any V2 plugin/API change; another beta is not a pass** | 2026-08-27 |
+| E43 | [Passthrough tools in a namespaced client](#e43-passthrough-tools-in-a-namespaced-client) | **Automated**: `bun scripts/e2e-passthrough-namespaced-tools.mjs [--stream]` — real proxy + SDK. A client tool declared `mcp__oc__read` collides with the namespace Meridian nests client tools under; asserts the call is still dispatched and captured, delivered under the name the client declared, and answered from the client's real result, with an ordinary and a foreign-namespace control alongside. **Run before any release touching passthrough tool registration, the deny hook, or tool-name delivery** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3848,6 +3849,59 @@ Run this real-client sequence:
 `EXACTUNDO`, `EXACTFORK`, `EXACTORIGINAL`,
 `EXACTPARALLEL[ALPHA,BRAVO]`, and `EXACTAFTERCOMPACT`. The binary SHA-256 stayed
 unchanged through the matrix.
+
+## E43: Passthrough tools in a namespaced client
+
+**What it proves:** a client whose own tool names already carry an MCP
+namespace can still receive, execute, and answer a forwarded passthrough call.
+
+**Why it needs the real SDK:** Meridian nests client tools inside its own `oc`
+MCP server, so a client that aggregates MCP servers itself — a Claude Code CLI
+job with an `oc` server configured, for instance — declares tools like
+`mcp__oc__read` that collide with that namespace. The collision broke two
+things at once, and only one of them is visible to a mocked SDK:
+
+- **Registration.** The tool was advertised as `mcp__oc__mcp__oc__read`. On SDK
+  0.2.141 / CLI 2.1.263 the CLI lists that name but never dispatches it, so the
+  PreToolUse hook never fired and nothing was captured (`tools=0/1` in the
+  `sdk_termination` line). Non-streaming returned HTTP 500; streaming ended
+  `stop_reason: max_tokens` with an inline `error` event.
+- **Delivery.** The reverse translation was a blind prefix strip, so the leaked
+  tool_use reached the client renamed to `read` — a tool it never declared.
+
+Either half breaks the promise the forwarding hook makes to the model ("the
+result will be delivered in a future turn"): a client cannot answer a call it
+does not recognize, so that turn never comes, and a coordinator watching the
+stalled job re-dispatches it (#967).
+
+```bash
+bun scripts/e2e-passthrough-namespaced-tools.mjs
+bun scripts/e2e-passthrough-namespaced-tools.mjs --stream
+PROBE_MODEL=claude-opus-5 bun scripts/e2e-passthrough-namespaced-tools.mjs
+PROBE_MODEL=claude-opus-5 bun scripts/e2e-passthrough-namespaced-tools.mjs --stream
+```
+
+**Pass criteria** (asserted per tool shape and response mode, non-zero exit on any):
+
+- The call is dispatched and captured: `stop_reason: tool_use`, exactly one
+  tool_use block, no error event.
+- The delivered name is byte-identical to what the client declared, and its
+  arguments survive.
+- Replaying that call's real `tool_result` yields an answer quoting the
+  fixture's content, and the answer never claims the call went unanswered.
+- The ordinary (`read`) and foreign-namespace (`mcp__zed__read`) controls pass
+  in the same process, so a green run cannot come from a dead proxy.
+
+The fixture uses a deliberately short `/tmp` path. Under macOS `mkdtemp`, Opus
+truncates a `/private/var/folders/...`-length path in its own tool argument and
+says so in its reply — a model artifact that would fail the argument check for a
+reason unrelated to what this gate measures.
+
+**Verified:** 2026-09-08 on the fix branch, SDK 0.2.141 / bundled CLI 2.1.259 /
+system CLI 2.1.263. All four combinations passed: haiku and `claude-opus-5`,
+streaming and non-streaming, subject plus both controls. Against the same commit
+without the fix, the subject shape returned HTTP 500 non-streaming and delivered
+`read` with `stop_reason: max_tokens` streaming.
 
 ## Concurrent transcript publication
 

--- a/docs/maintenance/REVIEW_HANDOFF.md
+++ b/docs/maintenance/REVIEW_HANDOFF.md
@@ -1,6 +1,6 @@
 # Upstream review handoff
 
-Checkpoint: 2026-09-08, before the workflow-documentation PR. Refresh GitHub and
+Checkpoint: 2026-09-08, at PR #969 (issue #967 triage). Refresh GitHub and
 origin/main before continuing; this is a dated checkpoint, not a live queue.
 The owner requested portable skills and agent instructions so either Claude,
 Codex, or another repository agent can resume this work.
@@ -8,11 +8,12 @@ Codex, or another repository agent can resume this work.
 ## Read first
 
 Follow [meridian-upstream-review](../../.agents/skills/meridian-upstream-review/SKILL.md)
-and [AGENTS.md](../../AGENTS.md). The prior review run stopped after its current
-ticket and an authorized release. No new backlog fix is in progress. Continue
-when the owner asks; this document does not start background work or authorize
-two agents to work the same queue. A prior agent's paused/blocked goal is not a
-claim that the backlog is complete.
+and [AGENTS.md](../../AGENTS.md). The current item is
+[PR #969](https://github.com/rynfar/meridian/pull/969), open and awaiting
+final-head CI at this checkpoint. Continue when the owner asks; this document
+does not start background work or authorize two agents to work the same queue.
+A prior agent's paused/blocked goal is not a claim that the backlog is
+complete.
 
 Keep this checkpoint current after a delivered ticket or meaningful pause.
 Record the item, disposition, original/delivery/base SHAs, author mapping,
@@ -20,6 +21,98 @@ worktree/branch, before/after proof, tests and E2E versions, CI URLs, merge and
 closure status, limitations, and the exact next action. Put portable evidence in
 the PR or linked review record; optional private local logs are not prerequisites
 for discovering the workflow. Never invent test evidence if those logs are absent.
+
+## Current item: issue #967 triage, delivered as PR #969
+
+**Item.** [Issue #967](https://github.com/rynfar/meridian/issues/967) —
+"Passthrough tool forwards are undeliverable for headless bg-job subagents →
+compounding respawn loop", reported by filipporovelli against 1.68.0.
+
+**Disposition.** Accepted in part, as a maintainer fix from triage. Triage found
+a real and distinct Meridian defect that produces the reported symptom exactly,
+and it is fixed in
+[PR #969](https://github.com/rynfar/meridian/pull/969) (branch
+`codex/fix-oc-prefixed-client-tools`, worktree
+`/Users/rynfar/repos/meridian-wt/oc-prefixed-client-tools`). Base
+`38c1db2b25de70be873f4b1b6436334566107bff`; delivery commits
+`4646b932` (fix + tests) and `8ec39e41` (E43 gate + E2E.md), head
+`8ec39e41871d589a244482952d0537e36bc60894`. No contributor commits exist for
+this item, so there is no cherry-pick author mapping; the reporter is credited
+in the PR body. **#967 is NOT resolved and must stay open** — see below.
+
+**The defect that was fixed.** Client tools are registered inside Meridian's own
+`oc` MCP server, so a client whose tool names already start with `mcp__oc__` —
+a Claude Code CLI job with an `oc` MCP server configured, for instance —
+collides with that namespace. Registration advertised
+`mcp__oc__mcp__oc__read`, which SDK 0.2.141 / CLI 2.1.263 lists but never
+dispatches: the PreToolUse hook never fired, nothing was captured
+(`tools=0/1`), non-streaming returned HTTP 500, and streaming ended
+`stop_reason: max_tokens` with an inline `error` event while leaking a tool_use
+the blind reverse strip had renamed to `read`. Fixed by registering colliding
+tools under a collision-free alias and reversing through an explicit map.
+Ordinary tool sets alias to themselves, so model-visible names and the prompt
+cache are unchanged. Only the exact `mcp__oc__` collision was affected; a
+foreign `mcp__*` namespace was and remains fine.
+
+**Two of the issue's inferences were refuted. Do not chase them again.**
+
+- A nested SDK transcript terminating at the forward stub is the **designed
+  steady state** of every passthrough tool step, on every client — not evidence
+  of a stall. `PASSTHROUGH_DENY_REASON` has exactly one call site, inside
+  Meridian's own PreToolUse hook, and is never sent to a client as a
+  `tool_result`; Meridian then resumes the checkpoint with `forkSession`, so the
+  denial branch is deliberately dead history. E41 already asserts the active
+  fork holds exactly one real answer and zero denials per delivered call. The
+  issue's "18 of 20 newest transcripts terminate at the forward stub" therefore
+  describes Meridian's own nested sessions.
+- The compounding "strict prefix-extension" replay is
+  [#767](https://github.com/rynfar/meridian/issues/767)'s signature: a fresh
+  replay opens a new SDK session, hence a new transcript that is a
+  prefix-extension of the last. Still unfixed on main for the trailing-block
+  shape connor-grady measured — `hasOnlyNewToolResults` in
+  `src/proxy/session/lineage.ts` requires every appended boundary block to be a
+  new `tool_result`, so an appended `text` block (`user[tool_result,text]`)
+  falls through to `modified-history` and replays. Verified present on
+  `38c1db2b`.
+
+The respawn decision itself is above Meridian — the reporter's own job records
+show `respawnFlags: []`.
+
+**Validation.** `npm test` 3622 pass / 0 fail / 1 pre-existing skip;
+`npm run typecheck` and `npm run build` clean. Failed-before/passed-after on the
+same assertions: `src/__tests__/proxy-passthrough-oc-prefixed-tools.test.ts`
+fails 6/8 on the parent commit (delivering `read` and `read_2` where
+`mcp__oc__read` was declared) and passes 8/8 with the fix; the 2 that pass
+either way are the no-regression controls. New **E43** live gate
+(`scripts/e2e-passthrough-namespaced-tools.mjs`) passed all four combinations —
+haiku and `claude-opus-5`, streaming and non-streaming, subject plus an ordinary
+and a foreign-namespace control. **E41 all four modes** (chain/parallel ×
+stream/non-stream) PASS. Post-fix live accounting shows `captured=1` and
+`sdk_termination_recovered` where the same probe previously logged `tools=0/1`
+with `envelope=open`. Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system
+CLI 2.1.263, OpenCode 1.18.29, Node v22.22.3, macOS arm64.
+
+**Known limitations and next action.**
+
+- Attribution of the reporter's incident to this defect is **not established**.
+  It holds only if those bg jobs declared `mcp__oc__*`-named tools, which needs
+  their tool list. `opencode-with-claude` was not installed locally and was not
+  inspected. No comment has been posted — asking the reporter needs the owner's
+  authorization.
+- #967 stays open. Closing it needs both the attribution above and #767's
+  replay driver.
+- #893 (the `oc` namespace ignoring `getMcpServerName()`) stays open and is
+  untouched. If it lands, `buildPassthroughToolAliases` and the
+  `passthroughEarlyStop.ts` prefix mirror must follow the same value.
+- A pre-existing gap deliberately left alone: `isClientForwardedToolUse` treats
+  a bare `mcp__*` name as an internal SDK tool, so a foreign-namespace client
+  tool would not arm the early-stop tracker if the SDK emitted its bare form.
+  It does not today; the E43 foreign-namespace control passes in both modes.
+- **Next action:** confirm PR #969's final-head CI (including `test`), recheck
+  head/base/merge state immediately before merging, then
+  `gh pr merge 969 --squash --match-head-commit <verified-SHA>`. After merge,
+  the strongest remaining lead is #767's `hasOnlyNewToolResults` trailing-`text`
+  shape, which is the compounding-replay half of #967.
 
 ## Completed checkpoint
 
@@ -70,18 +163,18 @@ released; original #898 was closed as superseded.
 The September 8 snapshot had **32 open PRs and 18 open issues** before the
 workflow-documentation PR. Refresh both lists; do not act solely on this count.
 
-Prioritize bounded triage of [issue #967](https://github.com/rynfar/meridian/issues/967),
-which reports a growing headless-background-job respawn loop on Meridian1.68.0.
-The reporter's environment is OpenCode1.18.29, opencode-with-claude1.10.1,
-Claude Code2.1.263 and a resumed Opus session. Headless jobs reportedly receive
-client-tool forwarding stubs without a client able to return the result.
+Issue #967 has been triaged and its Meridian half fixed in PR #969. Read the
+current-item section above before touching it again, and do not re-derive the
+two refuted inferences recorded there. The unresolved half of that report is
+#767's replay driver, plus attribution that needs the reporter's tool list.
 
-This is a report, **not a verified root cause, a proven regression, or an approved
-implementation**. Reproduce with bounded attempts and isolated fixtures, establish
-which component owns the behavior, and validate the affected model/client versions.
-Their fresh Haiku attempts passed; earlier Haiku validation neither disproves the
-report nor resolves it. Do not read private SDK transcript files referenced in
-an issue; use supported APIs and controlled reproduction.
+Pick one bounded item from the refreshed lists. Each is a report or proposal,
+**not a verified root cause, a proven regression, or an approved
+implementation**. Reproduce with bounded attempts and isolated fixtures,
+establish which component owns the behavior, and validate the affected
+model/client versions — a passing Haiku run neither disproves nor resolves an
+Opus report. Do not read private SDK transcript files referenced in an issue;
+use supported APIs and controlled reproduction.
 
 New unreviewed contributor PRs since the prior checkpoint:
 

--- a/docs/maintenance/REVIEW_HANDOFF.md
+++ b/docs/maintenance/REVIEW_HANDOFF.md
@@ -9,11 +9,11 @@ Codex, or another repository agent can resume this work.
 
 Follow [meridian-upstream-review](../../.agents/skills/meridian-upstream-review/SKILL.md)
 and [AGENTS.md](../../AGENTS.md). The current item is
-[PR #969](https://github.com/rynfar/meridian/pull/969), open and awaiting
-final-head CI at this checkpoint. Continue when the owner asks; this document
-does not start background work or authorize two agents to work the same queue.
-A prior agent's paused/blocked goal is not a claim that the backlog is
-complete.
+[PR #969](https://github.com/rynfar/meridian/pull/969); check its live state
+rather than trusting this line, since it was written from the branch being
+merged. Continue when the owner asks; this document does not start background
+work or authorize two agents to work the same queue. A prior agent's
+paused/blocked goal is not a claim that the backlog is complete.
 
 Keep this checkpoint current after a delivered ticket or meaningful pause.
 Record the item, disposition, original/delivery/base SHAs, author mapping,
@@ -113,11 +113,12 @@ haiku in both modes after that commit and stayed green.
   a bare `mcp__*` name as an internal SDK tool, so a foreign-namespace client
   tool would not arm the early-stop tracker if the SDK emitted its bare form.
   It does not today; the E43 foreign-namespace control passes in both modes.
-- **Next action:** confirm PR #969's final-head CI (including `test`), recheck
-  head/base/merge state immediately before merging, then
-  `gh pr merge 969 --squash --match-head-commit <verified-SHA>`. After merge,
-  the strongest remaining lead is #767's `hasOnlyNewToolResults` trailing-`text`
-  shape, which is the compounding-replay half of #967.
+- **Next action:** PR #969 was taken to green final-head CI and squash-merged
+  with `--match-head-commit` on the verified head; this file was written from
+  that branch, so confirm the merge landed and that #967 is still open before
+  building on it. Then the strongest remaining lead is #767's
+  `hasOnlyNewToolResults` trailing-`text` shape — the compounding-replay half of
+  #967 — followed by the five unreviewed Codex-adapter PRs (#962–#966).
 
 ## Completed checkpoint
 

--- a/docs/maintenance/REVIEW_HANDOFF.md
+++ b/docs/maintenance/REVIEW_HANDOFF.md
@@ -35,8 +35,8 @@ and it is fixed in
 `codex/fix-oc-prefixed-client-tools`, worktree
 `/Users/rynfar/repos/meridian-wt/oc-prefixed-client-tools`). Base
 `38c1db2b25de70be873f4b1b6436334566107bff`; delivery commits
-`4646b932` (fix + tests) and `8ec39e41` (E43 gate + E2E.md), head
-`8ec39e41871d589a244482952d0537e36bc60894`. No contributor commits exist for
+`4646b932` (fix + tests), `8ec39e41` (E43 gate + E2E.md), `6823b687` (this
+checkpoint) and `9447f8a7` (doubled-name hardening). No contributor commits exist for
 this item, so there is no cherry-pick author mapping; the reporter is credited
 in the PR body. **#967 is NOT resolved and must stay open** — see below.
 
@@ -78,7 +78,7 @@ foreign `mcp__*` namespace was and remains fine.
 The respawn decision itself is above Meridian — the reporter's own job records
 show `respawnFlags: []`.
 
-**Validation.** `npm test` 3622 pass / 0 fail / 1 pre-existing skip;
+**Validation.** `npm test` 3624 pass / 0 fail / 1 pre-existing skip;
 `npm run typecheck` and `npm run build` clean. Failed-before/passed-after on the
 same assertions: `src/__tests__/proxy-passthrough-oc-prefixed-tools.test.ts`
 fails 6/8 on the parent commit (delivering `read` and `read_2` where
@@ -91,6 +91,11 @@ stream/non-stream) PASS. Post-fix live accounting shows `captured=1` and
 `sdk_termination_recovered` where the same probe previously logged `tools=0/1`
 with `envelope=open`. Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system
 CLI 2.1.263, OpenCode 1.18.29, Node v22.22.3, macOS arm64.
+
+The Opus E43 runs were made before `9447f8a7`, which only changes names
+carrying two or more leading copies of the prefix — a shape the gate does not
+exercise and whose single-prefix behavior is byte-identical. E43 was re-run on
+haiku in both modes after that commit and stayed green.
 
 **Known limitations and next action.**
 

--- a/scripts/e2e-passthrough-namespaced-tools.mjs
+++ b/scripts/e2e-passthrough-namespaced-tools.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env bun
+/**
+ * Live E2E: can a client whose tool names already carry an MCP namespace
+ * actually receive, execute, and answer a forwarded passthrough call?
+ *
+ * Meridian nests client tools inside its own `oc` MCP server, so a client that
+ * aggregates MCP servers itself — a Claude Code CLI job with an `oc` server
+ * configured, for instance — declares tools like `mcp__oc__read` that collide
+ * with that namespace. Before the fix the collision was fatal in two ways at
+ * once, and neither is reachable from a mocked SDK:
+ *
+ *   - REGISTRATION. The tool was advertised as `mcp__oc__mcp__oc__read`. On SDK
+ *     0.2.141 / CLI 2.1.263 the CLI lists that name but never dispatches it, so
+ *     the PreToolUse hook never fired and nothing was captured (`tools=0/1`).
+ *     Non-streaming returned HTTP 500; streaming ended `stop_reason: max_tokens`
+ *     with an inline `error` event.
+ *   - DELIVERY. The reverse translation was a blind prefix strip, so the leaked
+ *     tool_use reached the client as `read` — a tool it never declared.
+ *
+ * Either half breaks the promise the forwarding hook makes to the model ("the
+ * result will be delivered in a future turn"): a client cannot answer a call it
+ * does not recognize, so that turn never comes. A coordinator watching the
+ * stalled job then re-dispatches it, which is the compounding respawn loop in
+ * #967.
+ *
+ * What this gate asserts, per tool shape and per response mode:
+ *
+ *   1. The call is dispatched and captured — `stop_reason: tool_use`, exactly
+ *      one tool_use block, no error event. This is the registration claim.
+ *   2. The delivered name is byte-identical to what the client declared, and
+ *      its arguments survive. This is the delivery claim.
+ *   3. Replaying that call's real tool_result gets a real answer quoting the
+ *      file's content — the promised future turn actually arrives. Without this
+ *      the first two could pass on a call the client still cannot complete.
+ *
+ * Controls run in the same process so a pass cannot come from a dead proxy: an
+ * ordinary `read` and a foreign `mcp__zed__read` must keep working unchanged.
+ *
+ * Costs a few cents of real tokens and needs Claude Max. Run before any release
+ * touching passthrough tool registration, the deny hook, or tool-name delivery.
+ *
+ *   bun scripts/e2e-passthrough-namespaced-tools.mjs [--stream]
+ */
+import { mkdtempSync, realpathSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { setSessionStoreDir } from "../src/proxy/sessionStore.ts"
+
+process.env.MERIDIAN_PASSTHROUGH = "1"
+const { startProxyServer } = await import("../src/proxy/server.ts")
+
+const STREAM = process.argv.includes("--stream")
+const PORT = Number(process.env.PROBE_PORT ?? 3524)
+const MODEL = process.env.PROBE_MODEL ?? "claude-haiku-4-5-20251001"
+
+// Deliberately a SHORT isolated path, not the OS temp dir. On macOS mkdtemp
+// lands under /private/var/folders/<random>/T/, and Opus truncates a path that
+// long in its own tool argument ("I passed a truncated path on that call") —
+// which fails the argument check for a reason that has nothing to do with what
+// this gate measures. Still per-run isolated, just short enough to survive.
+const WORKDIR = realpathSync(mkdtempSync("/tmp/mns-"))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, "store"))
+
+const CONTENT = "namespaced-tool-probe-content-zeta"
+const FILE = join(WORKDIR, "data.txt")
+writeFileSync(FILE, CONTENT + "\n")
+
+// Keep proxy logs out of the verdict but retain them for a failure report.
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ["log", "error", "debug"]) console[k] = (...a) => { proxyLog.push(a.map(String).join(" ")) }
+const inst = await startProxyServer({ port: PORT, host: "127.0.0.1" })
+
+const failures = []
+function check(ok, label, detail) {
+  say(`  ${ok ? "PASS" : "FAIL"}  ${label}${detail ? ` — ${detail}` : ""}`)
+  if (!ok) failures.push(label)
+}
+
+const toolDef = name => ({
+  name,
+  description: "Read a file from disk and return its contents",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string", description: "Absolute path" } },
+    required: ["file_path"],
+  },
+})
+
+async function send(sessionId, tools, messages) {
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": "dummy",
+      "x-opencode-session": sessionId,
+      "user-agent": "opencode/1.0.0",
+    },
+    body: JSON.stringify({ model: MODEL, max_tokens: 2048, stream: STREAM, tools, messages }),
+  })
+  const text = await res.text()
+  if (!STREAM) {
+    let body
+    try { body = JSON.parse(text) } catch { return { status: res.status, blocks: [], stop: null, errors: 1 } }
+    return {
+      status: res.status,
+      blocks: body.content ?? [],
+      stop: body.stop_reason ?? null,
+      errors: body.type === "error" ? 1 : 0,
+    }
+  }
+  const blocks = []
+  let stop = null
+  let errors = 0
+  for (const line of text.split("\n")) {
+    if (!line.startsWith("data:")) continue
+    let ev
+    try { ev = JSON.parse(line.slice(5)) } catch { continue }
+    if (ev.type === "error") errors++
+    if (ev.type === "message_delta" && ev.delta?.stop_reason) stop = ev.delta.stop_reason
+    if (ev.type === "content_block_start") {
+      blocks[ev.index] = { ...ev.content_block, ...(ev.content_block.type === "tool_use" ? { _json: "" } : {}) }
+    }
+    if (ev.type === "content_block_delta") {
+      const b = blocks[ev.index]
+      if (!b) continue
+      if (ev.delta.type === "text_delta") b.text = (b.text ?? "") + ev.delta.text
+      if (ev.delta.type === "input_json_delta") b._json += ev.delta.partial_json
+    }
+  }
+  return {
+    status: res.status,
+    stop,
+    errors,
+    blocks: blocks.filter(Boolean).map(b => {
+      if (b.type !== "tool_use") return b
+      const { _json, ...rest } = b
+      return { ...rest, input: _json ? JSON.parse(_json) : (b.input ?? {}) }
+    }),
+  }
+}
+
+/** Drive one full forward → execute → answer round trip for one tool name. */
+async function probe(label, toolName) {
+  say(`\n=== ${label}: declared "${toolName}" (stream=${STREAM}) ===`)
+  const tools = [toolDef(toolName)]
+  const sessionId = `ns-tools-${STREAM ? "stream" : "nonstream"}-${toolName}-${process.pid}`
+  const messages = [{
+    role: "user",
+    content: `Use the ${toolName} tool to read ${FILE}, then tell me its exact contents.`,
+  }]
+
+  const first = await send(sessionId, tools, messages)
+  const calls = first.blocks.filter(b => b.type === "tool_use")
+
+  // 1. Registration: the call was dispatched to the hook and captured.
+  check(
+    first.status === 200 && first.stop === "tool_use" && calls.length === 1 && first.errors === 0,
+    "call dispatched and captured",
+    `http=${first.status} stop=${first.stop} calls=${calls.length} errors=${first.errors}`,
+  )
+  if (calls.length !== 1) {
+    say("    cannot continue this shape without exactly one forwarded call")
+    return
+  }
+
+  // 2. Delivery: the client got back the name it declared, arguments intact.
+  const call = calls[0]
+  check(call.name === toolName, "delivered the declared tool name", `delivered="${call.name}"`)
+  check(
+    call.input?.file_path === FILE,
+    "delivered the tool arguments intact",
+    `file_path=${JSON.stringify(call.input?.file_path)}`,
+  )
+
+  // 3. The promised future turn arrives: replay the real result, get an answer.
+  messages.push({ role: "assistant", content: first.blocks })
+  messages.push({
+    role: "user",
+    content: [{ type: "tool_result", tool_use_id: call.id, content: CONTENT }],
+  })
+  const second = await send(sessionId, tools, messages)
+  const answer = second.blocks.filter(b => b.type === "text").map(b => b.text ?? "").join("")
+  check(
+    second.status === 200 && answer.includes(CONTENT),
+    "answered from the client's real tool_result",
+    `http=${second.status} quoted=${answer.includes(CONTENT)} stop=${second.stop}`,
+  )
+  check(
+    !/forwarded|no content|never returned|no result|unable to read/i.test(answer),
+    "answer does not claim the call went unanswered",
+    answer.slice(0, 120).replace(/\s+/g, " "),
+  )
+}
+
+// The subject first, then the controls — a dead proxy cannot fake the controls.
+await probe("subject: collides with our own namespace", "mcp__oc__read")
+await probe("control: ordinary tool name", "read")
+await probe("control: foreign MCP namespace", "mcp__zed__read")
+
+say(`\n=== verdict (stream=${STREAM}) ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s) failed`)
+  for (const f of failures) say(`    - ${f}`)
+  say("\n  recent proxy diagnostics:")
+  for (const line of proxyLog.filter(l => l.includes("[PROXY]")).slice(-12)) say(`    ${line}`)
+} else {
+  say("  PASS: every declared tool shape was dispatched, delivered by name, and answered")
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/passthrough-tool-aliases.test.ts
+++ b/src/__tests__/passthrough-tool-aliases.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Passthrough tool aliasing (#967).
+ *
+ * Client tools are nested inside Meridian's own `oc` MCP server, so a client
+ * tool whose declared name already starts with `mcp__oc__` used to be
+ * advertised as `mcp__oc__mcp__oc__read` — a name the CLI lists but never
+ * dispatches, so nothing was captured and the forwarded result the proxy
+ * promised the model could never arrive.
+ *
+ * These are direct unit tests on the pure alias/reverse-map pair.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  buildPassthroughToolAliases,
+  resolveClientToolName,
+  createPassthroughMcpServer,
+  stripMcpPrefix,
+  PASSTHROUGH_MCP_PREFIX,
+} from "../proxy/passthroughTools"
+
+describe("buildPassthroughToolAliases", () => {
+  it("leaves ordinary tool names untouched, so model-visible names never move", () => {
+    const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases([
+      "read",
+      "write",
+      "Bash",
+    ])
+    expect([...aliasByClientName]).toEqual([
+      ["Bash", "Bash"],
+      ["read", "read"],
+      ["write", "write"],
+    ])
+    for (const [client, alias] of aliasByClientName) {
+      expect(clientNameByAlias.get(alias)).toBe(client)
+    }
+  })
+
+  it("drops the redundant prefix so the canonical SDK name equals the declared name", () => {
+    const { aliasByClientName } = buildPassthroughToolAliases(["mcp__oc__read"])
+    expect(aliasByClientName.get("mcp__oc__read")).toBe("read")
+    // What the model is shown is exactly what the client declared.
+    expect(`${PASSTHROUGH_MCP_PREFIX}read`).toBe("mcp__oc__read")
+  })
+
+  it("leaves a foreign mcp__ prefix alone — only our own namespace collides", () => {
+    const { aliasByClientName } = buildPassthroughToolAliases(["mcp__zed__read"])
+    expect(aliasByClientName.get("mcp__zed__read")).toBe("mcp__zed__read")
+  })
+
+  it("never lets an escaped name steal an identity a plain tool declared", () => {
+    const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases([
+      "read",
+      "mcp__oc__read",
+    ])
+    expect(aliasByClientName.get("read")).toBe("read")
+    expect(aliasByClientName.get("mcp__oc__read")).toBe("read_2")
+    // Both directions stay exact, which is what the delivery paths rely on.
+    expect(clientNameByAlias.get("read")).toBe("read")
+    expect(clientNameByAlias.get("read_2")).toBe("mcp__oc__read")
+  })
+
+  it("is order-independent — the alias map cannot depend on request key order", () => {
+    const a = buildPassthroughToolAliases(["read", "mcp__oc__read", "write"])
+    const b = buildPassthroughToolAliases(["write", "mcp__oc__read", "read"])
+    expect([...a.aliasByClientName]).toEqual([...b.aliasByClientName])
+  })
+
+  it("survives a degenerate name that is nothing but the prefix", () => {
+    const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases(["mcp__oc__"])
+    const alias = aliasByClientName.get("mcp__oc__")!
+    expect(alias.length).toBeGreaterThan(0)
+    expect(clientNameByAlias.get(alias)).toBe("mcp__oc__")
+  })
+
+  it("keeps every alias unique across a colliding set", () => {
+    const names = ["read", "mcp__oc__read", "read_2", "mcp__oc__read_2"]
+    const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases(names)
+    expect(new Set(aliasByClientName.values()).size).toBe(names.length)
+    for (const name of names) {
+      expect(clientNameByAlias.get(aliasByClientName.get(name)!)).toBe(name)
+    }
+  })
+})
+
+describe("resolveClientToolName", () => {
+  it("round-trips a colliding name that the blind strip reduced to the wrong tool", () => {
+    const { clientNameByAlias } = buildPassthroughToolAliases(["mcp__oc__read"])
+    // The defect: a blind strip turns the SDK-side name into `read`, which the
+    // client never declared and therefore cannot execute.
+    expect(stripMcpPrefix("mcp__oc__read")).toBe("read")
+    // Both shapes the SDK emits resolve back to the declared name.
+    expect(resolveClientToolName("mcp__oc__read", clientNameByAlias)).toBe("mcp__oc__read")
+    expect(resolveClientToolName("read", clientNameByAlias)).toBe("mcp__oc__read")
+  })
+
+  it("matches the legacy strip for ordinary tools", () => {
+    const { clientNameByAlias } = buildPassthroughToolAliases(["read"])
+    expect(resolveClientToolName("mcp__oc__read", clientNameByAlias)).toBe("read")
+    expect(resolveClientToolName("read", clientNameByAlias)).toBe("read")
+  })
+
+  it("falls back to the legacy strip with no map, for internal SDK tools", () => {
+    expect(resolveClientToolName("mcp__oc__read")).toBe("read")
+    expect(resolveClientToolName("ToolSearch")).toBe("ToolSearch")
+    expect(resolveClientToolName("mcp__opencode__read")).toBe("mcp__opencode__read")
+  })
+})
+
+describe("createPassthroughMcpServer aliasing", () => {
+  const schema = { type: "object" as const, properties: { file_path: { type: "string" as const } } }
+
+  it("advertises a colliding tool once, not doubled", () => {
+    const mcp = createPassthroughMcpServer([
+      { name: "mcp__oc__read", description: "read", input_schema: schema },
+    ])
+    expect(mcp.toolNames).toEqual(["mcp__oc__read"])
+    expect(mcp.toolNames).not.toContain("mcp__oc__mcp__oc__read")
+    expect(mcp.clientNameByAlias.get("read")).toBe("mcp__oc__read")
+  })
+
+  it("leaves an ordinary tool set byte-identical", () => {
+    const mcp = createPassthroughMcpServer([
+      { name: "read", description: "read", input_schema: schema },
+      { name: "write", description: "write", input_schema: schema },
+    ])
+    expect(mcp.toolNames).toEqual(["mcp__oc__read", "mcp__oc__write"])
+  })
+
+  it("keeps allowedTools names unique when a plain and a prefixed tool collide", () => {
+    const mcp = createPassthroughMcpServer([
+      { name: "read", description: "read", input_schema: schema },
+      { name: "mcp__oc__read", description: "bridged read", input_schema: schema },
+    ])
+    expect(new Set(mcp.toolNames).size).toBe(2)
+    expect(mcp.toolNames).toContain("mcp__oc__read")
+    expect(mcp.toolNames).toContain("mcp__oc__read_2")
+  })
+})

--- a/src/__tests__/passthrough-tool-aliases.test.ts
+++ b/src/__tests__/passthrough-tool-aliases.test.ts
@@ -66,6 +66,27 @@ describe("buildPassthroughToolAliases", () => {
     expect([...a.aliasByClientName]).toEqual([...b.aliasByClientName])
   })
 
+  it("strips every leading copy, so an already-doubled name is still dispatchable", () => {
+    const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases([
+      "mcp__oc__mcp__oc__read",
+    ])
+    // Stripping only one copy would alias back to the undispatchable form.
+    expect(aliasByClientName.get("mcp__oc__mcp__oc__read")).toBe("read")
+    expect(clientNameByAlias.get("read")).toBe("mcp__oc__mcp__oc__read")
+  })
+
+  it("keeps a singly- and doubly-prefixed name apart", () => {
+    const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases([
+      "mcp__oc__read",
+      "mcp__oc__mcp__oc__read",
+    ])
+    const single = aliasByClientName.get("mcp__oc__read")!
+    const double = aliasByClientName.get("mcp__oc__mcp__oc__read")!
+    expect(single).not.toBe(double)
+    expect(clientNameByAlias.get(single)).toBe("mcp__oc__read")
+    expect(clientNameByAlias.get(double)).toBe("mcp__oc__mcp__oc__read")
+  })
+
   it("survives a degenerate name that is nothing but the prefix", () => {
     const { aliasByClientName, clientNameByAlias } = buildPassthroughToolAliases(["mcp__oc__"])
     const alias = aliasByClientName.get("mcp__oc__")!

--- a/src/__tests__/proxy-passthrough-oc-prefixed-tools.test.ts
+++ b/src/__tests__/proxy-passthrough-oc-prefixed-tools.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Passthrough delivery for client tools already named mcp__oc__* (#967).
+ *
+ * A client that aggregates its own MCP servers declares tools like
+ * `mcp__oc__read`. Those names collide with the namespace Meridian nests
+ * client tools under, and the reverse translation was a blind
+ * `stripMcpPrefix`, so the forwarded tool_use reached the client renamed to
+ * `read` — a tool it never declared and cannot execute. The result the proxy
+ * promised the model "in a future turn" then never arrived.
+ *
+ * Live on SDK 0.2.141 / CLI 2.1.263 the same collision also cost the model its
+ * dispatch (HTTP 500 non-streaming, `stop_reason: max_tokens` streaming); that
+ * half needs the real CLI and is covered by the E43 gate. What is asserted here
+ * is the wire contract these paths own: whatever shape the SDK emits, the name
+ * delivered to the client is the name the client declared.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+import {
+  messageStart,
+  toolUseBlockStart,
+  inputJsonDelta,
+  blockStop,
+  messageDelta,
+  messageStop,
+  parseSSE,
+  assistantMessage,
+  makeRequest,
+  withMockSdkSessionId,
+} from "./helpers"
+
+let mockMessages: any[] = []
+
+installSdkMock(() => ({
+  query: (params: any) =>
+    (async function* () {
+      for (const msg of mockMessages) yield withMockSdkSessionId(msg, params.options)
+    })(),
+  createSdkMcpServer: () => ({
+    type: "sdk",
+    name: "test",
+    instance: { tool: () => {}, registerTool: () => ({}) },
+  }),
+}), "proxy-passthrough-oc-prefixed-tools.test.ts")
+
+installLoggerMock(() => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: any, fn: any) => fn(),
+}))
+
+installMcpToolsMock(() => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+/** A client whose own tool name already carries the passthrough namespace. */
+const OC_PREFIXED_TOOL = {
+  name: "mcp__oc__read",
+  description: "Read a file",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string" } },
+    required: ["file_path"],
+  },
+}
+
+const PLAIN_TOOL = {
+  name: "read",
+  description: "Read a file",
+  input_schema: {
+    type: "object",
+    properties: { file_path: { type: "string" } },
+    required: ["file_path"],
+  },
+}
+
+function app() {
+  return createProxyServer({ port: 0, host: "127.0.0.1" }).app
+}
+
+async function postStream(tools: any[]): Promise<Array<{ name: string; input: unknown }>> {
+  const res = await app().fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(makeRequest({
+      stream: true,
+      tools,
+      messages: [{ role: "user", content: "Read /tmp/a.txt" }],
+    })),
+  }))
+  const reader = res.body!.getReader()
+  const dec = new TextDecoder()
+  let raw = ""
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    raw += dec.decode(value, { stream: true })
+  }
+  return parseSSE(raw)
+    .filter(e => e.event === "content_block_start"
+      && (e.data as any).content_block?.type === "tool_use")
+    .map(e => ({
+      name: (e.data as any).content_block.name,
+      input: (e.data as any).content_block.input,
+    }))
+}
+
+async function postNonStream(tools: any[]): Promise<Array<{ name: string; input: unknown }>> {
+  const res = await app().fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(makeRequest({
+      stream: false,
+      tools,
+      messages: [{ role: "user", content: "Read /tmp/a.txt" }],
+    })),
+  }))
+  expect(res.status).toBe(200)
+  const body: any = await res.json()
+  return (body.content ?? [])
+    .filter((b: any) => b.type === "tool_use")
+    .map((b: any) => ({ name: b.name, input: b.input }))
+}
+
+describe("passthrough delivery of mcp__oc__-named client tools (#967)", () => {
+  let orig: string | undefined
+
+  beforeEach(() => {
+    mockMessages = []
+    orig = process.env.MERIDIAN_PASSTHROUGH
+    process.env.MERIDIAN_PASSTHROUGH = "1"
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    if (orig !== undefined) process.env.MERIDIAN_PASSTHROUGH = orig
+    else delete process.env.MERIDIAN_PASSTHROUGH
+  })
+
+  // The SDK emits the canonical prefixed name in some paths and the bare
+  // registered name in others. Both must land on the declared name.
+  for (const [shape, sdkName] of [
+    ["canonical prefixed name", "mcp__oc__read"],
+    ["bare registered name", "read"],
+  ] as const) {
+    it(`STREAM delivers the declared name from the SDK's ${shape}`, async () => {
+      mockMessages = [
+        messageStart(),
+        toolUseBlockStart(0, sdkName, "toolu_1"),
+        inputJsonDelta(0, '{"file_path":"/tmp/a.txt"}'),
+        blockStop(0),
+        messageDelta("tool_use"),
+        messageStop(),
+      ]
+      const calls = await postStream([OC_PREFIXED_TOOL])
+      expect(calls.map(c => c.name)).toEqual(["mcp__oc__read"])
+    })
+
+    it(`NON-STREAM delivers the declared name from the SDK's ${shape}`, async () => {
+      mockMessages = [
+        assistantMessage([
+          { type: "tool_use", id: "toolu_2", name: sdkName, input: { file_path: "/tmp/a.txt" } },
+        ]),
+      ]
+      const calls = await postNonStream([OC_PREFIXED_TOOL])
+      expect(calls.map(c => c.name)).toEqual(["mcp__oc__read"])
+    })
+  }
+
+  it("keeps the tool arguments intact alongside the corrected name", async () => {
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_3", name: "mcp__oc__read", input: { file_path: "/tmp/a.txt" } },
+      ]),
+    ]
+    const calls = await postNonStream([OC_PREFIXED_TOOL])
+    expect(calls).toEqual([{ name: "mcp__oc__read", input: { file_path: "/tmp/a.txt" } }])
+  })
+
+  it("still delivers a plain tool name unchanged (no regression)", async () => {
+    mockMessages = [
+      messageStart(),
+      toolUseBlockStart(0, "mcp__oc__read", "toolu_4"),
+      inputJsonDelta(0, '{"file_path":"/tmp/a.txt"}'),
+      blockStop(0),
+      messageDelta("tool_use"),
+      messageStop(),
+    ]
+    const calls = await postStream([PLAIN_TOOL])
+    expect(calls.map(c => c.name)).toEqual(["read"])
+  })
+
+  it("keeps a plain and a colliding tool distinguishable in one request", async () => {
+    // `read` keeps its identity; `mcp__oc__read` is registered as `read_2`.
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_5", name: "mcp__oc__read", input: { file_path: "/tmp/a.txt" } },
+        { type: "tool_use", id: "toolu_6", name: "mcp__oc__read_2", input: { file_path: "/tmp/b.txt" } },
+      ]),
+    ]
+    const calls = await postNonStream([PLAIN_TOOL, OC_PREFIXED_TOOL])
+    expect(calls.map(c => c.name)).toEqual(["read", "mcp__oc__read"])
+  })
+
+  it("leaves a foreign mcp__ namespace untouched", async () => {
+    const foreign = { ...OC_PREFIXED_TOOL, name: "mcp__zed__read" }
+    mockMessages = [
+      assistantMessage([
+        { type: "tool_use", id: "toolu_7", name: "mcp__oc__mcp__zed__read", input: { file_path: "/tmp/a.txt" } },
+      ]),
+    ]
+    const calls = await postNonStream([foreign])
+    expect(calls.map(c => c.name)).toEqual(["mcp__zed__read"])
+  })
+})

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -320,6 +320,7 @@ describe("buildQueryOptions", () => {
       toolNames: ["mcp__passthrough__custom_tool"],
       server: {} as any,
       hasDeferredTools: false,
+      clientNameByAlias: new Map([["custom_tool", "custom_tool"]]),
     }
     const result = buildQueryOptions(makeContext({
       passthrough: true,
@@ -349,6 +350,7 @@ describe("buildQueryOptions", () => {
       toolNames: ["mcp__passthrough__custom_tool"],
       server: {} as any,
       hasDeferredTools: false,
+      clientNameByAlias: new Map([["custom_tool", "custom_tool"]]),
     }
     const result = buildQueryOptions(makeContext({
       passthrough: true,

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -375,7 +375,13 @@ export function buildPassthroughToolAliases(
   for (const name of ordered) {
     if (!name.startsWith(PASSTHROUGH_MCP_PREFIX)) continue
     if (aliasByClientName.has(name)) continue
-    const base = name.slice(PASSTHROUGH_MCP_PREFIX.length) || "tool"
+    // Strip EVERY leading copy, not just one: a name that is already doubled
+    // would otherwise alias straight back to the undispatchable form.
+    let base = name
+    while (base.startsWith(PASSTHROUGH_MCP_PREFIX)) {
+      base = base.slice(PASSTHROUGH_MCP_PREFIX.length)
+    }
+    if (!base) base = "tool"
     let alias = base
     let attempt = 2
     while (clientNameByAlias.has(alias)) alias = `${base}_${attempt++}`

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -222,10 +222,13 @@ export function createPassthroughMcpServer(
   // order. Non-deterministic ordering changes the SDK system prompt between
   // requests, invalidating prompt cache and causing full context re-reads.
   const sortedTools = [...tools].sort((a, b) => a.name.localeCompare(b.name))
+  // Register under collision-free aliases; alwaysLoad and the deferral decision
+  // still key off the CLIENT's name, which is what coreToolNames describes.
+  const aliases = buildPassthroughToolAliases(sortedTools.map(tool => tool.name))
   const definitions = sortedTools.map((passthroughTool) => {
     const alwaysLoad = hasDeferredTools && shouldAlwaysLoad(passthroughTool, coreSet)
     const defineTool = (shape: Record<string, z.ZodType>): SdkMcpToolDefinition<Record<string, z.ZodType>> => ({
-      name: passthroughTool.name,
+      name: aliases.aliasByClientName.get(passthroughTool.name) ?? passthroughTool.name,
       description: passthroughTool.description || passthroughTool.name,
       inputSchema: shape,
       handler: async () => ({ content: [{ type: "text" as const, text: "passthrough" }] }),
@@ -252,8 +255,9 @@ export function createPassthroughMcpServer(
   const server = createSdkMcpServer({ name: PASSTHROUGH_MCP_NAME, tools: definitions })
   return {
     server,
-    toolNames: sortedTools.map(tool => `${PASSTHROUGH_MCP_PREFIX}${tool.name}`),
+    toolNames: definitions.map(definition => `${PASSTHROUGH_MCP_PREFIX}${definition.name}`),
     hasDeferredTools,
+    clientNameByAlias: aliases.clientNameByAlias,
   }
 }
 
@@ -326,6 +330,74 @@ export function stripMcpPrefix(toolName: string): string {
     return toolName.slice(PASSTHROUGH_MCP_PREFIX.length)
   }
   return toolName
+}
+
+export interface PassthroughToolAliases {
+  /** SDK-side name to register a tool under, by the client's declared name. */
+  aliasByClientName: ReadonlyMap<string, string>
+  /** The client's declared name, by the SDK-side registered name. */
+  clientNameByAlias: ReadonlyMap<string, string>
+}
+
+/**
+ * Choose the SDK-side name to register each client tool under.
+ *
+ * Client tools are nested inside our own MCP server, so a tool whose declared
+ * name ALREADY starts with `mcp__oc__` would be advertised to the model as
+ * `mcp__oc__mcp__oc__read`. Verified against SDK 0.2.141 / CLI 2.1.263: the CLI
+ * lists that doubled name but never dispatches it, so the PreToolUse hook never
+ * fires, nothing is captured, and the turn dies at the maxTurns cap — HTTP 500
+ * non-streaming, and streaming leaks a tool_use whose name the blind reverse
+ * strip has reduced to `read`, a tool the client never declared. Either way the
+ * client cannot answer a call it does not recognize, so the result the proxy
+ * promised the model "in a future turn" can never arrive (#967).
+ *
+ * Dropping the redundant prefix makes the canonical SDK name identical to the
+ * name the client already declared, which both dispatches and round-trips.
+ * Tools that need no alias claim their identity first, so an escaped name can
+ * never steal a name a plain tool declared; a genuine clash falls back to a
+ * numbered suffix, which the reverse map still resolves exactly.
+ *
+ * Ordinary tool sets alias to themselves, leaving model-visible names — and so
+ * the prompt cache — byte-identical.
+ */
+export function buildPassthroughToolAliases(
+  names: readonly string[],
+): PassthroughToolAliases {
+  const aliasByClientName = new Map<string, string>()
+  const clientNameByAlias = new Map<string, string>()
+  const ordered = [...names].sort((a, b) => a.localeCompare(b))
+  for (const name of ordered) {
+    if (name.startsWith(PASSTHROUGH_MCP_PREFIX)) continue
+    aliasByClientName.set(name, name)
+    clientNameByAlias.set(name, name)
+  }
+  for (const name of ordered) {
+    if (!name.startsWith(PASSTHROUGH_MCP_PREFIX)) continue
+    if (aliasByClientName.has(name)) continue
+    const base = name.slice(PASSTHROUGH_MCP_PREFIX.length) || "tool"
+    let alias = base
+    let attempt = 2
+    while (clientNameByAlias.has(alias)) alias = `${base}_${attempt++}`
+    aliasByClientName.set(name, alias)
+    clientNameByAlias.set(alias, name)
+  }
+  return { aliasByClientName, clientNameByAlias }
+}
+
+/**
+ * Map an SDK-side tool name back to the name the client declared.
+ *
+ * Strips our MCP prefix as before, then resolves the alias. Falls back to the
+ * stripped name so internal SDK tools and legacy callers without a map keep
+ * today's behavior.
+ */
+export function resolveClientToolName(
+  sdkToolName: string,
+  clientNameByAlias?: ReadonlyMap<string, string>,
+): string {
+  const alias = stripMcpPrefix(sdkToolName)
+  return clientNameByAlias?.get(alias) ?? alias
 }
 
 function toCamelCase(s: string): string {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -45,7 +45,7 @@ import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
-import { createPassthroughMcpServer, stripMcpPrefix, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { createPassthroughMcpServer, resolveClientToolName, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
@@ -2983,7 +2983,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
                 markPriorityAttemptExposure("tool_use")
                 // Track deferred tools that were discovered via ToolSearch
-                const toolName = stripMcpPrefix(input.tool_name)
+                const toolName = resolveClientToolName(input.tool_name, passthroughMcp?.clientNameByAlias)
                 if (hasDeferredTools && coreSet && !coreSet.has(toolName.toLowerCase())) {
                   discoveredTools.add(toolName)
                 }
@@ -3716,7 +3716,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }
                     // In passthrough mode, strip MCP prefix from tool names
                     if (passthrough && b.type === "tool_use" && typeof b.name === "string") {
-                      b.name = stripMcpPrefix(b.name as string)
+                      b.name = resolveClientToolName(b.name as string, passthroughMcp?.clientNameByAlias)
                     }
                     contentBlocks.push(b)
                   }
@@ -4909,8 +4909,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         }
                         if (passthrough && block.name.startsWith(PASSTHROUGH_MCP_PREFIX)) {
                           // Passthrough mode: SDK sent the name WITH the mcp__oc__ prefix.
-                          // Strip it so OpenCode sees the bare tool name.
-                          block.name = stripMcpPrefix(block.name)
+                          // Resolve it back to the name the client declared — usually just
+                          // the prefix stripped, but not for a client tool whose own name
+                          // carries this namespace (#967).
+                          block.name = resolveClientToolName(block.name, passthroughMcp?.clientNameByAlias)
                           if (block.id) streamedToolUseIds.add(block.id)
                         } else if (block.name.startsWith("mcp__")) {
                           // Internal MCP tool (mcp__opencode__* etc.) — skip, SDK handles it
@@ -4920,7 +4922,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           // Passthrough mode: SDK already stripped the mcp__oc__ prefix before
                           // emitting the stream_event (observed in practice — the SDK normalises
                           // tool names in stream events). Track the ID so the early-break
-                          // condition fires correctly.
+                          // condition fires correctly. The name here is the registered alias,
+                          // so it still needs resolving back to what the client declared —
+                          // for an ordinary tool that is a no-op.
+                          block.name = resolveClientToolName(block.name, passthroughMcp?.clientNameByAlias)
                           streamedToolUseIds.add(block.id)
                         }
                         if (passthrough && eventIndex !== undefined) {


### PR DESCRIPTION
Triage of #967 found a real, distinct defect in Meridian's passthrough tool
loop. This fixes that defect. It does **not** confirm the root cause the issue
proposes — see "What #967 got right and wrong" below.

Reported by @filipporovelli in #967, whose incident write-up (job records,
transcript prefix-extension measurements, and the ruled-out #946 controls) is
what made this reproducible from the outside.

## The defect

Client tools are registered inside Meridian's own `oc` MCP server, so a client
that aggregates MCP servers itself — a Claude Code CLI job with an `oc` server
configured, for instance — declares tools like `mcp__oc__read` that collide
with that namespace. The collision broke two things at once:

- **Registration.** The tool was advertised as `mcp__oc__mcp__oc__read`. On SDK
  0.2.141 / CLI 2.1.263 the CLI lists that doubled name but never dispatches
  it, so the PreToolUse hook never fired and nothing was captured
  (`tools=0/1` in the `sdk_termination` line). Non-streaming returned
  **HTTP 500**; streaming ended `stop_reason: max_tokens` with an inline
  `error` event.
- **Delivery.** The reverse translation was a blind `stripMcpPrefix`, so the
  tool_use that did leak reached the client renamed to `read` — a tool it never
  declared.

Either half breaks the promise the forwarding hook makes to the model, that
"the result will be delivered in a future turn": a client cannot answer a call
it does not recognize, so that turn never comes. A coordinator watching the
stalled job then re-dispatches it.

Confirmed live before the fix, `x-meridian-agent: claude-code`, haiku:

```
OK       declared=read             stream=false delivered=[read]  stop=tool_use   errors=0 http=200
BROKEN   declared=mcp__oc__read    stream=false delivered=[]      stop=undefined  errors=1 http=500
OK       declared=mcp__zed__read   stream=false delivered=[mcp__zed__read] stop=tool_use errors=0 http=200
OK       declared=read             stream=true  delivered=[read]  stop=tool_use   errors=0 http=200
BROKEN   declared=mcp__oc__read    stream=true  delivered=[read]  stop=max_tokens errors=1 http=200
OK       declared=mcp__zed__read   stream=true  delivered=[mcp__zed__read] stop=tool_use errors=0 http=200
```

Only the exact collision with our own prefix is affected; a foreign `mcp__*`
namespace was and remains fine.

## The fix

Register colliding tools under a collision-free alias and reverse it through an
explicit map instead of a blind string strip. Dropping the redundant prefix
makes the canonical SDK name identical to the name the client already declared,
which both dispatches and round-trips. Every leading copy is stripped, so a
name that arrives already doubled cannot alias back to the undispatchable form.

Tools needing no alias claim their identity first, so an escaped name can never
steal a name a plain tool declared; a genuine clash (a client declaring both
`read` and `mcp__oc__read`) falls back to a numbered suffix that the map still
resolves exactly. **Ordinary tool sets alias to themselves**, so model-visible
names — and therefore the prompt cache — are byte-identical.

Verified model-visible naming, same client tool, before → after:

```
declared mcp__oc__read → model saw mcp__oc__mcp__oc__read   (before)
declared mcp__oc__read → model saw mcp__oc__read            (after)
```

## What #967 got right and wrong

The reported symptom is real and this fix addresses a mechanism that produces
it exactly. Two of the issue's supporting inferences do not hold, and are worth
recording so they are not chased again:

- **"18 of the 20 newest transcripts terminate at the forward stub" is the
  designed steady state, not evidence of a stall.** The forward stub is
  generated by Meridian's PreToolUse hook *inside its own nested SDK session*
  and is never sent to a client as a `tool_result` — `PASSTHROUGH_DENY_REASON`
  has exactly one call site. Meridian then resumes the assistant checkpoint
  with `forkSession`, so the denial branch is deliberately dead history. E41
  already asserts this: the active fork must hold exactly one *real* answer and
  *zero* denials per delivered call. A nested transcript ending at the stub is
  what every passthrough tool step looks like, on every client.
- **The compounding "strict prefix-extension" replay is #767's signature**, not
  this defect's. A fresh replay starts a new SDK session, hence a new
  transcript whose history is a prefix-extension of the last.

  > **Correction (added after merge).** This section originally claimed that
  > shape was still unfixed on main via `hasOnlyNewToolResults`. That was
  > wrong. `hasOnlyNewToolResults` no longer exists — `9d283288` (2026-09-04,
  > shipped in 1.68.0) replaced it with `appendedBlocksAreNew`, which permits
  > non-`tool_result` blocks appended to a slot that is already a tool-result
  > turn. So `user[tool_result,text]` continues on main; verified directly.
  > The error came from reading `session/lineage.ts` out of a stale local
  > branch and asserting it was main's state. Nothing in this PR's own change
  > or validation depended on that claim.

The respawn decision itself is above Meridian; the issue's own job records show
`respawnFlags: []`.

**Attribution to that incident is therefore not established.** It holds only if
those bg jobs declared `mcp__oc__*`-named tools, which needs the reporter's tool
list. I could not verify it locally — `opencode-with-claude` is not installed
here. The fix stands on its own regardless: the defect is reproducible from a
bare `curl`.

## Validation

- `npm test`: **3624 pass, 0 fail, 1 pre-existing skip**.
- `npm run typecheck`, `npm run build`: clean.
- **Failed-before / passed-after**, same assertions: the new integration test
  fails 6/8 on the base commit (delivering `read` and `read_2` where
  `mcp__oc__read` was declared) and passes 8/8 with the fix. The 2 that pass
  either way are the no-regression controls.
- **New E43 live gate**, real proxy + SDK, full forward → execute → answer round
  trip per shape and mode. Passed all four combinations: haiku and
  `claude-opus-5`, streaming and non-streaming, subject plus both controls.
  Opus was run because #967 is an Opus report; haiku alone would not settle it.
  The Opus runs predate the doubled-name commit, which only affects names with
  two or more leading copies — a shape the gate does not exercise, and whose
  single-prefix behavior is byte-identical. E43 was re-run on haiku in both
  modes afterwards and stayed green.
- **E41 all four modes** (chain/parallel × stream/non-stream), required for
  changes touching passthrough resume or the deny hook: all PASS — correct tool
  batching, a distinct durable fork per result round, exactly one real answer
  per delivered call in the active history, and every continuation reading the
  prior cached prefix.
- Post-fix live accounting shows `captured=1` and
  `sdk_termination_recovered` on every request, where the same probe previously
  logged `tools=0/1` with `envelope=open`.

Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system CLI 2.1.263,
OpenCode 1.18.29 — the CLI and OpenCode versions in the report. Node v22.22.3,
macOS arm64. Isolated ports, session-store dirs and fixture workdirs throughout;
history inspected only through supported SDK APIs.

## Known limitations

- Issue #967 stays open, and deliberately so — it is NOT resolved by this PR.
  The respawn loop's attribution is unestablished and the replay amplification
  belongs to #767. (An earlier draft of this line paired a closing keyword with
  that issue number to deny it; GitHub read it as a closing reference and
  auto-closed the issue on merge. It has been reopened, and the phrasing here
  now avoids the pattern entirely.)
- Does not change the `oc` namespace itself, so #893 stays open. If that lands
  and makes the prefix adapter-derived, `buildPassthroughToolAliases` and the
  `passthroughEarlyStop.ts` prefix mirror must follow the same value.
- A pre-existing gap left alone: `isClientForwardedToolUse` treats a bare
  `mcp__*` name as an internal SDK tool, so a foreign-namespace client tool
  would not arm the early-stop tracker if the SDK ever emitted its bare form.
  It does not today — the E43 foreign-namespace control passes in both modes.



