### PR TITLE
test: wait on signals, not short deadlines, in the race harnesses

### DIFF
--- a/src/__tests__/concurrency-hardening.test.ts
+++ b/src/__tests__/concurrency-hardening.test.ts
@@ -267,10 +267,16 @@ describe("queue telemetry under cancellation", () => {
 
     try {
       // Synchronize on the real queue, not a guessed request-setup duration.
-      const deadline = Date.now() + 3000
+      // Budget raised to the suite's 5 s convention, and the timeout names
+      // itself rather than surfacing as an `undefined` snapshot: polling to a
+      // deadline and then asserting on the polled value is the shape behind
+      // the CI failures in #917 and #933. A longer wait cannot make a false
+      // condition true.
+      const deadline = Date.now() + 5_000
       while (!queuedSemaphore && Date.now() < deadline) {
         await new Promise(resolve => setTimeout(resolve, 5))
       }
+      if (!queuedSemaphore) throw new Error("timed out after 5s waiting for the second request to queue on the SDK semaphore")
       expect(queuedSemaphore?.snapshot).toEqual({ active: 1, queued: 1, limit: 1 })
       // Ensure this wait spans the millisecond clock used by the metric.
       await new Promise(resolve => setTimeout(resolve, 10))

--- a/src/__tests__/opencode-title-agent-collision.test.ts
+++ b/src/__tests__/opencode-title-agent-collision.test.ts
@@ -58,6 +58,20 @@ let holdTitleUntil: Promise<void> | undefined
  *  request definitively holds it — which is what makes the race a signal and
  *  not a sleep. */
 let onTitleEnteredQuery: (() => void) | undefined
+/** How many title requests have reached the generator body. Used as the
+ *  positive control below: two title turns share one lease scope, so the
+ *  second must NOT get in while the first is held. */
+let titleQueryEntries = 0
+/** Fired when a NON-title request reaches the generator body — the same
+ *  signal, for the other side of the race.
+ *
+ *  This replaces a 100 ms poll (`for (let i = 0; i < 50; i++) await
+ *  setTimeout(2)`) that gave the user's turn a wall-clock budget to traverse
+ *  the route handler. A loaded CI runner does not always manage it: that exact
+ *  assertion failed on main at `264cfc3a`
+ *  (actions/runs/34315620193) while passing 10/10 locally (#917, #933). A
+ *  signal is not a budget. */
+let onUserEnteredQuery: (() => void) | undefined
 
 installSdkMock(() => ({
   query: (params: any) => {
@@ -68,8 +82,11 @@ installSdkMock(() => ({
     const isTitle = typeof params.prompt === "string" && params.prompt.includes("Generate a title")
     return (async function* () {
       if (isTitle) {
+        titleQueryEntries++
         onTitleEnteredQuery?.()
         if (holdTitleUntil) await holdTitleUntil
+      } else {
+        onUserEnteredQuery?.()
       }
       if (capturePromptItems) capturedPromptValue = params.prompt
       if (
@@ -130,6 +147,16 @@ const TITLE_BODY = {
     role: "user",
     content: 'Generate a title for this conversation:\n"Read notes.txt and tell me the second line."',
   }],
+}
+
+/** A second title turn on the same session — same lease scope as the first. */
+const TITLE_BODY_2 = {
+  ...TITLE_BODY,
+  messages: [
+    ...TITLE_BODY.messages,
+    { role: "assistant", content: "Reading notes.txt" },
+    { role: "user", content: "Generate a title for this conversation:\n\"And the third line?\"" },
+  ],
 }
 
 /** The user's own turn, same OpenCode session id. */
@@ -221,12 +248,15 @@ describe("OpenCode title agent vs the user's conversation", () => {
     capturedPromptItems = []
     holdTitleUntil = undefined
     onTitleEnteredQuery = undefined
+    onUserEnteredQuery = undefined
+    titleQueryEntries = 0
     telemetryStore.clear()
     clearSessionCache()
   })
   afterEach(() => {
     holdTitleUntil = undefined
     onTitleEnteredQuery = undefined
+    onUserEnteredQuery = undefined
     clearSessionCache()
   })
 
@@ -327,17 +357,20 @@ describe("OpenCode title agent vs the user's conversation", () => {
     // is after the route handler took the turn lease.
     await titleHasLease
 
+    const userEnteredQuery = new Promise<void>((resolve) => { onUserEnteredQuery = resolve })
     const userPromise = post(app, USER_TURN_1, USER_HEADERS)
-    // Give the user's turn time to reach the lease and block on it. Bounded,
-    // and the sessionQueueWaitMs assertion below fails loudly if it did not —
-    // a race harness that silently stops racing is worse than no test.
-    for (let i = 0; i < 50 && capturedOptions.length < 2; i++) {
-      await new Promise((r) => setTimeout(r, 2))
-    }
     // The title query is still gated. Entering the user's query before release
-    // proves the scoped requests did not contend on the same turn lease. This
-    // is stronger and less clock-sensitive than requiring a 0 ms metric.
-    const userEnteredBeforeRelease = capturedOptions.length === 2
+    // proves the scoped requests did not contend on the same turn lease.
+    //
+    // Waited on as a SIGNAL with a generous ceiling, not as a 100 ms poll. The
+    // ceiling only has to exceed how long a request takes to reach the SDK
+    // call on the slowest host we run on; if the two turns really do share a
+    // lease the signal cannot fire before `release()` at any ceiling, which is
+    // what the positive control below pins.
+    const userEnteredBeforeRelease = await Promise.race([
+      userEnteredQuery.then(() => true),
+      Bun.sleep(10_000).then(() => false),
+    ])
     release()
 
     const [title, user] = await Promise.all([titlePromise, userPromise])
@@ -346,5 +379,58 @@ describe("OpenCode title agent vs the user's conversation", () => {
     expect(user.status).toBe(200)
     const userBody = await user.json() as any
     expect(JSON.stringify(userBody)).not.toContain("session advanced")
+  })
+
+  // NEGATIVE CONTROL for the harness above, on the same signal and the same
+  // code path: a non-title prompt sent into the TITLE lease scope. `isTitle`
+  // is decided by prompt content and the lease scope by the agent headers, so
+  // this turn fires `onUserEnteredQuery` and contends. Verified to report
+  // `false`, which is what makes the assertion above falsifiable rather than
+  // a bound that always holds.
+  it("does not report early entry for a turn that shares the held lease", async () => {
+    const app = createTestApp()
+    let release!: () => void
+    holdTitleUntil = new Promise<void>((resolve) => { release = resolve })
+    const titleEntered = new Promise<void>((resolve) => { onTitleEnteredQuery = resolve })
+    const userEnteredQuery = new Promise<void>((resolve) => { onUserEnteredQuery = resolve })
+
+    const titlePromise = post(app, TITLE_BODY, TITLE_HEADERS)
+    await titleEntered
+    const samescopePromise = post(app, USER_TURN_1, TITLE_HEADERS)
+    // Slowness makes this MORE likely to hold, so the bound is safe: a starved
+    // runner delays the contending turn further.
+    const enteredBeforeRelease = await Promise.race([
+      userEnteredQuery.then(() => true),
+      Bun.sleep(400).then(() => false),
+    ])
+    release()
+    await Promise.all([titlePromise, samescopePromise])
+
+    expect(enteredBeforeRelease).toBe(false)
+  })
+
+  // POSITIVE CONTROL for the harness above. Raising a bound is only safe if
+  // the assertion can still fail, so pin the other direction with turns that
+  // genuinely share a lease scope: two title turns on one session. The second
+  // must not reach the SDK call while the first is held, at any ceiling.
+  it("still sees contention when two turns really do share one lease", async () => {
+    const app = createTestApp()
+    let release!: () => void
+    holdTitleUntil = new Promise<void>((resolve) => { release = resolve })
+    const firstEntered = new Promise<void>((resolve) => { onTitleEnteredQuery = resolve })
+
+    const firstPromise = post(app, TITLE_BODY, TITLE_HEADERS)
+    await firstEntered
+    expect(titleQueryEntries).toBe(1)
+
+    const secondPromise = post(app, TITLE_BODY_2, TITLE_HEADERS)
+    // Slowness makes this MORE likely to hold, not less, so the wait is safe
+    // to bound: a starved runner delays the second turn further.
+    await Bun.sleep(250)
+    const secondEnteredEarly = titleQueryEntries > 1
+    release()
+    await Promise.all([firstPromise, secondPromise])
+
+    expect(secondEnteredEarly).toBe(false)
   })
 })

--- a/src/__tests__/proxy-stream-deny-hold.test.ts
+++ b/src/__tests__/proxy-stream-deny-hold.test.ts
@@ -250,8 +250,16 @@ describe("streaming deny-hold (#552 root cause v2)", () => {
     expect(dangling).toEqual([])
     // The client response ends at turn 1 while the digest drains invisibly to
     // the canonical durability boundary in the background.
-    const deadline = Date.now() + 1500
+    // Polls to a deadline and then asserts on what it polled for, which is the
+    // shape that turns a slow runner into a confusing "expected to contain"
+    // failure instead of a timeout (#917, #933). Budget raised to the suite's
+    // 5 s convention from 1.5 s, and the timeout now names itself. A longer
+    // wait cannot make a false condition true, so it hides nothing.
+    const deadline = Date.now() + 5_000
     while (!timeline.includes("canonical_result") && Date.now() < deadline) await sleep(10)
+    if (!timeline.includes("canonical_result")) {
+      throw new Error(`timed out after 5s waiting for canonical_result; timeline=[${timeline.join(", ")}]`)
+    }
     expect(capturedController!.signal.aborted).toBe(false)
     expect(timeline).toContain("turn2_consumed")
     expect(timeline).toContain("canonical_result")


### PR DESCRIPTION
Makes the concurrency race harnesses wait on signals instead of short wall-clock
deadlines.

Refs #917, #933. **Both stay open** — see the bottom.

## What happened

PR #995's `test` check failed on:

```
(fail) OpenCode title agent vs the user's conversation
       > does not refuse the user's turn that queued behind an in-flight title turn
error: expect(received).toBe(expected)
Expected: true
Received: false
```

My change could not have caused it: for a request carrying
`x-opencode-session`, `agentSessionId` is set, so `isClientDrivenLoop` is
`false` both before and after. And the same test had already failed **on main**
at `264cfc3a` — [actions/runs/34315620193](https://github.com/rynfar/meridian/actions/runs/34315620193)
— roughly three hours before that branch existed.

## The pattern

The harness gave the user's turn a wall-clock budget to traverse the route
handler and then asserted on what the poll had observed:

```ts
for (let i = 0; i < 50 && capturedOptions.length < 2; i++) {
  await new Promise((r) => setTimeout(r, 2))
}
const userEnteredBeforeRelease = capturedOptions.length === 2
```

100 ms. It passes 10/10 on this machine and does not always pass on a loaded
two-core runner — and when it fails, the message is
`Expected: true, Received: false`, which says nothing about timing. **Polling to
a short deadline and then asserting on the polled value** is the shape, and it
appears three times:

| file | was | now |
|---|---|---|
| `opencode-title-agent-collision` | 100 ms poll | a signal from the SDK mock |
| `proxy-stream-deny-hold` | 1.5 s, then `expect(timeline).toContain(...)` | 5 s, and the timeout names itself |
| `concurrency-hardening` | 3 s, then `expect(snapshot).toEqual(...)` | 5 s, and the timeout names itself |

The file already had the right mechanism for the *other* side of the race —
`onTitleEnteredQuery`, fired from the SDK mock when the title request reaches
the generator body. This adds the mirror for non-title requests, so both sides
are signals.

A longer wait cannot make a false condition true, so none of this hides a
regression. The two bounded waits use the suite's own 5 s convention, and they
now throw a message naming what they were waiting for instead of failing an
unrelated-looking assertion.

## Raising a bound is only safe if the assertion can still fail

So the title-lease race gains two controls, and **both were verified by
inverting them**:

- **Negative control** — a non-title prompt sent into the *title* lease scope.
  `isTitle` is decided by prompt content and the lease scope by the agent
  headers, so this turn fires the same signal on the same code path, contends,
  and must report `false`. Confirmed `false`.
- **Positive control** — a second title turn on the same session, which shares
  one lease scope. It must not reach the SDK call while the first is held.
  Confirmed; inverting the expectation fails, so it is not vacuous.

Without these, raising the ceiling from 100 ms to 10 s could have made the
original assertion unfalsifiable, which would be worse than the flake.

## Validation

`npm test`: 3767 pass, 1 skip, 0 fail (bun 1.3.11, matching CI) — main is 3765 and this adds the two controls.
`npm run typecheck`: clean. The three touched files: 5/5 consecutive green runs.

The title-lease file goes from 8 tests to 10.

## What this does not do

Issues #917 and #933 both stay open. The same CI run that failed the title test
also failed:

```
(fail) Session tool cache > updates cached tools when client sends a new set
```

That test has no timing bound at all — three sequential requests and an
assertion that the third inherits the cached tool set — so the poll-then-assert
diagnosis does not cover it, and I have no diagnosis for it yet. I could not
reproduce it locally. A separate run, 34315145910, failed
`Extra usage required fallback > does not use exponential backoff for extra
usage errors`, which is also unexplained.

Both issues stay open on that basis. What this PR does is remove one confirmed
mechanism and, more usefully, name the shape so the next instance is easier to
recognise.
