### PR TITLE
fix(opencode): admit a plugin-less client's concurrent turns instead of refusing them

### DIFF
--- a/src/__tests__/pluginless-opencode-warning.test.ts
+++ b/src/__tests__/pluginless-opencode-warning.test.ts
@@ -11,7 +11,9 @@
  *   seq 2  tools=10  msgs=1  x-session-affinity: ses_fe4c…   ← the user's turn
  *
  * Both attempts of that run returned HTTP 400 `session_turn_conflict` after a
- * ~8s wait. The agent-scoped session key that fixes this reads the plugin's
+ * ~8s wait. Since #1024 that collision is admitted and reclassified instead —
+ * the loser replays against a cold cache — so the exposure is a cost rather
+ * than a failure. The warning still fires, because the fix is still the plugin. The agent-scoped session key that fixes this reads the plugin's
  * `x-opencode-agent-mode`, so it cannot reach a client that sends none.
  *
  * Inferring the agent from request shape was tried and reverted — "tool-less,
@@ -30,7 +32,7 @@ import { installSdkMock, setSdkMock } from "./sdkMock"
 import { installLoggerMock, setLoggerMock } from "./loggerMock"
 import { installMcpToolsMock, setMcpToolsMock } from "./mcpToolsMock"
 import { resolveMockSdkSessionId } from "./helpers"
-import { notePluginlessOpenCodeRequest, clearPluginlessWarnings } from "../proxy/setup"
+import { notePluginlessOpenCodeRequest, clearPluginlessWarnings, isPluginlessOpenCodeRequest } from "../proxy/setup"
 
 const OPENCODE_UA = "opencode/1.18.11 ai-sdk/provider-utils/4.0.27 runtime/bun/1.3.14"
 
@@ -105,8 +107,12 @@ describe("notePluginlessOpenCodeRequest", () => {
       userAgent: OPENCODE_UA, agentModeHeader: undefined, sessionId: "ses_g",
     })!
     // An operator who reads only this line should understand why they care.
+    // Since #1024 the consequence is a cold replay rather than a 400, so the
+    // line must name the cost that remains, not the failure that no longer
+    // happens.
     expect(msg.toLowerCase()).toContain("title")
-    expect(msg).toMatch(/cold cache|400/)
+    expect(msg).toMatch(/cold prompt cache/)
+    expect(msg).not.toContain("400")
   })
 
   it("does not leak a whole session id into the log line", () => {
@@ -193,5 +199,35 @@ describe("plugin-less warning through the HTTP path", () => {
     const afterPluginful = diagnosticLog.getRecent({ limit: 50 })
       .filter((l) => l.message.includes("without the Meridian plugin"))
     expect(afterPluginful.length).toBe(1)
+  })
+})
+
+/**
+ * The same fact now decides more than the warning: a client that cannot send
+ * the plugin's signal is not held to the strict one-turn-per-session-key rule
+ * (#1024). Both readers must agree, so the predicate is pinned directly.
+ */
+describe("isPluginlessOpenCodeRequest", () => {
+  const OPENCODE_UA = "opencode/1.18.30 ai-sdk/provider-utils/4.0.46 runtime/bun/1.3.14"
+
+  it("is true for an OpenCode client that sends no agent mode", () => {
+    expect(isPluginlessOpenCodeRequest({ userAgent: OPENCODE_UA, agentModeHeader: undefined })).toBe(true)
+    // Case is not the client's to guarantee.
+    expect(isPluginlessOpenCodeRequest({ userAgent: "OpenCode/1.18.30", agentModeHeader: undefined })).toBe(true)
+  })
+
+  it("is false once the plugin stamps an agent mode", () => {
+    for (const mode of ["primary", "subagent"]) {
+      expect(isPluginlessOpenCodeRequest({ userAgent: OPENCODE_UA, agentModeHeader: mode })).toBe(false)
+    }
+  })
+
+  it("is false for anything that is not OpenCode", () => {
+    // Relaxing the conflict guard must not reach another client by accident —
+    // `opencode2` is the V2 host, which ships its own plugin signal, and the
+    // substring must not match in the middle of an unrelated agent string.
+    for (const ua of [undefined, "", "crush/0.87.0", "Polytoken v0.8.6", "curl/8.7.1", "my-opencode/1.0"]) {
+      expect(isPluginlessOpenCodeRequest({ userAgent: ua, agentModeHeader: undefined })).toBe(false)
+    }
   })
 })

--- a/src/__tests__/proxy-concurrency-coordination.test.ts
+++ b/src/__tests__/proxy-concurrency-coordination.test.ts
@@ -321,6 +321,61 @@ describe("SDK and Session concurrency coordination", () => {
     expect(stored).toContain(loserSessionId!)
   })
 
+  it("answers, instead of refusing, a plugin-less OpenCode client's concurrent turn (#1024)", async () => {
+    // OpenCode fires a Haiku `agent=title` stream and the primary turn about a
+    // second apart on ONE session id. With Meridian's plugin the title says so
+    // in a header and is detached; a client running some other plugin sends no
+    // such header, so both look like the same conversation and the loser used
+    // to take a hard 400 on the FIRST turn of every new session.
+    //
+    // It is exactly pi's situation — one session id for the main turn and its
+    // side calls, no per-flow signal available — so it gets pi's treatment.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const ua = { "user-agent": "opencode/1.18.30 ai-sdk/provider-utils/4.0.46 runtime/bun/1.3.14" }
+    const messages = [{ role: "user", content: "same request" }]
+    const firstP = app.fetch(request(messages, "pluginless", false, ua))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(messages, "pluginless", false, ua))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    const secondControl = await waitForControl(1)
+    secondControl.release()
+    expect((await secondP).status).toBe(200)
+
+    // Degraded, not waved through: still one turn at a time, and the loser runs
+    // fresh rather than resuming the winner and merging two conversations.
+    expect(maxActiveQueries).toBe(1)
+    expect(queryCalls).toBe(2)
+    expect(capturedParams[1]?.options?.resume).toBeUndefined()
+    expect(telemetryStore.getRecent().filter(m => m.error === "session_turn_conflict")).toHaveLength(0)
+  })
+
+  it("still refuses the loser when the OpenCode plugin's signal is present", async () => {
+    // The control for #1024: relaxing the rule must reach ONLY clients that
+    // cannot send the signal. A plugin-equipped client that genuinely races
+    // itself keeps the loud failure, because for it a collision is a defect
+    // rather than an unavoidable protocol shape.
+    const app = createProxyServer({ port: 0, host: "127.0.0.1", silent: true }).app
+    const headers = {
+      "user-agent": "opencode/1.18.30 ai-sdk/provider-utils/4.0.46 runtime/bun/1.3.14",
+      "x-opencode-agent-mode": "primary",
+    }
+    const messages = [{ role: "user", content: "same request" }]
+    const firstP = app.fetch(request(messages, "plugged", false, headers))
+    const firstControl = await waitForControl(0)
+    const secondP = app.fetch(request(messages, "plugged", false, headers))
+
+    firstControl.release()
+    expect((await firstP).status).toBe(200)
+    const second = await secondP
+    expect(second.status).toBe(400)
+    expect((await second.json() as { error: { message: string } }).error.message)
+      .toContain("advanced while the request was waiting")
+    expect(queryCalls).toBe(1)
+    expect(telemetryStore.getRecent().filter(m => m.error === "session_turn_conflict")).toHaveLength(1)
+  })
+
   it("replays a declared-flow loser instead of rewinding the turn it lost to (#870)", async () => {
     // A side call carries a prefix of the main history, so once the main turn
     // commits the loser reads as an undo against it. Honouring that would roll

--- a/src/proxy/server.ts
+++ b/src/proxy/server.ts
@@ -68,7 +68,7 @@ import {
   isDesignAuthFailure,
   DESIGN_UPSTREAM_ORIGIN,
 } from "./design"
-import { checkPluginConfigured, notePluginlessOpenCodeRequest } from "./setup"
+import { checkPluginConfigured, isPluginlessOpenCodeRequest, notePluginlessOpenCodeRequest } from "./setup"
 import { describeBuildDrift, getBuildInfo } from "./buildInfo"
 import { getLatestVersion, startUpdateCheck, stopUpdateCheck } from "./updateCheck"
 import { mapModelToClaudeModel, resolveClaudeExecutableAsync, resolveSdkModelDefaults, explicitModelPin, CANONICAL_SONNET_MODEL, isClosedControllerError, getClaudeAuthStatusAsync, getAuthCacheInfo, getResolvedClaudeExecutableInfo, hasExtendedContext, stripExtendedContext, recordExtendedContextUnavailable, recordExtendedContextRateLimited, subscriptionIncludesExtendedContext } from "./models"
@@ -2123,6 +2123,12 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // conversation, and that exposure is otherwise silent — the startup
         // warning is gated on an OpenCode config file existing. Once per
         // session; the helper owns the bookkeeping.
+        // The same fact the warning reports also decides whether this request
+        // can be held to the strict one-turn-per-session-key rule (#1024).
+        const pluginlessOpenCode = isPluginlessOpenCodeRequest({
+          userAgent: c.req.header("user-agent"),
+          agentModeHeader: c.req.header("x-opencode-agent-mode"),
+        })
         const pluginlessWarning = notePluginlessOpenCodeRequest({
           userAgent: c.req.header("user-agent"),
           agentModeHeader: c.req.header("x-opencode-agent-mode"),
@@ -2290,12 +2296,25 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         // client has no per-flow signal to send: pi carries one session id for
         // the main turn and its side calls alike, so the loser of that race is
         // reclassified rather than refused. See runsConcurrentTurnsPerSessionKey.
+        //
+        // NOTE: agent-specific (opencode). An OpenCode client with no Meridian
+        // plugin is in exactly pi's position and for the same reason: it runs a
+        // hidden title/summary agent under the user's own session id and has no
+        // header with which to say so. Holding it to the strict rule failed the
+        // FIRST turn of every new session with a 400 (#1024). Degrade it to the
+        // same reclassification instead — a cold replay, which the pluginless
+        // warning already names as the alternative outcome — and keep warning
+        // that `meridian setup` is the actual fix. A plugin-equipped client
+        // sends the signal, so it keeps the strict guard.
+        const protocolRunsConcurrentTurnsPerSessionKey =
+          adapter.runsConcurrentTurnsPerSessionKey === true
+          || pluginlessOpenCode
         const declaresPerRequestConcurrentFlow =
           requestSource?.startsWith("fork-") === true
           || isSubagentRequest
         const declaresConcurrentFlow =
           declaresPerRequestConcurrentFlow
-          || adapter.runsConcurrentTurnsPerSessionKey === true
+          || protocolRunsConcurrentTurnsPerSessionKey
         // Exact pending tool IDs identify the batch, not the earlier history.
         // Rebinding a checkpoint must also preserve its complete stored prefix;
         // otherwise a revised user instruction would be silently discarded.
@@ -2428,7 +2447,7 @@ export function createProxyServer(config: Partial<ProxyConfig> = {}): ProxyServe
         if (
           lostRaceWhileWaiting &&
           !declaresPerRequestConcurrentFlow &&
-          adapter.runsConcurrentTurnsPerSessionKey === true &&
+          protocolRunsConcurrentTurnsPerSessionKey &&
           lineageResult.type === "undo"
         ) {
           lineageResult = { type: "diverged", reason: "concurrent-race" }

--- a/src/proxy/setup.ts
+++ b/src/proxy/setup.ts
@@ -322,6 +322,25 @@ export function clearPluginlessWarnings(): void {
  * Returns the message to log, or undefined when there is nothing to say.
  * Stateful but I/O-free — the caller owns the logging.
  */
+/**
+ * Is this an OpenCode request that carries no Meridian plugin signal?
+ *
+ * Such a client cannot tell Meridian which of its concurrent streams is the
+ * hidden title/summary agent, so the proxy must not hold it to the strict
+ * one-turn-per-session-key rule — see the concurrent-flow declaration in
+ * server.ts. Pure so both the warning and that decision read the same fact.
+ */
+export function isPluginlessOpenCodeRequest(input: {
+  userAgent: string | undefined
+  /** The plugin's `x-opencode-agent-mode` header, if it sent one. */
+  agentModeHeader: string | undefined
+}): boolean {
+  if (!input.userAgent?.toLowerCase().startsWith("opencode/")) return false
+  // A plugin old enough to omit the agent headers is equally unable to prevent
+  // the collision, so it counts the same.
+  return !input.agentModeHeader
+}
+
 export function notePluginlessOpenCodeRequest(input: {
   userAgent: string | undefined
   /** The plugin's `x-opencode-agent-mode` header, if it sent one. */
@@ -329,10 +348,7 @@ export function notePluginlessOpenCodeRequest(input: {
   /** Client session id — used only to warn once per conversation. */
   sessionId: string | undefined
 }): string | undefined {
-  if (!input.userAgent?.toLowerCase().startsWith("opencode/")) return undefined
-  // A plugin old enough to omit the agent headers is equally unable to prevent
-  // the collision, so it gets the same warning.
-  if (input.agentModeHeader) return undefined
+  if (!isPluginlessOpenCodeRequest(input)) return undefined
 
   const key = input.sessionId || "(keyless)"
   if (pluginlessWarned.get(key)) return undefined
@@ -343,8 +359,9 @@ export function notePluginlessOpenCodeRequest(input: {
   return (
     `OpenCode request without the Meridian plugin's agent headers (session ${shortId}). ` +
     `OpenCode runs its internal title/summary agents under your session id, so Meridian ` +
-    `cannot tell them apart from your conversation: the first turn of each session can fail ` +
-    `with a 400 or replay against a cold cache. Fix: meridian setup (or update the plugin).`
+    `cannot tell them apart from your conversation: concurrent turns are admitted rather ` +
+    `than refused, but the one that loses the race replays against a cold prompt cache — ` +
+    `slower and billed as uncached input. Fix: meridian setup (or update the plugin).`
   )
 }
 


### PR DESCRIPTION
Stops a plugin-less OpenCode client failing the first turn of every new session.

Refs #1024, reported by @calebdw.

## The shape

OpenCode fires a Haiku `agent=title` stream and the primary turn about a second
apart on **one** OpenCode session id. With Meridian's plugin the hidden turn
says so in a header and is detached. A client running a different OpenCode
plugin sends no such header, so both streams look like one conversation, one
loses the commit race, and it took a hard 400:

```
This session advanced while the request was waiting.
```

Reproduced live on the 1.71.0 candidate with the reporter's own models, then
again here with the fix:

| headerless, Opus primary + Haiku title | before | after |
|---|---|---|
| primary | 200 | 200 |
| title | **400** | **200** |

## Why this shape, not a bigger change

This is precisely pi's situation — one session id for the main turn and its side
calls, no per-flow signal available — and the code already says so:

> An adapter can declare the same fact for its whole protocol when the client
> has no per-flow signal to send: pi carries one session id for the main turn
> and its side calls alike, so the loser of that race is reclassified rather
> than refused.

So this reuses that mechanism rather than inventing one, and applies it **only**
to requests that carry no plugin signal. A plugin-equipped OpenCode client keeps
the strict guard, because for it a collision is a defect rather than an
unavoidable protocol shape. Deliberately **not** done: setting
`runsConcurrentTurnsPerSessionKey` on the whole adapter, which would have
relaxed the guard for correctly configured users too.

The decision reads the same pure predicate the pluginless warning already
used — extracted as `isPluginlessOpenCodeRequest` — so the warning and the
behaviour cannot drift apart.

This is not inferring which stream is the title. That was tried and reverted
before, and the reasons are still in `pluginless-opencode-warning.test.ts`:
"tool-less, one message" is equally the first turn of an ordinary chat.

## What does not change

Serialization is untouched: one turn at a time per session key, `maxActiveQueries`
still 1. The loser still runs **fresh** rather than resuming the winner and
merging two histories. The cost is a cold prompt cache — slower, billed as
uncached input — which is what 1.62.1 did before the strict check existed, and
what the reporter experienced as "working".

The warning still fires, because `meridian setup` is still the real fix. Its
text now names the cost that remains instead of predicting a 400 that no longer
happens, and a test pins that it no longer says "400".

## Validation

`npm test` 3927 pass / 1 skip / 0 fail on bun 1.3.14 (+5), typecheck, build.

New coverage, all of it absent before:

- `isPluginlessOpenCodeRequest` — UA case-insensitivity, both agent modes, and
  negatives including `opencode2`, `crush`, `Polytoken` and `my-opencode/1.0`
  (prefix, not substring).
- HTTP-layer: a plugin-less concurrent pair is admitted, still serialized, loser
  runs fresh, and emits no `session_turn_conflict` telemetry. **Fails on the
  tree without this change** — verified by reverting the one-line condition.
- HTTP-layer control: with `x-opencode-agent-mode` present the loser still takes
  the 400 and still records the conflict. Passes both with and without the fix,
  which is what proves the change is scoped.

Live, real SDK and Claude Max: the reported shape now returns 200/200 with the
warning still emitted; the plugin-equipped control is unchanged at 200/200 with
no warning; all four E41 modes pass.
