### PR TITLE
fix(responses): carry Codex namespace and custom tools through to Claude

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -269,6 +269,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E43 | [Passthrough tools in a namespaced client](#e43-passthrough-tools-in-a-namespaced-client) | **Automated**: `bun scripts/e2e-passthrough-namespaced-tools.mjs [--stream]` — real proxy + SDK. A client tool declared `mcp__oc__read` collides with the namespace Meridian nests client tools under; asserts the call is still dispatched and captured, delivered under the name the client declared, and answered from the client's real result, with an ordinary and a foreign-namespace control alongside. **Run before any release touching passthrough tool registration, the deny hook, or tool-name delivery** | 2026-09-08 |
 | E44 | [Tier refusal failover](#e44-tier-refusal-failover) | **Automated**: `bun scripts/e2e-tier-refusal-failover.mjs [--stream]` — local refusal fixture, **real Claude Max fallback**. Asserts the credits-era per-tier banner is recorded 429 on the refusing profile and that a healthy profile actually answers. Catches what unit tests cannot: the shape that arrives carries the upstream status. **Run before releases touching error classification or priority failover** | 2026-09-08 |
 | E45 | [Codex auto-defer](#e45-codex-auto-defer) | **Automated**: `bun scripts/e2e-codex-auto-defer.mjs` — real proxy + SDK, 40 Codex-shaped tools. Asserts a Codex request reports no deferral and that `exec_command` is loaded rather than found via ToolSearch. The codex transform inherited OpenCode's core tool names, which match nothing Codex sends, so every tool was deferred. **Run before releases touching the codex transform, auto-defer, or `computePassthroughMaxTurns`** | 2026-09-08 |
+| E46 | [Codex namespace and MCP tools](#e46-codex-namespace-and-mcp-tools) | **Automated**: `bun scripts/e2e-codex-namespace-tools.mjs [--stream]` — real proxy + SDK. Codex 0.15x sends MCP servers as `{type:"namespace", tools:[...]}`, which the Responses translator dropped. Asserts namespaced tools reach Claude, calls come back carrying `namespace`, and a `function_call_output` whose output is a content-item ARRAY does not 400. **Run before releases touching the Responses translator or Codex tool handling** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -3997,6 +3998,52 @@ gate does not carry a check that looks meaningful and discriminates nothing.
 
 **Verified:** 2026-09-08. Against pre-fix code the first two checks fail with
 the diagnostics quoted above; with the fix all five pass.
+
+## E46: Codex namespace and MCP tools
+
+**What it proves:** a Codex session's MCP tools reach Claude, its calls come
+back in a form Codex can route, and a turn replaying an MCP result succeeds.
+
+**The shapes were taken from a real capture, not from docs.** codex-cli 0.153.4
+was pointed at a recording endpoint with an actual stdio MCP server attached.
+It sent 13 top-level tool entries: 10 flat `function`, one `web_search`, and
+**2 `namespace` entries holding 7 nested tools**. Feeding that captured request
+through the pre-fix translator, 10 tools reached Claude and all 7 namespaced
+ones vanished — including Codex's own `multi_agent_v1` namespace
+(`spawn_agent`, `wait_agent`, …), so sub-agents were unavailable, not just the
+user's MCP server.
+
+```bash
+bun scripts/e2e-codex-namespace-tools.mjs
+bun scripts/e2e-codex-namespace-tools.mjs --stream
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- The flattened client tool count reaches Claude (`tools=4` for the fixture:
+  one flat plus three nested; `web_search` is correctly dropped, having no
+  client-side counterpart).
+- A `function_call` comes back named as Codex declared it and **carrying its
+  `namespace`**. Codex's router resolves `ToolName::new(namespace, name)`, so a
+  flattened name is silently unroutable — the call looks fine and never
+  dispatches.
+- A follow-up turn whose `function_call_output.output` is an **array of content
+  items** returns 200 and the model answers from it. MCP tools return arrays;
+  passed verbatim they reach Anthropic as `tool_result.content[0].type =
+  "input_text"` and 400, killing every turn after an MCP call.
+
+**Harness note.** In streaming, `function_call` arguments arrive as their own
+delta events and the completed item can carry an empty `arguments`. The gate
+accumulates them before replaying turn 2 — without that it replays an
+argument-less call, the model simply calls the tool again, and the run looks
+like a broken emitter when the emitter is fine.
+
+**Not covered.** Codex's freeform `apply_patch` (`{type:"custom", format:
+{grammar}}`) did not appear in a default-config capture, so the custom-tool
+path is covered by unit tests only and is **not** live-verified here.
+
+**Verified:** 2026-09-08, both modes. Against pre-fix code the same gate fails
+with `tools=1` and no call returned.
 
 ## Concurrent transcript publication
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/aleksei/dev/meridian/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/aleksei/dev/meridian/node_modules

--- a/scripts/e2e-codex-namespace-tools.mjs
+++ b/scripts/e2e-codex-namespace-tools.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+// Live: do Codex's namespaced (MCP) tools reach Claude, come back as calls
+// Codex can route, and survive a second turn carrying their results?
+//
+// Codex 0.15x stopped sending MCP tools as flat `function` entries. Each server
+// arrives as one `{type:"namespace", name:"mcp__<server>", tools:[...]}` with
+// the definitions nested inside. `translateResponsesToAnthropic` kept only
+// `type:"function"`, so every namespace was dropped silently (#964).
+//
+// Verified against a real capture from codex-cli 0.153.4 driving an actual
+// stdio MCP server: 13 top-level entries, 2 of them namespaces holding 7 tools.
+// Pre-fix, 10 tools reached Claude and all 7 namespaced ones vanished — and not
+// only the user's MCP server: Codex's own `multi_agent_v1` namespace
+// (spawn_agent, wait_agent, ...) went with it, so sub-agents were unavailable.
+//
+// The fixture below reproduces those shapes rather than embedding the capture,
+// which carried local paths. Shapes asserted here were taken from that capture,
+// not from the API docs.
+//
+// Three claims, and the third is the one that made this urgent:
+//
+//   1. Namespaced tools reach Claude, under deterministic aliases.
+//   2. A call comes back as `function_call` carrying `namespace`, because
+//      Codex's router resolves `ToolName::new(namespace, name)` — a flattened
+//      name never matches and the call is silently unroutable.
+//   3. A follow-up turn replaying `function_call_output` whose `output` is an
+//      ARRAY of content items succeeds. MCP tools return arrays, and passed
+//      verbatim they reach Anthropic as `tool_result.content[0].type =
+//      "input_text"` → HTTP 400, killing every turn after an MCP call.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching the Responses translator or Codex tool handling.
+//
+//   bun scripts/e2e-codex-namespace-tools.mjs [--stream]
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mcodexns-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const STREAM = process.argv.includes('--stream')
+const PORT = Number(process.env.PROBE_PORT ?? 3546)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+const REALM = 'realm-fixture-zeta'
+
+// Codex 0.153.4's real shape: flat built-ins, namespaces with nested tools,
+// and a server-side kind that has no client-side counterpart.
+const tools = [
+  { type: 'function', name: 'exec_command', description: 'Run a shell command',
+    parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] } },
+  { type: 'namespace', name: 'mcp__iskron', description: 'Tools in the mcp__iskron namespace.', tools: [
+    { type: 'function', name: 'realm_lookup', description: 'Look up a realm by id',
+      parameters: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } },
+    { type: 'function', name: 'realm_list', description: 'List all realms',
+      parameters: { type: 'object', properties: {} } },
+  ] },
+  { type: 'namespace', name: 'multi_agent_v1', description: 'Tools for spawning and managing sub-agents.', tools: [
+    { type: 'function', name: 'spawn_agent', description: 'Spawn a sub-agent',
+      parameters: { type: 'object', properties: { task: { type: 'string' } } } },
+  ] },
+  { type: 'web_search' },
+]
+
+async function post(input) {
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-meridian-agent': 'codex' },
+    body: JSON.stringify({ model: MODEL, stream: STREAM, tools, input }),
+  })
+  const text = await res.text()
+  if (!STREAM) {
+    let body = null
+    try { body = JSON.parse(text) } catch { /* reported by the caller */ }
+    return { status: res.status, output: body?.output ?? [], raw: text }
+  }
+  const output = []
+  // Function-call arguments stream as their own delta events; the completed
+  // item can arrive with `arguments` empty. Accumulate them, or turn 2 replays
+  // a call with no arguments and the model just calls the tool again — which
+  // looks exactly like a broken emitter but is the harness's fault.
+  const argsByItem = new Map()
+  for (const line of text.split('\n')) {
+    if (!line.startsWith('data:')) continue
+    let ev
+    try { ev = JSON.parse(line.slice(5)) } catch { continue }
+    if (ev.type === 'response.function_call_arguments.delta' && ev.item_id) {
+      argsByItem.set(ev.item_id, (argsByItem.get(ev.item_id) ?? '') + (ev.delta ?? ''))
+    }
+    if (ev.type === 'response.function_call_arguments.done' && ev.item_id && ev.arguments !== undefined) {
+      argsByItem.set(ev.item_id, ev.arguments)
+    }
+    if (ev.type === 'response.output_item.done' && ev.item) output.push(ev.item)
+  }
+  for (const item of output) {
+    if (item.type === 'function_call' && !item.arguments && argsByItem.has(item.id)) {
+      item.arguments = argsByItem.get(item.id)
+    }
+  }
+  return { status: res.status, output, raw: text }
+}
+
+// ---- turn 1: the namespaced tool must be visible and callable -------------
+const first = await post([{ role: 'user', content: [{ type: 'input_text',
+  text: 'Call the realm_lookup tool in the mcp__iskron namespace with id "zeta". Call the tool now.' }] }])
+
+const toolLine = proxyLog.find(l => l.includes('[PROXY]') && l.includes('adapter=codex'))
+const toolCount = Number(/tools=(\d+)/.exec(toolLine ?? '')?.[1] ?? -1)
+say(`\n=== codex namespace tools (stream=${STREAM}, model=${MODEL}) ===`)
+say(`  request: ${toolLine?.replace(/^.*\[PROXY\]\s*\S+\s*/, '') ?? '(none)'}`)
+
+// 1 flat + 2 + 1 nested = 4 client tools; web_search is correctly dropped.
+check(toolCount === 4, 'namespaced tools were flattened through to Claude',
+  `tools=${toolCount} (expected 4: exec_command + 2 iskron + 1 multi_agent)`)
+
+const calls = first.output.filter(o => o?.type === 'function_call')
+check(first.status === 200, 'turn 1 succeeded', `http=${first.status}`)
+check(calls.length >= 1, 'a function_call was returned', `calls=${calls.length}`)
+
+const nsCall = calls.find(c => c.name === 'realm_lookup')
+// 2. Codex resolves ToolName::new(namespace, name); a flattened name is unroutable.
+check(Boolean(nsCall), 'the call is named as Codex declared it, not as the alias',
+  calls.map(c => `${c.namespace ?? '-'}::${c.name}`).join(', ') || 'none')
+if (nsCall) {
+  check(nsCall.namespace === 'mcp__iskron', 'the call carries its namespace',
+    `namespace=${JSON.stringify(nsCall.namespace)}`)
+}
+
+// ---- turn 2: an MCP result is an ARRAY of content items -------------------
+if (nsCall) {
+  const second = await post([
+    { role: 'user', content: [{ type: 'input_text', text: 'Call the realm_lookup tool in the mcp__iskron namespace with id "zeta".' }] },
+    { type: 'function_call', name: nsCall.name, namespace: nsCall.namespace,
+      call_id: nsCall.call_id, arguments: nsCall.arguments, status: 'completed' },
+    // The shape that used to 400: output is a content-item array, not a string.
+    { type: 'function_call_output', call_id: nsCall.call_id,
+      output: [{ type: 'input_text', text: REALM }] },
+  ])
+  const text = second.output
+    .filter(o => o?.type === 'message')
+    .flatMap(o => (o.content ?? []).map(c => c.text ?? ''))
+    .join('')
+  check(second.status === 200, 'turn 2 accepted a content-item tool output',
+    `http=${second.status}${second.status !== 200 ? ` body=${second.raw.slice(0, 220)}` : ''}`)
+  check(text.includes(REALM) || text.length > 0, 'the model answered from the MCP result',
+    text ? `quoted=${text.includes(REALM)}` : 'no assistant text')
+}
+
+say(`\n=== verdict (stream=${STREAM}) ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-10)) say(`    ${l}`)
+} else {
+  say('  PASS: namespaces reach Claude, calls carry their namespace, content-item results round-trip')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/openai-responses-namespaces.test.ts
+++ b/src/__tests__/openai-responses-namespaces.test.ts
@@ -185,3 +185,46 @@ describe("createResponsesSseTranslator with aliases", () => {
     expect(done).toEqual({ type: "custom_tool_call", id: "fc_toolu_p", call_id: "toolu_p", name: "apply_patch", input: "*** Begin Patch\n*** End Patch\n", status: "completed" })
   })
 })
+
+describe("function_call_output content items", () => {
+  // MCP tool results come back from Codex as content items, not a string
+  // (FunctionCallOutputBody::ContentItems); a verbatim pass-through reached
+  // Anthropic as `tool_result.content[0].type = "input_text"` → 400.
+  it("maps input_text and data-URL input_image items to tool_result blocks", () => {
+    const png = "data:image/png;base64,iVBORw0KGgo="
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      tools,
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", arguments: "{}", call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: [
+          { type: "input_text", text: "ГРАФ: merkazim [60]" },
+          { type: "input_image", image_url: png },
+          { type: "encrypted_content", encrypted_content: "opaque" },
+        ] },
+      ] as never,
+    })!
+    const result = (r.messages.at(-1)!.content as unknown as Array<Record<string, unknown>>).find((b) => b.type === "tool_result")!
+    expect(result.tool_use_id).toBe("call_1")
+    expect(result.content).toEqual([
+      { type: "text", text: "ГРАФ: merkazim [60]" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBORw0KGgo=" } },
+      { type: "text", text: "[Unsupported encrypted_content tool output part omitted]" },
+    ])
+  })
+
+  it("keeps string outputs as strings and turns an empty item list into an empty string", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "function_call", name: "shell", arguments: "{}", call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: "a.txt" },
+        { type: "function_call", name: "shell", arguments: "{}", call_id: "call_2" },
+        { type: "function_call_output", call_id: "call_2", output: [] },
+      ] as never,
+    })!
+    const results = r.messages.flatMap((m) => m.content as unknown as Array<Record<string, unknown>>).filter((b) => b.type === "tool_result")
+    expect(results.map((b) => b.content)).toEqual(["a.txt", ""])
+  })
+})

--- a/src/__tests__/openai-responses-namespaces.test.ts
+++ b/src/__tests__/openai-responses-namespaces.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Namespaced (MCP) and custom tools on the Responses API — Codex 0.153 ships
+ * every MCP server as one `{type:"namespace", tools:[…]}` entry and its
+ * freeform `apply_patch` as `{type:"custom"}`; a translator that keeps only
+ * `type:"function"` silently loses all of them. Wire shapes mirror a request
+ * captured from Codex Desktop 0.153.4 (25 tools, 12 namespaces).
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  translateResponsesToAnthropic,
+  translateAnthropicToResponses,
+  createResponsesSseTranslator,
+  buildResponsesToolAliases,
+  responsesToolAlias,
+  RESPONSES_TOOL_ALIAS_MAX,
+} from "../proxy/openaiResponses"
+import { PASSTHROUGH_MCP_PREFIX } from "../proxy/passthroughTools"
+
+const iskronNamespace = {
+  type: "namespace",
+  name: "mcp__iskron-bridge",
+  description: "Graph tools.",
+  tools: [
+    { type: "function", name: "iskron_orient", description: "Orient in a realm.", strict: false, parameters: { type: "object", properties: { realm: { type: "string" } }, required: ["realm"] } },
+    { type: "function", name: "iskron_look", description: "Read one node.", strict: false, parameters: { type: "object", properties: { node_id: { type: "string" } } } },
+  ],
+}
+const applyPatch = {
+  type: "custom",
+  name: "apply_patch",
+  description: "The `apply_patch` tool can be used to edit files.",
+  format: { type: "grammar", syntax: "lark", definition: "start: begin_patch hunk+ end_patch" },
+}
+const tools = [
+  { type: "function", name: "shell", description: "run", strict: false, parameters: { type: "object", properties: {} } },
+  applyPatch,
+  iskronNamespace,
+  { type: "web_search", external_web_access: true } as unknown as { type: string; name: string },
+]
+
+describe("responsesToolAlias", () => {
+  it("leaves the alias budget for the passthrough MCP prefix", () => {
+    expect(RESPONSES_TOOL_ALIAS_MAX).toBe(64 - PASSTHROUGH_MCP_PREFIX.length)
+  })
+
+  it("joins namespace and name, sanitizing characters Claude rejects", () => {
+    expect(responsesToolAlias("mcp__iskron-bridge", "iskron_orient")).toBe("mcp__iskron-bridge__iskron_orient")
+    expect(responsesToolAlias("mcp__a.b", "x y")).toBe("mcp__a_b__x_y")
+    expect(responsesToolAlias(undefined, "apply_patch")).toBe("apply_patch")
+  })
+
+  it("hashes names over the budget deterministically", () => {
+    const long = responsesToolAlias("mcp__codex_apps__codex_document_control", "codex_document_control_list_sections")
+    expect(long.length).toBeLessThanOrEqual(RESPONSES_TOOL_ALIAS_MAX)
+    expect(long).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(long).toBe(responsesToolAlias("mcp__codex_apps__codex_document_control", "codex_document_control_list_sections"))
+    expect(long).not.toBe(responsesToolAlias("mcp__codex_apps__codex_document_control", "codex_document_control_list_section"))
+  })
+})
+
+describe("buildResponsesToolAliases", () => {
+  it("lists nested and custom tools, not top-level functions", () => {
+    const aliases = buildResponsesToolAliases(tools)
+    expect([...aliases.keys()].sort()).toEqual(["apply_patch", "mcp__iskron-bridge__iskron_look", "mcp__iskron-bridge__iskron_orient"])
+    expect(aliases.get("mcp__iskron-bridge__iskron_orient")).toEqual({ namespace: "mcp__iskron-bridge", name: "iskron_orient", kind: "function" })
+    expect(aliases.get("apply_patch")).toEqual({ name: "apply_patch", kind: "custom" })
+  })
+})
+
+describe("translateResponsesToAnthropic with namespaces", () => {
+  it("flattens namespace tools and exposes custom tools as a single-string function", () => {
+    const r = translateResponsesToAnthropic({ model: "m", input: "x", tools })!
+    expect(r.tools!.map((t) => t.name)).toEqual(["shell", "apply_patch", "mcp__iskron-bridge__iskron_orient", "mcp__iskron-bridge__iskron_look"])
+    const orient = r.tools!.find((t) => t.name === "mcp__iskron-bridge__iskron_orient")!
+    expect(orient.description).toBe("[mcp__iskron-bridge] Orient in a realm.")
+    expect(orient.input_schema).toEqual({ type: "object", properties: { realm: { type: "string" } }, required: ["realm"] })
+    const patch = r.tools!.find((t) => t.name === "apply_patch")!
+    expect(patch.description).toContain("edit files")
+    expect(patch.description).toContain("Input grammar (lark)")
+    expect((patch.input_schema as { required: string[] }).required).toEqual(["input"])
+  })
+
+  it("replays namespaced and custom calls from history under the same aliases", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      tools,
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", arguments: '{"realm":"r60"}', call_id: "call_1" },
+        { type: "function_call_output", call_id: "call_1", output: "ГРАФ: merkazim [60]" },
+        { type: "custom_tool_call", name: "apply_patch", input: "*** Begin Patch\n*** End Patch\n", call_id: "call_2" },
+        { type: "custom_tool_call_output", call_id: "call_2", output: "Done!" },
+      ] as never,
+    })!
+    const assistant = r.messages.filter((m) => m.role === "assistant").flatMap((m) => m.content as unknown as Array<Record<string, unknown>>)
+    expect(assistant).toEqual([
+      { type: "tool_use", id: "call_1", name: "mcp__iskron-bridge__iskron_orient", input: { realm: "r60" } },
+      { type: "tool_use", id: "call_2", name: "apply_patch", input: { input: "*** Begin Patch\n*** End Patch\n" } },
+    ])
+    const results = r.messages.filter((m) => m.role === "user").flatMap((m) => m.content as unknown as Array<Record<string, unknown>>).filter((b) => b.type === "tool_result")
+    expect(results.map((b) => b.tool_use_id)).toEqual(["call_1", "call_2"])
+  })
+})
+
+describe("translateAnthropicToResponses with aliases", () => {
+  const ctx = { responseId: "resp_1", model: "m", created: 1, toolAliases: buildResponsesToolAliases(tools) }
+
+  it("turns an aliased tool_use into a namespaced function_call", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "tool_use", id: "toolu_1", name: "mcp__iskron-bridge__iskron_orient", input: { realm: "r60" } }],
+      stop_reason: "tool_use",
+    }, ctx)
+    expect((out.output as Array<Record<string, unknown>>)[0]).toEqual({
+      type: "function_call", id: "fc_toolu_1", call_id: "toolu_1", name: "iskron_orient", namespace: "mcp__iskron-bridge",
+      arguments: '{"realm":"r60"}', status: "completed",
+    })
+  })
+
+  it("turns a custom tool_use into a custom_tool_call carrying the raw input", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "tool_use", id: "toolu_2", name: "apply_patch", input: { input: "*** Begin Patch\n*** End Patch\n" } }],
+      stop_reason: "tool_use",
+    }, ctx)
+    expect((out.output as Array<Record<string, unknown>>)[0]).toEqual({
+      type: "custom_tool_call", id: "fc_toolu_2", call_id: "toolu_2", name: "apply_patch",
+      input: "*** Begin Patch\n*** End Patch\n", status: "completed",
+    })
+  })
+
+  it("leaves top-level function tools untouched", () => {
+    const out = translateAnthropicToResponses({
+      content: [{ type: "tool_use", id: "toolu_3", name: "shell", input: { command: ["ls"] } }],
+      stop_reason: "tool_use",
+    }, ctx)
+    const item = (out.output as Array<Record<string, unknown>>)[0]!
+    expect(item.type).toBe("function_call")
+    expect(item.name).toBe("shell")
+    expect("namespace" in item).toBe(false)
+  })
+})
+
+describe("createResponsesSseTranslator with aliases", () => {
+  const ctx = { responseId: "resp_s", model: "m", created: 1, toolAliases: buildResponsesToolAliases(tools) }
+  function run(events: Array<Record<string, unknown>>) {
+    const translate = createResponsesSseTranslator(ctx)
+    return events.flatMap((e) => translate(e as never))
+  }
+  const start = { type: "message_start", message: { id: "m1", usage: { input_tokens: 1 } } }
+  const end = [
+    { type: "content_block_stop", index: 0 },
+    { type: "message_delta", delta: { stop_reason: "tool_use" }, usage: { output_tokens: 1 } },
+    { type: "message_stop" },
+  ]
+
+  it("streams a namespaced function_call with argument deltas", () => {
+    const out = run([
+      start,
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_9", name: "mcp__iskron-bridge__iskron_orient", input: {} } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"realm":"r60"}' } },
+      ...end,
+    ])
+    const added = out.find((e) => e.event === "response.output_item.added")!.data.item as Record<string, unknown>
+    expect(added).toMatchObject({ type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", call_id: "toolu_9" })
+    expect(out.filter((e) => e.event === "response.function_call_arguments.delta")).toHaveLength(1)
+    const done = out.find((e) => e.event === "response.output_item.done")!.data.item as Record<string, unknown>
+    expect(done).toMatchObject({ type: "function_call", name: "iskron_orient", namespace: "mcp__iskron-bridge", arguments: '{"realm":"r60"}', status: "completed" })
+    const completed = out.find((e) => e.event === "response.completed")!.data.response as { output: Array<Record<string, unknown>> }
+    expect(completed.output[0]).toMatchObject({ type: "function_call", namespace: "mcp__iskron-bridge" })
+  })
+
+  it("streams a custom tool as one custom_tool_call item without argument deltas", () => {
+    const out = run([
+      start,
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_p", name: "apply_patch", input: {} } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"input":"*** Begin ' } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: 'Patch\\n*** End Patch\\n"}' } },
+      ...end,
+    ])
+    const added = out.find((e) => e.event === "response.output_item.added")!.data.item as Record<string, unknown>
+    expect(added).toMatchObject({ type: "custom_tool_call", name: "apply_patch", call_id: "toolu_p", status: "in_progress" })
+    expect(out.some((e) => e.event === "response.function_call_arguments.delta")).toBe(false)
+    expect(out.some((e) => e.event === "response.function_call_arguments.done")).toBe(false)
+    const done = out.find((e) => e.event === "response.output_item.done")!.data.item as Record<string, unknown>
+    expect(done).toEqual({ type: "custom_tool_call", id: "fc_toolu_p", call_id: "toolu_p", name: "apply_patch", input: "*** Begin Patch\n*** End Patch\n", status: "completed" })
+  })
+})

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -53,10 +53,20 @@ interface ResponsesFunctionCallItem {
   arguments: string
   call_id: string
 }
+/**
+ * `function_call_output.output` is a plain string for shell-style tools and an
+ * array of content items for MCP tools (Codex's FunctionCallOutputBody is an
+ * untagged Text | ContentItems); custom tool outputs are always strings.
+ */
+interface ResponsesOutputContentItem {
+  type: "input_text" | "input_image" | "input_audio" | "encrypted_content" | string
+  text?: string
+  image_url?: string
+}
 interface ResponsesFunctionCallOutputItem {
   type: "function_call_output"
   call_id: string
-  output: string
+  output: string | ResponsesOutputContentItem[]
 }
 /** A freeform (`type:"custom"`) tool call — Codex's `apply_patch`. */
 interface ResponsesCustomToolCallItem {
@@ -315,6 +325,32 @@ function partsToBlocks(content: ResponsesContentPart[] | string | undefined): An
 }
 
 /**
+ * Anthropic `tool_result.content` for a Responses tool output. Content items
+ * are mapped part by part — `input_text` → text, data-URL `input_image` →
+ * image — and anything else becomes an omission note, so an MCP tool that
+ * answered with structured content never reaches the API as an unknown tag.
+ */
+function toolOutputToContent(output: string | ResponsesOutputContentItem[] | undefined): string | AnthropicContentBlock[] {
+  if (output === undefined || output === null) return ""
+  if (typeof output === "string") return output
+  if (!Array.isArray(output)) return typeof output === "object" ? JSON.stringify(output) : String(output)
+  const blocks: AnthropicContentBlock[] = []
+  for (const part of output) {
+    if (!part || typeof part !== "object") continue
+    if (typeof part.text === "string") {
+      blocks.push({ type: "text", text: part.text })
+    } else if (part.type === "input_image") {
+      const image = typeof part.image_url === "string" ? parseDataUrlImage(part.image_url) : null
+      blocks.push(image ?? { type: "text", text: "[Unsupported input_image omitted: only data URLs are currently supported]" })
+    } else {
+      blocks.push({ type: "text", text: `[Unsupported ${String(part.type)} tool output part omitted]` })
+    }
+  }
+  // Anthropic rejects an empty content array; an empty string is fine.
+  return blocks.length > 0 ? blocks : ""
+}
+
+/**
  * Map a Responses `tool_choice` to Anthropic's. Codex sends `"auto"`,
  * `"required"`, `"none"`, or `{type:"function", name}`. `"none"` maps to
  * undefined (Anthropic has no explicit none — omitting lets the model decide,
@@ -391,7 +427,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
       }
       case "function_call_output": {
         const fo = item as ResponsesFunctionCallOutputItem
-        pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: fo.output })
+        pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: toolOutputToContent(fo.output) })
         break
       }
       case "custom_tool_call": {
@@ -402,7 +438,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
       }
       case "custom_tool_call_output": {
         const co = item as ResponsesCustomToolCallOutputItem
-        pushBlock("user", { type: "tool_result", tool_use_id: co.call_id, content: co.output })
+        pushBlock("user", { type: "tool_result", tool_use_id: co.call_id, content: toolOutputToContent(co.output) })
         break
       }
       case "reasoning":

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -26,6 +26,7 @@ import type {
   AnthropicUsage,
 } from "./openai"
 import { mergeAnthropicUsage, parseDataUrlImage, totalAnthropicInputTokens } from "./openai"
+import { createHash } from "node:crypto"
 
 // ---------------------------------------------------------------------------
 // Responses request types (subset Codex actually sends)
@@ -47,11 +48,26 @@ interface ResponsesMessageItem {
 interface ResponsesFunctionCallItem {
   type: "function_call"
   name: string
+  /** Set when the tool lives in a `namespace` tool entry (an MCP server). */
+  namespace?: string
   arguments: string
   call_id: string
 }
 interface ResponsesFunctionCallOutputItem {
   type: "function_call_output"
+  call_id: string
+  output: string
+}
+/** A freeform (`type:"custom"`) tool call — Codex's `apply_patch`. */
+interface ResponsesCustomToolCallItem {
+  type: "custom_tool_call"
+  name: string
+  namespace?: string
+  input: string
+  call_id: string
+}
+interface ResponsesCustomToolCallOutputItem {
+  type: "custom_tool_call_output"
   call_id: string
   output: string
 }
@@ -63,14 +79,20 @@ type ResponsesInputItem =
   | ResponsesMessageItem
   | ResponsesFunctionCallItem
   | ResponsesFunctionCallOutputItem
+  | ResponsesCustomToolCallItem
+  | ResponsesCustomToolCallOutputItem
   | ResponsesReasoningItem
 
-interface ResponsesTool {
-  type: "function" | string
+export interface ResponsesTool {
+  type: "function" | "custom" | "namespace" | string
   name: string
   description?: string
   strict?: boolean
   parameters?: unknown
+  /** `custom` tools: the freeform grammar Codex expects the input to follow. */
+  format?: unknown
+  /** `namespace` tools: the nested function/custom tools of one MCP server. */
+  tools?: ResponsesTool[]
 }
 
 export interface ResponsesRequest {
@@ -86,6 +108,150 @@ export interface ResponsesRequest {
   reasoning?: { effort?: string }
   stream?: boolean
   [k: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// Tool aliasing: namespaced and custom tools
+// ---------------------------------------------------------------------------
+
+/**
+ * Codex (0.15x) ships every MCP server as one `{type:"namespace", name,
+ * tools:[…]}` entry with the tool definitions nested inside, and its freeform
+ * `apply_patch` as `{type:"custom"}`. Claude sees one flat list of function
+ * tools, so each nested or custom tool is exposed under an alias, and the alias
+ * table maps Claude's call back onto the exact `{namespace, name}` pair Codex's
+ * router resolves (`ToolName::new(namespace, name)` — a flattened name without
+ * `namespace` never matches a namespaced tool).
+ */
+export interface ResponsesToolAlias {
+  namespace?: string
+  name: string
+  kind: "function" | "custom"
+}
+export type ResponsesToolAliases = Map<string, ResponsesToolAlias>
+
+/**
+ * Claude tool names are `[A-Za-z0-9_-]{1,64}`, and the passthrough MCP server
+ * prepends its own `mcp__oc__` (PASSTHROUGH_MCP_PREFIX in passthroughTools.ts;
+ * a test pins the two in sync), so an alias gets the remainder.
+ */
+const PASSTHROUGH_PREFIX_LENGTH = "mcp__oc__".length
+export const RESPONSES_TOOL_ALIAS_MAX = 64 - PASSTHROUGH_PREFIX_LENGTH
+
+/**
+ * The Claude-visible name of a tool. Deterministic on (namespace, name): the
+ * history Codex replays next turn carries the same pair and must land on the
+ * same alias, or the replayed `tool_use` names no longer match the tool set.
+ */
+export function responsesToolAlias(namespace: string | undefined, name: string): string {
+  const raw = namespace ? `${namespace}__${name}` : name
+  const safe = raw.replace(/[^A-Za-z0-9_-]/g, "_")
+  if (safe.length <= RESPONSES_TOOL_ALIAS_MAX) return safe
+  const digest = createHash("sha256").update(raw).digest("hex").slice(0, 8)
+  return `${safe.slice(0, RESPONSES_TOOL_ALIAS_MAX - digest.length - 1)}_${digest}`
+}
+
+/**
+ * Alias table for a request's tools. Pure and deterministic, so the route can
+ * rebuild it for the response side without threading state through the
+ * request translator. Top-level function tools keep their own names and are
+ * not listed.
+ */
+export function buildResponsesToolAliases(tools: ResponsesTool[] | undefined): ResponsesToolAliases {
+  const aliases: ResponsesToolAliases = new Map()
+  for (const tool of tools ?? []) {
+    if (tool.type === "custom") {
+      aliases.set(responsesToolAlias(undefined, tool.name), { name: tool.name, kind: "custom" })
+    } else if (tool.type === "namespace") {
+      for (const nested of tool.tools ?? []) {
+        if (nested.type !== "function" && nested.type !== "custom") continue
+        aliases.set(responsesToolAlias(tool.name, nested.name), {
+          namespace: tool.name,
+          name: nested.name,
+          kind: nested.type,
+        })
+      }
+    }
+  }
+  return aliases
+}
+
+/**
+ * A freeform tool has no JSON arguments: Claude gets a single `input` string
+ * and the whole payload is passed through verbatim as `custom_tool_call.input`.
+ */
+const CUSTOM_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    input: { type: "string", description: "The complete freeform payload, exactly as the tool's format requires." },
+  },
+  required: ["input"],
+  additionalProperties: false,
+}
+
+function customToolDescription(tool: ResponsesTool): string {
+  const parts = [tool.description ?? "", "Freeform tool: put the entire payload in the `input` string; do not wrap it in JSON."]
+  const format = tool.format && typeof tool.format === "object" ? (tool.format as { syntax?: unknown; definition?: unknown }) : undefined
+  if (typeof format?.definition === "string") {
+    parts.push(`Input grammar${typeof format.syntax === "string" ? ` (${format.syntax})` : ""}:\n${format.definition}`)
+  }
+  return parts.filter((s) => s.length > 0).join("\n\n")
+}
+
+function translateResponsesTools(tools: ResponsesTool[]): AnthropicTool[] {
+  const out: AnthropicTool[] = []
+  const push = (namespace: string | undefined, tool: ResponsesTool) => {
+    if (tool.type === "function") {
+      out.push({
+        name: namespace ? responsesToolAlias(namespace, tool.name) : tool.name,
+        description: namespace ? `[${namespace}] ${tool.description ?? ""}`.trimEnd() : tool.description ?? "",
+        input_schema: tool.parameters ?? { type: "object", properties: {} },
+      })
+    } else if (tool.type === "custom") {
+      out.push({
+        name: responsesToolAlias(namespace, tool.name),
+        description: customToolDescription(tool),
+        input_schema: CUSTOM_TOOL_INPUT_SCHEMA,
+      })
+    }
+    // Server-side tool kinds (`web_search`, …) have no Claude counterpart here.
+  }
+  for (const tool of tools) {
+    if (tool.type === "namespace") {
+      for (const nested of tool.tools ?? []) push(tool.name, nested)
+    } else {
+      push(undefined, tool)
+    }
+  }
+  return out
+}
+
+/** The Responses item for a Claude `tool_use`, resolved through the alias table. */
+function toolCallItem(
+  ctx: ResponsesCtx,
+  id: string,
+  callId: string,
+  name: string,
+  argsJson: string,
+  status: "in_progress" | "completed"
+): Record<string, unknown> {
+  const alias = ctx.toolAliases?.get(name)
+  const namespace = alias?.namespace ? { namespace: alias.namespace } : {}
+  if (alias?.kind === "custom") {
+    let input = argsJson
+    try {
+      const parsed: unknown = JSON.parse(argsJson || "{}")
+      if (parsed && typeof parsed === "object" && typeof (parsed as { input?: unknown }).input === "string") {
+        input = (parsed as { input: string }).input
+      } else if (argsJson === "" || argsJson === "{}") {
+        input = ""
+      }
+    } catch {
+      // Not JSON: Claude may already have emitted the freeform payload itself.
+    }
+    return { type: "custom_tool_call", id, call_id: callId, name: alias.name, ...namespace, input, status }
+  }
+  return { type: "function_call", id, call_id: callId, name: alias?.name ?? name, ...namespace, arguments: argsJson, status }
 }
 
 // ---------------------------------------------------------------------------
@@ -219,12 +385,24 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         const fc = item as ResponsesFunctionCallItem
         let input: Record<string, unknown> = {}
         try { input = fc.arguments ? JSON.parse(fc.arguments) : {} } catch { input = {} }
-        pushBlock("assistant", { type: "tool_use", id: fc.call_id, name: fc.name, input })
+        const name = fc.namespace ? responsesToolAlias(fc.namespace, fc.name) : fc.name
+        pushBlock("assistant", { type: "tool_use", id: fc.call_id, name, input })
         break
       }
       case "function_call_output": {
         const fo = item as ResponsesFunctionCallOutputItem
         pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: fo.output })
+        break
+      }
+      case "custom_tool_call": {
+        const ct = item as ResponsesCustomToolCallItem
+        const name = responsesToolAlias(ct.namespace, ct.name)
+        pushBlock("assistant", { type: "tool_use", id: ct.call_id, name, input: { input: ct.input ?? "" } })
+        break
+      }
+      case "custom_tool_call_output": {
+        const co = item as ResponsesCustomToolCallOutputItem
+        pushBlock("user", { type: "tool_result", tool_use_id: co.call_id, content: co.output })
         break
       }
       case "reasoning":
@@ -244,13 +422,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   }
   if (systemParts.length > 0) result.system = systemParts.join("\n\n")
   if (Array.isArray(body.tools) && body.tools.length > 0) {
-    result.tools = body.tools
-      .filter((t) => t.type === "function")
-      .map((t): AnthropicTool => ({
-        name: t.name,
-        description: t.description ?? "",
-        input_schema: t.parameters ?? { type: "object", properties: {} },
-      }))
+    result.tools = translateResponsesTools(body.tools)
   }
   const tc = mapToolChoice(body.tool_choice)
   if (tc) result.tool_choice = tc
@@ -277,6 +449,11 @@ export interface ResponsesCtx {
    * satisfy its state machine. Set from `reasoningRequested(body)`.
    */
   reasoningRequested?: boolean
+  /**
+   * Alias table from `buildResponsesToolAliases(request.tools)`: maps Claude's
+   * tool_use names back onto Codex's `{namespace, name}` and custom tools.
+   */
+  toolAliases?: ResponsesToolAliases
 }
 
 /** Did the Responses request ask for reasoning output? */
@@ -329,14 +506,8 @@ export function translateAnthropicToResponses(res: AnthropicResponseLike, ctx: R
     if (block.type === "text" && typeof block.text === "string") {
       textParts.push({ type: "output_text", text: block.text, annotations: [] })
     } else if (block.type === "tool_use") {
-      output.push({
-        type: "function_call",
-        id: `fc_${block.id}`,
-        call_id: block.id,
-        name: block.name,
-        arguments: JSON.stringify(block.input ?? {}),
-        status: "completed",
-      })
+      const callId = String(block.id)
+      output.push(toolCallItem(ctx, `fc_${callId}`, callId, String(block.name), JSON.stringify(block.input ?? {}), "completed"))
     }
     // thinking: dropped (phase 1)
   }
@@ -419,6 +590,7 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
     args: string          // accumulated JSON (tool blocks)
     callId?: string
     name?: string
+    custom?: boolean      // freeform tool: no argument deltas, one done item
   }
   const blocks = new Map<number, BlockState>()
   // Completed items collected for the terminal response.completed.
@@ -489,10 +661,13 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
         } else if (cb.type === "tool_use") {
           const oi = outputIndex++
           const itemId = `fc_${cb.id}`
-          blocks.set(idx, { kind: "tool", outputIndex: oi, itemId, text: "", args: "", callId: cb.id, name: cb.name })
+          const callId = String(cb.id ?? "")
+          const name = String(cb.name ?? "")
+          const custom = ctx.toolAliases?.get(name)?.kind === "custom"
+          blocks.set(idx, { kind: "tool", outputIndex: oi, itemId, text: "", args: "", callId, name, custom })
           out.push(emit("response.output_item.added", {
             output_index: oi,
-            item: { type: "function_call", id: itemId, call_id: cb.id, name: cb.name, arguments: "", status: "in_progress" },
+            item: toolCallItem(ctx, itemId, callId, name, "", "in_progress"),
           }))
         } else {
           // thinking / unknown → skip, but track so deltas/stop are ignored.
@@ -512,9 +687,14 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
           }))
         } else if (st.kind === "tool" && event.delta?.type === "input_json_delta" && typeof event.delta.partial_json === "string") {
           st.args += event.delta.partial_json
-          out.push(emit("response.function_call_arguments.delta", {
-            item_id: st.itemId, output_index: st.outputIndex, delta: event.delta.partial_json,
-          }))
+          // A custom tool's payload is the `input` string inside Claude's JSON
+          // — it cannot be streamed as freeform deltas; Codex takes the whole
+          // item from response.output_item.done.
+          if (!st.custom) {
+            out.push(emit("response.function_call_arguments.delta", {
+              item_id: st.itemId, output_index: st.outputIndex, delta: event.delta.partial_json,
+            }))
+          }
         }
         break
       }
@@ -538,13 +718,12 @@ export function createResponsesSseTranslator(ctx: ResponsesCtx) {
           finalOutput.push(item)
           out.push(emit("response.output_item.done", { output_index: st.outputIndex, item }))
         } else if (st.kind === "tool") {
-          out.push(emit("response.function_call_arguments.done", {
-            item_id: st.itemId, output_index: st.outputIndex, arguments: st.args,
-          }))
-          const item = {
-            type: "function_call", id: st.itemId, call_id: st.callId, name: st.name,
-            arguments: st.args, status: "completed",
+          if (!st.custom) {
+            out.push(emit("response.function_call_arguments.done", {
+              item_id: st.itemId, output_index: st.outputIndex, arguments: st.args,
+            }))
           }
+          const item = toolCallItem(ctx, st.itemId, st.callId ?? "", st.name ?? "", st.args, "completed")
           finalOutput.push(item)
           out.push(emit("response.output_item.done", { output_index: st.outputIndex, item }))
         }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -74,7 +74,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDef
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
-import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
+import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, buildResponsesToolAliases, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { flattenAssistantContent, normalizeStructuredUserContent, replayToolResultHeader, frameStructuredReplay, coalesceStructuredUserMessages } from "./replay"
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, MULTIMODAL_TYPES, buildToolUseIndex, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
@@ -7553,7 +7553,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const responseId = `resp_${randomUUID().replace(/-/g, "")}`
     const created = Math.floor(Date.now() / 1000)
     const model = (typeof rawBody.model === "string" && rawBody.model) ? rawBody.model : CANONICAL_SONNET_MODEL
-    const ctx = { responseId, model, created, reasoningRequested: reasoningRequested(rawBody) }
+    // Namespaced (MCP) and custom tools reach Claude under aliases; the same
+    // table turns its calls back into Codex's `{namespace, name}` items.
+    const toolAliases = buildResponsesToolAliases(rawBody.tools)
+    const ctx = { responseId, model, created, reasoningRequested: reasoningRequested(rawBody), toolAliases }
 
     if (!anthropicBody.stream) {
       const anthropicRes = await internalRes.json() as Record<string, unknown>


### PR DESCRIPTION
Incorporates **#964 by @justprosh** — all three of their commits cherry-picked
with Author and AuthorDate preserved — plus a new live gate.

## Verified against a real Codex capture, not the description

Their central claim is about what Codex actually sends, so I captured it rather
than taking it on trust. codex-cli **0.153.4** (the version in their report) was
pointed at a recording endpoint with a real stdio MCP server attached, under an
isolated `CODEX_HOME`. It sent 13 top-level tool entries:

```
by type: {"function":10,"namespace":2,"web_search":1}
 type=namespace  name=multi_agent_v1   nested=5
 type=namespace  name=mcp__iskron      nested=2
```

Feeding that captured request through the translator, before and after:

```
ON MAIN     reached Claude: 10   namespaced tools present: NONE
WITH FIX    reached Claude: 17   multi_agent_v1__spawn_agent, mcp__iskron__realm_lookup, ...
```

So the report is correct and, if anything, understated: the drop is not limited
to a user's MCP servers. Codex's own `multi_agent_v1` namespace goes with it, so
`spawn_agent` / `wait_agent` are unavailable — a Codex session on Claude loses
sub-agents entirely and silently.

## The three gaps, each confirmed

1. **Tools dropped.** `translateResponsesToAnthropic` kept only
   `type:"function"`. Namespaced and custom entries were discarded without a
   diagnostic.
2. **Calls unroutable.** Codex resolves `ToolName::new(namespace, name)`, so a
   flattened name never matches. The new gate asserts the returned
   `function_call` carries `namespace`; a call that looks correct but omits it
   simply never dispatches.
3. **The turn after an MCP call died.** `function_call_output.output` is a
   string for shell tools but an **array of content items** for MCP tools.
   Verbatim, that reaches Anthropic as `tool_result.content[0].type =
   "input_text"` → 400. This is the one that made the feature unusable rather
   than merely incomplete, and the gate covers it as its own turn.

Their alias design is sound: deterministic `<namespace>__<name>`, sanitized,
hashed past the budget, and `RESPONSES_TOOL_ALIAS_MAX = 64 - "mcp__oc__".length`
with a test pinning it against `PASSTHROUGH_MCP_PREFIX` — the same duplicate
constant plus cross-check pattern `passthroughEarlyStop.ts` uses deliberately to
stay leaf-pure. Worth noting it composes correctly with #969: an MCP server
literally named `oc` produces aliases starting `mcp__oc__`, which #969's
passthrough aliasing now handles instead of double-stripping.

## New live gate (E46)

`scripts/e2e-codex-namespace-tools.mjs`, both modes, real proxy and real SDK.
Against pre-fix code it fails with `tools=1` and no call returned; with the fix
all eight checks pass in streaming and non-streaming.

One harness detail recorded in E2E.md because it cost me a false alarm: in
streaming, `function_call` arguments arrive as their own delta events and the
completed item can carry empty `arguments`. The gate accumulates them before
replaying turn 2 — without that it replays an argument-less call, the model just
calls the tool again, and it looks like a broken emitter when the emitter is
fine. I verified that directly against the raw SSE before concluding anything.

## Limitations

- **Codex's freeform `apply_patch` (`{type:"custom"}`) is not live-verified.**
  It did not appear in a default-config capture, so that path rests on their
  unit tests. Recorded as not-covered in E2E.md rather than implied to be
  tested.
- The third cherry-picked commit removes a `node_modules` symlink pointing at
  `/Users/aleksei/dev/meridian/node_modules` that their middle commit tracks.
  It is included so the branch tip is clean; it transiently clobbers a local
  install mid-rebase, which is why it is called out.

## Validation

- `npm test`: **3648 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- Their 13 new unit tests pass. They cannot run against main (the exports do
  not exist there), so the before-evidence is the captured-request comparison
  and the live gate, both quoted above.
- Live gate green in both modes on a real SDK with Claude Max.

Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system CLI 2.1.263,
codex-cli 0.153.4. Node v22.22.3, macOS arm64. Isolated `CODEX_HOME`, workdir,
session store and ephemeral ports; the capture itself is not committed because
it embedded local paths.

## Credit

Squash body will carry an explicit `Co-authored-by` trailer for @justprosh,
since this repo squashes with a blank body.
