### PR TITLE
fix(session): name the reason on every lineage divergence

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -277,6 +277,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E51 | [Boot identity](#e51-boot-identity) | **Automated, needs Docker** (skips cleanly without it, costs no tokens): `bun scripts/e2e-boot-identity.mjs`. In an image with no `/etc/machine-id`, asserts startup refuses with an actionable cause and `/health` returns 503 `unhealthy`; with a valid machine-id the same image starts normally. **Run before releases touching startup validation, `/health`, or process incarnation** | 2026-09-08 |
 | E52 | [Host identity](#e52-host-identity) | **Automated, needs Docker** (skips cleanly without it, costs no tokens): `bun scripts/e2e-host-id.mjs`. Reproduces the derived `hostId` moving with the pid-namespace inode across `docker restart`, then asserts `MERIDIAN_HOST_ID` makes it stable across namespaces and distinct across hosts sharing a baked machine-id. **Run before releases touching process incarnation or store locking** | 2026-09-08 |
 | E53 | [Auto-defer pin](#e53-auto-defer-pin) | **Automated**: `bun scripts/e2e-defer-pin.mjs` — real proxy + SDK, A/B. Two three-turn conversations, one crossing the auto-defer threshold on its last turn. Asserts deferral (and so `maxTurns`) does not flip mid-session and that the suppressed flip is logged. **Run before releases touching auto-defer, tool registration, or prompt assembly** | 2026-09-09 |
+| E54 | [Lineage divergence reason](#e54-lineage-divergence-reason) | **Automated**: `bun scripts/e2e-lineage-divergence-reason.mjs` — real proxy + SDK, A/B. Drives a headerless pi tool loop and the same loop with `x-session-affinity`. Asserts no divergence is silent, that the headerless bypass names itself, that the advice is printed once per process, and that the named remedy actually restores resume and prompt-cache reuse. **Run before releases touching lineage classification, the independence guards, or the request log line** | 2026-09-09 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4371,6 +4372,71 @@ of it, and that is what is asserted. The cache numbers are printed as context.
 **Verified:** 2026-09-09. Pre-change the crossing conversation flips to
 `deferred=true` on turn 3 and no `defer_flip` line appears; with the pin it
 stays `false` and the suppression is logged.
+
+## E54: Lineage divergence reason
+
+**What it proves:** every lineage divergence names why it diverged, and the
+remedy the log names for the expensive one actually works.
+
+`classifyLineage` logged four outcomes, and for `diverged` only
+`modified-history` and `undo-gap`. Everything else was silent, and the request
+line renders every divergence without a cached session as the same literal
+`lineage=new`. #820 is the cost of that: 6,514 `lineage=new` requests with zero
+explanatory lines, across which the four `classifyLineage` diagnostics all sat
+at exactly zero. The most expensive outcome — the headerless tool-result bypass
+— is assigned before `classifyLineage` runs, so it printed nothing at all and
+was identified only by reading `server.ts`. Two reporters drained a Max
+subscription window first, because every one of those requests returns 200.
+
+```bash
+bun scripts/e2e-lineage-divergence-reason.mjs
+```
+
+A four-round client-driven tool loop on the `pi` adapter in passthrough mode,
+run twice — once headerless, once with `x-session-affinity`. 22 filler tools
+give the prompt prefix enough mass to clear Anthropic's minimum cacheable
+length; without them every round of both loops reports `cache_read=0
+cache_write=0` and the cost claim is untestable.
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- No round in either loop diverges without a `diverged=` reason.
+- A headerless tool round names `independent-request:headerless-tool-result`.
+- The one-time advice is printed **exactly once** across all rounds of both
+  loops, not once per round.
+- A first turn under a key that resolved to nothing reports `not-found`, which
+  used to be indistinguishable from the bypass.
+- The keyed loop resumes on every tool round and prints no `diverged=` at all.
+- **The field cache signature is reproduced.** A bypassed round reads the same
+  static prefix however far the conversation got, while a resumed round reads
+  more as it grows; and a bypassed round pays several times over per round to
+  re-write the prefix.
+
+**What this gate deliberately does not assert.** Not every headerless tool
+round takes the bypass. A headerless passthrough loop recovers through the
+durable checkpoint exactly once: the checkpoint upgrade rewrites the lineage
+result but leaves the request independent, so the end-of-turn store is still
+skipped and the checkpoint never advances past the first tool call. Every later
+round then finds a stale checkpoint and takes the bypass. That is the shape the
+field report shows — 6,019 `new` against 10 `continuation` at 1000+ messages —
+so the gate asserts that a bypassed round names itself, not that every round is
+one. It also does not assert the field's cost magnitude: ~280k cache-write
+tokens per turn against ~214 was measured on a 454-message conversation, and a
+four-round probe reproduces the direction and the signature, not the size.
+
+**Verified:** 2026-09-09, Haiku 4.5, two consecutive runs. Pre-change the same
+rounds print `lineage=new session=new` with no reason and no warning. After:
+
+```
+A headerless  round 3  msgs=5  lineage=new           diverged=independent-request:headerless-tool-result  cache_write=1286  cache_read=5789
+A headerless  round 4  msgs=7  lineage=new           diverged=independent-request:headerless-tool-result  cache_write=1497  cache_read=5789
+B keyed       round 3  msgs=5  lineage=continuation  diverged=—                                           cache_write= 167  cache_read=6752
+B keyed       round 4  msgs=7  lineage=continuation  diverged=—                                           cache_write= 166  cache_read=6919
+```
+
+`cache_read` pinned at 5789 while the conversation grows is the reporters' own
+signature at probe scale; they measured it pinned at 30629 across 12,781 to
+13,030 messages. Per-round cache-write ratio measured 7.2x and 7.1x.
 
 ## Concurrent transcript publication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,6 +246,128 @@ While draining:
   whichever comes first. If the grace period elapses first, a warning is
   logged and any remaining HTTP connections are forcibly closed.
 
+## Session identity
+
+Meridian resumes the backing Claude SDK session between turns. Resuming is
+what keeps the model's own earlier turns in context and what keeps the prompt
+cache warm; a turn that cannot resume is sent as a fresh session and pays to
+re-write its prompt prefix.
+
+Identity is resolved in this order:
+
+1. **The adapter's session header**, if the client sends one.
+2. **A conversation fingerprint** — a hash of the opening user message plus the
+   client working directory — when there is no header.
+
+The fingerprint is a fallback, not an equivalent. It cannot distinguish two
+concurrent conversations that open with the same text, and it moves if anything
+rewrites the opening message.
+
+| Adapter | Session identity it reads |
+|---|---|
+| `opencode` | `x-opencode-session`, then `x-session-affinity` |
+| `pi`, `prime` | `x-session-affinity`, then `metadata.user_id` `{"session_id": …}` |
+| `claudecode` | `metadata.user_id` `{"session_id": …}` |
+| `codex` | `x-codex-session` |
+| `crush` | `x-session-id`, then `x-session-affinity` |
+| `jcode` | `x-jcode-session` |
+| `passthrough` (LiteLLM) | `x-litellm-session-id` |
+| `cherry`, `droid`, `forgecode`, `openai` | none — fingerprint only |
+
+### Client-driven tool loops need a session header
+
+A request whose last message is a `tool_result` is a round of the client's own
+tool loop. When such a request carries **no** session identity, Meridian skips
+session lookup entirely and runs it as a fresh session.
+
+That is deliberate. Headerless rounds all collapse onto the same
+`(first user message, working directory)` fingerprint, so a workflow engine
+running several loops concurrently would have one run resume another run's
+Claude session and corrupt it — premature `end_turn`, dropped tool calls. A
+conversation fingerprint is not proof that two requests are the same chat, and
+an explicit key is.
+
+For an **interactive** client the same rule is expensive, because every
+agentic turn ends in a `tool_result`:
+
+- the model receives none of its own previous turns and re-derives the same
+  intent each round, re-issuing the same read-only tool calls;
+- the prompt cache decays to the static-prefix floor — `cache_read` stops
+  moving while the conversation grows, and `cache_write` is paid again every
+  round.
+
+None of this fails a request. Every one returns 200, so it is invisible in
+success metrics and shows up only as burn rate and a model that behaves as
+though it has amnesia.
+
+Send a session header and the loop resumes. If the client has no native
+header, `x-session-affinity` is honoured by the `opencode`, `pi`, `prime` and
+`crush` adapters.
+
+Pi has no native header, but it exposes a `before_provider_headers`
+extension hook. Save this as `~/.pi/agent/extensions/session-affinity.ts`:
+
+```ts
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+const PROVIDER = "anthropic"
+
+export default function (pi: ExtensionAPI) {
+  pi.on("before_provider_headers", (event, ctx) => {
+    if (ctx.model?.provider !== PROVIDER) return
+    // Without this, adapter detection does not resolve to `pi` and the
+    // affinity key is not read the way the pi adapter reads it.
+    event.headers["x-meridian-agent"] = "pi"
+    const sessionId = ctx.sessionManager.getSessionId()
+    if (sessionId) event.headers["x-session-affinity"] = sessionId
+  })
+}
+```
+
+Contributed by @odfalik and @RobertoNegro in
+[#820](https://github.com/rynfar/meridian/issues/820) and verified there
+against pi 0.84.1 with a full 27-tool configuration: turns 3 onward moved from
+`lineage=new` to `lineage=continuation` at 99% cache hit rate and
+`cache_write` around 214 tokens, against ~280k per turn on a control session
+started before the extension existed.
+
+The `provider` check is broad — it also sets both headers when the `anthropic`
+provider points straight at `api.anthropic.com`, which is harmless since
+unknown headers are ignored upstream. Gate on the resolved base URL being a
+local Meridian endpoint instead if your pi version exposes it on the hook
+context.
+
+Extensions load at startup, so a pi session started before the file existed
+keeps the old behaviour until pi is restarted.
+
+### Reading the log
+
+Every request line carries `lineage=`, and every divergence also carries
+`diverged=` naming why the turn did not resume:
+
+| `diverged=` | Meaning |
+|---|---|
+| `not-found` | The key resolved to nothing — a first turn, or an evicted entry |
+| `unverifiable` | An entry exists but cannot prove which history its session holds |
+| `replayed-request` | The same history arrived again; a retry, not a continuation |
+| `modified-history` | The stored prefix changed, so resume would skip history |
+| `undo-gap` | An undo whose rollback point would omit supplied history |
+| `unrelated-history` | The key resolved to a different conversation |
+| `missing-session-header` | An OpenCode request arrived without its session header |
+| `concurrent-race`, `priority-failback` | Lost a commit race; routed to another profile |
+| `independent-request:headerless-tool-result` | The client-driven tool loop above |
+| `independent-request:fork-source` | Declared `x-meridian-source: fork-*` |
+| `independent-request:subagent` | Declared a subagent flow |
+| `independent-request:no-cache-identity` | No header and no derivable fingerprint |
+
+A resumed turn prints no `diverged=` field at all. The three
+`independent-request:*` causes skip session lookup before it happens; the rest
+are the verdict of a lookup that ran.
+
+`headerless-tool-result` also prints a one-time warning at the first
+occurrence, because it is a property of how the client is wired rather than of
+a single turn.
+
 ## Concurrent requests to the same session
 
 Requests that share a reliable session identity supplied by the client

--- a/scripts/e2e-lineage-divergence-reason.mjs
+++ b/scripts/e2e-lineage-divergence-reason.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env bun
+// Live: when a client's tool loop does not resume, does the log say so — and
+// is the remedy it names actually the remedy?
+//
+// #820: on the pi adapter, 99.8% of requests carrying 1000+ messages
+// classified as `lineage=new`, and NONE of them logged a reason. The bypass is
+// assigned before `classifyLineage` runs, so the four `classifyLineage`
+// diagnostics all sat at zero while 6,514 requests skipped resume. The
+// reporter identified it only by reading `server.ts`; two others drained a
+// Max subscription window first, because every one of those requests returns
+// 200 and nothing in the proxy's own success metrics moves.
+//
+// Two claims, and the second is what makes the first worth printing:
+//
+//   1. A real headerless pi tool loop names its bypass on every round
+//      (`diverged=independent-request:headerless-tool-result`), and says once
+//      that the conversation is not resuming.
+//   2. The header that line tells the operator to send ACTUALLY FIXES IT.
+//      The same loop with `x-session-affinity` resumes, and stops paying to
+//      re-write the prompt prefix every round.
+//
+// Claim 2 is the discriminator. A diagnostic that names a cause nobody can act
+// on is not a fix, and the advice is only correct if the keyed run measurably
+// costs less. Asserted as a ratio of cache-write tokens rather than absolute
+// numbers: the field reports measured ~280k per turn against ~214 with a key,
+// but that was a 454-message conversation, and a four-round probe cannot
+// reproduce that magnitude — only its direction and rough shape.
+//
+// Needs Claude Max and costs a few cents of real tokens. Run before releases
+// touching lineage classification, the independence guards, or the request log
+// line.
+//
+//   bun scripts/e2e-lineage-divergence-reason.mjs
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync(join(tmpdir(), 'mdivreason-')))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+process.env.MERIDIAN_PASSTHROUGH = '1'
+
+const FILES = { 'alpha.txt': 'ALPHA-CONTENT', 'bravo.txt': 'BRAVO-CONTENT', 'charlie.txt': 'CHARLIE-CONTENT' }
+for (const [name, body] of Object.entries(FILES)) writeFileSync(join(WORKDIR, name), body + '\n')
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3556)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug', 'warn'] ) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+const READ_TOOL = {
+  name: 'read',
+  description: 'Read a file from disk. Read exactly one file per call.',
+  input_schema: {
+    type: 'object',
+    properties: { file_path: { type: 'string', description: 'Absolute path' } },
+    required: ['file_path'],
+  },
+}
+
+// Filler tools, exactly as e2e-responses-developer-cache.mjs uses them: the
+// prompt prefix has to clear Anthropic's minimum cacheable length before any
+// cache accounting appears at all. Measured without them, every round of both
+// loops reported cache_read=0 cache_write=0 and the cost claim was untestable.
+const FILLER = Array.from({ length: 22 }, (_, i) => ({
+  name: `bridge_tool_${i}`,
+  description: `Bridge tool ${i}. ` + 'Filler to give the prompt prefix real mass so a re-written prefix is visible in the numbers rather than lost in noise. '.repeat(6),
+  input_schema: { type: 'object', properties: { arg: { type: 'string', description: 'An argument.' } } },
+}))
+const TOOLS = [READ_TOOL, ...FILLER]
+
+const PROMPT = 'Read these three files ONE AT A TIME, waiting for each result before the next call: '
+  + Object.keys(FILES).map(f => join(WORKDIR, f)).join(', ')
+  + '. After the third, reply with the three contents separated by commas.'
+
+/**
+ * Drive a client-side tool loop exactly as pi does: send the growing history,
+ * execute whatever tool_use comes back, append the tool_result, repeat.
+ */
+async function runLoop(label, affinityKey, maxRounds = 4) {
+  const messages = [{ role: 'user', content: PROMPT }]
+  const rounds = []
+  for (let round = 1; round <= maxRounds; round++) {
+    const headers = { 'content-type': 'application/json', 'x-meridian-agent': 'pi' }
+    if (affinityKey) headers['x-session-affinity'] = affinityKey
+    const before = proxyLog.length
+    const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+      method: 'POST', headers,
+      body: JSON.stringify({ model: MODEL, max_tokens: 1024, stream: false, tools: TOOLS, messages }),
+    })
+    const body = await res.json().catch(() => null)
+    const line = proxyLog.slice(before).find(l => l.includes('[PROXY]') && l.includes('adapter=') && l.includes('msgCount=')) ?? ''
+    const usage = body?.usage ?? {}
+    const info = {
+      round,
+      status: res.status,
+      line,
+      lineage: /lineage=(\S+)/.exec(line)?.[1] ?? '?',
+      diverged: /diverged=(\S+)/.exec(line)?.[1],
+      msgCount: Number(/msgCount=(\d+)/.exec(line)?.[1] ?? 0),
+      cacheWrite: usage.cache_creation_input_tokens ?? 0,
+      cacheRead: usage.cache_read_input_tokens ?? 0,
+      lastIsToolResult: Array.isArray(messages.at(-1)?.content)
+        && messages.at(-1).content.some(b => b?.type === 'tool_result'),
+    }
+    rounds.push(info)
+    say(`  ${label.padEnd(12)} round ${round}  msgs=${String(info.msgCount).padStart(2)}`
+      + ` lineage=${info.lineage.padEnd(12)} diverged=${String(info.diverged ?? '—').padEnd(46)}`
+      + ` cache_write=${String(info.cacheWrite).padStart(6)} cache_read=${String(info.cacheRead).padStart(6)}`)
+
+    const blocks = body?.content ?? []
+    const calls = blocks.filter(b => b.type === 'tool_use')
+    if (!calls.length) break
+    messages.push({ role: 'assistant', content: blocks })
+    messages.push({
+      role: 'user',
+      content: calls.map(c => ({
+        type: 'tool_result',
+        tool_use_id: c.id,
+        content: FILES[String(c.input?.file_path ?? '').split('/').pop()] ?? 'NOT FOUND',
+      })),
+    })
+  }
+  return rounds
+}
+
+const adviceCount = () => proxyLog.filter(l =>
+  l.includes('Client-driven tool loop with no session identity')).length
+
+say(`\n=== lineage divergence reason (model=${MODEL}, adapter=pi, passthrough) ===`)
+
+// A: the reported configuration. pi sends no session header of its own.
+const A = await runLoop('A headerless', undefined)
+const adviceAfterA = adviceCount()
+
+// B: the same loop, with the key the new log line tells the operator to send.
+const B = await runLoop('B keyed', `pi-affinity-${process.pid}`)
+
+say('')
+// --- Claim 1: no divergence is silent, anywhere in either loop. ---
+check(A.every(r => r.status === 200) && B.every(r => r.status === 200),
+  'both loops completed', `A=${A.map(r => r.status).join(',')} B=${B.map(r => r.status).join(',')}`)
+
+// THE INVARIANT. Before this change every one of these printed `lineage=new`
+// and nothing else; the reporter had 6,514 of them and no way to tell a key
+// that never resolved from a request that never looked.
+const silent = [...A, ...B].filter(r => r.lineage !== 'continuation' && r.lineage !== 'compaction' && !r.diverged)
+check(silent.length === 0, 'every diverged round names a reason',
+  silent.length ? `silent: ${silent.map(r => `round ${r.round} lineage=${r.lineage}`).join(', ')}`
+    : `${[...A, ...B].filter(r => r.diverged).length} of ${A.length + B.length} rounds diverged, all named`)
+
+const toolRounds = A.filter(r => r.lastIsToolResult)
+check(toolRounds.length >= 2, 'the headerless loop ran real tool rounds',
+  `${toolRounds.length} of ${A.length} rounds carried a tool_result`)
+
+// The reported bypass, named. Not asserted on EVERY tool round: a headerless
+// passthrough loop recovers through the durable checkpoint exactly once — the
+// checkpoint upgrade rewrites the lineage result but leaves the request
+// independent, so the store is still skipped and the checkpoint never
+// advances. Every later round then finds a checkpoint two tool calls stale and
+// takes the bypass. That is the shape the field report shows: 6,019 `new`
+// against 10 `continuation` at 1000+ messages.
+const bypassed = toolRounds.filter(r => r.diverged === 'independent-request:headerless-tool-result')
+check(bypassed.length >= 1, 'a headerless tool round names the bypass',
+  `${bypassed.length} of ${toolRounds.length} tool rounds; others: `
+  + `${[...new Set(toolRounds.filter(r => !bypassed.includes(r)).map(r => r.lineage))].join(', ') || 'none'}`)
+
+// Once per process, not once per round: the reporter's log had 6,019 of these
+// in a single conversation, and a per-round line would bury itself.
+check(adviceAfterA === 1, 'the advice is printed exactly once, not once per round',
+  `${adviceAfterA} occurrence(s) across ${A.length} rounds`)
+check(adviceCount() === 1, 'the second loop does not repeat it', `${adviceCount()} total`)
+
+// The first turn of the keyed loop resolved no key — a different outcome that
+// used to render as the same `lineage=new`.
+check(B[0].diverged === 'not-found', 'a key that never resolved says so instead',
+  `round 1 diverged=${B[0].diverged}`)
+
+// --- Claim 2: THE DISCRIMINATOR. Is the advice the log gives correct? ---
+const keyedToolRounds = B.filter(r => r.lastIsToolResult)
+check(keyedToolRounds.length > 0 && keyedToolRounds.every(r => r.lineage === 'continuation'),
+  'the keyed loop resumes on every tool round',
+  `saw ${[...new Set(keyedToolRounds.map(r => r.lineage))].join(', ')}`)
+check(keyedToolRounds.every(r => r.diverged === undefined),
+  'a resumed round prints no divergence at all',
+  `saw ${[...new Set(keyedToolRounds.map(r => String(r.diverged)))].join(', ')}`)
+
+// Cost, which is the only reason any of this matters. A resumed round reads
+// its prefix; a bypassed round pays to write one. Asserted as a ratio and only
+// over the rounds that actually diverged, because absolute numbers here encode
+// one model's verbosity at one probe size. The field measured ~280k written
+// per turn against ~214 with a key, on a 454-message conversation; a
+// four-round probe reproduces the direction, not that magnitude.
+const sum = (rs, k) => rs.reduce((n, r) => n + r[k], 0)
+const writeA = sum(bypassed, 'cacheWrite'), writeB = sum(keyedToolRounds, 'cacheWrite')
+const readA = sum(bypassed, 'cacheRead'), readB = sum(keyedToolRounds, 'cacheRead')
+say(`\n  bypassed rounds: cache_write=${writeA} cache_read=${readA}`)
+say(`  resumed  rounds: cache_write=${writeB} cache_read=${readB}`)
+check(readB > 0, 'a resumed round reads its prompt prefix from cache',
+  `keyed cache_read=${readB} across ${keyedToolRounds.length} tool rounds`)
+check(readB > readA, 'the keyed loop reads more from cache than the bypassed one',
+  `${readB} vs ${readA}`)
+
+// THE FIELD SIGNATURE, reproduced. #820 and the passthrough report both
+// measured a cache_read that does not move while the conversation grows, and a
+// cache_write that does — 30k read on every one of 12,781 to 13,030 messages.
+// That is the static-prefix floor: a fresh SDK session re-reads the tools and
+// system block and nothing else, then pays to write the history again.
+const readsOf = rs => rs.map(r => r.cacheRead)
+const bypassReads = readsOf(bypassed)
+check(bypassed.length >= 2 && new Set(bypassReads).size === 1,
+  'a bypassed round reads the same static prefix no matter how far the conversation got',
+  `cache_read ${bypassReads.join(' -> ')} while msgCount went ${bypassed.map(r => r.msgCount).join(' -> ')}`)
+const keyedReads = readsOf(keyedToolRounds)
+check(keyedReads.at(-1) > keyedReads[0],
+  'a resumed round reads MORE as the conversation grows',
+  `cache_read ${keyedReads.join(' -> ')} across msgCount ${keyedToolRounds.map(r => r.msgCount).join(' -> ')}`)
+
+// Per-round rather than total: the two loops ran a different number of
+// bypassed rounds, and the operator pays per turn.
+const perRound = rs => (rs.length ? sum(rs, 'cacheWrite') / rs.length : 0)
+const ratio = perRound(keyedToolRounds) > 0 ? perRound(bypassed) / perRound(keyedToolRounds) : Infinity
+check(ratio >= 3, 'a bypassed round pays several times over to re-write the prefix',
+  `${Math.round(perRound(bypassed))} vs ${Math.round(perRound(keyedToolRounds))} cache-write tokens per round = ${ratio.toFixed(1)}x`
+  + ' (field measured ~280k vs ~214 on a 454-message conversation)')
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-10)) say(`    ${l}`)
+} else {
+  say('  PASS: every divergence names itself, and the named remedy works')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/lineage-divergence-reason.test.ts
+++ b/src/__tests__/lineage-divergence-reason.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Every lineage divergence names itself (#820).
+ *
+ * `classifyLineage` logged four outcomes; `diverged` logged only for
+ * `modified-history` and `undo-gap`. Everything else was silent, and the
+ * request line renders every divergence without a cached session as the same
+ * literal `lineage=new` — so a key that never resolved, a key that resolved
+ * against a history that did not match, and a request that never looked at
+ * all were indistinguishable from a log.
+ *
+ * #820 is the cost of that: 6,514 `lineage=new` requests with zero explanatory
+ * lines, and the reporter could only identify the bypass by reading
+ * `server.ts`. Two reporters drained a Max subscription window first, because
+ * every one of those requests returns 200 and nothing in the proxy's own
+ * success metrics moves.
+ *
+ * `independent-request` is the worst of them: it is assigned before
+ * `classifyLineage` ever runs, and four unrelated rules collapse into it.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  independentRequestCause,
+  formatDivergence,
+  type LineageResult,
+  type SessionState,
+} from "../proxy/session/lineage"
+
+describe("independentRequestCause", () => {
+  const base = {
+    hasSessionKey: false,
+    forkSource: false,
+    isSubagent: false,
+    clientDrivenLoop: false,
+    hasDurableKey: true,
+  }
+
+  it("returns no cause for an ordinary keyed request", () => {
+    expect(independentRequestCause({ ...base, hasSessionKey: true })).toBeUndefined()
+  })
+
+  it("returns no cause for an ordinary headerless request", () => {
+    expect(independentRequestCause(base)).toBeUndefined()
+  })
+
+  it("names the headerless tool-result loop — the #820 bypass", () => {
+    expect(independentRequestCause({ ...base, clientDrivenLoop: true }))
+      .toBe("headerless-tool-result")
+  })
+
+  it("names a fork source and a subagent separately", () => {
+    expect(independentRequestCause({ ...base, forkSource: true })).toBe("fork-source")
+    expect(independentRequestCause({ ...base, isSubagent: true })).toBe("subagent")
+  })
+
+  it("names a request with no derivable cache identity", () => {
+    expect(independentRequestCause({ ...base, hasDurableKey: false }))
+      .toBe("no-cache-identity")
+  })
+
+  // The invariant the guard is built on: an explicit key cannot collide, so a
+  // keyed fork or subagent resumes normally. Losing this re-broke pylon's
+  // long-lived workers once already (they fresh-replayed every turn).
+  it("lets an explicit key override the fork and subagent guards", () => {
+    expect(independentRequestCause({ ...base, hasSessionKey: true, forkSource: true }))
+      .toBeUndefined()
+    expect(independentRequestCause({ ...base, hasSessionKey: true, isSubagent: true }))
+      .toBeUndefined()
+  })
+
+  // `isClientDrivenLoop` already requires a headerless request, so a session
+  // key cannot reach this branch at all — asserted so the precedence is not
+  // read as "a key also overrides the tool-result bypass".
+  it("reports the first rule that fired when several apply", () => {
+    expect(independentRequestCause({ ...base, forkSource: true, clientDrivenLoop: true }))
+      .toBe("fork-source")
+    expect(independentRequestCause({ ...base, clientDrivenLoop: true, hasDurableKey: false }))
+      .toBe("headerless-tool-result")
+  })
+})
+
+describe("formatDivergence", () => {
+  const state = { claudeSessionId: "s", lastAccess: 0, messageCount: 1 } as SessionState
+
+  it("says nothing for a resumable classification", () => {
+    expect(formatDivergence({ type: "continuation", session: state, resumeFrom: 1 })).toBeUndefined()
+    expect(formatDivergence({ type: "undo", session: state, prefixOverlap: 1, rollbackUuid: undefined }))
+      .toBeUndefined()
+    expect(formatDivergence({ type: "compaction", session: state, resumeFrom: 1, suffixOverlap: 1 }))
+      .toBeUndefined()
+  })
+
+  // connor-grady's point: these two are different bugs with the same visible
+  // symptom, and the log could not tell them apart.
+  it("separates a key that never resolved from a history that did not match", () => {
+    expect(formatDivergence({ type: "diverged", reason: "not-found" })).toBe("not-found")
+    expect(formatDivergence({ type: "diverged", reason: "modified-history" })).toBe("modified-history")
+  })
+
+  it("appends the cause only to independent-request", () => {
+    expect(formatDivergence({ type: "diverged", reason: "independent-request" }, "headerless-tool-result"))
+      .toBe("independent-request:headerless-tool-result")
+    expect(formatDivergence({ type: "diverged", reason: "modified-history" }, "headerless-tool-result"))
+      .toBe("modified-history")
+  })
+
+  it("still names independent-request when no cause was supplied", () => {
+    expect(formatDivergence({ type: "diverged", reason: "independent-request" }))
+      .toBe("independent-request")
+  })
+
+  // The field is pasted into public issues alongside the request line, so it
+  // must stay a fixed identifier and never carry message content.
+  it("emits only fixed identifiers", () => {
+    const reasons: LineageResult[] = [
+      { type: "diverged", reason: "unverifiable" },
+      { type: "diverged", reason: "replayed-request" },
+      { type: "diverged", reason: "modified-history" },
+      { type: "diverged", reason: "undo-gap" },
+      { type: "diverged", reason: "unrelated-history" },
+      { type: "diverged", reason: "not-found" },
+      { type: "diverged", reason: "independent-request" },
+      { type: "diverged", reason: "priority-failback" },
+      { type: "diverged", reason: "missing-session-header" },
+      { type: "diverged", reason: "concurrent-race" },
+    ]
+    for (const r of reasons) {
+      expect(formatDivergence(r, "no-cache-identity")).toMatch(/^[a-z-]+(:[a-z-]+)?$/)
+    }
+  })
+})
+
+/**
+ * The rejections that reached `classifyLineage` and printed nothing: a stored
+ * session existed under the key and was refused without a word.
+ */
+describe("classifyLineage names the rejections that were silent", () => {
+  let dir: string
+  let errSpy: ReturnType<typeof spyOn>
+  let cache: typeof import("../proxy/session/cache")
+  let store: typeof import("../proxy/sessionStore")
+
+  beforeEach(async () => {
+    cache = await import("../proxy/session/cache")
+    store = await import("../proxy/sessionStore")
+    dir = mkdtempSync(join(tmpdir(), "meridian-divergence-reason-"))
+    store.setSessionStoreDir(dir, { skipLocking: false })
+    cache.clearSessionCache()
+    errSpy = spyOn(console, "error")
+  })
+
+  afterEach(() => {
+    errSpy.mockRestore()
+    cache.clearSessionCache()
+    store.setSessionStoreDir(null)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  const lines = (): string[] => errSpy.mock.calls.map((c: any) => String(c[0]))
+  const notResumable = () => lines().find((l: string) => l.includes("Session not resumable"))
+
+  it("names a replayed request", () => {
+    const messages = [{ role: "user", content: "hello" }]
+    cache.storeSession("key-replay", messages, "sdk-a")
+    expect(cache.lookupSession("key-replay", messages).type).toBe("diverged")
+    expect(notResumable()).toContain("reason=replayed-request")
+    expect(notResumable()).toContain("incoming 1 msgs")
+  })
+
+  it("names an unrelated history", () => {
+    cache.storeSession("key-unrelated", [{ role: "user", content: "first conversation" }], "sdk-b")
+    const result = cache.lookupSession("key-unrelated", [{ role: "user", content: "different conversation" }])
+    expect(result.type).toBe("diverged")
+    expect(notResumable()).toContain("reason=unrelated-history")
+  })
+
+  it("names an entry that cannot prove what it holds", () => {
+    cache.storeSession("key-unverifiable", [], "sdk-c")
+    const result = cache.lookupSession("key-unverifiable", [{ role: "user", content: "anything" }])
+    expect(result.type).toBe("diverged")
+    expect(notResumable()).toContain("reason=unverifiable")
+  })
+
+  it("keeps the existing wording for a history rewrite", () => {
+    const stored = [{ role: "user", content: "a" }, { role: "assistant", content: "b" }]
+    cache.storeSession("key-modified", stored, "sdk-d")
+    const rewritten = [{ role: "user", content: "a" }, { role: "assistant", content: "CHANGED" },
+      { role: "user", content: "c" }]
+    expect(cache.lookupSession("key-modified", rewritten).type).toBe("diverged")
+    // `Stale session detected` is what field log analysis already greps for.
+    expect(lines().find((l: string) => l.includes("Stale session detected"))).toBeDefined()
+    expect(notResumable()).toBeUndefined()
+  })
+
+  // `not-found` is returned before classification, and it is the first turn of
+  // every conversation. It belongs on the request line, not on a line of its
+  // own, or the diagnostic drowns the thing it is supposed to reveal.
+  it("stays quiet for a key that simply is not there", () => {
+    expect(cache.lookupSession("key-absent", [{ role: "user", content: "hi" }]))
+      .toEqual({ type: "diverged", reason: "not-found" })
+    expect(notResumable()).toBeUndefined()
+  })
+
+  it("leaks no message content", () => {
+    const secret = "SUPER-SECRET-PROMPT-TEXT"
+    cache.storeSession("key-secret", [{ role: "user", content: secret }], "sdk-e")
+    cache.lookupSession("key-secret", [{ role: "user", content: secret }])
+    expect(notResumable()).toBeDefined()
+    expect(notResumable()).not.toContain(secret)
+  })
+})

--- a/src/__tests__/proxy-divergence-reason-log.test.ts
+++ b/src/__tests__/proxy-divergence-reason-log.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The request line names why a turn did not resume (#820).
+ *
+ * `lineage=` collapses every divergence without a cached session into the
+ * literal `new`, so the reporter's log held 6,514 of them and not one line
+ * saying why. The most expensive of those — the headerless tool-result bypass
+ * — is assigned before `classifyLineage` runs, so it emitted nothing at all;
+ * it was identified only by reading `server.ts`.
+ *
+ * Two reporters measured the cost first: ~280k cache-write tokens per turn
+ * against ~214 with a session key, and a drained Max window. Every request
+ * returns 200 throughout, which is why nothing in the proxy's own success
+ * metrics moved.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
+
+let mockMessages: unknown[] = []
+
+installSdkMock(() => ({
+  query: (params: any) => {
+    const options = params.options || {}
+    const sessionId = resolveMockSdkSessionId(options, "divergence-log-session")
+    return (async function* () {
+      for (const msg of mockMessages) yield { ...(msg as object), session_id: sessionId }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}), "proxy-divergence-reason-log.test.ts")
+
+installLoggerMock(() => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+installMcpToolsMock(() => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+const { resetHeaderlessToolLoopWarningForTests } = await import("../proxy/session/cache")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+const TURN_1 = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "read the config and summarise it" }],
+}
+
+/** Ends in user[tool_result] — the shape that triggers the bypass. */
+const TOOL_TURN = {
+  ...TURN_1,
+  messages: [
+    ...TURN_1.messages,
+    { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "read", input: { path: "a" } }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "file contents" }] },
+  ],
+}
+
+describe("divergence reason on the request line", () => {
+  let errSpy: ReturnType<typeof spyOn>
+  let warnSpy: ReturnType<typeof spyOn>
+
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    clearSessionCache()
+    resetHeaderlessToolLoopWarningForTests()
+    errSpy = spyOn(console, "error")
+    warnSpy = spyOn(console, "warn")
+  })
+
+  afterEach(() => {
+    errSpy.mockRestore()
+    warnSpy.mockRestore()
+    clearSessionCache()
+  })
+
+  const requestLines = (): string[] => errSpy.mock.calls
+    .map((c: any) => String(c[0]))
+    .filter((l: string) => l.includes("[PROXY]") && l.includes("adapter=") && l.includes("msgCount="))
+
+  const lastRequestLine = (): string => {
+    const all = requestLines()
+    expect(all.length).toBeGreaterThan(0)
+    const last = all.at(-1)
+    if (last === undefined) throw new Error("no [PROXY] request line was logged")
+    return last
+  }
+
+  const warnings = (): string[] => warnSpy.mock.calls.map((c: any) => String(c[0]))
+    .filter((l: string) => l.includes("Client-driven tool loop with no session identity"))
+
+  // THE REPORTED CASE. pi sends no session header, and every agentic turn ends
+  // in a tool_result, so this fires on every round of every conversation.
+  it("names the headerless tool-result bypass", async () => {
+    const app = createTestApp()
+    expect((await post(app, TOOL_TURN, { "x-meridian-agent": "pi" })).status).toBe(200)
+    expect(lastRequestLine()).toContain("diverged=independent-request:headerless-tool-result")
+  })
+
+  it("says once per process that the conversation is not resuming", async () => {
+    const app = createTestApp()
+    await post(app, TOOL_TURN, { "x-meridian-agent": "pi" })
+    expect(warnings()).toHaveLength(1)
+    expect(warnings()[0]).toContain("adapter=pi")
+    expect(warnings()[0]).toContain("does not resume")
+
+    // A per-round line would bury itself: the reporter's log had 6,019 of these
+    // in a single conversation.
+    await post(app, TOOL_TURN, { "x-meridian-agent": "pi" })
+    await post(app, TOOL_TURN, { "x-meridian-agent": "pi" })
+    expect(warnings()).toHaveLength(1)
+    expect(requestLines().filter(l => l.includes("headerless-tool-result"))).toHaveLength(3)
+  })
+
+  // connor-grady's distinction: "the key never resolved" and "the key resolved
+  // and the history did not match" are different bugs with the same symptom.
+  it("separates a key that never resolved from the bypass", async () => {
+    const app = createTestApp()
+    await post(app, TURN_1, { "x-meridian-agent": "pi", "x-session-affinity": "pi-run-1" })
+    expect(lastRequestLine()).toContain("diverged=not-found")
+    expect(lastRequestLine()).not.toContain("independent-request")
+    expect(warnings()).toHaveLength(0)
+  })
+
+  it("says nothing at all once the turn actually resumes", async () => {
+    const app = createTestApp()
+    const headers = { "x-meridian-agent": "pi", "x-session-affinity": "pi-run-2" }
+    await post(app, TURN_1, headers)
+    await post(app, TOOL_TURN, headers)
+    expect(lastRequestLine()).toContain("lineage=continuation")
+    expect(lastRequestLine()).not.toContain("diverged=")
+    expect(warnings()).toHaveLength(0)
+  })
+
+  it("names a headerless fork source, which is a different bypass", async () => {
+    const app = createTestApp()
+    await post(app, TURN_1, { "x-meridian-source": "fork-memory-extract" })
+    expect(lastRequestLine()).toContain("diverged=independent-request:fork-source")
+    // The fork guard is deliberate and correct; the tool-loop advice must not
+    // fire for it.
+    expect(warnings()).toHaveLength(0)
+  })
+
+  // REGRESSION GUARD. `lineage=<value> session=<value>` is matched as one unit
+  // by e2e-passthrough-turns.mjs and by field log analysis. The reason is a
+  // separate field precisely so that pairing survives.
+  it("leaves lineage= adjacent to session=", async () => {
+    const app = createTestApp()
+    await post(app, TOOL_TURN, { "x-meridian-agent": "pi" })
+    expect(lastRequestLine()).toMatch(/lineage=\S+ session=\S+/)
+    expect(lastRequestLine()).toContain("lineage=new session=")
+  })
+})

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -121,6 +121,8 @@ import {
   normalizeContextUsage,
   withClientAssistantUuid,
   reconcileReturnedSessionUuids,
+  independentRequestCause,
+  formatDivergence,
   type LineageResult,
   type TokenUsageIteration,
   type TokenUsage,
@@ -137,6 +139,7 @@ import {
   getMaxSessionsLimit,
   evictSession as evictCachedSession,
   getSessionByClaudeId,
+  warnHeaderlessToolLoopOnce,
   type PrioritySessionPublication,
 } from "./session/cache"
 import { processSessionTurns, type SessionTurnLease } from "./session/turnCoordinator"
@@ -2161,6 +2164,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // preserve fingerprint resume instead of treating their tool results
         // as unrelated headerless workflow requests.
         const isClientDrivenLoop = adapterBase !== "claude-code" && !agentSessionId && lastIsToolResult
+        const durableMappingKey = profileSessionId
+          || getConversationFingerprint(lineageMessages, profileScopedCwd)
         // The fork/subagent independence guard protects HEADERLESS flows from
         // colliding on the shared (firstUserMessage, cwd) fingerprint. Adapter
         // mode and generic source declarations share the subagent behavior. An
@@ -2169,15 +2174,25 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // fork/subagent source. Without this, pylon's long-lived subagent
         // workers fresh-replayed every turn: prompt-cache hits decayed to the
         // static-prefix floor and turn latency grew with conversation length.
-        let isIndependentSession =
-          (!agentSessionId && (requestSource?.startsWith("fork-") || isSubagentRequest)) ||
-          isClientDrivenLoop || false
-        const durableMappingKey = profileSessionId
-          || getConversationFingerprint(lineageMessages, profileScopedCwd)
-        // Image-only and otherwise text-free headerless requests have no stable
-        // cache identity. Run them fresh instead of manufacturing a generation
-        // for an empty key or failing before the SDK is called.
-        if (!durableMappingKey) isIndependentSession = true
+        //
+        // A request with no session key and no derivable fingerprint (image-only
+        // and otherwise text-free bodies) has no stable cache identity either,
+        // and runs fresh rather than manufacturing a generation for an empty key.
+        //
+        // One decision, one reported cause: deriving the flag from the cause is
+        // what keeps the log honest. #820 was a log full of `lineage=new` whose
+        // only explanation lived in this file, and a label computed separately
+        // from the decision would drift away from it.
+        const independentCause = independentRequestCause({
+          hasSessionKey: Boolean(agentSessionId),
+          forkSource: Boolean(requestSource?.startsWith("fork-")),
+          isSubagent: isSubagentRequest,
+          clientDrivenLoop: isClientDrivenLoop,
+          hasDurableKey: Boolean(durableMappingKey),
+        })
+        const isIndependentSession = independentCause !== undefined
+        // Once per process: the operator cannot see this in success metrics.
+        if (independentCause === "headerless-tool-result") warnHeaderlessToolLoopOnce(adapter.name)
         const durableMappingAtTurn = durableMappingKey
           ? lookupSharedSessionResult(durableMappingKey)
           : { status: "missing" as const }
@@ -2484,10 +2499,17 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
           return `${m.role}[${contentTypes}]`
         }).join(" → ")
         const lineageType = lineageResult.type === "diverged" && !cachedSession ? "new" : lineageResult.type
+        // `lineage=` renders every divergence without a cached session as the
+        // same `new`, so a key that never resolved, a history that did not
+        // match and a request that never looked were indistinguishable (#820).
+        // Added as its own field rather than folded into `lineage=`: existing
+        // log analysis and the E2E gates match `lineage=<value> session=`, and
+        // widening that value would break them for no gain.
+        const divergedReason = formatDivergence(lineageResult, independentCause)
         const msgCount = Array.isArray(body.messages) ? body.messages.length : 0
         const toolCount = body.tools?.length ?? 0
         const sdkSnapshot = sdkSemaphore.snapshot
-        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : options.forcedProfileId ? "(priority)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${agentMode ? ` agent=${agentMode}` : ""} sdkActive=${sdkSnapshot.active}/${sdkSnapshot.limit} sdkQueued=${sdkSnapshot.queued} sessionWait=${requestMeta.sessionQueueWaitMs}ms msgCount=${msgCount}`
+        const requestLogLine = `${requestMeta.requestId} adapter=${adapter.name}${requestSource ? ` source=${requestSource}` : ""}${profile.id !== "default" ? ` profile=${profile.id}${routingMode === "sticky" ? "(sticky)" : options.forcedProfileId ? "(priority)" : ""}` : ""} model=${model} stream=${stream} tools=${toolCount} lineage=${lineageType} session=${resumeSessionId?.slice(0, 8) || "new"}${isUndo && undoRollbackUuid ? ` rollback=${undoRollbackUuid.slice(0, 8)}` : ""}${divergedReason ? ` diverged=${divergedReason}` : ""}${agentMode ? ` agent=${agentMode}` : ""} sdkActive=${sdkSnapshot.active}/${sdkSnapshot.limit} sdkQueued=${sdkSnapshot.queued} sessionWait=${requestMeta.sessionQueueWaitMs}ms msgCount=${msgCount}`
         plog(`[PROXY] ${requestLogLine} msgs=${msgSummary}`)
         diagnosticLog.session(`${requestLogLine}`, requestMeta.requestId)
 

--- a/src/proxy/session/cache.ts
+++ b/src/proxy/session/cache.ts
@@ -265,6 +265,20 @@ function classifyLineage(
       + (detail ? `\n  ${detail}` : "")
     console.error(`[PROXY] ${msg}`)
     diagnosticLog.lineage(msg)
+  } else if (result.type === "diverged") {
+    // Every remaining rejection was silent. A stored session existed under
+    // this key and was refused, but the request line renders all of them as
+    // the same `lineage=new`, so `unverifiable`, `replayed-request` and
+    // `unrelated-history` were indistinguishable from a key that never
+    // resolved (#820).
+    //
+    // `not-found` never reaches here: `lookupSession` returns it before
+    // classifying, which is right — it is the first turn of every
+    // conversation, so it belongs on the request line that is printed anyway
+    // rather than on a diagnostic line of its own.
+    const msg = `Session not resumable (key=${cacheKey.slice(0, 8)}…): reason=${result.reason}, prefix overlap ${result.prefixOverlap || 0}/${state.messageCount}, incoming ${messages.length} msgs. Starting fresh replay.`
+    console.error(`[PROXY] ${msg}`)
+    diagnosticLog.lineage(msg)
   }
 
   return result
@@ -289,6 +303,43 @@ function warnDegradedFingerprintOnce(): void {
     + "will share a session. The directory is read from the <env> block of the system prompt; a "
     + "plugin implementing experimental.chat.system.transform (for example opencode-scrub) may "
     + "have removed it. Send a session header (meridian setup) to key conversations explicitly."
+  console.warn(msg)
+  diagnosticLog.lineage(msg)
+}
+
+let warnedHeaderlessToolLoop = false
+
+/** Reset between tests; the warning is one-shot per process by design. */
+export function resetHeaderlessToolLoopWarningForTests(): void {
+  warnedHeaderlessToolLoop = false
+}
+
+/**
+ * Say once that a client's tool loop is not resuming.
+ *
+ * The headerless tool-result bypass is the most expensive lineage outcome in
+ * the field and the only one that printed nothing at all: #820 measured 99.8%
+ * of 1000+-message pi requests skipping resume, and two reporters
+ * independently drained a Max window before finding it — one measured ~280k
+ * cache-write tokens per turn against ~214 with a session key. Every request
+ * still returns 200, so nothing in the proxy's own success metrics moves.
+ *
+ * Warned once per process, matching the degraded-fingerprint warning above:
+ * it is a property of how the client is wired, not of a turn, and one line per
+ * tool round would bury it. The per-request detail rides on the request line
+ * as `diverged=independent-request:headerless-tool-result`.
+ */
+export function warnHeaderlessToolLoopOnce(adapterName: string): void {
+  if (warnedHeaderlessToolLoop) return
+  warnedHeaderlessToolLoop = true
+  const msg =
+    `[PROXY] Client-driven tool loop with no session identity (adapter=${adapterName}): `
+    + "the request ends in a tool_result and carries no session key, so this and every "
+    + "following tool round starts a fresh SDK session. The conversation does not resume, "
+    + "and the model sees none of its own earlier turns. This is correct for concurrent "
+    + "headless workflow loops, which must not share one conversation fingerprint; an "
+    + "interactive client should send a session header instead — see \"Session identity\" "
+    + "in docs/configuration.md."
   console.warn(msg)
   diagnosticLog.lineage(msg)
 }

--- a/src/proxy/session/lineage.ts
+++ b/src/proxy/session/lineage.ts
@@ -366,6 +366,72 @@ export function formatLineageMismatch(mismatch: LineageMismatch): string | undef
 }
 
 /**
+ * Why a request skipped session lookup entirely.
+ *
+ * `independent-request` is assigned in server.ts before `classifyLineage` runs,
+ * so it is the one divergence that emits no diagnostic at all — and four
+ * unrelated causes collapse into that single silent outcome. #820 was a log
+ * full of `lineage=new` with zero explanatory lines; the reporter could only
+ * identify the bypass by reading server.ts.
+ *
+ * Naming the cause is log-only. The `LineageDivergenceReason` handed to the
+ * `onSession` transform hook is unchanged, so plugins switching on it are
+ * unaffected.
+ */
+export type IndependentRequestCause =
+  | "fork-source"
+  | "subagent"
+  | "headerless-tool-result"
+  | "no-cache-identity"
+
+/**
+ * Decide whether a request bypasses session lookup, and say which rule did it.
+ *
+ * The caller derives `isIndependentSession` from this result rather than
+ * computing it separately, so the reported cause cannot drift away from the
+ * decision it explains. Evaluation order mirrors the guards' own precedence.
+ */
+export function independentRequestCause(input: {
+  /** An explicit session key. Distinct flows carry distinct keys, so a keyed
+   *  request cannot collide and never needs the independence guard. */
+  hasSessionKey: boolean
+  /** `x-meridian-source: fork-*` — a declared independent sub-request flow. */
+  forkSource: boolean
+  isSubagent: boolean
+  /** The last message carries a tool_result and the request has no session
+   *  key, so it is a self-contained round of the client's own tool loop. */
+  clientDrivenLoop: boolean
+  /** Whether a session key or a conversation fingerprint could be derived.
+   *  Image-only and otherwise text-free headerless requests have neither. */
+  hasDurableKey: boolean
+}): IndependentRequestCause | undefined {
+  if (!input.hasSessionKey && input.forkSource) return "fork-source"
+  if (!input.hasSessionKey && input.isSubagent) return "subagent"
+  if (input.clientDrivenLoop) return "headerless-tool-result"
+  if (!input.hasDurableKey) return "no-cache-identity"
+  return undefined
+}
+
+/**
+ * The `diverged=` field for the request log line.
+ *
+ * The line renders `lineage=new` for every divergence without a cached
+ * session, so a key that never resolved, a history that did not match and a
+ * request that never looked are indistinguishable (#820). The reason is
+ * already in memory on every request; it was only reachable by writing a
+ * plugin. Reasons are fixed identifiers, never message content.
+ */
+export function formatDivergence(
+  result: LineageResult,
+  cause?: IndependentRequestCause,
+): string | undefined {
+  if (result.type !== "diverged") return undefined
+  return result.reason === "independent-request" && cause
+    ? `${result.reason}:${cause}`
+    : result.reason
+}
+
+/**
  * Compute per-message hashes for an entire message array.
  */
 export function computeMessageHashes(messages: Array<{ role: string; content: any }>): string[] {


### PR DESCRIPTION
Names the reason on every lineage divergence, and documents the session
identity that the most expensive one asks for.

Refs #820.

## The problem

`classifyLineage` logs four outcomes, and for `diverged` only
`modified-history` and `undo-gap`. Every other rejection is silent. The request
line then renders each divergence without a cached session as the same literal
`lineage=new`, so three different bugs look identical from a log:

- the key never resolved (`not-found`)
- the key resolved and the history did not match (`modified-history`,
  `unrelated-history`, `unverifiable`, `replayed-request`)
- the request never looked at all (`independent-request`)

The third is the worst, because it is assigned before `classifyLineage` runs
and four unrelated rules collapse into it. @odfalik measured **99.8% of
requests carrying 1000+ messages classifying as `lineage=new`** on the `pi`
adapter, with all four `classifyLineage` diagnostics at exactly zero across
6,514 of them — and identified the cause only by reading `server.ts`.

On `pi` that rule fires on every agentic turn: pi sends no session header, and
every tool round ends in `user[tool_result]`. @RobertoNegro hit the same thing
from the other direction and drained a just-reset 5-hour window on a 20x Max
subscription before finding it. Every one of those requests returns 200, so
nothing in the proxy's own success metrics moves.

## What this changes

**The request line carries `diverged=<reason>` on every divergence**, and
`independent-request` names which of its four rules fired
(`headerless-tool-result`, `fork-source`, `subagent`, `no-cache-identity`).
This is @connor-grady's proposal from the issue: the reason is already in
memory on every request, and was only reachable by writing an `onSession`
plugin.

It is a separate field rather than a wider `lineage=` value because
`e2e-passthrough-turns.mjs` and field log analysis match
`lineage=<value> session=<value>` as one unit. A regression test pins that
adjacency.

**`isIndependentSession` is now derived from the cause** rather than computed
beside it, so the printed label cannot drift from the decision it explains. The
pure `independentRequestCause` also moves that precedence out of `server.ts`.

**`classifyLineage` names the rest**: `unverifiable`, `replayed-request` and
`unrelated-history` get a `Session not resumable` line with the same overlap
numbers the existing `Stale session detected` line carries. `not-found` stays
on the request line only — it is the first turn of every conversation, so a
line of its own would bury the diagnostic it is meant to reveal. The
`modified-history` wording is unchanged, because field log analysis already
greps it.

**The headerless tool-result bypass warns once per process.** The bypass is
correct for concurrent headless workflow loops, which must not share one
conversation fingerprint — but for an interactive client it means the
conversation never resumes. Once per process, matching the degraded-fingerprint
warning: it is a property of how the client is wired, not of a turn.

**Docs**: a new "Session identity" section in `docs/configuration.md` — the
resolution order, the per-adapter header table, why the bypass exists, what it
costs, and the pi extension that fixes it, contributed by @RobertoNegro and
refined by @odfalik.

## Validation

`npm test`: **3765 pass, 1 skip, 0 fail** (bun 1.3.11, matching CI).
`npm run typecheck`, `npm run build`: clean.

**Failed before, passes after.** The new integration test run against
unmodified `origin/main` (`0e773b56`) fails 4 of 6 with exactly the reporter's
log:

```
Expected to contain: "diverged=independent-request:headerless-tool-result"
Received: "[PROXY] … adapter=pi … lineage=new session=new … msgCount=3"
```

The 2 that pass on main are the regression guards, which assert unchanged
behavior.

**Live E2E — new gate E54** (`bun scripts/e2e-lineage-divergence-reason.mjs`),
real SDK, Haiku 4.5, `pi` adapter in passthrough, two consecutive runs:

```
A headerless  round 3  msgs=5  lineage=new           diverged=independent-request:headerless-tool-result  cache_write=1286  cache_read=5789
A headerless  round 4  msgs=7  lineage=new           diverged=independent-request:headerless-tool-result  cache_write=1497  cache_read=5789
B keyed       round 3  msgs=5  lineage=continuation  diverged=—                                           cache_write= 167  cache_read=6752
B keyed       round 4  msgs=7  lineage=continuation  diverged=—                                           cache_write= 166  cache_read=6919
```

The gate asserts no divergence is silent, that the advice prints exactly once
across 8 rounds, and — the discriminator — that the remedy the log names
actually works: `cache_read` pinned at 5789 while the conversation grows on the
bypassed rounds against 6562 → 6811 → 6919 when keyed, and 7.2x the cache-write
tokens per round. That is the reporters' own signature at probe scale; they
measured `cache_read` pinned at 30629 across 12,781 to 13,030 messages.

**E41 all four modes** (lineage and independence decision changed): pass.

## What this does not do

- **It does not remove the bypass for `pi`.** @odfalik tried that and found it
  breaks `proxy-source-keyed-session.test.ts`, which deliberately asserts that
  a tool-result turn with no identity at all does not resume. A relaxation
  gated on lineage verification would not help either: several identical
  concurrent loops match at the prefix, which is exactly the collision the
  guard exists to stop. The header approach respects the invariant.
- **It does not assert the field's cost magnitude.** ~280k cache-write tokens
  per turn against ~214 was measured on a 454-message conversation; a
  four-round probe reproduces the direction and the signature, not the size.
- Not every headerless tool round takes the bypass. A headerless passthrough
  loop recovers through the durable checkpoint exactly once — the checkpoint
  upgrade rewrites the lineage result but leaves the request independent, so
  the store is skipped and the checkpoint never advances past the first tool
  call. That is the shape the field report shows: 6,019 `new` against 10
  `continuation` at 1000+ messages. E54 documents this and asserts accordingly.
- @StanChmielewski's `passthrough` report needs a session identity that does
  not exist on that adapter today, which is a separate change and is not in
  this PR.

Issue #820 stays open for that remaining half.
