### PR TITLE
fix(passthrough): give each adapter its own client-tool namespace

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -273,6 +273,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E47 | [Codex thread identity](#e47-codex-thread-identity) | **Automated**: `bun scripts/e2e-codex-thread-identity.mjs` — real proxy + SDK. Codex hands a spawned subagent and its compaction the PARENT's `prompt_cache_key`. Asserts a user thread still resumes unchanged, siblings get their own sessions, and the parent still resumes after both. **Run before releases touching Responses session identity, the turn coordinator, or request-source admission** | 2026-09-08 |
 | E48 | [Responses developer-note cache](#e48-responses-developer-note-cache) | **Automated**: `bun scripts/e2e-responses-developer-cache.mjs` — real proxy + SDK, A/B. A `developer` item folded into `system` mid-conversation re-wrote the whole cached prefix. Asserts the note's turn re-writes no more than the control's (measured 7.8x pre-fix, 1.2x after). **Run before releases touching Responses prompt assembly or system-block construction** | 2026-09-08 |
 | E49 | [max_tokens enforcement](#e49-max_tokens-enforcement) | **Automated**: `bun scripts/e2e-max-tokens.mjs` — real proxy + SDK. Opt-in via `MERIDIAN_ENFORCE_MAX_TOKENS=1`: a tiny cap bounds output and reports `stop_reason: max_tokens` in both modes, a generous cap is untouched, and with the flag unset the cap is ignored exactly as before. **Run before releases touching the SDK call builder, env plumbing, or terminal stop reasons** | 2026-09-08 |
+| E50 | [Passthrough MCP namespace](#e50-passthrough-mcp-namespace) | **Automated**: `bun scripts/e2e-passthrough-mcp-namespace.mjs` — real proxy + SDK. Asks the model to state its own tool name, the only place the namespace is visible. A LiteLLM-pinned request must read `mcp__litellm__*`; an OpenCode request must still read `mcp__oc__*`. **Run before releases touching passthrough tool registration or adapter tool config** | 2026-09-08 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4196,6 +4197,45 @@ The capability is exact when asked for, and off otherwise.
 
 **Verified:** 2026-09-08. Ten checks pass. Enabling it turned the reported
 16 -> 3900 overshoot into 16 -> 64 with `stop_reason: max_tokens`.
+
+## E50: Passthrough MCP namespace
+
+**What it proves:** an adapter's declared passthrough namespace reaches the
+model, and OpenCode's does not move.
+
+In passthrough mode the client's tools are nested inside an SDK MCP server, so
+the model reads them as `mcp__<namespace>__<tool>`. That namespace was a module
+constant, `oc`, on every adapter — including the LiteLLM/`passthrough` adapter,
+whose own file has documented `mcp__litellm__*` since it was written and whose
+`getMcpServerName()` was computed and then discarded on exactly the path where
+client tools get registered (#893).
+
+**Why the model has to be asked.** `stripMcpPrefix` maps the name back before
+the client ever sees it, so nothing errors and no response differs — the effect
+exists only in what the model reads. @groundnuty found it by asking the model to
+state its own tool name, and that is the only method that proves it.
+
+```bash
+bun scripts/e2e-passthrough-mcp-namespace.mjs
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- A LiteLLM-pinned request (`x-meridian-agent: passthrough`) has the model read
+  `mcp__litellm__sparql_select`.
+- **An OpenCode request still has the model read `mcp__oc__sparql_select`**, and
+  explicitly not `mcp__opencode__sparql_select`.
+
+**Why the second check is the important one.** The obvious implementation —
+reuse `getMcpServerName()` — returns "opencode" for the OpenCode adapter. That
+would rename every client tool from `mcp__oc__read` to `mcp__opencode__read`,
+moving the model-visible prompt and therefore the prompt cache for the entire
+existing user base, and colliding with the `mcp__opencode__*` names
+`passthroughEarlyStop` excludes precisely because they are internal. The
+namespace is a separate, explicit adapter method defaulting to `oc` for that
+reason.
+
+**Verified:** 2026-09-08. Both namespaces confirmed from the model's own words.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-passthrough-mcp-namespace.mjs
+++ b/scripts/e2e-passthrough-mcp-namespace.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+// Live: does an adapter's declared passthrough namespace actually reach the
+// model, and is OpenCode's left exactly where it was?
+//
+// In passthrough mode the client's tools are nested inside an SDK MCP server,
+// so the model reads them as `mcp__<namespace>__<tool>`. That namespace was the
+// module constant `oc` on EVERY adapter, including the LiteLLM/`passthrough`
+// adapter — whose own file has documented `mcp__litellm__*` since it was
+// written, and whose `getMcpServerName()` was computed and then discarded on
+// exactly the path where client tools get registered (#893).
+//
+// @groundnuty found this by asking the model to state its own tool name, which
+// is the only place the effect is visible — `stripMcpPrefix` maps the name back
+// before the client ever sees it, so nothing errors. This gate uses the same
+// method, because it is the only thing that actually proves what the model read.
+//
+// Two claims, and the second is the one that protects everyone else:
+//
+//   1. A LiteLLM-pinned request shows the model `mcp__litellm__<tool>`.
+//   2. An OpenCode request STILL shows `mcp__oc__<tool>`. Reusing
+//      `getMcpServerName()` would have renamed it to `mcp__opencode__<tool>`,
+//      moving the model-visible prompt — and the prompt cache — for the entire
+//      existing user base, and colliding with the `mcp__opencode__*` names
+//      `passthroughEarlyStop` excludes precisely because they are internal.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching passthrough tool registration or adapter tool config.
+//
+//   bun scripts/e2e-passthrough-mcp-namespace.mjs
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mns3-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+process.env.MERIDIAN_PASSTHROUGH = '1'
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3554)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+const TOOL = {
+  name: 'sparql_select',
+  description: 'Run a SPARQL SELECT query',
+  input_schema: { type: 'object', properties: { query: { type: 'string' } }, required: ['query'] },
+}
+
+/** Ask the model to state its own tool name — the only place this is visible. */
+async function nameSeenBy(agentHeader) {
+  const headers = { 'content-type': 'application/json', 'x-opencode-session': `ns-${agentHeader ?? 'default'}-${process.pid}` }
+  if (agentHeader) headers['x-meridian-agent'] = agentHeader
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: 'POST', headers,
+    body: JSON.stringify({
+      model: MODEL, max_tokens: 300, stream: false, tools: [TOOL],
+      messages: [{ role: 'user', content: 'State the exact name of the tool you have available, verbatim, and nothing else. Do not call it.' }],
+    }),
+  })
+  const body = await res.json().catch(() => null)
+  const text = (body?.content ?? []).filter(b => b.type === 'text').map(b => b.text ?? '').join('')
+  const match = /mcp__[A-Za-z0-9_]*__sparql_select/.exec(text)
+  say(`  agent=${String(agentHeader ?? '(default/opencode)').padEnd(22)} http=${res.status} model said: ${match?.[0] ?? (text.trim().slice(0, 60) || '(no name)')}`)
+  return { status: res.status, seen: match?.[0], text }
+}
+
+say(`\n=== passthrough MCP namespace (model=${MODEL}) ===`)
+
+// 1. The reported case: a LiteLLM-pinned model must see its own namespace.
+const litellm = await nameSeenBy('passthrough')
+check(litellm.status === 200, 'the LiteLLM-pinned request succeeded', `http=${litellm.status}`)
+check(litellm.seen === 'mcp__litellm__sparql_select',
+  'a LiteLLM-pinned model reads its tools as mcp__litellm__*',
+  `saw ${litellm.seen ?? '(none)'}`)
+
+// 2. THE REGRESSION GUARD. OpenCode's model-visible names must not move.
+const opencode = await nameSeenBy(undefined)
+check(opencode.status === 200, 'the OpenCode request succeeded', `http=${opencode.status}`)
+check(opencode.seen === 'mcp__oc__sparql_select',
+  'an OpenCode model still reads its tools as mcp__oc__* (prompt cache unmoved)',
+  `saw ${opencode.seen ?? '(none)'}`)
+check(opencode.seen !== 'mcp__opencode__sparql_select',
+  'OpenCode did NOT inherit getMcpServerName()',
+  'renaming it would cold-cache every existing session')
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-8)) say(`    ${l}`)
+} else {
+  say('  PASS: declared namespaces reach the model, OpenCode unchanged')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/passthrough-mcp-namespace.test.ts
+++ b/src/__tests__/passthrough-mcp-namespace.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Per-adapter passthrough MCP namespace (#893).
+ *
+ * In passthrough mode the client's tools are nested inside an SDK MCP server,
+ * so the model reads them as `mcp__<namespace>__<tool>`. That namespace was the
+ * module constant `oc` on EVERY adapter — including the LiteLLM/`passthrough`
+ * adapter, whose own file has documented `mcp__litellm__*` since it was written
+ * and whose `getMcpServerName()` was computed and then discarded on exactly the
+ * path where client tools are registered.
+ *
+ * The default stays `oc`. Reusing `getMcpServerName()` was rejected: for
+ * OpenCode it returns "opencode", so it would rename every client tool from
+ * `mcp__oc__read` to `mcp__opencode__read` — moving the model-visible prompt,
+ * and the prompt cache, for the entire existing user base — and collide with
+ * the `mcp__opencode__*` names `passthroughEarlyStop` excludes precisely
+ * because they are internal.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  PASSTHROUGH_MCP_NAME,
+  PASSTHROUGH_MCP_PREFIX,
+  passthroughMcpPrefix,
+  stripMcpPrefix,
+  buildPassthroughToolAliases,
+  resolveClientToolName,
+} from "../proxy/passthroughTools"
+import { RESPONSES_TOOL_ALIAS_MAX } from "../proxy/openaiResponses"
+import { isClientForwardedToolUse } from "../proxy/passthroughEarlyStop"
+import { openCodeAdapter } from "../proxy/adapters/opencode"
+import { passthroughAdapter } from "../proxy/adapters/passthrough"
+import { codexAdapter } from "../proxy/adapters/codex"
+
+describe("passthroughMcpPrefix", () => {
+  it("defaults to the historical namespace", () => {
+    expect(PASSTHROUGH_MCP_NAME).toBe("oc")
+    expect(passthroughMcpPrefix()).toBe(PASSTHROUGH_MCP_PREFIX)
+    expect(passthroughMcpPrefix()).toBe("mcp__oc__")
+  })
+
+  it("builds the prefix for a declared namespace", () => {
+    expect(passthroughMcpPrefix("litellm")).toBe("mcp__litellm__")
+  })
+})
+
+describe("adapter namespaces", () => {
+  // The whole point of the default: OpenCode's model-visible tool names must
+  // not move, or every existing session pays a cold prompt cache.
+  it("leaves OpenCode on the default namespace", () => {
+    const name = openCodeAdapter.getPassthroughMcpName?.() ?? PASSTHROUGH_MCP_NAME
+    expect(name).toBe("oc")
+    expect(passthroughMcpPrefix(name)).toBe("mcp__oc__")
+  })
+
+  it("does NOT reuse getMcpServerName, which would rename OpenCode's tools", () => {
+    expect(openCodeAdapter.getMcpServerName()).toBe("opencode")
+    const passthroughName = openCodeAdapter.getPassthroughMcpName?.() ?? PASSTHROUGH_MCP_NAME
+    expect(passthroughName).not.toBe(openCodeAdapter.getMcpServerName())
+  })
+
+  it("gives the LiteLLM adapter the namespace its own file documents", () => {
+    expect(passthroughAdapter.getPassthroughMcpName?.()).toBe("litellm")
+    expect(passthroughMcpPrefix(passthroughAdapter.getPassthroughMcpName!())).toBe("mcp__litellm__")
+  })
+
+  it("leaves Codex on the default, which the Responses alias budget assumes", () => {
+    const name = codexAdapter.getPassthroughMcpName?.() ?? PASSTHROUGH_MCP_NAME
+    expect(name).toBe("oc")
+    // The Responses route is Codex-only and its alias budget subtracts the
+    // default prefix length. A longer Codex namespace would push an alias past
+    // Claude's 64-character tool-name limit, so pin the pairing here too.
+    expect(RESPONSES_TOOL_ALIAS_MAX).toBe(64 - passthroughMcpPrefix(name).length)
+  })
+})
+
+describe("name translation under a non-default namespace", () => {
+  it("strips the declared prefix, not the default one", () => {
+    expect(stripMcpPrefix("mcp__litellm__read", "litellm")).toBe("read")
+    // The default stripper must NOT touch another namespace's name.
+    expect(stripMcpPrefix("mcp__litellm__read")).toBe("mcp__litellm__read")
+  })
+
+  it("round-trips a colliding client name within its own namespace", () => {
+    const { aliasByClientName, clientNameByAlias } =
+      buildPassthroughToolAliases(["mcp__litellm__read"], "litellm")
+    expect(aliasByClientName.get("mcp__litellm__read")).toBe("read")
+    expect(resolveClientToolName("mcp__litellm__read", clientNameByAlias, "litellm"))
+      .toBe("mcp__litellm__read")
+  })
+
+  it("leaves a foreign namespace alone under a custom namespace", () => {
+    const { aliasByClientName } = buildPassthroughToolAliases(["mcp__oc__read"], "litellm")
+    // Under the litellm namespace, `mcp__oc__read` is just an ordinary name.
+    expect(aliasByClientName.get("mcp__oc__read")).toBe("mcp__oc__read")
+  })
+})
+
+describe("early-stop client-tool detection follows the namespace", () => {
+  const call = (name: string) => ({ type: "tool_use", id: "t1", name })
+
+  it("accepts a client tool in the declared namespace", () => {
+    expect(isClientForwardedToolUse(call("mcp__litellm__read"), "mcp__litellm__")).toBe(true)
+  })
+
+  // This is the failure the parameter exists to prevent: with the hardcoded
+  // default, a LiteLLM client tool looks like an INTERNAL MCP tool and never
+  // arms the tracker, so its forwarded call is silently dropped.
+  it("would reject that same tool under the default prefix", () => {
+    expect(isClientForwardedToolUse(call("mcp__litellm__read"))).toBe(false)
+  })
+
+  it("still rejects a genuinely internal MCP tool", () => {
+    expect(isClientForwardedToolUse(call("mcp__opencode__read"), "mcp__litellm__")).toBe(false)
+  })
+
+  it("still accepts a bare name, which the SDK emits on some paths", () => {
+    expect(isClientForwardedToolUse(call("read"), "mcp__litellm__")).toBe(true)
+  })
+
+  it("keeps the default behaviour when no prefix is passed", () => {
+    expect(isClientForwardedToolUse(call("mcp__oc__read"))).toBe(true)
+    expect(isClientForwardedToolUse(call("ToolSearch"))).toBe(false)
+  })
+})

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -321,6 +321,8 @@ describe("buildQueryOptions", () => {
       server: {} as any,
       hasDeferredTools: false,
       clientNameByAlias: new Map([["custom_tool", "custom_tool"]]),
+      serverName: "passthrough",
+      prefix: "mcp__passthrough__",
     }
     const result = buildQueryOptions(makeContext({
       passthrough: true,
@@ -351,6 +353,8 @@ describe("buildQueryOptions", () => {
       server: {} as any,
       hasDeferredTools: false,
       clientNameByAlias: new Map([["custom_tool", "custom_tool"]]),
+      serverName: "passthrough",
+      prefix: "mcp__passthrough__",
     }
     const result = buildQueryOptions(makeContext({
       passthrough: true,

--- a/src/proxy/adapter.ts
+++ b/src/proxy/adapter.ts
@@ -137,6 +137,23 @@ export interface AgentIdentity {
    * Tools are registered as `mcp__{name}__{tool}`.
    */
   getMcpServerName(): string
+
+  /**
+   * The namespace the CLIENT'S tools are nested under in passthrough mode,
+   * where they appear to the model as `mcp__{name}__{tool}`.
+   *
+   * Deliberately NOT `getMcpServerName()`, which names the server Meridian
+   * registers in INTERNAL mode. Reusing that would rename every OpenCode
+   * client tool from `mcp__oc__read` to `mcp__opencode__read`, moving the
+   * model-visible prompt — and so the prompt cache — for the entire existing
+   * user base, and colliding with the `mcp__opencode__*` names
+   * `passthroughEarlyStop` excludes precisely because they are internal.
+   *
+   * Defaults to `oc` when unset, which is what every adapter used before this
+   * existed. Override it only where the default actively misleads: `oc` reads
+   * as "opencode" to a model on an adapter that is not OpenCode (#893).
+   */
+  getPassthroughMcpName?(): string
 }
 
 /**

--- a/src/proxy/adapters/passthrough.ts
+++ b/src/proxy/adapters/passthrough.ts
@@ -100,6 +100,17 @@ export const passthroughAdapter: AgentAdapter = {
     return MCP_SERVER_NAME
   },
 
+  /**
+   * This file has documented `mcp__litellm__*` since it was written, and the
+   * name was computed and then discarded on the one path where client tools are
+   * registered — so a LiteLLM-pinned model actually read its own tools as
+   * `mcp__oc__*`, i.e. as OpenCode's (#893, reported by @groundnuty while
+   * measuring the tool names a model reasons about).
+   */
+  getPassthroughMcpName(): string {
+    return MCP_SERVER_NAME
+  },
+
   getAllowedMcpTools(): readonly string[] {
     return ALLOWED_MCP_TOOLS
   },

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -41,8 +41,10 @@
  * Pure module — no I/O, no imports from server.ts or session/.
  */
 
-/** Passthrough MCP prefix — mirrors PASSTHROUGH_MCP_PREFIX in passthroughTools.
- *  Duplicated here (with a cross-check test) to keep this module leaf-pure. */
+/** Default passthrough MCP prefix — mirrors PASSTHROUGH_MCP_PREFIX in
+ *  passthroughTools. Duplicated here (with a cross-check test) to keep this
+ *  module leaf-pure. An adapter with its own namespace passes it in instead
+ *  (#893); the default is what every adapter used before that existed. */
 const CLIENT_TOOL_PREFIX = "mcp__oc__"
 
 /** Internal SDK tools execute inside the SDK. Their results never require
@@ -79,23 +81,30 @@ export interface ClientForwardedToolUse {
   name: string
 }
 
-export function isClientForwardedToolUse(block: unknown): block is ClientForwardedToolUse {
+export function isClientForwardedToolUse(
+  block: unknown,
+  clientToolPrefix: string = CLIENT_TOOL_PREFIX,
+): block is ClientForwardedToolUse {
   const b = block as { type?: unknown; id?: unknown; name?: unknown } | null | undefined
   if (!b || b.type !== "tool_use") return false
   if (typeof b.id !== "string" || b.id.length === 0) return false
   if (typeof b.name !== "string") return false
   if (INTERNAL_TOOLS.has(b.name)) return false
-  if (b.name.startsWith("mcp__") && !b.name.startsWith(CLIENT_TOOL_PREFIX)) return false
+  if (b.name.startsWith("mcp__") && !b.name.startsWith(clientToolPrefix)) return false
   return true
 }
 
 /**
  * Record the client-forwarded tool_use ids from an assistant message's content.
  */
-export function noteAssistantContent(tracker: EarlyStopTracker, content: unknown): void {
+export function noteAssistantContent(
+  tracker: EarlyStopTracker,
+  content: unknown,
+  clientToolPrefix: string = CLIENT_TOOL_PREFIX,
+): void {
   if (!Array.isArray(content)) return
   for (const block of content) {
-    if (isClientForwardedToolUse(block)) {
+    if (isClientForwardedToolUse(block, clientToolPrefix)) {
       tracker.expected.add(block.id)
     }
   }

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -13,8 +13,16 @@
 import { createSdkMcpServer, type SdkMcpToolDefinition } from "@anthropic-ai/claude-agent-sdk"
 import { z } from "zod"
 
+/** The namespace client tools are nested under unless an adapter overrides it.
+ *  Every adapter used this before `getPassthroughMcpName` existed, so it stays
+ *  the default: changing it would move the model-visible prompt for everyone. */
 export const PASSTHROUGH_MCP_NAME = "oc"
 export const PASSTHROUGH_MCP_PREFIX = `mcp__${PASSTHROUGH_MCP_NAME}__`
+
+/** The model-visible prefix for a given passthrough namespace. */
+export function passthroughMcpPrefix(serverName: string = PASSTHROUGH_MCP_NAME): string {
+  return `mcp__${serverName}__`
+}
 
 /**
  * The JSON Schema subset a client's tool definitions actually use. Anything
@@ -208,7 +216,8 @@ export function getAutoDeferThreshold(): number {
  */
 export function createPassthroughMcpServer(
   tools: Array<{ name: string; description?: string; input_schema?: JsonSchemaNode; defer_loading?: boolean }>,
-  coreToolNames?: readonly string[]
+  coreToolNames?: readonly string[],
+  serverName: string = PASSTHROUGH_MCP_NAME,
 ) {
   // Auto-defer: if tool count exceeds threshold and adapter provides core tools
   const threshold = getAutoDeferThreshold()
@@ -224,7 +233,7 @@ export function createPassthroughMcpServer(
   const sortedTools = [...tools].sort((a, b) => a.name.localeCompare(b.name))
   // Register under collision-free aliases; alwaysLoad and the deferral decision
   // still key off the CLIENT's name, which is what coreToolNames describes.
-  const aliases = buildPassthroughToolAliases(sortedTools.map(tool => tool.name))
+  const aliases = buildPassthroughToolAliases(sortedTools.map(tool => tool.name), serverName)
   const definitions = sortedTools.map((passthroughTool) => {
     const alwaysLoad = hasDeferredTools && shouldAlwaysLoad(passthroughTool, coreSet)
     const defineTool = (shape: Record<string, z.ZodType>): SdkMcpToolDefinition<Record<string, z.ZodType>> => ({
@@ -252,10 +261,13 @@ export function createPassthroughMcpServer(
     }
   })
 
-  const server = createSdkMcpServer({ name: PASSTHROUGH_MCP_NAME, tools: definitions })
+  const server = createSdkMcpServer({ name: serverName, tools: definitions })
+  const prefix = passthroughMcpPrefix(serverName)
   return {
     server,
-    toolNames: definitions.map(definition => `${PASSTHROUGH_MCP_PREFIX}${definition.name}`),
+    serverName,
+    prefix,
+    toolNames: definitions.map(definition => `${prefix}${definition.name}`),
     hasDeferredTools,
     clientNameByAlias: aliases.clientNameByAlias,
   }
@@ -325,9 +337,10 @@ export function toolUseSignature(name: string, input: unknown): string {
  * Strip the MCP prefix from a tool name to get the OpenCode tool name.
  * e.g., "mcp__oc__todowrite" → "todowrite"
  */
-export function stripMcpPrefix(toolName: string): string {
-  if (toolName.startsWith(PASSTHROUGH_MCP_PREFIX)) {
-    return toolName.slice(PASSTHROUGH_MCP_PREFIX.length)
+export function stripMcpPrefix(toolName: string, serverName: string = PASSTHROUGH_MCP_NAME): string {
+  const prefix = passthroughMcpPrefix(serverName)
+  if (toolName.startsWith(prefix)) {
+    return toolName.slice(prefix.length)
   }
   return toolName
 }
@@ -363,23 +376,25 @@ export interface PassthroughToolAliases {
  */
 export function buildPassthroughToolAliases(
   names: readonly string[],
+  serverName: string = PASSTHROUGH_MCP_NAME,
 ): PassthroughToolAliases {
+  const PREFIX = passthroughMcpPrefix(serverName)
   const aliasByClientName = new Map<string, string>()
   const clientNameByAlias = new Map<string, string>()
   const ordered = [...names].sort((a, b) => a.localeCompare(b))
   for (const name of ordered) {
-    if (name.startsWith(PASSTHROUGH_MCP_PREFIX)) continue
+    if (name.startsWith(PREFIX)) continue
     aliasByClientName.set(name, name)
     clientNameByAlias.set(name, name)
   }
   for (const name of ordered) {
-    if (!name.startsWith(PASSTHROUGH_MCP_PREFIX)) continue
+    if (!name.startsWith(PREFIX)) continue
     if (aliasByClientName.has(name)) continue
     // Strip EVERY leading copy, not just one: a name that is already doubled
     // would otherwise alias straight back to the undispatchable form.
     let base = name
-    while (base.startsWith(PASSTHROUGH_MCP_PREFIX)) {
-      base = base.slice(PASSTHROUGH_MCP_PREFIX.length)
+    while (base.startsWith(PREFIX)) {
+      base = base.slice(PREFIX.length)
     }
     if (!base) base = "tool"
     let alias = base
@@ -401,8 +416,9 @@ export function buildPassthroughToolAliases(
 export function resolveClientToolName(
   sdkToolName: string,
   clientNameByAlias?: ReadonlyMap<string, string>,
+  serverName: string = PASSTHROUGH_MCP_NAME,
 ): string {
-  const alias = stripMcpPrefix(sdkToolName)
+  const alias = stripMcpPrefix(sdkToolName, serverName)
   return clientNameByAlias?.get(alias) ?? alias
 }
 

--- a/src/proxy/query.ts
+++ b/src/proxy/query.ts
@@ -514,7 +514,10 @@ export function buildQueryOptions(ctx: QueryContext, abortController?: AbortCont
             disallowedTools: [...allBlockedTools],
             ...(passthroughMcp ? {
               allowedTools: [...passthroughMcp.toolNames],
-              mcpServers: { [PASSTHROUGH_MCP_NAME]: passthroughMcp.server },
+              // The namespace comes from the server the caller built, not a
+              // module constant — that constant was computed and then
+              // discarded on exactly this path (#893).
+              mcpServers: { [passthroughMcp.serverName]: passthroughMcp.server },
             } : {}),
           }
         : {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -45,7 +45,7 @@ import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
-import { createPassthroughMcpServer, resolveClientToolName, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX } from "./passthroughTools"
+import { createPassthroughMcpServer, resolveClientToolName, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX, passthroughMcpPrefix } from "./passthroughTools"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
 import { checkEmptyToolInputs, checkUndeliveredToolUses, type EnvelopeViolation } from "./envelopeIntegrity"
@@ -2925,13 +2925,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           plog(`[PROXY] ${requestMeta.requestId} tools_restored: client sent 0 tools but continued branch had ${cached.tools.length} — reusing cached tools to preserve prompt cache`)
         }
       }
+      // #893: the namespace client tools are nested under. `oc` for every
+      // adapter that does not declare its own, which is what they all used
+      // before this existed — so no existing client's prompt moves.
+      const passthroughMcpName = adapter.getPassthroughMcpName?.() ?? PASSTHROUGH_MCP_NAME
+      const clientToolPrefix = passthroughMcpPrefix(passthroughMcpName)
       if (passthrough && requestTools.length > 0) {
         const toolSetKey = computeToolSetKey(requestTools)
         const cachedMcp = profileSessionId ? sessionMcpCache.get(profileSessionId) : undefined
         if (cachedMcp && cachedMcp.key === toolSetKey) {
           passthroughMcp = cachedMcp.mcp
         } else {
-          passthroughMcp = createPassthroughMcpServer(requestTools, pipelineCtx.coreToolNames ? [...pipelineCtx.coreToolNames] : undefined)
+          passthroughMcp = createPassthroughMcpServer(requestTools, pipelineCtx.coreToolNames ? [...pipelineCtx.coreToolNames] : undefined, passthroughMcpName)
           if (profileSessionId) {
             sessionMcpCache.set(profileSessionId, { key: toolSetKey, mcp: passthroughMcp })
             if (cachedMcp) {
@@ -3003,7 +3008,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 }
                 markPriorityAttemptExposure("tool_use")
                 // Track deferred tools that were discovered via ToolSearch
-                const toolName = resolveClientToolName(input.tool_name, passthroughMcp?.clientNameByAlias)
+                const toolName = resolveClientToolName(input.tool_name, passthroughMcp?.clientNameByAlias, passthroughMcpName)
                 if (hasDeferredTools && coreSet && !coreSet.has(toolName.toLowerCase())) {
                   discoveredTools.add(toolName)
                 }
@@ -3656,7 +3661,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // The predicate the tracker arms `expected` with, so the two
                   // sets are comparable by construction.
                   const block = event.content_block
-                  if (isClientForwardedToolUse(block)) streamedToolUseIds.add(block.id)
+                  if (isClientForwardedToolUse(block, clientToolPrefix)) streamedToolUseIds.add(block.id)
                 }
               }
               if (message.type === "assistant") {
@@ -3736,7 +3741,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     }
                     // In passthrough mode, strip MCP prefix from tool names
                     if (passthrough && b.type === "tool_use" && typeof b.name === "string") {
-                      b.name = resolveClientToolName(b.name as string, passthroughMcp?.clientNameByAlias)
+                      b.name = resolveClientToolName(b.name as string, passthroughMcp?.clientNameByAlias, passthroughMcpName)
                     }
                     contentBlocks.push(b)
                   }
@@ -4942,12 +4947,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           if (eventIndex !== undefined) skipBlockIndices.add(eventIndex)
                           continue
                         }
-                        if (passthrough && block.name.startsWith(PASSTHROUGH_MCP_PREFIX)) {
+                        if (passthrough && block.name.startsWith(clientToolPrefix)) {
                           // Passthrough mode: SDK sent the name WITH the mcp__oc__ prefix.
                           // Resolve it back to the name the client declared — usually just
                           // the prefix stripped, but not for a client tool whose own name
                           // carries this namespace (#967).
-                          block.name = resolveClientToolName(block.name, passthroughMcp?.clientNameByAlias)
+                          block.name = resolveClientToolName(block.name, passthroughMcp?.clientNameByAlias, passthroughMcpName)
                           if (block.id) streamedToolUseIds.add(block.id)
                         } else if (block.name.startsWith("mcp__")) {
                           // Internal MCP tool (mcp__opencode__* etc.) — skip, SDK handles it
@@ -4960,7 +4965,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                           // condition fires correctly. The name here is the registered alias,
                           // so it still needs resolving back to what the client declared —
                           // for an ordinary tool that is a no-op.
-                          block.name = resolveClientToolName(block.name, passthroughMcp?.clientNameByAlias)
+                          block.name = resolveClientToolName(block.name, passthroughMcp?.clientNameByAlias, passthroughMcpName)
                           streamedToolUseIds.add(block.id)
                         }
                         if (passthrough && eventIndex !== undefined) {
@@ -5498,7 +5503,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     if (recoveryEvent.type === "message_start") turnGenerating = true
                     if (
                       recoveryEvent.type === "content_block_start"
-                      && isClientForwardedToolUse(recoveryEvent.content_block)
+                      && isClientForwardedToolUse(recoveryEvent.content_block, clientToolPrefix)
                     ) {
                       recoveryStreamedToolUseIds.add(
                         (recoveryEvent.content_block as { id: string }).id,


### PR DESCRIPTION
Reported by @groundnuty in #893, who found it by asking the model to state its
own tool name — the only place the effect is visible.

## The gap

In passthrough mode the client's tools are nested inside an SDK MCP server, so
the model reads them as `mcp__<namespace>__<tool>`. That namespace was the module
constant `oc` on **every** adapter, including the LiteLLM/`passthrough` adapter —
whose own file has documented `mcp__litellm__*` since it was written, and whose
`getMcpServerName()` was computed and then discarded on exactly the path where
client tools get registered.

`stripMcpPrefix` maps the name back before the client sees it, so nothing errors
and no response differs. That is why this needed the model's own words to prove,
and why the new gate asks for them.

## Why I did not implement the suggested fix as written

The report suggests threading `adapter.getMcpServerName()`. I checked what it
returns first: **"opencode"** for the OpenCode adapter. Threading it would

- rename every OpenCode client tool from `mcp__oc__read` to
  `mcp__opencode__read`, moving the model-visible prompt and therefore the
  prompt cache for the entire existing user base, and
- collide with the `mcp__opencode__*` names `passthroughEarlyStop` excludes
  *precisely because they are internal* — client tools would start reading as
  internal ones.

The report also asked for `oc` to stay the default so existing clients are
unaffected, which is incompatible with reusing that method. So the namespace is
a separate, explicit `getPassthroughMcpName()` defaulting to `oc` — what every
adapter used before it existed — and only the LiteLLM adapter overrides it, to
the value its own header comment already claimed.

## A latent hazard this closes

Threading the prefix rather than assuming it also fixes something the alias work
left behind: `isClientForwardedToolUse` treated any `mcp__*` name that was not
`mcp__oc__` as an internal tool. A client tool in another namespace would
therefore never have armed the early-stop tracker, and its forwarded call would
have been dropped silently. A test pins both directions.

## Validation

- **New E50 live gate**, using the reporter's own method. The model's words:

```
agent=passthrough          model said: mcp__litellm__sparql_select
agent=(default/opencode)   model said: mcp__oc__sparql_select
```

  The second is the check that matters — it asserts OpenCode still reads
  `mcp__oc__*` and explicitly not `mcp__opencode__*`.
- 14 new unit tests: prefix construction, per-adapter resolution, the explicit
  "does not reuse getMcpServerName" assertion, name translation and alias
  round-trip under a non-default namespace, and early-stop detection both
  accepting a declared namespace and rejecting a genuinely internal tool.
- `npm test`: **3703 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- Full battery green: **E41 all four modes**, E45, E46, E47, E48, E50.

## Kept deliberately

The Responses alias budget keeps its duplicated `"mcp__oc__".length` constant
and existing cross-check rather than importing from `passthroughTools` — the
same leaf-purity convention `passthroughEarlyStop` follows. A new test
additionally pins it against the Codex namespace, so a future override there
cannot silently push an alias past Claude's 64-character tool-name limit.
