### PR TITLE
fix(passthrough): keep the Claude Code tool-loop exemption behind a gateway

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -278,6 +278,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E52 | [Host identity](#e52-host-identity) | **Automated, needs Docker** (skips cleanly without it, costs no tokens): `bun scripts/e2e-host-id.mjs`. Reproduces the derived `hostId` moving with the pid-namespace inode across `docker restart`, then asserts `MERIDIAN_HOST_ID` makes it stable across namespaces and distinct across hosts sharing a baked machine-id. **Run before releases touching process incarnation or store locking** | 2026-09-08 |
 | E53 | [Auto-defer pin](#e53-auto-defer-pin) | **Automated**: `bun scripts/e2e-defer-pin.mjs` — real proxy + SDK, A/B. Two three-turn conversations, one crossing the auto-defer threshold on its last turn. Asserts deferral (and so `maxTurns`) does not flip mid-session and that the suppressed flip is logged. **Run before releases touching auto-defer, tool registration, or prompt assembly** | 2026-09-09 |
 | E54 | [Lineage divergence reason](#e54-lineage-divergence-reason) | **Automated**: `bun scripts/e2e-lineage-divergence-reason.mjs` — real proxy + SDK, A/B. Drives a headerless pi tool loop and the same loop with `x-session-affinity`. Asserts no divergence is silent, that the headerless bypass names itself, that the advice is printed once per process, and that the named remedy actually restores resume and prompt-cache reuse. **Run before releases touching lineage classification, the independence guards, or the request log line** | 2026-09-09 |
+| E55 | [Gateway-fronted Claude Code](#e55-gateway-fronted-claude-code) | **Automated, needs the `claude` CLI** (skips cleanly without it): `bun scripts/e2e-passthrough-claude-code-session.mjs` — real proxy + SDK, and the REAL Claude Code CLI as the client. Asserts a gateway-fronted Claude Code session keeps the tool-loop exemption it has on a direct connection, that its following turn resumes, and that the CLI's auxiliary requests do not collide with the conversation. **Run before releases touching the independence guards, adapter detection, or passthrough session identity** | 2026-09-09 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4437,6 +4438,86 @@ B keyed       round 4  msgs=7  lineage=continuation  diverged=—               
 `cache_read` pinned at 5789 while the conversation grows is the reporters' own
 signature at probe scale; they measured it pinned at 30629 across 12,781 to
 13,030 messages. Per-round cache-write ratio measured 7.2x and 7.1x.
+
+## E55: Gateway-fronted Claude Code
+
+**What it proves:** a Claude Code session behind an API gateway keeps the
+tool-loop exemption it already has on a direct connection — and the change
+that delivers it does not turn a silent inefficiency into a hard failure.
+
+The headerless tool-result bypass exempts `adapterBase === "claude-code"`,
+because Claude Code owns its tool loop but still expects Meridian to resume the
+backing SDK session. Behind LiteLLM the passthrough heuristic claims the
+request first, so that exemption was lost — and LiteLLM owns the
+`x-litellm-*` namespace for its own Langfuse session tracking and does not
+forward `x-litellm-session-id` upstream on the `anthropic/` provider route, so
+there was no session key either. Every tool round of the whole agentic loop
+took the bypass (#820): 35k-56k cache-write tokens per turn with `cache_read`
+pinned at 30629, against 46-53 tokens on a direct connection, and one 764-turn
+session accumulating 90M cache-creation tokens.
+
+**Why it needs the real CLI, and why it changed the fix.** The obvious change
+was to read `x-claude-code-session-id` as a session key. The header is real —
+verified against Claude Code 2.1.266 that it is the CLI session UUID, pinned
+exactly by `--session-id` and distinct across sessions. But driving the actual
+client showed the CLI reusing one session id across the auxiliary requests it
+makes alongside a conversation. Keyed that way, two unrelated first messages
+land under one key: classified `unrelated-history`, then refused with
+**HTTP 400 "This session advanced while the request was waiting."** A
+hand-written two-request probe would never have produced that second request.
+So the header identifies the client and nothing else; keying stays on the
+conversation fingerprint, exactly as a direct Claude Code request already does.
+
+```bash
+bun scripts/e2e-passthrough-claude-code-session.mjs
+```
+
+`MERIDIAN_DEFAULT_AGENT=passthrough` resolves the ambiguous `claude-cli/`
+User-Agent to the passthrough adapter, reproducing the reported topology
+without a LiteLLM instance: same adapter, same absent `x-litellm-session-id`,
+same real client. The client runs with its own `CLAUDE_CONFIG_DIR` and a dummy
+bearer token; the proxy keeps its real Claude Max authentication. The child
+environment is scrubbed of `CLAUDE*` variables so running the gate from inside
+Claude Code cannot hand the client a live messaging socket.
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- All three client invocations exit 0 and answer correctly.
+- **No request takes the headerless tool-result bypass.**
+- The turn after the tool round reports `lineage=continuation`. Before the fix
+  the bypass skipped the end-of-turn store, so nothing was ever written under
+  the key and no later turn could resume either.
+- **No request classifies `unrelated-history`, and no invocation is refused
+  with a 4xx** — the guard against the session-id keying above.
+- A second conversation with the same prompt in its own directory does not
+  inherit the first, which is what the fingerprint's working-directory
+  component has to do in the absence of a key.
+
+**What this gate deliberately does not assert.** The tool round *itself* still
+classifies `not-found`, which is a separate and larger defect tracked in #996:
+the passthrough adapter never resumes a tool round even with a session key it
+does read, while `pi` and `opencode` resume the identical shape. The entry
+stored at a passthrough early stop is a checkpoint boundary that lineage lookup
+reports as missing by design, and the recovery path that should upgrade it does
+not fire on this adapter. It predates this change and behaves identically with
+a forwarded `x-litellm-session-id`, so the gate prints the classification as a
+note rather than asserting it. It is also not a LiteLLM integration test — a real gateway would rewrite
+the User-Agent and relay the body, which this does not model.
+
+**Verified:** 2026-09-09, Claude Code 2.1.266 client, Haiku 4.5, 7 proxy
+requests across three invocations. Pre-change the tool round reports
+`diverged=independent-request:headerless-tool-result` and the `--resume`d turn
+cannot resume. After:
+
+```
+turn 1   tools=0   msgCount=1  lineage=new           diverged=not-found      (auxiliary CLI request)
+turn 1   tools=12  msgCount=1  lineage=new           diverged=not-found
+turn 1   tools=12  msgCount=3  lineage=new           diverged=not-found      (tool round, no longer bypassed)
+turn 2   tools=12  msgCount=5  lineage=continuation
+```
+
+Keyed on `x-claude-code-session-id` instead, the same run produced
+`diverged=unrelated-history` and `API Error: 400`.
 
 ## Concurrent transcript publication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,49 @@ rewrites the opening message.
 | `passthrough` (LiteLLM) | `x-litellm-session-id` |
 | `cherry`, `droid`, `forgecode`, `openai` | none — fingerprint only |
 
+### Claude Code behind a gateway
+
+The bypass described below exempts Claude Code, because Claude Code owns its
+tool loop but still expects Meridian to resume the backing SDK session. That
+exemption follows the **client**, identified by the `x-claude-code-session-id`
+header the CLI sends on every request — not the adapter that happens to be
+handling it.
+
+This matters behind an API gateway. LiteLLM traffic resolves to the
+`passthrough` adapter, so a Claude Code session used to lose the exemption; and
+LiteLLM owns the `x-litellm-*` namespace for its own Langfuse session tracking
+and does not forward `x-litellm-session-id` upstream on the `anthropic/`
+provider route, so it had no session key either. Every tool round of the whole
+agentic loop then took the bypass, measured in
+[#820](https://github.com/rynfar/meridian/issues/820) at 35k-56k cache-write
+tokens per turn with `cache_read` pinned at 30629, against 46-53 tokens on a
+direct connection — one 764-turn session accumulated 90M cache-creation tokens.
+
+Two things the header is deliberately **not** used for:
+
+- **Adapter selection.** Routing gateway traffic to the `claudecode` adapter on
+  this signal would swap tool handling, MCP naming and prompt shape for every
+  existing LiteLLM user and move their prompt-cache prefix.
+- **A session key.** The CLI reuses one session id across the auxiliary
+  requests it makes alongside a conversation, so keying on it puts two
+  unrelated histories under one key. Measured live, that produced
+  `diverged=unrelated-history` and then `HTTP 400 This session advanced while
+  the request was waiting` — a hard client failure where there had only been a
+  silent inefficiency. Keying stays on the conversation fingerprint, exactly as
+  a direct Claude Code request already does.
+
+If you run LiteLLM and would rather it forward its own session header, an
+explicit pass-through route restores it, and an explicit key always wins over
+the fingerprint:
+
+```yaml
+general_settings:
+  pass_through_endpoints:
+    - path: "/meridian/v1/messages"
+      target: "http://<meridian>/v1/messages"
+      forward_headers: true
+```
+
 ### Client-driven tool loops need a session header
 
 A request whose last message is a `tool_result` is a round of the client's own

--- a/scripts/e2e-passthrough-claude-code-session.mjs
+++ b/scripts/e2e-passthrough-claude-code-session.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env bun
+// Live: does a Claude Code session behind a gateway keep the exemption it has
+// on a direct connection — using the REAL Claude Code CLI as the client?
+//
+// The headerless tool-result bypass exempts `adapterBase === "claude-code"`,
+// because Claude Code owns its tool loop but still expects Meridian to resume
+// the backing SDK session. Behind LiteLLM the passthrough heuristic claims the
+// request first, so that exemption was lost — and LiteLLM owns the
+// `x-litellm-*` namespace for its own Langfuse session tracking and does not
+// forward `x-litellm-session-id` upstream on the `anthropic/` provider route,
+// so there was no session key either. Every tool round of the whole agentic
+// loop took the bypass (#820).
+//
+// @StanChmielewski measured 35k-56k cache-write tokens per turn with
+// `cache_read` pinned at 30629, against 46-53 tokens on a direct connection;
+// one 764-turn session accumulated 90M cache-creation tokens, and a fresh
+// 5-hour Max window drained in about two hours of ordinary work.
+//
+// Why this gate needs the real CLI, and why it changed the fix. The obvious
+// change was to read `x-claude-code-session-id` as a session key. That header
+// is real — verified against 2.1.266 that it is the CLI session UUID, pinned
+// exactly by `--session-id`. But this gate, driving the actual client, showed
+// the CLI reusing one session id across the auxiliary requests it makes
+// alongside a conversation: two unrelated first messages under one key,
+// classified `unrelated-history`, and then refused with HTTP 400 "This session
+// advanced while the request was waiting." That turns a silent inefficiency
+// into a hard client failure. No hand-written request would have found it.
+//
+// So the header identifies the CLIENT and nothing else. Adapter selection is
+// untouched — routing gateway traffic to the claude-code adapter would swap
+// tool handling, MCP naming and prompt shape for every existing LiteLLM user
+// and move their cache prefix — and keying stays on the conversation
+// fingerprint, exactly as a direct Claude Code request already does.
+//
+// `MERIDIAN_DEFAULT_AGENT=passthrough` resolves the ambiguous `claude-cli/`
+// User-Agent to the passthrough adapter, which reproduces the reported
+// topology without a LiteLLM instance: same adapter, same absent
+// `x-litellm-session-id`, same real client. A real gateway would also rewrite
+// the User-Agent and relay the body, which this gate does not model.
+//
+// The client runs with its own CLAUDE_CONFIG_DIR and a dummy bearer token; the
+// proxy keeps its real Claude Max authentication. Needs Claude Max and the
+// `claude` CLI on PATH, and costs a few cents of real tokens. Skips cleanly
+// with a non-zero exit if the CLI is missing.
+//
+//   bun scripts/e2e-passthrough-claude-code-session.mjs
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const say = console.log.bind(console)
+
+const which = spawnSync('command', ['-v', 'claude'], { shell: true, encoding: 'utf8' })
+if (which.status !== 0 || !which.stdout.trim()) {
+  say('SKIP: the `claude` CLI is not on PATH; this gate drives the real client')
+  process.exit(1)
+}
+const CLI = which.stdout.trim()
+const version = spawnSync(CLI, ['--version'], { encoding: 'utf8' }).stdout.trim()
+
+const WORKDIR = realpathSync(mkdtempSync(join(tmpdir(), 'mccsess-')))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+const STORE = join(WORKDIR, 'store')
+setSessionStoreDir(STORE)
+process.env.MERIDIAN_PASSTHROUGH = '1'
+// Resolve the ambiguous `claude-cli/` User-Agent to the passthrough adapter,
+// which is where a gateway would have landed it.
+process.env.MERIDIAN_DEFAULT_AGENT = 'passthrough'
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3557)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const proxyLog = []
+for (const k of ['log', 'error', 'debug', 'warn']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+/** One client project per conversation, plus its own CLI config dir. */
+function clientDir(files) {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), 'mccproj-')))
+  for (const [name, body] of Object.entries(files)) writeFileSync(join(dir, name), body + '\n')
+  return dir
+}
+
+const requestLines = () => proxyLog
+  .filter(l => l.includes('adapter=') && l.includes('msgCount='))
+  .map(l => l.replace(/^\[PROXY\] \S+ /, ''))
+
+/**
+ * Run the real Claude Code CLI against this proxy.
+ *
+ * The child environment is scrubbed of the harness's own `CLAUDE*` variables.
+ * Anyone running this gate from inside Claude Code would otherwise hand the
+ * client a live messaging socket and a foreign session id, and it would be
+ * talking to the wrong session rather than to this proxy.
+ */
+function childEnv(configDir) {
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (/^CLAUDE(CODE|_)/.test(key)) delete env[key]
+  }
+  return {
+    ...env,
+    CLAUDE_CONFIG_DIR: configDir,
+    ANTHROPIC_BASE_URL: `http://127.0.0.1:${PORT}`,
+    ANTHROPIC_AUTH_TOKEN: 'meridian-e2e-dummy',
+  }
+}
+
+/**
+ * Spawned asynchronously and drained concurrently, NOT with `spawnSync`:
+ * `spawnSync` deadlocks here. The client keeps writing while it waits on the
+ * proxy, and a synchronous parent never reads the pipes, so both sides block
+ * once a buffer fills. Measured as an indefinite hang with no output at all.
+ */
+async function runClient(cwd, configDir, args) {
+  const proc = Bun.spawn([CLI, ...args, '--model', MODEL, '--permission-mode', 'bypassPermissions'], {
+    cwd,
+    env: childEnv(configDir),
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const timer = setTimeout(() => proc.kill(), 300000)
+  const [out, err, status] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  clearTimeout(timer)
+  return { status, out: out.trim(), err: err.trim() }
+}
+
+say(`\n=== gateway-fronted Claude Code session identity ===`)
+say(`  client: ${version}   adapter: passthrough   model: ${MODEL}`)
+
+const SESSION = randomUUID()
+const CONFIG = realpathSync(mkdtempSync(join(tmpdir(), 'mccconf-')))
+const PROJECT = clientDir({ 'alpha.txt': 'ALPHA-VALUE' })
+
+const before = requestLines().length
+const first = await runClient(PROJECT, CONFIG, [
+  '-p', 'Read alpha.txt and reply with exactly its contents.',
+  '--session-id', SESSION,
+  '--allowedTools', 'Read',
+])
+const firstLines = requestLines().slice(before)
+say(`\n  turn 1 (${firstLines.length} proxy requests) exit=${first.status}: ${first.out.slice(0, 60)}`)
+for (const l of firstLines) say(`    ${l.replace(/ sdkActive.*?msgCount=/, ' msgCount=').replace(/ msgs=.*/, '')}`)
+
+const resumedFrom = requestLines().length
+const second = await runClient(PROJECT, CONFIG, [
+  '--resume', SESSION,
+  '-p', 'Reply with exactly the word FINISHED.',
+])
+const secondLines = requestLines().slice(resumedFrom)
+say(`\n  turn 2 after --resume (${secondLines.length} proxy requests) exit=${second.status}: ${second.out.slice(0, 60)}`)
+for (const l of secondLines) say(`    ${l.replace(/ sdkActive.*?msgCount=/, ' msgCount=').replace(/ msgs=.*/, '')}`)
+
+// A third invocation: an independent conversation in its own project
+// directory, with the SAME prompt text. Keying is by fingerprint, so the
+// client working directory is what has to keep these apart.
+const OTHER = randomUUID()
+const OTHER_CONFIG = realpathSync(mkdtempSync(join(tmpdir(), 'mccconf2-')))
+const OTHER_PROJECT = clientDir({ 'alpha.txt': 'BRAVO-VALUE' })
+const isoFrom = requestLines().length
+const other = await runClient(OTHER_PROJECT, OTHER_CONFIG, [
+  '-p', 'Read alpha.txt and reply with exactly its contents.',
+  '--session-id', OTHER,
+  '--allowedTools', 'Read',
+])
+const otherLines = requestLines().slice(isoFrom)
+say(`\n  conversation 2, identical prompt, own directory, exit=${other.status}: ${other.out.slice(0, 60)}`)
+for (const l of otherLines) say(`    ${l.replace(/ sdkActive.*?msgCount=/, ' msgCount=').replace(/ msgs=.*/, '')}`)
+
+say('')
+check(first.status === 0 && second.status === 0 && other.status === 0,
+  'every client invocation succeeded',
+  `exit=${first.status},${second.status},${other.status}${first.err ? ` stderr=${first.err.slice(0, 160)}` : ''}`)
+check(first.out.includes('ALPHA-VALUE'), 'the tool loop actually ran and answered',
+  `answer=${JSON.stringify(first.out.slice(0, 60))}`)
+check(second.out.includes('FINISHED'), 'the --resumed invocation answered too',
+  `answer=${JSON.stringify(second.out.slice(0, 60))}`)
+
+// 1. THE BYPASS IS GONE. This is the line the fix removes.
+const bypassed = requestLines().filter(l => l.includes('headerless-tool-result'))
+check(bypassed.length === 0, 'no request takes the headerless tool-result bypass',
+  bypassed.length ? `${bypassed.length} of ${requestLines().length} request(s) still bypassed`
+    : `across ${requestLines().length} requests`)
+
+// 2. Because the round is no longer bypassed, the end-of-turn store happens
+//    and the following turn resumes. Before the fix nothing was ever written
+//    under the key, so no later turn could resume either.
+check(firstLines.some(l => /msgCount=[3-9]/.test(l)), 'the client ran a tool round',
+  `${firstLines.length} request(s) in the first invocation`)
+check(secondLines.some(l => l.includes('lineage=continuation')),
+  'the turn after the tool round resumes the stored SDK session',
+  secondLines.map(l => /lineage=(\S+)/.exec(l)?.[1]).join(', '))
+// Reported, not asserted: the tool round ITSELF still classifies `not-found`.
+// The entry stored at a passthrough early stop is a checkpoint boundary, which
+// lineage lookup reports as missing by design, and the recovery path that
+// should upgrade it does not fire on this adapter. That is a separate and
+// larger defect — #996, where `pi` and `opencode` resume the identical shape —
+// unchanged by this fix and identical with a forwarded `x-litellm-session-id`.
+say('  note  the tool round itself reports diverged='
+  + (firstLines.filter(l => /msgCount=[3-9]/.test(l))
+      .map(l => /diverged=(\S+)/.exec(l)?.[1] ?? 'none').join(', ') || 'nothing')
+  + ' — a passthrough checkpoint boundary is reported missing by design, unchanged here')
+
+// 3. THE GUARD AGAINST THE FIX THAT LOOKED OBVIOUS. Keying on
+//    `x-claude-code-session-id` put the CLI's auxiliary requests under the
+//    same key as the conversation. Measured that way: `unrelated-history`,
+//    then HTTP 400 "This session advanced while the request was waiting."
+const collided = requestLines().filter(l => l.includes('diverged=unrelated-history'))
+check(collided.length === 0, "the CLI's auxiliary requests do not collide with the conversation",
+  collided.length ? `${collided.length} request(s) classified unrelated-history`
+    : `no unrelated-history across ${requestLines().length} requests`)
+const refused = [first, second, other].filter(r => /API Error: 4\d\d/.test(`${r.out}\n${r.err}`))
+check(refused.length === 0, 'no invocation was refused with a 4xx',
+  refused.length ? refused.map(r => r.out.slice(0, 90)).join(' | ') : 'all invocations accepted')
+
+// 4. Two conversations in different directories stay apart. With no session
+//    key the fingerprint's working-directory component is what does this.
+check(other.out.includes('BRAVO-VALUE') && !other.out.includes('ALPHA-VALUE'),
+  'a second conversation with the same prompt does not inherit the first',
+  `answer=${JSON.stringify(other.out.slice(0, 60))}`)
+check(otherLines.length > 0 && !otherLines.some(l => l.includes('lineage=continuation')),
+  'its first turns start fresh rather than resuming the other conversation',
+  otherLines.map(l => /lineage=(\S+)/.exec(l)?.[1]).join(', ') || '(no request)')
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-12)) say(`    ${l.slice(0, 200)}`)
+} else {
+  say('  PASS: a gateway-fronted Claude Code session resumes, and nothing collides')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/proxy-litellm-adapter.test.ts
+++ b/src/__tests__/proxy-litellm-adapter.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, mock } from "bun:test"
 import { passthroughAdapter } from "../proxy/adapters/passthrough"
+import { isClaudeCodeClient } from "../proxy/adapters/claudecode"
 import { detectAdapter } from "../proxy/adapters/detect"
 
 // ============================================================
@@ -58,6 +59,70 @@ describe("passthroughAdapter.getSessionId", () => {
       },
     }
     expect(passthroughAdapter.getSessionId(c as any)).toBeUndefined()
+  })
+})
+
+/**
+ * The gateway-fronted Claude Code case (#820).
+ *
+ * Behind LiteLLM the passthrough heuristic claims the request first, so a
+ * Claude Code session lands on this adapter and loses the
+ * `adapterBase === "claude-code"` exemption from the headerless tool-result
+ * bypass. LiteLLM also owns the `x-litellm-*` namespace for its own Langfuse
+ * session tracking and does not forward `x-litellm-session-id` upstream on the
+ * `anthropic/` provider route, so there is no session key either — and every
+ * tool round of the whole agentic loop took the bypass.
+ *
+ * `isClaudeCodeClient` answers "who owns the tool loop" from a header only the
+ * CLI sends. It deliberately does not answer "which adapter should run", and
+ * it is deliberately not a session key.
+ */
+describe("isClaudeCodeClient", () => {
+  const ctx = (headers: Record<string, string>) => ({
+    req: { header: (name: string) => headers[name] },
+  })
+
+  it("recognises the Claude Code CLI by its session-id header", () => {
+    expect(isClaudeCodeClient(ctx({
+      "x-claude-code-session-id": "b2004dfc-6042-48d9-9c23-b4475f64b6f5",
+    }) as any)).toBe(true)
+  })
+
+  it("does not recognise a client that only claims to be a CLI", () => {
+    expect(isClaudeCodeClient(ctx({ "x-app": "cli", "user-agent": "litellm/1.0.0" }) as any)).toBe(false)
+  })
+
+  it("does not recognise another agent's session header", () => {
+    expect(isClaudeCodeClient(ctx({ "x-litellm-session-id": "litellm-abc123" }) as any)).toBe(false)
+    expect(isClaudeCodeClient(ctx({ "x-opencode-session": "ses_1" }) as any)).toBe(false)
+  })
+
+  // The header must not move adapter selection. Routing gateway traffic to the
+  // claude-code adapter on this signal would swap tool handling, MCP naming
+  // and prompt shape for every existing LiteLLM user and move their cache
+  // prefix.
+  it("leaves the request on the passthrough adapter", () => {
+    const c = {
+      req: {
+        header: (name: string) => ({
+          "x-claude-code-session-id": "b2004dfc-6042-48d9-9c23-b4475f64b6f5",
+          "x-app": "cli",
+          "user-agent": "litellm/1.0.0",
+        })[name],
+      },
+    }
+    expect(detectAdapter(c as any).name).toBe("passthrough")
+  })
+
+  // The header is NOT a session key. The CLI reuses one session id across the
+  // auxiliary requests it makes alongside a conversation; keying on it put two
+  // unrelated histories under one key, which was measured live as
+  // `unrelated-history` and an HTTP 400 concurrent conflict — a hard failure
+  // where there had only been a silent inefficiency.
+  it("is not adopted as a session key", () => {
+    expect(passthroughAdapter.getSessionId(ctx({
+      "x-claude-code-session-id": "b2004dfc-6042-48d9-9c23-b4475f64b6f5",
+    }) as any)).toBeUndefined()
   })
 })
 

--- a/src/__tests__/proxy-passthrough-claude-code-session.test.ts
+++ b/src/__tests__/proxy-passthrough-claude-code-session.test.ts
@@ -1,0 +1,174 @@
+/**
+ * A gateway-fronted Claude Code session keeps the exemption it has directly
+ * (#820).
+ *
+ * The headerless tool-result bypass exempts `adapterBase === "claude-code"`,
+ * because Claude Code owns its tool loop but still expects Meridian to resume
+ * the backing SDK session. Behind LiteLLM the passthrough heuristic claims the
+ * request first, so that exemption was lost — and LiteLLM owns the
+ * `x-litellm-*` namespace for its own Langfuse session tracking and does not
+ * forward `x-litellm-session-id` upstream on the `anthropic/` provider route,
+ * so there was no session key either. @StanChmielewski verified that with an
+ * identical two-request probe down both paths: direct to Meridian logged
+ * `Stale session detected`, through LiteLLM logged nothing.
+ *
+ * Every tool round of the whole agentic loop then took the bypass, at 35k-56k
+ * cache-write tokens per turn with `cache_read` pinned at 30629, against 46-53
+ * tokens on a direct connection; one 764-turn session accumulated 90M
+ * cache-creation tokens.
+ *
+ * The exemption now follows the CLIENT rather than the adapter. Adapter
+ * selection is untouched, and `x-claude-code-session-id` is deliberately NOT
+ * adopted as a session key — see the collision case at the bottom.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test"
+import { installSdkMock } from "./sdkMock"
+import { installLoggerMock } from "./loggerMock"
+import { installMcpToolsMock } from "./mcpToolsMock"
+import { assistantMessage, resolveMockSdkSessionId } from "./helpers"
+
+let mockMessages: unknown[] = []
+let capturedOptions: any[] = []
+
+installSdkMock(() => ({
+  query: (params: any) => {
+    const options = params.options || {}
+    capturedOptions.push(options)
+    const sessionId = resolveMockSdkSessionId(options, "cc-gateway-session")
+    return (async function* () {
+      for (const msg of mockMessages) yield { ...(msg as object), session_id: sessionId }
+    })()
+  },
+  createSdkMcpServer: () => ({ type: "sdk", name: "test", instance: {} }),
+  tool: () => ({}),
+}), "proxy-passthrough-claude-code-session.test.ts")
+
+installLoggerMock(() => ({
+  claudeLog: () => {},
+  withClaudeLogContext: (_ctx: unknown, fn: () => unknown) => fn(),
+}))
+
+installMcpToolsMock(() => ({
+  createOpencodeMcpServer: () => ({ type: "sdk", name: "opencode", instance: {} }),
+}))
+
+const { createProxyServer, clearSessionCache } = await import("../proxy/server")
+
+function createTestApp() {
+  const { app } = createProxyServer({ port: 0, host: "127.0.0.1" })
+  return app
+}
+
+async function post(app: any, body: any, headers: Record<string, string> = {}) {
+  return app.fetch(new Request("http://localhost/v1/messages", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  }))
+}
+
+/** The real header value shape: a CLI session UUID. */
+const CC_SESSION = "b2004dfc-6042-48d9-9c23-b4475f64b6f5"
+
+const TURN_1 = {
+  model: "claude-sonnet-4-5",
+  max_tokens: 1024,
+  stream: false,
+  messages: [{ role: "user", content: "read alpha.txt and tell me what it says" }],
+}
+
+/** Ends in user[tool_result] — the shape that took the bypass. */
+const TURN_2 = {
+  ...TURN_1,
+  messages: [
+    ...TURN_1.messages,
+    { role: "assistant", content: [{ type: "tool_use", id: "tu1", name: "Read", input: { file_path: "alpha.txt" } }] },
+    { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "ALPHA-VALUE" }] },
+  ],
+}
+
+/** A plain follow-up after the tool round. */
+const TURN_3 = {
+  ...TURN_1,
+  messages: [
+    ...TURN_2.messages,
+    { role: "assistant", content: "It says ALPHA-VALUE." },
+    { role: "user", content: "thanks, now say FINISHED" },
+  ],
+}
+
+describe("gateway-fronted Claude Code session identity", () => {
+  const gateway = { "x-meridian-agent": "passthrough", "x-claude-code-session-id": CC_SESSION }
+
+  beforeEach(() => {
+    mockMessages = [assistantMessage([{ type: "text", text: "ok" }])]
+    capturedOptions = []
+    clearSessionCache()
+  })
+
+  afterEach(() => {
+    clearSessionCache()
+  })
+
+  // THE REPORTED CASE. The tool round used to take the bypass, which skips the
+  // lineage lookup AND the end-of-turn store.
+  it("resumes a tool-result round instead of bypassing it", async () => {
+    const app = createTestApp()
+    expect((await post(app, TURN_1, gateway)).status).toBe(200)
+    expect((await post(app, TURN_2, gateway)).status).toBe(200)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[0].resume).toBeUndefined()
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
+  })
+
+  it("keeps resuming across a following plain turn", async () => {
+    const app = createTestApp()
+    await post(app, TURN_1, gateway)
+    await post(app, TURN_2, gateway)
+    await post(app, TURN_3, gateway)
+    expect(capturedOptions).toHaveLength(3)
+    expect(capturedOptions[2].resume).toBeDefined()
+  })
+
+  // The bypass must stay intact for every client that is NOT Claude Code. This
+  // is the guard the exemption could quietly remove.
+  it("leaves the bypass in place for a client that does not send the header", async () => {
+    const app = createTestApp()
+    const headerless = { "x-meridian-agent": "passthrough" }
+    await post(app, TURN_1, headerless)
+    await post(app, TURN_2, headerless)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+
+  // An explicit LiteLLM key still wins, and still keys the conversation.
+  it("resumes a keyed LiteLLM conversation as before", async () => {
+    const app = createTestApp()
+    const keyed = { "x-meridian-agent": "passthrough", "x-litellm-session-id": "litellm-forwarded" }
+    await post(app, TURN_1, keyed)
+    await post(app, TURN_2, keyed)
+    expect(capturedOptions).toHaveLength(2)
+    expect(capturedOptions[1].resume).toBe(capturedOptions[0].sessionId)
+  })
+
+  // WHY THE HEADER IS NOT THE KEY. The CLI reuses one session id across the
+  // auxiliary requests it makes alongside a conversation. Keying on it put two
+  // unrelated first messages under one key; live, that produced
+  // `unrelated-history` and an HTTP 400 concurrent conflict — turning a silent
+  // inefficiency into a hard client failure. Keyed by fingerprint the two
+  // simply do not meet.
+  it("does not conflate two different conversations under one CLI session id", async () => {
+    const app = createTestApp()
+    const AUXILIARY = {
+      ...TURN_1,
+      messages: [{ role: "user", content: "Summarise this conversation in five words." }],
+    }
+    expect((await post(app, TURN_1, gateway)).status).toBe(200)
+    expect((await post(app, AUXILIARY, gateway)).status).toBe(200)
+    expect(capturedOptions).toHaveLength(2)
+    // A shared key would have classified this as unrelated-history and, once
+    // the first turn had committed, refused it outright.
+    expect(capturedOptions[1].resume).toBeUndefined()
+  })
+})

--- a/src/proxy/adapters/claudecode.ts
+++ b/src/proxy/adapters/claudecode.ts
@@ -121,6 +121,31 @@ export function extractClaudeCodeParentSessionId(body: unknown): string | undefi
   return extractClaudeCodeSessionIdentity(body)?.parentSessionId
 }
 
+/**
+ * Is this request from the Claude Code CLI, whatever adapter is handling it?
+ *
+ * Claude Code sends `x-claude-code-session-id` on every request — verified
+ * against 2.1.266 that it is the CLI session UUID, pinned exactly by
+ * `--session-id`. No other client sends it, so it identifies the client even
+ * when a gateway has rewritten the User-Agent and the LiteLLM heuristic has
+ * already claimed the request.
+ *
+ * This answers "who owns the tool loop", not "which adapter should run". The
+ * header is deliberately NOT used for adapter selection: routing gateway
+ * traffic to the claude-code adapter would swap tool handling, MCP naming and
+ * prompt shape for every existing LiteLLM user and move their cache prefix.
+ *
+ * It is also NOT a session key. The CLI reuses one session id across the
+ * auxiliary requests it makes alongside a conversation, so keying on it puts
+ * two unrelated histories under one key — measured live as
+ * `unrelated-history` and an HTTP 400 concurrent conflict, i.e. a hard failure
+ * where there had only been a silent inefficiency. See
+ * `scripts/e2e-passthrough-claude-code-session.mjs`, which guards that.
+ */
+export function isClaudeCodeClient(c: Context): boolean {
+  return Boolean(c.req.header("x-claude-code-session-id"))
+}
+
 export const claudeCodeAdapter: AgentAdapter = {
   name: "claude-code",
 

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -75,6 +75,7 @@ import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDef
 import type { AnthropicSseEvent } from "./openai"
 import { translateOpenAiToAnthropic, translateAnthropicToOpenAi, buildModelList, createSseTranslator } from "./openai"
 import { normalizeJcodeSessionId } from "./adapters/jcode"
+import { isClaudeCodeClient } from "./adapters/claudecode"
 import { translateResponsesToAnthropic, translateAnthropicToResponses, createResponsesSseTranslator, reasoningRequested, buildResponsesToolAliases, resolveCodexThreadIdentity, type ResponsesRequest, type AnthropicSseEvent as ResponsesAnthropicSseEvent } from "./openaiResponses"
 import { flattenAssistantContent, normalizeStructuredUserContent, replayToolResultHeader, frameStructuredReplay, coalesceStructuredUserMessages } from "./replay"
 import { extractAdvisorModel, extractSystemText, getLastUserMessage, stripAdvisorTools, stripNonStandardStreamFields, MULTIMODAL_TYPES, buildToolUseIndex, frameReplayTurns } from "./messages"
@@ -2163,7 +2164,19 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // resume the backing SDK session. Older clients may omit metadata, so
         // preserve fingerprint resume instead of treating their tool results
         // as unrelated headerless workflow requests.
-        const isClientDrivenLoop = adapterBase !== "claude-code" && !agentSessionId && lastIsToolResult
+        //
+        // The exemption follows the CLIENT, not the adapter. Behind a gateway
+        // the LiteLLM heuristic claims the request first, so a Claude Code
+        // session arrived on the passthrough adapter and lost the exemption —
+        // and LiteLLM does not forward `x-litellm-session-id` upstream on the
+        // `anthropic/` provider route, so it had no session key either. Every
+        // tool round of the whole agentic loop then took this bypass (#820),
+        // measured at 35k-56k cache-write tokens per turn against 46-53 on a
+        // direct connection. `isClaudeCodeClient` restores the parity: same
+        // fingerprint keying a direct Claude Code request already gets, with
+        // adapter selection untouched.
+        const ownsToolLoopWithResume = adapterBase === "claude-code" || isClaudeCodeClient(c)
+        const isClientDrivenLoop = !ownsToolLoopWithResume && !agentSessionId && lastIsToolResult
         const durableMappingKey = profileSessionId
           || getConversationFingerprint(lineageMessages, profileScopedCwd)
         // The fork/subagent independence guard protects HEADERLESS flows from


### PR DESCRIPTION
Keeps a gateway-fronted Claude Code session in the tool-loop exemption it
already has on a direct connection.

Refs #820. This is @StanChmielewski's half of that issue; the diagnostic half
shipped in #994.

## The problem

The headerless tool-result bypass exempts `adapterBase === "claude-code"`,
because Claude Code owns its tool loop but still expects Meridian to resume the
backing SDK session. Behind LiteLLM the passthrough heuristic claims the
request first, so that exemption was lost — and LiteLLM owns the
`x-litellm-*` namespace for its own Langfuse session tracking and does not
forward `x-litellm-session-id` upstream on the `anthropic/` provider route, so
there was no session key either.

@StanChmielewski verified both halves with an identical two-request probe down
both paths — direct to Meridian logged `Stale session detected`, through
LiteLLM logged nothing — and measured the cost:

```
via Meridian    cache_write 35k–56k per turn,  cache_read pinned at 30629
direct          cache_write 46 and 53 tokens,  cache_read 39352 → 39398
```

One 764-turn session accumulated 90M `cache_creation_input_tokens`, and a fresh
5-hour Max window drained in about two hours of ordinary work.

## What this changes

One line of decision: the exemption follows the **client**, not the adapter.

```ts
const ownsToolLoopWithResume = adapterBase === "claude-code" || isClaudeCodeClient(c)
const isClientDrivenLoop = !ownsToolLoopWithResume && !agentSessionId && lastIsToolResult
```

`isClaudeCodeClient` reads `x-claude-code-session-id`, which the CLI sends on
every request and no other client sends. Keying is unchanged: a gateway-fronted
Claude Code session now gets exactly the conversation-fingerprint resume a
direct one already gets.

## What I tried first, and why the live gate rejected it

@StanChmielewski's suggestion 1 was to read `x-claude-code-session-id` as a
session id in `passthroughAdapter.getSessionId`. I built that first and
verified the header is real: against Claude Code 2.1.266 it is the CLI session
UUID, `--session-id` pins it exactly, and separate sessions get distinct
values.

**Driving the actual CLI showed it is not usable as a key.** Claude Code makes
auxiliary requests alongside a conversation under the same session id — this
run shows a `tools=0` request and the `tools=12` conversation, each with a
different first message. Keyed on the session id they land under one key:

```
adapter=passthrough tools=0  lineage=new diverged=not-found          msgCount=1
[PROXY] Session not resumable (key=193de1c8…): reason=unrelated-history, prefix overlap 0/1
API Error: 400 This session advanced while the request was waiting.
```

That converts a silent inefficiency into a hard client failure. A hand-written
two-request probe would never have emitted that second request, so nothing
short of the real client would have caught it. The header therefore identifies
the client and nothing else.

I also declined suggestion 2 as written — making the header a Claude Code
signal in `detect.ts` — because routing gateway traffic to the `claudecode`
adapter would swap tool handling, MCP naming and prompt shape for every
existing LiteLLM user and move their prompt-cache prefix. Exempting the tool
loop achieves the reported outcome without touching adapter selection, which
is how @StanChmielewski himself framed suggestion 1: "defusing
`isClientDrivenLoop` without touching the guard."

## Validation

`npm test`: **3775 pass, 1 skip, 0 fail** (bun 1.3.11, matching CI).
`npm run typecheck`, `npm run build`: clean.

**Failed before, passes after.** `proxy-passthrough-claude-code-session.test.ts`
against `origin/main` fails exactly the reported case and passes all four
regression guards:

```
(fail) resumes a tool-result round instead of bypassing it
  Expected: "7b010e00-c7d1-48b1-a95d-f0686ebc1bd0"   Received: undefined
 4 pass  1 fail
```

**Live E2E — new gate E55** (`bun scripts/e2e-passthrough-claude-code-session.mjs`),
real proxy, real SDK, and the **real Claude Code CLI 2.1.266 as the client**,
7 proxy requests across three invocations:

```
turn 1   tools=0   msgCount=1  lineage=new           diverged=not-found   (auxiliary CLI request)
turn 1   tools=12  msgCount=1  lineage=new           diverged=not-found
turn 1   tools=12  msgCount=3  lineage=new           diverged=not-found   (tool round, no longer bypassed)
turn 2   tools=12  msgCount=5  lineage=continuation
```

All ten checks pass, including the two that guard the rejected approach: no
request classifies `unrelated-history`, and no invocation is refused with a
4xx.

**E41 all four modes** (the independence decision changed): pass.
**E54**: pass (cache-write ratio 6.5x this run, against 7.2x and 7.1x on #994).

## What this does not fix

The tool round *itself* still classifies `not-found`, and that turns out to be
a bigger and separate defect: **the passthrough adapter never resumes a
tool-result round, even with a session key it does read.** A controlled A/B —
same passthrough mode, same tools, same messages, same explicit key, only the
adapter differing — measures it cleanly:

```
pi           (x-session-affinity)     1:new(not-found)  3:continuation    5:continuation    7:continuation
passthrough  (x-litellm-session-id)   1:new(not-found)  3:new(not-found)  5:new(not-found)  7:new(not-found)
opencode     (x-opencode-session)     1:new(not-found)  3:continuation    5:continuation    7:continuation
```

That predates this change and is independent of it — it is neither caused nor
fixed here — so E55 prints the round's classification as a note rather than
asserting it. Filed as #996 with this reproduction and with where the trail
went cold (`advancesDurableCheckpoint` fires for `pi` and `opencode` and not
for `passthrough`; I have not established why).
