### PR TITLE
feat(proxy): classify abort causes in sdk_termination diagnostics

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -762,6 +762,30 @@ describe("formatSdkTermination", () => {
     expect(line).toContain("source=main")
     expect(line).toContain('raw="Some weird upstream failure"')
   })
+
+  it("appends abort=none when the cause snapshot says no Meridian-linked abort fired", () => {
+    const line = formatSdkTermination(
+      { reason: "max_turns", turns: 1 },
+      { model: "sonnet", abort: { cause: "none", aborted: false } },
+    )
+    expect(line).toContain("reason=max_turns")
+    expect(line).toContain("turns=1")
+    expect(line).toContain("abort=none")
+  })
+
+  it("appends the classified abort cause when one fired", () => {
+    const line = formatSdkTermination(
+      { reason: "aborted" },
+      { abort: { cause: "session_watchdog", aborted: true, elapsedMs: 600_012 } },
+    )
+    expect(line).toContain("abort=session_watchdog")
+    expect(line).not.toContain("elapsed")
+  })
+
+  it("omits the abort field entirely when no snapshot is provided", () => {
+    const line = formatSdkTermination({ reason: "max_turns", turns: 1 }, { model: "sonnet" })
+    expect(line).not.toContain("abort=")
+  })
 })
 
 describe("classifyError: session/usage limit phrasings (live-observed)", () => {

--- a/src/__tests__/request-abort-cause.test.ts
+++ b/src/__tests__/request-abort-cause.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the abort-cause registry on RequestAbortLink (FIX A).
+ *
+ * The registry latches the FIRST classified cause of a request abort so the
+ * sdk_termination diagnostic can distinguish "the client hung up" from "the
+ * watchdog fired" from "nothing Meridian linked ever aborted" (the latter is
+ * `none`, which is the discriminating marker for the uncaptured-tool-turn
+ * incident — it is NOT proof that no CLI-internal abort occurred).
+ */
+import { describe, expect, test } from "bun:test"
+import { linkRequestAbort } from "../proxy/requestAbort"
+
+describe("linkRequestAbort cause registry", () => {
+  test("no abort — snapshot reports cause none, aborted false", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    const snap = link.abortSnapshot()
+    expect(snap.aborted).toBe(false)
+    expect(snap.cause).toBe("none")
+    link.detach()
+  })
+
+  test("client_abort classified before forwarding wins as first cause", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.setCause("client_abort")
+    link.abort(new Error("client hung up"))
+    const snap = link.abortSnapshot()
+    expect(snap.aborted).toBe(true)
+    expect(snap.cause).toBe("client_abort")
+    expect(link.controller.signal.aborted).toBe(true)
+    link.detach()
+  })
+
+  test("abort without setCause — snapshot reports unknown_abort", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.abort(new Error("mystery"))
+    const snap = link.abortSnapshot()
+    expect(snap.aborted).toBe(true)
+    expect(snap.cause).toBe("unknown_abort")
+    link.detach()
+  })
+
+  test("first cause wins over later labels", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.setCause("session_watchdog")
+    link.setCause("client_abort")
+    link.abort(new Error("watchdog elapsed"))
+    const snap = link.abortSnapshot()
+    expect(snap.cause).toBe("session_watchdog")
+    link.detach()
+  })
+
+  test("already-aborted signal forwards reason and snapshots unknown_abort", () => {
+    const controller = new AbortController()
+    controller.abort(new Error("already gone"))
+    const link = linkRequestAbort(controller.signal)
+    const snap = link.abortSnapshot()
+    expect(snap.aborted).toBe(true)
+    expect(snap.cause).toBe("unknown_abort")
+    // forwardAbort ran for the pre-aborted signal; the linked controller is hot.
+    expect(link.controller.signal.aborted).toBe(true)
+    expect((link.controller.signal.reason as Error).message).toBe("already gone")
+    link.detach()
+  })
+
+  test("already-aborted signal with a prior label keeps the label", () => {
+    const controller = new AbortController()
+    controller.abort(new Error("gone"))
+    const link = linkRequestAbort(controller.signal)
+    link.setCause("process_shutdown")
+    expect(link.abortSnapshot().cause).toBe("process_shutdown")
+    link.detach()
+  })
+
+  test("direct controller.abort bypassing the helper surfaces as unknown_abort", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.controller.abort(new Error("third party abort"))
+    const snap = link.abortSnapshot()
+    expect(snap.aborted).toBe(true)
+    expect(snap.cause).toBe("unknown_abort")
+    link.detach()
+  })
+
+  test("detached link stops forwarding but keeps its snapshot", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.detach()
+    link.setCause("client_abort")
+    link.abort(new Error("after detach"))
+    expect(link.abortSnapshot().cause).toBe("client_abort")
+    expect(link.abortSnapshot().aborted).toBe(true)
+  })
+
+  test("signal.reason payload is preserved through abort", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.setCause("stream_cancel")
+    link.abort(new Error("body cancelled"))
+    expect((link.controller.signal.reason as Error).message).toBe("body cancelled")
+    expect(link.abortSnapshot().cause).toBe("stream_cancel")
+    link.detach()
+  })
+
+  test("abortSnapshot exposes monotonic elapsedMs between link and abort", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    link.abort()
+    const snap = link.abortSnapshot()
+    expect(snap.elapsedMs).toBeGreaterThanOrEqual(0)
+    link.detach()
+  })
+
+  test("elapsedMs is undefined when never aborted", () => {
+    const controller = new AbortController()
+    const link = linkRequestAbort(controller.signal)
+    expect(link.abortSnapshot().elapsedMs).toBeUndefined()
+    link.detach()
+  })
+})

--- a/src/__tests__/request-abort-cause.test.ts
+++ b/src/__tests__/request-abort-cause.test.ts
@@ -121,3 +121,24 @@ describe("linkRequestAbort cause registry", () => {
     link.detach()
   })
 })
+
+/**
+ * Maintainer guard. The commit that introduced `abort=<cause>` described all
+ * five `formatSdkTermination` call sites as passing the snapshot; one of them —
+ * `sdk_termination_recovered` on the captured-tool recovery path — did not, so
+ * the field was silently absent from the diagnostic closest to the incident it
+ * was written for. Nothing failed, because an omitted context field just does
+ * not render.
+ *
+ * The fixtures in `e2e-capped-turns.mjs` never reach that site, so no live gate
+ * covers it. This pins the invariant at the source instead.
+ */
+describe("every SDK termination diagnostic carries an abort cause", () => {
+  test("each formatSdkTermination call site passes the snapshot", async () => {
+    const source = await Bun.file(new URL("../proxy/server.ts", import.meta.url)).text()
+    const callSites = source.match(/formatSdkTermination\(/g) ?? []
+    const snapshots = source.match(/abort: requestAbort\.abortSnapshot\(\)/g) ?? []
+    expect(callSites.length).toBeGreaterThan(0)
+    expect(snapshots.length).toBe(callSites.length)
+  })
+})

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -3,6 +3,8 @@
  * Maps raw error messages to structured HTTP error responses.
  */
 
+import type { AbortCauseSnapshot } from "./requestAbort"
+
 export interface ClassifiedError {
   status: number
   type: string
@@ -799,6 +801,8 @@ export function formatSdkTermination(
     isResume?: boolean
     hasDeferredTools?: boolean
     sdkSessionId?: string
+    /** Abort-cause snapshot: which Meridian-linked producer fired, if any. */
+    abort?: AbortCauseSnapshot
   },
 ): string {
   const parts: string[] = [`reason=${t.reason}`]
@@ -809,6 +813,12 @@ export function formatSdkTermination(
   if (ctx.isResume !== undefined) parts.push(`resume=${ctx.isResume}`)
   if (ctx.hasDeferredTools !== undefined) parts.push(`deferred=${ctx.hasDeferredTools}`)
   if (ctx.sdkSessionId) parts.push(`session=${ctx.sdkSessionId.slice(0, 8)}`)
+  if (ctx.abort) {
+    // `none` means no Meridian-linked abort fired — the marker that
+    // discriminates the uncaptured-tool-turn incident from a genuine client
+    // or watchdog cancellation. It is NOT proof the CLI never aborted.
+    parts.push(`abort=${ctx.abort.cause}`)
+  }
   if (t.rawTail) parts.push(`raw=${JSON.stringify(t.rawTail)}`)
   if (t.stderrTail) parts.push(`stderr=${JSON.stringify(t.stderrTail)}`)
   return `sdk_termination ${parts.join(" ")}`

--- a/src/proxy/requestAbort.ts
+++ b/src/proxy/requestAbort.ts
@@ -1,13 +1,77 @@
+/**
+ * Request-scoped abort link with an abort-cause registry.
+ *
+ * Meridian aborts a request's SDK query from several producers (client
+ * disconnect, cancelled response body, session turn watchdog, subtree
+ * cancellation, process shutdown, the proxy's own passthrough single-step
+ * abort). When a capped turn then dies with an opaque SDK termination, the
+ * operator needs to know WHICH producer fired — or that none did, which is
+ * the discriminating marker for the uncaptured-tool-turn incident
+ * (2026-09-10 0a95wd-tusk): an externally-initiated CLI abort masqueraded as
+ * "Reached maximum number of turns (1)".
+ *
+ * The registry latches the FIRST classified cause. `abortSnapshot` is the
+ * single read side used by diagnostics. `cause: "none"` means no
+ * Meridian-linked abort was observed — it is NOT proof that no abort occurred
+ * inside the CLI subprocess; only that nothing Meridian controls aborted.
+ */
+export type RequestAbortCause =
+  | "client_abort"
+  | "stream_cancel"
+  | "session_watchdog"
+  | "process_shutdown"
+  | "subtree_cancel"
+  | "passthrough_single_step"
+  | "unknown_abort"
+
+export const REQUEST_ABORT_CAUSES: readonly RequestAbortCause[] = [
+  "client_abort",
+  "stream_cancel",
+  "session_watchdog",
+  "process_shutdown",
+  "subtree_cancel",
+  "passthrough_single_step",
+  "unknown_abort",
+] as const
+
+export interface AbortCauseSnapshot {
+  /** First classified cause; "none" when the observed signal never aborted. */
+  cause: RequestAbortCause | "none"
+  /** Whether the linked controller's signal is aborted. */
+  aborted: boolean
+  /** Monotonic ms from link creation to abort; undefined when not aborted. */
+  elapsedMs?: number
+}
+
 export interface RequestAbortLink {
   controller: AbortController
   abort: (reason?: unknown) => void
   detach: () => void
+  /**
+   * Latch the classified cause of an impending abort. First call wins; later
+   * labels are ignored so the earliest producer owns the diagnosis. Callers
+   * should label BEFORE invoking abort, and may label a cause that arrives
+   * with an already-aborted signal.
+   */
+  setCause: (cause: RequestAbortCause) => void
+  /** Read-side snapshot for diagnostics and telemetry. */
+  abortSnapshot: () => AbortCauseSnapshot
 }
 
 /** Forward an HTTP request abort into the SDK query lifecycle. */
 export function linkRequestAbort(signal: AbortSignal): RequestAbortLink {
   const controller = new AbortController()
   let attached = false
+  const linkedAt = Date.now()
+  let cause: RequestAbortCause | undefined
+
+  const classify = (): RequestAbortCause | "none" => {
+    if (!controller.signal.aborted) return "none"
+    // Any abort whose producer never labeled is unknown: the label registry
+    // is best-effort, not a proof of absence (a direct controller.abort by a
+    // third party must not masquerade as "nothing happened").
+    return cause ?? "unknown_abort"
+  }
 
   const abort = (reason?: unknown) => {
     if (!controller.signal.aborted) controller.abort(reason)
@@ -28,6 +92,19 @@ export function linkRequestAbort(signal: AbortSignal): RequestAbortLink {
       if (!attached) return
       signal.removeEventListener("abort", forwardAbort)
       attached = false
+    },
+    setCause: (labeled) => {
+      cause ??= labeled
+    },
+    abortSnapshot: (): AbortCauseSnapshot => {
+      const snapshot: AbortCauseSnapshot = {
+        cause: classify(),
+        aborted: controller.signal.aborted,
+      }
+      if (controller.signal.aborted) {
+        snapshot.elapsedMs = Math.max(0, Date.now() - linkedAt)
+      }
+      return snapshot
     },
   }
 }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -9,7 +9,7 @@ import { query } from "@anthropic-ai/claude-agent-sdk"
 import { rateLimitStore } from "./rateLimitStore"
 import { guardUpstreamIdle, UpstreamIdleError } from "./streamIdleGuard"
 import { IdleStallCeilingError, IdleStallTracker, idleStallRequestKey } from "./idleStallCeiling"
-import { linkRequestAbort } from "./requestAbort"
+import { linkRequestAbort, type RequestAbortLink } from "./requestAbort"
 import { processSessionTree, truncateSessionKey, type SessionTreeRegistration } from "./sessionTree"
 import { AbortableSemaphore, getProcessSdkSemaphore, type SemaphoreLease } from "./concurrency"
 import { closeServerWithGracePeriod, trackServerConnections } from "./shutdown"
@@ -295,6 +295,14 @@ interface HandleMessagesOptions {
   body: any
   forcedProfileId?: string
   turnWatchdogSignal?: AbortSignal
+  /**
+   * The request-wide abort link created by the outer handler. Adopted (not
+   * recreated) here so the single cause registry spans queue retries and
+   * profile-failover re-entries of this handler, and so outer producers —
+   * client disconnect, body cancel, watchdog, subtree cancel, process
+   * shutdown — label the same registry the SDK query sees.
+   */
+  requestAbortLink?: RequestAbortLink
   forceFreshPriorityReplay?: boolean
   priorityPublication?: PrioritySessionPublication
   priorityAttemptExposure?: PriorityAttemptExposure
@@ -559,6 +567,7 @@ type PriorityDispatchOptions = {
   readonly wantsStream: boolean
   readonly currentProfileId: string | undefined
   readonly turnWatchdogSignal?: AbortSignal
+  readonly requestAbortLink?: RequestAbortLink
   readonly publicationTurn?: {
     readonly turnId: string
     readonly issuedAt: number
@@ -755,6 +764,11 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
   let durableWritesRevoked = false
   let inFlightRequests = 0
   const activeRequestAborts = new Set<AbortController>()
+  /** Cause-aware shutdown aborts: each entry labels its request's registry
+   * before the controller fires, because the shutdown producer aborts the
+   * turnWatchdog controller directly (not through the request's own link)
+   * and would otherwise surface as unknown_abort. */
+  const activeShutdownLabels = new Map<AbortController, () => void>()
 
   // Admission belongs at the PUBLIC entrypoint. /v1/chat/completions and
   // /v1/responses translate their body before re-entering /v1/messages, so
@@ -1211,6 +1225,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         body: options.body,
         forcedProfileId: candidate,
         turnWatchdogSignal: options.turnWatchdogSignal,
+        requestAbortLink: options.requestAbortLink,
         forceFreshPriorityReplay: priorityPublication !== undefined
           && (options.durableRoute?.forceFreshReplay === true
             || (options.currentProfileId !== undefined && candidate !== options.currentProfileId)),
@@ -1315,7 +1330,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const requestSignal = options.turnWatchdogSignal
       ? AbortSignal.any([c.req.raw.signal, options.turnWatchdogSignal])
       : c.req.raw.signal
-    const requestAbort = linkRequestAbort(requestSignal)
+    // Adopt the outer handler's link when provided so one cause registry
+    // spans queue retries and profile-failover re-entries; create one only
+    // when no outer link exists (direct in-process callers).
+    const requestAbort = options.requestAbortLink ?? linkRequestAbort(requestSignal)
     let streamOwnsAbortLink = false
 
     return withClaudeLogContext({ requestId: requestMeta.requestId, endpoint: requestMeta.endpoint }, async () => {
@@ -1779,6 +1797,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                 wantsStream: body.stream === true,
                 currentProfileId: assignedProfile,
                 turnWatchdogSignal: options.turnWatchdogSignal,
+                requestAbortLink: options.requestAbortLink,
                 publicationTurn,
                 claimTurn: trustedTurn,
                 durableRoute,
@@ -3181,6 +3200,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   // real SDK). Aborting the query's controller SIGTERMs the
                   // subprocess; the abort-shaped termination is converted into a
                   // clean stop_reason:"tool_use" response by the recovery paths.
+                  requestAbort.setCause("passthrough_single_step")
                   requestAbort.abort("passthrough single-step complete")
                 } else {
                   capturedSignatures.add(signature)
@@ -3958,6 +3978,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
               diagnosticLog.session(
                 `${requestMeta.requestId} sdk_termination_recovered ${formatSdkTermination(sdkTerm, {
                   model, requestSource, isResume, hasDeferredTools, sdkSessionId: currentSessionId || resumeSessionId,
+                  abort: requestAbort.abortSnapshot(),
                 })} captured=${capturedToolUses.length}`,
                 requestMeta.requestId,
               )
@@ -4403,6 +4424,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             // terminal delta leaves the proxy, and it leaves last, once the
             // turn's real stop_reason is known.
             let pendingTerminalDelta: Uint8Array | null = null
+            // The turn budget the LAST SDK attempt asked for. attemptMaxTurns
+            // is attempt-local; the outer catch (recovery predicates) needs
+            // the final value.
+            let lastAttemptMaxTurns: number | undefined
             let pendingStructuredFrames: Array<{ payload: Uint8Array; source: string }> = []
             let pendingStructuredTextLength = 0
             let terminalDeltaSent = false
@@ -4558,6 +4583,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                       advisorModel,
                     }, requestAbort.controller)
                     attemptMaxTurns = attemptQuery.options.maxTurns
+                    lastAttemptMaxTurns = attemptMaxTurns
                     for await (const event of runSdkQueryAttempt(attemptQuery, requestAbort.controller.signal, requestMeta, "stream", managedSdkAttemptLocators())) {
                       // Same SDK rate-limit capture as the non-stream path.
                       if ((event as any).type === "rate_limit_event") {
@@ -6474,6 +6500,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     isResume,
                     hasDeferredTools,
                     sdkSessionId: currentSessionId || resumeSessionId,
+                    abort: requestAbort.abortSnapshot(),
                   })} blocks=${nextClientBlockIndex}`,
                   requestMeta.requestId,
                 )
@@ -6555,6 +6582,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   isResume,
                   hasDeferredTools,
                   sdkSessionId: currentSessionId || resumeSessionId,
+                  abort: requestAbort.abortSnapshot(),
                 })} envelope=${messageStartEmitted ? "open" : "unopened"} blocks=${contentBlocksForwarded} ` +
                 `text=${textEventsForwarded} tools=${capturedToolUses.length}/${streamedToolUseIds.size}`,
                 requestMeta.requestId,
@@ -6668,15 +6696,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             } finally {
               await abandonManagedFork("stream_complete_without_commit")
               if (priorityRollbackRetirement) await priorityRollbackRetirement
-              requestAbort.detach()
+              // Detach only when this handler owns the link. An ADOPTED
+              // request-wide link must stay attached: a later profile-failover
+              // attempt re-enters this handler with the same link, and a
+              // per-attempt detach would deafen it to watchdog, subtree,
+              // client, and shutdown aborts for the rest of the request.
+              if (!streamOwnsAbortLink) requestAbort.detach()
             }
             })().finally(() => {
               resolveStreamCompletion()
             })
           },
           cancel(reason) {
+            requestAbort.setCause("stream_cancel")
             requestAbort.abort(reason)
-            requestAbort.detach()
+            // Only the owner detaches the link; an adopted request-wide link
+            // stays attached for the outer handler's lifetime.
+            if (!streamOwnsAbortLink) requestAbort.detach()
             // A cancelled response body is the other way a client says "stop",
             // and the only one an in-process caller can reach. Children are
             // cancelled here as well, latched so a real socket teardown —
@@ -6747,6 +6783,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         diagnosticLog.error(
           `${requestMeta.requestId} ${formatSdkTermination(sdkTerm, {
             requestSource: c.req.header("x-meridian-source")?.slice(0, 64) || undefined,
+            abort: requestAbort.abortSnapshot(),
           })}`,
           requestMeta.requestId,
         )
@@ -6887,6 +6924,23 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     }
     const turnWatchdogAbort = new AbortController()
     activeRequestAborts.add(turnWatchdogAbort)
+    // One request-wide cause registry, created here where every external
+    // producer (client disconnect, body cancel, watchdog, subtree cancel,
+    // process shutdown) lives, and adopted by handleMessages across queue
+    // retries and profile-failover re-entries. It listens on the COMBINED
+    // signal — client + watchdog — so a watchdog or subtree abort reaches the
+    // SDK query exactly as the per-request link it replaces did.
+    // A raw request-signal abort with no other cause labeled is a client
+    // disconnect; label it before the link forwards so the diagnostic reads
+    // client_abort instead of unknown_abort. Watchdog/subtree/shutdown label
+    // first, and first-cause-wins keeps their more specific classification.
+    const requestSignalForLink = AbortSignal.any([c.req.raw.signal, turnWatchdogAbort.signal])
+    const labelClientAbort = () => {
+      if (!turnWatchdogAbort.signal.aborted) requestAbortLink?.setCause("client_abort")
+    }
+    c.req.raw.signal.addEventListener("abort", labelClientAbort, { once: true })
+    const requestAbortLink = linkRequestAbort(requestSignalForLink)
+    activeShutdownLabels.set(turnWatchdogAbort, () => requestAbortLink.setCause("process_shutdown"))
     let finished = false
     let leaseReleased = false
     let retainSessionTurnFence = false
@@ -6915,6 +6969,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     const finishRequest = () => {
       if (finished) return
       finished = true
+      // Terminal request cleanup for the request-wide abort link: detach its
+      // combined-signal listener and drop the raw client-abort label
+      // listener. handleMessages never detaches an adopted link (a later
+      // failover attempt must keep receiving aborts), so ownership of the
+      // terminal detach belongs here, which runs exactly once.
+      requestAbortLink.detach()
+      c.req.raw.signal.removeEventListener("abort", labelClientAbort)
       if (retainSessionTurnFence && (sessionTurnLease || crossProcessTurnLease)) {
         leaseReleased = true
         if (leaseWatchdog) clearTimeout(leaseWatchdog)
@@ -6930,6 +6991,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       sessionTreeRegistration?.release()
       sessionTreeRegistration = undefined
       activeRequestAborts.delete(turnWatchdogAbort)
+      activeShutdownLabels.delete(turnWatchdogAbort)
       inFlightRequests--
     }
 
@@ -6971,7 +7033,13 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             requestId,
             sessionKey: agentSessionId,
             parentKey: adapter.getParentSessionId?.(c, body),
-            abort: (reason) => turnWatchdogAbort.abort(reason),
+            abort: (reason) => {
+              // A parent cancellation reaches this request through the
+              // session tree; classify it distinctly from the watchdog,
+              // which shares the same controller.
+              requestAbortLink.setCause("subtree_cancel")
+              turnWatchdogAbort.abort(reason)
+            },
           })
           subtreeSessionKey = agentSessionId
           const clientSignal = c.req.raw.signal
@@ -6999,6 +7067,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
             leaseWatchdog = setTimeout(() => {
               claudeLog("session.turn_watchdog_abort", { requestId, heldMs: SESSION_TURN_MAX_HOLD_MS })
               plog(`[PROXY] ${requestId} session turn exceeded ${SESSION_TURN_MAX_HOLD_MS}ms — aborting without releasing its fencing lease`)
+              requestAbortLink.setCause("session_watchdog")
               turnWatchdogAbort.abort(new Error("Session turn exceeded its maximum hold time"))
             }, SESSION_TURN_MAX_HOLD_MS)
             leaseWatchdog.unref?.()
@@ -7084,6 +7153,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const response = await handleMessages(c, requestMeta, {
         body,
         turnWatchdogSignal: turnWatchdogAbort.signal,
+        requestAbortLink,
       })
       const completion = responseCompletions.get(response)
       if (completion) {
@@ -8191,6 +8261,9 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
     beginDrain: () => { draining = true },
     forceAbortInFlight: () => {
       durableWritesRevoked = true
+      // Label every request's cause registry BEFORE aborting: shutdown is
+      // the producer, and the diagnostic must not read unknown_abort.
+      for (const label of activeShutdownLabels.values()) label()
       for (const controller of activeRequestAborts) {
         controller.abort(new Error("Proxy shutdown grace period elapsed"))
       }

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -6245,6 +6245,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     isResume,
                     hasDeferredTools,
                     sdkSessionId: currentSessionId || resumeSessionId,
+                    abort: requestAbort.abortSnapshot(),
                   })} captured=${capturedToolUses.length}`,
                   requestMeta.requestId,
                 )


### PR DESCRIPTION
Incorporates the first of the two commits held back from contributor PR #980,
with **Jake Wimmer's authorship preserved** (`77667583` → `8f362e18`,
AuthorDate 2026-09-10 intact). Cherry-picked from `codex/polytoken-extras`, not
retyped.

Refs #1011. Held only so it gets its own changelog line and its own gate rather
than riding under the Polytoken adapter headline in #1010.

## What it does

Adds a request-wide abort-cause registry to `RequestAbortLink` (`setCause` /
`abortSnapshot`, first cause wins) and labels every Meridian producer: client
disconnect, cancelled response body, session turn watchdog, subtree
cancellation, process shutdown, and the passthrough single-step abort.
`formatSdkTermination` gains an `abort=<cause>` field.

Observability only — nothing a client receives changes. `abort=none` is the
load-bearing value: it means no Meridian-linked abort fired, which is what
separates an externally-initiated CLI abort from a genuine cancellation. As the
contributor's own commit message is careful to say, it is **not** proof that no
abort happened inside the CLI subprocess.

`requestAbort.ts` stays a pure leaf — it still has no imports. `errors.ts` takes
only a type from it, so no cycle.

## A maintainer correction, in its own commit

`1cf83e46`. The contributor's commit message says all five
`formatSdkTermination` call sites pass the snapshot. Four did. The fifth —
`sdk_termination_recovered` on the captured-tool recovery path — did not, so
`abort=<cause>` was missing from the diagnostic *closest to the incident the
field was written for*, and the groundwork #1009 is meant to build on. Nothing
failed, because an omitted context field simply does not render.

The `e2e-capped-turns.mjs` fixtures never reach that site, so no live gate can
cover it. The correction therefore comes with a source invariant: every
`formatSdkTermination` call site must pass `requestAbort.abortSnapshot()`. That
test fails on the tree without the one-line addition and passes with it.

## Validation

`npm test` 3904 pass / 1 skip / 0 fail on bun 1.3.14 (+15: the contributor's 14
plus the invariant), typecheck, build.

Live, real SDK and Claude Max:

| gate | result |
|---|---|
| E41 chain, non-stream | PASS |
| E41 parallel, non-stream | PASS |
| E41 chain, stream | PASS |
| E41 parallel, stream | PASS |
| `e2e-capped-turns.mjs`, all 7 cases × stream and non-stream | 14/14 PASS |

**The new field observed on a real termination.** The capped-turn gate runs the
proxy with `silent: true` and these diagnostics go to the in-memory telemetry
store rather than stdout, so nothing in its output shows the field either way. I
re-ran three cases against the same gate with the store dumped, and real
terminations now read:

```
sdk_termination reason=max_turns turns=1 abort=none
```

which is exactly the discriminating marker the change exists to provide.
