### PR TITLE
fix(passthrough): pin the auto-defer decision per session

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -276,6 +276,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E50 | [Passthrough MCP namespace](#e50-passthrough-mcp-namespace) | **Automated**: `bun scripts/e2e-passthrough-mcp-namespace.mjs` — real proxy + SDK. Asks the model to state its own tool name, the only place the namespace is visible. A LiteLLM-pinned request must read `mcp__litellm__*`; an OpenCode request must still read `mcp__oc__*`. **Run before releases touching passthrough tool registration or adapter tool config** | 2026-09-08 |
 | E51 | [Boot identity](#e51-boot-identity) | **Automated, needs Docker** (skips cleanly without it, costs no tokens): `bun scripts/e2e-boot-identity.mjs`. In an image with no `/etc/machine-id`, asserts startup refuses with an actionable cause and `/health` returns 503 `unhealthy`; with a valid machine-id the same image starts normally. **Run before releases touching startup validation, `/health`, or process incarnation** | 2026-09-08 |
 | E52 | [Host identity](#e52-host-identity) | **Automated, needs Docker** (skips cleanly without it, costs no tokens): `bun scripts/e2e-host-id.mjs`. Reproduces the derived `hostId` moving with the pid-namespace inode across `docker restart`, then asserts `MERIDIAN_HOST_ID` makes it stable across namespaces and distinct across hosts sharing a baked machine-id. **Run before releases touching process incarnation or store locking** | 2026-09-08 |
+| E53 | [Auto-defer pin](#e53-auto-defer-pin) | **Automated**: `bun scripts/e2e-defer-pin.mjs` — real proxy + SDK, A/B. Two three-turn conversations, one crossing the auto-defer threshold on its last turn. Asserts deferral (and so `maxTurns`) does not flip mid-session and that the suppressed flip is logged. **Run before releases touching auto-defer, tool registration, or prompt assembly** | 2026-09-09 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4326,6 +4327,50 @@ checks are unconditional.
 
 **Verified:** 2026-09-08. Five checks pass, including reproducing the reported
 instability.
+
+## E53: Auto-defer pin
+
+**What it proves:** crossing the auto-defer threshold mid-session no longer
+flips deferral, and therefore no longer flips `maxTurns`.
+
+The decision was taken from the LIVE tool count, so one tool added or removed
+flipped deferral for every non-core tool at once. That moves the
+`anthropic/alwaysLoad` marker on every definition, flips `ENABLE_TOOL_SEARCH`,
+and — since #860 — flips `maxTurns`, silently re-enabling the billed digest turn
+for that request (#861). OpenCode switching agents, an MCP server connecting or
+dropping, or a plugin toggling a tool all trigger it, and none looks to a user
+like a cache-affecting change.
+
+```bash
+bun scripts/e2e-defer-pin.mjs
+```
+
+Two three-turn conversations with identical prompts; only one crosses:
+
+```
+A (control)   15 -> 15 -> 15 tools
+B (crossing)  15 -> 15 -> 16 tools
+```
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- Both conversations complete.
+- **Deferral state is identical on turn 3**, so `maxTurns` did not change under
+  a live session. Measured pre-change: `control=false crossing=true`. With the
+  pin: both `false`.
+- The suppressed flip is logged (`defer_flip suppressed`) rather than hidden,
+  which is the observability the issue asked for regardless of which fix landed.
+
+**What this gate deliberately does not assert.** An earlier draft asserted a
+cache-write ratio and failed honestly. Adding a tool changes the tool block, and
+the tool block is prompt position 0, so the prompt cache is invalidated whatever
+the pin does — measured at `cache=0%` on turn 3 even *with* the pin. That cost
+is inherent to changing the tool set. The bug was the **amplification** on top
+of it, and that is what is asserted. The cache numbers are printed as context.
+
+**Verified:** 2026-09-09. Pre-change the crossing conversation flips to
+`deferred=true` on turn 3 and no `defer_flip` line appears; with the pin it
+stays `false` and the suppression is logged.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-defer-pin.mjs
+++ b/scripts/e2e-defer-pin.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env bun
+// Live A/B: does crossing the auto-defer threshold mid-session still cost the
+// whole conversation's prompt cache?
+//
+// The decision was taken from the LIVE tool count, so one tool added or removed
+// flipped deferral for every non-core tool at once. Tools render at position 0
+// of the prompt, so the `anthropic/alwaysLoad` marker moving re-renders the tool
+// block and invalidates the tools, system AND message cache tiers — a full cold
+// replay. It also flips `maxTurns`, silently re-enabling the billed digest turn
+// (#861). OpenCode switching agents, an MCP server connecting or dropping, or a
+// plugin toggling a tool all trigger it.
+//
+// Two conversations, three turns each, same prompts. Only one crosses the
+// threshold on its third turn:
+//
+//   A (control)  15 -> 15 -> 15 tools
+//   B (crossing) 15 -> 15 -> 16 tools
+//
+// What the pin does and does NOT do, because an earlier draft of this gate
+// asserted the wrong thing and failed honestly:
+//
+// Adding a tool changes the tool block, and the tool block is prompt position
+// 0, so the prompt cache is invalidated whatever the pin does. That cost is
+// inherent to changing the tool set — measured here at cache=0% on turn 3 for
+// the crossing conversation even WITH the pin.
+//
+// The bug was the AMPLIFICATION on top of that: the flip also re-marked
+// `alwaysLoad` on every other tool and flipped `maxTurns`, silently
+// re-enabling the billed digest turn. Those are what the pin removes, and what
+// this gate asserts. Cache numbers are reported as context, not asserted.
+//
+// Costs a few cents of real tokens and needs Claude Max. Run before releases
+// touching auto-defer, tool registration, or prompt assembly.
+//
+//   bun scripts/e2e-defer-pin.mjs
+import { mkdtempSync, realpathSync } from 'node:fs'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+import { getAutoDeferThreshold } from '../src/proxy/passthroughTools.ts'
+
+const WORKDIR = realpathSync(mkdtempSync('/tmp/mdefer-'))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+process.env.MERIDIAN_PASSTHROUGH = '1'
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+const { telemetryStore } = await import('../src/telemetry/index.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3556)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+const T = getAutoDeferThreshold()
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+const CORE = ['read', 'write', 'edit', 'bash', 'glob', 'grep']
+// Descriptions carry real mass so the tool block is worth caching.
+const mkTools = (n) => Array.from({ length: n }, (_, i) => ({
+  name: i < CORE.length ? CORE[i] : `bridge_tool_${i}`,
+  description: `Tool ${i}. ` + 'Filler so the tool block has enough mass that re-rendering it is visible in the token counts rather than lost in noise. '.repeat(4),
+  input_schema: { type: 'object', properties: { arg: { type: 'string' } }, required: [] },
+}))
+
+async function turn(session, tools, messages) {
+  const before = proxyLog.length
+  const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-opencode-session': session },
+    body: JSON.stringify({ model: MODEL, max_tokens: 512, stream: false, tools, messages }),
+  })
+  const body = await res.json().catch(() => null)
+  const line = proxyLog.slice(before).find(l => l.includes('[PROXY]') && l.includes('adapter=')) ?? ''
+  const requestId = /\[PROXY\]\s+(\S+)/.exec(line)?.[1]
+  const row = telemetryStore.getRecent({ limit: 300 }).find(r => r.requestId === requestId)
+  const text = (body?.content ?? []).filter(b => b.type === 'text').map(b => b.text ?? '').join('')
+  return {
+    status: res.status,
+    write: row?.cacheCreationInputTokens ?? 0,
+    read: row?.cacheReadInputTokens ?? 0,
+    deferred: proxyLog.slice(before).some(l => l.includes('deferred=')),
+    assistant: text,
+  }
+}
+
+async function run(label, session, crossOnThird) {
+  const msgs = [{ role: 'user', content: 'Reply with the single word ONE.' }]
+  const t1 = await turn(session, mkTools(T), msgs)
+  msgs.push({ role: 'assistant', content: t1.assistant || 'ONE' })
+  msgs.push({ role: 'user', content: 'Reply with the single word TWO.' })
+  const t2 = await turn(session, mkTools(T), msgs)
+  msgs.push({ role: 'assistant', content: t2.assistant || 'TWO' })
+  msgs.push({ role: 'user', content: 'Reply with the single word THREE.' })
+  // The only difference: one extra tool, crossing the threshold.
+  const t3 = await turn(session, mkTools(crossOnThird ? T + 1 : T), msgs)
+  say(`  ${label.padEnd(13)} turn3 cache_write=${String(t3.write).padStart(6)} cache_read=${String(t3.read).padStart(6)} deferred=${t3.deferred}`)
+  return { t1, t2, t3 }
+}
+
+say(`\n=== auto-defer pin (threshold=${T}, model=${MODEL}) ===`)
+const A = await run('A control', `defer-a-${process.pid}`, false)
+const B = await run('B crossing', `defer-b-${process.pid}`, true)
+
+check(A.t3.status === 200 && B.t3.status === 200, 'both conversations completed',
+  `http=${A.t3.status},${B.t3.status}`)
+
+// Reported, not asserted. Changing the tool set invalidates the tools prefix
+// regardless of the pin, so a ratio here would fail for a reason the pin is not
+// responsible for — and asserting it would make the gate lie about its subject.
+const ratio = A.t3.write > 0 ? B.t3.write / A.t3.write : (B.t3.write > 0 ? Infinity : 1)
+say(`  note  turn-3 cache_write B/A = ${ratio.toFixed(1)}x (${B.t3.write} vs ${A.t3.write}) —`
+  + ` changing the tool set re-renders prompt position 0 either way; not asserted`)
+
+// THE CLAIM. maxTurns must not flip under a live session, which `deferred=`
+// reports directly.
+check(A.t3.deferred === B.t3.deferred,
+  'deferral state is identical on turn 3, so maxTurns did not flip mid-session',
+  `control=${A.t3.deferred} crossing=${B.t3.deferred}`)
+
+// The suppression should be visible, not silent.
+const suppressed = proxyLog.some(l => l.includes('defer_flip suppressed'))
+check(suppressed, 'the suppressed flip is logged rather than hidden',
+  suppressed ? 'defer_flip suppressed present' : 'no defer_flip line found')
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-10)) say(`    ${l}`)
+} else {
+  say('  PASS: a threshold crossing no longer flips deferral or the turn budget')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/defer-pin.test.ts
+++ b/src/__tests__/defer-pin.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pinned auto-defer decision (#861).
+ *
+ * The decision was taken from the LIVE tool count, so a client crossing the
+ * threshold mid-conversation — one tool added or removed — flipped deferral for
+ * every non-core tool at once. Tools render at position 0 of the prompt, so
+ * that moves the `anthropic/alwaysLoad` marker on every definition and
+ * invalidates the tools, system AND message cache tiers: a full cold replay of
+ * the conversation. It also flips `ENABLE_TOOL_SEARCH` and, since #860,
+ * `maxTurns` — silently re-enabling the billed digest turn.
+ *
+ * The blast radius is the point: one added tool re-renders the whole tool list.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  autoDeferDecision,
+  createPassthroughMcpServer,
+  getAutoDeferThreshold,
+} from "../proxy/passthroughTools"
+
+const CORE = ["read", "write", "edit", "bash", "glob", "grep"]
+const tools = (n: number) => Array.from({ length: n }, (_, i) => ({
+  name: i < CORE.length ? CORE[i]! : `extra_tool_${i}`,
+  description: "t",
+  input_schema: { type: "object" as const, properties: {} },
+}))
+
+describe("autoDeferDecision", () => {
+  it("is off at or below the threshold and on above it", () => {
+    const t = getAutoDeferThreshold()
+    expect(autoDeferDecision(t, CORE, t)).toBe(false)
+    expect(autoDeferDecision(t, CORE, t + 1)).toBe(true)
+  })
+
+  it("is off without a core set, which is how an adapter opts out", () => {
+    expect(autoDeferDecision(15, undefined, 400)).toBe(false)
+    expect(autoDeferDecision(15, [], 400)).toBe(false)
+  })
+
+  it("is off when the threshold is disabled", () => {
+    expect(autoDeferDecision(0, CORE, 400)).toBe(false)
+  })
+
+  // The reported trigger: one tool either side of the boundary.
+  it("flips on a single tool across the boundary — the reported blast radius", () => {
+    const t = getAutoDeferThreshold()
+    expect(autoDeferDecision(t, CORE, t)).not.toBe(autoDeferDecision(t, CORE, t + 1))
+  })
+})
+
+describe("createPassthroughMcpServer with a pinned decision", () => {
+  const t = getAutoDeferThreshold()
+
+  it("defers by live count when unpinned", () => {
+    expect(createPassthroughMcpServer(tools(t), CORE).hasDeferredTools).toBe(false)
+    expect(createPassthroughMcpServer(tools(t + 1), CORE).hasDeferredTools).toBe(true)
+  })
+
+  // A session that started under the threshold keeps its cheap prompt shape
+  // even after growing past it, so the tool block does not re-render.
+  it("honours a pin of false while the live count says true", () => {
+    const mcp = createPassthroughMcpServer(tools(t + 50), CORE, undefined, false)
+    expect(mcp.hasDeferredTools).toBe(false)
+  })
+
+  // And the reverse: a session that started deferring keeps deferring, so
+  // maxTurns does not silently change under it.
+  it("honours a pin of true while the live count says false", () => {
+    const mcp = createPassthroughMcpServer(tools(3), CORE, undefined, true)
+    expect(mcp.hasDeferredTools).toBe(true)
+  })
+
+  it("still lets a client's explicit defer_loading win over a false pin", () => {
+    const explicit = [...tools(3), {
+      name: "deferred_one", description: "t",
+      input_schema: { type: "object" as const, properties: {} },
+      defer_loading: true,
+    }]
+    expect(createPassthroughMcpServer(explicit, CORE, undefined, false).hasDeferredTools).toBe(true)
+  })
+
+  // The mechanism behind the cache invalidation: the alwaysLoad marker moving
+  // is what re-renders the tool block, so a pin must keep the NAMES stable too.
+  it("keeps the advertised tool names stable across a pinned crossing", () => {
+    const under = createPassthroughMcpServer(tools(t), CORE, undefined, false)
+    const over = createPassthroughMcpServer(tools(t), CORE, undefined, false)
+    expect(over.toolNames).toEqual(under.toolNames)
+  })
+})

--- a/src/proxy/passthroughTools.ts
+++ b/src/proxy/passthroughTools.ts
@@ -207,6 +207,27 @@ export function getAutoDeferThreshold(): number {
 }
 
 /**
+ * Whether auto-defer applies to a tool set of this size.
+ *
+ * Pure, and exported so the caller can pin the answer for a session.
+ *
+ * The decision was taken from the LIVE tool count, so a client crossing the
+ * threshold mid-conversation — one tool added or removed — flipped deferral for
+ * every non-core tool at once. That moves the `anthropic/alwaysLoad` marker on
+ * each definition, and tools render at position 0 of the prompt, so it
+ * invalidates the tools, system AND message cache tiers. It also flips
+ * `ENABLE_TOOL_SEARCH` and, since #860, `maxTurns` — silently re-enabling the
+ * billed digest turn for that request (#861).
+ */
+export function autoDeferDecision(
+  threshold: number,
+  coreToolNames: readonly string[] | undefined,
+  toolCount: number,
+): boolean {
+  return !!(threshold > 0 && coreToolNames && coreToolNames.length > 0 && toolCount > threshold)
+}
+
+/**
  * Create an MCP server with tool definitions matching OpenCode's request.
  *
  * Auto-defer: when the tool count exceeds the threshold and coreToolNames
@@ -218,11 +239,13 @@ export function createPassthroughMcpServer(
   tools: Array<{ name: string; description?: string; input_schema?: JsonSchemaNode; defer_loading?: boolean }>,
   coreToolNames?: readonly string[],
   serverName: string = PASSTHROUGH_MCP_NAME,
+  /** Pinned auto-defer decision for this session, when one has been made (#861). */
+  pinnedAutoDefer?: boolean,
 ) {
   // Auto-defer: if tool count exceeds threshold and adapter provides core tools
   const threshold = getAutoDeferThreshold()
-  const autoDefer = !!(threshold > 0 && coreToolNames && coreToolNames.length > 0 && tools.length > threshold)
-  const coreSet = autoDefer ? new Set(coreToolNames.map(n => n.toLowerCase())) : undefined
+  const autoDefer = pinnedAutoDefer ?? autoDeferDecision(threshold, coreToolNames, tools.length)
+  const coreSet = autoDefer && coreToolNames ? new Set(coreToolNames.map(n => n.toLowerCase())) : undefined
 
   // hasDeferredTools is true when: client explicitly defers any tool, OR auto-defer kicks in
   const hasDeferredTools = tools.some(t => t.defer_loading === true) || autoDefer

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -45,7 +45,7 @@ import { exec as execCallback } from "child_process"
 import { promisify } from "util"
 import { randomUUID } from "crypto"
 import { withClaudeLogContext } from "../logger"
-import { createPassthroughMcpServer, resolveClientToolName, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX, passthroughMcpPrefix } from "./passthroughTools"
+import { createPassthroughMcpServer, resolveClientToolName, normalizeToolInput, hasRepairableToolInput, computeToolSetKey, toolUseSignature, PASSTHROUGH_MCP_NAME, PASSTHROUGH_MCP_PREFIX, passthroughMcpPrefix, autoDeferDecision, getAutoDeferThreshold } from "./passthroughTools"
 import { describeLocalBootIdentity } from "./session/processIncarnation"
 import { detectServerTools, serverToolErrorMessage } from "./tools"
 import { clientAbortDisposition, coalesceCompleteToolResultContinuation, createEarlyStopTracker, isClientForwardedToolUse, noteAssistantMessage, noteUserContent, settledToolCallAssistantUuid, shouldEarlyStop, trackerCoversStreamedCalls } from "./passthroughEarlyStop"
@@ -600,6 +600,18 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   // invalidation from MCP server re-creation. Key hashes tool name + schema
   // so silently-updated tool definitions force a rebuild.
   const sessionMcpCache = new LRUMap<string, { key: string; mcp: ReturnType<typeof createPassthroughMcpServer> }>(getMaxSessionsLimit())
+
+  // The auto-defer decision, pinned for the session's lifetime (#861).
+  //
+  // Taken from the LIVE tool count, one tool added or removed flipped deferral
+  // for every non-core tool at once. Tools render at position 0 of the prompt,
+  // so that moves the `alwaysLoad` marker on every definition, and it also
+  // flipped `maxTurns` — silently re-enabling the billed digest turn.
+  //
+  // Pinned rather than hysteresis-damped: hysteresis only helps a client
+  // oscillating AT the boundary, not one that swings wide, which is what
+  // OpenCode does when it switches agents. Bounded like its neighbours.
+  const sessionDeferPin = new LRUMap<string, boolean>(getMaxSessionsLimit())
 
   // Consecutive upstream-idle stalls per session, for the retry ceiling.
   const idleStalls = new IdleStallTracker(UPSTREAM_IDLE_MAX_CONSECUTIVE, getMaxSessionsLimit())
@@ -2934,16 +2946,32 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       if (passthrough && requestTools.length > 0) {
         const toolSetKey = computeToolSetKey(requestTools)
         const cachedMcp = profileSessionId ? sessionMcpCache.get(profileSessionId) : undefined
+        const coreNamesForDefer = pipelineCtx.coreToolNames ? [...pipelineCtx.coreToolNames] : undefined
+        // Consulted even when the MCP server is rebuilt: a changed tool set
+        // already costs one cache miss, and re-deciding on top of it would ALSO
+        // flip maxTurns mid-session. The suppressed flip is logged whenever the
+        // live count would decide differently, which is the observability the
+        // issue asked for regardless of which fix landed.
+        const pinnedDefer = profileSessionId ? sessionDeferPin.get(profileSessionId) : undefined
+        const liveDefer = autoDeferDecision(getAutoDeferThreshold(), coreNamesForDefer, requestTools.length)
+        if (pinnedDefer !== undefined && pinnedDefer !== liveDefer) {
+          plog(`[PROXY] ${requestMeta.requestId} defer_flip suppressed: session pinned autoDefer=${pinnedDefer}, live tool count ${requestTools.length} would give ${liveDefer}`)
+          claudeLog("passthrough.defer_flip_suppressed", { pinned: pinnedDefer, live: liveDefer, toolCount: requestTools.length })
+        }
         if (cachedMcp && cachedMcp.key === toolSetKey) {
           passthroughMcp = cachedMcp.mcp
         } else {
-          passthroughMcp = createPassthroughMcpServer(requestTools, pipelineCtx.coreToolNames ? [...pipelineCtx.coreToolNames] : undefined, passthroughMcpName)
+          passthroughMcp = createPassthroughMcpServer(requestTools, coreNamesForDefer, passthroughMcpName, pinnedDefer)
           if (profileSessionId) {
             sessionMcpCache.set(profileSessionId, { key: toolSetKey, mcp: passthroughMcp })
             if (cachedMcp) {
               plog(`[PROXY] ${requestMeta.requestId} tools_changed: MCP server recreated (prompt cache likely invalidates)`)
             }
           }
+        }
+        // First request in the session decides; later ones inherit.
+        if (profileSessionId && !sessionDeferPin.has(profileSessionId)) {
+          sessionDeferPin.set(profileSessionId, passthroughMcp.hasDeferredTools)
         }
       }
       const hasDeferredTools = passthroughMcp?.hasDeferredTools ?? false


### PR DESCRIPTION
Pins the auto-defer decision per session, which is the remedy issue #861
recommends, plus the observability it lists as an alternative rather than
instead of it.

## The defect

The decision came from the **live** tool count, so one tool added or removed
flipped deferral for every non-core tool at once. That moves the
`anthropic/alwaysLoad` marker on every definition, flips `ENABLE_TOOL_SEARCH`,
and since #860 flips **`maxTurns`** — silently re-enabling the billed digest
turn for that request.

OpenCode switching agents, an MCP server connecting or dropping, or a plugin
toggling a tool all trigger it, and none looks to a user like a cache-affecting
change. The blast radius is the point: one added tool re-marks the whole list.

## The fix

Pinned per session beside `sessionMcpCache` and `sessionToolCache`, which exist
for the same reason. First request decides, later ones inherit. The pin is
consulted **even when the MCP server is rebuilt**: a changed tool set already
costs one cache miss, and re-deciding on top of it would also flip `maxTurns`
mid-session.

Pinned rather than hysteresis-damped, per the issue's own weighing: hysteresis
only helps a client oscillating *at* the boundary, not one that swings wide,
which is exactly what OpenCode does when it switches agents.

The third option — log and observe first — is **included**, not chosen instead.
A suppressed flip emits `defer_flip suppressed` plus a
`passthrough.defer_flip_suppressed` event, so the frequency stays measurable
either way.

## What this does not fix, and how I know

The first version of the gate asserted a cache-write ratio and **failed
honestly**. Adding a tool changes the tool block, and the tool block is prompt
position 0, so the prompt cache is invalidated whatever the pin does — measured
at `cache=0%` on the crossing turn *with* the pin in place.

That cost is inherent to changing the tool set. The bug was the **amplification**
on top of it, and that is what is fixed. The gate now asserts the amplification
is gone and prints the cache numbers as context, rather than carrying a check
the pin cannot satisfy.

## Validation

- **New E53 live gate**, A/B. Two three-turn conversations with identical
  prompts, `15 → 15 → 15` versus `15 → 15 → 16` tools. Measured:

```
pre-change   control deferred=false   crossing deferred=true    (flip, no log)
with the pin control deferred=false   crossing deferred=false   (defer_flip suppressed logged)
```

- 9 new unit tests on the extracted pure `autoDeferDecision` and the pinned
  path: the boundary, the opt-out shapes (no core set, disabled threshold), a
  pin of `false` holding against a live `true` and vice versa, an explicit
  client `defer_loading` still winning over a `false` pin, and advertised tool
  names staying stable.
- `npm test`: **3727 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.
- E45 (Codex auto-defer), E46 and E50 re-run green, since this touches the same
  registration path.
