### PR TITLE
fix(codex): keep auto-defer off for Codex requests

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -268,6 +268,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E42 | [OpenCode V2 beta compatibility](#e42-opencode-v2-beta-compatibility) | **Automated**, exact betas `18314` and `18866`: run `e2e-opencode-v2-package.mjs --live --extended` with each pinned binary. Covers hidden title/summary isolation, process restart, passthrough tools, undo/fork/compaction and overlapping general children. Also test source and packed npm artifacts. **Run after any V2 plugin/API change; another beta is not a pass** | 2026-08-27 |
 | E43 | [Passthrough tools in a namespaced client](#e43-passthrough-tools-in-a-namespaced-client) | **Automated**: `bun scripts/e2e-passthrough-namespaced-tools.mjs [--stream]` — real proxy + SDK. A client tool declared `mcp__oc__read` collides with the namespace Meridian nests client tools under; asserts the call is still dispatched and captured, delivered under the name the client declared, and answered from the client's real result, with an ordinary and a foreign-namespace control alongside. **Run before any release touching passthrough tool registration, the deny hook, or tool-name delivery** | 2026-09-08 |
 | E44 | [Tier refusal failover](#e44-tier-refusal-failover) | **Automated**: `bun scripts/e2e-tier-refusal-failover.mjs [--stream]` — local refusal fixture, **real Claude Max fallback**. Asserts the credits-era per-tier banner is recorded 429 on the refusing profile and that a healthy profile actually answers. Catches what unit tests cannot: the shape that arrives carries the upstream status. **Run before releases touching error classification or priority failover** | 2026-09-08 |
+| E45 | [Codex auto-defer](#e45-codex-auto-defer) | **Automated**: `bun scripts/e2e-codex-auto-defer.mjs` — real proxy + SDK, 40 Codex-shaped tools. Asserts a Codex request reports no deferral and that `exec_command` is loaded rather than found via ToolSearch. The codex transform inherited OpenCode's core tool names, which match nothing Codex sends, so every tool was deferred. **Run before releases touching the codex transform, auto-defer, or `computePassthroughMaxTurns`** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3949,6 +3950,53 @@ condition we cannot cause, not the behavior under test.
 **Verified:** 2026-09-08. Both modes pass. Against the contributor's suffix fix
 alone the gate fails with the refused attempt recorded 500 and no failover,
 which is what identified the missing status allowance.
+
+## E45: Codex auto-defer
+
+**What it proves:** a Codex request past the auto-defer threshold keeps its
+tools loaded, and `exec_command` in particular does not have to be discovered
+before it can be used.
+
+**Why it needs the real SDK.** `codexTransforms` runs after the shared OpenCode
+transform and inherited its `coreToolNames`
+(`read, write, edit, bash, glob, grep`). Codex sends none of those names, so
+once a session crossed the threshold — trivial for Codex, which inlines every
+MCP namespace's tool definitions — the core set matched nothing and **every**
+tool was deferred, `exec_command` included. Live pre-fix diagnostic:
+
+```
+deferred=40/40 tools (core: read,write,edit,bash,glob,grep)
+discovered=1 (exec_command) session_total=1
+```
+
+Deferral also has a second cost: `computePassthroughMaxTurns` only returns the
+single-turn cap when `singleTurnHandoff` holds, and that requires
+`!hasDeferredTools` — so turning deferral on lifted the cap from 1 to 4 and let
+the SDK's discarded digest turn generate on the full context.
+
+```bash
+bun scripts/e2e-codex-auto-defer.mjs
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- No `deferred=` diagnostic. That line is the observable for
+  `hasDeferredTools`, which is what moves the turn cap.
+- No `discovered=` diagnostic — `exec_command` is loaded directly rather than
+  costing a ToolSearch round trip.
+- HTTP 200, at least one `function_call` returned, and one of them named
+  `exec_command`. These are regression guards, not discriminators: they pass
+  before and after, and exist so a "fix" that merely made the prompt cheaper
+  while breaking Codex would still fail.
+
+**What this gate does NOT prove.** The digest-turn cost is real but
+scale-dependent — #963 measured 2–3× cache reads per turn on a 680k-token
+session, and a 40-tool probe on a short prompt does not reliably provoke the
+extra turn. The model-call count is therefore reported, not asserted, so the
+gate does not carry a check that looks meaningful and discriminates nothing.
+
+**Verified:** 2026-09-08. Against pre-fix code the first two checks fail with
+the diagnostics quoted above; with the fix all five pass.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-codex-auto-defer.mjs
+++ b/scripts/e2e-codex-auto-defer.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env bun
+// Live: does a Codex request past the auto-defer threshold still defer every
+// tool, and does `exec_command` stay loaded rather than needing discovery?
+//
+// `codexTransforms` runs after the shared OpenCode transform and used to
+// inherit its `coreToolNames` (`read, write, edit, bash, glob, grep`). Codex
+// sends none of those names, so once a session crosses the threshold — trivial
+// for Codex, which inlines every MCP namespace's tool definitions — the core
+// set matched nothing and EVERY tool was deferred, `exec_command` included.
+//
+// The expensive part is not the deferral itself. `computePassthroughMaxTurns`
+// only returns the single-turn cap when `singleTurnHandoff` holds, and that
+// requires `!hasDeferredTools` — so switching deferral on silently lifted the
+// cap from 1 to 4 and every tool-calling turn also generated the SDK's
+// discarded digest turn on the full context. @justprosh measured 2-3x cache
+// reads per turn on a 680k-token session (#963), with no `ToolSearch` call
+// anywhere in the transcripts: the extra reads were digest turns, not
+// discovery. Meridian was paying for a feature it never used.
+//
+// What this asserts, against a real proxy and a real SDK:
+//
+//   1. A 40-tool Codex request reports NO deferral. The `deferred=` diagnostic
+//      is the observable for `hasDeferredTools`, which is what moves the cap.
+//   2. `exec_command` is loaded rather than discovered via ToolSearch. Pre-fix
+//      the diagnostic reads `discovered=1 (exec_command)` — Codex's primary
+//      tool cost a discovery round trip before it could be used.
+//   3. Codex still gets its tool call, named as it declared it. A cheaper
+//      prompt that stops driving Codex would not be a fix.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching the codex transform, auto-defer, or `computePassthroughMaxTurns`.
+//
+//   bun scripts/e2e-codex-auto-defer.mjs
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mcodex-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+writeFileSync(join(WORKDIR, 'target.txt'), 'codex-auto-defer-probe\n')
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3544)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+// Above DEFAULT_DEFER_THRESHOLD (15) so auto-defer is genuinely in play.
+const TOOL_COUNT = Number(process.env.PROBE_TOOLS ?? 40)
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+// Codex's real shape: its own built-ins plus a large MCP namespace, none of
+// whose names appear in OpenCode's core list.
+const tools = [
+  {
+    type: 'function', name: 'exec_command',
+    description: 'Run a shell command and return its output',
+    parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+  },
+  ...Array.from({ length: TOOL_COUNT - 1 }, (_, i) => ({
+    type: 'function', name: `mcp__iskron_bridge__tool_${i}`,
+    description: `Namespaced bridge tool ${i}`,
+    parameters: { type: 'object', properties: { arg: { type: 'string' } } },
+  })),
+]
+
+const res = await fetch(`http://127.0.0.1:${PORT}/v1/responses`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json', 'x-meridian-agent': 'codex' },
+  body: JSON.stringify({
+    model: MODEL, stream: false, tools,
+    input: [{ role: 'user', content: [{ type: 'input_text',
+      text: `Use the exec_command tool to run: cat ${join(WORKDIR, 'target.txt')}. Call the tool now.` }] }],
+  }),
+})
+const body = await res.text()
+let parsed
+try { parsed = JSON.parse(body) } catch { parsed = null }
+
+const requestLine = proxyLog.find(l => l.includes('[PROXY]') && l.includes('adapter=codex'))
+const deferLine = proxyLog.find(l => l.includes('deferred='))
+const calls = (parsed?.output ?? []).filter(o => o?.type === 'function_call')
+
+say(`\n=== codex auto-defer (tools=${TOOL_COUNT}, model=${MODEL}) ===`)
+say(`  request: ${requestLine?.replace(/^.*\[PROXY\]\s*\S+\s*/, '') ?? '(none)'}`)
+
+// 1. No deferral. This is the observable for hasDeferredTools.
+check(!deferLine, 'auto-defer is off for a Codex request', deferLine ?? 'no deferred= diagnostic emitted')
+
+// 2. exec_command is LOADED, not discovered. Deferring it forced a ToolSearch
+// round trip before Codex's own primary tool could be called; the diagnostic
+// says `discovered=1 (exec_command)` pre-fix. This discriminates as reliably
+// as the deferral line and is the concrete consequence for Codex.
+const discoveredLine = proxyLog.find(l => l.includes('discovered='))
+check(!discoveredLine, 'exec_command was loaded directly, not found via ToolSearch',
+  discoveredLine?.replace(/^.*\[PROXY\]\s*\S+\s*/, '') ?? 'no discovered= diagnostic emitted')
+
+// Reported, not asserted. The digest-turn cost is real but scale-dependent:
+// #963 measured 2-3x cache reads per turn on a 680k-token session, and a
+// 40-tool probe on a short prompt does not reliably provoke the extra turn —
+// it passed both before and after the fix. Asserting it here would be a check
+// that looks meaningful and discriminates nothing.
+const assistantTurns = proxyLog.filter(l => l.includes('usage:') && l.includes('[PROXY]')).length
+say(`  note  model calls this turn: ${assistantTurns} (cap is 1 with deferral off, 4 with it on;`
+  + ` the digest cost shows up at real session size, not here)`)
+
+// 3. Codex still gets a usable tool call under its own name.
+check(res.status === 200, 'request succeeded', `http=${res.status}`)
+check(calls.length >= 1, 'a function_call was returned', `calls=${calls.length}`)
+if (calls.length) {
+  check(calls.some(c => c.name === 'exec_command'),
+    'exec_command survived in the prompt and was callable',
+    `named: ${calls.map(c => c.name).join(',')}`)
+}
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-10)) say(`    ${l}`)
+  if (!parsed) say(`  raw body: ${body.slice(0, 400)}`)
+} else {
+  say('  PASS: no deferral, no ToolSearch discovery, exec_command callable')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/codex-transform-core-tools.test.ts
+++ b/src/__tests__/codex-transform-core-tools.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The codex transform must switch auto-defer off: it inherits OpenCode's core
+ * tool list, which names nothing Codex sends, so a Codex request past the
+ * defer threshold deferred every tool (exec_command included) and each
+ * tool-calling turn paid the SDK's digest turn on the full context. With no
+ * core set the passthrough MCP server never defers and the single-turn cap
+ * holds.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { codexTransforms } from "../proxy/transforms/codex"
+import { openCodeTransforms } from "../proxy/transforms/opencode"
+import type { RequestContext } from "../proxy/transform"
+import { createPassthroughMcpServer } from "../proxy/passthroughTools"
+
+function runCodexPipeline(body: Record<string, unknown>): RequestContext {
+  let ctx = { body, adapter: "codex" } as unknown as RequestContext
+  for (const t of [...openCodeTransforms, ...codexTransforms]) {
+    if ((t.adapters === undefined || t.adapters.includes("codex")) && t.onRequest) ctx = t.onRequest(ctx)
+  }
+  return ctx
+}
+
+describe("codex transform auto-defer", () => {
+  it("forces passthrough and leaves no core set so nothing is deferred", () => {
+    const tools = Array.from({ length: 40 }, (_, i) => ({ name: i === 0 ? "exec_command" : `mcp__iskron_bridge__tool_${i}` }))
+    const ctx = runCodexPipeline({ model: "m", messages: [], tools })
+    expect(ctx.passthrough).toBe(true)
+    expect(ctx.coreToolNames).toBeUndefined()
+    const mcp = createPassthroughMcpServer(tools, ctx.coreToolNames ? [...ctx.coreToolNames] : undefined)
+    expect(mcp.hasDeferredTools).toBe(false)
+  })
+})

--- a/src/proxy/transforms/codex.ts
+++ b/src/proxy/transforms/codex.ts
@@ -9,12 +9,24 @@ import type { Transform, RequestContext } from "../transform"
  * global MERIDIAN_PASSTHROUGH setting. Internal mode (SDK executes tools) would
  * leave Codex waiting for tool calls that never come back.
  */
+/**
+ * Codex sends every MCP server as a `namespace` entry with the tool
+ * definitions inline, so a desktop session easily carries 250+ tools and
+ * crosses the auto-defer threshold. Deferring them is a net loss here: the
+ * deferred budget lifts the single-turn cap (see computePassthroughMaxTurns),
+ * so every tool-calling turn also generates the SDK's discarded digest turn —
+ * one or two extra reads of the full context, measured 2-3x cache reads per
+ * turn on a 680k-token session — while the alternative, loading the schemas,
+ * costs ~125k cached tokens once. Codex never sets `defer_loading` itself, so
+ * with no core set auto-defer stays off, the cap stays at 1, and a tool turn
+ * is one model call again.
+ */
 export const codexTransforms: Transform[] = [
   {
     name: "codex-force-passthrough",
     adapters: ["codex"],
     onRequest(ctx: RequestContext): RequestContext {
-      return { ...ctx, passthrough: true }
+      return { ...ctx, passthrough: true, coreToolNames: undefined }
     },
   },
 ]


### PR DESCRIPTION
Incorporates **#963 by @justprosh**, cherry-picked with their Author and
AuthorDate preserved, plus a new live gate.

## The defect

`codexTransforms` runs after the shared OpenCode transform and inherited its
`coreToolNames` (`read, write, edit, bash, glob, grep`). Codex sends none of
those names, so once a session crossed the auto-defer threshold — trivial for
Codex, which inlines every MCP namespace's tool definitions — the core set
matched nothing and **every** tool was deferred, `exec_command` included.

Verified independently rather than taken on trust. Their test fails on main
with exactly the leak they describe:

```
expect(ctx.coreToolNames).toBeUndefined()
Received: [ "read", "write", "edit", "bash", "glob", "grep" ]
```

and the consequence measured directly: 40/40 tools deferred including
`exec_command`, and `maxTurns` going 1 → 4 because `singleTurnHandoff` requires
`!hasDeferredTools`, which is what lets the SDK's discarded digest turn
generate on the full context.

`coreToolNames: undefined` is also the documented idiom, not a trick —
`AgentAdapter.getCoreToolNames` says "Return undefined to disable auto-defer for
this agent". The codex adapter defines no `getCoreToolNames` of its own, so the
leak was purely via the inherited transform and the fix belongs exactly where
they put it. Their earlier revision (naming Codex's built-ins as the core set)
was correctly abandoned: any non-empty core set still sets `hasDeferredTools`
and still lifts the cap.

## New live gate (E45)

There was **no Codex E2E coverage at all** before this. `scripts/e2e-codex-auto-defer.mjs`
drives a real proxy and real SDK with 40 Codex-shaped tools. Against pre-fix
code it fails with the reporter's own diagnostic:

```
deferred=40/40 tools (core: read,write,edit,bash,glob,grep)
discovered=1 (exec_command) session_total=1
```

With the fix, both clear. The `discovered=` line is worth noting on its own —
deferring `exec_command` made Codex's primary tool cost a ToolSearch round trip
before it could be called.

The gate deliberately does **not** assert the digest-turn cost. That cost is
real but scale-dependent (2–3× cache reads on a 680k-token session), and a
40-tool probe on a short prompt does not reliably provoke the extra turn — it
passed both before and after. It is reported instead, so the gate doesn't carry
a check that looks meaningful and discriminates nothing. Three regression guards
(200, a `function_call` returned, `exec_command` among them) pass both ways by
design: they exist so a change that merely made the prompt cheaper while
breaking Codex would still fail.

## One thing worth flagging on the source branch

The intermediate commit `b9bca255` tracks a `node_modules` symlink pointing at
`/Users/aleksei/dev/meridian/node_modules`. Their own follow-up `6781ff43`
removes it, but anyone cherry-picking or checking out that middle commit gets a
dangling symlink over their real install — it clobbered mine once. Only the
final commit is incorporated here, so main is unaffected. Mentioned in the
closing comment so it doesn't bite them on a future branch.

## Validation

- `npm test`: **3635 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- Failed-before / passed-after on their unit test and on the new live gate,
  both quoted above.
- Live gate run on a real SDK with Claude Max, `x-meridian-agent: codex` through
  `/v1/responses`.

Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system CLI 2.1.263,
codex-cli 0.153.4 available locally (the version in the report). Node v22.22.3,
macOS arm64. Isolated workdir, session store and ephemeral port.

## Credit

This repo squashes with a blank body, which would drop the contributor's
authorship. The squash body will carry an explicit `Co-authored-by` trailer for
@justprosh.
