### PR TITLE
test(e2e): make the V2 gate exercise model discovery and report its exit code

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -265,7 +265,7 @@ UI. Both fixtures isolate Meridian state and work only in temporary directories.
 | E39 | [OpenCode internal-agent session key (#845)](#e39-opencode-internal-agent-session-key-845) | **Manual**, real OpenCode: its `title` agent runs under the USER'S session id, so the user's first turn used to queue behind it and then get HTTP 400 `session_turn_conflict`. Asserts the first turn succeeds, waits ~0ms on the session lease, and every later request is `lineage=continuation`. **Run after any OpenCode upgrade and before releases touching session keys or the turn coordinator** | 2026-08-19 |
 | E40 | [Passthrough digest-turn cap](#e40-passthrough-digest-turn-cap) | **Automated**: `bun scripts/e2e-digest-turn-cap.mjs` — real SDK. Asserts the capped tool turn generates no digest text, costs materially less than uncapped on an identical prompt, still RESUMES at its captured checkpoint, leaves text-only turns returning `success`, and does not truncate parallel tool calls. **Run before any release touching the passthrough tool loop, `maxTurns`, or the early-stop checkpoint** | 2026-08-20 |
 | E41 | [Passthrough multi-turn: one call, one answer](#e41-passthrough-multi-turn-one-call-one-answer) | **Automated**: `bun scripts/e2e-passthrough-turns.mjs [--stream]` — real proxy + SDK + Claude Max. Chain and `PROBE_PARALLEL=1` modes assert exact tool-call batching, a distinct durable fork per result round, one real answer per delivered call in the active transcript, and full prompt-cache continuity. **Run all four chain/parallel × stream/non-stream combinations before releases touching passthrough resume or the deny hook** | 2026-08-26 |
-| E42 | [OpenCode V2 beta compatibility](#e42-opencode-v2-beta-compatibility) | **Automated**, exact betas `18314` and `18866`: run `e2e-opencode-v2-package.mjs --live --extended` with each pinned binary. Covers hidden title/summary isolation, process restart, passthrough tools, undo/fork/compaction and overlapping general children. Also test source and packed npm artifacts. **Run after any V2 plugin/API change; another beta is not a pass** | 2026-08-27 |
+| E42 | [OpenCode V2 beta compatibility](#e42-opencode-v2-beta-compatibility) | **Automated**, exact betas `18314` and `18866`: run `e2e-opencode-v2-package.mjs --live --extended` with each pinned binary. Covers hidden title/summary isolation, process restart, passthrough tools, undo/fork/compaction, overlapping general children and the model-discovery round trip with its Meridian-only effort variant. Also test source and packed npm artifacts. **Run after any V2 plugin/API change; another beta is not a pass** | 2026-08-27 |
 | E43 | [Passthrough tools in a namespaced client](#e43-passthrough-tools-in-a-namespaced-client) | **Automated**: `bun scripts/e2e-passthrough-namespaced-tools.mjs [--stream]` — real proxy + SDK. A client tool declared `mcp__oc__read` collides with the namespace Meridian nests client tools under; asserts the call is still dispatched and captured, delivered under the name the client declared, and answered from the client's real result, with an ordinary and a foreign-namespace control alongside. **Run before any release touching passthrough tool registration, the deny hook, or tool-name delivery** | 2026-09-08 |
 | E44 | [Tier refusal failover](#e44-tier-refusal-failover) | **Automated**: `bun scripts/e2e-tier-refusal-failover.mjs [--stream]` — local refusal fixture, **real Claude Max fallback**. Asserts the credits-era per-tier banner is recorded 429 on the refusing profile and that a healthy profile actually answers. Catches what unit tests cannot: the shape that arrives carries the upstream status. **Run before releases touching error classification or priority failover** | 2026-09-08 |
 | E45 | [Codex auto-defer](#e45-codex-auto-defer) | **Automated**: `bun scripts/e2e-codex-auto-defer.mjs` — real proxy + SDK, 40 Codex-shaped tools. Asserts a Codex request reports no deferral and that `exec_command` is loaded rather than found via ToolSearch. The codex transform inherited OpenCode's core tool names, which match nothing Codex sends, so every tool was deferred. **Run before releases touching the codex transform, auto-defer, or `computePassthroughMaxTurns`** | 2026-09-08 |
@@ -3798,6 +3798,41 @@ Without `--live`, this uses the actual client against a scripted local API. It
 requires successful file reading and the exact tool result reaching the API,
 continuation, detached title/summary requests, and independent fork/original
 histories. `--source` runs setup from TypeScript and loads the source package.
+
+### Model discovery (#1004)
+
+The gate asserts the discovery round trip, not merely that some request arrived.
+It requires a `GET` to exactly `/v1/models` — the first version of this feature
+asked for `/v1/v1/models`, because the Anthropic provider carries the API version
+in its base URL, and a silent 404 disabled discovery with nothing failing. It then
+requires the response to carry `claude-haiku-4-5` with a 200k window and a
+supported `xhigh` effort: the two values OpenCode's own models.dev entry gets
+wrong, and the reason the catalog must be overwritten rather than skipped.
+
+Discovery attempts the client abandons when a one-shot process exits are
+recorded and allowed; at least one must complete, and no attempt may fail for
+any other reason.
+
+In `--live --extended` the gate additionally selects
+`anthropic/claude-haiku-4-5#xhigh` and requires the run to succeed with
+`effort: "xhigh"` reaching the proxy. That variant is
+`provider.no-route — Variant unavailable` without discovery, so a pass can only
+come from the applied catalog. It needs the warm server that `--extended`
+starts: a one-shot client process outruns the catalog reload (#1008).
+
+`--no-discovery` is the negative control. The fixture answers the catalog request
+with 404 and the whole gate must still pass, proving discovery fails closed
+rather than breaking the session.
+
+```bash
+E2E_OPENCODE_BIN=/tmp/opencode-18866/node_modules/.bin/opencode2 \
+  bun scripts/e2e-opencode-v2-package.mjs --no-discovery
+```
+
+The fixture answers non-`POST` requests without parsing a body, and forwards them
+upstream with their original method. Parsing unconditionally used to throw on the
+body-less catalog `GET`, which failed discovery closed **and** set the process
+exit code — the gate printed `PASS` and exited 1 (#1014).
 Set `E2E_MERIDIAN_ROOT` to an independently installed `npm pack` consumer to test
 the shipped package without development dependencies. Run both betas in source
 and consumer modes. `--v1` with the pinned V1 `opencode@1.18.11` executable is the

--- a/scripts/e2e-opencode-v2-package.mjs
+++ b/scripts/e2e-opencode-v2-package.mjs
@@ -13,6 +13,8 @@ const live = process.argv.includes('--live')
 const source = process.argv.includes('--source')
 const v1 = process.argv.includes('--v1')
 const extended = process.argv.includes('--extended')
+// The negative control: serve no catalog and require discovery to fail closed.
+const discovery = !process.argv.includes('--no-discovery')
 assert(!extended || (live && !v1), '--extended requires --live and a V2 host')
 const root = realpathSync(mkdtempSync(join(tmpdir(), 'meridian-v2-package-')))
 const proxyWorkdir = process.argv.includes('--separate-proxy-cwd') ? join(root, 'proxy-workdir') : root
@@ -64,15 +66,60 @@ if (live) {
   await startMeridian()
 }
 const requests = []
+const discoveryRequests = []
 let primaryRequests = 0
 let deliveredResultSeen = false
+// Mirrors Meridian's own /v1/models shape for the non-live mode, including the
+// two values OpenCode's models.dev entry disagrees with: Haiku's full effort set
+// and a 200k window.
+const fixtureCatalog = { data: [{
+  id: 'claude-haiku-4-5', object: 'model', owned_by: 'anthropic',
+  display_name: 'Claude Haiku 4.5', context_window: 200_000,
+  capabilities: { effort: { low: { supported: true }, medium: { supported: true }, high: { supported: true },
+    xhigh: { supported: true }, max: { supported: true }, supported: true } },
+}] }
 const endpoint = Bun.serve({ hostname: '127.0.0.1', port: 0, async fetch(request) {
+  // #1004's model discovery issues a body-less `GET /v1/models`. Parsing a body
+  // unconditionally threw here, which both failed discovery closed and set this
+  // process's exit code, so the gate reported PASS and exited 1 (#1014).
+  if (request.method !== 'POST') {
+    const url = new URL(request.url)
+    const row = { method: request.method, path: url.pathname, startedAt: Date.now() }
+    discoveryRequests.push(row)
+    if (!discovery) {
+      row.status = 404
+      return new Response('discovery disabled', { status: 404 })
+    }
+    if (live) {
+      // A one-shot client process can exit while its discovery request is still
+      // in flight, which aborts this forward. Record that instead of throwing:
+      // an unhandled rejection here is what made the gate exit 1 (#1014).
+      try {
+        const upstream = await fetch(`${proxyUrl}${url.pathname}${url.search}`,
+          { method: request.method, headers: request.headers, signal: request.signal })
+        const text = await upstream.text()
+        row.status = upstream.status
+        row.body = text
+        return new Response(text, { status: upstream.status,
+          headers: { 'content-type': upstream.headers.get('content-type') ?? 'application/json' } })
+      } catch (error) {
+        row.status = 0
+        row.aborted = request.signal.aborted
+        row.error = String(error)
+        return new Response('discovery forward failed', { status: 502 })
+      }
+    }
+    const text = JSON.stringify(fixtureCatalog)
+    row.status = 200
+    row.body = text
+    return new Response(text, { status: 200, headers: { 'content-type': 'application/json' } })
+  }
   const body = await request.json()
   const headers = Object.fromEntries([...request.headers].filter(([key]) => (key.startsWith('x-') && key !== 'x-api-key') || key === 'user-agent'))
   const systemText = typeof body.system === 'string' ? body.system : (body.system ?? []).map(block => block.text ?? '').join('\n')
   const clientCwd = systemText.match(/Working directory:\s*([^\n]+)/i)?.[1]?.trim()
   const clientSystemHash = createHash('sha256').update(JSON.stringify(body.system ?? null)).digest('hex')
-  const row = { clientSystemHash, clientCwd, requestId: crypto.randomUUID(), path: new URL(request.url).pathname, model: body.model, headers, hasForkMarker: JSON.stringify(body.messages).includes(forkMarker),
+  const row = { clientSystemHash, clientCwd, requestId: crypto.randomUUID(), path: new URL(request.url).pathname, model: body.model, effort: body.effort, headers, hasForkMarker: JSON.stringify(body.messages).includes(forkMarker),
     hasUndoMarker: JSON.stringify(body.messages).includes(undoMarker), hasSummaryMarker: JSON.stringify(body.messages).includes(summaryMarker), startedAt: Date.now() }
   requests.push(row)
   if (live) {
@@ -101,13 +148,13 @@ const endpoint = Bun.serve({ hostname: '127.0.0.1', port: 0, async fetch(request
   ]
   return new Response(events.map(event => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(''), { headers: { 'content-type': 'text/event-stream' } })
 } })
-async function run(args) {
+async function run(args, { allowFailure = false } = {}) {
   const child = Bun.spawn(args, { cwd: root, env, stdout: 'pipe', stderr: 'pipe' })
   const timer = setTimeout(() => child.kill(), 180_000)
   try {
     const [stdout, stderr, exitCode] = await Promise.all([new Response(child.stdout).text(), new Response(child.stderr).text(), child.exited])
     console.log(JSON.stringify({ root, args, exitCode, stdout, stderr }))
-    assert.equal(exitCode, 0)
+    if (!allowFailure) assert.equal(exitCode, 0)
     return stdout
   } finally { clearTimeout(timer) }
 }
@@ -196,6 +243,37 @@ try {
     assert(restarted.some(event => event.type === 'text' && event.part?.text.includes(receipt)), 'Restart lost the receipt')
     verifyResume(priorTelemetry, await latestPrimaryTelemetry(session), 'process restart')
   }
+  // #1004's user-visible payoff: an effort variant that only Meridian advertises
+  // must become selectable, and the effort must reach the proxy. Verified live on
+  // beta-18866: `#xhigh` is `provider.no-route` without discovery, so a pass here
+  // can only come from the applied catalog. This needs the warm server `extended`
+  // starts — a one-shot client process outruns the catalog reload (#1008).
+  let variantProbe
+  if (extended && discovery && !v1) {
+    const variantModel = 'anthropic/claude-haiku-4-5#xhigh'
+    const modelIndex = base.lastIndexOf('--model')
+    const variantArgs = [...base.slice(0, modelIndex), '--model', variantModel,
+      'Reply with exactly VARIANT_OK and nothing else. Do not call tools.']
+    const before = requests.length
+    const output = await run(variantArgs, { allowFailure: true })
+    const events = parse(output)
+    const errors = events.filter(event => event.type === 'error').map(event => event.error?.type ?? 'unknown')
+    const served = requests.slice(before)
+    variantProbe = {
+      model: variantModel,
+      selected: errors.length === 0,
+      errors,
+      efforts: served.map(row => row.effort ?? null),
+      completed: served.filter(row => row.effort === 'xhigh').every(row => typeof row.completedAt === 'number'),
+      // Recorded, not asserted: the wording the model chooses varies between runs.
+      answered: events.some(event => event.type === 'text' && event.part?.text.includes('VARIANT_OK')),
+    }
+    console.log(JSON.stringify({ variantProbe }))
+    assert(variantProbe.selected, `Meridian-only variant was rejected: ${JSON.stringify(variantProbe.errors)}`)
+    assert(variantProbe.efforts.includes('xhigh'), `Variant did not send its effort: ${JSON.stringify(variantProbe.efforts)}`)
+    assert(variantProbe.completed, 'Variant request never completed upstream')
+  }
+
   // Hidden-agent header probing must not switch the primary client's active agent.
   if (!v1) {
     const summary = parse(await run([...base, '--session', session, '--fork', '--agent', 'summary', `Summarize the fixture receipt in one sentence. Probe token: ${summaryMarker}`]))
@@ -266,9 +344,38 @@ try {
   assert(primaryRows.every(row => !row.hasSummaryMarker), 'Hidden-agent probe entered primary client history')
   assert(primaryRows.every(row => row.clientCwd === root), JSON.stringify(primaryRows.map(row => row.clientCwd)))
   if (process.argv.includes('--separate-proxy-cwd')) assert.notEqual(proxyWorkdir, root)
-  console.log(JSON.stringify({ result: 'PASS', version, source, live, extended, root, session, requests, resumeEvidence }))
+
+  // #1004 model discovery. The original contributor version requested
+  // `/v1/v1/models` because the Anthropic provider carries the version in its
+  // base URL, so discovery 404'd and silently applied nothing. Assert the exact
+  // path, not merely that some request arrived.
+  if (!v1) {
+    const catalogHits = discoveryRequests.filter(row => row.method === 'GET' && row.path.endsWith('/models'))
+    assert(catalogHits.length > 0, 'Model discovery never requested the catalog')
+    assert(catalogHits.every(row => row.path === '/v1/models'),
+      `Discovery requested the wrong path: ${JSON.stringify(catalogHits.map(row => row.path))}`)
+    if (discovery) {
+      // Attempts the client abandoned on process exit are expected; at least one
+      // must have completed, and nothing may fail for another reason.
+      assert(catalogHits.every(row => row.status === 200 || row.aborted === true),
+        `Discovery failed for an unexpected reason: ${JSON.stringify(catalogHits.map(row => ({ status: row.status, error: row.error })))}`)
+      const served = catalogHits.filter(row => row.status === 200)
+      assert(served.length > 0, 'No discovery request ever completed')
+      const payload = JSON.parse(served[0].body)
+      assert(Array.isArray(payload.data) && payload.data.length > 0, 'Discovery response carried no catalog')
+      const haiku = payload.data.find(model => model.id === 'claude-haiku-4-5')
+      assert(haiku, `Catalog omitted claude-haiku-4-5: ${JSON.stringify(payload.data.map(model => model.id))}`)
+      // The two values OpenCode's own entry gets wrong, and the reason applying
+      // the catalog has to overwrite rather than skip an existing model.
+      assert.equal(haiku.context_window, 200_000, 'Catalog advertised an unexpected Haiku context window')
+      assert.equal(haiku.capabilities?.effort?.xhigh?.supported, true, 'Catalog did not advertise the xhigh effort')
+    } else {
+      assert(catalogHits.every(row => row.status === 404), 'Negative control served a catalog')
+    }
+  }
+  console.log(JSON.stringify({ result: 'PASS', version, source, live, extended, discovery, root, session, requests, resumeEvidence, discoveryRequests, variantProbe }))
 } finally {
-  console.log(JSON.stringify({ requestTrace: requests }))
+  console.log(JSON.stringify({ requestTrace: requests, discoveryTrace: discoveryRequests }))
   if (server) { server.kill(); await server.exited; console.log(JSON.stringify({ serverOutput: await serverOutput })) }
   await endpoint.stop(true)
   await proxy?.close()


### PR DESCRIPTION
Fixes the E42 OpenCode V2 gate, which had stopped being a usable pass/fail
signal, and gives #1004's model discovery the automated coverage it shipped
without.

Closes #1014.

## The defect

The gate's recording fixture parsed a JSON body on every request:

```js
const endpoint = Bun.serve({ ..., async fetch(request) {
  const body = await request.json()
```

`GET /v1/models` — the request model discovery issues — has no body, so this
threw. Two consequences, both silent:

1. Discovery failed closed against the fixture, so the catalog application
   #1004 added was never exercised by the gate that is mandatory for V2 changes.
2. The unhandled rejection set the process exit code. The gate printed
   `{"result":"PASS"}` and exited **1**. In CI or any `&&` chain that reads as
   failure, and a future real failure would have been indistinguishable from it.

Proven by A/B on an otherwise identical tree before touching anything:

| fixture | `result` | `GET - /v1/models failed` | exit |
|---|---|---|---|
| as shipped | `PASS` | 5 | **1** |
| patched to answer non-POST | `PASS` | 0 | **0** |

In live mode there was a second instance of the same class: the forward
hardcoded `method: 'POST'`, and an abort mid-forward threw out of the handler.
A one-shot client process exiting with discovery in flight triggers exactly
that — it showed up as `status: null` once the first fix let the run get far
enough to see it.

## The change

The fixture answers non-`POST` requests without parsing a body and forwards
them upstream with their original method. An abandoned forward is recorded,
not thrown.

New assertions, all on observed traffic:

- A `GET` to **exactly** `/v1/models`. The first version of this feature asked
  for `/v1/v1/models`, because the Anthropic provider carries the API version in
  its base URL, and the resulting 404 disabled discovery with nothing failing.
  Asserting the exact path is what would have caught that.
- The response carries `claude-haiku-4-5` with a 200k window and a supported
  `xhigh` effort — the two values OpenCode's own models.dev entry gets wrong,
  and the reason the catalog must be overwritten rather than skipped.
- Attempts the client abandons on exit are allowed; at least one must complete,
  and none may fail for any other reason.
- In `--live --extended`, `anthropic/claude-haiku-4-5#xhigh` is selected and the
  effort must reach the proxy. Without discovery that variant is
  `provider.no-route — Variant unavailable`, verified by hand on beta-18866, so
  a pass here can only come from the applied catalog.
- `--no-discovery` is the negative control: the catalog request gets a 404 and
  the whole gate must still pass, proving discovery fails closed.

The variant probe records whether the model emitted the literal sentinel but
does **not** assert it — that came back true on one run and false on the next,
so asserting it would have made the gate flaky. The deterministic facts are
asserted instead: no error events, the effort observed at the proxy, and the
request completing upstream.

## Validation

Local: `npm test` 3880 pass / 1 skip / 0 fail on bun 1.3.14, typecheck, build.

| run | exit |
|---|---|
| `--live --extended --separate-proxy-cwd`, `0.0.0-beta-18866` | **0** |
| `--live --extended --separate-proxy-cwd`, `0.0.0-beta-18314` | **0** |
| non-live, beta-18866 | **0** |
| `--no-discovery` negative control | **0** |
| `--v1` control, pinned `opencode@1.18.11` | **0**, `discoveryTrace: []` |
| one assertion deliberately broken | **1**, no `PASS` printed |

Both live runs report the variant selected with `effort: "xhigh"` reaching the
proxy and 100% cache reuse on ordinary continuation and process restart. The V1
control confirms V1 issues no discovery request, so the new assertions are
correctly scoped. `e2e-opencode-package-integrity.mjs` passes with and without
`--manifest`.

Test infrastructure only — no source, plugin or configuration changes.
