### PR TITLE
fix(errors): classify the per-tier refusal that ends in prose

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -267,6 +267,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E41 | [Passthrough multi-turn: one call, one answer](#e41-passthrough-multi-turn-one-call-one-answer) | **Automated**: `bun scripts/e2e-passthrough-turns.mjs [--stream]` — real proxy + SDK + Claude Max. Chain and `PROBE_PARALLEL=1` modes assert exact tool-call batching, a distinct durable fork per result round, one real answer per delivered call in the active transcript, and full prompt-cache continuity. **Run all four chain/parallel × stream/non-stream combinations before releases touching passthrough resume or the deny hook** | 2026-08-26 |
 | E42 | [OpenCode V2 beta compatibility](#e42-opencode-v2-beta-compatibility) | **Automated**, exact betas `18314` and `18866`: run `e2e-opencode-v2-package.mjs --live --extended` with each pinned binary. Covers hidden title/summary isolation, process restart, passthrough tools, undo/fork/compaction and overlapping general children. Also test source and packed npm artifacts. **Run after any V2 plugin/API change; another beta is not a pass** | 2026-08-27 |
 | E43 | [Passthrough tools in a namespaced client](#e43-passthrough-tools-in-a-namespaced-client) | **Automated**: `bun scripts/e2e-passthrough-namespaced-tools.mjs [--stream]` — real proxy + SDK. A client tool declared `mcp__oc__read` collides with the namespace Meridian nests client tools under; asserts the call is still dispatched and captured, delivered under the name the client declared, and answered from the client's real result, with an ordinary and a foreign-namespace control alongside. **Run before any release touching passthrough tool registration, the deny hook, or tool-name delivery** | 2026-09-08 |
+| E44 | [Tier refusal failover](#e44-tier-refusal-failover) | **Automated**: `bun scripts/e2e-tier-refusal-failover.mjs [--stream]` — local refusal fixture, **real Claude Max fallback**. Asserts the credits-era per-tier banner is recorded 429 on the refusing profile and that a healthy profile actually answers. Catches what unit tests cannot: the shape that arrives carries the upstream status. **Run before releases touching error classification or priority failover** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3902,6 +3903,52 @@ system CLI 2.1.263. All four combinations passed: haiku and `claude-opus-5`,
 streaming and non-streaming, subject plus both controls. Against the same commit
 without the fix, the subject shape returned HTTP 500 non-streaming and delivered
 `read` with `stop_reason: max_tokens` streaming.
+
+## E44: Tier refusal failover
+
+**What it proves:** a credits-era per-tier refusal is classified as a rate limit
+and priority routing really moves the request to a healthy profile.
+
+**Why unit tests were not enough.** `classifyError` returned
+`rate_limit_error` for the banner as quoted in #962 while the live request still
+returned 500 and failed nothing over. The reason is that an API-key or gateway
+profile never delivers the banner bare — the SDK splices the upstream status in
+front of it:
+
+```
+Claude Code returned an error result: API Error: 400 You've reached your Fable limit. Switch to another model to continue.
+```
+
+That numeric status sat between the accepted wrappers and the banner and
+defeated the line anchor for *every* suffix, including the two that already
+worked. Only driving the real failover path surfaced it.
+
+```bash
+bun scripts/e2e-tier-refusal-failover.mjs
+bun scripts/e2e-tier-refusal-failover.mjs --stream
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- A pre-flight check that the banner classifies as `rate_limit_error` and that
+  the type is a failover trigger, so a classifier regression is named as such
+  rather than surfacing as a confusing routing failure.
+- The real CLI reaches the refusal upstream on every case — a cooldown carried
+  over from the previous case cannot let a run skip straight to the fallback.
+- Exactly one refused attempt, recorded against the refusing profile with
+  status **429**, not 500.
+- HTTP 200 overall, exactly one served row, served by the healthy profile, and
+  the real Claude Max fallback answers with the run's receipt string.
+
+**What is stubbed, and why that is acceptable.** The refusal is a local fixture
+upstream: producing this banner for real means exhausting a real Fable tier on
+a real account, which a gate cannot do on demand. The **fallback leg is real** —
+a live Claude Max profile answering a live prompt — so what is stubbed is the
+condition we cannot cause, not the behavior under test.
+
+**Verified:** 2026-09-08. Both modes pass. Against the contributor's suffix fix
+alone the gate fails with the refused attempt recorded 500 and no failover,
+which is what identified the missing status allowance.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-tier-refusal-failover.mjs
+++ b/scripts/e2e-tier-refusal-failover.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env bun
+// Actual proxy + real Claude Max fallback: does the credits-era per-tier
+// refusal whose suffix is PROSE fail over to a healthy profile?
+//
+// `REACHED_YOUR_TIER_LIMIT` accepted the banner only when the line ended at
+// `limit.` or continued with a slash command. A Claude Max pool receives a
+// fourth shape and it is the only one that arrives there:
+//
+//   Claude Code returned an error result: You've reached your Fable limit.
+//   Switch to another model to continue.
+//
+// The prefix was already anticipated; the suffix is prose, so the refusal fell
+// through to `500 api_error`, `isAccountFailoverError` never saw it, and a pool
+// with three other profiles holding Fable window went unused (#962, reported by
+// @justprosh with a live 1.66.0 capture).
+//
+// Unit tests pin the regex. What they cannot show is the consequence: that the
+// classification actually reaches priority routing and that the next profile
+// really answers. This drives the whole path with a real Claude Max second leg.
+//
+// The refusal itself is a local fixture upstream, deliberately: producing this
+// banner for real means exhausting a real Fable tier on a real account, which
+// is not something a gate can do on demand. The FALLBACK leg is real — a live
+// Claude Max profile answering a live prompt — so what is stubbed is the thing
+// we cannot cause, not the thing under test.
+//
+// Run before releases touching error classification or priority failover.
+//
+//   bun scripts/e2e-tier-refusal-failover.mjs [--stream]
+import assert from 'node:assert/strict'
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const repo = resolve(process.env.E2E_MERIDIAN_ROOT ?? '.')
+const root = realpathSync(mkdtempSync(join(tmpdir(), 'meridian-tier-refusal-')))
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('MERIDIAN_') || key.startsWith('CLAUDE_PROXY_')) delete process.env[key]
+}
+Object.assign(process.env, {
+  MERIDIAN_CONFIG_DIR: join(root, 'config'),
+  MERIDIAN_SESSION_DIR: join(root, 'sessions'),
+  MERIDIAN_WORKDIR: root,
+  MERIDIAN_TELEMETRY_PERSIST: '0',
+  MERIDIAN_ROUTING: 'priority',
+  MERIDIAN_PROFILE_ORDER: 'refused,working',
+})
+
+// The exact string captured live on 1.66.0. Kept verbatim — the whole defect is
+// that its suffix is prose rather than a slash command, so paraphrasing it here
+// would silently stop testing the reported shape.
+const TIER_REFUSAL = "You've reached your Fable limit. Switch to another model to continue."
+
+let refusedCalls = 0
+const upstream = Bun.serve({
+  hostname: '127.0.0.1',
+  port: 0,
+  fetch(request) {
+    if (!new URL(request.url).pathname.endsWith('/messages')) return Response.json({ input_tokens: 100 })
+    refusedCalls++
+    return Response.json(
+      { type: 'error', error: { type: 'api_error', message: TIER_REFUSAL } },
+      { status: 400, headers: { 'x-should-retry': 'false', 'request-id': 'fixture-tier-refusal' } },
+    )
+  },
+})
+
+const { startProxyServer } = await import(pathToFileURL(join(repo, 'src/proxy/server.ts')).href)
+const { telemetryStore } = await import(pathToFileURL(join(repo, 'src/telemetry/index.ts')).href)
+const { rateLimitStore } = await import(pathToFileURL(join(repo, 'src/proxy/rateLimitStore.ts')).href)
+const { classifyError, isAccountFailoverError } = await import(pathToFileURL(join(repo, 'src/proxy/errors.ts')).href)
+
+// Cheap pre-flight so a classifier regression is named as such rather than
+// showing up as a confusing routing failure further down.
+const classified = classifyError(`Claude Code returned an error result: ${TIER_REFUSAL}`)
+console.log(JSON.stringify({ step: 'classify', status: classified.status, type: classified.type }))
+assert.equal(classified.type, 'rate_limit_error', 'the prose-suffix banner must classify as a rate limit')
+assert(isAccountFailoverError(classified.type), 'that classification must be a failover trigger')
+
+const start = () => startProxyServer({
+  port: 0, host: '127.0.0.1', silent: true,
+  profiles: [
+    { id: 'refused', type: 'api', apiKey: 'local-fixture-key', baseUrl: `http://127.0.0.1:${upstream.port}` },
+    { id: 'working', type: 'claude-max' },
+  ],
+  defaultProfile: 'refused',
+})
+
+const cases = process.argv.includes('--stream') ? ['failover-stream'] : ['failover', 'failover-stream']
+let proxy = await start()
+try {
+  for (const mode of cases) {
+    // A fresh proxy per case, so the previous case's expected account cooldown
+    // cannot let this one skip straight to the fallback without a refusal.
+    if (mode !== cases[0]) { await proxy.close(); proxy = await start() }
+    const port = proxy.server.address().port
+    rateLimitStore.clear()
+    const requestId = crypto.randomUUID()
+    const receipt = `TIERFAILOVER_${crypto.randomUUID()}`
+    const stream = mode.endsWith('-stream')
+    const callsBefore = refusedCalls
+
+    const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-request-id': requestId, 'x-opencode-session': requestId },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001', max_tokens: 128, stream,
+        messages: [{ role: 'user', content: `Reply with exactly ${receipt}.` }],
+      }),
+      signal: AbortSignal.timeout(180000),
+    })
+    const body = await response.text()
+    const rows = telemetryStore.getRecent({ limit: 100 }).filter(row => row.requestId === requestId)
+    const failures = rows.filter(row => row.error !== null)
+    const served = rows.filter(row => row.error === null)
+
+    let reply = ''
+    if (stream) {
+      for (const line of body.split('\n')) {
+        if (!line.startsWith('data:')) continue
+        const event = JSON.parse(line.slice(5))
+        if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') reply += event.delta.text
+      }
+    } else {
+      reply = (JSON.parse(body).content ?? []).filter(b => b.type === 'text').map(b => b.text).join('')
+    }
+
+    console.log(JSON.stringify({
+      mode, status: response.status, refusedCalls,
+      rows: rows.map(r => ({ profile: r.profileId, status: r.status, error: r.error })),
+      answered: reply.includes(receipt),
+    }))
+
+    assert(refusedCalls > callsBefore, 'the real CLI must reach the local refusal upstream for this case')
+    assert.equal(failures.length, 1, 'exactly one attempt should have been refused')
+    assert.equal(failures[0].profileId, 'refused')
+    // The point of the fix: the refusal is recorded as a rate limit, not a 500.
+    assert.equal(failures[0].status, 429, 'the prose-suffix refusal must be recorded as 429, not 500')
+    // And the consequence: a healthy profile actually served the request.
+    assert.equal(response.status, 200)
+    assert.equal(served.length, 1)
+    assert.equal(served[0].profileId, 'working')
+    assert(reply.includes(receipt), 'the real Claude Max fallback must answer the prompt')
+  }
+  console.log(JSON.stringify({ result: 'PASS', root, refusedCalls, cases }))
+} finally {
+  await proxy.close()
+  upstream.stop(true)
+}

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -910,6 +910,13 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["SDK wrapper newline", "Claude Code returned an error result:\nYou've reached your Fable 5 limit."],
     ["trailing newline", "You've reached your Fable 5 limit.\n"],
     ["CRLF line ending", "You've reached your Fable 5 limit.\r\n"],
+    // The prose suffix, not a slash command. Observed live on 1.66.0 through a
+    // gateway fronting a Claude Max pool: every Fable turn came back in this
+    // exact shape, classified api_error, and failed nothing over while three
+    // other profiles in the pool had Fable window left.
+    ["prose switch suffix", "Claude Code returned an error result: You've reached your Fable limit. Switch to another model to continue."],
+    ["prose switch suffix, bare banner", "You've reached your Fable 5 limit. Switch to another model to continue."],
+    ["prose switch suffix without the trailing clause", "You've reached your Opus limit. Switch to another model."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
@@ -931,6 +938,9 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["joined run command", "You've reached your Fable 5 limitRun /usage-credits"],
     ["joined usage command", "You've reached your Fable 5 limit/usage-credits"],
     ["unspaced punctuated command", "You've reached your Fable 5 limit.Run /usage-credits"],
+    // The prose suffix is enumerated, not a licence for any tail: a sentence
+    // that merely starts like it must still fall through.
+    ["prose switch suffix continuing into documentation", "You've reached your Fable 5 limit. Switch to another model to continue, the docs say, but the account is healthy"],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -917,6 +917,14 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["prose switch suffix", "Claude Code returned an error result: You've reached your Fable limit. Switch to another model to continue."],
     ["prose switch suffix, bare banner", "You've reached your Fable 5 limit. Switch to another model to continue."],
     ["prose switch suffix without the trailing clause", "You've reached your Opus limit. Switch to another model."],
+    // An API-key or gateway profile gets the upstream status spliced in ahead of
+    // the banner. Found by driving the real failover path: the classifier said
+    // rate_limit_error for the bare string while the live request still 500'd,
+    // because this is the shape that actually arrives. It defeated every suffix,
+    // including the two that already worked.
+    ["status-prefixed prose suffix", "Claude Code returned an error result: API Error: 400 You've reached your Fable limit. Switch to another model to continue."],
+    ["status-prefixed slash suffix", "Claude Code returned an error result: API Error: 429 You've reached your Fable 5 limit. /model to switch models."],
+    ["status-prefixed bare banner", "API Error: 400 You've reached your Opus limit."],
   ])("maps the credits-era per-tier %s to rate_limit_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("rate_limit_error")
@@ -941,6 +949,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     // The prose suffix is enumerated, not a licence for any tail: a sentence
     // that merely starts like it must still fall through.
     ["prose switch suffix continuing into documentation", "You've reached your Fable 5 limit. Switch to another model to continue, the docs say, but the account is healthy"],
+    // The status allowance is exactly three digits immediately before the
+    // banner, so neither a longer number nor an arbitrary numeric preamble
+    // opens the line up.
+    ["four-digit lookalike before the banner", "API Error: 4000 You've reached your Fable limit."],
+    ["numeric preamble that is not a status", "Retried 3 times: you've reached your Fable limit before, but not now"],
+    ["status prefix on a non-quota qualifier", "API Error: 400 You've reached your configured limit."],
   ])("does not classify credits-era per-tier %s as a rate limit", (_label, msg) => {
     expect(classifyError(msg).type).toBe("api_error")
   })

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -122,10 +122,18 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * #764 and #787. Enumerate tiers rather than wildcarding the qualifier: the
  * CLI also emits "reached your specified/configured ..." prose that is not
  * account quota exhaustion (#909). A numeric version suffix accepts real tier
- * versions without arbitrary words, and only known CLI command suffixes are
+ * versions without arbitrary words, and only known CLI suffixes are
  * accepted: a false positive exhausts a healthy profile pool-wide, so the
  * banner must occupy its whole line rather than merely open one. New tier
  * names must be added to the enumeration.
+ *
+ * Not every accepted suffix is a slash command. The credits-era banner also
+ * ends in plain prose — "Switch to another model to continue." — which is the
+ * shape a Claude Max pool receives today, observed live through a gateway on
+ * 1.66.0 and still unmatched by this pattern as released in 1.68.0. It is
+ * enumerated like the others rather than admitted as a wildcard tail, because
+ * the negative cases below turn on exactly that distinction: a documentation
+ * sentence continuing past the banner must not exhaust a healthy profile.
  *
  * The bound is the LINE, not the message — `/m`, like HIT_YOUR_SPEND_LIMIT
  * above and CONTEXT_OVERFLOW_SIGNALS below. `server.ts` appends captured
@@ -136,7 +144,7 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * always, the harmless "custom betas" warning being emitted first. Both shapes
  * then fell through to the code-1 branch, which tells the operator to run
  * `claude login` for what is actually a quota refusal. */
-const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models)\.?|[.!]?)[ \t\r]*$/m
+const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models|switch[ \t]+to[ \t]+another[ \t]+model(?:[ \t]+to[ \t]+continue)?)\.?|[.!]?)[ \t\r]*$/m
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -127,6 +127,15 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * banner must occupy its whole line rather than merely open one. New tier
  * names must be added to the enumeration.
  *
+ * An API-key or gateway profile does not deliver the banner bare: the SDK
+ * prefixes the upstream status, so the line arrives as "... error result: API
+ * Error: 400 You've reached your Fable limit. ...". That numeric status sat
+ * between the accepted wrappers and the banner and defeated the anchor for
+ * EVERY suffix, including the two that were already supported — found by
+ * driving the real failover path rather than by reading the pattern. Exactly
+ * three digits are allowed, immediately before the banner, so a 4-digit
+ * lookalike or a "Retried 3 times:" preamble still falls through.
+ *
  * Not every accepted suffix is a slash command. The credits-era banner also
  * ends in plain prose — "Switch to another model to continue." — which is the
  * shape a Claude Max pool receives today, observed live through a gateway on
@@ -144,7 +153,7 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * always, the harmless "custom betas" warning being emitted first. Both shapes
  * then fell through to the code-1 branch, which tells the operator to run
  * `claude login` for what is actually a quota refusal. */
-const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models|switch[ \t]+to[ \t]+another[ \t]+model(?:[ \t]+to[ \t]+continue)?)\.?|[.!]?)[ \t\r]*$/m
+const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*(?:\d{3}[ \t]+)?you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models|switch[ \t]+to[ \t]+another[ \t]+model(?:[ \t]+to[ \t]+continue)?)\.?|[.!]?)[ \t\r]*$/m
 
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose


### PR DESCRIPTION
Incorporates **#962 by @justprosh**, whose commit is cherry-picked here with
their Author and AuthorDate preserved, plus one maintainer correction that live
validation turned up.

## The contributor's fix

`REACHED_YOUR_TIER_LIMIT` accepted the credits-era banner only when the line
ended at `limit.` or continued with a slash command. A Claude Max pool receives
a fourth shape, and it is the only one that arrives there — the suffix is prose:

```
You've reached your Fable limit. Switch to another model to continue.
```

So the refusal fell through to `500 api_error`, `isAccountFailoverError` never
saw it, and a pool with three other profiles holding Fable window went unused.
Verified independently against main before touching anything: that string
returns `false` from the released pattern while the two known shapes return
`true`.

They enumerated the new suffix rather than admitting a wildcard tail, and added
a negative case pinning the boundary — a documentation sentence continuing past
the banner must not exhaust a healthy profile pool-wide. That judgement is
right and is kept as-is.

## The maintainer correction, and why it took live E2E to find

Their fix is correct for the banner as quoted, but not sufficient for the
deployment they observed it in. #962 reports it "through a gateway fronting a
pool of Claude Max profiles" — and an API-key or gateway profile never delivers
the banner bare. The SDK splices the upstream status in front:

```
Claude Code returned an error result: API Error: 400 You've reached your Fable limit. Switch to another model to continue.
```

That numeric status sits between the accepted wrappers and the banner and
defeated the line anchor for **every** suffix, including the two that already
worked. The unit tests could not see this: `classifyError` returned
`rate_limit_error` for the bare string while the live request still returned
500 and failed nothing over, because the bare string is not what arrives.

The new E44 gate is what exposed it. Against the contributor's commit alone it
fails with the refused attempt recorded 500 and no failover; with the correction
both modes pass.

The allowance is exactly three digits immediately before the banner, so a
4-digit lookalike, a `Retried 3 times:` preamble, and a status in front of a
non-quota qualifier all still fall through. A false positive here exhausts a
healthy pool, so the guard matters more than the convenience.

## Validation

- `npm test`: **3634 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- **New E44 live gate** (`scripts/e2e-tier-refusal-failover.mjs`), both
  streaming and non-streaming: the refusing profile records **429 /
  rate_limit_error** and a **real Claude Max** profile answers the prompt with
  the run's receipt string. Before/after is explicit — the same gate fails
  `500 !== 429` on the contributor's commit alone.
- The refusal itself is a local fixture upstream, deliberately: producing this
  banner for real means exhausting a real Fable tier on a real account. The
  **fallback leg is live**, so what is stubbed is the condition we cannot cause,
  not the behavior under test. Recorded as a limitation in E2E.md.
- Regex matrix checked against 12 cases including 6 negatives, several of which
  I invented rather than inheriting from the PR, so the boundary is not merely
  self-consistent.

Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system CLI 2.1.263, Node
v22.22.3, macOS arm64. Isolated config/session/telemetry dirs and an ephemeral
port throughout.

## Note on credit

This repo squashes with a blank body, which would drop the contributor's
authorship from the resulting commit. The squash body will carry an explicit
`Co-authored-by` trailer for @justprosh, matching how `9d283288` credited
@sbaranov. Their original PR should be closed as incorporated, not superseded.
