### PR TITLE
feat(messages): honour the client's max_tokens, behind a flag

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -272,6 +272,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E46 | [Codex namespace and MCP tools](#e46-codex-namespace-and-mcp-tools) | **Automated**: `bun scripts/e2e-codex-namespace-tools.mjs [--stream]` — real proxy + SDK. Codex 0.15x sends MCP servers as `{type:"namespace", tools:[...]}`, which the Responses translator dropped. Asserts namespaced tools reach Claude, calls come back carrying `namespace`, and a `function_call_output` whose output is a content-item ARRAY does not 400. **Run before releases touching the Responses translator or Codex tool handling** | 2026-09-08 |
 | E47 | [Codex thread identity](#e47-codex-thread-identity) | **Automated**: `bun scripts/e2e-codex-thread-identity.mjs` — real proxy + SDK. Codex hands a spawned subagent and its compaction the PARENT's `prompt_cache_key`. Asserts a user thread still resumes unchanged, siblings get their own sessions, and the parent still resumes after both. **Run before releases touching Responses session identity, the turn coordinator, or request-source admission** | 2026-09-08 |
 | E48 | [Responses developer-note cache](#e48-responses-developer-note-cache) | **Automated**: `bun scripts/e2e-responses-developer-cache.mjs` — real proxy + SDK, A/B. A `developer` item folded into `system` mid-conversation re-wrote the whole cached prefix. Asserts the note's turn re-writes no more than the control's (measured 7.8x pre-fix, 1.2x after). **Run before releases touching Responses prompt assembly or system-block construction** | 2026-09-08 |
+| E49 | [max_tokens enforcement](#e49-max_tokens-enforcement) | **Automated**: `bun scripts/e2e-max-tokens.mjs` — real proxy + SDK. Opt-in via `MERIDIAN_ENFORCE_MAX_TOKENS=1`: a tiny cap bounds output and reports `stop_reason: max_tokens` in both modes, a generous cap is untouched, and with the flag unset the cap is ignored exactly as before. **Run before releases touching the SDK call builder, env plumbing, or terminal stop reasons** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4148,6 +4149,53 @@ with fix  A cache_write=117   B cache_write=141   ->  1.2x   PASS
 The hit rate is still printed, as context rather than as a check.
 
 **Verified:** 2026-09-08. Discriminates as tabled above.
+
+## E49: max_tokens enforcement
+
+**What it proves:** when enabled, the client's `max_tokens` actually bounds
+output and a truncated turn says so.
+
+`max_tokens` is required on `/v1/messages` and the contract makes it a hard cap
+on thinking plus output, with a cut-off response reporting
+`stop_reason: "max_tokens"`. Nothing on that path read it — #874 measured 16 ->
+3900 output tokens (244x) and `end_turn` every time.
+
+**Why this needed the real SDK.** The Agent SDK's `Options` has no output cap;
+the only lever is the CLI's `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, and when it trips
+the CLI **throws** rather than returning a truncated turn. Wiring it up naively
+converts a satisfiable request into a hard error. Probed at 64 against CLI
+2.1.263, the turn produced genuine text (154 chars) and then threw — the API
+really stopped generating, only the shape coming back was wrong. The fix
+translates that refusal into the stop reason the wire defines.
+
+```bash
+MERIDIAN_ENFORCE_MAX_TOKENS=1   # opt-in; the gate sets this itself
+bun scripts/e2e-max-tokens.mjs
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- A tiny cap does not fail the request, reports `stop_reason: max_tokens`, and
+  bounds output. The bound is asserted as a large multiple of the cap, not an
+  exact count: the cap covers thinking plus text, and the defect was a 244x
+  overshoot rather than an off-by-a-few.
+- Streaming delivers no error frame and closes as `max_tokens`, including when
+  thinking consumed the whole budget and no text was produced — an empty
+  response with that stop reason is what the wire defines for it.
+- A generous cap is unchanged in both modes.
+- **With the flag unset a tiny cap is ignored, exactly as before.** Asserted in
+  a second proxy, against the capped run rather than a fixed number.
+
+**Why it is opt-in.** The cap counts thinking plus text, and an agentic turn
+spends tokens on thinking the client never sized for. Measured: a 128-token cap
+could no longer complete a turn whose visible answer was ~15 tokens, and a
+16-token cap produced no text at all. Clients here send caps sized for a direct
+answer — OpenCode sends 32000 — so enforcing by default would change behaviour
+for every existing caller to close a conformance gap only some of them need.
+The capability is exact when asked for, and off otherwise.
+
+**Verified:** 2026-09-08. Ten checks pass. Enabling it turned the reported
+16 -> 3900 overshoot into 16 -> 64 with `stop_reason: max_tokens`.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-max-tokens.mjs
+++ b/scripts/e2e-max-tokens.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env bun
+// Live: is the client's `max_tokens` actually a cap, and does a truncated turn
+// say so?
+//
+// `max_tokens` is REQUIRED on `/v1/messages` and the API contract makes it a
+// hard cap on total output, with a cut-off response reporting
+// `stop_reason: "max_tokens"`. Nothing on this path ever read it (#874,
+// reported by @albe-jj with 16 -> 3900 output tokens, a 244x overshoot, and
+// `end_turn` every time).
+//
+// Why this needs the real SDK and could not be reasoned out:
+//
+//   - The Agent SDK's `Options` has NO output cap. The full key list has
+//     `maxBudgetUsd`, `maxThinkingTokens`, `maxTurns`, `taskBudget` and nothing
+//     for output tokens, so there is no parameter to pass through.
+//   - The CLI's `CLAUDE_CODE_MAX_OUTPUT_TOKENS` is the only lever, and when it
+//     trips the CLI does not return a truncated turn — it THROWS
+//     "Claude's response exceeded the N output token maximum". Wiring it up
+//     naively converts a satisfiable request into a hard error.
+//   - But the cap is real: probed at 64 against CLI 2.1.263, the turn produced
+//     genuine assistant text (154 chars, ~38 tokens) and then threw. The API
+//     stopped generating; only the shape coming back was wrong.
+//
+// So the fix passes the cap through and translates that refusal into the stop
+// reason the wire defines. Because generation really stopped, the SDK session
+// holds the same truncated text the client receives — no post-hoc truncation,
+// so resume stays consistent.
+//
+// Four claims:
+//
+//   1. A small cap actually bounds output. Asserted as a large multiple of the
+//      cap rather than an exact number: the cap counts thinking plus text, and
+//      the point is that a 244x overshoot is gone, not that a specific token
+//      count lands.
+//   2. A capped turn reports `stop_reason: "max_tokens"`, not `end_turn` and
+//      not an HTTP error.
+//   3. A generous cap is unchanged — same stop reason as today, no truncation.
+//      This is the regression guard: the cap now rides on EVERY request.
+//   4. Streaming behaves the same as non-streaming.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching the SDK call builder, env plumbing, or terminal stop reasons.
+//
+//   bun scripts/e2e-max-tokens.mjs
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mmaxtok-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+
+// Opt-in. The gate must set it explicitly, and the DEFAULT path is asserted
+// separately below so the off-by-default promise is tested, not assumed.
+process.env.MERIDIAN_ENFORCE_MAX_TOKENS = '1'
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3552)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+const PROMPT = 'Write a detailed essay on the history of planet Earth.'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+async function ask(maxTokens, stream) {
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-opencode-session': `maxtok-${maxTokens}-${stream}-${process.pid}` },
+    body: JSON.stringify({ model: MODEL, max_tokens: maxTokens, stream, messages: [{ role: 'user', content: PROMPT }] }),
+  })
+  const text = await res.text()
+  let stop = null, out = 0, chars = 0, errors = 0
+  if (stream) {
+    for (const line of text.split('\n')) {
+      if (!line.startsWith('data:')) continue
+      let ev
+      try { ev = JSON.parse(line.slice(5)) } catch { continue }
+      if (ev.type === 'error') errors++
+      if (ev.type === 'message_delta') {
+        if (ev.delta?.stop_reason) stop = ev.delta.stop_reason
+        if (ev.usage?.output_tokens) out = ev.usage.output_tokens
+      }
+      if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta') chars += (ev.delta.text ?? '').length
+    }
+  } else {
+    let body = null
+    try { body = JSON.parse(text) } catch { /* surfaced by the caller */ }
+    if (body?.type === 'error') errors++
+    stop = body?.stop_reason ?? null
+    out = body?.usage?.output_tokens ?? 0
+    chars = (body?.content ?? []).filter(b => b.type === 'text').map(b => b.text ?? '').join('').length
+  }
+  say(`  max_tokens=${String(maxTokens).padEnd(6)} stream=${String(stream).padEnd(5)} http=${res.status} stop=${String(stop).padEnd(11)} output_tokens=${String(out).padStart(5)} chars=${String(chars).padStart(5)} errors=${errors}`)
+  return { status: res.status, stop, out, chars, errors }
+}
+
+say(`\n=== max_tokens enforcement (model=${MODEL}) ===`)
+
+// The reported case: a 16-token cap that produced 3900 tokens and `end_turn`.
+const tiny = await ask(16, false)
+check(tiny.status === 200 && tiny.errors === 0, 'a tiny cap does not fail the request',
+  `http=${tiny.status} errors=${tiny.errors}`)
+check(tiny.stop === 'max_tokens', 'a capped turn reports stop_reason=max_tokens',
+  `stop=${tiny.stop}`)
+// Asserted as a bound, not an exact count: the cap covers thinking + text, and
+// the defect was a 244x overshoot, not an off-by-a-few.
+check(tiny.out > 0 && tiny.out < 16 * 20, 'output is actually bounded by the cap',
+  `output_tokens=${tiny.out} against cap 16 (reported 3900 = 244x)`)
+
+const tinyStream = await ask(16, true)
+check(tinyStream.status === 200 && tinyStream.errors === 0,
+  'streaming: a tiny cap delivers no error frame', `http=${tinyStream.status} errors=${tinyStream.errors}`)
+check(tinyStream.stop === 'max_tokens', 'streaming: capped turn closes as max_tokens',
+  `stop=${tinyStream.stop}`)
+
+// REGRESSION GUARD. The cap now rides on every request, so a generous value
+// must behave exactly as before: a full answer ending normally.
+const roomy = await ask(4096, false)
+check(roomy.status === 200 && roomy.errors === 0, 'a generous cap is unaffected',
+  `http=${roomy.status} errors=${roomy.errors}`)
+check(roomy.stop === 'end_turn', 'a generous cap still ends normally', `stop=${roomy.stop}`)
+check(roomy.chars > tiny.chars, 'a generous cap returns more content than a tiny one',
+  `${roomy.chars} chars vs ${tiny.chars}`)
+
+const roomyStream = await ask(4096, true)
+check(roomyStream.status === 200 && roomyStream.stop === 'end_turn',
+  'streaming: a generous cap still ends normally', `http=${roomyStream.status} stop=${roomyStream.stop}`)
+
+// The off-by-default promise, asserted rather than assumed: a fresh proxy with
+// the flag cleared must ignore a tiny cap exactly as before the change.
+delete process.env.MERIDIAN_ENFORCE_MAX_TOKENS
+const off = await startProxyServer({ port: PORT + 1, host: '127.0.0.1' })
+try {
+  const res = await fetch(`http://127.0.0.1:${PORT + 1}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-opencode-session': `maxtok-off-${process.pid}` },
+    body: JSON.stringify({ model: MODEL, max_tokens: 16, stream: false, messages: [{ role: 'user', content: PROMPT }] }),
+  })
+  const body = await res.json()
+  const out = body?.usage?.output_tokens ?? 0
+  say(`  default (flag unset)  http=${res.status} stop=${body?.stop_reason} output_tokens=${out}`)
+  // Compared against the capped run rather than an absolute number: what
+  // matters is that the cap had no effect, and "many times the capped output"
+  // says that at any model size. A fixed threshold just encodes one model's
+  // verbosity and fails on a quieter one.
+  check(res.status === 200 && body?.stop_reason === 'end_turn' && out > tiny.out * 2,
+    'with the flag unset a tiny cap is ignored, exactly as before',
+    `stop=${body?.stop_reason} output_tokens=${out} vs capped ${tiny.out}`)
+} finally {
+  await off.close()
+}
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-12)) say(`    ${l}`)
+} else {
+  say('  PASS: max_tokens bounds output and truncation is reported honestly')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/scripts/e2e-tier-refusal-failover.mjs
+++ b/scripts/e2e-tier-refusal-failover.mjs
@@ -97,7 +97,11 @@ try {
     const port = proxy.server.address().port
     rateLimitStore.clear()
     const requestId = crypto.randomUUID()
-    const receipt = `TIERFAILOVER_${crypto.randomUUID()}`
+    // A SHORT receipt, deliberately. An earlier version asked the model to echo
+    // a full UUID and the gate was flaky at roughly 1 in 3 on streaming: haiku
+    // does not reliably reproduce 36 random characters verbatim. That measured
+    // nothing about failover, which is what this gate exists to test.
+    const receipt = `TIEROK${crypto.randomUUID().replace(/-/g, '').slice(0, 6).toUpperCase()}`
     const stream = mode.endsWith('-stream')
     const callsBefore = refusedCalls
 
@@ -106,7 +110,7 @@ try {
       headers: { 'content-type': 'application/json', 'x-request-id': requestId, 'x-opencode-session': requestId },
       body: JSON.stringify({
         model: 'claude-haiku-4-5-20251001', max_tokens: 128, stream,
-        messages: [{ role: 'user', content: `Reply with exactly ${receipt}.` }],
+        messages: [{ role: 'user', content: `Reply with exactly this and nothing else: ${receipt}` }],
       }),
       signal: AbortSignal.timeout(180000),
     })
@@ -129,7 +133,7 @@ try {
     console.log(JSON.stringify({
       mode, status: response.status, refusedCalls,
       rows: rows.map(r => ({ profile: r.profileId, status: r.status, error: r.error })),
-      answered: reply.includes(receipt),
+      answered: reply.trim().length > 0, echoedReceipt: reply.includes(receipt),
     }))
 
     assert(refusedCalls > callsBefore, 'the real CLI must reach the local refusal upstream for this case')
@@ -141,7 +145,16 @@ try {
     assert.equal(response.status, 200)
     assert.equal(served.length, 1)
     assert.equal(served[0].profileId, 'working')
-    assert(reply.includes(receipt), 'the real Claude Max fallback must answer the prompt')
+    // Assert that the fallback ANSWERED, not that the model obeyed verbatim.
+    //
+    // This asserted `reply.includes(receipt)` and was flaky at roughly 1 in 3
+    // even after the receipt was shortened: sometimes the model paraphrases or
+    // adds a preamble. That measured the model's compliance, not failover —
+    // and a gate whose red is usually noise stops being read. Non-empty text
+    // from the healthy profile is the real claim: a refusal that failed over to
+    // an account which then produced nothing would still be a failure, and this
+    // catches it. The receipt is reported for eyeballing, not asserted.
+    assert(reply.trim().length > 0, 'the real Claude Max fallback must produce visible text')
   }
   console.log(JSON.stringify({ result: 'PASS', root, refusedCalls, cases }))
 } finally {

--- a/src/__tests__/max-output-tokens.test.ts
+++ b/src/__tests__/max-output-tokens.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Client `max_tokens` enforcement (#874).
+ *
+ * `max_tokens` is required on `/v1/messages` and the contract makes it a hard
+ * cap on output, with a cut-off response reporting `stop_reason: "max_tokens"`.
+ * Nothing on that path read it: 16 produced 3900 output tokens and `end_turn`.
+ *
+ * The Agent SDK's `Options` has no output cap, so the only lever is the CLI's
+ * `CLAUDE_CODE_MAX_OUTPUT_TOKENS` — which THROWS when it trips rather than
+ * returning a truncated turn. These tests cover the two pure pieces: the env
+ * value that is passed down, and the predicate that recognises the refusal.
+ *
+ * The end-to-end behaviour needs the real CLI and is gated by E49.
+ */
+
+import { describe, it, expect } from "bun:test"
+import { isOutputTokenCapExceeded } from "../proxy/errors"
+
+describe("isOutputTokenCapExceeded", () => {
+  it("recognises the CLI's refusal, wrapped as it actually arrives", () => {
+    // Captured verbatim from CLI 2.1.263 with a cap of 64.
+    expect(isOutputTokenCapExceeded(
+      "Claude Code returned an error result: API Error: Claude's response exceeded the 64 output token maximum."
+      + " To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
+    )).toBe(true)
+  })
+
+  it("matches any cap value", () => {
+    for (const n of [1, 16, 512, 32000]) {
+      expect(isOutputTokenCapExceeded(`Claude's response exceeded the ${n} output token maximum.`)).toBe(true)
+    }
+  })
+
+  // The context-window refusal is about INPUT length and must keep its own
+  // classification — conflating them would report a context overflow as a
+  // truncated answer and tell the client to simply continue.
+  it("does not match the input-length/context refusal", () => {
+    expect(isOutputTokenCapExceeded(
+      "input length and max_tokens exceed context limit: 200000 + 8192 > 200000",
+    )).toBe(false)
+  })
+
+  it("does not match other terminal reasons", () => {
+    for (const m of [
+      "Reached maximum number of turns (1)",
+      "Claude Code process exited with code 1",
+      "You've reached your Fable limit. Switch to another model to continue.",
+      "output token maximum",              // the phrase without the count
+      "response exceeded the limit",       // similar prose, no token count
+    ]) {
+      expect(isOutputTokenCapExceeded(m)).toBe(false)
+    }
+  })
+
+  it("is safe on absent or non-string input", () => {
+    expect(isOutputTokenCapExceeded(undefined)).toBe(false)
+    expect(isOutputTokenCapExceeded(null)).toBe(false)
+    expect(isOutputTokenCapExceeded("")).toBe(false)
+  })
+})
+
+/**
+ * The cap that reaches the subprocess. Mirrors the parse in server.ts: only a
+ * positive finite value is honoured, so a malformed request keeps the previous
+ * behaviour rather than clamping generation to zero.
+ */
+function resolveCap(maxTokens: unknown): number | undefined {
+  const raw = Number(maxTokens)
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : undefined
+}
+
+describe("client max_tokens -> subprocess cap", () => {
+  it("passes through a positive integer", () => {
+    expect(resolveCap(16)).toBe(16)
+    expect(resolveCap(4096)).toBe(4096)
+  })
+
+  it("floors a fractional value rather than sending a non-integer", () => {
+    expect(resolveCap(100.7)).toBe(100)
+  })
+
+  it("accepts a numeric string, as a lenient HTTP client may send", () => {
+    expect(resolveCap("512")).toBe(512)
+  })
+
+  // Every one of these must leave the cap UNSET. Sending 0 or a negative value
+  // would clamp generation to nothing on requests that are merely malformed.
+  it("leaves the cap unset for anything not a positive number", () => {
+    for (const bad of [0, -1, undefined, null, "", "abc", NaN, Infinity, -Infinity, {}, []]) {
+      expect(resolveCap(bad)).toBeUndefined()
+    }
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -155,6 +155,31 @@ const HIT_YOUR_SPEND_LIMIT = /^\s*(?:(?:error|api error|claude code returned an 
  * `claude login` for what is actually a quota refusal. */
 const REACHED_YOUR_TIER_LIMIT = /^[ \t]*(?:(?:error|api error|claude code returned an error result|subprocess stderr):[ \t]*)*(?:\d{3}[ \t]+)?you(?:'|’)ve reached your (?:claude )?(?:fable|mythos|opus|sonnet|haiku)(?: \d+(?:\.\d+)*)? limit(?:(?:[.!][ \t]+|[ \t]+)(?:(?:run[ \t]+)?\/usage-credits(?:[ \t]+to[ \t]+continue)?(?:[ \t]+or[ \t]+switch[ \t]+models[ \t]+with[ \t]+\/model)?|\/model[ \t]+to[ \t]+switch[ \t]+models|switch[ \t]+to[ \t]+another[ \t]+model(?:[ \t]+to[ \t]+continue)?)\.?|[.!]?)[ \t\r]*$/m
 
+/**
+ * The CLI's refusal when a turn hit the output-token maximum.
+ *
+ * `max_tokens` on `/v1/messages` is a hard cap on output, and a response cut
+ * short is supposed to report `stop_reason: "max_tokens"` (#874). The Agent
+ * SDK's `Options` has no output cap at all — the only lever is the CLI's
+ * `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, and when that trips the CLI does NOT return
+ * a truncated turn: it throws this. Verified against CLI 2.1.263 with a cap of
+ * 64, which produced real assistant text and then this error.
+ *
+ * So the cap works — the API genuinely stops generating — and the only thing
+ * wrong is the shape it comes back in. Recognising it lets the recovery paths
+ * deliver the content that did arrive under the stop reason the wire expects,
+ * instead of a 500.
+ *
+ * Anchored on the distinctive phrase and a digit count so it cannot collide
+ * with the context-window refusal above, which is about INPUT length.
+ */
+const OUTPUT_TOKEN_MAXIMUM = /response exceeded the \d+ output token maximum/i
+
+/** True when a turn failed only because it hit the client's output cap. */
+export function isOutputTokenCapExceeded(message: string | undefined | null): boolean {
+  return typeof message === "string" && OUTPUT_TOKEN_MAXIMUM.test(message)
+}
+
 /** Canonical Claude Code usage-credit banner. Anchor on the raw message or the
  * known SDK wrappers so quoted docs, MCP stderr, and negated/incidental prose
  * cannot exhaust every profile in a priority pool. */

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -181,6 +181,9 @@ export interface QueryContext {
   claudeAiConnectors?: boolean
   /** Per-request cost cap in USD */
   maxBudgetUsd?: number
+  /** The client's `max_tokens`, honoured through the CLI's own output cap.
+   *  Omitted when absent or non-positive, which leaves today's behaviour. */
+  maxOutputTokens?: number
   /** Fallback model when primary fails */
   fallbackModel?: string
   /** Enable SDK debug logging */
@@ -456,7 +459,7 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
     resumeSessionId, isUndo, resumeSessionAtUuid, forkSession, forkSessionId, sdkHooks, blockedTools, incompatibleTools,
     mcpServerName, allowedMcpTools, onStderr,
     effort, thinking, taskBudget, outputFormat, betas, settingSources, codeSystemPrompt, clientSystemPrompt,
-    memory, dreaming, sharedMemory, maxBudgetUsd, fallbackModel, sdkDebug, additionalDirectories,
+    memory, dreaming, sharedMemory, maxBudgetUsd, maxOutputTokens, fallbackModel, sdkDebug, additionalDirectories,
   } = ctx
   const cwdNote = buildCwdNote(workingDirectory, clientWorkingDirectory, {
     clientEnvironmentMayDifferFromProxy,
@@ -556,6 +559,18 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
         // Keychain auth.
         ...(sharedMemory ? stripConfigDir(cleanEnv) : cleanEnv),
         ENABLE_TOOL_SEARCH: hasDeferredTools ? "true" : "false",
+        // `max_tokens` is required on /v1/messages and is a hard cap on output,
+        // but the SDK's Options expose no output cap — this env var is the only
+        // lever the CLI offers (#874). Set it only when the client gave a
+        // positive value, so an omitted or malformed cap keeps today's
+        // behaviour rather than silently clamping to something invented.
+        //
+        // When it trips the CLI throws rather than returning a truncated turn;
+        // `isOutputTokenCapExceeded` in errors.ts recognises that and the
+        // recovery paths deliver the content with stop_reason "max_tokens".
+        ...(maxOutputTokens && maxOutputTokens > 0
+          ? { CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(Math.floor(maxOutputTokens)) }
+          : {}),
         // claude.ai connectors: MCP servers attached to the account's
         // claude.ai profile (Drive, Gmail, Calendar, …). The subprocess
         // otherwise fetches them from /v1/mcp_servers and connects each one

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -55,7 +55,7 @@ import { LRUMap } from "../utils/lruMap"
 
 import { telemetryStore, diagnosticLog, createTelemetryRoutes, landingHtml, renderPrometheusMetrics } from "../telemetry"
 import type { RequestMetric } from "../telemetry"
-import { canRecoverCapturedToolUses, classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal } from "./errors"
+import { canRecoverCapturedToolUses, classifyError, extractSdkTermination, formatSdkTermination, classifyResumeRefusal, isRateLimitError, isExtraUsageRequiredError, isExpiredTokenError, isAccountFailoverError, isQuotaRefusal, isOutputTokenCapExceeded } from "./errors"
 import { refreshOAuthToken, ensureFreshToken, startBackgroundRefresh, stopBackgroundRefresh, createPlatformCredentialStore, getAuthRenewalStatus, resolveRenewalWarnDays, type CredentialStore } from "./tokenRefresh"
 import {
   createFileDesignTokenStore,
@@ -1505,6 +1505,26 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       let attemptedRequestModel: string | undefined
       try {
         const body = options.body
+        // #874: `max_tokens` is required on /v1/messages and is a hard cap on
+        // output, but nothing on this path ever read it. Honour it through the
+        // CLI's own cap (see query.ts). Only a positive finite value counts —
+        // anything else leaves the cap unset rather than inventing one, so a
+        // malformed request keeps today's behaviour instead of clamping to 0.
+        //
+        // OPT-IN, and deliberately so. The cap counts thinking PLUS text, just
+        // as the Anthropic contract says, and an agentic turn spends tokens on
+        // thinking the client never sized for. Measured: a 128-token cap could
+        // no longer complete a turn whose visible answer was ~15 tokens, and a
+        // 16-token cap produced no text at all. Clients here send caps sized
+        // for a direct answer (OpenCode sends 32000), so enforcing it by
+        // default would change behaviour for every existing caller to fix a
+        // conformance gap only some of them care about. Off unless asked for;
+        // when asked for, it is exact.
+        const rawMaxTokens = Number(body?.max_tokens)
+        const clientMaxOutputTokens = envBool("ENFORCE_MAX_TOKENS")
+          && Number.isFinite(rawMaxTokens) && rawMaxTokens > 0
+          ? Math.floor(rawMaxTokens)
+          : undefined
         const idleRequestKey = idleStallRequestKey(body)
         const markPriorityAttemptExposure = (reason: string): void => {
           const exposure = options.priorityAttemptExposure
@@ -3279,7 +3299,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
                     claudeAiConnectors: sdkFeatures.claudeAiConnectors,
-                    maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
+                    maxBudgetUsd: sdkFeatures.maxBudgetUsd, maxOutputTokens: clientMaxOutputTokens, fallbackModel: sdkFeatures.fallbackModel,
                     sdkDebug: sdkFeatures.sdkDebug,
                     additionalDirectories: sdkFeatures.additionalDirectories
                       ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
@@ -3384,7 +3404,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
                     claudeAiConnectors: sdkFeatures.claudeAiConnectors,
-                      maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
+                      maxBudgetUsd: sdkFeatures.maxBudgetUsd, maxOutputTokens: clientMaxOutputTokens, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
@@ -3444,7 +3464,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
                     claudeAiConnectors: sdkFeatures.claudeAiConnectors,
-                      maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
+                      maxBudgetUsd: sdkFeatures.maxBudgetUsd, maxOutputTokens: clientMaxOutputTokens, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
@@ -3856,6 +3876,21 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // Do not rethrow — execution continues into the merge block, which
               // backfills contentBlocks from capturedToolUses and builds a clean
               // stop_reason:"tool_use" response.
+            } else if (clientMaxOutputTokens && isOutputTokenCapExceeded(error instanceof Error ? error.message : String(error ?? ""))) {
+              // The client's own `max_tokens` stopped generation (#874). The
+              // API really did cap the turn, so the content that arrived is a
+              // complete truncated response — not a partial one we invented —
+              // and the SDK session holds the same text, so resume stays
+              // consistent. Report the stop reason the wire defines for this
+              // instead of answering a satisfiable request with a 500.
+              lastStopReason = "max_tokens"
+              claudeLog("upstream.output_cap_truncated", {
+                mode: "non_stream",
+                cap: clientMaxOutputTokens,
+                blocks: contentBlocks.length,
+              })
+              plog(`[PROXY] ${requestMeta.requestId} output capped at client max_tokens=${clientMaxOutputTokens} — reporting stop_reason=max_tokens`)
+              if (lastUsage) logUsage(requestMeta.requestId, lastUsage)
             } else if (passthrough && sdkTerm.reason === "max_turns" && hasTruncatableText(contentBlocks)) {
               // The turn hit its budget without producing a forwardable tool
               // call, but it did produce visible text. Throwing here would answer a
@@ -4409,7 +4444,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
                     claudeAiConnectors: sdkFeatures.claudeAiConnectors,
-                      maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
+                      maxBudgetUsd: sdkFeatures.maxBudgetUsd, maxOutputTokens: clientMaxOutputTokens, fallbackModel: sdkFeatures.fallbackModel,
                       sdkDebug: sdkFeatures.sdkDebug,
                       additionalDirectories: sdkFeatures.additionalDirectories
                         ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
@@ -4493,7 +4528,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                     webFetchPreflight: sdkFeatures.webFetchPreflight,
                     claudeAiConnectors: sdkFeatures.claudeAiConnectors,
-                        maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
+                        maxBudgetUsd: sdkFeatures.maxBudgetUsd, maxOutputTokens: clientMaxOutputTokens, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
@@ -4549,7 +4584,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                         memory: sdkFeatures.memory, dreaming: sdkFeatures.dreaming, sharedMemory: sdkFeatures.sharedMemory,
                         webFetchPreflight: sdkFeatures.webFetchPreflight,
                         claudeAiConnectors: sdkFeatures.claudeAiConnectors,
-                        maxBudgetUsd: sdkFeatures.maxBudgetUsd, fallbackModel: sdkFeatures.fallbackModel,
+                        maxBudgetUsd: sdkFeatures.maxBudgetUsd, maxOutputTokens: clientMaxOutputTokens, fallbackModel: sdkFeatures.fallbackModel,
                         sdkDebug: sdkFeatures.sdkDebug,
                         additionalDirectories: sdkFeatures.additionalDirectories
                           ? sdkFeatures.additionalDirectories.split(",").map(d => d.trim()).filter(Boolean)
@@ -6295,13 +6330,35 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               // overflow, duplicate abort, early-stop reversion). Ending that
               // with `max_tokens` leaves a call the client is told neither to
               // run nor to discard, so it keeps the error it gets today.
+              // #874: the client's own `max_tokens` stopping generation is the
+              // same shape as a capped turn — a truncated but complete answer
+              // that must close as `max_tokens`, not as an error frame. It is
+              // not passthrough-specific and does not arrive as `max_turns`,
+              // so it joins the condition rather than reusing it.
+              //
+              // The no-tool-calls guard is deliberately kept for the cap case
+              // too. A cap that lands mid-`tool_use` would otherwise deliver a
+              // half-built call, which is the #552 "red reads" failure this
+              // codebase has paid for repeatedly. That shape stays on the error
+              // path until it can be delivered safely.
+              const outputCapTruncated = Boolean(clientMaxOutputTokens) && isOutputTokenCapExceeded(errMsg)
               if (
-                passthrough &&
-                sdkTerm.reason === "max_turns" &&
+                (
+                  (passthrough && sdkTerm.reason === "max_turns") ||
+                  outputCapTruncated
+                ) &&
                 capturedToolUses.length === 0 &&
                 streamedToolUseIds.size === 0 &&
                 messageStartEmitted &&
-                textCharsForwarded > 0
+                // A capped turn need not have produced text. With a small cap
+                // the model's thinking can consume the whole budget before any
+                // text is forwarded, and an EMPTY response with
+                // `stop_reason: max_tokens` is exactly what the wire defines
+                // for that — the client asked for 16 tokens and thinking spent
+                // them. For `max_turns` the same emptiness means something went
+                // wrong and stays on the error path, which is why the text
+                // requirement survives only for that case.
+                (outputCapTruncated || textCharsForwarded > 0)
               ) {
                 flushOpenClientBlocks("capped_turn")
                 diagnosticLog.session(


### PR DESCRIPTION
Reported by @albe-jj in #874, with a clean reproduction table: 16 -> 3900 output
tokens (a 244x overshoot) and `end_turn` every time.

## What was actually wrong

`max_tokens` is required on `/v1/messages` and the contract makes it a hard cap
on thinking plus output, with a cut-off response reporting
`stop_reason: "max_tokens"`. Nothing on that path ever read it — confirmed by
grep: the SDK call builder contains no reference to it at all.

## Why the obvious fix does not exist

The Agent SDK's `Options` has **no output cap**. The full key list is
`maxBudgetUsd`, `maxThinkingTokens`, `maxTurns`, `taskBudget` — nothing for
output tokens. There is no parameter to pass through.

The only lever is the CLI's `CLAUDE_CODE_MAX_OUTPUT_TOKENS`, and it does not
truncate: when it trips the CLI **throws**
`Claude's response exceeded the N output token maximum`. Wiring it up naively
turns a satisfiable request into a hard error, which is worse than the bug.

Probing it against CLI 2.1.263 with a cap of 64 is what made this tractable: the
turn produced **real assistant text** (154 chars, ~38 tokens) and *then* threw.
The API genuinely stopped generating — only the shape coming back was wrong. So
the fix passes the cap through and translates that refusal into the stop reason
the wire defines, on both response paths.

Because generation really stopped, the SDK session holds the same truncated text
the client receives. No post-hoc truncation, so resume stays consistent — the
alternative (trimming a full answer before delivery) would desync client history
from the SDK session and break the next turn.

## Off by default, and that is the real decision

The cap counts thinking **plus** text, exactly as the contract says. An agentic
turn spends tokens on thinking the client never sized for, so enforcing a
client's answer-sized budget over the whole turn is not free. Measured:

- a 128-token cap could no longer complete a turn whose visible answer was ~15
  tokens (it broke the E44 gate, which is how I found it);
- a 16-token cap produced **no text at all** — thinking consumed the budget.

Clients here send caps sized for a direct answer; OpenCode sends 32000. Turning
this on by default would change behaviour for every existing caller to close a
conformance gap only some of them need, and I could not prove that safe. It is
exact when asked for via `MERIDIAN_ENFORCE_MAX_TOKENS=1`, and a no-op otherwise
— asserted, not assumed.

If you want it on by default, that is a one-line change with the gate already in
place to prove it.

## Two deliberate boundaries

- **An empty capped turn closes cleanly.** With a small cap, thinking can eat
  the whole budget before any text is forwarded; an empty response with
  `stop_reason: max_tokens` is what the wire defines for that, so streaming no
  longer emits an error frame there. For `max_turns` the same emptiness still
  means something went wrong and stays on the error path.
- **A cap landing mid `tool_use` stays on the error path.** Delivering a
  half-built call is the #552 "red reads" shape this codebase has paid for
  repeatedly; that case is not made "safe" by this change.

## Validation

- **New E49 live gate**, 10 checks: tiny cap bounds output and reports
  `max_tokens` in both modes, generous cap untouched in both modes, and — in a
  second proxy with the flag cleared — the cap is ignored exactly as before,
  compared against the capped run rather than a fixed number.
- Enabling it turns the reported **16 -> 3900** into **16 -> 64** with
  `stop_reason: max_tokens`.
- 9 new unit tests on the two pure pieces: the refusal predicate (including that
  it does **not** match the input-length/context refusal, which is a different
  failure) and the cap parse (0, negative, NaN, Infinity, `{}`, `[]` all leave
  the cap unset rather than clamping generation to zero).
- `npm test`: **3689 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- Full gate battery green with the flag off: E41 all four modes, E43, E44, E45,
  E46, E47, E48, and the lineage divergence gate.

## Also in this PR

A separate commit fixes **E44's own flakiness**, found while running the
battery. It asserted the model echoed a receipt verbatim and failed about 1 in 3
on streaming — instrumenting it showed the model echoed the receipt once in five
runs while the fallback answered every time. It now asserts the healthy profile
produced visible text, which is the claim the gate exists to make. Five
consecutive streaming runs pass; before, one in three failed on unmodified
source.
