### PR TITLE
test: give two time-budgeted tests budgets they can meet

### DIFF
--- a/src/__tests__/failover-request-id.test.ts
+++ b/src/__tests__/failover-request-id.test.ts
@@ -114,5 +114,12 @@ describe("request id stability across priority failover", () => {
     expect(served).toHaveLength(1)
     expect(served[0]!.profileId).toBe("personal")
     expect(mine.filter(m => m.status === 429)).toHaveLength(1)
-  })
+  // Measured at 4.05s locally against bun's 5s default — under a second of
+  // margin, which a contended CI runner eats. It failed twice in one day at
+  // exactly 5002.97ms, on diffs that could not have affected it, and
+  // @justprosh hit the same thing and pushed an empty commit to retrigger
+  // (#917/#933). The work is a full priority-failover round trip through the
+  // HTTP layer with a mocked SDK; it is legitimately slow, not stuck, so the
+  // budget is the thing that was wrong.
+  }, 30_000)
 })

--- a/src/__tests__/process-incarnation.test.ts
+++ b/src/__tests__/process-incarnation.test.ts
@@ -119,7 +119,19 @@ describe("process incarnation protocol", () => {
 
   it("captures and conservatively probes the current process on every supported platform", () => {
     if (!(["darwin", "linux", "win32"] as string[]).includes(process.platform)) return
-    const current = captureProcessIncarnation()
+    // Retried, mirroring what startProxyServer now does. On Linux the identity
+    // is read from files and is deterministic, but darwin and win32 derive it
+    // from a subprocess with a 10s budget. This test failed on Windows CI at
+    // 10265ms — the probe expired and the module correctly FAILED CLOSED,
+    // returning undefined, while this assertion demanded success (#917/#933).
+    //
+    // The strict assertion is kept deliberately: a capture that never succeeds
+    // across three attempts is a real defect, and loosening this to "defined or
+    // undefined" would assert nothing at all.
+    let current = captureProcessIncarnation()
+    for (let attempt = 0; current === undefined && attempt < 2; attempt++) {
+      current = captureProcessIncarnation()
+    }
     expect(current).toBeDefined()
     expect(parseProcessIncarnation(current)).toEqual(current)
     expect(probeProcessIncarnation(current!))


### PR DESCRIPTION
Two of the intermittent CI failures #917 and #933 describe, diagnosed and fixed.
Both were found during other work in this repo, on diffs that could not have
affected them, which is what makes them clean observations.

## What they actually were

Neither was a logic failure. Both were **time-budget expiries**:

```
windows-smoke   process-incarnation.test.ts:123    10265 ms
test            failover-request-id.test.ts:76     5002.97 ms
```

@justprosh hit the second one independently and pushed an empty commit to
retrigger, which is a second sighting rather than a coincidence.

## Measured, not guessed

`failover-request-id` runs **4.05 s locally against bun's 5 s default** — under
a second of margin. That is the whole story: it drives a full priority-failover
round trip through the HTTP layer with a mocked SDK, so it is legitimately slow
rather than stuck, and 5002.97 ms is the default boundary to the millisecond
rather than an assertion failing. Given an explicit 30 s.

I also scanned every test file doing real I/O without an explicit timeout, since
the useful question is which tests run closest to their budget:

```
launcher-script                      2.01s
passthrough-early-stop-integration   6.15s   (81 tests, ~76ms each)
everything else                      <1s
```

No other single test is near the default. `passthrough-early-stop-integration`
is the slowest *file*, but no test in it approaches 5 s, so widening budgets
there would be noise.

## The Windows one is a different bug, and not a budget change

The probe has its own 10 s subprocess budget. When it expired, the module did
exactly what it is designed to do — **failed closed and returned undefined** —
while the test demanded success. The test now retries, mirroring the retry
`startProxyServer` gained in #985 for precisely the same reason.

**The strict assertion is kept deliberately.** A capture that never succeeds
across three attempts is a real defect, and loosening it to "defined or
undefined" would be a check that asserts nothing — the failure mode I have been
careful about in the gates added this session.

## What this does not claim

This is a candidate mechanism for *part* of #917/#933, not a fix for all of it.
Neither of these is a concurrency test, and #917 is specifically about
concurrency tests failing fast and never the same one twice. Both issues should
stay open; the remaining work is whether the concurrency suite has its own
distinct cause.

Resisting the obvious shortcut is worth stating too: widening timeouts across
the suite would quiet CI and mask exactly the concurrency failures #917 is
about. Only the one test with a measured sub-second margin was touched.

## Validation

- `npm test`: **3703 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  clean.
- Both previously-failing tests pass, and the durations above are from actual
  runs on this checkout.



---

**Correction (added after merge).** The scan described above was too narrow: it
filtered to files mentioning `startProxyServer` / `spawnSync` /
`createProxyServer`, so it missed `session-lineage.test.ts`, which drives HTTP
through a local `createTestApp()` helper and expired at 5317 ms shortly
afterwards. The claim that no other single test sat near the default was wrong.
#990 rescans every test file and raises the harness budget suite-wide instead of
annotating tests individually.
