### PR TITLE
fix(session): take the bookkeeping off the request path

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -423,6 +423,37 @@ describe("classifyError", () => {
     })
   })
 
+  describe("session bookkeeping saturation", () => {
+    it("classifies the lifecycle lock wait as proxy load, not a request timeout", () => {
+      const result = classifyError("timed out waiting for /var/lib/meridian/.cache/meridian/session-gc.json.lock")
+      expect(result.status).toBe(503)
+      expect(result.type).toBe("overloaded_error")
+      expect(result.message).toContain("a bookkeeping lock is busy")
+      // The raw message carries absolute host paths; the client sees none.
+      expect(result.message).not.toContain("/var/lib")
+      expect(result.message).not.toContain(".lock")
+    })
+
+    it("classifies the ownership backlog limit as proxy load", () => {
+      const result = classifyError("session transcript ownership backlog is full")
+      expect(result.status).toBe(503)
+      expect(result.type).toBe("overloaded_error")
+      expect(result.message).toContain("the retirement backlog is full")
+    })
+
+    it("classifies the ownership capacity limit as proxy load", () => {
+      const result = classifyError("session transcript ownership capacity is full")
+      expect(result.status).toBe(503)
+      expect(result.type).toBe("overloaded_error")
+    })
+
+    it("still classifies an unrelated timeout as a request timeout", () => {
+      const result = classifyError("connection timed out")
+      expect(result.status).toBe(504)
+      expect(result.type).toBe("timeout_error")
+    })
+  })
+
   describe("server errors", () => {
     it("detects 500 status codes", () => {
       const result = classifyError("HTTP 500 from API")

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -133,10 +133,8 @@ describe("Shared session store", () => {
   })
 
   it("never aliases a caller-owned locator into the cached document", () => {
-    // The read cache serves the document the last write published. If that
-    // document shared a locator object with its caller, any later mutation of
-    // the caller's object (a lifecycle fill-back, a stray assignment) would
-    // silently diverge the cache from the file on disk.
+    // A shared locator object would let a later caller-side mutation diverge the
+    // read cache from the file on disk.
     const callerLocator: { sessionId: string; configDir: string; projectDir?: string } =
       { sessionId: "claude-sess-alias", configDir: "/config" }
     storeSharedSession(

--- a/src/__tests__/proxy-session-store.test.ts
+++ b/src/__tests__/proxy-session-store.test.ts
@@ -12,6 +12,7 @@ import {
   lookupSharedSessionResult,
   evictSharedSession,
   storeSharedSession,
+  attachSharedTranscriptLocator,
   clearSharedSessions,
   getSessionStoreDir,
   readSessionStoreSnapshot,
@@ -19,7 +20,7 @@ import {
   setSessionStoreDir,
 } from "../proxy/sessionStore"
 import { join } from "node:path"
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 
 describe("Shared session store", () => {
@@ -87,6 +88,73 @@ describe("Shared session store", () => {
     clearSharedSessions()
     expect(lookupSharedSession("sess-1")).toBeUndefined()
     expect(lookupSharedSession("sess-2")).toBeUndefined()
+  })
+
+  it("should serve consecutive reads from the identity cache", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    const first = lookupSharedSessionResult("session-123")
+    const second = lookupSharedSessionResult("session-123")
+    if (first.status !== "found" || second.status !== "found") throw new Error("lookup failed")
+    // Same object identity proves the second read served the cached document.
+    expect(second.session).toBe(first.session)
+    expect(second.generation).toBe(first.generation)
+  })
+
+  it("should reflect an in-process write after a cached read", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    expect(lookupSharedSession("session-123")!.claudeSessionId).toBe("claude-sess-abc")
+
+    storeSharedSession("session-123", "claude-sess-def")
+    expect(lookupSharedSession("session-123")!.claudeSessionId).toBe("claude-sess-def")
+  })
+
+  it("should pick up a store replaced out of band by another process", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    expect(lookupSharedSession("session-123")!.claudeSessionId).toBe("claude-sess-abc")
+
+    // Imitate a foreign proxy: a different valid document renamed over the
+    // store path, which changes the inode but not the path.
+    const replacement = join(tmpDir, "sessions.json.replacement")
+    writeFileSync(replacement, JSON.stringify({
+      "session-456": { claudeSessionId: "claude-sess-xyz", createdAt: 1, lastUsedAt: 1, messageCount: 0 },
+    }), { mode: 0o600 })
+    renameSync(replacement, join(getSessionStoreDir(), "sessions.json"))
+
+    expect(lookupSharedSession("session-123")).toBeUndefined()
+    expect(lookupSharedSession("session-456")!.claudeSessionId).toBe("claude-sess-xyz")
+  })
+
+  it("should treat a deleted store as missing instead of serving the stale cache", () => {
+    storeSharedSession("session-123", "claude-sess-abc")
+    expect(lookupSharedSession("session-123")!.claudeSessionId).toBe("claude-sess-abc")
+
+    unlinkSync(join(getSessionStoreDir(), "sessions.json"))
+    expect(lookupSharedSessionResult("session-123").status).toBe("missing")
+  })
+
+  it("never aliases a caller-owned locator into the cached document", () => {
+    // The read cache serves the document the last write published. If that
+    // document shared a locator object with its caller, any later mutation of
+    // the caller's object (a lifecycle fill-back, a stray assignment) would
+    // silently diverge the cache from the file on disk.
+    const callerLocator: { sessionId: string; configDir: string; projectDir?: string } =
+      { sessionId: "claude-sess-alias", configDir: "/config" }
+    storeSharedSession(
+      "alias-session", "claude-sess-alias", undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, callerLocator
+    )
+    expect(lookupSharedSession("alias-session")!.currentTranscript).toEqual(callerLocator)
+
+    callerLocator.projectDir = "/mutated-by-caller"
+    expect(lookupSharedSession("alias-session")!.currentTranscript).not.toHaveProperty("projectDir")
+    expect(JSON.parse(readFileSync(join(getSessionStoreDir(), "sessions.json"), "utf8"))["alias-session"].currentTranscript)
+      .not.toHaveProperty("projectDir")
+
+    const attachedLocator: { sessionId: string; configDir: string; lifecycleGeneration?: string } =
+      { sessionId: "claude-sess-alias", configDir: "/config-2" }
+    expect(attachSharedTranscriptLocator("alias-session", "claude-sess-alias", attachedLocator)).not.toBe(false)
+    attachedLocator.lifecycleGeneration = "r:forged:1"
+    expect(lookupSharedSession("alias-session")!.currentTranscript).not.toHaveProperty("lifecycleGeneration")
   })
 
   it("should persist context usage and find it by Claude session ID", () => {

--- a/src/__tests__/session-lifecycle-process.test.ts
+++ b/src/__tests__/session-lifecycle-process.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
+import { randomUUID } from "node:crypto"
 import { existsSync, readFileSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
@@ -6,6 +7,7 @@ import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import {
   getTranscriptResourceKey,
+  prepareFork,
   reconcile,
   runGc,
   type TranscriptLocator,
@@ -96,6 +98,8 @@ interface StoredActiveLease {
 
 interface StoredResource {
   state: string
+  attempts?: number
+  lastError?: string
   activeLeases?: Record<string, StoredActiveLease>
 }
 
@@ -342,4 +346,30 @@ describe("session lifecycle leases across OS processes", () => {
     expect(deletes).toBe(1)
     expect(readSidecar(fixture.root).resources[key]?.state).toBe("deleted")
   }, 15_000)
+
+  test("classifies a child-reported absent transcript as notFound and tombstones it", async () => {
+    if (process.platform === "win32") return
+    const fixture = await makeFixture(randomUUID())
+    await prepareFork(fixture.locator, gcOptions(fixture.root))
+
+    const result = await runGc([], gcOptions(fixture.root))
+
+    expect(result).toEqual({ deleted: 0, notFound: 1, failed: 0, deferred: 0 })
+    expect(readSidecar(fixture.root).resources[getTranscriptResourceKey(fixture.locator)]?.state)
+      .toBe("deleted")
+  }, 20_000)
+
+  test("keeps a genuine child deletion failure failed for retry", async () => {
+    if (process.platform === "win32") return
+    const fixture = await makeFixture("not-a-uuid")
+    await prepareFork(fixture.locator, gcOptions(fixture.root))
+
+    const result = await runGc([], gcOptions(fixture.root))
+
+    expect(result).toEqual({ deleted: 0, notFound: 0, failed: 1, deferred: 1 })
+    const resource = readSidecar(fixture.root).resources[getTranscriptResourceKey(fixture.locator)]
+    expect(resource?.state).toBe("retired")
+    expect(resource?.attempts).toBe(1)
+    expect(resource?.lastError).toContain("session deletion child exited 1")
+  }, 20_000)
 })

--- a/src/__tests__/session-lifecycle.test.ts
+++ b/src/__tests__/session-lifecycle.test.ts
@@ -21,6 +21,7 @@ import {
   acquireActiveTranscriptLease,
   attachActiveTranscriptExecutor,
   attachPinnedTranscript,
+  clipChildOutput,
   commitFork,
   getSessionGcNodeExecutable,
   getTranscriptResourceKey,
@@ -437,6 +438,40 @@ describe("session transcript lifecycle", () => {
     await releaseActiveTranscriptLease(second, options)
   })
 
+  it("expires an unarmed writer lease older than its TTL, independently of the prepared grace", async () => {
+    const graceOptions = { ...options, unarmedLeaseTtlMs: 100, preparedGraceMs: 10_000 }
+    const fork = locator("stale-unarmed-writer")
+    await prepareFork(fork, graceOptions)
+    const first = await acquireActiveTranscriptLease([fork], graceOptions)
+    await expect(acquireActiveTranscriptLease([fork], graceOptions)).rejects.toThrow("active SDK writer")
+
+    now += 101
+    const second = await acquireActiveTranscriptLease([fork], graceOptions)
+    expect(second.token).not.toBe(first.token)
+    await releaseActiveTranscriptLease(second, graceOptions)
+  })
+
+  it("keeps a fresh unarmed writer lease exclusive", async () => {
+    const graceOptions = { ...options, unarmedLeaseTtlMs: 100 }
+    const fork = locator("fresh-unarmed-writer")
+    await prepareFork(fork, graceOptions)
+    await acquireActiveTranscriptLease([fork], graceOptions)
+    now += 50
+    await expect(acquireActiveTranscriptLease([fork], graceOptions)).rejects.toThrow("active SDK writer")
+  })
+
+  it("retires an unpinned live resource once its stale publication lease expires", async () => {
+    const graceOptions = { ...options, unarmedLeaseTtlMs: 100 }
+    const fork = locator("stale-publication-lease")
+    await prepareForkForPublication(fork, graceOptions)
+    await commitFork(fork, graceOptions)
+    expect((await reconcile([], graceOptions)).liveRetired).toBe(0)
+
+    now += 101
+    expect((await reconcile([], graceOptions)).liveRetired).toBe(1)
+    expect(readSidecar(storeDir).resources[getTranscriptResourceKey(fork)]?.state).toBe("retired")
+  })
+
   it("keeps current and previous pins and deletes only retired forks", async () => {
     const current = locator("current")
     const previous = locator("previous")
@@ -501,6 +536,17 @@ describe("session transcript lifecycle", () => {
   it("uses a real Node executable when tests run under Bun", () => {
     expect(process.versions.bun).toBeDefined()
     expect(getSessionGcNodeExecutable()).toBe("node")
+  })
+
+  it("clips child output keeping both ends within the budget", () => {
+    const head = "h".repeat(2_000)
+    const tail = "t".repeat(2_000)
+    const clipped = clipChildOutput(`${head}${"m".repeat(3_000)}${tail}`)
+
+    expect(clipped.startsWith(head)).toBe(true)
+    expect(clipped.endsWith(tail)).toBe(true)
+    expect(clipped).toContain("3000 chars elided")
+    expect(clipChildOutput("short child output")).toBe("short child output")
   })
 
   it("defers retired deletion through the reader-drain grace period", async () => {

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -454,12 +454,10 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
-  // The proxy's own session-bookkeeping locks and limits. These arrive with
-  // "timed out" in the text, so the generic timeout branch below would call
-  // them a request timeout and send the operator to shrink a context that has
-  // nothing to do with it. 503 overloaded names the real cause: proxy load.
-  // The raw message stays out of the body — it names absolute host paths,
-  // which are not the client's business; the diagnostic log keeps them.
+  // The proxy's own bookkeeping locks and limits. They carry "timed out", so
+  // the generic timeout branch below would answer them as a request timeout and
+  // send the operator to shrink a context that has nothing to do with it. The
+  // raw text names absolute host paths, so only the reason reaches the client.
   if (
     (lower.includes("timed out waiting for") && lower.includes(".lock"))
     || lower.includes("ownership backlog is full")

--- a/src/proxy/errors.ts
+++ b/src/proxy/errors.ts
@@ -454,6 +454,29 @@ export function classifyError(errMsg: string, model?: string): ClassifiedError {
     }
   }
 
+  // The proxy's own session-bookkeeping locks and limits. These arrive with
+  // "timed out" in the text, so the generic timeout branch below would call
+  // them a request timeout and send the operator to shrink a context that has
+  // nothing to do with it. 503 overloaded names the real cause: proxy load.
+  // The raw message stays out of the body — it names absolute host paths,
+  // which are not the client's business; the diagnostic log keeps them.
+  if (
+    (lower.includes("timed out waiting for") && lower.includes(".lock"))
+    || lower.includes("ownership backlog is full")
+    || lower.includes("ownership capacity is full")
+  ) {
+    const reason = lower.includes("ownership backlog is full")
+      ? "the retirement backlog is full"
+      : lower.includes("ownership capacity is full")
+        ? "the ownership capacity is full"
+        : "a bookkeeping lock is busy"
+    return {
+      status: 503,
+      type: "overloaded_error",
+      message: `Meridian's session bookkeeping is saturated: ${reason}. This is proxy load, not the request; retry shortly.`
+    }
+  }
+
   // Timeout
   if (lower.includes("timeout") || lower.includes("timed out")) {
     return {

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -678,6 +678,14 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       0,
       envInt("SESSION_GC_GRACE_MS", SESSION_TURN_MAX_HOLD_MS + 60_000),
     ),
+    // The lock wait is a queue budget on one global lifecycle lock: a deployment
+    // with many concurrent conversations may prefer a slower turn over a failed
+    // one. The default stays what sessionLifecycle ships.
+    lockWaitMs: Math.max(100, envInt("SESSION_GC_LOCK_WAIT_MS", 2_000)),
+    // Sized by the turn watchdog, like the prepared grace: a lease a request
+    // still holds cannot outlive the watchdog, and one that did is a release
+    // that failed — collect it by age instead of fencing the conversation.
+    unarmedLeaseTtlMs: SESSION_TURN_MAX_HOLD_MS + 60_000,
     deletionTimeoutMs: Math.max(1_000, envInt("SESSION_GC_DELETE_TIMEOUT_MS", 30_000)),
     runTimeoutMs: Math.max(1_000, envInt("SESSION_GC_RUN_TIMEOUT_MS", 30_000)),
   }
@@ -2692,8 +2700,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const prepareManagedFork = async (sourceSessionId: string): Promise<void> => {
         if (managedForkTarget) return
         managedFreshTarget = false
+        // A shallow copy, on purpose: this locator is handed to lifecycle calls
+        // that fill the caller's locator back (Object.assign), and the session
+        // store now serves its cached document — mutating the stored object in
+        // place would silently diverge the cache from the file on disk.
         managedForkSource = cachedSession?.currentTranscript?.sessionId === sourceSessionId
-          ? cachedSession.currentTranscript
+          ? { ...cachedSession.currentTranscript }
           : transcriptLocator(sourceSessionId)
         managedForkTarget = transcriptLocator(randomUUID())
         releaseManagedForkPins = pinActiveSessionGcLocators(managedForkSource, managedForkTarget)
@@ -5577,8 +5589,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                   if (!recoverySourceId || !lifecycleMappingKey) {
                     throw new Error("Silent recovery has no durable source mapping")
                   }
-                  recoveryForkSource = lookupSharedSession(lifecycleMappingKey)?.currentTranscript
-                    ?? transcriptLocator(recoverySourceId)
+                  const storedRecoverySource = lookupSharedSession(lifecycleMappingKey)?.currentTranscript
+                  // Shallow copy for the same reason as the managed fork source:
+                  // the stored locator must not be filled back in place (cache).
+                  recoveryForkSource = storedRecoverySource
+                    ? { ...storedRecoverySource }
+                    : transcriptLocator(recoverySourceId)
                   const recoveryAttachedGeneration = recoveryForkSource.sessionId === recoverySourceId
                     ? await attachPinnedTranscript(
                       recoveryForkSource,

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -678,13 +678,10 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       0,
       envInt("SESSION_GC_GRACE_MS", SESSION_TURN_MAX_HOLD_MS + 60_000),
     ),
-    // The lock wait is a queue budget on one global lifecycle lock: a deployment
-    // with many concurrent conversations may prefer a slower turn over a failed
-    // one. The default stays what sessionLifecycle ships.
+    // A queue budget on one global lock: a deployment with many concurrent
+    // conversations may prefer a slower turn over a failed one.
     lockWaitMs: Math.max(100, envInt("SESSION_GC_LOCK_WAIT_MS", 2_000)),
-    // Sized by the turn watchdog, like the prepared grace: a lease a request
-    // still holds cannot outlive the watchdog, and one that did is a release
-    // that failed — collect it by age instead of fencing the conversation.
+    // No lease a live request holds can outlive the turn watchdog.
     unarmedLeaseTtlMs: SESSION_TURN_MAX_HOLD_MS + 60_000,
     deletionTimeoutMs: Math.max(1_000, envInt("SESSION_GC_DELETE_TIMEOUT_MS", 30_000)),
     runTimeoutMs: Math.max(1_000, envInt("SESSION_GC_RUN_TIMEOUT_MS", 30_000)),
@@ -2700,10 +2697,8 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
       const prepareManagedFork = async (sourceSessionId: string): Promise<void> => {
         if (managedForkTarget) return
         managedFreshTarget = false
-        // A shallow copy, on purpose: this locator is handed to lifecycle calls
-        // that fill the caller's locator back (Object.assign), and the session
-        // store now serves its cached document — mutating the stored object in
-        // place would silently diverge the cache from the file on disk.
+        // Copy: lifecycle calls fill the caller's locator back in place, and the
+        // store now serves a cached document that must not be mutated.
         managedForkSource = cachedSession?.currentTranscript?.sessionId === sourceSessionId
           ? { ...cachedSession.currentTranscript }
           : transcriptLocator(sourceSessionId)
@@ -5590,8 +5585,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
                     throw new Error("Silent recovery has no durable source mapping")
                   }
                   const storedRecoverySource = lookupSharedSession(lifecycleMappingKey)?.currentTranscript
-                  // Shallow copy for the same reason as the managed fork source:
-                  // the stored locator must not be filled back in place (cache).
+                  // Copy, for the same reason as the managed fork source above.
                   recoveryForkSource = storedRecoverySource
                     ? { ...storedRecoverySource }
                     : transcriptLocator(recoverySourceId)

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -47,17 +47,15 @@ const DEFAULT_LOCK_STALE_MS = 60_000
 const DEFAULT_PREPARED_GRACE_MS = 5 * 60_000
 const DEFAULT_DELETING_LEASE_MS = 60_000
 const DEFAULT_RETIRED_GRACE_MS = 11 * 60_000
-// An unarmed lease's lifetime is its own knob and NOT the prepared grace: a
-// deployment (or test) may size the grace small to fast-forward prepared-fork
-// expiry, and that must not instantly expire leases a live request still holds.
+// Deliberately its own knob, not the prepared grace: a deployment may size the
+// grace small to expire prepared forks fast, which must not expire leases a
+// live request still holds.
 const DEFAULT_UNARMED_LEASE_TTL_MS = 11 * 60_000
 const DEFAULT_RETRY_BASE_MS = 5_000
 const DEFAULT_RETRY_MAX_MS = 60 * 60_000
 const DEFAULT_DELETE_TIMEOUT_MS = 30_000
-// The deletion child reports "nothing to delete" by exit code, not by message:
-// the parent only keeps a bounded clip of the child output, and a Node crash
-// report buries the SDK's "not found" verdict under minified vendor source.
-// 75 is already taken by the gate timeout inside the child script.
+// "Nothing to delete" travels as an exit code because child output is clipped,
+// and a Node crash report can bury the verdict. 75 is the gate timeout.
 const SESSION_GC_NOT_FOUND_EXIT_CODE = 69
 
 export interface TranscriptLocator {
@@ -600,10 +598,7 @@ export async function reconcile(
       deletingRecovered: 0,
     }
     const now = nowMs(options)
-    // One grace bounds both a prepared fork and an unarmed lease: neither may
-    // outlive the turn watchdog by which the caller sizes it.
-    const preparedGraceMs = nonNegativeOption(options.preparedGraceMs, DEFAULT_PREPARED_GRACE_MS, "preparedGraceMs")
-    const preparedCutoff = now - preparedGraceMs
+    const preparedCutoff = now - nonNegativeOption(options.preparedGraceMs, DEFAULT_PREPARED_GRACE_MS, "preparedGraceMs")
     let changed = false
     const unarmedLeaseTtlMs = nonNegativeOption(options.unarmedLeaseTtlMs, DEFAULT_UNARMED_LEASE_TTL_MS, "unarmedLeaseTtlMs")
     for (const resource of Object.values(sidecar.resources)) {
@@ -872,6 +867,9 @@ async function countDeferred(
 
 class DeletionStillRunningError extends Error {}
 
+/** The SDK reported the transcript already gone: there is nothing left to delete. */
+class TranscriptAlreadyAbsentError extends Error {}
+
 async function awaitCustomDeleter(deletion: Promise<void>, timeoutMs: number): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined
   const timeout = new Promise<never>((_resolve, reject) => {
@@ -963,25 +961,30 @@ while (!existsSync(process.env.MERIDIAN_GC_GATE_PATH)) {
   await wait(10);
 }
 const sdk = await import(process.env.MERIDIAN_GC_SDK_URL);
+const sessionId = process.env.MERIDIAN_GC_SESSION_ID;
 const options = process.env.MERIDIAN_GC_PROJECT_DIR
   ? { dir: process.env.MERIDIAN_GC_PROJECT_DIR }
   : undefined;
+// Only the SDK's session-specific verdict means "already absent". A generic
+// "not found" can be the SDK or the child itself failing to load, and must stay
+// a retryable failure rather than tombstone a transcript still on disk.
+const absent = (message) => message.includes(process.env.MERIDIAN_GC_ABSENT_PHRASE);
 try {
-  await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID, options);
+  await sdk.deleteSession(sessionId, options);
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
   if (!message.includes("not found")) throw error;
   if (options) {
     try {
-      await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID);
-      // The dir-less fallback really deleted it — report a deletion,
-      // not an absence.
-      process.exit(0);
+      await sdk.deleteSession(sessionId);
+      process.exit(0); // The dir-less retry deleted it: a deletion, not an absence.
     } catch (fallbackError) {
       const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
-      if (!fallbackMessage.includes("not found")) throw fallbackError;
+      if (!absent(fallbackMessage)) throw fallbackError;
+      process.exit(${SESSION_GC_NOT_FOUND_EXIT_CODE});
     }
   }
+  if (!absent(message)) throw error;
   process.exit(${SESSION_GC_NOT_FOUND_EXIT_CODE});
 }
 `
@@ -991,6 +994,7 @@ try {
       CLAUDE_CONFIG_DIR: locator.configDir,
       MERIDIAN_GC_SDK_URL: sdkUrl,
       MERIDIAN_GC_SESSION_ID: locator.sessionId,
+      MERIDIAN_GC_ABSENT_PHRASE: sessionAbsentPhrase(locator.sessionId),
       MERIDIAN_GC_PROJECT_DIR: locator.projectDir ?? "",
       MERIDIAN_GC_GATE_PATH: gatePath,
       MERIDIAN_GC_GATE_TIMEOUT_MS: String(timeoutMs),
@@ -1043,11 +1047,9 @@ try {
       throw new DeletionStillRunningError("session deletion process group remains active")
     }
     if (status.code === SESSION_GC_NOT_FOUND_EXIT_CODE) {
-      // The child exits this code only when the SDK itself reported the
-      // transcript already absent on its final attempt. Phrase it in the exact
-      // wording the not-found classifier matches, instead of trusting the
-      // truncatable child output.
-      throw new Error(`session deletion child reported the transcript already absent: Session ${locator.sessionId} not found`)
+      throw new TranscriptAlreadyAbsentError(
+        `session deletion child reported transcript ${locator.sessionId} already absent`,
+      )
     }
     if (status.code !== 0) {
       throw new Error(`session deletion child exited ${status.code ?? status.signal}: ${clipChildOutput(output)}`)
@@ -1074,13 +1076,8 @@ try {
   }
 }
 
-/**
- * Keep both ends of collected child output within the storage budget. The
- * SDK's error verdict sits at the head while a Node crash report floods the
- * tail with minified vendor source; keeping only the tail is what hid the
- * not-found cause from stored errors. Exported for the clipper unit test,
- * like getSessionGcNodeExecutable.
- */
+/** Keep both ends of child output within the storage budget: the verdict sits
+ *  at the head, while a Node crash report floods the tail with vendor source. */
 export function clipChildOutput(output: string): string {
   const halfBudget = 2_000
   if (output.length <= halfBudget * 2) return output
@@ -1453,9 +1450,8 @@ async function writeSidecar(path: string, sidecar: SessionGcSidecar): Promise<vo
   let handle: Awaited<ReturnType<typeof open>> | undefined
   try {
     handle = await open(temp, "wx", 0o600)
-    // Compact JSON on purpose: the sidecar is machine-read only, and
-    // indentation costs ~25% of its bytes and of the CPU spent serialising it
-    // under the lock on a long-lived store.
+    // Compact on purpose: machine-read only, and indentation costs ~25% of the
+    // bytes and of the serialisation CPU spent under the lock.
     await handle.writeFile(`${JSON.stringify(sidecar)}\n`, "utf8")
     await handle.sync()
     await handle.close()
@@ -1641,11 +1637,10 @@ function pruneDeadActiveLeases(resource: TranscriptResource, now: number, unarme
       ? processIncarnationIsDead(lease.executor)
       : false
     // An unarmed lease cannot have started a physical writer: production opens
-    // the SDK gate only after attachActiveTranscriptExecutor commits. No request
-    // legitimately holds one longer than the turn watchdog (the TTL passed here
-    // is sized by it), so an unarmed lease older than that — writer or
-    // publication, with its owner still alive — can only be a release that
-    // failed; age retires it.
+    // the SDK gate only after attachActiveTranscriptExecutor commits. The TTL is
+    // sized by the turn watchdog, so one that outlives it with its owner still
+    // alive can only be a release that failed — collect it by age instead of
+    // fencing the conversation until restart.
     const unarmedOwnerDead = !lease.executor && processIncarnationIsDead(lease.owner)
     const unarmedLeaseExpired = !lease.executor && now - lease.createdAt > unarmedLeaseTtlMs
     if (!executorDead && !unarmedOwnerDead && !unarmedLeaseExpired) continue
@@ -1746,10 +1741,16 @@ function isState(value: unknown): value is TranscriptResourceState {
     || value === "deleting" || value === "deleted"
 }
 
+/** The SDK's UUID-specific absence verdict — the only wording either the parent
+ *  or the deletion child may read as "already gone". ENOENT and generic "not
+ *  found" can mean the child or the SDK failed to load, and must be retried. */
+function sessionAbsentPhrase(sessionId: string): string {
+  return `Session ${sessionId} not found`
+}
+
 function isNotFoundError(error: unknown, sessionId: string): boolean {
-  // Match the SDK's UUID-specific response only. ENOENT and generic "not found"
-  // errors can mean the child or SDK failed to load and must be retried.
-  return errorMessage(error).includes(`Session ${sessionId} not found`)
+  if (error instanceof TranscriptAlreadyAbsentError) return true
+  return errorMessage(error).includes(sessionAbsentPhrase(sessionId))
 }
 
 /** Resolve a real Node runtime even when Meridian itself is bundled under Bun. */

--- a/src/proxy/sessionLifecycle.ts
+++ b/src/proxy/sessionLifecycle.ts
@@ -47,9 +47,18 @@ const DEFAULT_LOCK_STALE_MS = 60_000
 const DEFAULT_PREPARED_GRACE_MS = 5 * 60_000
 const DEFAULT_DELETING_LEASE_MS = 60_000
 const DEFAULT_RETIRED_GRACE_MS = 11 * 60_000
+// An unarmed lease's lifetime is its own knob and NOT the prepared grace: a
+// deployment (or test) may size the grace small to fast-forward prepared-fork
+// expiry, and that must not instantly expire leases a live request still holds.
+const DEFAULT_UNARMED_LEASE_TTL_MS = 11 * 60_000
 const DEFAULT_RETRY_BASE_MS = 5_000
 const DEFAULT_RETRY_MAX_MS = 60 * 60_000
 const DEFAULT_DELETE_TIMEOUT_MS = 30_000
+// The deletion child reports "nothing to delete" by exit code, not by message:
+// the parent only keeps a bounded clip of the child output, and a Node crash
+// report buries the SDK's "not found" verdict under minified vendor source.
+// 75 is already taken by the gate timeout inside the child script.
+const SESSION_GC_NOT_FOUND_EXIT_CODE = 69
 
 export interface TranscriptLocator {
   sessionId: string
@@ -118,6 +127,8 @@ export interface SessionLifecycleOptions {
   deletingLeaseMs?: number
   /** Quarantine after retirement so old readers and rolling upgrades can drain. */
   retiredGraceMs?: number
+  /** Lifetime of an unarmed lease; sized by the caller's turn watchdog. */
+  unarmedLeaseTtlMs?: number
   retryBaseMs?: number
   retryMaxMs?: number
   deletionTimeoutMs?: number
@@ -190,12 +201,13 @@ export async function acquireActiveTranscriptLease(
   const token = randomUUID()
   await withSidecarLock(options, async (paths) => {
     const sidecar = await readSidecar(paths.sidecar)
+    const unarmedLeaseTtlMs = nonNegativeOption(options.unarmedLeaseTtlMs, DEFAULT_UNARMED_LEASE_TTL_MS, "unarmedLeaseTtlMs")
     for (const [key, locator] of normalized) {
       const resource = sidecar.resources[key]
       if (!resource) throw new SessionLifecycleError(`cannot lease unjournaled transcript ${key}`)
       assertSameLocator(resource.locator, locator)
       assertExactLifecycleGeneration(resource, locator)
-      pruneDeadActiveLeases(resource)
+      pruneDeadActiveLeases(resource, nowMs(options), unarmedLeaseTtlMs)
       if (Object.values(resource.activeLeases ?? {}).some(lease => lease.purpose !== "publication")) {
         throw new SessionLifecycleError(`transcript ${key} already has an active SDK writer`)
       }
@@ -588,10 +600,14 @@ export async function reconcile(
       deletingRecovered: 0,
     }
     const now = nowMs(options)
-    const preparedCutoff = now - nonNegativeOption(options.preparedGraceMs, DEFAULT_PREPARED_GRACE_MS, "preparedGraceMs")
+    // One grace bounds both a prepared fork and an unarmed lease: neither may
+    // outlive the turn watchdog by which the caller sizes it.
+    const preparedGraceMs = nonNegativeOption(options.preparedGraceMs, DEFAULT_PREPARED_GRACE_MS, "preparedGraceMs")
+    const preparedCutoff = now - preparedGraceMs
     let changed = false
+    const unarmedLeaseTtlMs = nonNegativeOption(options.unarmedLeaseTtlMs, DEFAULT_UNARMED_LEASE_TTL_MS, "unarmedLeaseTtlMs")
     for (const resource of Object.values(sidecar.resources)) {
-      if (pruneDeadActiveLeases(resource)) changed = true
+      if (pruneDeadActiveLeases(resource, now, unarmedLeaseTtlMs)) changed = true
     }
     let pending = pendingResourceCount(sidecar)
     const maxPending = option(options.maxPending, DEFAULT_MAX_PENDING, "maxPending")
@@ -757,9 +773,10 @@ async function claimDeletion(
     const sidecar = await readSidecar(paths.sidecar)
     const finalPins = (options.pinProvider?.() ?? pins).map(canonicalizeTranscriptLocator)
     const now = nowMs(options)
+    const unarmedLeaseTtlMs = nonNegativeOption(options.unarmedLeaseTtlMs, DEFAULT_UNARMED_LEASE_TTL_MS, "unarmedLeaseTtlMs")
     let leasesChanged = false
     for (const resource of Object.values(sidecar.resources)) {
-      if (pruneDeadActiveLeases(resource)) leasesChanged = true
+      if (pruneDeadActiveLeases(resource, now, unarmedLeaseTtlMs)) leasesChanged = true
     }
     const candidate = Object.values(sidecar.resources)
       .filter((resource) =>
@@ -953,8 +970,19 @@ try {
   await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID, options);
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
-  if (!options || !message.includes("not found")) throw error;
-  await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID);
+  if (!message.includes("not found")) throw error;
+  if (options) {
+    try {
+      await sdk.deleteSession(process.env.MERIDIAN_GC_SESSION_ID);
+      // The dir-less fallback really deleted it — report a deletion,
+      // not an absence.
+      process.exit(0);
+    } catch (fallbackError) {
+      const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+      if (!fallbackMessage.includes("not found")) throw fallbackError;
+    }
+  }
+  process.exit(${SESSION_GC_NOT_FOUND_EXIT_CODE});
 }
 `
   const child = spawn(getSessionGcNodeExecutable(), ["--input-type=module", "--eval", script], {
@@ -1014,8 +1042,15 @@ try {
     if (!joined) {
       throw new DeletionStillRunningError("session deletion process group remains active")
     }
+    if (status.code === SESSION_GC_NOT_FOUND_EXIT_CODE) {
+      // The child exits this code only when the SDK itself reported the
+      // transcript already absent on its final attempt. Phrase it in the exact
+      // wording the not-found classifier matches, instead of trusting the
+      // truncatable child output.
+      throw new Error(`session deletion child reported the transcript already absent: Session ${locator.sessionId} not found`)
+    }
     if (status.code !== 0) {
-      throw new Error(`session deletion child exited ${status.code ?? status.signal}: ${output.slice(-4_000)}`)
+      throw new Error(`session deletion child exited ${status.code ?? status.signal}: ${clipChildOutput(output)}`)
     }
   } finally {
     if (timer) clearTimeout(timer)
@@ -1037,6 +1072,20 @@ try {
       throw new DeletionStillRunningError("session deletion process group remains unjoined")
     }
   }
+}
+
+/**
+ * Keep both ends of collected child output within the storage budget. The
+ * SDK's error verdict sits at the head while a Node crash report floods the
+ * tail with minified vendor source; keeping only the tail is what hid the
+ * not-found cause from stored errors. Exported for the clipper unit test,
+ * like getSessionGcNodeExecutable.
+ */
+export function clipChildOutput(output: string): string {
+  const halfBudget = 2_000
+  if (output.length <= halfBudget * 2) return output
+  const elided = output.length - halfBudget * 2
+  return `${output.slice(0, halfBudget)}\n…[${elided} chars elided]…\n${output.slice(-halfBudget)}`
 }
 
 function getStoreDir(options: SessionLifecycleOptions): string {
@@ -1404,7 +1453,10 @@ async function writeSidecar(path: string, sidecar: SessionGcSidecar): Promise<vo
   let handle: Awaited<ReturnType<typeof open>> | undefined
   try {
     handle = await open(temp, "wx", 0o600)
-    await handle.writeFile(`${JSON.stringify(sidecar, null, 2)}\n`, "utf8")
+    // Compact JSON on purpose: the sidecar is machine-read only, and
+    // indentation costs ~25% of its bytes and of the CPU spent serialising it
+    // under the lock on a long-lived store.
+    await handle.writeFile(`${JSON.stringify(sidecar)}\n`, "utf8")
     await handle.sync()
     await handle.close()
     handle = undefined
@@ -1581,7 +1633,7 @@ function releasePublicationLease(resource: TranscriptResource): boolean {
   return changed
 }
 
-function pruneDeadActiveLeases(resource: TranscriptResource): boolean {
+function pruneDeadActiveLeases(resource: TranscriptResource, now: number, unarmedLeaseTtlMs: number): boolean {
   if (!resource.activeLeases) return false
   let changed = false
   for (const [token, lease] of Object.entries(resource.activeLeases)) {
@@ -1589,9 +1641,14 @@ function pruneDeadActiveLeases(resource: TranscriptResource): boolean {
       ? processIncarnationIsDead(lease.executor)
       : false
     // An unarmed lease cannot have started a physical writer: production opens
-    // the SDK gate only after attachActiveTranscriptExecutor commits.
+    // the SDK gate only after attachActiveTranscriptExecutor commits. No request
+    // legitimately holds one longer than the turn watchdog (the TTL passed here
+    // is sized by it), so an unarmed lease older than that — writer or
+    // publication, with its owner still alive — can only be a release that
+    // failed; age retires it.
     const unarmedOwnerDead = !lease.executor && processIncarnationIsDead(lease.owner)
-    if (!executorDead && !unarmedOwnerDead) continue
+    const unarmedLeaseExpired = !lease.executor && now - lease.createdAt > unarmedLeaseTtlMs
+    if (!executorDead && !unarmedOwnerDead && !unarmedLeaseExpired) continue
     delete resource.activeLeases[token]
     changed = true
   }

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -15,6 +15,7 @@ import {
   closeSync,
   existsSync,
   fchmodSync,
+  fstatSync,
   fsyncSync,
   linkSync,
   lstatSync,
@@ -958,6 +959,64 @@ function validateStoreMeta(value: unknown): SessionStoreMeta {
   }
 }
 
+interface StoreDocumentCache {
+  path: string
+  ino: number
+  mtimeMs: number
+  size: number
+  document: SessionStoreDocument
+}
+
+// Meridian usually runs one proxy per store, so nearly every read sees a file
+// this process wrote itself, and a foreign writer always publishes through
+// renameSync — a new inode — so identity-keyed caching is exact. It takes the
+// synchronous full-file parse (well over a hundred milliseconds on a
+// long-lived store) off every lookup, including out from under the session
+// lifecycle lock. Callers must treat the returned
+// document and its sessions as immutable; mutation goes through mutateStore.
+let storeDocumentCache: StoreDocumentCache | undefined
+
+function readStoreDocumentCached(path: string): SessionStoreDocument {
+  let info: ReturnType<typeof statSync>
+  try {
+    info = statSync(path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      storeDocumentCache = undefined
+      return emptyStoreDocument()
+    }
+    throw error
+  }
+  const cached = storeDocumentCache
+  if (cached?.path === path && cached.ino === info.ino && cached.mtimeMs === info.mtimeMs && cached.size === info.size) {
+    return cached.document
+  }
+  // Read from the same inode the identity was taken from: if another process
+  // renames a new file into place between stat and read, this parses exactly
+  // the file the identity names or throws — never mixes identity and content
+  // of two different files. A deletion landing in that same window is the one
+  // ENOENT the strict read treats as an empty store; match it here instead of
+  // surfacing a transient read error to the caller.
+  let fd: number
+  try {
+    fd = openSync(path, "r")
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      storeDocumentCache = undefined
+      return emptyStoreDocument()
+    }
+    throw error
+  }
+  try {
+    const identity = fstatSync(fd)
+    const document = parseStoreDocument(readFileSync(fd, "utf8"))
+    storeDocumentCache = { path, ino: identity.ino, mtimeMs: identity.mtimeMs, size: identity.size, document }
+    return document
+  } finally {
+    closeSync(fd)
+  }
+}
+
 function readStoreDocumentStrict(path: string): SessionStoreDocument {
   let data: string
   try {
@@ -966,7 +1025,12 @@ function readStoreDocumentStrict(path: string): SessionStoreDocument {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyStoreDocument()
     throw error
   }
+  return parseStoreDocument(data)
+}
 
+/** Parse and validate raw store bytes. Shared by the strict read and the
+ *  cached read so validation exists in exactly one place. */
+function parseStoreDocument(data: string): SessionStoreDocument {
   const parsed: unknown = JSON.parse(data)
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error("session store must contain a JSON object")
@@ -1000,7 +1064,7 @@ function readStoreDocumentStrict(path: string): SessionStoreDocument {
 }
 
 function readStoreStrict(path: string): Record<string, StoredSession> {
-  return readStoreDocumentStrict(path).sessions
+  return readStoreDocumentCached(path).sessions
 }
 
 /** Read a strict, coherent snapshot for maintenance tasks such as session GC.
@@ -1014,7 +1078,7 @@ export function readSessionStoreGenerationSnapshot(
   adapterSessionId: string,
   profileIds: readonly string[] = [],
 ): Record<string, StoredSessionGeneration> {
-  const document = readStoreDocumentStrict(getStorePath())
+  const document = readStoreDocumentCached(getStorePath())
   const keys = new Set(Object.keys(document.sessions).filter((key) =>
     key === adapterSessionId || key.endsWith(`:${adapterSessionId}`)))
   keys.add(adapterSessionId)
@@ -1056,7 +1120,9 @@ function writeStore(path: string, document: SessionStoreDocument): void {
     fd = openSync(tmp, "wx", 0o600)
     fchmodSync(fd, 0o600)
     const serialized = { [STORE_META_KEY]: document.meta, ...document.sessions }
-    writeFileSync(fd, JSON.stringify(serialized, null, 2), "utf8")
+    // Compact JSON on purpose: machine-read only, and indentation costs ~20%
+    // of the bytes and of the stringify CPU on a large store.
+    writeFileSync(fd, JSON.stringify(serialized), "utf8")
     fsyncSync(fd)
     closeSync(fd)
     fd = undefined
@@ -1086,7 +1152,14 @@ function mutateStore(mutator: (document: SessionStoreDocument) => boolean): void
   const lock = acquireLock(`${path}.lock`)
   try {
     const document = readStoreDocumentStrict(path)
-    if (mutator(document)) writeStore(path, document)
+    if (mutator(document)) {
+      writeStore(path, document)
+      // writeStore renamed the mutated document into place: publish it under
+      // the new inode's identity so the next cached read serves exactly these
+      // bytes. A mutator returning false leaves the cache untouched.
+      const info = statSync(path)
+      storeDocumentCache = { path, ino: info.ino, mtimeMs: info.mtimeMs, size: info.size, document }
+    }
   } finally {
     releaseLock(lock)
   }
@@ -1105,7 +1178,7 @@ export type SharedSessionLookupResult =
 /** Distinguish an authoritative absence from a transient/corrupt read. */
 export function lookupSharedSessionResult(key: string): SharedSessionLookupResult {
   try {
-    const document = readStoreDocumentStrict(getStorePath())
+    const document = readStoreDocumentCached(getStorePath())
     const session = document.sessions[key]
     const generation = keyGeneration(key, session, document.meta)
     if (!session) return { status: "missing", generation }
@@ -1139,7 +1212,7 @@ export type PriorityAssignmentLookupResult =
 /** Read one exact durable route. V1 documents authoritatively contain none. */
 export function lookupPriorityAssignmentResult(routeKey: string): PriorityAssignmentLookupResult {
   try {
-    const document = readStoreDocumentStrict(getStorePath())
+    const document = readStoreDocumentCached(getStorePath())
     const assignment = document.meta.version === PRIORITY_STORE_META_VERSION
       ? document.meta.priorityAssignments[routeKey]
       : undefined
@@ -1159,7 +1232,7 @@ export function lookupPriorityAssignmentResult(routeKey: string): PriorityAssign
 
 export function lookupSharedSessionByClaudeIdResult(claudeSessionId: string): SharedSessionLookupResult {
   try {
-    const document = readStoreDocumentStrict(getStorePath())
+    const document = readStoreDocumentCached(getStorePath())
     let newest: StoredSession | undefined
     let newestKey: string | undefined
     for (const [key, session] of Object.entries(document.sessions)) {
@@ -1280,8 +1353,12 @@ export function storeSharedSession(
         ? existing?.passthroughToolCallIds
         : passthroughToolCallIds ?? undefined,
       contextUsage: contextUsage ?? existing?.contextUsage,
-      ...(resolvedCurrentTranscript ? { currentTranscript: resolvedCurrentTranscript } : {}),
-      ...(previousTranscript ? { previousTranscript } : {}),
+      // Never alias caller-owned locators into the document: the document is
+      // republished as the read cache, and an aliased object lets a later
+      // caller-side mutation (or a lifecycle fill-back) diverge the cache
+      // from the file. Shallow copy — a locator is flat.
+      ...(resolvedCurrentTranscript ? { currentTranscript: { ...resolvedCurrentTranscript } } : {}),
+      ...(previousTranscript ? { previousTranscript: { ...previousTranscript } } : {}),
       ...(previousClaudeSessionId ? { previousClaudeSessionId } : {}),
     }
 
@@ -1898,7 +1975,9 @@ export function attachSharedTranscriptLocator(
     if (!existing || existing.claudeSessionId !== expectedClaudeSessionId) return false
     if (expectedGeneration !== undefined && getStoredSessionGeneration(existing, key) !== expectedGeneration) return false
     if (!sameTranscriptLocator(existing.currentTranscript, locator)) {
-      existing.currentTranscript = locator
+      // Copy, never alias: the caller's locator outlives this mutation, and
+      // the document (republished as the read cache) must not share it.
+      existing.currentTranscript = { ...locator }
       existing.revision = (existing.revision ?? 0) + 1
       existing.generationId = randomUUID()
       advanceKeySlot(key, meta)

--- a/src/proxy/sessionStore.ts
+++ b/src/proxy/sessionStore.ts
@@ -967,53 +967,48 @@ interface StoreDocumentCache {
   document: SessionStoreDocument
 }
 
-// Meridian usually runs one proxy per store, so nearly every read sees a file
-// this process wrote itself, and a foreign writer always publishes through
-// renameSync — a new inode — so identity-keyed caching is exact. It takes the
-// synchronous full-file parse (well over a hundred milliseconds on a
-// long-lived store) off every lookup, including out from under the session
-// lifecycle lock. Callers must treat the returned
-// document and its sessions as immutable; mutation goes through mutateStore.
+// Takes the synchronous full-file parse — well over a hundred milliseconds on a
+// long-lived store — off every lookup and out from under the session lifecycle
+// lock. Identity keying is exact because every writer, this process or a
+// foreign one, publishes through renameSync and therefore a new inode.
+// Callers must treat the document and its sessions as immutable; mutation goes
+// through mutateStore.
 let storeDocumentCache: StoreDocumentCache | undefined
 
 function readStoreDocumentCached(path: string): SessionStoreDocument {
-  let info: ReturnType<typeof statSync>
+  let fd: number | undefined
   try {
-    info = statSync(path)
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      storeDocumentCache = undefined
-      return emptyStoreDocument()
+    const info = statSync(path)
+    const cached = storeDocumentCache
+    if (cached?.path === path && cached.ino === info.ino && cached.mtimeMs === info.mtimeMs && cached.size === info.size) {
+      return cached.document
     }
-    throw error
-  }
-  const cached = storeDocumentCache
-  if (cached?.path === path && cached.ino === info.ino && cached.mtimeMs === info.mtimeMs && cached.size === info.size) {
-    return cached.document
-  }
-  // Read from the same inode the identity was taken from: if another process
-  // renames a new file into place between stat and read, this parses exactly
-  // the file the identity names or throws — never mixes identity and content
-  // of two different files. A deletion landing in that same window is the one
-  // ENOENT the strict read treats as an empty store; match it here instead of
-  // surfacing a transient read error to the caller.
-  let fd: number
-  try {
+    // Identity is re-taken from the same fd the content is read from, so a
+    // rename landing between stat and read can never pair one file's identity
+    // with another file's bytes.
     fd = openSync(path, "r")
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      storeDocumentCache = undefined
-      return emptyStoreDocument()
-    }
-    throw error
-  }
-  try {
     const identity = fstatSync(fd)
     const document = parseStoreDocument(readFileSync(fd, "utf8"))
     storeDocumentCache = { path, ino: identity.ino, mtimeMs: identity.mtimeMs, size: identity.size, document }
     return document
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    storeDocumentCache = undefined
+    return emptyStoreDocument()
   } finally {
-    closeSync(fd)
+    if (fd !== undefined) closeSync(fd)
+  }
+}
+
+/** Publish a just-written document under the identity of the file it landed in.
+ *  A failure to read that identity only costs the next reader a re-parse, so it
+ *  must never turn a committed write into a thrown mutation. */
+function publishStoreCache(path: string, document: SessionStoreDocument): void {
+  try {
+    const info = statSync(path)
+    storeDocumentCache = { path, ino: info.ino, mtimeMs: info.mtimeMs, size: info.size, document }
+  } catch {
+    storeDocumentCache = undefined
   }
 }
 
@@ -1028,8 +1023,7 @@ function readStoreDocumentStrict(path: string): SessionStoreDocument {
   return parseStoreDocument(data)
 }
 
-/** Parse and validate raw store bytes. Shared by the strict read and the
- *  cached read so validation exists in exactly one place. */
+/** Parse and validate raw store bytes, for both the strict and the cached read. */
 function parseStoreDocument(data: string): SessionStoreDocument {
   const parsed: unknown = JSON.parse(data)
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
@@ -1120,8 +1114,8 @@ function writeStore(path: string, document: SessionStoreDocument): void {
     fd = openSync(tmp, "wx", 0o600)
     fchmodSync(fd, 0o600)
     const serialized = { [STORE_META_KEY]: document.meta, ...document.sessions }
-    // Compact JSON on purpose: machine-read only, and indentation costs ~20%
-    // of the bytes and of the stringify CPU on a large store.
+    // Compact on purpose: machine-read only, and indentation costs ~20% of the
+    // bytes and of the stringify CPU on a large store.
     writeFileSync(fd, JSON.stringify(serialized), "utf8")
     fsyncSync(fd)
     closeSync(fd)
@@ -1154,11 +1148,7 @@ function mutateStore(mutator: (document: SessionStoreDocument) => boolean): void
     const document = readStoreDocumentStrict(path)
     if (mutator(document)) {
       writeStore(path, document)
-      // writeStore renamed the mutated document into place: publish it under
-      // the new inode's identity so the next cached read serves exactly these
-      // bytes. A mutator returning false leaves the cache untouched.
-      const info = statSync(path)
-      storeDocumentCache = { path, ino: info.ino, mtimeMs: info.mtimeMs, size: info.size, document }
+      publishStoreCache(path, document)
     }
   } finally {
     releaseLock(lock)
@@ -1353,10 +1343,8 @@ export function storeSharedSession(
         ? existing?.passthroughToolCallIds
         : passthroughToolCallIds ?? undefined,
       contextUsage: contextUsage ?? existing?.contextUsage,
-      // Never alias caller-owned locators into the document: the document is
-      // republished as the read cache, and an aliased object lets a later
-      // caller-side mutation (or a lifecycle fill-back) diverge the cache
-      // from the file. Shallow copy — a locator is flat.
+      // Copy, never alias: the document is republished as the read cache, so a
+      // later mutation of the caller's locator would diverge it from the file.
       ...(resolvedCurrentTranscript ? { currentTranscript: { ...resolvedCurrentTranscript } } : {}),
       ...(previousTranscript ? { previousTranscript: { ...previousTranscript } } : {}),
       ...(previousClaudeSessionId ? { previousClaudeSessionId } : {}),
@@ -1975,8 +1963,7 @@ export function attachSharedTranscriptLocator(
     if (!existing || existing.claudeSessionId !== expectedClaudeSessionId) return false
     if (expectedGeneration !== undefined && getStoredSessionGeneration(existing, key) !== expectedGeneration) return false
     if (!sameTranscriptLocator(existing.currentTranscript, locator)) {
-      // Copy, never alias: the caller's locator outlives this mutation, and
-      // the document (republished as the read cache) must not share it.
+      // Copy, never alias — same reason as in storeSharedSession.
       existing.currentTranscript = { ...locator }
       existing.revision = (existing.revision ?? 0) + 1
       existing.generationId = randomUUID()


### PR DESCRIPTION
## Symptom

On a long-lived single-proxy deployment (many conversations a day, ~500 turns/hour at peak) 13–16% of turns end in

> 504 — Request timed out. The operation may have been too complex. Try a simpler request.

Shrinking the request does not help, because the request was never the problem: the proxy's own session bookkeeping is. Four defects, each read off the running process, each independent, together compounding.

---

### 1. The deletion backlog never drains — and then blocks every new conversation

`deleteSession` **throws** when the transcript file is already gone: a success in disguise. The child exits 1, and the parent tries to recognise the case by matching `Session <id> not found` against `output.slice(-4_000)` — but a Node crash report fills that tail with minified vendor source and leaves the verdict at the head, so the match never fires.

Entries stay `retired` and are retried with backoff forever (**254 attempts** on one resource) until `pending` reaches `maxPending`. From that moment **every new conversation** fails with `ownership backlog is full`.

**Fix.** The child reports "nothing to delete" by **exit code** (`69`; `75` is the gate timeout), and the parent turns it into a typed `TranscriptAlreadyAbsentError` that the existing `notFound` path accepts — no prose re-parsed by a string matcher. Only the SDK's session-specific wording counts as absence, in the child exactly as in the parent (one shared phrase, passed to the child by env): a generic "not found" can be the SDK or the child failing to load, and stays a retryable failure rather than tombstoning a transcript still on disk. Child output now keeps **head and tail**, so the next verdict is not hidden by truncation either.

### 2. Every store read parses the whole file, synchronously — sometimes under the lock

`sessions.json` grows with conversation history: **26 MiB** on this deployment, three quarters of it per-message hashes. `JSON.parse` of it costs **135 ms**. `lookupSharedSessionResult` and friends do it several times per request, and the GC pin provider does it **while holding the lifecycle lock**, so every deletion claim blocks that lock for a full parse. This is where the 2 s lock budget goes.

**Fix.** An in-process read cache keyed by file *identity* — `{path, ino, mtimeMs, size}`, taken from the same fd the bytes are read from, so a rename landing mid-read can never pair one file's identity with another's content. Identity keying is exact because every writer publishes through `rename`, hence a new inode. Writers still parse fresh and republish the cache after `writeStore`.

Callers must treat the served document as immutable, so: the store copies locators in on write, and the two `server.ts` call sites that handed a **stored** locator into a lifecycle call that fills the caller's object back in place now pass a shallow copy.

### 3. An unarmed lease has no TTL — and fences the conversation until restart

`releaseActiveTranscriptLease` runs in a `finally` and itself waits on the lifecycle lock; when that wait times out, the lease survives. `pruneDeadActiveLeases` collects an unarmed lease only when its *owner* is dead — and the owner is the proxy itself, which is alive. The conversation then fails with `already has an active SDK writer` until a restart. Observed: **30 leaked leases, 28 older than 15 minutes**, none with a live executor.

**Fix.** Retire an unarmed lease once it is older than its TTL — the turn watchdog plus margin, as **its own knob**, not the prepared grace, which a deployment may deliberately size small. By the file's own invariant an unarmed lease never started a physical writer, so one that outlives the watchdog can only be a release that failed. Publication leases are covered too: in the same state they block retirement and deletion of their resource.

### 4. Pretty-printed bookkeeping files

`JSON.stringify(doc, null, 2)` on two machine-read-only files costs ~20–25% of the bytes and of the serialisation CPU spent under the lock: sidecar **1610 → 1216 KiB**, store stringify **72 → 48 ms**.

### And: stop blaming the request

Lock waits and backlog-full failures now answer **503 `overloaded_error`** naming the actual reason ("the retirement backlog is full", "a bookkeeping lock is busy") instead of a 504 that sends the operator to shrink a context unrelated to the failure. Absolute host paths stay out of the response body; the diagnostic log keeps them. New operator knob `SESSION_GC_LOCK_WAIT_MS` (default unchanged) for deployments that would rather wait than fail.

---

## Tests

Full suite green (`npm test`), `tsc --noEmit` clean. New coverage:

- **deletion verdict**, against a real child process: the exit-code absence lands as `notFound` and tombstones; a genuine child failure still lands as `failed` and retries;
- **output clipping**: the head survives;
- **read cache**: consecutive reads reuse the document; an in-process write is visible immediately; a store replaced out of band by another process is picked up; a deleted store is not served from the stale cache; no caller-owned locator is ever aliased into the cached document (neither through `storeSharedSession` nor `attachSharedTranscriptLocator`);
- **leases**: a stale unarmed lease no longer blocks `acquire` while a fresh one still does; a stale publication lease no longer blocks retirement.
