### PR TITLE
fix(responses): key a Codex turn by its thread, not the parent's cache key

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -270,6 +270,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E44 | [Tier refusal failover](#e44-tier-refusal-failover) | **Automated**: `bun scripts/e2e-tier-refusal-failover.mjs [--stream]` — local refusal fixture, **real Claude Max fallback**. Asserts the credits-era per-tier banner is recorded 429 on the refusing profile and that a healthy profile actually answers. Catches what unit tests cannot: the shape that arrives carries the upstream status. **Run before releases touching error classification or priority failover** | 2026-09-08 |
 | E45 | [Codex auto-defer](#e45-codex-auto-defer) | **Automated**: `bun scripts/e2e-codex-auto-defer.mjs` — real proxy + SDK, 40 Codex-shaped tools. Asserts a Codex request reports no deferral and that `exec_command` is loaded rather than found via ToolSearch. The codex transform inherited OpenCode's core tool names, which match nothing Codex sends, so every tool was deferred. **Run before releases touching the codex transform, auto-defer, or `computePassthroughMaxTurns`** | 2026-09-08 |
 | E46 | [Codex namespace and MCP tools](#e46-codex-namespace-and-mcp-tools) | **Automated**: `bun scripts/e2e-codex-namespace-tools.mjs [--stream]` — real proxy + SDK. Codex 0.15x sends MCP servers as `{type:"namespace", tools:[...]}`, which the Responses translator dropped. Asserts namespaced tools reach Claude, calls come back carrying `namespace`, and a `function_call_output` whose output is a content-item ARRAY does not 400. **Run before releases touching the Responses translator or Codex tool handling** | 2026-09-08 |
+| E47 | [Codex thread identity](#e47-codex-thread-identity) | **Automated**: `bun scripts/e2e-codex-thread-identity.mjs` — real proxy + SDK. Codex hands a spawned subagent and its compaction the PARENT's `prompt_cache_key`. Asserts a user thread still resumes unchanged, siblings get their own sessions, and the parent still resumes after both. **Run before releases touching Responses session identity, the turn coordinator, or request-source admission** | 2026-09-08 |
 | E48 | [Responses developer-note cache](#e48-responses-developer-note-cache) | **Automated**: `bun scripts/e2e-responses-developer-cache.mjs` — real proxy + SDK, A/B. A `developer` item folded into `system` mid-conversation re-wrote the whole cached prefix. Asserts the note's turn re-writes no more than the control's (measured 7.8x pre-fix, 1.2x after). **Run before releases touching Responses prompt assembly or system-block construction** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
@@ -4045,6 +4046,63 @@ path is covered by unit tests only and is **not** live-verified here.
 
 **Verified:** 2026-09-08, both modes. Against pre-fix code the same gate fails
 with `tools=1` and no call returned.
+
+## E47: Codex thread identity
+
+**What it proves:** a Codex conversation keeps its own SDK session when a
+sibling flow shares its `prompt_cache_key`.
+
+**The metadata was verified against a real capture**, not read from docs.
+codex-cli 0.153.4 sends, inside `client_metadata`:
+
+```
+"x-codex-turn-metadata": "{... \"thread_id\":\"<id>\", \"request_kind\":\"turn\",
+                           \"thread_source\":\"user\", \"agent_name\":\"/root\" ...}"
+```
+
+and for a user-driven thread **`thread_id` equals `prompt_cache_key`**. That
+equality is the safety property: keying on the thread cannot re-anchor a session
+any existing client already established.
+
+```bash
+bun scripts/e2e-codex-thread-identity.mjs
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- A user thread completes two turns and the second is a `continuation` — the
+  no-regression property, and the one worth failing loudest.
+- A spawned thread (`thread_source: subagent`, own `thread_id`, parent's cache
+  key) is admitted and gets its own SDK session.
+- A `request_kind: compact` request on the same thread is admitted and does not
+  land on the conversation's session.
+- **After both siblings, the parent turn is still a `continuation`.**
+
+**Which check actually discriminates.** Only the last one. Pre-fix, each
+sibling's first turn also opened its own SDK session, so those two checks pass
+either way — they are guards against a worse shape, not evidence. Measured
+against pre-fix code the parent's third turn returns `lineage=undo`: the
+compaction landed on the conversation's session and the next real turn read as a
+rewrite of it. With the fix it is `continuation`.
+
+The gate also asserts the parent still recalls a word from turn 1. That check
+passes **both** ways — an `undo` replays the history, so correctness survives
+and only cost does not (fresh session, 0% cache). It exists to catch the worse
+failure where the parent answers out of a sibling's session.
+
+**Harness note.** `/v1/responses` is stateless; a real Codex client resends the
+whole thread as `input` every turn. A harness that sends one message per request
+makes every turn a fresh one-message conversation, nothing ever resumes, and it
+looks exactly like broken session identity.
+
+**Not covered.** A genuine `thread_source: subagent` request could not be
+produced locally — `codex exec` offers `multi_agent_v1.spawn_agent` but does not
+spawn, so that shape needs Codex Desktop's interactive flow. The subagent case
+here uses the verified metadata wire format rather than a captured subagent
+request.
+
+**Verified:** 2026-09-08. All nine checks pass with the fix; pre-fix the
+discriminating check fails with `lineage=undo`.
 
 ## E48: Responses developer-note cache
 

--- a/scripts/e2e-codex-thread-identity.mjs
+++ b/scripts/e2e-codex-thread-identity.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env bun
+// Live: does a Codex thread keep its own SDK session when a sibling flow shares
+// its prompt_cache_key?
+//
+// Since #655, `prompt_cache_key` was the whole identity `/v1/responses` had.
+// Codex Desktop hands a spawned subagent the PARENT's cache key, and runs
+// compaction against the same thread id — so two live conversations collided on
+// one session key. The subagent's first turn rebound the key to its own SDK
+// session and the parent's next turn then read as a rewrite of it: either a 400
+// "This session advanced while the request was waiting", or, when it won the
+// race instead, a full replay at 0% cache (#965).
+//
+// The metadata this keys on was verified against a real capture from codex-cli
+// 0.153.4, not taken from docs. A user-driven turn sends, inside
+// `client_metadata`:
+//
+//   "x-codex-turn-metadata": "{... \"thread_id\":\"<id>\", \"request_kind\":\"turn\",
+//                              \"thread_source\":\"user\", \"agent_name\":\"/root\" ...}"
+//
+// and for that user thread `thread_id` EQUALS `prompt_cache_key`. That equality
+// is the safety property: keying on the thread cannot re-anchor any session a
+// real client already established. Check 1 below is that property, and it is
+// the one worth failing loudly.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching Responses session identity, the turn coordinator, or request-source
+// admission.
+//
+//   bun scripts/e2e-codex-thread-identity.mjs
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mcodexid-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+const { telemetryStore } = await import('../src/telemetry/index.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3548)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+const THREAD = '01a082ad-84cb-7630-a124-dd37fd82c39e'
+const SUBAGENT_THREAD = '01a07806-1111-7000-9999-aaaaaaaaaaaa'
+
+// Faithful to the captured shape, including the fields this route ignores.
+const meta = (o) => JSON.stringify({
+  installation_id: 'f45565ce-4477-49b1-be2d-ad5bc38c9996',
+  session_id: THREAD, thread_id: o.thread ?? THREAD,
+  agent_name: o.agent ?? '/root', turn_id: `${THREAD}-turn`,
+  request_kind: o.kind ?? 'turn', thread_source: o.source ?? 'user',
+  sandbox: 'seatbelt', sandbox_mode: 'read-only',
+})
+
+/** Assistant text from a Responses body, as an input item for the next turn. */
+function replyItems(body) {
+  try {
+    const parsed = JSON.parse(body)
+    return (parsed.output ?? []).filter(o => o?.type === 'message').map(o => ({
+      type: 'message', role: 'assistant',
+      content: (o.content ?? []).map(c => ({ type: 'output_text', text: c.text ?? '' })),
+    }))
+  } catch { return [] }
+}
+
+// `/v1/responses` is stateless: a real Codex client resends the whole thread as
+// `input` every turn. A harness that sends one message per request makes every
+// turn a fresh 1-message conversation and nothing ever resumes — which looks
+// exactly like broken session identity.
+async function post(label, { thread, source, kind, agent, text, cacheKey, history }) {
+  const before = proxyLog.length
+  const input = [...(history ?? []), { role: 'user', content: [{ type: 'input_text', text }] }]
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-meridian-agent': 'codex' },
+    body: JSON.stringify({
+      model: MODEL, stream: false,
+      // Codex always sends the PARENT's cache key, even for a spawned thread.
+      prompt_cache_key: cacheKey ?? THREAD,
+      client_metadata: { 'x-codex-turn-metadata': meta({ thread, source, kind, agent }) },
+      input,
+    }),
+  })
+  const body = await res.text()
+  const sent = input
+  const line = proxyLog.slice(before).find(l => l.includes('[PROXY]') && l.includes('adapter=codex')) ?? ''
+  const lineage = /lineage=(\S+)/.exec(line)?.[1] ?? '?'
+  const requestId = /\[PROXY\]\s+(\S+)/.exec(line)?.[1]
+  // The log prints session=new for any first turn, so comparing that string
+  // would pass even if two flows collided. Read the resolved SDK session id.
+  const rows = telemetryStore.getRecent({ limit: 200 })
+  const sdkSessionId = rows.find(r => r.requestId === requestId)?.sdkSessionId ?? undefined
+  say(`  ${label.padEnd(28)} lineage=${lineage.padEnd(13)} sdk=${String(sdkSessionId ?? '?').slice(0, 8).padEnd(9)} http=${res.status}`)
+  return { status: res.status, lineage, sdkSessionId, body, next: [...sent, ...replyItems(body)] }
+}
+
+say(`\n=== codex thread identity (model=${MODEL}) ===`)
+
+// 1. SAFETY: a user thread, whose thread_id equals its cache key, must behave
+//    exactly as before — establish, then resume.
+const t1 = await post('user turn 1', { text: 'Remember the word ZEBRA. Reply OK.' })
+const t2 = await post('user turn 2 (same thread)', { text: 'What word did I ask you to remember?', history: t1.next })
+check(t1.status === 200 && t2.status === 200, 'a user thread still completes both turns',
+  `http=${t1.status},${t2.status}`)
+check(t2.lineage.includes('continuation'), 'a user thread still RESUMES its own session',
+  `turn 2 lineage=${t2.lineage}`)
+
+// 2. A spawned thread carries the PARENT's cache key but its own thread_id.
+//    It must get its own session rather than rebinding the parent's.
+//    GUARD, not a discriminator: pre-fix each sibling's FIRST turn also opened
+//    its own SDK session, so this passes either way. The damage is not that the
+//    sibling lacks a session — it is that it rebinds the key the parent is
+//    using, which only shows up in check 4.
+const sub = await post('subagent turn', {
+  thread: SUBAGENT_THREAD, source: 'subagent', agent: '/root/sub',
+  // Its own conversation, not the parent's — only the cache key is shared.
+  text: 'You are a subagent. Reply SUBOK.',
+})
+check(sub.status === 200, 'a spawned thread is admitted, not refused', `http=${sub.status}`)
+check(Boolean(sub.sdkSessionId) && Boolean(t2.sdkSessionId) && sub.sdkSessionId !== t2.sdkSessionId,
+  'the spawned thread got its OWN SDK session',
+  `subagent=${String(sub.sdkSessionId).slice(0, 8)} parent=${String(t2.sdkSessionId).slice(0, 8)}`)
+
+// 3. Compaction runs against the same thread id with its own request_kind.
+//    It must not rebind the conversation's session.
+const compact = await post('compaction (same thread)', {
+  // Compaction really does carry the conversation's history; the point is that
+  // it must not be keyed ON the conversation.
+  kind: 'compact', history: t2.next, text: 'Summarize the conversation so far in one line.',
+})
+check(compact.status === 200, 'a compaction request is admitted', `http=${compact.status}`)
+check(Boolean(compact.sdkSessionId) && compact.sdkSessionId !== t2.sdkSessionId,
+  'compaction did NOT land on the conversation session',
+  `compact=${String(compact.sdkSessionId).slice(0, 8)} conversation=${String(t2.sdkSessionId).slice(0, 8)}`)
+
+// 4. THE DISCRIMINATOR. After both sibling flows the parent must still resume.
+//    Measured pre-fix: `lineage=undo` — the compaction landed on the
+//    conversation's session and the next real turn read as a rewrite of it,
+//    which is #965's reported symptom exactly. With the fix: `continuation`.
+//
+//    Note what the ZEBRA check does and does not prove. It passes BOTH ways,
+//    because an `undo` still replays the history — correctness survives, cost
+//    does not (a fresh session at 0% cache). It is here to catch the worse
+//    failure where the parent silently answers from the sibling's session, not
+//    as evidence the fix works.
+const t3 = await post('user turn 3 (after both)', { text: 'Repeat only the word I asked you to remember.', history: t2.next })
+check(t3.status === 200, 'the parent turn after both siblings succeeded', `http=${t3.status}`)
+check(t3.lineage.includes('continuation'), 'the parent thread STILL resumes its own session',
+  `lineage=${t3.lineage}`)
+let answered = false
+try {
+  const parsed = JSON.parse(t3.body)
+  const text = (parsed.output ?? []).filter(o => o?.type === 'message')
+    .flatMap(o => (o.content ?? []).map(c => c.text ?? '')).join('')
+  answered = /zebra/i.test(text)
+} catch { /* reported below */ }
+check(answered, 'the parent conversation kept its history across both siblings',
+  answered ? 'recalled ZEBRA' : 'did NOT recall ZEBRA — history was lost')
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-14)) say(`    ${l}`)
+} else {
+  say('  PASS: user thread unchanged, siblings isolated, parent history intact')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -696,4 +696,44 @@ describe("resolveCodexThreadIdentity", () => {
     )
     expect(identity.requestSource).toBeUndefined()
   })
+
+  // Codex runs compaction (and title/summary/review/memory) as a side request
+  // under the SAME thread id, with no tools and the whole history. Keyed on the
+  // thread alone it lands on the conversation's session as a rewrite of it.
+  it("keys a compaction beside the thread, not on it, and declares its flow", () => {
+    const thread = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: thread },
+      turnMetadata({ thread_id: thread, request_kind: "compact" }),
+    )
+    expect(identity).toEqual({ sessionKey: `${thread}:compact`, requestSource: "fork-codex-compact" })
+  })
+
+  it("leaves a plain turn exactly as before", () => {
+    const thread = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: thread }, turnMetadata({ thread_id: thread, request_kind: "turn" })))
+      .toEqual({ sessionKey: thread })
+  })
+
+  it("treats a missing request_kind as a turn", () => {
+    const meta = JSON.parse(turnMetadata({ thread_id: "t1" }))
+    delete meta.request_kind
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: "t1" }, JSON.stringify(meta))).toEqual({ sessionKey: "t1" })
+  })
+
+  it("lets the kind name the flow when a spawned thread compacts", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "parent" },
+      turnMetadata({ thread_id: "child", thread_source: "subagent", request_kind: "compact" }),
+    )
+    expect(identity).toEqual({ sessionKey: "child:compact", requestSource: "fork-codex-compact" })
+  })
+
+  it("handles a kind Codex has not sent yet the same way", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "t1" },
+      turnMetadata({ thread_id: "t1", request_kind: "Memory Extract" }),
+    )
+    expect(identity).toEqual({ sessionKey: "t1:memory-extract", requestSource: "fork-codex-memory-extract" })
+  })
 })

--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -10,6 +10,7 @@ import {
   translateResponsesToAnthropic,
   translateAnthropicToResponses,
   createResponsesSseTranslator,
+  resolveCodexThreadIdentity,
 } from "../proxy/openaiResponses"
 import type { AnthropicContentBlock } from "../proxy/openai"
 
@@ -599,5 +600,100 @@ describe("createResponsesSseTranslator (stream)", () => {
     for (const e of run(textStream)) {
       expect((e.data as any).type).toBe(e.event)
     }
+  })
+})
+
+describe("resolveCodexThreadIdentity", () => {
+  // Wire shapes below are a real capture: Codex Desktop 0.144.4 sends this
+  // metadata as both a header and a `client_metadata` entry, and a subagent's
+  // rollout records the same split — own `id`, parent's `session_id`.
+  const turnMetadata = (over: Record<string, unknown>) => JSON.stringify({
+    installation_id: "66bcfba4-e581-41e3-9487-57705ef35f60",
+    session_id: "01a07829-00b2-7c23-b950-26b07808dc26",
+    thread_id: "01a07829-00b2-7c23-b950-26b07808dc26",
+    turn_id: "01a07829-00f7-7a71-82d6-6b3a2626ebc8",
+    request_kind: "turn",
+    thread_source: "user",
+    ...over,
+  })
+
+  it("falls back to prompt_cache_key when no metadata is sent", () => {
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: "conv-a" })).toEqual({ sessionKey: "conv-a" })
+  })
+
+  it("carries no identity at all when neither is sent", () => {
+    expect(resolveCodexThreadIdentity({ model: "claude-sonnet-5" })).toEqual({})
+  })
+
+  it("keys a user thread the same way prompt_cache_key did", () => {
+    const key = "01a07829-00b2-7c23-b950-26b07808dc26"
+    const identity = resolveCodexThreadIdentity({ prompt_cache_key: key }, turnMetadata({}))
+    expect(identity).toEqual({ sessionKey: key })
+  })
+
+  it("keys a subagent by its own thread, not the parent's cache key", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "01a077c4-9c1c-73d1-bddb-7887bef18554" },
+      turnMetadata({
+        session_id: "01a077c4-9c1c-73d1-bddb-7887bef18554",
+        thread_id: "01a07806-a29d-79b3-af96-876d8fa1be83",
+        thread_source: "subagent",
+      }),
+    )
+    expect(identity).toEqual({
+      sessionKey: "01a07806-a29d-79b3-af96-876d8fa1be83",
+      requestSource: "fork-codex-subagent",
+    })
+  })
+
+  it("declares a concurrent flow even when the spawned thread reuses the id", () => {
+    const shared = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: shared },
+      turnMetadata({ session_id: shared, thread_id: shared, thread_source: "subagent" }),
+    )
+    expect(identity.sessionKey).toBe(shared)
+    expect(identity.requestSource).toBe("fork-codex-subagent")
+  })
+
+  it("reads the metadata from client_metadata when the header is absent", () => {
+    const identity = resolveCodexThreadIdentity({
+      prompt_cache_key: "parent",
+      client_metadata: {
+        "x-codex-turn-metadata": turnMetadata({ thread_id: "child", thread_source: "subagent" }),
+      },
+    })
+    expect(identity).toEqual({ sessionKey: "child", requestSource: "fork-codex-subagent" })
+  })
+
+  it("prefers the header over client_metadata", () => {
+    const identity = resolveCodexThreadIdentity(
+      {
+        prompt_cache_key: "parent",
+        client_metadata: { "x-codex-turn-metadata": turnMetadata({ thread_id: "from-body" }) },
+      },
+      turnMetadata({ thread_id: "from-header" }),
+    )
+    expect(identity.sessionKey).toBe("from-header")
+  })
+
+  it("keeps the cache-key path when the metadata is unparseable", () => {
+    expect(resolveCodexThreadIdentity({ prompt_cache_key: "conv-a" }, "{not json")).toEqual({ sessionKey: "conv-a" })
+  })
+
+  it("sanitizes an unexpected thread_source into a header-safe source", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "parent" },
+      turnMetadata({ thread_id: "child", thread_source: "Cloud Task/2" }),
+    )
+    expect(identity.requestSource).toBe("fork-codex-cloud-task-2")
+  })
+
+  it("declares nothing for a thread_source that survives sanitizing as separators only", () => {
+    const identity = resolveCodexThreadIdentity(
+      { prompt_cache_key: "parent" },
+      turnMetadata({ thread_id: "child", thread_source: "///" }),
+    )
+    expect(identity.requestSource).toBeUndefined()
   })
 })

--- a/src/__tests__/proxy-responses-endpoint.test.ts
+++ b/src/__tests__/proxy-responses-endpoint.test.ts
@@ -243,3 +243,80 @@ describe("/v1/responses session continuity via prompt_cache_key (#655)", () => {
     expect(capturedOptions[1].resume).toBeUndefined()
   })
 })
+
+describe("/v1/responses keeps a spawned Codex thread out of its parent's session", () => {
+  beforeEach(() => {
+    clearSessionCache()
+    capturedOptions = []
+  })
+
+  const parentKey = "01a077c4-9c1c-73d1-bddb-7887bef18554"
+  const childThread = "01a07806-a29d-79b3-af96-876d8fa1be83"
+
+  const userItem = {
+    type: "message",
+    role: "user",
+    content: [{ type: "input_text", text: "Read data.txt and count the lines." }],
+  }
+  const loopTurnInput = [
+    userItem,
+    { type: "function_call", name: "exec_command", arguments: '{"cmd":"wc -l data.txt"}', call_id: "toolu_test_1" },
+    { type: "function_call_output", call_id: "toolu_test_1", output: "3 data.txt" },
+  ]
+
+  // Codex Desktop hands a spawned subagent the parent's prompt_cache_key, so
+  // the key alone cannot tell two live conversations apart. Its turn metadata
+  // can: the thread id is the subagent's own.
+  const clientMetadata = (thread: string, source: string) => ({
+    "x-codex-turn-metadata": JSON.stringify({
+      session_id: parentKey,
+      thread_id: thread,
+      turn_id: "01a07829-00f7-7a71-82d6-6b3a2626ebc8",
+      request_kind: "turn",
+      thread_source: source,
+    }),
+  })
+
+  it("gives the subagent its own SDK session and leaves the parent's resumable", async () => {
+    const app = createTestApp()
+    const parentTurn = (input: unknown) => postResponses(app, {
+      model: "claude-sonnet-5",
+      input,
+      stream: false,
+      prompt_cache_key: parentKey,
+      client_metadata: clientMetadata(parentKey, "user"),
+    })
+
+    expect((await parentTurn([userItem])).status).toBe(200)
+    const subagent = await postResponses(app, {
+      model: "claude-sonnet-5",
+      input: [userItem],
+      stream: false,
+      prompt_cache_key: parentKey,
+      client_metadata: clientMetadata(childThread, "subagent"),
+    })
+    expect(subagent.status).toBe(200)
+    expect((await parentTurn(loopTurnInput)).status).toBe(200)
+
+    expect(capturedOptions).toHaveLength(3)
+    // The subagent starts its own conversation rather than rebinding the key…
+    expect(capturedOptions[1].resume).toBeUndefined()
+    expect(capturedOptions[1].sessionId).not.toBe(capturedOptions[0].sessionId)
+    // …so the parent's next turn still resumes the session it left.
+    expect(capturedOptions[2].resume).toBe(capturedOptions[0].sessionId)
+  })
+
+  it("keeps resuming a user thread that sends turn metadata", async () => {
+    const app = createTestApp()
+    const body = (input: unknown) => ({
+      model: "claude-sonnet-5",
+      input,
+      stream: false,
+      prompt_cache_key: parentKey,
+      client_metadata: clientMetadata(parentKey, "user"),
+    })
+    await postResponses(app, body([userItem]))
+    await postResponses(app, body(loopTurnInput))
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
+  })
+})

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -280,16 +280,26 @@ interface CodexTurnMetadata {
   thread_id?: unknown
   session_id?: unknown
   thread_source?: unknown
+  request_kind?: unknown
 }
 
 /** Codex sends this both as a request header and inside `client_metadata`. */
 const CODEX_TURN_METADATA = "x-codex-turn-metadata"
 
-/** Longest `thread_source` tag echoed into a request source. */
+/** Longest `thread_source` / `request_kind` tag echoed into a key or source. */
 const CODEX_THREAD_SOURCE_MAX = 24
+
+/** The one `request_kind` that IS the conversation; every other kind rides beside it. */
+const CODEX_TURN_KIND = "turn"
 
 function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+/** A Codex tag reduced to what a header and a session key may carry. */
+function codexTag(value: string): string | undefined {
+  const tag = value.toLowerCase().replace(/[^a-z0-9-]/g, "-").slice(0, CODEX_THREAD_SOURCE_MAX)
+  return tag.replace(/-/g, "") ? tag : undefined
 }
 
 function parseCodexTurnMetadata(value: unknown): CodexTurnMetadata | undefined {
@@ -332,6 +342,16 @@ function codexTurnMetadataFromBody(body: ResponsesRequest): unknown {
  * refused should a client ever reuse one id across flows. `fork-` and not
  * `subagent-`: the tier a Codex subagent runs on is the client's choice, and
  * a concurrency declaration must not silently rewrite it.
+ *
+ * `request_kind` is the third signal. Codex runs side requests against the
+ * same thread id — `compact` carries the whole history with no tools to
+ * summarise it, and the binary also names `title`, `summary`, `review`,
+ * `memory` — and none of them is the conversation: keyed on the thread alone
+ * a compaction lands on the conversation's session as a rewrite of it.
+ * Observed live: a 379-message `compact` under a live thread's key. Any kind
+ * other than `turn` therefore gets its own key beside the thread's and
+ * declares its own flow; a kind Codex has not sent yet is handled the same
+ * way, since the property that matters — not being the turn — is shared.
  */
 export function resolveCodexThreadIdentity(
   body: ResponsesRequest,
@@ -341,17 +361,17 @@ export function resolveCodexThreadIdentity(
     ?? parseCodexTurnMetadata(codexTurnMetadataFromBody(body))
   const identity: CodexThreadIdentity = {}
 
-  const sessionKey = nonEmptyString(metadata?.thread_id) ?? nonEmptyString(body.prompt_cache_key)
-  if (sessionKey) identity.sessionKey = sessionKey
+  const threadKey = nonEmptyString(metadata?.thread_id) ?? nonEmptyString(body.prompt_cache_key)
+
+  const kind = nonEmptyString(metadata?.request_kind)
+  const kindTag = kind && kind !== CODEX_TURN_KIND ? codexTag(kind) : undefined
+
+  if (threadKey) identity.sessionKey = kindTag ? `${threadKey}:${kindTag}` : threadKey
 
   const threadSource = nonEmptyString(metadata?.thread_source)
-  if (threadSource && threadSource !== "user") {
-    const tag = threadSource
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, "-")
-      .slice(0, CODEX_THREAD_SOURCE_MAX)
-    if (tag.replace(/-/g, "")) identity.requestSource = `fork-codex-${tag}`
-  }
+  const sourceTag = threadSource && threadSource !== "user" ? codexTag(threadSource) : undefined
+  const flow = kindTag ?? sourceTag
+  if (flow) identity.requestSource = `fork-codex-${flow}`
 
   return identity
 }

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -264,6 +264,97 @@ function toolCallItem(
   return { type: "function_call", id, call_id: callId, name: alias?.name ?? name, ...namespace, arguments: argsJson, status }
 }
 
+// Codex thread identity
+// ---------------------------------------------------------------------------
+
+/** What one Codex turn says about the conversation it belongs to. */
+export interface CodexThreadIdentity {
+  /** Conversation key for session resume — the codex adapter's `x-codex-session`. */
+  sessionKey?: string
+  /** Concurrency declaration for a turn that is not the thread the user drives. */
+  requestSource?: string
+}
+
+/** The fields of Codex's turn metadata this route reads. */
+interface CodexTurnMetadata {
+  thread_id?: unknown
+  session_id?: unknown
+  thread_source?: unknown
+}
+
+/** Codex sends this both as a request header and inside `client_metadata`. */
+const CODEX_TURN_METADATA = "x-codex-turn-metadata"
+
+/** Longest `thread_source` tag echoed into a request source. */
+const CODEX_THREAD_SOURCE_MAX = 24
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function parseCodexTurnMetadata(value: unknown): CodexTurnMetadata | undefined {
+  if (value && typeof value === "object") return value as CodexTurnMetadata
+  const raw = nonEmptyString(value)
+  if (!raw) return undefined
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === "object" ? parsed as CodexTurnMetadata : undefined
+  } catch {
+    // A client that garbles its own metadata still gets the cache-key path.
+    return undefined
+  }
+}
+
+function codexTurnMetadataFromBody(body: ResponsesRequest): unknown {
+  const metadata = body.client_metadata
+  if (!metadata || typeof metadata !== "object") return undefined
+  return (metadata as Record<string, unknown>)[CODEX_TURN_METADATA]
+}
+
+/**
+ * Reads the conversation identity Codex attaches to a turn.
+ *
+ * `prompt_cache_key` was the only identity this route had (#655), and for the
+ * thread a user drives it is exactly that thread's id. A subagent is the case
+ * it cannot describe: Codex Desktop spawns one as its own thread, with its own
+ * instructions and its own tools, and hands it the *parent's*
+ * `prompt_cache_key`. Keyed on that alone two live conversations become one
+ * session — the subagent's first turn rebinds the key to its own SDK session,
+ * and the parent's next turn then reads as a rewrite of it: refused as a
+ * concurrent conflict when it loses the session-turn race, replayed from
+ * scratch when it wins.
+ *
+ * `x-codex-turn-metadata` names the thread itself, so the thread id is the
+ * honest key: identical to `prompt_cache_key` for a user thread — this
+ * re-anchors no existing session — and distinct for every spawned one.
+ * `thread_source` carries the same fact independently, so a turn from a
+ * spawned thread also declares a concurrent flow and is admitted rather than
+ * refused should a client ever reuse one id across flows. `fork-` and not
+ * `subagent-`: the tier a Codex subagent runs on is the client's choice, and
+ * a concurrency declaration must not silently rewrite it.
+ */
+export function resolveCodexThreadIdentity(
+  body: ResponsesRequest,
+  metadataHeader?: string,
+): CodexThreadIdentity {
+  const metadata = parseCodexTurnMetadata(metadataHeader)
+    ?? parseCodexTurnMetadata(codexTurnMetadataFromBody(body))
+  const identity: CodexThreadIdentity = {}
+
+  const sessionKey = nonEmptyString(metadata?.thread_id) ?? nonEmptyString(body.prompt_cache_key)
+  if (sessionKey) identity.sessionKey = sessionKey
+
+  const threadSource = nonEmptyString(metadata?.thread_source)
+  if (threadSource && threadSource !== "user") {
+    const tag = threadSource
+      .toLowerCase()
+      .replace(/[^a-z0-9-]/g, "-")
+      .slice(0, CODEX_THREAD_SOURCE_MAX)
+    if (tag.replace(/-/g, "")) identity.requestSource = `fork-codex-${tag}`
+  }
+
+  return identity
+}
 // ---------------------------------------------------------------------------
 // Request translation: Responses → Anthropic
 // ---------------------------------------------------------------------------

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -74,7 +74,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDef
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
-import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, buildResponsesToolAliases, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
+import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, buildResponsesToolAliases, resolveCodexThreadIdentity, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { flattenAssistantContent, normalizeStructuredUserContent, replayToolResultHeader, frameStructuredReplay, coalesceStructuredUserMessages } from "./replay"
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, MULTIMODAL_TYPES, buildToolUseIndex, frameReplayTurns } from "./messages"
 import { requireAuth, authEnabled } from "./auth"
@@ -7523,15 +7523,16 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       "Content-Type": "application/json",
       "x-meridian-agent": "codex",
     }
-    // NOTE: agent-specific (Codex) — prompt_cache_key is Codex's stable
-    // per-conversation id (mirrored as session_id in its client_metadata).
-    // Forward it as the codex adapter's session header so consecutive turns
+    // NOTE: agent-specific (Codex) — the thread this turn belongs to.
+    // Forwarded as the codex adapter's session header so consecutive turns
     // resume the same SDK session: Claude's signed thinking then persists
-    // across turns natively and the prompt cache stays warm (#655).
-    const promptCacheKey = (rawBody as { prompt_cache_key?: unknown }).prompt_cache_key
-    if (typeof promptCacheKey === "string" && promptCacheKey.length > 0) {
-      internalHeaders["x-codex-session"] = promptCacheKey
-    }
+    // across turns natively and the prompt cache stays warm (#655). A turn
+    // from a spawned thread also declares its own concurrent flow, because a
+    // subagent inherits its parent's `prompt_cache_key` — see
+    // resolveCodexThreadIdentity for what each signal answers.
+    const codexThread = resolveCodexThreadIdentity(rawBody, c.req.header("x-codex-turn-metadata"))
+    if (codexThread.sessionKey) internalHeaders["x-codex-session"] = codexThread.sessionKey
+    if (codexThread.requestSource) internalHeaders["x-meridian-source"] = codexThread.requestSource
     const xApiKey = c.req.header("x-api-key")
     if (xApiKey) internalHeaders["x-api-key"] = xApiKey
     const authz = c.req.header("authorization")


### PR DESCRIPTION
Incorporates **#965 by @justprosh**, both commits cherry-picked with their
Author and AuthorDate preserved, plus a new live gate.

**This one is staged for owner review rather than merged.** It changes what
identifies a conversation, where a mistake corrupts history rather than
degrading it. Everything below is green; the decision to land it is not mine to
take unilaterally.

## Verified against a real capture, not the description

codex-cli **0.153.4** was pointed at a recording endpoint under an isolated
`CODEX_HOME`. It sends, inside `client_metadata`:

```json
"x-codex-turn-metadata": "{... \"thread_id\":\"01a082ad-…\", \"request_kind\":\"turn\",
                           \"thread_source\":\"user\", \"agent_name\":\"/root\" ...}"
```

and for that user-driven thread **`thread_id` === `prompt_cache_key`**
(`01a082ad-84cb-7630-a124-dd37fd82c39e` for both). That equality is the safety
property the whole change rests on: keying on the thread cannot re-anchor a
session any existing client already established. Confirmed, not assumed.

## What the gate measured, before and after

The discriminating result, on real SDK sessions:

| parent's turn after a compaction on its thread | lineage |
|---|---|
| pre-fix (main) | **`undo`** |
| with the fix | `continuation` |

That is #965's reported symptom reproduced exactly — "a compaction lands on the
live conversation's session as a rewrite of it; the conversation's next real
turn then reads as `undo` and starts a fresh session at 0% cache."

## What I am explicit about not having proved

- **A genuine `thread_source: subagent` request could not be produced locally.**
  `codex exec` does offer `multi_agent_v1.spawn_agent`, but it does not spawn —
  that needs Codex Desktop's interactive flow. The subagent case in the gate
  uses the *verified metadata wire format* rather than a captured subagent
  request. The subagent half therefore rests on their live Desktop 0.144.4
  capture, which includes the `SESSION RECOVERY` line and the 6.4s
  `sessionWait` → 400.
- **Two of the nine checks do not discriminate.** Pre-fix, each sibling's first
  turn also opened its own SDK session, so "the sibling got its own session"
  passes either way. They are guards against a worse shape, and the gate and
  E2E.md now say so rather than implying nine independent proofs.
- **The history-recall check passes both ways.** An `undo` still replays, so
  correctness survives and only cost does not. It is there to catch the parent
  answering out of a sibling's session, not as evidence the fix works.

## Conflict resolution worth reviewing

#965's base predates #976, which I merged earlier today and which rewrote
`openaiResponses.ts`. Both conflicted regions turned out to be **purely
additive** — #976 contributes tool-alias machinery, #965 contributes thread
identity, with no shared declarations — so both blocks were kept in sequence
(143 lines + 91 lines). The import in `server.ts` needed both new symbols.
Typecheck is clean, #976's own E46 gate still passes 8/8 alongside it, and the
70 tests across the three affected files pass together.

## Validation

- `npm test`: **3665 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- **New E47 gate** (`scripts/e2e-codex-thread-identity.mjs`), real proxy + SDK:
  nine checks pass; pre-fix the discriminating one fails with `lineage=undo`.
- **E41 all four modes** (chain/parallel × stream/non-stream) PASS — required
  here because this touches session identity and the turn coordinator.
- **E46 re-run** alongside the merge, 8/8, to prove co-existence with #976.

Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system CLI 2.1.263,
codex-cli 0.153.4. Node v22.22.3, macOS arm64. Isolated `CODEX_HOME`, workdir,
session store, ephemeral ports.

## Credit

Squash body should carry `Co-authored-by: Aleksey Proshutinskiy
<alexey.prosh@fluence.one>` — this repo squashes with a blank body, so without
it the contributor is dropped from the commit.

One authorship note on this branch: my gate commit initially inherited the
contributor's author line (committing straight after a multi-commit
cherry-pick). It has been reset to me, so the two fix commits are theirs and the
gate is mine. Worth knowing as a recurring hazard in this workflow.
