### PR TITLE
fix(errors): classify a disabled subscription entitlement as billing

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1021,6 +1021,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     ["short 'org' spelling", "Your org has disabled Claude subscription access for Claude Code"],
     ["behind an API status prefix", "API Error: 403 Your organization has disabled Claude subscription access for Claude Code"],
     ["on an unlabelled stderr line", "Claude Code process exited with code 1\nSubprocess stderr: Your organization has disabled Claude subscription access for Claude Code"],
+    // The shape the CLI actually emits on the API-key/gateway path: a bare
+    // "Failed to authenticate." sits between its own wrapper and the upstream
+    // status. Captured from a real refusal driven through the error-telemetry
+    // failover harness; the hand-written "API Error: 403 ..." case above does
+    // not exercise it, and the entitlement fell through to api_error without it.
+    ["behind the CLI's own authenticate notice", "Claude Code returned an error result: Failed to authenticate. API Error: 403 Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access"],
   ])("maps the %s of a disabled subscription entitlement to a failover-eligible billing_error", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).toBe("billing_error")
@@ -1032,6 +1038,12 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
   it.each([
     ["quoted mid-line", "The runbook says your organization has disabled Claude subscription access when a seat is revoked"],
     ["a different capability", "Your organization has disabled MCP servers for Claude Code"],
+    // The authenticate notice is only allowed to PREFIX the entitlement string,
+    // never to stand in for it: a plain auth failure must keep its own
+    // classification, and a different disabled capability must not fail over
+    // just because the notice precedes it.
+    ["the authenticate notice alone", "Claude Code returned an error result: Failed to authenticate."],
+    ["the notice before a different capability", "Claude Code returned an error result: Failed to authenticate. API Error: 403 Your organization has disabled MCP servers for Claude Code"],
   ])("does not read %s as a disabled subscription entitlement", (_label, msg) => {
     const r = classifyError(msg)
     expect(r.type).not.toBe("billing_error")

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1006,6 +1006,38 @@ describe("classifyError: session/usage limit phrasings (live-observed)", () => {
     expect(isQuotaRefusal(r.type)).toBe(false)
   })
 
+  // The org-admin switch, observed live on a Max profile: every request came
+  // back 500 while a Pro profile in the same priority pool served the identical
+  // request. The refusal names no limit and no payment method, so nothing
+  // matched it, isAccountFailoverError said no, and the pool sat on an account
+  // that could not serve any request until an admin re-enabled it.
+  //
+  // billing_error rather than rate_limit_error, for the same reason as the
+  // entitlement cap above: an access switch an admin has to flip is not a spent
+  // window, so isQuotaRefusal must not send the cooldown looking up a five-hour
+  // reset that will never arrive.
+  it.each([
+    ["verbatim CLI refusal", "Claude Code returned an error result: Your organization has disabled Claude subscription access for Claude Code · Use an Anthropic API key instead, or ask your admin to enable access"],
+    ["short 'org' spelling", "Your org has disabled Claude subscription access for Claude Code"],
+    ["behind an API status prefix", "API Error: 403 Your organization has disabled Claude subscription access for Claude Code"],
+    ["on an unlabelled stderr line", "Claude Code process exited with code 1\nSubprocess stderr: Your organization has disabled Claude subscription access for Claude Code"],
+  ])("maps the %s of a disabled subscription entitlement to a failover-eligible billing_error", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).toBe("billing_error")
+    expect(r.status).toBe(402)
+    expect(isAccountFailoverError(r.type)).toBe(true)
+    expect(isQuotaRefusal(r.type)).toBe(false)
+  })
+
+  it.each([
+    ["quoted mid-line", "The runbook says your organization has disabled Claude subscription access when a seat is revoked"],
+    ["a different capability", "Your organization has disabled MCP servers for Claude Code"],
+  ])("does not read %s as a disabled subscription entitlement", (_label, msg) => {
+    const r = classifyError(msg)
+    expect(r.type).not.toBe("billing_error")
+    expect(isAccountFailoverError(r.type)).toBe(false)
+  })
+
   // #764 and #787 were the same bug twice: a new qualifier, a 500 instead of
   // failover, a PR. These pin the shape so the next variant is already covered.
   it.each([

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -93,8 +93,17 @@ const BILLING_SIGNALS: readonly RegExp[] = [
  *  the same reason: this classification can pull a profile out of a pool, so a
  *  runbook or an MCP server quoting the sentence mid-line must not trigger it.
  *  An optional three-digit status covers the API-key/gateway shape, where the
- *  SDK prefixes the upstream status ("API Error: 403 Your organization ..."). */
-const SUBSCRIPTION_ACCESS_DISABLED = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*(?:\d{3} )?your (?:organization|org) has disabled claude subscription access/m
+ *  SDK prefixes the upstream status ("API Error: 403 Your organization ...").
+ *
+ *  On that gateway path the CLI also interposes a bare "Failed to authenticate."
+ *  between its own wrapper and the upstream status, so the real string is
+ *  "Claude Code returned an error result: Failed to authenticate. API Error: 403
+ *  Your organization has disabled ...". That clause ends in a period rather than
+ *  a colon, so it is alternated into the wrapper group instead of being a
+ *  wrapper itself. Without it the API-key shape still fell through to api_error
+ *  and did not fail over — caught by driving a real refusal through the
+ *  error-telemetry failover harness, not by the string in the bug report. */
+const SUBSCRIPTION_ACCESS_DISABLED = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*|failed to authenticate\.\s*)*(?:\d{3} )?your (?:organization|org) has disabled claude subscription access/m
 
 /** "hit your limit", "hit your session limit", "hit your weekly limit", and any
  *  future single-word qualifier the CLI adopts. Anchored on both sides so it

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -76,6 +76,26 @@ const BILLING_SIGNALS: readonly RegExp[] = [
   /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*your (?:group|organization|org)(?:'|’)s usage limit is set to \$\d/m,
 ]
 
+/** The org-admin entitlement switch: "Your organization has disabled Claude
+ *  subscription access for Claude Code · Use an Anthropic API key instead, or
+ *  ask your admin to enable access". Observed live on a Max profile that
+ *  returned 500 on every request while a Pro profile in the same priority pool
+ *  served the identical request from the same container.
+ *
+ *  It names no limit and no payment method, so nothing above matched it: the
+ *  refusal fell through to a generic api_error, isAccountFailoverError said no,
+ *  and priority routing kept handing requests to an account that could not
+ *  serve any of them. In the stderr shape it was worse than a missed failover —
+ *  a bare code-1 exit reads as an auth failure, so the operator was told to run
+ *  `claude login` for an entitlement an admin has to restore.
+ *
+ *  Line-anchored after the known SDK wrappers, like the banners above and for
+ *  the same reason: this classification can pull a profile out of a pool, so a
+ *  runbook or an MCP server quoting the sentence mid-line must not trigger it.
+ *  An optional three-digit status covers the API-key/gateway shape, where the
+ *  SDK prefixes the upstream status ("API Error: 403 Your organization ..."). */
+const SUBSCRIPTION_ACCESS_DISABLED = /^\s*(?:(?:error|api error|claude code returned an error result|subprocess stderr):\s*)*(?:\d{3} )?your (?:organization|org) has disabled claude subscription access/m
+
 /** "hit your limit", "hit your session limit", "hit your weekly limit", and any
  *  future single-word qualifier the CLI adopts. Anchored on both sides so it
  *  can't drift into unrelated text that happens to contain "limit". */
@@ -279,6 +299,21 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
       status: 401,
       type: "authentication_error",
       message: "Claude OAuth token has expired and could not be refreshed automatically. Run 'claude login' in your terminal to re-authenticate."
+    }
+  }
+
+  // Org-level entitlement, checked before the auth branches below: the stderr
+  // shape of this refusal ends in a code-1 exit, which those branches read as
+  // an expired login. billing_error rather than rate_limit_error — an access
+  // switch an admin has to flip is not a spent window, so isQuotaRefusal must
+  // not send the cooldown looking up a five-hour reset that never arrives —
+  // and failover-eligible, because another profile in the pool may well be on
+  // an organization that still allows it.
+  if (SUBSCRIPTION_ACCESS_DISABLED.test(lower)) {
+    return {
+      status: 402,
+      type: "billing_error",
+      message: "This account's organization has disabled Claude subscription access for Claude Code. Ask the organization admin to re-enable it, or serve this request from an API-key profile — an identical retry on this account fails the same way."
     }
   }
 


### PR DESCRIPTION
Incorporates @StanChmielewski's #1005 — classify an org-disabled Claude Code subscription entitlement as a failover-eligible `billing_error` — with one maintainer correction found by live testing.

Contributor commit `06a44e2a` is cherry-picked as `2b6681e5` with Author and AuthorDate preserved.

## The bug, reproduced on current main

Confirmed by reading the code, not the report. All three shapes the reporter described, against `main` at `3db622fa`:

```
sdk result     -> 500  api_error             failover=false
stderr exit1   -> 401  authentication_error  failover=false
api 403        -> 500  api_error             failover=false
```

The `401` is the worst of them: a bare code-1 exit reads as an expired login, so the operator is told to run `claude login` for an entitlement only an org admin can restore. And with `failover=false`, priority routing keeps handing requests to an account that cannot serve any of them — `/profiles/list` reporting `exhausted: []` while every request 500s.

The contributor's classification choice is right and the reasoning holds up in source: `billing_error` is in `ACCOUNT_FAILOVER_ERROR_TYPES`, so `isAccountFailoverError` is true, while `isQuotaRefusal` is `rate_limit_error`-only, so the cooldown never goes looking for a five-hour reset that will not arrive. Same precedent as the group entitlement cap in #909.

## Maintainer correction: the string the CLI actually emits

The PR claims to cover the API-key/gateway shape via `API Error: 403 Your organization has disabled ...`. Driving a real refusal through the error-telemetry failover harness showed that is not what reaches `classifyError`:

```
Claude Code returned an error result: Failed to authenticate. API Error: 403
Your organization has disabled Claude subscription access for Claude Code · ...
```

A bare `Failed to authenticate.` sits between the CLI's own wrapper and the upstream status. It ends in a period, so it is not one of the recognised colon-wrappers, and the anchored pattern never reached the entitlement string:

```
observed live shape -> 500 api_error      (still broken)
PR's claimed shape  -> 402 billing_error  (only the hand-written string worked)
```

So one of the three paths the PR claims to fix was still broken. `0560d4a7` alternates the notice into the wrapper group. It may only *prefix* the entitlement string — a plain authentication failure keeps its own classification, and a different disabled capability behind the same notice still does not fail over. Both pinned as negative tests.

## Validation

**Failed-before / passed-after**, both commits. Reverting only the maintainer fix leaves `errors.test.ts` at 208 pass / 1 fail on exactly the new gateway case; restored, 209 / 0.

**Adversarial classification**, ten cases, all as expected:

| accepted | rejected |
|---|---|
| `Your org has disabled …` (abbrev) | `Your organization has **not** disabled …` |
| indented log line | `Notes: your organization has disabled …` (mid-line) |
| `Error: API Error: 403 …` (double wrapper) | `… has disabled MCP servers …` |
| bare `403 …`, UPPERCASE, 2nd line of a multiline | `Failed to authenticate.` alone |

**Live E2E** — real SDK, real CLI, real Claude Max on the fallback. The #836/#829 error-telemetry harness, unmodified except for the refusal fixture, which now returns the org-disabled message with HTTP 403 instead of the credit-balance one. Two-profile priority pool, blocked profile first:

```
pinned          status=402  refused: billing_error
pinned-stream   status=402  refused: billing_error
failover        status=200  working: 200 (real Claude Max)  reply=RECOVERED_bcc5d620…
failover-stream status=200  working: 200 (real Claude Max)  reply=RECOVERED_290d6cfa…
PASS
```

Before the maintainer fix this same harness failed at the pinned assertion with `api_error` — that is how the gap was found.

The contributor's own run against a genuinely org-disabled Max account remains the primary evidence for the real-world shape; I cannot reproduce an org entitlement switch, so the harness drives the refusal instead.

Gates: `npm test` **3880 pass / 0 fail / 1 pre-existing skip** (bun 1.3.14), `npm run typecheck`, `npm run build`.

Closes #1005
