### PR TITLE
fix(opencode): seed the V2 model catalog so a cold start accepts a variant

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -3822,7 +3822,26 @@ starts: a one-shot client process outruns the catalog reload (#1008).
 
 `--no-discovery` is the negative control. The fixture answers the catalog request
 with 404 and the whole gate must still pass, proving discovery fails closed
-rather than breaking the session.
+rather than breaking the session. With no cache present the catalog is left
+exactly as OpenCode built it.
+
+### Cold start and cache invalidation (#1008)
+
+After the main flow has discovered once, the gate spawns a **fresh
+`--standalone` process** — deliberately not the warm server — and requires
+`anthropic/claude-haiku-4-5#xhigh` to be accepted on its first request with the
+effort reaching the proxy. That only passes if the plugin seeded the catalog
+from `opencode-v2-catalog.json` before the first transform ran. On a pre-fix
+tree it reports `{"errors":["provider.no-route"],"efforts":[]}`.
+
+In non-live mode the gate then repoints the provider at a non-Meridian URL and
+runs cold twice. It requires the cache file to be deleted and the second run to
+reject the variant, which is the self-healing half of invalidation: the seed
+cannot be validated against the provider's URL inside a transform, because a
+draft `Provider.Info` exposes only `id`, `name`, `activation`, `package`,
+`integrationID` and `headers` — no URL at all, verified on beta-18866. The first
+repointed run is recorded but not asserted; whether it still offers the variant
+depends on how far model resolution gets before discovery lands.
 
 ```bash
 E2E_OPENCODE_BIN=/tmp/opencode-18866/node_modules/.bin/opencode2 \

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -106,14 +106,26 @@ accepts. This corrects OpenCode's built-in models.dev entries, which advertise a
 1M Sonnet that Meridian deliberately serves at 200k. Select an effort with
 `provider/model#variant`, for example `anthropic/claude-opus-5#high`. Discovery
 never blocks startup: if Meridian is unreachable or answers with anything
-unexpected, the catalog is left exactly as OpenCode built it.
+unexpected, and nothing has been discovered before, the catalog is left exactly
+as OpenCode built it.
 
-**Known limitation.** Discovery cannot run until OpenCode has finished
-assembling the catalog, so the very first request against a freshly started
-server still sees the built-in entries. Naming a Meridian-only variant on that
-first request — `anthropic/claude-haiku-4-5#xhigh`, say — fails with
-`provider.no-route`; the next request succeeds. Selecting the model in the TUI is
-unaffected, because the picker renders after discovery has landed.
+Discovery cannot run until OpenCode has finished assembling the catalog, so the
+first request against a freshly started server used to see only the built-in
+entries and reject a Meridian-only variant with `provider.no-route`. The plugin
+now caches each successful discovery in
+`~/.config/meridian/opencode-v2-catalog.json` and seeds the catalog from it
+before the first request, so a cold `anthropic/claude-haiku-4-5#xhigh` works.
+The cache is refreshed by every successful discovery and is ignored after seven
+days.
+
+**What this means if you change the provider.** While a cache is present, a
+freshly started server uses the last catalog Meridian served rather than
+OpenCode's built-in entries — including when Meridian is down. If you repoint
+the provider at something that is not Meridian, discovery notices that no
+Meridian base URL is configured, deletes the cache and rebuilds the catalog
+without it; the run after that is back to OpenCode's own entries. To clear it by
+hand, delete that file. The very first run after a brand-new install has no
+cache yet, so a Meridian-only variant still needs one prior request.
 
 For either generation, the plugin enables:
 

--- a/plugin/meridian-v2.ts
+++ b/plugin/meridian-v2.ts
@@ -18,11 +18,14 @@
 import * as Plugin from "@opencode-ai/plugin/promise/plugin"
 import { Model } from "@opencode-ai/schema/model"
 import type { CatalogDraft } from "@opencode-ai/plugin/promise/catalog"
+import { readFileSync, renameSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
 import {
   PRIORITY_ATTESTATION_HEADER,
   createPriorityAttestation,
   deleteHeader,
   getHeader,
+  meridianConfigDirectory,
   setHeader,
   type MutableHeaders,
 } from "./priority-attestation"
@@ -36,6 +39,25 @@ const PARENT_SESSION_ONE_SHOTS = new Set(["title", "summary"])
 const ATTACHED_COMPACTION_AGENT = "compaction"
 const MODEL_DISCOVERY_TIMEOUT_MS = 3_000
 const PROVIDER_READY_POLL_MS = 25
+
+/**
+ * Catalog cache, for the cold-start gap (#1008).
+ *
+ * Discovery cannot begin until OpenCode has finished assembling the catalog, so
+ * the first request against a freshly started server used to see only
+ * OpenCode's built-in models.dev entries and rejected a Meridian-only variant
+ * with `provider.no-route`. Awaiting the catalog inside `setup` deadlocks the
+ * server, so the seed has to come from somewhere that is not the catalog: a
+ * plain file, read synchronously before the first transform runs.
+ *
+ * The entry records the base URL it was discovered from and is only applied to a
+ * provider still pointed at that URL, so repointing OpenCode at a different
+ * Meridian cannot apply another one's models.
+ */
+const CATALOG_CACHE_FILE = "opencode-v2-catalog.json"
+const CATALOG_CACHE_VERSION = 1
+/** Bounds how stale a seed can be if discovery never succeeds again. */
+const CATALOG_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1_000
 // The plugin tree does not import from src/, so this mirrors VALID_EFFORTS in
 // src/proxy/effort.ts. A test asserts the two stay identical. Filtering in this
 // order also gives every model its variants low -> max regardless of the order
@@ -152,6 +174,8 @@ export interface MeridianModel {
 
 export interface MeridianProviderModels {
   providerID: string
+  /** The URL these models came from, so a cached seed is never applied to another. */
+  baseURL?: string
   models: MeridianModel[]
 }
 
@@ -260,11 +284,17 @@ function isLegacyMeridianBaseURL(baseURL: unknown): boolean {
   }
 }
 
+export interface MeridianCatalogLoad {
+  /** Providers whose base URL still looks like Meridian, reachable or not. */
+  readonly configured: string[]
+  readonly discovered: MeridianProviderModels[]
+}
+
 export async function loadMeridianModels(
   catalog: MeridianCatalogClient,
   signal: AbortSignal,
   fetcher: ModelFetcher = globalThis.fetch,
-): Promise<MeridianProviderModels[]> {
+): Promise<MeridianCatalogLoad> {
   const deadline = Date.now() + MODEL_DISCOVERY_TIMEOUT_MS
   while (!signal.aborted) {
     const providers = await Promise.all([...MERIDIAN_PROVIDERS].map(async (providerID) => {
@@ -281,14 +311,176 @@ export async function loadMeridianModels(
     if (configured.length > 0) {
       const discovered = await Promise.all(configured.map(async ({ providerID, baseURL }) => {
         const models = await fetchMeridianModels(baseURL, signal, fetcher)
-        return models ? { providerID, models } : undefined
+        return models ? { providerID, baseURL: typeof baseURL === "string" ? baseURL : undefined, models } : undefined
       }))
-      return discovered.flatMap(result => result ? [result] : [])
+      return {
+        configured: configured.map(provider => provider.providerID),
+        discovered: discovered.flatMap(result => result ? [result] : []),
+      }
     }
-    if (Date.now() >= deadline) return []
+    if (Date.now() >= deadline) return { configured: [], discovered: [] }
     await new Promise<void>((resolve) => setTimeout(resolve, PROVIDER_READY_POLL_MS))
   }
-  return []
+  return { configured: [], discovered: [] }
+}
+
+export interface CachedProviderCatalog {
+  readonly baseURL: string
+  readonly models: readonly MeridianModel[]
+}
+
+export function catalogCachePath(): string {
+  return join(meridianConfigDirectory(), CATALOG_CACHE_FILE)
+}
+
+/**
+ * Validate a cache document as strictly as a discovery response.
+ *
+ * A corrupt or hand-edited file must seed nothing rather than write junk into
+ * the catalog, so every failure returns an empty map.
+ */
+export function parseCatalogCache(value: unknown, now: number): Map<string, CachedProviderCatalog> {
+  const entries = new Map<string, CachedProviderCatalog>()
+  if (!isRecord(value) || value.version !== CATALOG_CACHE_VERSION) return entries
+  if (!isRecord(value.providers)) return entries
+  for (const [providerID, entry] of Object.entries(value.providers)) {
+    if (!MERIDIAN_PROVIDERS.has(providerID) || !isRecord(entry)) continue
+    const { baseURL, fetchedAt } = entry
+    if (typeof baseURL !== "string" || meridianModelsURL(baseURL) === undefined) continue
+    if (typeof fetchedAt !== "number" || !Number.isSafeInteger(fetchedAt) || fetchedAt <= 0) continue
+    if (fetchedAt > now || now - fetchedAt > CATALOG_CACHE_TTL_MS) continue
+    const models = parseCachedModels(entry.models)
+    if (!models || models.length === 0) continue
+    entries.set(providerID, { baseURL, models })
+  }
+  return entries
+}
+
+function parseCachedModels(value: unknown): MeridianModel[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const models: MeridianModel[] = []
+  const ids = new Set<string>()
+  for (const item of value) {
+    if (!isRecord(item)) return undefined
+    const { id, name, contextWindow, efforts } = item
+    if (
+      typeof id !== "string"
+      || id.length === 0
+      || id.length > 256
+      || /[^\x21-\x7E]/.test(id)
+      || ids.has(id)
+      || typeof name !== "string"
+      || name.trim().length === 0
+      || name.length > 256
+      || typeof contextWindow !== "number"
+      || !Number.isSafeInteger(contextWindow)
+      || contextWindow <= 0
+      || !Array.isArray(efforts)
+      || efforts.some(effort => typeof effort !== "string" || !MERIDIAN_EFFORTS.includes(effort as never))
+    ) {
+      return undefined
+    }
+    ids.add(id)
+    models.push({ id, name, contextWindow, efforts: efforts as string[] })
+  }
+  return models
+}
+
+export function serializeCatalogCache(
+  discovered: readonly MeridianProviderModels[],
+  now: number,
+): string {
+  const providers: Record<string, unknown> = {}
+  for (const entry of discovered) {
+    if (typeof entry.baseURL !== "string" || entry.models.length === 0) continue
+    providers[entry.providerID] = { baseURL: entry.baseURL, fetchedAt: now, models: entry.models }
+  }
+  return `${JSON.stringify({ version: CATALOG_CACHE_VERSION, providers }, null, 2)}\n`
+}
+
+/**
+ * Drop the seed. Called when no Meridian-shaped provider is configured any
+ * more, so a later cold start cannot describe a provider this catalog no longer
+ * points at. Best effort, like the write.
+ */
+export function removeCatalogCache(remove: (path: string) => void = path => rmSync(path, { force: true })): void {
+  try {
+    remove(catalogCachePath())
+  } catch {
+    // Ignored on purpose: a stale seed is corrected by the next discovery.
+  }
+}
+
+/** Read the seed. Any failure — missing, unreadable, corrupt — seeds nothing. */
+export function readCatalogCache(
+  now: number,
+  read: (path: string) => string = path => readFileSync(path, "utf-8"),
+): Map<string, CachedProviderCatalog> {
+  try {
+    return parseCatalogCache(JSON.parse(read(catalogCachePath())), now)
+  } catch {
+    return new Map()
+  }
+}
+
+/**
+ * Persist the seed for the next cold start. Best effort: a cache we cannot write
+ * costs a deferred catalog on the next start, which is the old behaviour, so it
+ * must never interrupt a working session.
+ */
+export function writeCatalogCache(
+  discovered: readonly MeridianProviderModels[],
+  now: number,
+  write: (path: string, contents: string) => void = (path, contents) => {
+    // Rename onto the target so a concurrent reader never sees a partial file.
+    const temporary = `${path}.${process.pid}.tmp`
+    writeFileSync(temporary, contents, { encoding: "utf-8", mode: 0o600 })
+    renameSync(temporary, path)
+  },
+): void {
+  try {
+    const contents = serializeCatalogCache(discovered, now)
+    if (contents.includes('"providers": {}')) return
+    write(catalogCachePath(), contents)
+  } catch {
+    // Ignored on purpose: see above.
+  }
+}
+
+/**
+ * The only thing choosing a seed needs from the draft: whether a provider is
+ * still in the catalog. Narrower than `CatalogDraft` on purpose, so the decision
+ * stays unit-testable without standing up a whole branded provider record.
+ */
+export interface CatalogProviderProbe {
+  readonly provider: { get(providerID: string): unknown }
+}
+
+/**
+ * Choose what the transform should write: live discovery when it has landed,
+ * otherwise the cached seed.
+ *
+ * The seed cannot be validated against the provider's configured URL here. A
+ * draft `Provider.Info` exposes only `id`, `name`, `activation`, `package`,
+ * `integrationID` and `headers` — verified on beta-18866, where the whole
+ * record contains no URL at all. So the seed is applied optimistically to any
+ * Meridian provider that still exists in the catalog, and `discoverModels`
+ * corrects or drops it once it can read the real URL.
+ */
+export function resolveCatalogModels(
+  catalog: CatalogProviderProbe,
+  discovered: readonly MeridianProviderModels[],
+  cached: ReadonlyMap<string, CachedProviderCatalog>,
+): MeridianProviderModels[] {
+  if (discovered.length > 0) return [...discovered]
+  const seeded: MeridianProviderModels[] = []
+  for (const providerID of MERIDIAN_PROVIDERS) {
+    const entry = cached.get(providerID)
+    if (!entry) continue
+    if (!catalog.provider.get(providerID)) continue
+    seeded.push({ providerID, baseURL: entry.baseURL, models: [...entry.models] })
+  }
+  return seeded
 }
 
 /**
@@ -391,19 +583,41 @@ const MeridianV2Plugin = Plugin.define({
     const modelDiscoveryController = new AbortController()
     let discoveredModels: MeridianProviderModels[] = []
     let discoveryStarted = false
+    // Read synchronously, before the first transform can run. Awaiting the
+    // catalog here would deadlock the server, which is why the seed is a file
+    // and not a catalog read (#1008).
+    const cachedModels = readCatalogCache(Date.now())
 
     registered.push(await context.catalog.transform((catalog) => {
-      for (const discovered of discoveredModels) {
-        applyMeridianModels(catalog, discovered.providerID, discovered.models)
+      for (const entry of resolveCatalogModels(catalog, discoveredModels, cachedModels)) {
+        applyMeridianModels(catalog, entry.providerID, entry.models)
       }
     }))
 
     const discoverModels = async () => {
       if (discoveryStarted || modelDiscoveryController.signal.aborted) return false
-      const models = await loadMeridianModels(context.catalog, modelDiscoveryController.signal).catch(() => [])
-      if (models.length === 0 || modelDiscoveryController.signal.aborted) return false
+      const loaded = await loadMeridianModels(context.catalog, modelDiscoveryController.signal)
+        .catch((): MeridianCatalogLoad => ({ configured: [], discovered: [] }))
+      if (modelDiscoveryController.signal.aborted) return false
+      if (loaded.configured.length === 0) {
+        // Nothing here points at Meridian any more — the user repointed the
+        // provider. A seed from a previous run would describe a different
+        // endpoint, so drop it and rebuild the catalog without it.
+        if (cachedModels.size > 0) {
+          cachedModels.clear()
+          removeCatalogCache()
+          await context.catalog.reload()
+        }
+        return false
+      }
+      // Configured but unreachable: keep the seed. It is the last thing Meridian
+      // actually served, which beats OpenCode's models.dev entries.
+      if (loaded.discovered.length === 0) return false
       discoveryStarted = true
-      discoveredModels = models
+      discoveredModels = loaded.discovered
+      // Seed the next cold start before the reload, so a crash mid-reload still
+      // leaves the catalog available to the following process.
+      writeCatalogCache(loaded.discovered, Date.now())
       await context.catalog.reload()
       return true
     }

--- a/plugin/priority-attestation.ts
+++ b/plugin/priority-attestation.ts
@@ -32,8 +32,18 @@ export interface PriorityAttestationSignInput {
   readonly issuedAt: number
 }
 
-function configDirectory(): string {
+/**
+ * Meridian's own configuration directory, as the plugin sees it.
+ *
+ * Exported because the V2 plugin also keeps its catalog cache here: the plugin
+ * tree must not import from src/, so this is the one place the resolution lives.
+ */
+export function meridianConfigDirectory(): string {
   return process.env.MERIDIAN_CONFIG_DIR ?? join(homedir(), ".config", "meridian")
+}
+
+function configDirectory(): string {
+  return meridianConfigDirectory()
 }
 
 export function priorityAttestationKeyPath(): string {

--- a/scripts/e2e-opencode-v2-package.mjs
+++ b/scripts/e2e-opencode-v2-package.mjs
@@ -2,7 +2,7 @@
 // Actual pinned OpenCode host against a local API, with isolated client state.
 import assert from 'node:assert/strict'
 import { createHash } from 'node:crypto'
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, realpathSync } from 'node:fs'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, realpathSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -274,6 +274,27 @@ try {
     assert(variantProbe.completed, 'Variant request never completed upstream')
   }
 
+  // #1008: a cold client process must accept a Meridian-only variant on its
+  // FIRST request. That only works if the plugin seeded the catalog from its
+  // cache before the first transform ran, so this deliberately spawns a fresh
+  // `--standalone` process rather than reusing the warm server.
+  let coldStartProbe
+  if (!v1 && discovery) {
+    const coldArgs = [client, 'run', '--standalone', '--format', 'json',
+      '--model', 'anthropic/claude-haiku-4-5#xhigh',
+      'Reply with exactly COLD_OK and nothing else. Do not call tools.']
+    const before = requests.length
+    const output = await run(coldArgs, { allowFailure: true })
+    const events = parse(output)
+    const errors = events.filter(event => event.type === 'error').map(event => event.error?.type ?? 'unknown')
+    const served = requests.slice(before)
+    coldStartProbe = { errors, efforts: served.map(row => row.effort ?? null) }
+    console.log(JSON.stringify({ coldStartProbe }))
+    assert(errors.length === 0, `Cold start rejected the Meridian-only variant: ${JSON.stringify(errors)}`)
+    assert(coldStartProbe.efforts.includes('xhigh'),
+      `Cold start did not send the effort: ${JSON.stringify(coldStartProbe.efforts)}`)
+  }
+
   // Hidden-agent header probing must not switch the primary client's active agent.
   if (!v1) {
     const summary = parse(await run([...base, '--session', session, '--fork', '--agent', 'summary', `Summarize the fixture receipt in one sentence. Probe token: ${summaryMarker}`]))
@@ -373,7 +394,35 @@ try {
       assert(catalogHits.every(row => row.status === 404), 'Negative control served a catalog')
     }
   }
-  console.log(JSON.stringify({ result: 'PASS', version, source, live, extended, discovery, root, session, requests, resumeEvidence, discoveryRequests, variantProbe }))
+
+  // #1008 invalidation. The seed is applied optimistically, because a draft
+  // Provider.Info carries no URL to check it against, so the guarantee is
+  // self-healing rather than prevention: once a cold process sees no
+  // Meridian-shaped provider it drops the cache, and the next one is back to
+  // OpenCode's own catalog. Only those two facts are asserted. The first
+  // repointed run is recorded but not asserted — whether it still offers the
+  // variant depends on how far model resolution gets before discovery lands.
+  // Asserted here, at the end, because it rewrites the client config.
+  let invalidationProbe
+  if (!v1 && discovery && !live) {
+    const cachePath = join(root, 'meridian', 'opencode-v2-catalog.json')
+    assert(existsSync(cachePath), 'Discovery never wrote a catalog cache to seed')
+    const repointed = JSON.parse(readFileSync(path, 'utf8'))
+    repointed.providers = { anthropic: { settings: { apiKey: 'local-fixture-key', baseURL: 'https://meridian-repointed.invalid/v1' } } }
+    writeFileSync(path, JSON.stringify(repointed, null, 2))
+    const variantArgs = ['run', '--standalone', '--format', 'json',
+      '--model', 'anthropic/claude-haiku-4-5#xhigh', 'Reply with exactly REPOINTED and nothing else.']
+    const firstOutput = await run([client, ...variantArgs], { allowFailure: true })
+    const cacheDropped = !existsSync(cachePath)
+    const secondOutput = await run([client, ...variantArgs], { allowFailure: true })
+    const errorsOf = output => parse(output).filter(event => event.type === 'error').map(event => event.error?.type ?? 'unknown')
+    invalidationProbe = { cacheDropped, first: errorsOf(firstOutput), second: errorsOf(secondOutput) }
+    console.log(JSON.stringify({ invalidationProbe }))
+    assert(cacheDropped, 'Repointing the provider away from Meridian left the seed in place')
+    assert(invalidationProbe.second.includes('provider.no-route'),
+      `A repointed provider still offered a Meridian-only variant: ${JSON.stringify(invalidationProbe.second)}`)
+  }
+  console.log(JSON.stringify({ result: 'PASS', version, source, live, extended, discovery, root, session, requests, resumeEvidence, discoveryRequests, variantProbe, coldStartProbe, invalidationProbe }))
 } finally {
   console.log(JSON.stringify({ requestTrace: requests, discoveryTrace: discoveryRequests }))
   if (server) { server.kill(); await server.exited; console.log(JSON.stringify({ serverOutput: await serverOutput })) }

--- a/src/__tests__/plugin-v2-catalog-cache.test.ts
+++ b/src/__tests__/plugin-v2-catalog-cache.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The cold-start seed (#1008).
+ *
+ * Discovery cannot start until OpenCode has assembled the catalog, so the first
+ * request against a freshly started server saw only OpenCode's models.dev
+ * entries and rejected a Meridian-only variant with `provider.no-route`.
+ * Awaiting the catalog inside `setup` deadlocks the server, so the seed is a
+ * file read synchronously before the first transform.
+ */
+import { describe, expect, test } from "bun:test"
+import {
+  parseCatalogCache,
+  readCatalogCache,
+  resolveCatalogModels,
+  serializeCatalogCache,
+  writeCatalogCache,
+  type CachedProviderCatalog,
+  type CatalogProviderProbe,
+  type MeridianProviderModels,
+} from "../../plugin/meridian-v2"
+
+const NOW = 1_700_000_000_000
+const MODELS = [
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", contextWindow: 200_000, efforts: ["low", "xhigh"] },
+]
+const DOCUMENT = {
+  version: 1,
+  providers: { anthropic: { baseURL: "http://127.0.0.1:3466/v1", fetchedAt: NOW - 1_000, models: MODELS } },
+}
+
+/** `resolveCatalogModels` consults only provider existence, so that is all this needs. */
+function draft(providerIDs: readonly string[]): CatalogProviderProbe {
+  return { provider: { get: (providerID: string) => providerIDs.includes(providerID) ? { id: providerID } : undefined } }
+}
+
+describe("catalog cache document", () => {
+  test("round-trips a discovered catalog", () => {
+    const discovered: MeridianProviderModels[] = [
+      { providerID: "anthropic", baseURL: "http://127.0.0.1:3466/v1", models: MODELS },
+    ]
+    const parsed = parseCatalogCache(JSON.parse(serializeCatalogCache(discovered, NOW)), NOW)
+    expect(parsed.get("anthropic")).toEqual({ baseURL: "http://127.0.0.1:3466/v1", models: MODELS })
+  })
+
+  test("a discovery that fetched nothing writes no file at all", () => {
+    const writes: string[] = []
+    writeCatalogCache([], NOW, (_path, contents) => writes.push(contents))
+    writeCatalogCache([{ providerID: "anthropic", models: [] }], NOW, (_path, contents) => writes.push(contents))
+    expect(writes).toEqual([])
+  })
+
+  test("seeds nothing from a document it cannot trust", () => {
+    const rejected: unknown[] = [
+      undefined,
+      null,
+      "{}",
+      { version: 2, providers: DOCUMENT.providers },
+      { version: 1 },
+      { version: 1, providers: { anthropic: { baseURL: "not a url", fetchedAt: NOW, models: MODELS } } },
+      { version: 1, providers: { anthropic: { baseURL: DOCUMENT.providers.anthropic.baseURL, models: MODELS } } },
+      { version: 1, providers: { anthropic: { baseURL: DOCUMENT.providers.anthropic.baseURL, fetchedAt: NOW, models: [] } } },
+      // An unknown provider must not be seeded even if the entry is well formed.
+      { version: 1, providers: { openai: DOCUMENT.providers.anthropic } },
+      // Effort levels the proxy does not accept.
+      {
+        version: 1,
+        providers: {
+          anthropic: {
+            baseURL: DOCUMENT.providers.anthropic.baseURL,
+            fetchedAt: NOW,
+            models: [{ ...MODELS[0], efforts: ["turbo"] }],
+          },
+        },
+      },
+    ]
+    for (const value of rejected) expect(parseCatalogCache(value, NOW).size).toBe(0)
+  })
+
+  test("expires a seed that is too old, and one dated in the future", () => {
+    const stale = { ...DOCUMENT, providers: { anthropic: { ...DOCUMENT.providers.anthropic, fetchedAt: NOW - 8 * 24 * 60 * 60 * 1_000 } } }
+    expect(parseCatalogCache(stale, NOW).size).toBe(0)
+    const ahead = { ...DOCUMENT, providers: { anthropic: { ...DOCUMENT.providers.anthropic, fetchedAt: NOW + 1_000 } } }
+    expect(parseCatalogCache(ahead, NOW).size).toBe(0)
+  })
+
+  test("an unreadable or corrupt file seeds nothing instead of throwing", () => {
+    expect(readCatalogCache(NOW, () => { throw new Error("ENOENT") }).size).toBe(0)
+    expect(readCatalogCache(NOW, () => "not json").size).toBe(0)
+    expect(readCatalogCache(NOW, () => JSON.stringify(DOCUMENT)).get("anthropic")?.models).toEqual(MODELS)
+  })
+
+  test("a write that fails never interrupts the session", () => {
+    expect(() => writeCatalogCache(
+      [{ providerID: "anthropic", baseURL: "http://127.0.0.1:3466/v1", models: MODELS }],
+      NOW,
+      () => { throw new Error("EROFS") },
+    )).not.toThrow()
+  })
+})
+
+describe("what the transform writes", () => {
+  const cached = new Map<string, CachedProviderCatalog>([
+    ["anthropic", { baseURL: "http://127.0.0.1:3466/v1", models: MODELS }],
+  ])
+
+  test("live discovery wins over the seed", () => {
+    const live: MeridianProviderModels[] = [{ providerID: "meridian", baseURL: "http://127.0.0.1:9/v1", models: MODELS }]
+    expect(resolveCatalogModels(draft(["anthropic", "meridian"]), live, cached)).toEqual(live)
+  })
+
+  test("seeds a provider the catalog still has, before discovery lands", () => {
+    expect(resolveCatalogModels(draft(["anthropic"]), [], cached)).toEqual([
+      { providerID: "anthropic", baseURL: "http://127.0.0.1:3466/v1", models: MODELS },
+    ])
+  })
+
+  test("seeds nothing for a provider the catalog no longer has", () => {
+    expect(resolveCatalogModels(draft(["openai"]), [], cached)).toEqual([])
+  })
+
+  test("with no seed and no discovery nothing is written at all", () => {
+    expect(resolveCatalogModels(draft(["anthropic"]), [], new Map())).toEqual([])
+  })
+})

--- a/src/__tests__/plugin-v2-model-discovery.test.ts
+++ b/src/__tests__/plugin-v2-model-discovery.test.ts
@@ -125,7 +125,8 @@ describe("Meridian OpenCode V2 model discovery", () => {
       provider: { get: async () => { throw new Error("provider unavailable") } },
       reload: async () => { throw new Error("must not reload") },
     }
-    expect(await loadMeridianModels(failingCatalog, controller.signal)).toEqual([])
+    expect(await loadMeridianModels(failingCatalog, controller.signal))
+      .toEqual({ configured: [], discovered: [] })
 
     const models = await fetchMeridianModels(
       "http://127.0.0.1:3456",
@@ -157,7 +158,14 @@ describe("Meridian OpenCode V2 model discovery", () => {
 
     expect(meridianLookups).toBeGreaterThan(1)
     expect(urls).toEqual(["http://127.0.0.1:3456/v1/models"])
-    expect(discovered).toEqual([{ providerID: "meridian", models: parseMeridianModels(MERIDIAN_MODELS) ?? [] }])
+    expect(discovered).toEqual({
+      configured: ["meridian"],
+      discovered: [{
+        providerID: "meridian",
+        baseURL: "http://127.0.0.1:3456",
+        models: parseMeridianModels(MERIDIAN_MODELS) ?? [],
+      }],
+    })
   })
 
   // OpenCode's built-in models.dev catalog already carries every model Meridian
@@ -215,9 +223,13 @@ describe("Meridian OpenCode V2 model discovery", () => {
 
     expect(providerLookups.sort()).toEqual(["anthropic", "meridian"])
     expect(urls).toEqual(["http://localhost:3456/v1/models"])
-    expect(discovered).toEqual([{
-      providerID: "anthropic",
-      models: parseMeridianModels(MERIDIAN_MODELS) ?? [],
-    }])
+    expect(discovered).toEqual({
+      configured: ["anthropic"],
+      discovered: [{
+        providerID: "anthropic",
+        baseURL: "http://localhost:3456",
+        models: parseMeridianModels(MERIDIAN_MODELS) ?? [],
+      }],
+    })
   })
 })


### PR DESCRIPTION
Makes a cold OpenCode V2 start accept a Meridian-only model variant on its
first request.

Closes #1008.

## Before

Discovery cannot start until OpenCode has finished assembling the catalog, so
the first request against a freshly started server saw only OpenCode's built-in
models.dev entries:

```
$ opencode2 run --model 'anthropic/claude-haiku-4-5#xhigh' '...'
{"type":"error","error":{"type":"provider.no-route",
 "message":"Variant unavailable for anthropic/claude-haiku-4-5: xhigh"}}
```

The second request succeeded. Reproduced on the pre-fix tree with the new gate
assertion: `{"errors":["provider.no-route"],"efforts":[]}`, exit 1.

## After

Each successful discovery is cached in
`~/.config/meridian/opencode-v2-catalog.json`. The plugin reads it
**synchronously** in `setup`, before the first transform can run, so the first
request already has Meridian's context windows and effort variants. Same gate
assertion on this tree: `{"errors":[],"efforts":[null,"xhigh"]}`, exit 0.

The seed has to be a file rather than a catalog read because awaiting the
catalog inside `setup` deadlocks the server — that is why discovery is driven
off `catalog.updated` in the first place.

## The part that shaped the design

I intended to validate a cached entry against the provider's configured base
URL, so a repointed provider could never apply another Meridian's models. That
is not possible inside a transform. Instrumenting the real host showed a draft
`Provider.Info` carries only:

```
["id","name","activation","package","integrationID","headers"]
```

and the whole record contains no URL at all (beta-18866). I had assumed
otherwise from the types; printing it was what settled it.

So the guarantee is self-healing instead of preventive:

- The seed is applied optimistically to any Meridian provider still present in
  the catalog.
- When discovery finds **no** Meridian-shaped base URL, the provider has been
  repointed: the cache is deleted and the catalog rebuilt without it.
- A provider that is configured but **unreachable** keeps its seed. The last
  catalog Meridian actually served beats models.dev, which advertises a 1M
  Sonnet that Meridian deliberately serves at 200k.

A corrupt, unreadable, truncated, wrong-version, future-dated or over-week-old
cache seeds nothing. A cache that cannot be written or removed never interrupts
a session.

## Behaviour change worth your attention

The old line "if Meridian is unreachable the catalog is left exactly as OpenCode
built it" now holds **only when no cache is present**. With a cache, a freshly
started server uses the last catalog Meridian served even while Meridian is
down. That is the whole point of the seed, but it is a real narrowing, so it is
called out in `docs/agents.md` together with how to clear the file by hand. The
existing `--no-discovery` negative control still passes, because it runs with an
isolated config directory and therefore no cache.

Also unchanged by design: the very first run after a brand-new install has no
cache yet, so a Meridian-only variant there still needs one prior request. No
plugin API exists to do better — `@opencode-ai/plugin@0.0.0-beta-19271`, nine
betas past our newest supported host, still has a synchronous `Transform` and no
config domain.

## New gate coverage

- **Cold start.** After the main flow has discovered once, the gate spawns a
  fresh `--standalone` process — deliberately not the warm server — and requires
  the variant to be accepted on its first request with the effort reaching the
  proxy.
- **Invalidation.** In non-live mode the gate repoints the provider at a
  non-Meridian URL and runs cold twice, requiring the cache file to be deleted
  and the second run to reject the variant. The first repointed run is recorded
  but not asserted: whether it still offers the variant depends on how far model
  resolution gets before discovery lands, and asserting it would be flaky.

## Validation

`npm test` 3890 pass / 1 skip / 0 fail on bun 1.3.14 (10 new), typecheck, build.

| run | exit |
|---|---|
| pre-fix tree, same gate | **1** — `provider.no-route`, `efforts: []` |
| `--live --extended --separate-proxy-cwd`, beta-18866 | 0 |
| `--live --extended --separate-proxy-cwd`, beta-18314 | 0 |
| same, against an independently `npm pack`-installed consumer | 0 |
| non-live, beta-18866 | 0 |
| `--no-discovery` negative control | 0 |
| `--v1` control, pinned `opencode@1.18.11` | 0, `discoveryTrace: []` |
| one new assertion deliberately broken | 1 |

`e2e-opencode-package-integrity.mjs` passes with and without `--manifest`.
