### PR TITLE
feat: discover Meridian models in OpenCode V2

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -40,15 +40,15 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:3456
 
 ### OpenCode V2 beta
 
-Meridian currently supports the exact public beta used by its V2 plugin:
-`@opencode-ai/cli@0.0.0-beta-18314`. V2 plugin APIs are still changing, so setup
-fails closed for another V2 version instead of installing a plugin with an
-unknown contract.
+Meridian supports the exact public betas its V2 plugin is validated against:
+`@opencode-ai/cli@0.0.0-beta-18314` and `0.0.0-beta-18866`. V2 plugin APIs are
+still changing, so setup fails closed for another V2 version instead of
+installing a plugin with an unknown contract.
 
-Install the pinned beta and select its executable:
+Install a supported beta and select its executable:
 
 ```bash
-npm install -g --prefix ~/.local @opencode-ai/cli@0.0.0-beta-18314
+npm install -g --prefix ~/.local @opencode-ai/cli@0.0.0-beta-18866
 meridian setup --v2 --opencode-bin ~/.local/bin/opencode2
 ```
 
@@ -67,11 +67,11 @@ Configure V2's Anthropic provider to use Meridian. Keep the existing settings in
 {
   "model": "anthropic/claude-opus-4-6",
   "small_model": "anthropic/claude-haiku-4-5",
-  "provider": {
+  "providers": {
     "anthropic": {
-      "options": {
+      "settings": {
         "apiKey": "x",
-        "baseURL": "http://127.0.0.1:3456"
+        "baseURL": "http://127.0.0.1:3456/v1"
       },
       "models": {
         "claude-opus-4-6": { "name": "Claude Opus 4.6" },
@@ -81,6 +81,12 @@ Configure V2's Anthropic provider to use Meridian. Keep the existing settings in
   }
 }
 ```
+
+V2 renamed these keys: it reads `providers` and `settings`, where V1 read
+`provider` and `options`. A V1-shaped block is silently ignored, so the client
+would talk to the real Anthropic API instead of Meridian. Anything you put under
+`models` is your own override and wins over both the built-in catalog and
+Meridian's advertised models.
 
 Then start the pinned client:
 
@@ -92,6 +98,22 @@ The V2 plugin uses the native `model.request` and `http.request` hooks. It keeps
 primary and compaction requests attached to the correct OpenCode session,
 detaches concurrent hidden title/summary requests, and gives each visible
 subagent its own trusted identity. Request bodies and model input are unchanged.
+
+The V2 plugin also reads `GET /v1/models` from the configured Meridian base URL
+and writes what it finds into V2's model catalog: the context window your
+subscription actually gets, and one model variant per effort level the proxy
+accepts. This corrects OpenCode's built-in models.dev entries, which advertise a
+1M Sonnet that Meridian deliberately serves at 200k. Select an effort with
+`provider/model#variant`, for example `anthropic/claude-opus-5#high`. Discovery
+never blocks startup: if Meridian is unreachable or answers with anything
+unexpected, the catalog is left exactly as OpenCode built it.
+
+**Known limitation.** Discovery cannot run until OpenCode has finished
+assembling the catalog, so the very first request against a freshly started
+server still sees the built-in entries. Naming a Meridian-only variant on that
+first request — `anthropic/claude-haiku-4-5#xhigh`, say — fails with
+`provider.no-route`; the next request succeeds. Selecting the model in the TUI is
+unaffected, because the picker renders after discovery has landed.
 
 For either generation, the plugin enables:
 

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -16,6 +16,8 @@
  */
 
 import * as Plugin from "@opencode-ai/plugin/promise/plugin"
+import { Model } from "@opencode-ai/schema/model"
+import type { CatalogDraft } from "@opencode-ai/plugin/promise/catalog"
 import {
   PRIORITY_ATTESTATION_HEADER,
   createPriorityAttestation,
@@ -34,7 +36,13 @@ const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
 const ATTACHED_COMPACTION_AGENT = "compaction"
 const MODEL_DISCOVERY_TIMEOUT_MS = 3_000
 const PROVIDER_READY_POLL_MS = 25
+// The plugin tree does not import from src/, so this mirrors VALID_EFFORTS in
+// src/proxy/effort.ts. A test asserts the two stay identical. Filtering in this
+// order also gives every model its variants low -> max regardless of the order
+// the proxy happens to serialise its capability object in.
 const MERIDIAN_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const
+
+export const MERIDIAN_V2_EFFORTS: readonly string[] = MERIDIAN_EFFORTS
 
 const SESSION_AFFINITY_HEADERS = [
   "x-opencode-session",
@@ -154,18 +162,6 @@ type MeridianCatalogClient = {
   reload(): Promise<void>
 }
 
-type MeridianCatalogDraft = {
-  provider: {
-    get(providerID: string): { models: ReadonlyMap<string, unknown> } | undefined
-  }
-  model: {
-    update(providerID: string, modelID: string, update: (model: {
-      name: string
-      limit: { context: number }
-    }) => void): void
-  }
-}
-
 type ModelFetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
 
 export function meridianModelsURL(baseURL: unknown): string | undefined {
@@ -176,7 +172,13 @@ export function meridianModelsURL(baseURL: unknown): string | undefined {
     url.search = ""
     url.hash = ""
     if (!url.pathname.endsWith("/")) url.pathname += "/"
-    return new URL("v1/models", url).toString()
+    // OpenCode's Anthropic provider carries the API version in the base URL
+    // (`http://127.0.0.1:3456/v1`), which is also the shape the V2 package gate
+    // configures. Appending `v1/models` there requests `/v1/v1/models`, a 404
+    // that silently disables discovery, so resolve `models` against an existing
+    // version segment instead.
+    const endpoint = /(?:^|\/)v1\/$/.test(url.pathname) ? "models" : "v1/models"
+    return new URL(endpoint, url).toString()
   } catch {
     return undefined
   }
@@ -289,23 +291,31 @@ export async function loadMeridianModels(
   return []
 }
 
+/**
+ * Write Meridian's advertised models over the assembled V2 catalog.
+ *
+ * Meridian is authoritative for what it will actually serve: the context window
+ * follows the signed-in subscription (Sonnet stays 200k so a 1M turn is not
+ * billed as Extra Usage), and the effort levels are the ones the proxy accepts.
+ * OpenCode's built-in models.dev entries disagree — beta-18866 advertises a 1M
+ * Sonnet — so an entry that already exists must be corrected, not skipped.
+ *
+ * This does not overwrite user configuration. V2 layers `providers.<id>.models`
+ * on top of plugin transforms, verified live on beta-18866: a configured
+ * `claude-opus-5` override survived a transform that wrote a different name and
+ * context to the same model.
+ */
 export function applyMeridianModels(
-  catalog: MeridianCatalogDraft,
+  catalog: CatalogDraft,
   providerID: string,
   models: readonly MeridianModel[],
 ): void {
-  const configuredModels = catalog.provider.get(providerID)?.models
   for (const model of models) {
-    // An existing model is user-owned configuration, including aliases and overrides.
-    if (configuredModels?.has(model.id)) continue
     catalog.model.update(providerID, model.id, (entry) => {
       entry.name = model.name
       entry.limit.context = model.contextWindow
-      const variants = entry as unknown as {
-        variants: Array<{ id: string; headers: Record<string, string>; body: Record<string, string> }>
-      }
-      variants.variants = model.efforts.map((effort) => ({
-        id: effort,
+      entry.variants = model.efforts.map((effort) => ({
+        id: Model.VariantID.make(effort),
         headers: {},
         body: { effort },
       }))

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -529,6 +529,9 @@ const MeridianV2Plugin = Plugin.define({
         }, { providerID }))
       }
     } catch (error) {
+      // Setup never returns its cleanup on this path, so the discovery
+      // subscription and its poll loop would otherwise outlive the failure.
+      modelDiscoveryController.abort()
       await Promise.allSettled(registered.map(({ dispose }) => dispose()))
       throw error
     }

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -29,8 +29,12 @@ import {
 export const SUPPORTED_OPENCODE_V2_VERSION = "0.0.0-beta-18314"
 
 const MERIDIAN_PROVIDERS = new Set(["anthropic", "meridian"])
+const MERIDIAN_CATALOG_PROVIDER = "meridian"
 const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
 const ATTACHED_COMPACTION_AGENT = "compaction"
+const MODEL_DISCOVERY_TIMEOUT_MS = 3_000
+const PROVIDER_READY_POLL_MS = 25
+const MERIDIAN_EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const
 
 const SESSION_AFFINITY_HEADERS = [
   "x-opencode-session",
@@ -131,6 +135,184 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+export interface MeridianModel {
+  id: string
+  name: string
+  contextWindow: number
+  efforts: string[]
+}
+
+export interface MeridianProviderModels {
+  providerID: string
+  models: MeridianModel[]
+}
+
+type MeridianCatalogClient = {
+  provider: {
+    get(input: { providerID: string }): Promise<unknown>
+  }
+  reload(): Promise<void>
+}
+
+type MeridianCatalogDraft = {
+  provider: {
+    get(providerID: string): { models: ReadonlyMap<string, unknown> } | undefined
+  }
+  model: {
+    update(providerID: string, modelID: string, update: (model: {
+      name: string
+      limit: { context: number }
+    }) => void): void
+  }
+}
+
+type ModelFetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+export function meridianModelsURL(baseURL: unknown): string | undefined {
+  if (typeof baseURL !== "string" || baseURL.length === 0) return undefined
+  try {
+    const url = new URL(baseURL)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return undefined
+    url.search = ""
+    url.hash = ""
+    if (!url.pathname.endsWith("/")) url.pathname += "/"
+    return new URL("v1/models", url).toString()
+  } catch {
+    return undefined
+  }
+}
+
+export function parseMeridianModels(value: unknown): MeridianModel[] | undefined {
+  if (!isRecord(value) || !Array.isArray(value.data)) return undefined
+
+  const models: MeridianModel[] = []
+  const ids = new Set<string>()
+  for (const item of value.data) {
+    if (!isRecord(item)) return undefined
+    const id = item.id
+    const name = item.display_name
+    const contextWindow = item.context_window
+    if (
+      typeof id !== "string"
+      || id.length === 0
+      || id.length > 256
+      || /[^\x21-\x7E]/.test(id)
+      || ids.has(id)
+      || typeof name !== "string"
+      || name.trim().length === 0
+      || name.length > 256
+      || typeof contextWindow !== "number"
+      || !Number.isSafeInteger(contextWindow)
+      || contextWindow <= 0
+    ) {
+      return undefined
+    }
+    const capabilities = isRecord(item.capabilities) ? item.capabilities : undefined
+    const effort = capabilities && isRecord(capabilities.effort) ? capabilities.effort : undefined
+    const efforts = MERIDIAN_EFFORTS.filter((level) => isRecord(effort?.[level]) && effort[level].supported === true)
+    ids.add(id)
+    models.push({ id, name, contextWindow, efforts })
+  }
+  return models
+}
+
+export async function fetchMeridianModels(
+  baseURL: unknown,
+  signal: AbortSignal,
+  fetcher: ModelFetcher = globalThis.fetch,
+): Promise<MeridianModel[] | undefined> {
+  const url = meridianModelsURL(baseURL)
+  if (!url || signal.aborted) return undefined
+
+  const controller = new AbortController()
+  const abort = () => controller.abort()
+  const timeout = setTimeout(abort, MODEL_DISCOVERY_TIMEOUT_MS)
+  timeout.unref?.()
+  signal.addEventListener("abort", abort, { once: true })
+  try {
+    const response = await fetcher(url, { signal: controller.signal })
+    if (!response.ok) return undefined
+    return parseMeridianModels(await response.json())
+  } catch {
+    return undefined
+  } finally {
+    clearTimeout(timeout)
+    signal.removeEventListener("abort", abort)
+  }
+}
+
+function meridianProviderBaseURL(value: unknown): unknown {
+  if (!isRecord(value)) return undefined
+  const provider = isRecord(value.data) ? value.data : value
+  if (!isRecord(provider.settings)) return undefined
+  return provider.settings.baseURL
+}
+
+function isLegacyMeridianBaseURL(baseURL: unknown): boolean {
+  if (typeof baseURL !== "string") return false
+  try {
+    const { hostname } = new URL(baseURL)
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
+  } catch {
+    return false
+  }
+}
+
+export async function loadMeridianModels(
+  catalog: MeridianCatalogClient,
+  signal: AbortSignal,
+  fetcher: ModelFetcher = globalThis.fetch,
+): Promise<MeridianProviderModels[]> {
+  const deadline = Date.now() + MODEL_DISCOVERY_TIMEOUT_MS
+  while (!signal.aborted) {
+    const providers = await Promise.all([...MERIDIAN_PROVIDERS].map(async (providerID) => {
+      try {
+        const baseURL = meridianProviderBaseURL(await catalog.provider.get({ providerID }))
+        if (providerID === MERIDIAN_CATALOG_PROVIDER && meridianModelsURL(baseURL) === undefined) return undefined
+        if (providerID !== MERIDIAN_CATALOG_PROVIDER && !isLegacyMeridianBaseURL(baseURL)) return undefined
+        return { providerID, baseURL }
+      } catch {
+        return undefined
+      }
+    }))
+    const configured = providers.flatMap(provider => provider ? [provider] : [])
+    if (configured.length > 0) {
+      const discovered = await Promise.all(configured.map(async ({ providerID, baseURL }) => {
+        const models = await fetchMeridianModels(baseURL, signal, fetcher)
+        return models ? { providerID, models } : undefined
+      }))
+      return discovered.flatMap(result => result ? [result] : [])
+    }
+    if (Date.now() >= deadline) return []
+    await new Promise<void>((resolve) => setTimeout(resolve, PROVIDER_READY_POLL_MS))
+  }
+  return []
+}
+
+export function applyMeridianModels(
+  catalog: MeridianCatalogDraft,
+  providerID: string,
+  models: readonly MeridianModel[],
+): void {
+  const configuredModels = catalog.provider.get(providerID)?.models
+  for (const model of models) {
+    // An existing model is user-owned configuration, including aliases and overrides.
+    if (configuredModels?.has(model.id)) continue
+    catalog.model.update(providerID, model.id, (entry) => {
+      entry.name = model.name
+      entry.limit.context = model.contextWindow
+      const variants = entry as unknown as {
+        variants: Array<{ id: string; headers: Record<string, string>; body: Record<string, string> }>
+      }
+      variants.variants = model.efforts.map((effort) => ({
+        id: effort,
+        headers: {},
+        body: { effort },
+      }))
+    })
+  }
+}
+
 async function withTimeout<T>(pending: Promise<T>, timeoutMs: number): Promise<T | undefined> {
   let timer: ReturnType<typeof setTimeout> | undefined
   const timedOut = new Promise<undefined>((resolve) => {
@@ -196,6 +378,33 @@ const MeridianV2Plugin = Plugin.define({
       pending: Promise<ResolvedAgentMetadata>
     }>()
     const registered: Array<{ dispose: () => Promise<void> }> = []
+    const modelDiscoveryController = new AbortController()
+    let discoveredModels: MeridianProviderModels[] = []
+    let discoveryStarted = false
+
+    registered.push(await context.catalog.transform((catalog) => {
+      for (const discovered of discoveredModels) {
+        applyMeridianModels(catalog, discovered.providerID, discovered.models)
+      }
+    }))
+
+    const discoverModels = async () => {
+      if (discoveryStarted || modelDiscoveryController.signal.aborted) return false
+      const models = await loadMeridianModels(context.catalog, modelDiscoveryController.signal).catch(() => [])
+      if (models.length === 0 || modelDiscoveryController.signal.aborted) return false
+      discoveryStarted = true
+      discoveredModels = models
+      await context.catalog.reload()
+      return true
+    }
+
+    const catalogEvents = context.event.subscribe({ signal: modelDiscoveryController.signal })
+    void (async () => {
+      for await (const event of catalogEvents) {
+        if (event.type !== "catalog.updated") continue
+        if (await discoverModels()) return
+      }
+    })().catch(() => {})
 
     const resolveAgentTraits = (agent: string, refresh = false): Promise<ResolvedAgentMetadata> => {
       const cached = traitsByAgent.get(agent)
@@ -325,6 +534,7 @@ const MeridianV2Plugin = Plugin.define({
     }
 
     return async () => {
+      modelDiscoveryController.abort()
       const results = await Promise.allSettled(registered.map(({ dispose }) => dispose()))
       const failures = results.flatMap(result => result.status === "rejected" ? [result.reason] : [])
       if (failures.length > 0) throw new AggregateError(failures, "Failed to dispose Meridian V2 hooks")

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -234,6 +234,7 @@ async function installHooks(options: {
   contextMessages?: unknown[]
   failHttpRegistration?: boolean
   disposed?: string[]
+  subscribeSignals?: Array<AbortSignal | undefined>
 } = {}) {
   let modelHook: HookCallback | undefined
   let httpHook: HookCallback | undefined
@@ -242,6 +243,7 @@ async function installHooks(options: {
   const sessionLookups: string[] = []
   const contextLookups: string[] = []
   const registrations: Array<{ name: string; providerID: string | undefined }> = []
+  const subscribeSignals = options.subscribeSignals ?? []
 
   const context = {
     catalog: {
@@ -252,7 +254,10 @@ async function installHooks(options: {
       reload: async () => {},
     },
     event: {
-      subscribe: async function* () {},
+      subscribe: (subscribeOptions?: { signal?: AbortSignal }) => {
+        subscribeSignals.push(subscribeOptions?.signal)
+        return (async function* () {})()
+      },
     },
     agent: {
       get: async ({ agentID }: { agentID: string }) => {
@@ -412,6 +417,16 @@ describe("plugin/meridian-v2.ts V2 hook registration", () => {
     const installed = installHooks({ failHttpRegistration: true, disposed })
     await expect(installed).rejects.toThrow("http hook unavailable")
     expect(disposed).toEqual(["catalog:transform", "anthropic:model.request"])
+  })
+
+  // Setup never returns its cleanup when registration throws, so the discovery
+  // subscription has to be cancelled on that path or it outlives the plugin.
+  test("cancels model discovery when registration fails", async () => {
+    const signals: Array<AbortSignal | undefined> = []
+    await expect(installHooks({ failHttpRegistration: true, subscribeSignals: signals }))
+      .rejects.toThrow("http hook unavailable")
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.aborted).toBe(true)
   })
 })
 

--- a/src/__tests__/plugin-v2-headers.test.ts
+++ b/src/__tests__/plugin-v2-headers.test.ts
@@ -244,6 +244,16 @@ async function installHooks(options: {
   const registrations: Array<{ name: string; providerID: string | undefined }> = []
 
   const context = {
+    catalog: {
+      transform: async () => ({ dispose: async () => { disposed.push("catalog:transform") } }),
+      provider: {
+        get: async () => ({ settings: {} }),
+      },
+      reload: async () => {},
+    },
+    event: {
+      subscribe: async function* () {},
+    },
     agent: {
       get: async ({ agentID }: { agentID: string }) => {
         lookups.push(agentID)
@@ -334,6 +344,7 @@ describe("plugin/meridian-v2.ts V2 hook registration", () => {
     expect(hooks.disposed.sort()).toEqual([
       "anthropic:http.request",
       "anthropic:model.request",
+      "catalog:transform",
       "meridian:http.request",
       "meridian:model.request",
     ])
@@ -400,7 +411,7 @@ describe("plugin/meridian-v2.ts V2 hook registration", () => {
     const disposed: string[] = []
     const installed = installHooks({ failHttpRegistration: true, disposed })
     await expect(installed).rejects.toThrow("http hook unavailable")
-    expect(disposed).toEqual(["anthropic:model.request"])
+    expect(disposed).toEqual(["catalog:transform", "anthropic:model.request"])
   })
 })
 

--- a/src/__tests__/plugin-v2-model-discovery.test.ts
+++ b/src/__tests__/plugin-v2-model-discovery.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
+import type { CatalogDraft } from "@opencode-ai/plugin/promise/catalog"
+import type { DeepMutable } from "@opencode-ai/plugin/promise/types"
+import { Model } from "@opencode-ai/schema/model"
+import { Provider } from "@opencode-ai/schema/provider"
+import { VALID_EFFORTS } from "../proxy/effort"
 import {
+  MERIDIAN_V2_EFFORTS,
   applyMeridianModels,
   fetchMeridianModels,
   loadMeridianModels,
@@ -20,12 +26,72 @@ const MERIDIAN_MODELS = {
   ],
 }
 
+/**
+ * Stand-in for V2's catalog draft, built from the SDK's own model factory so the
+ * entries carry the real shape. `model.update` creates a missing entry the way
+ * beta-18866 does, and records what the transform wrote.
+ */
+function makeCatalogDraft(existing: readonly string[]) {
+  const models = new Map<string, DeepMutable<Model.Info>>(
+    existing.map(id => [id, { ...Model.Info.default(Provider.ID.make("meridian"), Model.ID.make(id)), name: `existing ${id}` }]),
+  )
+  const written: DeepMutable<Model.Info>[] = []
+  const catalog: CatalogDraft = {
+    provider: {
+      list: () => [],
+      // applyMeridianModels reads the catalog only through model.update.
+      get: () => undefined,
+      update: () => {},
+      remove: () => {},
+    },
+    model: {
+      get: (_providerID, modelID) => models.get(modelID),
+      update: (providerID, modelID, update) => {
+        const entry = models.get(modelID)
+          ?? { ...Model.Info.default(Provider.ID.make(providerID), Model.ID.make(modelID)) }
+        update(entry)
+        models.set(modelID, entry)
+        written.push(entry)
+      },
+      remove: () => {},
+      default: { get: () => undefined, set: () => {} },
+    },
+  }
+  const wrote = () => written.map(entry => ({
+    modelID: String(entry.id),
+    name: entry.name,
+    context: entry.limit.context,
+    variants: entry.variants.map(variant => ({ id: String(variant.id), body: variant.body })),
+  }))
+  return { catalog, wrote }
+}
+
 describe("Meridian OpenCode V2 model discovery", () => {
+  // The plugin cannot import from src/, so the effort vocabulary is duplicated.
+  // A drift here would advertise a variant the proxy drops, or hide one it takes.
+  test("advertises exactly the effort levels the proxy accepts", () => {
+    expect(MERIDIAN_V2_EFFORTS).toEqual([...VALID_EFFORTS])
+  })
+
   test("preserves a configured base URL path when finding the models endpoint", () => {
     expect(meridianModelsURL("http://127.0.0.1:3456/meridian")).toBe(
       "http://127.0.0.1:3456/meridian/v1/models",
     )
     expect(meridianModelsURL("not a URL")).toBeUndefined()
+  })
+
+  // The V2 Anthropic provider is configured with the API version already in the
+  // base URL, which is what the packaged V2 gate writes. Appending `v1/models`
+  // there asked Meridian for `/v1/v1/models` and got a 404, so discovery never
+  // ran on the documented configuration.
+  test("does not double the version segment of an already-versioned base URL", () => {
+    expect(meridianModelsURL("http://127.0.0.1:3456/v1")).toBe("http://127.0.0.1:3456/v1/models")
+    expect(meridianModelsURL("http://127.0.0.1:3456/v1/")).toBe("http://127.0.0.1:3456/v1/models")
+    expect(meridianModelsURL("http://127.0.0.1:3456")).toBe("http://127.0.0.1:3456/v1/models")
+    // Only an exact trailing `v1` segment counts.
+    expect(meridianModelsURL("http://127.0.0.1:3456/apiv1")).toBe(
+      "http://127.0.0.1:3456/apiv1/v1/models",
+    )
   })
 
   test("accepts only a complete, unique model list", () => {
@@ -94,33 +160,34 @@ describe("Meridian OpenCode V2 model discovery", () => {
     expect(discovered).toEqual([{ providerID: "meridian", models: parseMeridianModels(MERIDIAN_MODELS) ?? [] }])
   })
 
-  test("adds discovered models but preserves exact user-defined overrides", () => {
-    const updates: Array<{ providerID: string; modelID: string; name: string; context: number; variants: string[] }> = []
-    const catalog = {
-      provider: {
-        get: () => ({
-          provider: { settings: {} },
-          models: new Map([["claude-haiku-4-5", { name: "Fast alias" }]]),
-        }),
-      },
-      model: {
-        update: (providerID: string, modelID: string, update: (model: { name: string; limit: { context: number } }) => void) => {
-          const model = { name: modelID, limit: { context: 200_000 }, variants: [] as Array<{ id: string }> }
-          update(model)
-          updates.push({ providerID, modelID, name: model.name, context: model.limit.context, variants: model.variants.map(variant => variant.id) })
-        },
-      },
-    }
+  // OpenCode's built-in models.dev catalog already carries every model Meridian
+  // advertises, so skipping known ids applied nothing at all on the documented
+  // provider. It also disagrees with the proxy: beta-18866 lists a 1M Sonnet
+  // while Meridian pins Sonnet to 200k. Existing entries must be corrected.
+  test("corrects catalog entries that already exist for models Meridian serves", () => {
+    const { catalog, wrote } = makeCatalogDraft(["claude-haiku-4-5"])
 
     applyMeridianModels(catalog, "meridian", parseMeridianModels(MERIDIAN_MODELS) ?? [])
 
-    expect(updates).toEqual([{
-      providerID: "meridian",
-      modelID: "claude-fable-5",
-      name: "Claude Fable 5",
-      context: 1_000_000,
-      variants: ["low", "high"],
-    }])
+    // Both models are written, including the one the catalog already had, and
+    // the effort level lands in the request body the proxy reads.
+    expect(wrote()).toEqual([
+      {
+        modelID: "claude-fable-5",
+        name: "Claude Fable 5",
+        context: 1_000_000,
+        variants: [
+          { id: "low", body: { effort: "low" } },
+          { id: "high", body: { effort: "high" } },
+        ],
+      },
+      {
+        modelID: "claude-haiku-4-5",
+        name: "Claude Haiku 4.5",
+        context: 200_000,
+        variants: [],
+      },
+    ])
   })
 
   test("supports the legacy local Anthropic provider without fetching a direct Anthropic endpoint", async () => {

--- a/src/__tests__/plugin-v2-model-discovery.test.ts
+++ b/src/__tests__/plugin-v2-model-discovery.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test"
+import {
+  applyMeridianModels,
+  fetchMeridianModels,
+  loadMeridianModels,
+  meridianModelsURL,
+  parseMeridianModels,
+} from "../../plugin/meridian-v2"
+
+const MERIDIAN_MODELS = {
+  object: "list",
+  data: [
+    {
+      id: "claude-fable-5",
+      display_name: "Claude Fable 5",
+      context_window: 1_000_000,
+      capabilities: { effort: { low: { supported: true }, high: { supported: true } } },
+    },
+    { id: "claude-haiku-4-5", display_name: "Claude Haiku 4.5", context_window: 200_000 },
+  ],
+}
+
+describe("Meridian OpenCode V2 model discovery", () => {
+  test("preserves a configured base URL path when finding the models endpoint", () => {
+    expect(meridianModelsURL("http://127.0.0.1:3456/meridian")).toBe(
+      "http://127.0.0.1:3456/meridian/v1/models",
+    )
+    expect(meridianModelsURL("not a URL")).toBeUndefined()
+  })
+
+  test("accepts only a complete, unique model list", () => {
+    expect(parseMeridianModels(MERIDIAN_MODELS)).toEqual([
+      { id: "claude-fable-5", name: "Claude Fable 5", contextWindow: 1_000_000, efforts: ["low", "high"] },
+      { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", contextWindow: 200_000, efforts: [] },
+    ])
+    expect(parseMeridianModels({ data: [{ id: "claude-fable-5" }] })).toBeUndefined()
+    expect(parseMeridianModels({ data: [MERIDIAN_MODELS.data[0], MERIDIAN_MODELS.data[0]] })).toBeUndefined()
+  })
+
+  test("fetches the configured Meridian provider", async () => {
+    const controller = new AbortController()
+    const urls: string[] = []
+    const models = await fetchMeridianModels(
+      "http://127.0.0.1:3456",
+      controller.signal,
+      async (input) => {
+        urls.push(String(input))
+        return new Response(JSON.stringify(MERIDIAN_MODELS), { status: 200 })
+      },
+    )
+
+    expect(urls).toEqual(["http://127.0.0.1:3456/v1/models"])
+    expect(models).toHaveLength(2)
+  })
+
+  test("leaves the existing catalog untouched when provider lookup or fetch fails", async () => {
+    const controller = new AbortController()
+    const failingCatalog = {
+      provider: { get: async () => { throw new Error("provider unavailable") } },
+      reload: async () => { throw new Error("must not reload") },
+    }
+    expect(await loadMeridianModels(failingCatalog, controller.signal)).toEqual([])
+
+    const models = await fetchMeridianModels(
+      "http://127.0.0.1:3456",
+      controller.signal,
+      async () => new Response("down", { status: 503 }),
+    )
+    expect(models).toBeUndefined()
+  })
+
+  test("waits for a usable Meridian provider before fetching models", async () => {
+    const controller = new AbortController()
+    let meridianLookups = 0
+    const urls: string[] = []
+    const catalog = {
+      provider: {
+        get: async ({ providerID }: { providerID: string }) => {
+          if (providerID !== "meridian") return undefined
+          meridianLookups += 1
+          return meridianLookups === 1 ? undefined : { settings: { baseURL: "http://127.0.0.1:3456" } }
+        },
+      },
+      reload: async () => {},
+    }
+
+    const discovered = await loadMeridianModels(catalog, controller.signal, async (input) => {
+      urls.push(String(input))
+      return new Response(JSON.stringify(MERIDIAN_MODELS), { status: 200 })
+    })
+
+    expect(meridianLookups).toBeGreaterThan(1)
+    expect(urls).toEqual(["http://127.0.0.1:3456/v1/models"])
+    expect(discovered).toEqual([{ providerID: "meridian", models: parseMeridianModels(MERIDIAN_MODELS) ?? [] }])
+  })
+
+  test("adds discovered models but preserves exact user-defined overrides", () => {
+    const updates: Array<{ providerID: string; modelID: string; name: string; context: number; variants: string[] }> = []
+    const catalog = {
+      provider: {
+        get: () => ({
+          provider: { settings: {} },
+          models: new Map([["claude-haiku-4-5", { name: "Fast alias" }]]),
+        }),
+      },
+      model: {
+        update: (providerID: string, modelID: string, update: (model: { name: string; limit: { context: number } }) => void) => {
+          const model = { name: modelID, limit: { context: 200_000 }, variants: [] as Array<{ id: string }> }
+          update(model)
+          updates.push({ providerID, modelID, name: model.name, context: model.limit.context, variants: model.variants.map(variant => variant.id) })
+        },
+      },
+    }
+
+    applyMeridianModels(catalog, "meridian", parseMeridianModels(MERIDIAN_MODELS) ?? [])
+
+    expect(updates).toEqual([{
+      providerID: "meridian",
+      modelID: "claude-fable-5",
+      name: "Claude Fable 5",
+      context: 1_000_000,
+      variants: ["low", "high"],
+    }])
+  })
+
+  test("supports the legacy local Anthropic provider without fetching a direct Anthropic endpoint", async () => {
+    const controller = new AbortController()
+    const providerLookups: string[] = []
+    const urls: string[] = []
+    const catalog = {
+      provider: {
+        get: async ({ providerID }: { providerID: string }) => {
+          providerLookups.push(providerID)
+          return {
+            settings: {
+              baseURL: providerID === "anthropic" ? "http://localhost:3456" : undefined,
+            },
+          }
+        },
+      },
+      reload: async () => {},
+    }
+
+    const discovered = await loadMeridianModels(catalog, controller.signal, async (input) => {
+      urls.push(String(input))
+      return new Response(JSON.stringify(MERIDIAN_MODELS), { status: 200 })
+    })
+
+    expect(providerLookups.sort()).toEqual(["anthropic", "meridian"])
+    expect(urls).toEqual(["http://localhost:3456/v1/models"])
+    expect(discovered).toEqual([{
+      providerID: "anthropic",
+      models: parseMeridianModels(MERIDIAN_MODELS) ?? [],
+    }])
+  })
+})


### PR DESCRIPTION
Incorporates @martinmiglio's #1003, which adds Meridian model autodiscovery to
the OpenCode V2 plugin, with maintainer corrections in separate commits.

Contributor commit `a6657962` is cherry-picked as `9a25b773` with Author and
AuthorDate preserved.

### What was taken, and what was dropped

#1003 also packaged the V2 plugin as a directory package. That work already
landed on `main` in #988, byte-for-byte for `plugin/meridian-v2/`, plus a
generalized `scripts/package-opencode-plugins.mjs` that covers V1 as well. The
PR branched from `1ea97d01` and predates it, so that half is dropped as
superseded and only the discovery work is carried over.

### Maintainer corrections

**Discovery never reached Meridian.** V2's Anthropic provider carries the API
version in its base URL, so `http://127.0.0.1:3456/v1` was turned into a request
for `/v1/v1/models`. Live against `0.0.0-beta-18866`: that path answers 404,
`/v1/models` answers 200. The fetch failed and discovery silently produced
nothing.

**Nothing would have been applied even with the URL fixed.** The skip guard read
`catalog.provider.get(id).models`, which inside a transform is the assembled
models.dev catalog rather than user configuration — and that catalog already
lists all nine models Meridian serves, so every one was skipped. V2 layers
`providers.<id>.models` on top of plugin transforms, verified live: a configured
`claude-opus-5` override survived a transform that wrote a different name and
context to the same model. Existing entries can therefore be corrected without
touching user overrides.

Correcting them is the point. beta-18866 advertises a 1M Sonnet; Meridian
deliberately serves Sonnet at 200k so a long turn is not billed as Extra Usage.

**Lifecycle leak.** Setup starts the discovery subscription before registering
hooks, and on a registration failure it rethrows without returning its cleanup,
leaving the subscription and poll loop running.

**Types.** Uses the SDK's `CatalogDraft` and `Model.VariantID` instead of a
hand-rolled draft type, which removes the `as unknown as` cast the variant
assignment needed.

**Docs.** `docs/agents.md` documented a V1-shaped provider block for V2.
`provider`/`options` are silently ignored by V2, which points the client at the
real Anthropic API instead of Meridian; V2 reads `providers`/`settings`.

### Validation

Live, `opencode2 0.0.0-beta-18866` against a Meridian on an isolated port 3466,
isolated `OPENCODE_CONFIG_DIR`/`XDG_*`/session store, real Claude Max (`max`
subscription, profile `work`).

Catalog, same config, before and after Meridian became reachable:

```
Meridian unreachable (= the pre-fix result)
  claude-sonnet-5    ctx=1000000  ['none','low','medium','high','xhigh','max']
  claude-haiku-4-5   ctx=200000   ['high','max']

Meridian reachable, fix applied
  claude-sonnet-5    ctx=200000   ['low','medium','high','xhigh','max']
  claude-sonnet-4-6  ctx=200000   ['low','medium','high','xhigh','max']
  claude-haiku-4-5   ctx=200000   ['low','medium','high','xhigh','max']
  claude-opus-4-5    ctx=200000   ['low','medium','high']        <- not served, untouched
  claude-sonnet-4-5  ctx=1000000  ['high','max']                 <- not served, untouched
```

End-to-end through a logging tap in front of the proxy, selecting a discovered
variant with `--model 'anthropic/claude-haiku-4-5#xhigh'`:

```
POST /v1/messages?beta=true model=claude-haiku-4-5 effort="xhigh" stream=true
<- 200
```

Meridian logged `agent=primary model=haiku` with `source=subagent-title`
detached separately, so the existing V2 identity handling is unchanged.

Negative control: with the base URL pointed at a dead port the catalog is left
exactly as OpenCode built it and nothing is logged as an error.

Gates: `npm test` 3803 pass / 0 fail / 1 pre-existing skip (bun 1.3.14),
`npm run typecheck`, `npm run build` (including `node --check
dist/meridian-v2/index.js`).

Failed-before / passed-after is recorded for both new plugin regressions: with
the URL and lifecycle fixes reverted, `does not double the version segment of an
already-versioned base URL` and `cancels model discovery when registration
fails` both fail.

### Known limitation

Discovery cannot read the catalog until OpenCode has finished assembling it —
awaiting `catalog.provider.get()` inside `setup` deadlocks, confirmed live — so
the first request against a freshly started server still sees the built-in
entries. Naming a Meridian-only variant on that first request, for example
`anthropic/claude-haiku-4-5#xhigh`, fails with `provider.no-route`; the next
request succeeds. Reproducible, not intermittent. Selecting a model in the TUI
is unaffected because the picker renders after discovery lands. Documented in
`docs/agents.md`; closing it would need a persisted catalog cache, which is a
separate design decision.

Closes #1003
