### PR TITLE
docs: correct a stale claim that PR 977 was held unmerged

### DIFF
--- a/docs/maintenance/REVIEW_HANDOFF.md
+++ b/docs/maintenance/REVIEW_HANDOFF.md
@@ -14,12 +14,17 @@ and [AGENTS.md](../../AGENTS.md). The last delivered items were issue #820
 race-harness deflake (#997), plus #996 — a regression in our own #983, found
 while validating #820 and fixed in #998.
 
-**Two things are open and deliberately unmerged.**
-[PR #977](https://github.com/rynfar/meridian/pull/977) is green on everything
-and held for owner review because it changes session identity.
+**One thing is open and deliberately unmerged.**
 [PR #970](https://github.com/rynfar/meridian/pull/970) is the Release Please
 PR for 1.69.0 and is held: a release needs explicit authorization and a backlog
 review does not grant it. Nothing else is in progress.
+
+An earlier version of this block said PR #977 was "green on everything and
+held for owner review". That was already stale when it was written: #977 merged
+at 2026-09-09T03:18Z as `03fe5716` and appears in #970's changelog. The claim
+was carried forward from the previous checkpoint without being rechecked, which
+is the specific failure the "Read first" instruction above warns about — refresh
+live GitHub state, do not trust the dated text.
 
 Continue when the owner asks; this document does not start background work or
 authorize two agents to work the same queue. A prior agent's


### PR DESCRIPTION
Corrects a stale claim in the checkpoint I merged in #999.

The "Read first" block said PR #977 was "green on everything and held for owner
review because it changes session identity." It had already merged as
`03fe5716` at 2026-09-09T03:18Z, and it appears in #970's 1.69.0 changelog.

I carried that sentence forward from the previous checkpoint text without
rechecking live state — which is the exact failure the same block instructs the
next reader to avoid. The correction says so explicitly rather than quietly
deleting it, because a checkpoint that has been wrong once is worth being
sceptical of.

Documentation only. No other claim in that block changed: #970 is still held,
because a release needs explicit authorization.
