### PR TITLE
fix(session): say when a session fingerprint has degraded

### DIFF
--- a/src/__tests__/degraded-fingerprint-warning.test.ts
+++ b/src/__tests__/degraded-fingerprint-warning.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Degraded session fingerprint is now visible (#889).
+ *
+ * `getConversationFingerprint` seeds on the working directory plus the opening
+ * user message; without a directory it hashes the message alone, so two
+ * conversations in different repositories that begin with the same text collide
+ * onto one session.
+ *
+ * The directory is regexed out of the `<env>` block of the system prompt, and
+ * any plugin implementing `experimental.chat.system.transform` may legally
+ * remove that block — `opencode-scrub` deletes it deliberately. Nothing logged
+ * when it happened, which is why @connor-grady could report the mechanism while
+ * observing no misbehaviour: the opencode adapter's session header keeps this
+ * path unreached.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { getConversationFingerprint, extractClientCwd } from "../proxy/session/fingerprint"
+import { lookupSession, resetDegradedFingerprintWarningForTests } from "../proxy/session/cache"
+
+const messages = [{ role: "user", content: "Refactor the auth module." }]
+
+describe("the collision this warns about", () => {
+  it("gives two different directories different keys", () => {
+    const a = getConversationFingerprint(messages, "/repo/alpha")
+    const b = getConversationFingerprint(messages, "/repo/bravo")
+    expect(a).not.toBe(b)
+    expect(a).toBeTruthy()
+  })
+
+  // The actual defect: with no directory the key is the message alone, so the
+  // two conversations above become indistinguishable.
+  it("collides when the directory is missing", () => {
+    expect(getConversationFingerprint(messages, undefined))
+      .toBe(getConversationFingerprint(messages, undefined))
+    expect(getConversationFingerprint(messages, undefined))
+      .not.toBe(getConversationFingerprint(messages, "/repo/alpha"))
+  })
+})
+
+describe("extractClientCwd against a scrubbed system prompt", () => {
+  const withEnv = { system: "Here is some useful information:\n<env>\nWorking directory: /repo/alpha\n</env>" }
+
+  it("finds the directory when the block is present", () => {
+    expect(extractClientCwd(withEnv)).toBe("/repo/alpha")
+  })
+
+  // What a system.transform plugin leaves behind.
+  it("returns undefined once the block is removed", () => {
+    expect(extractClientCwd({ system: "You are a helpful assistant." })).toBeUndefined()
+    expect(extractClientCwd({ system: "" })).toBeUndefined()
+    expect(extractClientCwd({})).toBeUndefined()
+  })
+})
+
+describe("the warning", () => {
+  let warnings: string[]
+  let originalWarn: typeof console.warn
+
+  beforeEach(() => {
+    resetDegradedFingerprintWarningForTests()
+    warnings = []
+    originalWarn = console.warn
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")) }
+  })
+  afterEach(() => { console.warn = originalWarn })
+
+  it("fires on a keyless lookup with no working directory", () => {
+    lookupSession(undefined, messages, undefined)
+    expect(warnings.some(w => w.includes("no working directory"))).toBe(true)
+  })
+
+  it("names the likely cause and the remedy, not just the symptom", () => {
+    lookupSession(undefined, messages, undefined)
+    const w = warnings.join("\n")
+    expect(w).toContain("<env>")
+    expect(w).toContain("system.transform")
+    expect(w).toContain("meridian setup")
+  })
+
+  it("does NOT fire when a working directory is present", () => {
+    lookupSession(undefined, messages, "/repo/alpha")
+    expect(warnings.some(w => w.includes("no working directory"))).toBe(false)
+  })
+
+  it("does NOT fire on the explicit-session path, which is unaffected", () => {
+    lookupSession("ses_explicit", messages, undefined)
+    expect(warnings.some(w => w.includes("no working directory"))).toBe(false)
+  })
+
+  // It describes the deployment, not the turn; per-request would bury it.
+  it("fires once per process, not once per request", () => {
+    for (let i = 0; i < 5; i++) lookupSession(undefined, messages, undefined)
+    expect(warnings.filter(w => w.includes("no working directory")).length).toBe(1)
+  })
+})

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -273,6 +273,26 @@ function classifyLineage(
 /** Look up a cached session by header or fingerprint.
  *  Returns a LineageResult that classifies the mutation and includes the
  *  session state needed for the correct SDK action. */
+let warnedDegradedFingerprint = false
+
+/** Reset between tests; the warning is one-shot per process by design. */
+export function resetDegradedFingerprintWarningForTests(): void {
+  warnedDegradedFingerprint = false
+}
+
+function warnDegradedFingerprintOnce(): void {
+  if (warnedDegradedFingerprint) return
+  warnedDegradedFingerprint = true
+  const msg =
+    "[PROXY] Session fingerprint has no working directory, so it hashes only the opening "
+    + "user message — two conversations in different directories that start with the same text "
+    + "will share a session. The directory is read from the <env> block of the system prompt; a "
+    + "plugin implementing experimental.chat.system.transform (for example opencode-scrub) may "
+    + "have removed it. Send a session header (meridian setup) to key conversations explicitly."
+  console.warn(msg)
+  diagnosticLog.lineage(msg)
+}
+
 export function lookupSession(
   sessionId: string | undefined,
   messages: Array<{ role: string; content: any }>,
@@ -302,6 +322,20 @@ export function lookupSession(
     return result
   }
 
+  // A fingerprint keyed WITHOUT a working directory is a degraded key: it is a
+  // hash of the opening user message alone, so two conversations in different
+  // repositories that begin with the same text collide onto one session (#889).
+  //
+  // The directory is regexed out of the `<env>` block in the system prompt, and
+  // any plugin implementing `experimental.chat.system.transform` may legally
+  // remove that block — `opencode-scrub` deletes it deliberately, and #769
+  // tracks an official equivalent. Nothing said so, which is the actual
+  // problem: the reporter observed no misbehaviour precisely because the
+  // opencode adapter's session header keeps this path unreached.
+  //
+  // Warned once per process rather than per request: it is a property of the
+  // deployment, not of a turn, and per-request would bury it.
+  if (!workingDirectory) warnDegradedFingerprintOnce()
   const fp = getConversationFingerprint(messages, workingDirectory)
   if (fp) {
     const shared = lookupSharedSessionResult(fp)


### PR DESCRIPTION
Makes the silent fingerprint degradation in issue #889 visible. Reported by
@connor-grady, whose write-up is unusually careful about its own scope and worth
preserving.

## The defect

`getConversationFingerprint` seeds on the working directory plus the opening
user message. Without a directory it hashes the message alone, so **two
conversations in different repositories that begin with the same text collide
onto one session**.

The directory is regexed out of the `<env>` block of the system prompt, and any
plugin implementing `experimental.chat.system.transform` may legally remove that
block. `opencode-scrub` deletes it deliberately, and #769 tracks an official
equivalent — so this is not a hypothetical plugin.

Nothing logged when it happened. That silence is the actual problem.

## Preserving what the report got right

They state they observed **no misbehaviour**, and explain why:
`openCodeAdapter.getSessionId` reads `x-opencode-session`, the shipped plugin
sets it on every request, so `lookupSession` takes the explicit-session path and
the fingerprint is never consulted. The exposure is an adapter without a session
header, a client running without the plugin, or a future change that reaches the
fingerprint for a keyed session.

That scoping is correct and is why this ships as a diagnostic rather than a
behaviour change: there is no observed breakage to fix, only an invisible
failure mode to make visible.

## Why not the header suggestion

Their first option — take the directory from a header the client already sends
— is deliberately not taken. No such header exists today, so it needs a plugin
change to emit one, and **every older plugin would keep silently degrading in
the meantime**. Making the existing degradation visible closes the silence now
and works for clients that will never be updated.

## The change

A keyless lookup with no working directory warns once per process, naming the
`<env>` block, `system.transform` as the likely cause, and `meridian setup` as
the remedy. Once per process rather than per request: it describes the
deployment, not the turn, and per-request would bury it.

## Validation

- 9 new unit tests, covering the collision itself (same message, two
  directories → different keys; no directory → identical keys),
  `extractClientCwd` against a scrubbed prompt, and the warning's conditions:
  it fires on the degraded path, names cause **and** remedy, does **not** fire
  when a directory is present, does **not** fire on the explicit-session path
  that the report correctly identifies as unaffected, and fires exactly once
  across five lookups.
- `npm test`: **3736 pass, 0 fail, 1 pre-existing skip**. `npm run typecheck`
  and `npm run build` clean.

## Not addressed

The report notes #873 and #876 are also open against the cwd path, "possibly
related, not verified". I have not verified that either, and this change does
not touch how the directory is extracted — only what happens when it is absent.
