### PR TITLE
Add new version for Opencode v2

### DIFF
--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -79,6 +79,7 @@ describe("OpenCode generation detection", () => {
     expect(SUPPORTED_OPENCODE_V2_VERSIONS).toEqual(new Set([
       "0.0.0-beta-18314",
       "0.0.0-beta-18866",
+      "0.0.0-beta-19425",
     ]))
   })
 

--- a/src/proxy/setup.ts
+++ b/src/proxy/setup.ts
@@ -137,6 +137,7 @@ export interface OpenCodeDetection {
 export const SUPPORTED_OPENCODE_V2_VERSIONS = new Set([
   "0.0.0-beta-18314",
   "0.0.0-beta-18866",
+  "0.0.0-beta-19425",
 ])
 
 /** Check our package manifest and entry without executing plugin code during setup. */


### PR DESCRIPTION
Hi, this adds a supported version of Opencode V2, 0.0.0-beta-19425, to the code. It's a small change. Thanks!