### PR TITLE
fix(errors): classify a disabled subscription entitlement as billing

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1006,6 +1006,38 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(isQuotaRefusal(r.type)).toBe(false)
   })
 
+  // The org-admin switch, observed live on a Max profile: every request came
+  // back 500 while a Pro profile in the same priority pool served the identical
+  // request. The refusal names no limit and no payment method, so nothing
+  // matched it, isAccountFailoverError said no, and the pool sat on an account
+  // that could not serve any request until an admin re-enabled it.
+  //
+  // billing_error rather than rate_limit_error, for the same reason as the
+  // entitlement cap above: an access switch an admin has to flip is not a spent
+  // window, so isQuotaRefusal must not send the cooldown looking up a five-hour
+  // reset that will never arrive.
+  it.each([
+    ["verbatim CLI refusal", "Claude Code returned an error result: Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access"],
+    ["short 'org' spelling", "Your org has disabled Claude subscription access for Claude Code"],
+    ["behind an API status prefix", "API Error: 403 Your organization has disabled Claude subscription access for Claude Code"],
+    ["on an unlabelled stderr line", "Claude Code process exited with code 1\nSubprocess stderr: Your organization has disabled Claude subscription access for Claude Code"],
+  ])("maps the %s of a disabled subscription entitlement to a failover-eligible billing_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("billing_error")
+    expect(r.status).toBe(402)
+    expect(isAccountFailoverError(r.type)).toBe(true)
+    expect(isQuotaRefusal(r.type)).toBe(false)
+  })
+
+  it.each([
+    ["quoted mid-line", "The runbook says your organization has disabled Claude subscription access when a seat is revoked"],
+    ["a different capability", "Your organization has disabled MCP servers for Claude Code"],
+  ])("does not read %s as a disabled subscription entitlement", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).not.toBe("billing_error")
+    expect(isAccountFailoverError(r.type)).toBe(false)
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -76,6 +76,26 @@ const BILLING_SIGNALS: readonly RegExp[] = [
   /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*your (?:group|organization|org)(?:'|’)s usage limit is set to \$\d/m,
 ]
 
+/** The org-admin entitlement switch: "Your organization has disabled Claude
+ *  subscription access for Claude Code · Use an Anthropic API key instead, or
+ *  ask your admin to enable access". Observed live on a Max profile that
+ *  returned 500 on every request while a Pro profile in the same priority pool
+ *  served the identical request from the same container.
+ *
+ *  It names no limit and no payment method, so nothing above matched it: the
+ *  refusal fell through to a generic api_error, isAccountFailoverError said no,
+ *  and priority routing kept handing requests to an account that could not
+ *  serve any of them. In the stderr shape it was worse than a missed failover —
+ *  a bare code-1 exit reads as an auth failure, so the operator was told to run
+ *  `claude login` for an entitlement an admin has to restore.
+ *
+ *  Line-anchored after the known SDK wrappers, like the banners above and for
+ *  the same reason: this classification can pull a profile out of a pool, so a
+ *  runbook or an MCP server quoting the sentence mid-line must not trigger it.
+ *  An optional three-digit status covers the API-key/gateway shape, where the
+ *  SDK prefixes the upstream status ("API Error: 403 Your organization ..."). */
+const SUBSCRIPTION_ACCESS_DISABLED = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*(?:\d{3} )?your (?:organization|org) has disabled claude subscription access/m
+
 /** "hit your limit", "hit your session limit", "hit your weekly limit", and any
  *  future single-word qualifier the CLI adopts. Anchored on both sides so it
  *  can't drift into unrelated text that happens to contain "limit". */
@@ -279,6 +299,21 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
       status: 401,
       type: "authentication_error",
       message: "Claude OAuth token has expired and could not be refreshed automatically. Run 'claude login' in your terminal to re-authenticate."
+    }
+  }
+
+  // Org-level entitlement, checked before the auth branches below: the stderr
+  // shape of this refusal ends in a code-1 exit, which those branches read as
+  // an expired login. billing_error rather than rate_limit_error — an access
+  // switch an admin has to flip is not a spent window, so isQuotaRefusal must
+  // not send the cooldown looking up a five-hour reset that never arrives —
+  // and failover-eligible, because another profile in the pool may well be on
+  // an organization that still allows it.
+  if (SUBSCRIPTION_ACCESS_DISABLED.test(lower)) {
+    return {
+      status: 402,
+      type: "billing_error",
+      message: "This account's organization has disabled Claude subscription access for Claude Code. Ask the organization admin to re-enable it, or serve this request from an API-key profile — an identical retry on this account fails the same way."
     }
   }
 


### PR DESCRIPTION
## The bug

An organization can turn Claude Code access off for subscription (non-API-key) profiles. The CLI then refuses every request with:

```
Claude Code returned an error result: Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access
```

It names no limit and no payment method, so nothing in `classifyError` matched it. The refusal fell through to a generic `api_error`, `isAccountFailoverError()` returned false, and under `MERIDIAN_ROUTING=priority` the pool kept handing requests to an account that could not serve any of them — `/profiles/list` reporting `exhausted: []` while every request returned 500.

Observed live on a two-profile pool (Max first, Pro second): every request 500 for hours, while the identical request forced onto the second profile with `x-meridian-profile` succeeded from the same container. Restarting did not help, because nothing about the process was wrong.

The stderr shape was worse than a missed failover. When the CLI surfaces the refusal by exiting non-zero, a bare code-1 exit reads as an auth failure, so the operator is told to run `claude login` for an entitlement only an org admin can restore:

| message | before | after |
|---|---|---|
| `Claude Code returned an error result: Your organization has disabled Claude subscription access …` | `500 api_error`, no failover | `402 billing_error`, fails over |
| `Claude Code process exited with code 1\nSubprocess stderr: Your organization has disabled Claude subscription access …` | `401 authentication_error`, "run claude login" | `402 billing_error`, fails over |
| `API Error: 403 Your organization has disabled Claude subscription access …` | `500 api_error`, no failover | `402 billing_error`, fails over |

## The classification

`billing_error`, not `rate_limit_error`, for the same reason as the group entitlement cap from #909: an access switch an admin has to flip is not a spent window, so `isQuotaRefusal` must not send the cooldown looking up a five-hour reset that will never arrive. It is failover-eligible because another profile in the pool may be on an organization that still allows subscription access — which is exactly the live case above.

Line-anchored after the known SDK wrappers, with an optional three-digit status for the API-key/gateway shape, like `HIT_YOUR_SPEND_LIMIT` and `REACHED_YOUR_TIER_LIMIT` beside it and for the same reason: this classification can pull a profile out of a pool, so a runbook or an MCP server quoting the sentence mid-line must not trigger it. Negative tests pin both that and a different capability being disabled (`Your organization has disabled MCP servers for Claude Code`).

## Validation

- Every new regression test was verified to fail against the version it guards: 4 of them as `api_error`/`authentication_error`, which is the reported bug.
- `npm test` exits 0; `npm run typecheck` clean; `errors.test.ts` 206/206.
- Live E2E on the affected flow — see below.

### Live E2E

Real refusal from a real account, not a fixture: a Max profile whose organization has Claude Code subscription access switched off, in a two-profile priority pool (`max` first, `pro` second) behind Meridian 1.69.0 + this commit, real SDK, real CLI, `POST /v1/messages` with `claude-sonnet-5`.

```
# 1. pinned to the blocked profile
$ curl -H 'x-meridian-profile: max' -d '{"model":"claude-sonnet-5",...}' :3456/v1/messages
HTTP 402 in 14.6s
{"type":"error","error":{"type":"billing_error","message":"This account's organization has disabled Claude
 subscription access for Claude Code. Ask the organization admin to re-enable it, or serve this request from
 an API-key profile — an identical retry on this account fails the same way."}}

# 2. the pool now knows the account is unusable
$ curl :3456/profiles/list
"profileOrder":["max","pro"],"exhausted":[{"id":"max","until":...,"reason":"billing_error"}]

# 3. unpinned request, blocked profile still first in the order
$ curl -d '{"model":"claude-sonnet-5",...}' :3456/v1/messages
HTTP 200 in 13.0s
{"content":[{"type":"text","text":"OK"}],"model":"claude-sonnet-5","stop_reason":"end_turn",
 "usage":{"input_tokens":2,"output_tokens":4,"cache_read_input_tokens":3298,...}}
```

On the same deployment before this commit the identical pinned request returned `500` with `api_error`, `exhausted` stayed `[]`, and the unpinned request failed too — the pool kept selecting the blocked account. That is the state the account sat in for two days.

`bun scripts/e2e-error-telemetry.mjs` (the #836/#829 harness) was not modified; this path is the same failover mechanism it exercises, driven by a live refusal rather than the local fixture.
