### PR TITLE
fix(responses): keep a mid-conversation developer message out of the system prompt

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -270,6 +270,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E44 | [Tier refusal failover](#e44-tier-refusal-failover) | **Automated**: `bun scripts/e2e-tier-refusal-failover.mjs [--stream]` — local refusal fixture, **real Claude Max fallback**. Asserts the credits-era per-tier banner is recorded 429 on the refusing profile and that a healthy profile actually answers. Catches what unit tests cannot: the shape that arrives carries the upstream status. **Run before releases touching error classification or priority failover** | 2026-09-08 |
 | E45 | [Codex auto-defer](#e45-codex-auto-defer) | **Automated**: `bun scripts/e2e-codex-auto-defer.mjs` — real proxy + SDK, 40 Codex-shaped tools. Asserts a Codex request reports no deferral and that `exec_command` is loaded rather than found via ToolSearch. The codex transform inherited OpenCode's core tool names, which match nothing Codex sends, so every tool was deferred. **Run before releases touching the codex transform, auto-defer, or `computePassthroughMaxTurns`** | 2026-09-08 |
 | E46 | [Codex namespace and MCP tools](#e46-codex-namespace-and-mcp-tools) | **Automated**: `bun scripts/e2e-codex-namespace-tools.mjs [--stream]` — real proxy + SDK. Codex 0.15x sends MCP servers as `{type:"namespace", tools:[...]}`, which the Responses translator dropped. Asserts namespaced tools reach Claude, calls come back carrying `namespace`, and a `function_call_output` whose output is a content-item ARRAY does not 400. **Run before releases touching the Responses translator or Codex tool handling** | 2026-09-08 |
+| E48 | [Responses developer-note cache](#e48-responses-developer-note-cache) | **Automated**: `bun scripts/e2e-responses-developer-cache.mjs` — real proxy + SDK, A/B. A `developer` item folded into `system` mid-conversation re-wrote the whole cached prefix. Asserts the note's turn re-writes no more than the control's (measured 7.8x pre-fix, 1.2x after). **Run before releases touching Responses prompt assembly or system-block construction** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4044,6 +4045,51 @@ path is covered by unit tests only and is **not** live-verified here.
 
 **Verified:** 2026-09-08, both modes. Against pre-fix code the same gate fails
 with `tools=1` and no call returned.
+
+## E48: Responses developer-note cache
+
+**What it proves:** a `developer` item that first appears mid-conversation does
+not invalidate the prompt cache for the whole history.
+
+Anthropic caches the prompt as one prefix ordered **tools → system →
+messages**. `/v1/responses` folded every `developer`/`system` input item into
+the Anthropic `system` block regardless of position, so a note arriving on turn
+N rewrote `system` and invalidated everything behind the tools block. Codex
+emits exactly these as ordinary conversation events —
+`<image_resize_notice>` after `view_image`, `<model_switch>` and
+`<collaboration_mode>` on a model change, `<app-context>` on app refresh.
+
+A real codex-cli 0.153.4 capture confirms the harness preamble arrives as a
+**leading** `developer` item (`input roles: ["developer","user",...]`). That case
+must keep folding into `system`; only a note arriving after the conversation
+starts is inlined.
+
+```bash
+bun scripts/e2e-responses-developer-cache.mjs
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- Both conversations complete, and the control's second turn reads its prefix
+  from cache.
+- **The note's turn re-writes no more than 3x the control's `cache_write`.**
+
+**Why the assertion is a ratio, not a hit rate.** Hit percentage does not scale
+down to a probe. The reported collapse was on a ~700k-token thread where
+`system` sits behind a ~125k tools block, so losing everything behind it cost
+240k-584k tokens. In a ~6.5k probe the same bug only moves the rate from 98% to
+~86%, which any sensible percentage threshold waves through — an earlier draft
+of this gate passed both before and after for exactly that reason. Re-written
+tokens are the invariant:
+
+```
+pre-fix   A cache_write=99    B cache_write=769   ->  7.8x   FAIL
+with fix  A cache_write=117   B cache_write=141   ->  1.2x   PASS
+```
+
+The hit rate is still printed, as context rather than as a check.
+
+**Verified:** 2026-09-08. Discriminates as tabled above.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-responses-developer-cache.mjs
+++ b/scripts/e2e-responses-developer-cache.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+// Live: does a developer note appearing mid-conversation destroy the prompt
+// cache for the whole history?
+//
+// Anthropic caches the prompt as one prefix, ordered tools -> system ->
+// messages. `/v1/responses` folded every `developer`/`system` input item into
+// the Anthropic `system` block regardless of where it sat, so a note that first
+// shows up on turn N rewrote the system block and invalidated every cached
+// token behind the tools — the entire conversation (#966).
+//
+// Codex emits exactly these as ordinary conversation events:
+// `<image_resize_notice>` after every `view_image`, `<model_switch>` and
+// `<collaboration_mode>` on a model change, `<app-context>` on app refresh. The
+// report measured 14 of 14 cache collapses on a long Desktop thread following
+// one of those within 1-3 seconds, with 240k-584k tokens re-written each time.
+//
+// Confirmed from a real codex-cli 0.153.4 capture that the harness preamble
+// arrives as a LEADING `developer` item (`input roles: ["developer","user",...]`).
+// That case must keep folding into `system` — it is genuinely the preamble, and
+// changing it would move every existing client's cache prefix. Only a note that
+// arrives AFTER the conversation starts is inlined.
+//
+// This is an A/B, because the claim is about cost rather than correctness. Two
+// identical conversations, sent twice each so the second turn can hit a warm
+// prefix; one carries a developer note in its replayed history.
+//
+//   A (control)   turn 2 reads its prefix from cache
+//   B (developer) turn 2 must re-write no more of it than A did
+//
+// Both sides use the same tools block and the same message text, so the only
+// variable is the note. What is asserted is the ratio of re-written tokens, not
+// the hit percentage — see the discriminator note below for why.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching Responses prompt assembly or system-block construction.
+//
+//   bun scripts/e2e-responses-developer-cache.mjs
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mdevcache-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+const { telemetryStore } = await import('../src/telemetry/index.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3550)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+// A tools block big enough that losing the cache behind it is unmistakable.
+const tools = Array.from({ length: 24 }, (_, i) => ({
+  type: 'function', name: `bridge_tool_${i}`,
+  description: `Bridge tool ${i}. ` + 'Filler to give the prompt prefix real mass so a cache collapse is visible in the numbers rather than lost in noise. '.repeat(6),
+  parameters: { type: 'object', properties: { arg: { type: 'string', description: 'An argument.' } } },
+}))
+
+// The shape Codex actually emits mid-conversation.
+const NOTE = '<image_resize_notice>The image was resized to fit the context window.</image_resize_notice>'
+
+async function post(thread, input) {
+  const before = proxyLog.length
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/responses`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-meridian-agent': 'codex' },
+    body: JSON.stringify({ model: MODEL, stream: false, tools, prompt_cache_key: thread, input }),
+  })
+  const body = await res.text()
+  const line = proxyLog.slice(before).find(l => l.includes('[PROXY]') && l.includes('adapter=codex')) ?? ''
+  const requestId = /\[PROXY\]\s+(\S+)/.exec(line)?.[1]
+  const row = telemetryStore.getRecent({ limit: 200 }).find(r => r.requestId === requestId)
+  return {
+    status: res.status, body,
+    read: row?.cacheReadInputTokens ?? 0,
+    write: row?.cacheCreationInputTokens ?? 0,
+    lineage: /lineage=(\S+)/.exec(line)?.[1] ?? '?',
+  }
+}
+
+const preamble = { role: 'developer', content: [{ type: 'input_text', text: 'You are a helpful assistant. Follow the harness rules.' }] }
+const u1 = { role: 'user', content: [{ type: 'input_text', text: 'Reply with the single word ALPHA.' }] }
+const a1 = (t) => ({ type: 'message', role: 'assistant', content: [{ type: 'output_text', text: t }] })
+const u2 = { role: 'user', content: [{ type: 'input_text', text: 'Now reply with the single word BRAVO.' }] }
+
+async function run(label, thread, withNote) {
+  // Turn 1 establishes the prefix. Identical on both sides.
+  const t1 = await post(thread, [preamble, u1])
+  let reply = 'ALPHA'
+  try {
+    const parsed = JSON.parse(t1.body)
+    reply = (parsed.output ?? []).filter(o => o?.type === 'message')
+      .flatMap(o => (o.content ?? []).map(c => c.text ?? '')).join('') || reply
+  } catch { /* keep the default */ }
+  // Turn 2 replays the history; B inserts the note where Codex would.
+  const history = withNote
+    ? [preamble, u1, a1(reply), { role: 'developer', content: [{ type: 'input_text', text: NOTE }] }, u2]
+    : [preamble, u1, a1(reply), u2]
+  const t2 = await post(thread, history)
+  const total = t2.read + t2.write
+  const pct = total ? Math.round((100 * t2.read) / total) : 0
+  say(`  ${label.padEnd(14)} turn2 lineage=${t2.lineage.padEnd(13)} cache_read=${String(t2.read).padStart(7)} cache_write=${String(t2.write).padStart(7)}  ${pct}% cached`)
+  return { ...t2, pct }
+}
+
+say(`\n=== responses developer-note cache A/B (model=${MODEL}) ===`)
+const A = await run('A control', `devcache-a-${process.pid}`, false)
+const B = await run('B developer', `devcache-b-${process.pid}`, true)
+
+check(A.status === 200 && B.status === 200, 'both conversations completed', `http=${A.status},${B.status}`)
+check(A.pct >= 80, 'the control turn 2 read its prefix from cache', `${A.pct}% cached`)
+
+// THE DISCRIMINATOR is re-written tokens, not hit percentage.
+//
+// Percentage does not scale down to a probe. The reported collapse was on a
+// ~700k-token thread where the system block sits behind a ~125k tools block, so
+// losing everything behind system cost 240k-584k. Here the whole conversation
+// is ~6.5k, so the same bug only moves the rate from 98% to ~86% — which any
+// reasonable percentage threshold would wave through. Measured on pre-fix code:
+//
+//   A control    cache_read=6581  cache_write=114   98% cached
+//   B developer  cache_read=5765  cache_write=931   86% cached
+//
+// The ratio of re-written tokens is the invariant: ~8x pre-fix, ~1.1x after.
+const writeRatio = A.write > 0 ? B.write / A.write : (B.write > 0 ? Infinity : 1)
+check(writeRatio <= 3,
+  'the note re-wrote no more of the prefix than the control',
+  `B/A cache_write = ${writeRatio.toFixed(1)}x (${B.write} vs ${A.write}); pre-fix measured ~8x`)
+say(`  note  hit rate control=${A.pct}% note=${B.pct}% — reported as context; at probe scale the`
+  + ` percentage barely moves even when the prefix is re-written, so it is not asserted`)
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-10)) say(`    ${l}`)
+} else {
+  say('  PASS: a mid-conversation developer note keeps the cached prefix')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/openai-responses.test.ts
+++ b/src/__tests__/openai-responses.test.ts
@@ -40,6 +40,66 @@ describe("translateResponsesToAnthropic", () => {
     expect(r.messages[0]!.role).toBe("user")
   })
 
+  // Anthropic caches the prompt as one prefix, tools → system → messages.
+  // A developer message that appears mid-conversation and gets folded into
+  // `system` rewrites the system block on the turn it first shows up and
+  // invalidates the entire cached history behind it. Observed live with
+  // Codex's `<image_resize_notice>`: 240k–584k tokens re-written per image.
+  it("keeps a mid-conversation developer message in the history, not in system", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      instructions: "You are Codex.",
+      input: [
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "House rules." }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "look at the picture" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "Looking." }] },
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "<image_resize_notice>resized</image_resize_notice>" }] },
+        { type: "message", role: "user", content: [{ type: "input_text", text: "and now?" }] },
+      ],
+    })!
+    expect(r.system).toBe("You are Codex.\n\nHouse rules.")
+    expect(r.system).not.toContain("image_resize_notice")
+    expect(r.messages).toEqual([
+      { role: "user", content: [{ type: "text", text: "look at the picture" }] },
+      { role: "assistant", content: [{ type: "text", text: "Looking." }] },
+      { role: "user", content: [
+        { type: "text", text: "<image_resize_notice>resized</image_resize_notice>" },
+        { type: "text", text: "and now?" },
+      ] },
+    ])
+  })
+
+  it("files a tool result ahead of a developer note that landed between two outputs", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { type: "message", role: "user", content: [{ type: "input_text", text: "go" }] },
+        { type: "function_call", name: "a", arguments: "{}", call_id: "c1" },
+        { type: "function_call", name: "b", arguments: "{}", call_id: "c2" },
+        { type: "function_call_output", call_id: "c1", output: "one" },
+        { type: "message", role: "developer", content: [{ type: "input_text", text: "<image_resize_notice/>" }] },
+        { type: "function_call_output", call_id: "c2", output: "two" },
+      ],
+    })!
+    const last = r.messages[r.messages.length - 1]!
+    expect(last.role).toBe("user")
+    const blocks = Array.isArray(last.content) ? last.content : []
+    expect(blocks.map((b) => b.type)).toEqual(["tool_result", "tool_result", "text"])
+  })
+
+  it("still folds a system-role item that opens the conversation", () => {
+    const r = translateResponsesToAnthropic({
+      model: "m",
+      input: [
+        { role: "system", content: "Be terse." },
+        { role: "developer", content: "And polite." },
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+      ],
+    })!
+    expect(r.system).toBe("Be terse.\n\nAnd polite.")
+    expect(r.messages).toHaveLength(1)
+  })
+
   // Bare `{role, content}` items are spec-valid and sent by the Vercel AI SDK.
   it("treats input items without a type as messages", () => {
     const r = translateResponsesToAnthropic({

--- a/src/proxy/openaiResponses.ts
+++ b/src/proxy/openaiResponses.ts
@@ -380,8 +380,10 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
       ? [{ type: "message", role: "user", content: [{ type: "input_text", text: body.input }] }]
       : body.input
 
-  // System: instructions + any developer/system-role messages folded in
-  // (Codex's harness rules arrive as developer turns).
+  // System: instructions + the developer/system-role messages that PRECEDE
+  // the conversation (Codex's harness rules arrive as leading developer
+  // turns). A developer message that arrives mid-history stays in the
+  // history — see the `message` case for why.
   const systemParts: string[] = []
   if (body.instructions) systemParts.push(body.instructions)
 
@@ -389,11 +391,25 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
   const pushBlock = (role: "user" | "assistant", block: AnthropicContentBlock) => {
     const last = messages[messages.length - 1]
     if (last && last.role === role && Array.isArray(last.content)) {
-      last.content.push(block)
+      // A tool_result must lead its user message. An inlined developer note
+      // can land between two tool outputs of one batch, so a result arriving
+      // after text is filed ahead of the text rather than behind it.
+      if (block.type === "tool_result") {
+        const firstText = last.content.findIndex(b => b.type !== "tool_result")
+        if (firstText === -1) last.content.push(block)
+        else last.content.splice(firstText, 0, block)
+      } else {
+        last.content.push(block)
+      }
     } else {
       messages.push({ role, content: [block] })
     }
   }
+
+  // Whether a conversation item (user, assistant, tool call or result) has
+  // been seen yet; developer/system items before that are the harness
+  // preamble, developer items after it are events inside the conversation.
+  let conversationStarted = false
 
   for (const item of items) {
     // NOTE: this switches on a COMPUTED discriminator, not on `item.type`, so
@@ -404,9 +420,28 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         const msg = item as ResponsesMessageItem
         if (msg.role === "developer" || msg.role === "system") {
           const t = partsToText(msg.content)
-          if (t) systemParts.push(t)
+          if (!t) break
+          if (!conversationStarted) {
+            systemParts.push(t)
+            break
+          }
+          // Anthropic caches the prompt as one prefix in the order
+          // tools → system → messages. Folding a developer message that
+          // appeared mid-conversation into `system` rewrites the system
+          // block on the turn it first shows up, which invalidates every
+          // cached token past the tools — the entire history. Codex emits
+          // exactly such messages as ordinary events: `<image_resize_notice>`
+          // after every image, `<model_switch>` on a model change,
+          // `<app-context>` when the app refreshes. Observed live: every
+          // cache collapse in a long thread (14 of 14, 240k–584k tokens
+          // re-written each) followed one of these by one to three seconds,
+          // with the tools block the only part still hitting. Kept in the
+          // history at its own position, the note is just another message:
+          // the prefix before it stays cached and the turn costs its size.
+          pushBlock("user", { type: "text", text: t })
           break
         }
+        conversationStarted = true
         const role = msg.role === "assistant" ? "assistant" : "user"
         const imageBlocks = partsToBlocks(msg.content)
         if (imageBlocks) {
@@ -418,6 +453,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         break
       }
       case "function_call": {
+        conversationStarted = true
         const fc = item as ResponsesFunctionCallItem
         let input: Record<string, unknown> = {}
         try { input = fc.arguments ? JSON.parse(fc.arguments) : {} } catch { input = {} }
@@ -426,6 +462,7 @@ export function translateResponsesToAnthropic(body: ResponsesRequest): Anthropic
         break
       }
       case "function_call_output": {
+        conversationStarted = true
         const fo = item as ResponsesFunctionCallOutputItem
         pushBlock("user", { type: "tool_result", tool_use_id: fo.call_id, content: toolOutputToContent(fo.output) })
         break


### PR DESCRIPTION
Incorporates **#966 by @justprosh**, cherry-picked with their Author and
AuthorDate preserved, plus a new live gate.

## The defect

Anthropic caches the prompt as one prefix ordered **tools → system →
messages**. `/v1/responses` folded every `developer`/`system` input item into
the Anthropic `system` block regardless of where it sat, so a note first
appearing on turn N rewrote `system` and invalidated everything behind the tools
block — the whole conversation. Confirmed in code: the fold at
`openaiResponses.ts` is unconditional on position.

Codex emits exactly these as ordinary conversation events:
`<image_resize_notice>` after every `view_image`, `<model_switch>` and
`<collaboration_mode>` on a model change, `<app-context>` on app refresh.

Their safety split is the right one, and I verified the premise from a real
capture rather than assuming it: codex-cli 0.153.4 sends the harness preamble as
a **leading** `developer` item (`input roles: ["developer","user","user"]`). That
case must keep folding into `system` — it genuinely is the preamble, and inlining
it would move every existing client's cache prefix. Only a note arriving after
the conversation starts is inlined, at its own position, which Codex replays
stably.

## New live gate (E48), and a correction to my own first attempt

`scripts/e2e-responses-developer-cache.mjs` is an A/B with real cache counters:
two identical conversations, one carrying a developer note in its replayed
history.

My first version asserted hit **percentage** and passed both before and after —
so it would have shipped as a check that proved nothing. Hit rate does not scale
down to a probe: the reported collapse was on a ~700k thread where `system` sits
behind a ~125k tools block, so losing everything behind it cost 240k–584k
tokens, whereas in a ~6.5k probe the same bug only moves the rate 98% → ~86%.

Re-written tokens are the invariant that does scale:

```
pre-fix   A cache_write=99    B cache_write=769   ->  7.8x   FAIL
with fix  A cache_write=117   B cache_write=141   ->  1.2x   PASS
```

The hit rate is still printed as context. E2E.md records why it is not asserted,
so nobody re-tightens the wrong knob later.

## Their CI-retrigger commit corroborates a separate finding

Their second commit is an empty `ci: retrigger — failover-request-id timed out
at 5s, unrelated to this change`. That is the **same flake I independently
diagnosed** earlier today and recorded against #917/#933: `failover-request-id`
has no explicit `it` timeout, so bun's default 5s applies and expires on a
contended runner. Their observation is a second, independent sighting. Only
their substantive commit is incorporated; the empty retrigger is not.

## Validation

- `npm test`: **3651 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- Their 34 unit tests in `openai-responses.test.ts` pass, including the
  existing leading-developer cases they deliberately left unchanged.
- New E48 gate discriminates as tabled above.

Versions: SDK 0.2.141, bundled Claude Code 2.1.259, system CLI 2.1.263,
codex-cli 0.153.4. Node v22.22.3, macOS arm64. Isolated workdir, session store,
ephemeral port.

## Credit

Squash body will carry `Co-authored-by: Aleksey Proshutinskiy
<alexey.prosh@fluence.one>`, since this repo squashes with a blank body.
