### PR TITLE
fix(passthrough): arm the early-stop tracker on the adapter's own namespace

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -279,6 +279,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E53 | [Auto-defer pin](#e53-auto-defer-pin) | **Automated**: `bun scripts/e2e-defer-pin.mjs` — real proxy + SDK, A/B. Two three-turn conversations, one crossing the auto-defer threshold on its last turn. Asserts deferral (and so `maxTurns`) does not flip mid-session and that the suppressed flip is logged. **Run before releases touching auto-defer, tool registration, or prompt assembly** | 2026-09-09 |
 | E54 | [Lineage divergence reason](#e54-lineage-divergence-reason) | **Automated**: `bun scripts/e2e-lineage-divergence-reason.mjs` — real proxy + SDK, A/B. Drives a headerless pi tool loop and the same loop with `x-session-affinity`. Asserts no divergence is silent, that the headerless bypass names itself, that the advice is printed once per process, and that the named remedy actually restores resume and prompt-cache reuse. **Run before releases touching lineage classification, the independence guards, or the request log line** | 2026-09-09 |
 | E55 | [Gateway-fronted Claude Code](#e55-gateway-fronted-claude-code) | **Automated, needs the `claude` CLI** (skips cleanly without it): `bun scripts/e2e-passthrough-claude-code-session.mjs` — real proxy + SDK, and the REAL Claude Code CLI as the client. Asserts a gateway-fronted Claude Code session keeps the tool-loop exemption it has on a direct connection, that its following turn resumes, and that the CLI's auxiliary requests do not collide with the conversation. **Run before releases touching the independence guards, adapter detection, or passthrough session identity** | 2026-09-09 |
+| E56 | [Namespaced tool-round resume](#e56-namespaced-tool-round-resume) | **Automated**: `bun scripts/e2e-passthrough-namespace-resume.mjs` — real proxy + SDK, three adapters. Drives an identical keyed tool loop on `pi`, `passthrough` and `opencode` and asserts every keyed tool round resumes on all of them, so an adapter-specific client-tool namespace cannot silently take the resume checkpoint away. **Run before releases touching the passthrough namespace, the early-stop tracker, or checkpoint storage** | 2026-09-09 |
 
 | P1 | [Profile: List & Auth Status](#p1-profile-list--auth-status) | `/profiles/list` returns profiles with emails, login status, auth timestamps | - |
 | P2 | [Profile: Switch via API](#p2-profile-switch-via-api) | `POST /profiles/active` switches profile; health endpoint reflects new email | - |
@@ -4518,6 +4519,50 @@ turn 2   tools=12  msgCount=5  lineage=continuation
 
 Keyed on `x-claude-code-session-id` instead, the same run produced
 `diverged=unrelated-history` and `API Error: 400`.
+
+## E56: Namespaced tool-round resume
+
+**What it proves:** a client-driven tool round resumes on **every** adapter,
+whatever namespace its client tools sit in.
+
+#983 gave each adapter its own passthrough client-tool namespace, so the
+LiteLLM adapter registers client tools as `mcp__litellm__*`. The early-stop
+tracker is what freezes the resume checkpoint, and it arms by matching those
+names — but `noteAssistantMessage` called `noteAssistantContent` with the
+**default** prefix. On that adapter nothing was ever added to `expected`: no
+checkpoint UUID was frozen, no `passthroughToolCallIds` were stored, and every
+tool round started a fresh SDK session (#996).
+
+`isClientForwardedToolUse` is strict about foreign `mcp__*` names on purpose,
+which is exactly what made the missed prefix silent instead of noisy. It took a
+cross-adapter A/B and then a bisect to find:
+
+```
+15529b12 (pre-#983)  passthrough resumed 3/3 keyed tool rounds
+96dc5605 (main)      passthrough resumed 0/3
+with the fix         passthrough resumed 3/3
+```
+
+```bash
+bun scripts/e2e-passthrough-namespace-resume.mjs
+```
+
+An identical four-round keyed tool loop on the three adapters that read an
+explicit session key and run passthrough tool loops. `passthrough` is the one
+that regressed; `pi` and `opencode` are the controls that made the regression
+visible as an asymmetry rather than as an absolute.
+
+**Pass criteria** (asserted, non-zero exit on any):
+
+- Every loop completes and runs at least two real tool rounds.
+- **Every keyed tool round reports `lineage=continuation`, on every adapter.**
+- All three adapters agree on the tool-round shape. This is the assertion that
+  actually catches the class of bug: a single-adapter gate would have passed
+  throughout, because each adapter looks self-consistent on its own.
+
+**Verified:** 2026-09-09, Haiku 4.5. On main before the fix, `pi` and
+`opencode` report `continuation` on all three tool rounds and `passthrough`
+reports `new` on all three. After, all three agree.
 
 ## Concurrent transcript publication
 

--- a/scripts/e2e-passthrough-namespace-resume.mjs
+++ b/scripts/e2e-passthrough-namespace-resume.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+// Live: does a client-driven tool round resume on EVERY adapter, or only on the
+// ones whose client tools happen to sit in the default namespace?
+//
+// #983 gave each adapter its own passthrough client-tool namespace, so the
+// LiteLLM adapter registers client tools as `mcp__litellm__*`. The early-stop
+// tracker is what freezes the resume checkpoint, and it arms by matching those
+// names — but `noteAssistantMessage` called `noteAssistantContent` with the
+// DEFAULT prefix. On that adapter nothing was ever added to `expected`: no
+// checkpoint UUID, no stored `passthroughToolCallIds`, and so every tool round
+// started a fresh SDK session (#996).
+//
+// `isClientForwardedToolUse` is strict about foreign `mcp__*` names on purpose,
+// which is exactly what made the missed prefix silent rather than noisy. It
+// cost a bisect to find:
+//
+//   15529b12 (pre-#983)  passthrough resumed 3/3 tool rounds
+//   96dc5605 (main)      passthrough resumed 0/3
+//
+// This gate is the A/B that found it, kept as a gate because nothing in a
+// single-adapter run would have shown it. Every adapter with an explicit
+// session key must resume its tool rounds; an adapter-specific namespace is
+// exactly the kind of change that can silently take that away again.
+//
+// Needs Claude Max and costs a few cents of real tokens. Run before releases
+// touching the passthrough namespace, the early-stop tracker, or checkpoint
+// storage.
+//
+//   bun scripts/e2e-passthrough-namespace-resume.mjs
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setSessionStoreDir } from '../src/proxy/sessionStore.ts'
+
+const WORKDIR = realpathSync(mkdtempSync(join(tmpdir(), 'mnsresume-')))
+process.env.MERIDIAN_WORKDIR = WORKDIR
+setSessionStoreDir(join(WORKDIR, 'store'))
+process.env.MERIDIAN_PASSTHROUGH = '1'
+
+const FILES = { 'alpha.txt': 'ALPHA-VALUE', 'bravo.txt': 'BRAVO-VALUE', 'charlie.txt': 'CHARLIE-VALUE' }
+for (const [name, body] of Object.entries(FILES)) writeFileSync(join(WORKDIR, name), body + '\n')
+
+const { startProxyServer } = await import('../src/proxy/server.ts')
+
+const PORT = Number(process.env.PROBE_PORT ?? 3558)
+const MODEL = process.env.PROBE_MODEL ?? 'claude-haiku-4-5-20251001'
+
+const say = console.log.bind(console)
+const proxyLog = []
+for (const k of ['log', 'error', 'debug', 'warn']) console[k] = (...a) => { proxyLog.push(a.map(String).join(' ')) }
+const inst = await startProxyServer({ port: PORT, host: '127.0.0.1' })
+
+const failures = []
+const check = (ok, label, detail) => {
+  say(`  ${ok ? 'PASS' : 'FAIL'}  ${label}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures.push(label)
+}
+
+const TOOL = {
+  name: 'read',
+  description: 'Read a file from disk. Read exactly one file per call.',
+  input_schema: {
+    type: 'object',
+    properties: { file_path: { type: 'string', description: 'Absolute path' } },
+    required: ['file_path'],
+  },
+}
+const PROMPT = 'Read these three files ONE AT A TIME, waiting for each result before the next call: '
+  + Object.keys(FILES).map(f => join(WORKDIR, f)).join(', ')
+  + '. After the third, reply with the three contents separated by commas.'
+
+/** Drive a client-side tool loop with an explicit session key. */
+async function loop(agent, headerName) {
+  const key = `nsresume-${agent}-${process.pid}`
+  const messages = [{ role: 'user', content: PROMPT }]
+  const rounds = []
+  for (let round = 1; round <= 4; round++) {
+    const before = proxyLog.length
+    const res = await fetch(`http://127.0.0.1:${PORT}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-meridian-agent': agent, [headerName]: key },
+      body: JSON.stringify({ model: MODEL, max_tokens: 1024, stream: false, tools: [TOOL], messages }),
+    })
+    const body = await res.json().catch(() => null)
+    const line = proxyLog.slice(before).find(l => l.includes('adapter=') && l.includes('msgCount=')) ?? ''
+    const lastIsToolResult = Array.isArray(messages.at(-1)?.content)
+      && messages.at(-1).content.some(b => b?.type === 'tool_result')
+    rounds.push({
+      round,
+      status: res.status,
+      msgCount: Number(/msgCount=(\d+)/.exec(line)?.[1] ?? 0),
+      lineage: /lineage=(\S+)/.exec(line)?.[1] ?? '?',
+      lastIsToolResult,
+    })
+    const blocks = body?.content ?? []
+    const calls = blocks.filter(b => b.type === 'tool_use')
+    if (!calls.length) break
+    messages.push({ role: 'assistant', content: blocks })
+    messages.push({
+      role: 'user',
+      content: calls.map(c => ({
+        type: 'tool_result',
+        tool_use_id: c.id,
+        content: FILES[String(c.input?.file_path ?? '').split('/').pop()] ?? 'NOT FOUND',
+      })),
+    })
+  }
+  say(`  ${agent.padEnd(12)} (${headerName.padEnd(20)}) -> `
+    + rounds.map(r => `${String(r.msgCount).padStart(2)}:${r.lineage}`).join('  '))
+  return rounds
+}
+
+say(`\n=== client-driven tool rounds resume on every adapter (model=${MODEL}) ===`)
+
+// The three adapters that read an explicit session key and run passthrough
+// tool loops. `passthrough` is the one that regressed; the other two are the
+// controls that made the regression visible as an asymmetry.
+const CASES = [
+  ['pi', 'x-session-affinity'],
+  ['passthrough', 'x-litellm-session-id'],
+  ['opencode', 'x-opencode-session'],
+]
+
+const results = []
+for (const [agent, header] of CASES) results.push([agent, await loop(agent, header)])
+
+say('')
+check(results.every(([, rounds]) => rounds.every(r => r.status === 200)), 'every loop completed',
+  results.map(([a, r]) => `${a}=${r.map(x => x.status).join(',')}`).join(' '))
+
+for (const [agent, rounds] of results) {
+  const toolRounds = rounds.filter(r => r.lastIsToolResult)
+  check(toolRounds.length >= 2, `${agent}: ran real tool rounds`,
+    `${toolRounds.length} of ${rounds.length} carried a tool_result`)
+  // THE ASSERTION. A keyed tool round must resume; the checkpoint is only
+  // frozen if the early-stop tracker armed on this adapter's namespace.
+  check(toolRounds.length > 0 && toolRounds.every(r => r.lineage === 'continuation'),
+    `${agent}: every keyed tool round resumes`,
+    toolRounds.map(r => `${r.msgCount}:${r.lineage}`).join(' '))
+}
+
+// Stated as an invariant, not per adapter: the point is that no adapter is
+// allowed to differ. Measured on main before the fix: pi and opencode all
+// `continuation`, passthrough all `new`.
+const shapes = new Set(results.map(([, rounds]) =>
+  rounds.filter(r => r.lastIsToolResult).map(r => r.lineage).join(',')))
+check(shapes.size === 1, 'all adapters agree on the tool-round shape',
+  [...shapes].map(s => `[${s}]`).join(' vs '))
+
+say(`\n=== verdict ===`)
+if (failures.length) {
+  say(`  FAIL: ${failures.length} check(s)`)
+  for (const f of failures) say(`    - ${f}`)
+  say('\n  recent proxy diagnostics:')
+  for (const l of proxyLog.filter(l => l.includes('[PROXY]')).slice(-10)) say(`    ${l.slice(0, 200)}`)
+} else {
+  say('  PASS: a keyed tool round resumes on every adapter, whatever its namespace')
+}
+await inst.close()
+process.exit(failures.length ? 1 : 0)

--- a/src/__tests__/early-stop-namespace.test.ts
+++ b/src/__tests__/early-stop-namespace.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The early-stop tracker must arm on the adapter's OWN client-tool namespace
+ * (#996, a regression from #983).
+ *
+ * #983 gave each adapter its own passthrough namespace, so the LiteLLM adapter
+ * registers client tools as `mcp__litellm__*`. `noteAssistantMessage` still
+ * called `noteAssistantContent` with the default prefix, so on that adapter
+ * nothing was ever added to `expected`: no checkpoint UUID was frozen, no
+ * `passthroughToolCallIds` were stored, and every client-driven tool round
+ * started a fresh SDK session.
+ *
+ * `isClientForwardedToolUse` is deliberately strict about foreign `mcp__*`
+ * names — that is what made a missed prefix silent instead of noisy. Bisected
+ * live: at `15529b12` (pre-#983) a passthrough tool loop resumed on every
+ * round; at `96dc5605` it resumed on none.
+ */
+
+import { describe, it, expect } from "bun:test"
+import {
+  createEarlyStopTracker,
+  noteAssistantMessage,
+  noteAssistantContent,
+  noteUserContent,
+  allForwardedCallsResolved,
+} from "../proxy/passthroughEarlyStop"
+import { passthroughMcpPrefix } from "../proxy/passthroughTools"
+import { passthroughAdapter } from "../proxy/adapters/passthrough"
+
+const assistant = (name: string, id = "tu1") => ({
+  type: "assistant",
+  uuid: "uuid-1",
+  message: { content: [{ type: "tool_use", id, name, input: {} }] },
+})
+
+describe("noteAssistantMessage honours the declared namespace", () => {
+  it("arms on a tool in the adapter's own namespace", () => {
+    const prefix = passthroughMcpPrefix(passthroughAdapter.getPassthroughMcpName!())
+    expect(prefix).toBe("mcp__litellm__")
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistant("mcp__litellm__read"), prefix)
+    expect([...tracker.expected]).toEqual(["tu1"])
+    expect(tracker.toolCallAssistantUuid).toBe("uuid-1")
+  })
+
+  // THE REGRESSION. Before the fix this was the only behaviour available from
+  // `noteAssistantMessage`, because it did not accept a prefix at all.
+  it("does NOT arm on that tool under the default namespace", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistant("mcp__litellm__read"))
+    expect(tracker.expected.size).toBe(0)
+    expect(tracker.toolCallAssistantUuid).toBeUndefined()
+  })
+
+  it("still arms on the default namespace when no prefix is passed", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistant("mcp__oc__read"))
+    expect([...tracker.expected]).toEqual(["tu1"])
+  })
+
+  it("still refuses a genuinely internal MCP tool", () => {
+    const tracker = createEarlyStopTracker()
+    noteAssistantMessage(tracker, assistant("mcp__opencode__read"), "mcp__litellm__")
+    expect(tracker.expected.size).toBe(0)
+  })
+
+  it("keeps the same semantics as noteAssistantContent", () => {
+    const viaMessage = createEarlyStopTracker()
+    noteAssistantMessage(viaMessage, assistant("mcp__litellm__read"), "mcp__litellm__")
+    const viaContent = createEarlyStopTracker()
+    noteAssistantContent(viaContent, assistant("mcp__litellm__read").message.content, "mcp__litellm__")
+    expect([...viaMessage.expected]).toEqual([...viaContent.expected])
+  })
+
+  // The whole point of arming: without it the turn never reaches the
+  // early-stop condition, so no checkpoint is frozen and no round can resume.
+  it("reaches the early-stop condition only once armed", () => {
+    const armed = createEarlyStopTracker()
+    noteAssistantMessage(armed, assistant("mcp__litellm__read"), "mcp__litellm__")
+    noteUserContent(armed, [{ type: "tool_result", tool_use_id: "tu1", content: "x" }])
+    expect(allForwardedCallsResolved(armed)).toBe(true)
+
+    const unarmed = createEarlyStopTracker()
+    noteAssistantMessage(unarmed, assistant("mcp__litellm__read"))
+    noteUserContent(unarmed, [{ type: "tool_result", tool_use_id: "tu1", content: "x" }])
+    expect(allForwardedCallsResolved(unarmed)).toBe(false)
+  })
+})

--- a/src/proxy/passthroughEarlyStop.ts
+++ b/src/proxy/passthroughEarlyStop.ts
@@ -119,12 +119,23 @@ export function noteAssistantContent(
  * updating the boundary for every forwarded call leaves the correct stable
  * checkpoint.
  */
-export function noteAssistantMessage(tracker: EarlyStopTracker, message: unknown): void {
+export function noteAssistantMessage(
+  tracker: EarlyStopTracker,
+  message: unknown,
+  clientToolPrefix: string = CLIENT_TOOL_PREFIX,
+): void {
   const m = message as { type?: unknown; uuid?: unknown; message?: { content?: unknown } } | null | undefined
   if (m?.type !== "assistant") return
   const content = m.message?.content
   const before = tracker.expected.size
-  noteAssistantContent(tracker, content)
+  // The prefix MUST be threaded through. Defaulting it here silently armed the
+  // tracker only for `mcp__oc__*`, so on an adapter with its own namespace
+  // (`mcp__litellm__*` since #983) nothing was ever expected: no checkpoint
+  // UUID, no stored `passthroughToolCallIds`, and therefore no tool round ever
+  // resumed (#996). `isClientForwardedToolUse` is deliberately strict about
+  // foreign `mcp__*` names, which is what makes a missed prefix silent rather
+  // than noisy.
+  noteAssistantContent(tracker, content, clientToolPrefix)
   if (tracker.expected.size > before) {
     // A newer tool-bearing assistant message supersedes the older checkpoint.
     // Fail closed when its UUID is absent: the older message may not contain

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -3668,7 +3668,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 // until the full client-visible ID set is covered; internal and
                 // duplicate calls are filtered by noteAssistantMessage.
                 const expectedBefore = earlyStop.expected.size
-                noteAssistantMessage(earlyStop, message)
+                noteAssistantMessage(earlyStop, message, clientToolPrefix)
                 assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
               } else if (passthrough && message.type === "user" && !earlyStopFired) {
                 noteUserContent(earlyStop, (message as any).message?.content)
@@ -4824,7 +4824,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   let assistantAddedForwardedCall = false
                   if (earlyStopEnabled && message.type === "assistant" && !earlyStopFired) {
                     const expectedBefore = earlyStop.expected.size
-                    noteAssistantMessage(earlyStop, message)
+                    noteAssistantMessage(earlyStop, message, clientToolPrefix)
                     assistantAddedForwardedCall = earlyStop.expected.size > expectedBefore
                   } else if (earlyStopEnabled && message.type === "user" && !earlyStopFired) {
                     noteUserContent(earlyStop, (message as any).message?.content)
@@ -5550,7 +5550,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       recoverySessionId = recoveryMessage.session_id
                     }
                     if (recoveryMessage.type === "assistant") {
-                      noteAssistantMessage(recoveryEarlyStop, recoveryMessage)
+                      noteAssistantMessage(recoveryEarlyStop, recoveryMessage, clientToolPrefix)
                     } else if (recoveryMessage.type === "user") {
                       noteUserContent(recoveryEarlyStop, recoveryMessage.message?.content)
                     }


### PR DESCRIPTION
Arms the passthrough early-stop tracker on the adapter's own client-tool
namespace, so a keyed tool round resumes on every adapter.

Refs #996, #820. **This is a regression from our own #983**, not long-standing
behaviour.

## Cause

#983 gave each adapter its own passthrough client-tool namespace, so the
LiteLLM adapter registers client tools as `mcp__litellm__*`. The early-stop
tracker is what freezes the resume checkpoint, and it arms by matching those
names:

```ts
export function noteAssistantMessage(tracker, message) {   // no prefix parameter
  ...
  noteAssistantContent(tracker, content)                   // defaults to mcp__oc__
}
```

`server.ts` computes `clientToolPrefix` from the adapter and passes it to both
`isClientForwardedToolUse` call sites — it could not pass it here. On the
passthrough adapter nothing was ever added to `expected`, so no checkpoint UUID
was frozen, no `passthroughToolCallIds` were stored, and
`advancesDurableCheckpoint` could never fire. Every client-driven tool round
started a fresh SDK session.

That is the remainder of @StanChmielewski's cost profile in #820, and it hit
even the LiteLLM operators who had already configured
`pass_through_endpoints` / `forward_headers: true`: the adapter read their
session key and the tool rounds still did not resume.

`isClientForwardedToolUse` is strict about foreign `mcp__*` names by design,
which is exactly what made the missed call site silent rather than noisy.
#983's own test file pins the hazard:

```ts
it("would reject that same tool under the default prefix", () => {
  expect(isClientForwardedToolUse(call("mcp__litellm__read"))).toBe(false)
})
```

The assertion existed. A call site that trips it was still missed.

## Fix

Thread the prefix through `noteAssistantMessage` and pass it at all three
`server.ts` call sites, including the recovery tracker. `noteUserContent` needs
no prefix — it records every `tool_result` id deliberately.

## Validation

**Bisected**, `pi` as the control, four-round keyed tool loop per adapter:

```
15529b12 (pre-#983)   pi 3/3 continuation   passthrough 3/3 continuation
96dc5605 (main)       pi 3/3 continuation   passthrough 0/3
with this change      pi 3/3 continuation   passthrough 3/3 continuation
```

The pre-#983 worktree is kept at `/Users/rynfar/repos/meridian-wt/pre-983-baseline`
as the before-code evidence.

**Failed before, passes after.** `early-stop-namespace.test.ts` on `main`:

```
(fail) arms on a tool in the adapter's own namespace
(fail) keeps the same semantics as noteAssistantContent
(fail) reaches the early-stop condition only once armed
 3 pass  3 fail
```

The 3 that pass on `main` are the guards asserting unchanged behaviour: the
default namespace still arms, and a genuinely internal `mcp__opencode__*` tool
is still refused.

`npm test`: **3793 pass, 1 skip, 0 fail** (bun 1.3.11, matching CI).
`npm run typecheck`, `npm run build`: clean.

**Live E2E — new gate E56** (`bun scripts/e2e-passthrough-namespace-resume.mjs`),
real proxy + SDK, Haiku 4.5:

```
pi           (x-session-affinity  ) ->  1:new   3:continuation   5:continuation   7:continuation
passthrough  (x-litellm-session-id) ->  1:new   3:continuation   5:continuation   7:continuation
opencode     (x-opencode-session  ) ->  1:new   3:continuation   5:continuation   7:continuation
```

## The gate's load-bearing assertion

E56 asserts that all three adapters **agree** on the tool-round shape, not just
that each one resumes. That distinction is the whole lesson here: **a
single-adapter gate passed throughout this regression**, because each adapter
looks self-consistent on its own and the defect was only ever visible as an
asymmetry. E50 already covers what the model *reads* under a custom namespace;
nothing covered what the tracker *matches*.

Anything that makes behaviour per-adapter needs a cross-adapter gate rather
than a deeper single-adapter one.
