### PR TITLE
fix(lineage): name the block edit in the mismatch diagnostic

### DIFF
--- a/src/__tests__/lineage-mismatch-block-shape.test.ts
+++ b/src/__tests__/lineage-mismatch-block-shape.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Lineage mismatch diagnostic: append vs drop vs rewrite (#886).
+ *
+ * Since #797 the `modified-history` line names the first mismatching index and
+ * both message digests, but it reported only what the message looks like NOW.
+ * Three different client behaviours were therefore indistinguishable from the
+ * log: a block was appended, a block was dropped, or a block was rewritten in
+ * place. That distinction is the whole question in #767 — an append can be a
+ * safe continuation, a drop means the client no longer claims history the SDK
+ * session still holds.
+ *
+ * The stored block hashes were already in hand (`computeMessageBlockHashes`
+ * populates them for every session, and `verifyLineage`'s own boundary
+ * tolerance consumes them); the diagnostic simply never read them.
+ *
+ * Pure unit tests: no mocks, no I/O.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  describeLineageMismatch,
+  formatLineageMismatch,
+  computeLineageHash,
+  computeMessageHashes,
+  computeMessageBlockHashes,
+  type SessionState,
+} from "../proxy/session/lineage"
+
+const toolResult = (id: string, content: string) => ({ type: "tool_result", tool_use_id: id, content })
+const text = (t: string) => ({ type: "text", text: t })
+
+function session(messages: Array<{ role: string; content: any }>, withBlockHashes = true): SessionState {
+  return {
+    claudeSessionId: "sess",
+    lastAccess: 0,
+    lineageHash: computeLineageHash(messages),
+    messageCount: messages.length,
+    messageHashes: computeMessageHashes(messages),
+    ...(withBlockHashes ? { messageBlockHashes: computeMessageBlockHashes(messages) } : {}),
+  } as SessionState
+}
+
+/** A two-message history whose trailing message we then vary. */
+function baseline(trailing: any[]) {
+  return [
+    { role: "user", content: [text("do the thing")] },
+    { role: "user", content: trailing },
+  ]
+}
+
+describe("describeLineageMismatch block accounting", () => {
+  it("names an append when the stored blocks survive as an ordered prefix", () => {
+    const stored = baseline([toolResult("a", "res")])
+    const incoming = baseline([toolResult("a", "res"), text("<system-reminder>note</system-reminder>")])
+    const m = describeLineageMismatch(session(stored), incoming)
+    expect(m.index).toBe(1)
+    expect(m.storedBlockCount).toBe(1)
+    expect(m.incomingBlockCount).toBe(2)
+    expect(m.blockChange).toBe("appended")
+  })
+
+  it("names a drop when the incoming blocks are an ordered prefix of stored", () => {
+    const stored = baseline([toolResult("a", "res"), text("note")])
+    const incoming = baseline([toolResult("a", "res")])
+    const m = describeLineageMismatch(session(stored), incoming)
+    expect(m.storedBlockCount).toBe(2)
+    expect(m.incomingBlockCount).toBe(1)
+    expect(m.blockChange).toBe("dropped")
+  })
+
+  it("names an in-place rewrite when the count is unchanged", () => {
+    const stored = baseline([text("original")])
+    const incoming = baseline([text("edited")])
+    const m = describeLineageMismatch(session(stored), incoming)
+    expect(m.storedBlockCount).toBe(1)
+    expect(m.incomingBlockCount).toBe(1)
+    expect(m.blockChange).toBe("rewritten")
+  })
+
+  // The distinction that matters for safety: growing is not the same as
+  // appending. Dropping one block and adding two also grows the list, and
+  // calling that an append would describe a rewrite as safe to resume.
+  it("does NOT call a grown-but-altered list an append", () => {
+    const stored = baseline([text("first"), text("second")])
+    const incoming = baseline([text("CHANGED"), text("second"), text("third")])
+    const m = describeLineageMismatch(session(stored), incoming)
+    expect(m.incomingBlockCount!).toBeGreaterThan(m.storedBlockCount!)
+    expect(m.blockChange).toBe("rewritten")
+  })
+
+  it("does NOT call a shrunk-but-altered list a drop", () => {
+    const stored = baseline([text("first"), text("second"), text("third")])
+    const incoming = baseline([text("CHANGED"), text("second")])
+    const m = describeLineageMismatch(session(stored), incoming)
+    expect(m.incomingBlockCount!).toBeLessThan(m.storedBlockCount!)
+    expect(m.blockChange).toBe("rewritten")
+  })
+
+  it("names a reorder when the same blocks moved", () => {
+    const stored = baseline([text("alpha"), text("bravo")])
+    const incoming = baseline([text("bravo"), text("alpha")])
+    const m = describeLineageMismatch(session(stored), incoming)
+    expect(m.blockChange).toBe("reordered")
+  })
+
+  it("reports unknown for a session cached before block hashes existed", () => {
+    const stored = baseline([toolResult("a", "res")])
+    const incoming = baseline([toolResult("a", "res"), text("note")])
+    const m = describeLineageMismatch(session(stored, false), incoming)
+    expect(m.storedBlockCount).toBeUndefined()
+    expect(m.blockChange).toBe("unknown")
+  })
+})
+
+describe("formatLineageMismatch output", () => {
+  it("prints the block transition and the verdict", () => {
+    const stored = baseline([toolResult("a", "res")])
+    const incoming = baseline([toolResult("a", "res"), text("note")])
+    const line = formatLineageMismatch(describeLineageMismatch(session(stored), incoming))!
+    expect(line).toContain("stored 1 blocks -> incoming 2 blocks")
+    expect(line).toContain("(appended)")
+  })
+
+  it("says so plainly when the stored block hashes are unavailable", () => {
+    const stored = baseline([text("a")])
+    const incoming = baseline([text("b")])
+    const line = formatLineageMismatch(describeLineageMismatch(session(stored, false), incoming))!
+    expect(line).toContain("stored block hashes unavailable")
+    expect(line).not.toContain("(unknown)")
+  })
+
+  // The line is pasted into public issues; it must stay content-free.
+  it("leaks no message content", () => {
+    const secret = "SUPER-SECRET-PROMPT-TEXT"
+    const stored = baseline([text(secret)])
+    const incoming = baseline([text(secret), text("ANOTHER-SECRET")])
+    const line = formatLineageMismatch(describeLineageMismatch(session(stored), incoming))!
+    expect(line).not.toContain(secret)
+    expect(line).not.toContain("ANOTHER-SECRET")
+  })
+
+  it("still returns undefined when the whole prefix matched", () => {
+    const stored = baseline([text("a")])
+    expect(formatLineageMismatch(describeLineageMismatch(session(stored), stored))).toBeUndefined()
+  })
+
+  // #886's own captures: four rows were `user[tool_result,text]` and two were
+  // `user[text]`, and the reporter could not tell which were appends. Both
+  // shapes now classify themselves.
+  it("classifies the two shapes from the report's captures", () => {
+    const appendShape = describeLineageMismatch(
+      session(baseline([toolResult("a", "res")])),
+      baseline([toolResult("a", "res"), text("reminder")]),
+    )
+    expect(appendShape.blockChange).toBe("appended")
+    const textOnlyShape = describeLineageMismatch(
+      session(baseline([text("turn")])),
+      baseline([text("turn edited")]),
+    )
+    expect(textOnlyShape.blockChange).toBe("rewritten")
+  })
+})

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -231,6 +231,17 @@ export interface LineageMismatch {
   previousDigest?: string
   storedCount: number
   incomingCount: number
+  /** How many blocks the STORED message had at this index. Undefined for a
+   *  session cached before block hashes were recorded (pre-1.61.0). */
+  storedBlockCount?: number
+  /** Blocks the incoming message has at this index, counted over the same
+   *  hashable domain as the stored side so the two are comparable. */
+  incomingBlockCount?: number
+  /** What the client did to this message, when the stored block hashes make it
+   *  decidable. Appended/dropped/rewritten are three different client bugs and
+   *  the log could not tell them apart (#886) — which is precisely the question
+   *  #767 turns on. */
+  blockChange?: "appended" | "dropped" | "rewritten" | "reordered" | "unknown"
 }
 
 function describeShape(message: { role: string; content: any }): MessageShape {
@@ -275,13 +286,49 @@ export function describeLineageMismatch(
   }
   if (index < 0) return base
 
+  // The stored block hashes are already in hand and verifyLineage's own
+  // boundary tolerance consumes them a few lines later; the diagnostic simply
+  // never looked. Counting both sides turns "this message changed" into
+  // "the client appended / dropped / rewrote a block", which is the difference
+  // between a safe continuation and a history the client no longer claims.
+  const storedBlocks = cached.messageBlockHashes?.[index]
+  const incomingMessage = messages[index]
+  const incomingBlocks = incomingMessage
+    ? computeMessageBlockHashes([incomingMessage])[0]
+    : undefined
+
   return {
     ...base,
     storedDigest: storedHashes[index],
     incomingDigest: incomingHashes[index],
-    incomingShape: messages[index] ? describeShape(messages[index]!) : undefined,
+    incomingShape: incomingMessage ? describeShape(incomingMessage) : undefined,
     previousDigest: index > 0 ? storedHashes[index - 1] : undefined,
+    storedBlockCount: storedBlocks?.length,
+    incomingBlockCount: incomingBlocks?.length,
+    blockChange: classifyBlockChange(storedBlocks, incomingBlocks),
   }
+}
+
+/**
+ * Name the block-level edit, using only the hashes both sides already carry.
+ *
+ * `appended` and `dropped` require the shorter side to be an exact ORDERED
+ * PREFIX of the longer one. A count change alone is not enough: dropping one
+ * block and adding two also grows the list, and calling that an append would
+ * describe a rewrite as something safe to resume.
+ */
+function classifyBlockChange(
+  stored: readonly string[] | undefined,
+  incoming: readonly string[] | undefined,
+): LineageMismatch["blockChange"] {
+  if (!stored || !incoming) return "unknown"
+  const isPrefix = (short: readonly string[], long: readonly string[]) =>
+    short.every((hash, i) => long[i] === hash)
+  if (incoming.length > stored.length) return isPrefix(stored, incoming) ? "appended" : "rewritten"
+  if (incoming.length < stored.length) return isPrefix(incoming, stored) ? "dropped" : "rewritten"
+  // Same length: an in-place edit, unless the same blocks merely moved.
+  const same = [...stored].sort().join() === [...incoming].sort().join()
+  return same ? "reordered" : "rewritten"
 }
 
 /**
@@ -305,10 +352,16 @@ export function formatLineageMismatch(mismatch: LineageMismatch): string | undef
   const shape = mismatch.incomingShape
     ? `${mismatch.incomingShape.role}[${mismatch.incomingShape.blocks}] ${mismatch.incomingShape.bytes}B`
     : "unknown"
+  // Block counts and the verdict are integers and a fixed word: no content, so
+  // the line stays as safe to paste into a public issue as it was before.
+  const blocks = mismatch.storedBlockCount !== undefined && mismatch.incomingBlockCount !== undefined
+    ? `, stored ${mismatch.storedBlockCount} blocks -> incoming ${mismatch.incomingBlockCount} blocks`
+      + (mismatch.blockChange && mismatch.blockChange !== "unknown" ? ` (${mismatch.blockChange})` : "")
+    : ", stored block hashes unavailable (session cached before 1.61.0)"
   return (
     `first mismatch at index ${mismatch.index}${trailing}: ` +
     `stored=${short(mismatch.storedDigest)} incoming=${short(mismatch.incomingDigest)}, ` +
-    `incoming now ${shape}`
+    `incoming now ${shape}${blocks}`
   )
 }
 


### PR DESCRIPTION
Reported by @connor-grady in #886, whose six captures are what showed the
diagnostic was unusable for the question it exists to answer.

## The gap

Since #797 the `modified-history` line names the first mismatching index and
both message digests, but it reported only what the message looks like **now**.
Three different client behaviours were indistinguishable from the log: a block
was appended, a block was dropped, or a block was rewritten in place.

That distinction is the whole question in #767 — an append can be a safe
continuation, a drop means the client no longer claims history the SDK session
still holds. Their captures show the problem exactly: four
`user[tool_result,text]` rows and two `user[text]` rows, with both readings
fitting and nothing in the output settling it.

I ran into this first-hand investigating #767 and reached the same dead end,
reasoning around the `user[text] 50B` rows sideways because the line would not
say whether a block had been added or removed.

## The change

Their observation that the data was already in hand is correct:
`computeMessageBlockHashes` populates block hashes for every stored session, and
`verifyLineage`'s own boundary tolerance consumes them a few lines later — the
diagnostic simply never read them.

Both block counts are now reported, plus a classification. I went past their
suggested bare integer to name the edit, because the count alone still leaves
the safety question open:

**`appended` and `dropped` require the shorter side to be an exact ORDERED
PREFIX of the longer one**, not merely shorter. Dropping one block and adding
two also grows the list, and calling that an append would describe a rewrite as
something safe to resume. Two tests pin that specifically — a grown-but-altered
list and a shrunk-but-altered list both classify as `rewritten`.

Live output:

```
first mismatch at index 2 (trailing message only — the rest of the history matched):
stored=a07423792992 incoming=82eb8265f680, incoming now user[tool_result,tool_result] 65B,
stored 2 blocks -> incoming 2 blocks (rewritten)
```

A session cached before block hashes existed (pre-1.61.0) says so plainly rather
than reporting a misleading verdict.

## Safety of the output

The line is meant to be pasted into public issues. Only integers and a fixed
verdict word are added, so it stays content-free — asserted by a test that runs
secret text through the formatter and requires it absent from the output.

## Validation

- 12 new pure unit tests, no mocks: append, drop, in-place rewrite, reorder,
  grown-but-altered, shrunk-but-altered, legacy session, formatter output,
  content-leak guard, and the two shapes from the report's own captures.
- **Live**: `bun scripts/e2e-lineage-divergence.mjs` exits 0 and its real
  divergence now carries `stored 2 blocks -> incoming 2 blocks (rewritten)`.
  That gate's scenario edits a tool result in place, so `rewritten` is the
  correct verdict — the classification is not merely present but right.
- `npm test`: **3680 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.

## Not addressed here

The issue's secondary note — that `diverged` with reason `not-found`,
`unrelated-history`, `unverifiable` or `replayed-request` produces no log line
at all, and the reason is only reachable through a plugin hook — is a separate
change and overlaps #820. It is deliberately not bundled into this one.
