### PR TITLE
test(e2e): assert E55 non-inheritance by session id, not by lineage word

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -4492,8 +4492,15 @@ Claude Code cannot hand the client a live messaging socket.
 - **No request classifies `unrelated-history`, and no invocation is refused
   with a 4xx** — the guard against the session-id keying above.
 - A second conversation with the same prompt in its own directory does not
-  inherit the first, which is what the fingerprint's working-directory
-  component has to do in the absence of a key.
+  inherit the first: its opening turn resumes nothing, and no session id it
+  resumes belongs to the first conversation. Asserted by session id rather than
+  by the absence of `continuation` — since #998 a passthrough tool round can
+  resume its own session, so the lineage word alone cannot tell "resumed mine"
+  from "inherited yours". Whether conversation 2 resumes at all is **not**
+  asserted: the real client chooses how many tool rounds to take, so whether a
+  checkpoint is stored varies between runs (measured both ways on consecutive
+  runs). E56 owns the resume question, which it can assert deterministically
+  because it drives the loop itself.
 
 **What this gate deliberately does not assert.** The tool round *itself* still
 classifies `not-found`, which is a separate and larger defect tracked in #996:

--- a/scripts/e2e-passthrough-claude-code-session.mjs
+++ b/scripts/e2e-passthrough-claude-code-session.mjs
@@ -231,12 +231,34 @@ check(refused.length === 0, 'no invocation was refused with a 4xx',
 
 // 4. Two conversations in different directories stay apart. With no session
 //    key the fingerprint's working-directory component is what does this.
+//
+//    Asserted as non-INHERITANCE, not as absence of resume. An earlier version
+//    required conversation 2 to show no `continuation` at all, which encoded
+//    the pre-#998 world where a passthrough tool round could never resume
+//    anything. Now that it can, "resumes its own session" and "inherits the
+//    other conversation's" have to be told apart by session id — the shape of
+//    the lineage word cannot do it.
+const resumedSessions = lines => [...new Set(
+  lines.map(l => /session=([0-9a-f]{6,})/.exec(l)?.[1]).filter(Boolean))]
+const conversation1 = new Set([...resumedSessions(firstLines), ...resumedSessions(secondLines)])
+const conversation2 = resumedSessions(otherLines)
+
 check(other.out.includes('BRAVO-VALUE') && !other.out.includes('ALPHA-VALUE'),
   'a second conversation with the same prompt does not inherit the first',
   `answer=${JSON.stringify(other.out.slice(0, 60))}`)
-check(otherLines.length > 0 && !otherLines.some(l => l.includes('lineage=continuation')),
-  'its first turns start fresh rather than resuming the other conversation',
-  otherLines.map(l => /lineage=(\S+)/.exec(l)?.[1]).join(', ') || '(no request)')
+check(otherLines.length > 0 && !otherLines[0].includes('lineage=continuation'),
+  'its first turn cannot resume anything',
+  otherLines[0] ? `round 1 lineage=${/lineage=(\S+)/.exec(otherLines[0])?.[1]}` : '(no request)')
+// Not conditioned on conversation 2 having resumed anything. The real client
+// decides how many tool rounds to take, so whether a checkpoint gets stored at
+// all varies between runs — measured both ways on consecutive runs. An empty
+// set satisfies non-inheritance correctly, and E56 owns the separate question
+// of whether a keyed tool round resumes, which it can assert deterministically
+// because it drives the loop itself.
+check(conversation2.every(s => !conversation1.has(s)),
+  'it never resumes a session belonging to the first conversation',
+  `conversation 2 resumed [${conversation2.join(', ') || 'nothing'}]; `
+  + `conversation 1 held [${[...conversation1].join(', ') || 'nothing'}]`)
 
 say(`\n=== verdict ===`)
 if (failures.length) {


### PR DESCRIPTION
Fixes a gate that started failing on correct behaviour.

Found while running the 1.69.0 release validation.

## What was wrong

E55 required the second conversation to show no `lineage=continuation` at all:

```js
check(otherLines.length > 0 && !otherLines.some(l => l.includes('lineage=continuation')),
  'its first turns start fresh rather than resuming the other conversation', ...)
```

That encoded the pre-#998 world, where a passthrough tool round could never
resume anything. #998 made it possible, so the gate began failing on behaviour
that is now correct:

```
FAIL  its first turns start fresh rather than resuming the other conversation — new, new, continuation
```

The behaviour was fine. Conversation 2 resumed `6e2c0208`; conversation 1 held
`9d462746` and `100bcdb9`; conversation 2's answer was `BRAVO-VALUE`, not
`ALPHA-VALUE`. It resumed **its own** session and inherited nothing.

## The process miss

#998 changed the passthrough tool loop and I re-ran only the new gate (E56),
not the existing gates that exercise the same path. The release validation
caught it, which is the argument for running the full set before merging a
release rather than after.

## The fix, and a second wrong attempt worth recording

Non-inheritance is now asserted **by session id**, because since #998 the
lineage word cannot distinguish "resumed mine" from "inherited yours":

- conversation 2's opening turn resumes nothing;
- no session id conversation 2 resumes appears in conversation 1's set.

My first attempt added `conversation2.length > 0 &&` to that check. The next
run had conversation 2 resume **nothing** and failed again — the real client
chooses how many tool rounds to take, so whether a checkpoint is stored varies
between runs. I measured it both ways on consecutive runs. Whether conversation
2 resumes at all is not E55's property; an empty set satisfies non-inheritance
correctly. **E56** owns the resume question and asserts it deterministically
because it drives the loop itself instead of going through the CLI.

E2E.md's pass criteria now say all of this, including why the count is
deliberately not asserted.

## Validation

E55 green on consecutive runs, with the two outcomes both observed and both
passing:

```
PASS  it never resumes a session belonging to the first conversation — conversation 2 resumed [nothing]; conversation 1 held [9b015ea5]
PASS  it never resumes a session belonging to the first conversation — conversation 2 resumed [6e2c0208]; conversation 1 held [9d462746, 100bcdb9]
```

Gate-only change: no `src/` files touched.
